### PR TITLE
Merchant e-solutions Verification Only Transaction

### DIFF
--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -84,7 +84,7 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 	def test_unsuccessful_unstore
 		assert unstore = @gateway.unstore('')
 		assert_failure unstore
-		assert_equal 'Invalid Card ID', unstore.message
+		assert_equal 'Card ID required', unstore.message
 	end
 
 	def test_unsuccessful_void
@@ -93,6 +93,12 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 		assert_equal 'Invalid Transaction ID', void.message
 	end
 
+	def test_verify
+		assert auth = @gateway.verify(@credit_card, @options)
+		assert_success auth
+		assert auth.authorization
+	end
+	
 	def test_successful_avs_check
     assert response = @gateway.purchase(@amount, @credit_card, @options)
 		assert_equal 'Y', response.avs_result['code']


### PR DESCRIPTION
I added support for this transaction type which has a unique success response code as defined in section 8.2 of the MeS gateway api document.  As well, created the remote test for this. 

From section 3.1 in the MeS gateway api doc:

Verification  Only 

"This  transaction  is  non-­monetary  in  nature   and  is  used  to  verify  the  card  number  and   billing  address  of  a  cardholder.    This   service  is  most  fully  supported  by  Visa  
   For  American  Express  and  Discover  this   service  will  validate  address  and  zip  only,   it  will  not  provide  any  status  on  the   account  (￿open,  closed,  etc)￿.    In  addition,   the  card  verification  value  is  not  validated.      MasterCard  supports  an  AVS  only   transaction  with  a  zero  amount  and  will   verify  only  address  match  and  not  the   status  of  the  card. "
