### PR TITLE
Add Support for Reference Transactions using BAIDs in Paypal Express Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
         base.cattr_accessor :signature
       end
       
-      API_VERSION = '62.0'
+      API_VERSION = '72'
       
       URLS = {
         :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -41,6 +41,12 @@ module ActiveMerchant #:nodoc:
         commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Sale', money, options)
       end
 
+      def reference_transaction(money, options = {})
+        requires!(options, :reference_id, :payment_type, :invoice_id, :description, :ip)
+
+        commit 'DoReferenceTransaction', build_reference_transaction_request('Sale', money, options)
+      end
+
       private
       def build_get_details_request(token)
         xml = Builder::XmlMarkup.new :indent => 2
@@ -171,6 +177,32 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
       
+      def build_reference_transaction_request(action, money, options)
+        currency_code = options[:currency] || currency(money)
+
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'DoReferenceTransactionReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'DoReferenceTransactionRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:DoReferenceTransactionRequestDetails' do
+              xml.tag! 'n2:ReferenceID', options[:reference_id]
+              xml.tag! 'n2:PaymentAction', action
+              xml.tag! 'n2:PaymentType', options[:payment_type] || 'Any'
+              xml.tag! 'n2:PaymentDetails' do
+                xml.tag! 'n2:OrderTotal', amount(money).to_f.zero? ? localized_amount(100, currency_code) : localized_amount(money, currency_code), 'currencyID' => currency_code
+                xml.tag! 'n2:OrderDescription', options[:description]
+                xml.tag! 'n2:InvoiceID', options[:invoice_id]
+                xml.tag! 'n2:ButtonSource', 'ActiveMerchant'
+                xml.tag! 'n2:NotifyURL', ''
+              end
+              xml.tag! 'n2:IPAddress', options[:ip]
+            end
+          end
+        end
+
+        xml.target!
+      end
+
       def build_response(success, message, response, options = {})
         PaypalExpressResponse.new(success, message, response, options)
       end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -230,6 +230,58 @@ class PaypalExpressTest < Test::Unit::TestCase
     xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Test', 100, {}))
     assert_equal 'ActiveMerchant_EC', REXML::XPath.first(xml, '//n2:ButtonSource').text
   end
+
+
+  def test_build_reference_transaction_test
+    xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000, {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' }))
+
+    assert_equal '72', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
+    assert_equal 'ref_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
+    assert_equal 'Sale', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentAction').text
+    assert_equal 'Any', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentType').text
+    assert_equal '20.00', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:OrderTotal').text
+    assert_equal 'Description', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:OrderDescription').text
+    assert_equal 'invoice_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:InvoiceID').text
+    assert_equal 'ActiveMerchant', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:ButtonSource').text
+    assert_equal '127.0.0.1', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text
+  end
+
+  def test_reference_transaction
+    @gateway.expects(:ssl_post).returns(successful_reference_transaction_response)
+    
+    response = @gateway.reference_transaction(2000,  {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' })
+      
+    assert_equal "Success", response.params['ack']
+    assert_equal "Success", response.message
+    assert_equal "9R43552341412482K", response.authorization
+  end
+
+  def test_reference_transaction_requires_fields
+    valid_options = {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' }
+
+    [:reference_id, :payment_type, :invoice_id, :description, :ip].each do |field|
+      options = valid_options.dup
+      options.delete(field)
+      assert_raise ArgumentError do
+        @gateway.reference_transaction(2000, options)
+      end
+    end
+  end
   
   def test_error_code_for_single_error 
     @gateway.expects(:ssl_post).returns(response_with_error)
@@ -268,6 +320,55 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   private
+  def successful_reference_transaction_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+	<SOAP-ENV:Header>
+		<Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+		<RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+			<Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+				<Username xsi:type="xs:string"></Username>
+				<Password xsi:type="xs:string"></Password>
+				<Signature xsi:type="xs:string">OMGOMGOMG</Signature>
+				<Subject xsi:type="xs:string"></Subject>
+				</Credentials>
+			</RequesterCredentials>
+		</SOAP-ENV:Header>
+	<SOAP-ENV:Body id="_0">
+		<DoReferenceTransactionResponse xmlns="urn:ebay:api:PayPalAPI">
+			<Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2011-05-23T21:36:32Z</Timestamp>
+			<Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+			<CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">4d6d3af55369b</CorrelationID>
+			<Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+			<Build xmlns="urn:ebay:apis:eBLBaseComponents">1863577</Build>
+			<DoReferenceTransactionResponseDetails xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:DoReferenceTransactionResponseDetailsType">
+				<BillingAgreementID xsi:type="xs:string">B-3R788221G4476823M</BillingAgreementID>
+				<PaymentInfo xsi:type="ebl:PaymentInfoType">
+					<TransactionID>9R43552341412482K</TransactionID>
+					<ParentTransactionID xsi:type="ebl:TransactionId"></ParentTransactionID>
+					<ReceiptID></ReceiptID>
+					<TransactionType xsi:type="ebl:PaymentTransactionCodeType">mercht-pmt</TransactionType>
+					<PaymentType xsi:type="ebl:PaymentCodeType">instant</PaymentType>
+					<PaymentDate xsi:type="xs:dateTime">2011-05-23T21:36:32Z</PaymentDate>
+					<GrossAmount xsi:type="cc:BasicAmountType" currencyID="USD">190.00</GrossAmount>
+					<FeeAmount xsi:type="cc:BasicAmountType" currencyID="USD">5.81</FeeAmount>
+					<TaxAmount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</TaxAmount>
+					<ExchangeRate xsi:type="xs:string"></ExchangeRate>
+					<PaymentStatus xsi:type="ebl:PaymentStatusCodeType">Completed</PaymentStatus>
+					<PendingReason xsi:type="ebl:PendingStatusCodeType">none</PendingReason>
+					<ReasonCode xsi:type="ebl:ReversalReasonCodeType">none</ReasonCode>
+					<ProtectionEligibility xsi:type="xs:string">Ineligible</ProtectionEligibility>
+					<ProtectionEligibilityType xsi:type="xs:string">None</ProtectionEligibilityType>
+					</PaymentInfo>
+				</DoReferenceTransactionResponseDetails>
+			</DoReferenceTransactionResponse>
+		</SOAP-ENV:Body>
+	</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+
   def successful_details_response
     <<-RESPONSE
 <?xml version='1.0' encoding='UTF-8'?>


### PR DESCRIPTION
I needed to adjust the PayPal Express Gateway to add support for using Reference Transactions after a user confirms a Billing Agreement.  The change is split into two commits, one for fixing the existing Billing Agreement code and for adding a transaction that references that agreement with a corresponding agreement.
## Fix Billing Agreement Request

Although the code supported passing through the billing_agreement, it was not triggering a billing agreement.  This problem was due to the fact that within the SOAP for PayPal order matters, and while the request appears to be valid PayPal did not respect the flag as being passed.  

Before even when sending billing_agreement details, PayPal would treat the request as a normal Purchase flow instead of a Billing Agreement Flow (the button on the form said 'Pay Now' instead of 'Agree and Pay Now', and no ID would be sent back, etc).

Changes
-   Adjust ordering of BillingAgreementDetails to be at the top of the XML request instead of the bottom
-   Add a unit test for calling billing agreement (was missing before).  Also added an explicit check that the XML generated has the BillingAgreementDetails before PaymentDetails
## Implement Action for DoReferenceTransaction

After making a purchase with BillingAgreementDetails a BillingAgreementID is returned.  This ID can be passed along to the DoReferenceTransaction action to bill a user without redirecting them to a PayPal site (it's like storing a credit card).

Changes
-    Adjust the version of PayPal API to be 72 (I also did this in my prior pull request).  
-    Add new function, reference_transaction, to the gateway
-    Add private method, build_reference_transaction_request, to build the xml to send the PayPal
-    Add unit tests for both reference_transaction and the private build_reference_transaction request method

If there are any changes I need to make to this in order to get this integrated let me know.
