### PR TITLE
Add Gateway for Integration with Paypal Express for Digital Goods

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
         base.cattr_accessor :signature
       end
       
-      API_VERSION = '62.0'
+      API_VERSION = '72'
       
       URLS = {
         :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',

--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -1,0 +1,43 @@
+require File.dirname(__FILE__) + '/paypal/paypal_common_api'
+require File.dirname(__FILE__) + '/paypal/paypal_express_response'
+require File.dirname(__FILE__) + '/paypal_express_common'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PaypalDigitalGoodsGateway < PaypalExpressGateway
+      self.test_redirect_url = 'https://www.sandbox.paypal.com/incontext'
+      self.live_redirect_url = 'https://www.paypal.com/incontext'
+
+      self.supported_countries = ['US']
+      self.homepage_url = 'https://www.x.com/community/ppx/xspaces/digital_goods'
+      self.display_name = 'PayPal Express Checkout for Digital Goods'
+      
+      def redirect_url_for(token, options = {})
+        "#{redirect_url}?token=#{token}&useraction=commit"
+      end
+
+      # GATEWAY.setup_purchase(100,
+      #  :ip                => "127.0.0.1",
+      #  :description       => "Test Title",
+      #  :return_url        => "http://return.url",
+      #  :cancel_return_url => "http://cancel.url",
+      #  :items             => [ { :name => "Charge",
+      #                            :number => "1",
+      #                            :quantity => "1",
+      #                            :amount   => 100,
+      #                            :description => "Description",
+      #                            :category => "Digital" } ] )
+      def build_setup_request(action, money, options)
+        requires!(options, :items)
+        raise ArgumentError, "Must include at least 1 Item" unless options[:items].length > 0
+        options[:items].each do |item|
+          requires!(item, :name, :number, :quantity, :amount, :description, :category)
+          raise ArgumentError, "Each of the items must have the category 'Digital'" unless item[:category] == 'Digital'
+        end
+
+        super
+      end
+
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -125,7 +125,8 @@ module ActiveMerchant #:nodoc:
                         xml.tag! 'n2:Amount', localized_amount(item[:amount], currency_code), 'currencyID' => currency_code
                       end
                       xml.tag! 'n2:Description', item[:description]
-                      xml.tag! 'n2:ItemURL', item[:url]
+                      xml.tag! 'n2:ItemURL', item[:url] if item[:url]
+                      xml.tag! 'n2:ItemCategory', item[:category] if item[:category]
                     end
                   end
                 end

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -2,8 +2,8 @@ module ActiveMerchant
   module Billing
     module PaypalExpressCommon
       def self.included(base)
-        base.cattr_accessor :test_redirect_url
-        base.cattr_accessor :live_redirect_url
+        base.class_inheritable_accessor :test_redirect_url
+        base.class_inheritable_accessor :live_redirect_url
         base.live_redirect_url = 'https://www.paypal.com/cgibin/webscr'
       end
       

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -1,0 +1,122 @@
+require 'test_helper'
+
+class PaypalDigitalGoodsTest < Test::Unit::TestCase
+  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/incontext?token=1234567890&useraction=commit'
+  LIVE_REDIRECT_URL        = 'https://www.paypal.com/incontext?token=1234567890&useraction=commit'
+  
+  def setup
+    @gateway = PaypalDigitalGoodsGateway.new(
+      :login => 'cody', 
+      :password => 'test',
+      :pem => 'PEM'
+    )
+
+    Base.gateway_mode = :test
+  end 
+  
+  def teardown
+    Base.gateway_mode = :test
+  end 
+
+  def test_live_redirect_url
+    Base.gateway_mode = :production
+    assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+  end
+
+  def test_test_redirect_url
+    assert_equal :test, Base.gateway_mode
+    assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+  end
+
+  def test_setup_request_invalid_requests
+   assert_raise ArgumentError do
+    @gateway.setup_purchase(100,
+      :ip                => "127.0.0.1",
+      :description       => "Test Title",
+      :return_url        => "http://return.url",
+      :cancel_return_url => "http://cancel.url")                                      
+   end
+
+   assert_raise ArgumentError do
+    @gateway.setup_purchase(100,
+      :ip                => "127.0.0.1",
+      :description       => "Test Title",
+      :return_url        => "http://return.url",
+      :cancel_return_url => "http://cancel.url",
+      :items             => [ ])
+   end
+
+   assert_raise ArgumentError do
+    @gateway.setup_purchase(100,
+      :ip                => "127.0.0.1",
+      :description       => "Test Title",
+      :return_url        => "http://return.url",
+      :cancel_return_url => "http://cancel.url",
+      :items             => [ Hash.new ] )
+   end
+
+   assert_raise ArgumentError do
+    @gateway.setup_purchase(100,
+      :ip                => "127.0.0.1",
+      :description       => "Test Title",
+      :return_url        => "http://return.url",
+      :cancel_return_url => "http://cancel.url",
+      :items             => [ { :name => "Charge",
+                                :number => "1",
+                                :quantity => "1",
+                                :amount   => 100,
+                                :description => "Description",
+                                :category => "Physical" } ] )
+   end
+  end
+
+
+  def test_build_setup_request_valid
+    @gateway.expects(:ssl_post).returns(successful_setup_response)
+    
+    @gateway.setup_purchase(100,
+      :ip                => "127.0.0.1",
+      :description       => "Test Title",
+      :return_url        => "http://return.url",
+      :cancel_return_url => "http://cancel.url",
+      :items             => [ { :name => "Charge",
+                                :number => "1",
+                                :quantity => "1",
+                                :amount   => 100,
+                                :description => "Description",
+                                :category => "Digital" } ] )
+
+  end
+
+
+  private
+
+  def successful_setup_response
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\">
+	<SOAP-ENV:Header>
+		<Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security>
+		<RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\">
+			<Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\">
+				<Username xsi:type=\"xs:string\"></Username>
+				<Password xsi:type=\"xs:string\"></Password>
+				<Signature xsi:type=\"xs:string\">OMGOMGOMGOMGOMG</Signature>
+				<Subject xsi:type=\"xs:string\"></Subject>
+				</Credentials>
+			</RequesterCredentials>
+		</SOAP-ENV:Header>
+	<SOAP-ENV:Body id=\"_0\">
+		<SetExpressCheckoutResponse xmlns=\"urn:ebay:api:PayPalAPI\">
+			<Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2011-05-19T20:13:30Z</Timestamp>
+			<Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack>
+			<CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">da0ed6bc90ef1</CorrelationID>
+			<Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version>
+			<Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">1882144</Build>
+			<Token xsi:type=\"ebl:ExpressCheckoutTokenType\">EC-0XOMGOMGOMG</Token>
+			</SetExpressCheckoutResponse>
+		</SOAP-ENV:Body>
+	</SOAP-ENV:Envelope>"
+  end
+  
+end
+


### PR DESCRIPTION
I needed to adjust ActiveMerchant to support PayPal's Express Checkout for Digital Goods (EC4DG).

This type of integration with PayPal allows a more integrated approach, where instead of bouncing the user to  PayPal in the same window, then bouncing the user back, it allows the user to add JavaScript to their site to do the redirection inside an iframe/lightbox.  This integration method has certain limitations, and differences;

CHANGES:
-different redirection url
-build_setup_request => calling this method in the DG integration requires additional parameters (need to include itemized options with category of all the items 'Digital').
-i had to tweak the PayPal Express base class to support additional fields when setting up a request.  These fields are allowed in any request, but required for a DG integration
-Digital Goods Integration is only supported at 65+ Version.  Upped the version to 72 since that is the latest
-changed the redirect_urls from being cattr_accessor (using the same class variable) to class_inheritable_accessor (plays nicer with inheritence)
-added test cases for this new gateway.

If there are any changes I need to make to this in order to get this integrated let me know.
