### PR TITLE
Support for paypal recurring payments, both express checkout and direct

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_recurring.rb
+++ b/lib/active_merchant/billing/gateways/paypal_recurring.rb
@@ -85,7 +85,9 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'n2:BillingAgreementDescription', options[:description]
               end
               xml.tag! 'n2:PaymentAction', action
-              xml.tag! 'n2:OrderTotal', amount(money).to_f.zero? ? amount(100) : amount(money), 'currencyID' => options[:currency] || currency(money)
+              xml.tag! 'n2:PaymentDetails' do
+                xml.tag! 'n2:OrderTotal', amount(money).to_f.zero? ? amount(100) : amount(money), 'currencyID' => options[:currency] || currency(money)
+              end
               xml.tag! 'n2:AddressOverride', '0'
               xml.tag! 'n2:NoShipping', '1'
               xml.tag! 'n2:ReturnURL', options[:return_url]


### PR DESCRIPTION
Hi!
I've been always lacking this functionality in active merchant, until yesterday I was using a fork by rayvinly which had it. Though, his fork uses old API version, which does not support mobile view for express checkout.
The class I added here is actually taken from vantran's fork. I only did a few fixes to it.
