### PR TITLE
support for ALLOWNOTE option on Paypal SetExpressCheckout 

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -100,6 +100,7 @@ module ActiveMerchant #:nodoc:
               add_address(xml, 'n2:Address', options[:shipping_address] || options[:address])
               xml.tag! 'n2:AddressOverride', options[:address_override] ? '1' : '0'
               xml.tag! 'n2:NoShipping', options[:no_shipping] ? '1' : '0'
+              xml.tag! 'n2:AllowNote', options[:allow_note] unless options[:allow_note].blank?
               xml.tag! 'n2:ReturnURL', options[:return_url]
               xml.tag! 'n2:CancelURL', options[:cancel_return_url]
               xml.tag! 'n2:IPAddress', options[:ip] unless options[:ip].blank?


### PR DESCRIPTION
Small patch to support setting the ALLOWNOTE option on a Paypal SetExpressCheckout request.

By default the customer may enter a note to the merchant on the PayPal page during checkout. By setting the :allow_note option to 0, the customer will not see a prompt to enter a note.
