### PR TITLE
Return raw AVS and CVV codes rather than booleans

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BraintreeBlueGateway < Gateway
       include BraintreeCommon
-      
+
       self.display_name = 'Braintree (Blue Platform)'
 
       def initialize(options = {})
@@ -195,21 +195,18 @@ module ActiveMerchant #:nodoc:
             response_options[:authorization] = result.transaction.id
           end
           if result.transaction
-            avs_result = {
-              'code' => '', 'message' => '',
-              'street_match' => result.transaction.avs_street_address_response_code == 'M',
-              'postal_match' => result.transaction.avs_postal_code_response_code == 'M'
+            response_options[:avs_result] = {
+              :code => nil, :message => nil,
+              :street_match => result.transaction.avs_street_address_response_code,
+              :postal_match => result.transaction.avs_postal_code_response_code
             }
-            cvv_result = {
-              'code' => result.transaction.cvv_response_code, 'message' => ''
-            }
+            response_options[:cvv_result] = result.transaction.cvv_response_code
             message = result.transaction.processor_response_code + " " + result.transaction.processor_response_text
           else
             message = message_from_result(result)
           end
           response = Response.new(result.success?, message, response_params, response_options)
-          response.instance_variable_set("@avs_result", avs_result)
-          response.instance_variable_set("@cvv_result", cvv_result)
+          response.cvv_result['message'] = ''
           response
         end
       end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -73,7 +73,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       )
     )
     assert_success response
-    assert_equal({'code' => '', 'message' => '', 'street_match' => true, 'postal_match' => true}, response.avs_result)
+    assert_equal({'code' => nil, 'message' => nil, 'street_match' => 'M', 'postal_match' => 'M'}, response.avs_result)
   end
 
   def test_avs_no_match
@@ -83,7 +83,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       )
     )
     assert_success response
-    assert_equal({'code' => '', 'message' => '', 'street_match' => false, 'postal_match' => false}, response.avs_result)
+    assert_equal({'code' => nil, 'message' => nil, 'street_match' => 'N', 'postal_match' => 'N'}, response.avs_result)
   end
 
   def test_cvv_match


### PR DESCRIPTION
As requested by Cody, this is a change to the BraintreeBlueGateway to return AVS/CVV response codes received from our API rather than just booleans.

We removed the `set_instance_variable` calls on the Response object, but we did still need to munge the CVV message, since the ActiveMerchant mapping of CVV Code to message is different than ours and we don't want the result to end up with a confusing or incorrect message.  We could avoid this minor hack if there were a way to set `message` directly on a `CVVResult` object.
