### PR TITLE
Add support for the NAB Transact payment gateway (AU)

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -1,0 +1,154 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class NabTransactGateway < Gateway
+      API_VERSION = 'xml-4.2'
+
+      TEST_URL = 'https://transact.nab.com.au/test/xmlapi/payment'
+      LIVE_URL = 'https://transact.nab.com.au/live/xmlapi/payment'
+
+      self.supported_countries = ['AU']
+      self.homepage_url = 'http://nab.com.au/nabtransact'
+      self.display_name = 'NAB Transact'
+      self.money_format = :cents
+      self.default_currency = 'AUD'
+
+      # The card types supported by the payment gateway
+      # Note that support for Diners, Amex, and JCB require extra
+      # steps in setting up your account, as detailed in the NAB Transact API
+      self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :diners_club]
+
+      class_inheritable_accessor :request_timeout
+      self.request_timeout = 60
+
+      #Transactions currently accepted by NAB Transact XML API
+      TRANSACTIONS = {
+        :purchase => 0,         #Standard Payment
+        :credit => 4,           #Refund
+        :void => 6,             #Client Reversal (Void)
+        :authorization => 10,   #Preauthorise
+        :capture => 11          #Preauthorise Complete (Advice)
+      }
+
+      SUCCESS_CODES = [ '00', '08', '11', '16' ]
+
+      def initialize(options = {})
+        requires!(options, :login, :password)
+        @options = options
+        super
+      end
+
+      def test?
+        @options[:test] || super
+      end
+
+      def purchase(money, credit_card, options = {})
+        commit :purchase, build_purchase_request(money, credit_card, options)
+      end
+
+      private
+
+      def build_purchase_request(money, credit_card, options)
+        xml = Builder::XmlMarkup.new
+        xml.tag! 'amount', amount(money)
+        xml.tag! 'currency', options[:currency] || currency(money)
+        xml.tag! 'purchaseOrderNo', options[:order_id].to_s.gsub(/[ ']/, '')
+
+        xml.tag! 'CreditCardInfo' do
+          xml.tag! 'cardNumber', credit_card.number
+          xml.tag! 'expiryDate', expdate(credit_card)
+          xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
+        end
+
+        xml.target!
+      end
+
+      #TODO : Credit Refund Request (available in the API) - (and other services available)
+
+      #Generate payment request XML
+      # - API is set to allow multiple Txn's but currentlu only allows one
+      # - txnSource = 23 - (XML)
+      def build_request(action, body)
+        xml = Builder::XmlMarkup.new
+        xml.instruct!
+        xml.tag! 'NABTransactMessage' do
+          xml.tag! 'MessageInfo' do
+            xml.tag! 'messageID', Utils.generate_unique_id.slice(0, 30)
+            xml.tag! 'messageTimestamp', generate_timestamp
+            xml.tag! 'timeoutValue', request_timeout
+            xml.tag! 'apiVersion', API_VERSION
+          end
+
+          xml.tag! 'MerchantInfo' do
+            xml.tag! 'merchantID', @options[:login]
+            xml.tag! 'password', @options[:password]
+          end
+
+          xml.tag! 'RequestType', 'Payment'
+          xml.tag! 'Payment' do
+            xml.tag! 'TxnList', "count" => 1 do
+              xml.tag! 'Txn', "ID" => 1 do
+                xml.tag! 'txnType', TRANSACTIONS[action]
+                xml.tag! 'txnSource', 23
+                xml << body
+              end
+            end
+          end
+        end
+
+        xml.target!
+      end
+
+      # YYYYDDMMHHNNSSKKK000sOOO
+      def generate_timestamp
+        time = Time.now.utc
+        time.strftime("%Y%d%m%H%M%S#{time.usec}+000")
+      end
+
+      def commit(action, request)
+        response = parse(ssl_post(test? ? TEST_URL : LIVE_URL, build_request(action, request)))
+
+        Response.new(success?(response), message_from(response), response,
+          :test => test?,
+          :authorization => authorization_from(response)
+        )
+      end
+
+      def success?(response)
+        SUCCESS_CODES.include?(response[:response_code])
+      end
+
+      def authorization_from(response)
+        response[:txn_id]
+      end
+
+      def message_from(response)
+        response[:response_text] || response[:status_description]
+      end
+
+      def expdate(credit_card)
+        "#{format(credit_card.month, :two_digits)}/#{format(credit_card.year, :two_digits)}"
+      end
+
+      def parse(body)
+        xml = REXML::Document.new(body)
+
+        response = {}
+
+        xml.root.elements.to_a.each do |node|
+          parse_element(response, node)
+        end
+
+        response
+      end
+
+      def parse_element(response, node)
+        if node.has_elements?
+          node.elements.each{|element| parse_element(response, element) }
+        else
+          response[node.name.underscore.to_sym] = node.text
+        end
+      end
+
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -130,6 +130,10 @@ moneris:
   login: store1
   password: yesguy
   
+nab_transact:
+  login: ABC0001
+  password: changeit
+
 netaxept:
   login: LOGIN
   password: PASSWORD

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class RemoteNabTransactTest < Test::Unit::TestCase
+
+  def setup
+    @gateway = NabTransactGateway.new(fixtures(:nab_transact))
+
+    @amount = 200
+    @credit_card = credit_card('4444333322221111')
+
+    @declined_card = credit_card('4111111111111234')
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'NAB Transact Purchase'
+    }
+  end
+
+  # Order totals to simulate approved transactions:
+  #   $1.00 $1.08 $105.00 $105.08 (or any total ending in 00, 08, 11 or 16)
+
+  # Order totals to simulate declined transactions:
+  #   $1.51 $1.05 $105.51 $105.05 (or any total not ending in 00, 08, 11 or 16)
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase_insufficient_funds
+    #Any total not ending in 00/08/11/16
+    failing_amount = 151 #Specifically tests 'Insufficient Funds'
+    assert response = @gateway.purchase(failing_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+  end
+
+  def test_unsuccessful_purchase_do_not_honour
+    #Any total not ending in 00/08/11/16
+    failing_amount = 105 #Specifically tests 'do not honour'
+    assert response = @gateway.purchase(failing_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Do Not Honour', response.message
+  end
+
+  def test_unsuccessful_purchase_bad_credit_card
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Invalid Credit Card Number', response.message
+  end
+
+  def test_invalid_login
+    gateway = NabTransactGateway.new(
+                :login => '',
+                :password => ''
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid merchant ID', response.message
+  end
+end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -1,0 +1,143 @@
+require 'test_helper'
+
+class NabTransactTest < Test::Unit::TestCase
+  def setup
+    @gateway = NabTransactGateway.new(
+                 :login => 'login',
+                 :password => 'password'
+               )
+
+    @credit_card = credit_card
+    @amount = 200
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Test NAB Purchase'
+    }
+  end
+
+
+    def test_successful_purchase
+      @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+      assert response = @gateway.purchase(@amount, @credit_card, @options)
+      assert_instance_of Response, response
+      assert_success response
+
+      assert_equal '009887', response.authorization
+      assert response.test?
+    end
+
+    def test_unsuccessful_purchase
+      @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+      assert response = @gateway.purchase(@amount, @credit_card, @options)
+      assert_instance_of Response, response
+      assert_failure response
+      assert response.test?
+      assert_equal "Expired Card", response.message
+    end
+
+    def test_failed_login
+      @gateway.expects(:ssl_post).returns(failed_login_response)
+
+      assert response = @gateway.purchase(@amount, @credit_card, @options)
+      assert_instance_of Response, response
+      assert_failure response
+      assert_equal "Invalid merchant ID", response.message
+    end
+
+    private
+
+    def failed_login_response
+      '<NABTransactMessage><Status><statusCode>504</statusCode><statusDescription>Invalid merchant ID</statusDescription></Status></NABTransactMessage>'
+    end
+
+    def successful_purchase_response
+      <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <NABTransactMessage>
+        <MessageInfo>
+          <messageID>8af793f9af34bea0cf40f5fb750f64</messageID>
+          <messageTimestamp>20042303111226938000+660</messageTimestamp>
+          <apiVersion>xml-4.2</apiVersion>
+        </MessageInfo>
+        <MerchantInfo>
+          <merchantID>ABC0001</merchantID>
+        </MerchantInfo>
+        <RequestType>Payment</RequestType>
+        <Status>
+          <statusCode>000</statusCode>
+          <statusDescription>Normal</statusDescription>
+        </Status>
+        <Payment>
+          <TxnList count="1">
+            <Txn ID="1">
+              <txnType>0</txnType>
+              <txnSource>23</txnSource>
+              <amount>200</amount>
+              <currency>AUD</currency>
+              <purchaseOrderNo>test</purchaseOrderNo>
+              <approved>Yes</approved>
+              <responseCode>00</responseCode>
+              <responseText>Approved</responseText>
+              <settlementDate>20040323</settlementDate>
+              <txnID>009887</txnID>
+              <CreditCardInfo>
+                <pan>444433...111</pan>
+                <expiryDate>08/12</expiryDate>
+                <cardType>6</cardType>
+                <cardDescription>Visa</cardDescription>
+              </CreditCardInfo>
+            </Txn>
+          </TxnList>
+        </Payment>
+      </NABTransactMessage>
+      XML
+    end
+
+    def failed_purchase_response
+      <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <NABTransactMessage>
+        <MessageInfo>
+          <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
+          <messageTimestamp>20042303111226938000+660</messageTimestamp>
+          <apiVersion>xml-4.2</apiVersion>
+        </MessageInfo>
+        <MerchantInfo>
+          <merchantID>ABC0001</merchantID>
+        </MerchantInfo>
+        <RequestType>Payment</RequestType>
+        <Status>
+          <statusCode>000</statusCode>
+          <statusDescription>Normal</statusDescription>
+        </Status>
+        <Payment>
+          <TxnList count="1">
+            <Txn ID="1">
+              <txnType>0</txnType>
+              <txnSource>23</txnSource>
+              <amount>200</amount>
+              <currency>AUD</currency>
+              <purchaseOrderNo>test</purchaseOrderNo>
+              <approved>No</approved>
+              <responseCode>54</responseCode>
+              <responseText>Expired Card</responseText>
+              <settlementDate>20040323</settlementDate>
+              <txnID>000000</txnID>
+              <CreditCardInfo>
+                <pan>444433...111</pan>
+                <expiryDate>08/12</expiryDate>
+                <cardType>6</cardType>
+                <cardDescription>Visa</cardDescription>
+              </CreditCardInfo>
+            </Txn>
+          </TxnList>
+        </Payment>
+      </NABTransactMessage>
+      XML
+    end
+
+end


### PR DESCRIPTION
This commit is a repackaging of code written by Tom Meier (github.com/tommeier) to add support for the NAB's Transact payment gateway. Gateway and remote gateway unit tests all appear to be good and pass.

Lighthouse ticket with the original patch appeared to go unnoticed. Updated here:
https://jadedpixel.lighthouseapp.com/projects/11599/tickets/164-patch-add-support-for-nab-transact-au-payment-gateway

Cheers,
  James Brooks
