### PR TITLE
Payment network ag

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -81,6 +81,7 @@ The {ActiveMerchant Wiki}[http://github.com/Shopify/active_merchant/wikis] conta
 * {2 Checkout}[http://www.2checkout.com]
 * {Banca Sella GestPay}[https://www.sella.it/banca/ecommerce/gestpay/gestpay.jsp]
 * {Chronopay}[http://www.chronopay.com]
+* {Direct-eBanking / sofortueberweisung.de by Payment-Networks AG}[https://www.payment-network.com/deb_com_en/merchantarea/home] - DE, AT, CH, BE, UK, NL
 * {DirecPay}[http://www.timesofmoney.com/direcpay/jsp/home.jsp]
 * {HiTRUST}[http://www.hitrust.com.hk/]
 * {Moneybookers}[http://www.moneybookers.com]

--- a/lib/active_merchant/billing/integrations/directebanking.rb
+++ b/lib/active_merchant/billing/integrations/directebanking.rb
@@ -1,0 +1,39 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Directebanking 
+        autoload :Return,       File.dirname(__FILE__) + '/directebanking/return.rb'
+        autoload :Helper,       File.dirname(__FILE__) + '/directebanking/helper.rb'
+        autoload :Notification, File.dirname(__FILE__) + '/directebanking/notification.rb'
+               
+        # Overwrite this if you want to change the directebanking test url
+        mattr_accessor :test_url
+        self.test_url = 'https://www.directebanking.com/payment/start'
+        
+        # Overwrite this if you want to change the directebanking production url
+        mattr_accessor :production_url 
+        self.production_url = 'https://www.directebanking.com/payment/start'
+        
+        def self.service_url
+          mode = ActiveMerchant::Billing::Base.integration_mode
+          case mode
+          when :production
+            self.production_url    
+          when :test
+            self.test_url
+          else
+            raise StandardError, "Integration mode set to an invalid value: #{mode}"
+          end
+        end
+
+        def self.notification(post)
+          Notification.new(post)
+        end  
+
+        def self.return(post, options = {})
+          Return.new(post, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/directebanking/helper.rb
+++ b/lib/active_merchant/billing/integrations/directebanking/helper.rb
@@ -1,0 +1,89 @@
+require 'base64'
+require 'stringio'
+require 'zlib'
+require 'openssl'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Directebanking
+        class Helper < ActiveMerchant::Billing::Integrations::Helper
+
+          # Variables that need to be set by the admin in Shopify interface
+          # All credentials are mandatory and need to be set
+          #
+          # credential1: User ID
+          # credential2: Project ID
+          # credential3: Project Password (Algorithm: SH1)
+          # credential4: Notification Password (Algorithm: SH1)
+
+          def initialize(order, account, options = {})
+            super
+            add_field(:user_variable_1.to_s, order)
+            @project_password = options[:credential3]
+          end
+
+          SIGNATURE_FIELDS = [
+            :user_id,
+            :project_id,
+            :sender_holder,
+            :sender_account_number,
+            :sender_bank_code,
+            :sender_country_id,
+            :amount,
+            :currency_id,
+            :reason_1,
+            :reason_2,
+            :user_variable_0,
+            :user_variable_1,
+            :user_variable_2,
+            :user_variable_3,
+            :user_variable_4,
+            :user_variable_5
+          ]
+          
+          SIGNATURE_IGNORE_AT_METHOD_CREATION_FIELDS = [
+            :user_id,
+            :amount,
+            :currency_id,
+            :user_variable_1
+          ]
+          
+          SIGNATURE_FIELDS.each do |key|
+            if !SIGNATURE_IGNORE_AT_METHOD_CREATION_FIELDS.include?(key) 
+              mapping "#{key}".to_sym, "#{key.to_s}"
+            end
+          end
+
+          # Need to format the amount to have 2 decimal places
+          def amount=(money)
+            cents = money.respond_to?(:cents) ? money.cents : money
+            if money.is_a?(String) or cents.to_i <= 0
+              raise ArgumentError, 'money amount must be either a Money object or a positive integer in cents.'
+            end
+            add_field mappings[:amount], sprintf("%.2f", cents.to_f/100)
+          end
+
+          def generate_signature_string
+            # format of signature: user_id|project_id|sender_holder|sender_account_number|sender_bank_code| sender_country_id|amount|currency_id|reason_1|reason_2|user_variable_0|user_variable_1| user_variable_2|user_variable_3|user_variable_4|user_variable_5|project_password
+            SIGNATURE_FIELDS.map {|key| @fields[key.to_s]} * "|"+ "|"+@project_password
+          end
+
+          def generate_signature
+            Digest::SHA1.hexdigest(generate_signature_string)
+          end
+          
+          def form_fields
+            @fields.merge('hash' => generate_signature)
+          end
+            
+          # Replace with the real mapping
+          mapping :account, 'user_id'
+          mapping :credential2, 'project_id'
+          mapping :amount, 'amount'
+          mapping :currency, 'currency_id'
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/directebanking/notification.rb
+++ b/lib/active_merchant/billing/integrations/directebanking/notification.rb
@@ -1,0 +1,116 @@
+require 'net/http'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Directebanking
+        class Notification < ActiveMerchant::Billing::Integrations::Notification
+          
+          def initialize(data, options)
+            if options[:credential4].nil?
+              raise ArgumentError, "You need to provide the notification password (SH1) as the option :credential4 to verify that the notification originated from Directebanking (Payment Networks AG)"
+            end
+            super
+          end
+          
+          def complete?
+            true
+          end
+          
+          def item_id
+            params[:user_variable_1.to_s]
+          end
+          
+          def transaction_id
+            params[:transaction.to_s]
+          end
+          
+          # When was this payment received by the client. 
+          def received_at
+            Time.parse(params[:created.to_s])
+          end
+          
+          # the money amount we received in X.2 decimal.
+          def gross
+            "%.2f" % params[:amount.to_s].to_f
+          end
+
+          def status
+            # Notifications: Please pay attention that you are only notified about successful transactions.
+            true # so it is always true
+          end
+
+          def currency
+            params[:currency_id.to_s]
+          end
+          
+          # for verifying the signature of the URL parameters returned by Adyen after the payment process
+          PAYMENT_HOOK_SIGNATURE_FIELDS = [
+            :transaction,
+            :user_id,
+            :project_id,
+            :sender_holder,
+            :sender_account_number,
+            :sender_bank_code,
+            :sender_bank_name,
+            :sender_bank_bic,
+            :sender_iban,
+            :sender_country_id,
+            :recipient_holder,
+            :recipient_account_number,
+            :recipient_bank_code,
+            :recipient_bank_name,
+            :recipient_bank_bic,
+            :recipient_iban,
+            :recipient_country_id,
+            :international_transaction,
+            :amount,
+            :currency_id,
+            :reason_1,
+            :reason_2,
+            :security_criteria,
+            :user_variable_0,
+            :user_variable_1,
+            :user_variable_2,
+            :user_variable_3,
+            :user_variable_4,
+            :user_variable_5,
+            :created
+          ]
+          
+          PAYMENT_HOOK_IGNORE_AT_METHOD_CREATION_FIELDS = [
+            :transaction,
+            :amount,
+            :currency_id,
+            :user_variable_1,
+            :created
+          ]
+          
+          # Provide access to raw fields from quickpay
+          PAYMENT_HOOK_SIGNATURE_FIELDS.each do |key|
+            if !PAYMENT_HOOK_IGNORE_AT_METHOD_CREATION_FIELDS.include?(key) 
+              define_method(key.to_s) do
+                 params[key.to_s]
+              end
+            end
+          end
+          
+          def generate_signature_string
+            #format is: transaction|user_id|project_id|sender_holder|sender_account_number|sender_bank_code| sender_bank_name|sender_bank_bic|sender_iban|sender_country_id|recipient_holder| recipient_account_number|recipient_bank_code|recipient_bank_name|recipient_bank_bic| recipient_iban|recipient_country_id|international_transaction|amount|currency_id| reason_1|reason_2|security_criteria|user_variable_0|user_variable_1|user_variable_2| user_variable_3|user_variable_4|user_variable_5|created|notification_password
+            PAYMENT_HOOK_SIGNATURE_FIELDS.map {|key| params[key.to_s]} * "|"+ "|"+@options[:credential4]
+          end
+
+          def generate_signature
+            Digest::SHA1.hexdigest(generate_signature_string)
+          end
+          
+          def acknowledge
+            # signature_is_valid?
+            generate_signature.to_s == params['hash'].to_s
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/directebanking/return.rb
+++ b/lib/active_merchant/billing/integrations/directebanking/return.rb
@@ -1,0 +1,37 @@
+require 'base64'
+require 'stringio'
+require 'zlib'
+require 'openssl'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Directebanking
+        class Return < ActiveMerchant::Billing::Integrations::Return
+
+          # For this to work you have to set the following url in the admin interface of directebanking
+          #
+          # Success link: 
+          #   http://-USER_VARIABLE_0-?authResult=success&transaction=-TRANSACTION-&sender_holder=-SENDER_HOLDER-
+          # 
+          # Abort link:
+          #   http://-USER_VARIABLE_0-?authResult=abort&transaction=-TRANSACTION-&sender_holder=-SENDER_HOLDER-
+
+          def success?
+            params['authResult'] == 'success'
+          end
+
+          def message
+            params['authResult']
+          end
+          
+          def transaction
+            params['transaction']
+          end
+
+        end
+      end
+    end
+  end
+end
+

--- a/test/unit/integrations/helpers/directebanking_helper_test.rb
+++ b/test/unit/integrations/helpers/directebanking_helper_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class DirectebankingHelperTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+  
+  def setup
+    @helper = Directebanking::Helper.new('order-500','UserID-24352435', :credential2 => "ProjectID-1234",
+            :amount => 500, :currency => 'EUR', :credential3 => "mysecretString")
+    @helper.user_variable_0 "localhost:8080/directebanking"
+  end
+
+  def test_basic_helper_fields
+    assert_field 'user_id', 'UserID-24352435'
+    assert_field 'project_id', 'ProjectID-1234'
+    assert_field 'amount', '5.00'
+    assert_field 'user_variable_0', 'localhost:8080/directebanking'
+    assert_field 'user_variable_1', 'order-500'
+  end
+  
+  def test_form_fields
+    assert !@helper.form_fields['hash'].empty?
+    assert_equal "083f2daf2fe10e827eb0d5205f97e6750cdf30bc", @helper.form_fields['hash']
+  end
+  
+  def test_generate_signature_string
+    assert_equal "UserID-24352435|ProjectID-1234|||||5.00|EUR|||localhost:8080/directebanking|order-500|||||mysecretString", 
+    @helper.generate_signature_string
+  end
+
+  def test_generate_signature
+    assert_equal '083f2daf2fe10e827eb0d5205f97e6750cdf30bc', @helper.generate_signature
+  end
+  
+  def test_unknown_mapping
+    assert_nothing_raised do
+      @helper.company_address :address => '501 Dwemthy Fox Road'
+    end
+  end
+  
+  def test_setting_invalid_address_field
+    fields = @helper.fields.dup
+    @helper.billing_address :street => 'My Street'
+    assert_equal fields, @helper.fields
+  end  
+end

--- a/test/unit/integrations/notifications/directebanking_notification_test.rb
+++ b/test/unit/integrations/notifications/directebanking_notification_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+class DirectebankingNotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @deb = Directebanking::Notification.new(http_raw_data, :credential4 => "3qx-:03DDfmUVh}b16#Y")
+  end
+
+  def test_accessors
+    assert @deb.complete?
+    assert_equal true, @deb.status
+    assert_equal "19488-100576-4D6A7F5F-7FC4", @deb.transaction_id
+    assert_equal "123456789", @deb.item_id
+    assert_equal "1.00", @deb.gross
+    assert_equal "EUR", @deb.currency
+    assert_equal Time.parse("2011-02-27 17:45:23"), @deb.received_at
+  end
+  
+  def test_compositions
+      assert_equal Money.new(100, 'EUR'), @deb.amount
+  end
+    
+  def test_acknowledgement    
+    assert @deb.acknowledge
+  end
+  
+  def test_acknowledgement_with_wrong_password
+    @deb = Directebanking::Notification.new(http_raw_data, :credential4 => "XXXX")
+    # needs to fail cause the password is wrong
+    assert !@deb.acknowledge
+  end
+  
+  def test_credential4_required
+    assert_raises ArgumentError do
+      Directebanking::Notification.new(http_raw_data, {})
+    end
+    assert_nothing_raised do
+      Directebanking::Notification.new(http_raw_data, :credential4 => 'secret')
+    end
+  end
+  
+  def test_directebanking_attributes
+    assert_equal "localhost:8080/directebanking/return", @deb.user_variable_0
+    assert_equal "", @deb.user_variable_5
+    assert_equal "19488", @deb.user_id
+    assert_equal "Project", @deb.reason_1
+    assert_equal "Test", @deb.reason_2
+  end
+  
+  def test_generate_signature_string
+    assert_equal "19488-100576-4D6A7F5F-7FC4|19488|100576|Musterman, Petra|2345XXXXXX|00XXX|Testbank|PNAGXXXXXXX|AT680000XXXXXXXXXXXX|AT|BIZZONS eMarketing GmbH|0000XXXXXX|19XXX|Bankhaus KXXXXX|KREXXXXX|AT031952XXXXXXXXXXXX|AT|0|1.00|EUR|Project|Test|1|localhost:8080/directebanking/return|123456789|||||2011-02-27 17:45:23|3qx-:03DDfmUVh}b16#Y",
+                 @deb.generate_signature_string
+  end
+  
+  def test_generate_md5check
+    assert_equal "13fe0f0199c53d44f13083037c964286963e7495", @deb.generate_signature
+  end
+  
+  private
+  def http_raw_data
+    "transaction=19488-100576-4D6A7F5F-7FC4&user_id=19488&project_id=100576&sender_holder=Musterman%2C+Petra"+
+    "&sender_account_number=2345XXXXXX&sender_bank_code=00XXX&sender_bank_name=Testbank&sender_bank_bic=PNAGXXXXXXX"+
+    "&sender_iban=AT680000XXXXXXXXXXXX&sender_country_id=AT&recipient_holder=BIZZONS+eMarketing+GmbH"+
+    "&recipient_account_number=0000XXXXXX&recipient_bank_code=19XXX&recipient_bank_name=Bankhaus+KXXXXX"+
+    "&recipient_bank_bic=KREXXXXX&recipient_iban=AT031952XXXXXXXXXXXX&recipient_country_id=AT"+
+    "&international_transaction=0&amount=1.00&currency_id=EUR&reason_1=Project&reason_2=Test&security_criteria=1"+
+    "&user_variable_0=localhost%3A8080%2Fdirectebanking%2Freturn&user_variable_1=123456789&user_variable_2="+
+    "&user_variable_3=&user_variable_4=&user_variable_5=&email_sender=&email_recipient="+
+    "&created=2011-02-27+17%3A45%3A23&hash=13fe0f0199c53d44f13083037c964286963e7495"
+  end  
+end

--- a/test/unit/integrations/returns/directebanking_return_test.rb
+++ b/test/unit/integrations/returns/directebanking_return_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class DirectebankingReturnTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def test_successful_purchase
+    r = Directebanking::Return.new(successful_purchase)
+    assert r.success?
+    assert_equal "success", r.message
+    assert_equal "39708-101654-4DA89F50-DCB1", r.transaction
+  end
+  
+  def test_pending_purchase
+    r = Directebanking::Return.new(failed_purchase)
+    assert !r.success?
+    assert_equal "abort", r.message
+    assert_equal "XXXX", r.transaction    
+  end
+
+  private
+  
+  def successful_purchase
+    'authResult=success&transaction=39708-101654-4DA89F50-DCB1&sender_holder=Max%20Mustermann'
+  end
+  
+  def failed_purchase
+    'authResult=abort&transaction=XXXX&sender_holder=Max%20Mustermann'
+  end
+end


### PR DESCRIPTION
Hi, 
here is an implementation for direct eBanking of Payment Networks AG in Germany.

Now to the nitty gritty parts. 
There exist two projects on github:

Vilango/active_merchant_test_app
https://github.com/Vilango/active_merchant_test_app
This is an test application that can be used to try out the payment module. 
It also comes with a cucumber test to see how the stuff should behave :)

Vilango/active_merchant
https://github.com/Vilango/active_merchant
This is the fork of active_merchant with the extensions for direct eBanking.
They reside in the 'payment-network-ag' branch

// Getting started with running your first transction // 

Register a merchant:
Normally you would go to the following address and register an account:
https://www.payment-network.com/deb_com_en/merchantarea/home

Because those accounts have a setup fee and a monthly minimum payment I already did that and created a account for you. 
And have it set to test mode by Payment Network AG

The account credentials are:
Customer number: will send it seperatly
Password: will send it seperatly

Set up project in merchant account:
https://www.sofortueberweisung.de/payment/users/login

1.) select 'My projects'  from the left menu
2.) select '101655 Testing-Shopify' (created that for you already / '101654 Testing-Gerwin' is the project I use for testing ) 
3.) scroll down to the 'interface' section
    a.) set 'Success link' to 'http://-USER_VARIABLE_0-?authResult=success&transaction=-TRANSACTION-&sender_holder=-SENDER_HOLDER-'
    b.) check 'Automatic redirection'
    c.) set 'Abort link' to '

4.) switch to tab 'Extended Settings'
    a.) click 'Notifications'
        a.) click 'Add new notification'
            b.) choose 'http' from the tabs on top
            c.) check 'activated'
            d.) insert 'Notification URL' this is like the paypal IPN (in the test_app it is http://yourip:8080/directebanking/hook
        e.) change existing email notification to your e-mail address 
    f.) click again on tab 'Extended Settings' and then click 'Passwords and hash algorithm'
        g.) click 'set project password'
        h.) check 'Activate input check'
        i.) choose 'Hash algorithm' -> 'SH1
        j.) click 'save'

Setting up the Apps
I'm assuming you are running rvm.

1.) Check out both apps
2.) cd into Vilango/active_merchant
git checkout payment-network-ag
./install-gem-locally.sh
# now the gem 1.12.0v (should be installed locally)

3.) cd into Vilango/active_merchant_test_app
cd into Vilango/active_merchant_test_app   # Very important! You should now see that RVM is taking over !!!
create file 'config/initializers/env_directebanking.rb' and add:
    DIRECTEBANKING_USER_ID = "39708"
    DIRECTEBANKING_PROJECT_ID = "101655" # This is already your project ID
    DIRECTEBANKING_PROJECT_PASSWORD = "your_project_password_here"    # to retrieve it see 'Set up project in merchant account' above
    DIRECTEBANKING_NOTIFICATION_PASSWORD = "your_notification_password_here" # to retrieve it see 'Set up project in merchant account' above
    DIRECTEBANKING_RETURN_URL = "yourip:8080/directebanking/return" 

bundle install
run script/server -p 8080

4.) open another terminal and cd into Vilango/active_merchant_test_app
rake cucumber

If everything went well you should have three calls to the above server:

1.) Processing DirectebankingController#index (for 127.0.0.1 at 2011-03-11 15:26:04) [GET]
2.) Processing DirectebankingController#hook (for 193.104.32.100 at 2011-03-11 15:26:17) [POST]
3.) Processing DirectebankingController#return (for 127.0.0.1 at 2011-03-11 15:28:10) [GET]

So that should it be... If you have any problems or questions...
Please feel free to contact me via email (gerwin.brunner@vilango.com) or Sykpe (AustroPretorian).

Best,
Gerwin Brunner

Usefull resources:
Manuals:  https://www.sofortueberweisung.de/payment/welcome
