### PR TITLE
Add support for custom processor id's to older braintree accounts.

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_orange.rb
+++ b/lib/active_merchant/billing/gateways/braintree_orange.rb
@@ -11,6 +11,10 @@ module ActiveMerchant #:nodoc:
       def api_url
         'https://secure.braintreepaymentgateway.com/api/transact.php'
       end
+
+      def add_processor(post, options)
+        post[:processor_id] = options[:processor] unless options[:processor].nil?
+      end
     end
   end
 end

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -23,6 +23,14 @@ class BraintreeOrangeTest < Test::Unit::TestCase
     assert_equal '510695343', response.authorization
   end
 
+  def test_add_processor
+    result = {}
+
+    @gateway.send(:add_processor, result,   {:processor => 'ccprocessorb'} )
+    assert_equal ["processor_id"], result.stringify_keys.keys.sort
+    assert_equal 'ccprocessorb', result[:processor_id]
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
   


### PR DESCRIPTION
Hi,

This commit adds support for custom processor id's in older Braintree accounts to active_merchant.

Previously it would send the key 'processor', however Braintree requires this to be 'processor_id'.
