### PR TITLE
PaypalExpress API: GetTransactionDetails

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -28,6 +28,10 @@ module ActiveMerchant #:nodoc:
       def details_for(token)
         commit 'GetExpressCheckoutDetails', build_get_details_request(token)
       end
+      
+      def transaction_details_for(transaction_id)
+        commit 'GetTransactionDetails', build_get_transaction_details_request(transaction_id)
+      end
 
       def authorize(money, options = {})
         requires!(options, :token, :payer_id)
@@ -51,6 +55,18 @@ module ActiveMerchant #:nodoc:
           end
         end
 
+        xml.target!
+      end
+      
+      def build_get_transaction_details_request(transaction_id)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'GetTransactionDetailsReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'GetTransactionDetailsRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'TransactionID', transaction_id
+          end
+        end
+        
         xml.target!
       end
       

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -98,6 +98,24 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_nil address['phone']
   end
   
+  def test_get_transaction_details
+      @gateway.expects(:ssl_post).returns(successful_transaction_details_response)
+      response = @gateway.transaction_details_for('1GR40996P1767570Y')
+      
+      assert_instance_of PaypalExpressResponse, response
+      assert response.success?
+      assert response.test?
+      
+      assert_equal '1GR40996P1767570Y', response.params['transaction_id']
+      assert_equal 'EGURACDVJPULC', response.payer_id
+      assert_equal 'test-sender@snaildeal.com', response.email
+      assert_equal 'Refunded', response.params['payment_status']
+      assert address = response.address
+      assert_equal 'Test', response.params['first_name']
+      assert_equal 'User', response.params['last_name']
+      assert_nil address['name']
+  end
+  
   def test_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
     response = @gateway.authorize(300, :token => 'EC-6WS104951Y388951L', :payer_id => 'FWRVKNRRZ3WUC')
@@ -244,6 +262,111 @@ class PaypalExpressTest < Test::Unit::TestCase
     </GetExpressCheckoutDetailsResponse>
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>    
+    RESPONSE
+  end
+  
+  def successful_transaction_details_response
+    <<-RESPONSE
+<?xml version='1.0' encoding='UTF-8'?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' xmlns:SOAP-ENC='http://schemas.xmlsoap.org/soap/encoding/' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:cc='urn:ebay:apis:CoreComponentTypes' xmlns:wsu='http://schemas.xmlsoap.org/ws/2002/07/utility' xmlns:saml='urn:oasis:names:tc:SAML:1.0:assertion' xmlns:ds='http://www.w3.org/2000/09/xmldsig#' xmlns:wsse='http://schemas.xmlsoap.org/ws/2002/12/secext' xmlns:ed='urn:ebay:apis:EnhancedDataTypes' xmlns:ebl='urn:ebay:apis:eBLBaseComponents' xmlns:ns='urn:ebay:api:PayPalAPI'>
+  <SOAP-ENV:Header>
+    <Security xmlns='http://schemas.xmlsoap.org/ws/2002/12/secext' xsi:type='wsse:SecurityType'></Security>
+    <RequesterCredentials xmlns='urn:ebay:api:PayPalAPI' xsi:type='ebl:CustomSecurityHeaderType'>
+      <Credentials xmlns='urn:ebay:apis:eBLBaseComponents' xsi:type='ebl:UserIdPasswordType'>
+        <Username xsi:type='xs:string'></Username>
+        <Password xsi:type='xs:string'></Password>
+        <Signature xsi:type='xs:string'></Signature>
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id='_0'>
+    <GetTransactionDetailsResponse xmlns='urn:ebay:api:PayPalAPI'>
+      <Timestamp xmlns='urn:ebay:apis:eBLBaseComponents'>2010-12-14T00:17:32Z</Timestamp>
+      <Ack xmlns='urn:ebay:apis:eBLBaseComponents'>Success</Ack>
+      <CorrelationID xmlns='urn:ebay:apis:eBLBaseComponents'>876620b655650</CorrelationID>
+      <Version xmlns='urn:ebay:apis:eBLBaseComponents'>59.0</Version>
+      <Build xmlns='urn:ebay:apis:eBLBaseComponents'>1603674</Build>
+      <PaymentTransactionDetails xmlns='urn:ebay:apis:eBLBaseComponents' xsi:type='ebl:PaymentTransactionType'>
+        <ReceiverInfo xsi:type='ebl:ReceiverInfoType'>
+          <Business xsi:type='ebl:EmailAddressType'></Business>
+          <Receiver xsi:type='ebl:EmailAddressType'>test-receiver@snaildeal.com</Receiver>
+          <ReceiverID xsi:type='ebl:UserIDType'>QWA6NRSTJC2UJ</ReceiverID>
+        </ReceiverInfo>
+        <PayerInfo xsi:type='ebl:PayerInfoType'>
+          <Payer xsi:type='ebl:EmailAddressType'>test-sender@snaildeal.com</Payer>
+          <PayerID xsi:type='ebl:UserIDType'>EGURACDVJPULC</PayerID>
+          <PayerStatus xsi:type='ebl:PayPalUserStatusCodeType'>verified</PayerStatus>
+          <PayerName xsi:type='ebl:PersonNameType'>
+            <Salutation xmlns='urn:ebay:apis:eBLBaseComponents'></Salutation>
+            <FirstName xmlns='urn:ebay:apis:eBLBaseComponents'>Test</FirstName>
+            <MiddleName xmlns='urn:ebay:apis:eBLBaseComponents'></MiddleName>
+            <LastName xmlns='urn:ebay:apis:eBLBaseComponents'>User</LastName>
+            <Suffix xmlns='urn:ebay:apis:eBLBaseComponents'></Suffix>
+          </PayerName>
+          <PayerCountry xsi:type='ebl:CountryCodeType'>US</PayerCountry>
+          <PayerBusiness xsi:type='xs:string'></PayerBusiness>
+          <Address xsi:type='ebl:AddressType'>
+            <Name xsi:type='xs:string'>Test User</Name>
+            <Street1 xsi:type='xs:string'>1 Main St</Street1>
+            <Street2 xsi:type='xs:string'></Street2>
+            <CityName xsi:type='xs:string'>San Jose</CityName>
+            <StateOrProvince xsi:type='xs:string'>CA</StateOrProvince>
+            <Country xsi:type='ebl:CountryCodeType'>US</Country>
+            <CountryName>United States</CountryName>
+            <PostalCode xsi:type='xs:string'>95131</PostalCode>
+            <AddressOwner xsi:type='ebl:AddressOwnerCodeType'>PayPal</AddressOwner>
+            <AddressStatus xsi:type='ebl:AddressStatusCodeType'>Confirmed</AddressStatus>
+          </Address>
+          <ContactPhone xsi:type='xs:string'></ContactPhone>
+        </PayerInfo>
+        <PaymentInfo xsi:type='ebl:PaymentInfoType'>
+          <TransactionID>1GR40996P1767570Y</TransactionID>
+          <ParentTransactionID xsi:type='ebl:TransactionId'>9BV74148LS099724N</ParentTransactionID>
+          <ReceiptID></ReceiptID>
+          <TransactionType xsi:type='ebl:PaymentTransactionCodeType'>express-checkout</TransactionType>
+          <PaymentType xsi:type='ebl:PaymentCodeType'>instant</PaymentType>
+          <PaymentDate xsi:type='xs:dateTime'>2010-12-01T12:57:02Z</PaymentDate>
+          <GrossAmount xsi:type='cc:BasicAmountType' currencyID='USD'>12.59</GrossAmount>
+          <FeeAmount xsi:type='cc:BasicAmountType' currencyID='USD'>0.67</FeeAmount>
+          <TaxAmount xsi:type='cc:BasicAmountType' currencyID='USD'>0.00</TaxAmount>
+          <ExchangeRate xsi:type='xs:string'></ExchangeRate>
+          <PaymentStatus xsi:type='ebl:PaymentStatusCodeType'>Refunded</PaymentStatus>
+          <PendingReason xsi:type='ebl:PendingStatusCodeType'>none</PendingReason>
+          <ReasonCode xsi:type='ebl:ReversalReasonCodeType'>refund</ReasonCode>
+          <ProtectionEligibility xsi:type='xs:string'>Eligible</ProtectionEligibility>
+          <ShipAmount xsi:type='xs:string'>0.00</ShipAmount>
+          <ShipHandleAmount xsi:type='xs:string'>0.00</ShipHandleAmount>
+          <ShipDiscount xsi:type='xs:string'></ShipDiscount>
+          <InsuranceAmount xsi:type='xs:string'></InsuranceAmount>
+          <Subject xsi:type='xs:string'></Subject>
+        </PaymentInfo>
+        <PaymentItemInfo xsi:type='ebl:PaymentItemInfoType'>
+          <InvoiceID xsi:type='xs:string'></InvoiceID>
+          <Custom xsi:type='xs:string'></Custom>
+          <Memo xsi:type='xs:string'></Memo>
+          <SalesTax xsi:type='xs:string'>0.00</SalesTax>
+          <PaymentItem xmlns='urn:ebay:apis:eBLBaseComponents' xsi:type='ebl:PaymentItemType'>
+            <Name xsi:type='xs:string'></Name>
+            <Number xsi:type='xs:string'></Number>
+            <Quantity xsi:type='xs:string'>1</Quantity>
+            <SalesTax xsi:type='xs:string'>0.00</SalesTax>
+            <ShippingAmount xsi:type='xs:string'></ShippingAmount>
+            <HandlingAmount xsi:type='xs:string'></HandlingAmount>
+          </PaymentItem>
+          <Subscription xsi:type='ebl:SubscriptionInfoType' recurring='' reattempt=''>
+            <SubscriptionID></SubscriptionID>
+            <Username xsi:type='xs:string'></Username>
+            <Password xsi:type='xs:string'></Password>
+            <Recurrences xsi:type='xs:string'></Recurrences>
+          </Subscription>
+          <Auction xsi:type='ebl:AuctionInfoType' multiItem=''>
+            <BuyerID xsi:type='xs:string'></BuyerID>
+          </Auction>
+        </PaymentItemInfo>
+      </PaymentTransactionDetails>
+    </GetTransactionDetailsResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
     RESPONSE
   end
   


### PR DESCRIPTION
Because Paypal has a customer-facing Terminal, it is vital for merchants to be able to retrieve transaction details from Paypal so as to keep internal records "in sync" with what Paypal has in file. 
GetTransactionDetails ensures that any follow-up on a transaction (refund, cancellation, chargeback) that may have happened directly from Paypal's own virtual terminal can be checked for and dealt with accordingly.

Implemented as per https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_nvp_r_GetTransactionDetails
