### PR TITLE
Gem/Bundler compatibility in Rails 2.3

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,0 +1,3 @@
+# If Active Merchant is included into a Rails project as a gem, then
+# this file gets loaded instead of the top-level init.rb
+require File.dirname(__FILE__) + '/../init'


### PR DESCRIPTION
Tested with Rails 2.3.11 with Bundler enabled (http://gembundler.com/rails23.html).

Gemfile:
source 'http://gems.github.com'
gem 'rails', '2.3.11'
gem "sqlite3-ruby", :require => "sqlite3"
gem 'activemerchant', :git => 'https://github.com/rudolfs/active_merchant', :ref => '76ca979e5cf61216e33d'

Result:
ActionView::TemplateError (undefined method `payment_service_for' for #ActionView::Base:0x7f5e2a330f10)

Gemfile including change:
source 'http://gems.github.com'
gem 'rails', '2.3.11'
gem "sqlite3-ruby", :require => "sqlite3"
gem 'activemerchant', :git => 'https://github.com/rudolfs/active_merchant', :ref => '2ded476ac4ff3d6f06f4'

Result:
No errors
