### PR TITLE
supporting PayPal Express GetTransactionDetails operation

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -29,6 +29,10 @@ module ActiveMerchant #:nodoc:
         commit 'GetExpressCheckoutDetails', build_get_details_request(token)
       end
 
+      def transaction_details_for(transaction_id)
+        commit 'GetTransactionDetails', build_get_transaction_details_request(transaction_id)
+      end
+
       def authorize(money, options = {})
         requires!(options, :token, :payer_id)
       
@@ -53,6 +57,19 @@ module ActiveMerchant #:nodoc:
 
         xml.target!
       end
+
+      def build_get_transaction_details_request(transaction_id)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'GetTransactionDetailsReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'GetTransactionDetailsRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'TransactionID', transaction_id
+          end
+        end
+
+        xml.target!
+      end
+
       
       def build_sale_or_authorization_request(action, money, options)
         currency_code = options[:currency] || currency(money)


### PR DESCRIPTION
Here's a patch to support the PayPal Express GetTransactionDetails.

It doesn't have a test -- I wondered if you guys have a good recipe for generating your successful_foo_response blobs and could just throw one together quickly. If that's not possible, I can try to put one together at some point.

Thanks for Active Merchant!

John
