### PR TITLE
x_duplicate_window bug in authorize.net bindings

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -131,6 +131,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>authorization</tt> - The authorization returned from the previous authorize request.
       def void(authorization, options = {})
         post = {:trans_id => authorization}
+        add_duplicate_window(post)
         commit('VOID', nil, post)
       end
 
@@ -155,6 +156,7 @@ module ActiveMerchant #:nodoc:
                  :card_num => options[:card_number]
                }
         add_invoice(post, options)
+        add_duplicate_window(post)
 
         commit('CREDIT', money, post)
       end


### PR DESCRIPTION
Currently, authorize.net bindings don't respect the x_duplicate_window param for refunds and voids. This is pretty problematic, for obvious reasons. As things stand:
- Set duplicate window to 0.
- Refund two $10 transactions to the same card.
- Second refund will fail.
