### PR TITLE
Gem/Bundler compatibility

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,0 +1,3 @@
+require 'active_merchant'
+require 'active_merchant/billing/integrations/action_view_helper'
+ActionView::Base.send(:include, ActiveMerchant::Billing::Integrations::ActionViewHelper)


### PR DESCRIPTION
To be able to include ActiveMerchant via bundler into a Rails project, there needs to be a rails/init.rb file, as the top-level init.rb file gets ignored and the ActionView mixins don't get loaded. For further info see:

http://guides.rubyonrails.org/plugins.html#plugins-as-gems
