### PR TITLE
Payment Express have deprecated their old domain names. This commit uses the new URI.

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.paymentexpress.com/'
       self.display_name = 'PaymentExpress'
       
-      URL = 'https://www.paymentexpress.com/pxpost.aspx'
+      URL = 'https://sec.paymentexpress.com/pxpost.aspx'
       
       APPROVED = '1'
       


### PR DESCRIPTION
Use new URI for Payment Express according to migration documentation here:
  http://www.paymentexpress.com/migration.html
