### PR TITLE
Issue76 Fixed - Tests Passing

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -76,22 +76,22 @@ module ActiveMerchant #:nodoc:
       # The format of the amounts used by the gateway
       # :dollars => '12.50'
       # :cents => '1250'
-      class_inheritable_accessor :money_format
+      class_attribute :money_format
       self.money_format = :dollars
       
       # The default currency for the transactions if no currency is provided
-      class_inheritable_accessor :default_currency
+      class_attribute :default_currency
       
       # The countries of merchants the gateway supports
-      class_inheritable_accessor :supported_countries
+      class_attribute :supported_countries
       self.supported_countries = []
       
       # The supported card types for the gateway
-      class_inheritable_accessor :supported_cardtypes
+      class_attribute :supported_cardtypes
       self.supported_cardtypes = []
       
-      class_inheritable_accessor :homepage_url
-      class_inheritable_accessor :display_name
+      class_attribute :homepage_url
+      class_attribute :display_name
       
       # The application making the calls to the gateway
       # Useful for things like the PayPal build notation (BN) id fields

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
     class AuthorizeNetGateway < Gateway
       API_VERSION = '3.1'
 
-      class_inheritable_accessor :test_url, :live_url, :arb_test_url, :arb_live_url
+      class_attribute :test_url, :live_url, :arb_test_url, :arb_live_url
 
       self.test_url = "https://test.authorize.net/gateway/transact.dll"
       self.live_url = "https://secure.authorize.net/gateway/transact.dll"
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
       self.arb_test_url = 'https://apitest.authorize.net/xml/v1/request.api'
       self.arb_live_url = 'https://api.authorize.net/xml/v1/request.api'
       
-      class_inheritable_accessor :duplicate_window
+      class_attribute :duplicate_window
 
       APPROVED, DECLINED, ERROR, FRAUD_REVIEW = 1, 2, 3, 4
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
     # 5. Click Submit
     class AuthorizeNetCimGateway < Gateway
     
-      class_inheritable_accessor :test_url, :live_url
+      class_attribute :test_url, :live_url
 
       self.test_url = 'https://apitest.authorize.net/xml/v1/request.api'
       self.live_url = 'https://api.authorize.net/xml/v1/request.api'

--- a/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
+++ b/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
     # - does not support multiple subID per merchant
     # - language is fixed to 'nl'
     class IdealBaseGateway < Gateway
-      class_inheritable_accessor :test_url, :live_url, :server_pem, :pem_password, :default_expiration_period
+      class_attribute :test_url, :live_url, :server_pem, :pem_password, :default_expiration_period
       self.default_expiration_period = 'PT10M'
       self.default_currency = 'EUR'
       self.pem_password = true

--- a/lib/active_merchant/billing/gateways/ideal_rabobank.rb
+++ b/lib/active_merchant/billing/gateways/ideal_rabobank.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
     # - does not support multiple subID per merchant
     # - language is fixed to 'nl'
     class IdealRabobankGateway < IdealBaseGateway
-      class_inheritable_accessor :test_url, :live_url
+      class_attribute :test_url, :live_url
 
       self.test_url = 'https://idealtest.rabobank.nl/ideal/iDeal'
       self.live_url = 'https://ideal.rabobank.nl/ideal/iDeal'

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
     class PayJunctionGateway < Gateway
       API_VERSION   = '1.2'
 
-      class_inheritable_accessor :test_url, :live_url
+      class_attribute :test_url, :live_url
 
       self.test_url = "https://www.payjunctionlabs.com/quick_link"
       self.live_url = "https://payjunction.com/quick_link"

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -4,14 +4,14 @@ module ActiveMerchant #:nodoc:
       def self.included(base)
         base.default_currency = 'USD'
           
-        base.class_inheritable_accessor :partner
+        base.class_attribute :partner
         
         # Set the default partner to PayPal
         base.partner = 'PayPal'
         
         base.supported_countries = ['US', 'CA', 'SG', 'AU']
         
-        base.class_inheritable_accessor :timeout
+        base.class_attribute :timeout
         base.timeout = 60
         
         # Enable safe retry of failed connections

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       # The name of the gateway
       self.display_name = 'SecurePay'
       
-      class_inheritable_accessor :request_timeout
+      class_attribute :request_timeout
       self.request_timeout = 60
       
       self.money_format = :cents

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -1,7 +1,7 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class ViaklixGateway < Gateway
-      class_inheritable_accessor :test_url, :live_url, :delimiter, :actions
+      class_attribute :test_url, :live_url, :delimiter, :actions
 
       self.test_url = 'https://demo.viaklix.com/process.asp'
       self.live_url = 'https://www.viaklix.com/process.asp'

--- a/lib/active_merchant/billing/integrations/helper.rb
+++ b/lib/active_merchant/billing/integrations/helper.rb
@@ -3,14 +3,14 @@ module ActiveMerchant #:nodoc:
     module Integrations #:nodoc:
       class Helper #:nodoc:
         attr_reader :fields
-        class_inheritable_accessor :service_url
+        class_attribute :service_url
         class_inheritable_hash :mappings
-        class_inheritable_accessor :country_format
+        class_attribute :country_format
         self.country_format = :alpha2
         
         # The application making the calls to the gateway
         # Useful for things like the PayPal build notation (BN) id fields
-        class_inheritable_accessor :application_id
+        class_attribute :application_id
         self.application_id = 'ActiveMerchant'
 
         def initialize(order, account, options = {})

--- a/lib/active_merchant/billing/integrations/notification.rb
+++ b/lib/active_merchant/billing/integrations/notification.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
         attr_accessor :raw
         
         # set this to an array in the subclass, to specify which IPs are allowed to send requests
-        class_inheritable_accessor :production_ips
+        class_attribute :production_ips
 
         def initialize(post, options = {})
           @options = options

--- a/lib/active_merchant/common/post_data.rb
+++ b/lib/active_merchant/common/post_data.rb
@@ -2,7 +2,7 @@ require 'cgi'
 
 module ActiveMerchant
   class PostData < Hash
-    class_inheritable_accessor :required_fields, :instance_writer => false
+    class_attribute :required_fields, :instance_writer => false
     self.required_fields = []
   
     def []=(key, value)

--- a/lib/active_merchant/common/posts_data.rb
+++ b/lib/active_merchant/common/posts_data.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
       base.superclass_delegating_accessor :ssl_strict
       base.ssl_strict = true
       
-      base.class_inheritable_accessor :retry_safe
+      base.class_attribute :retry_safe
       base.retry_safe = false
 
       base.superclass_delegating_accessor :open_timeout


### PR DESCRIPTION
Under current Edge Rails 3.1.pre I was getting the deprecation warnings I mentioned in this issue (https://github.com/Shopify/active_merchant/issues#issue/76).  I've applied the deprecation warning's suggested remedy to the codebase and confirmed the warnings have been silenced and the active_merchant unit tests still all pass.
