### PR TITLE
Braintree merchant account id support

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -158,36 +158,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def create_transaction(transaction_type, money, credit_card_or_vault_id, options)
-        parameters = {
-          :amount => amount(money).to_s,
-          :order_id => options[:order_id],
-          :customer => {
-            :id => options[:store] == true ? "" : options[:store],
-            :email => options[:email]
-          },
-          :options => {
-            :store_in_vault => options[:store] ? true : false,
-            :submit_for_settlement => options[:submit_for_settlement]
-          }
-        }
-        if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
-          parameters[:customer_id] = credit_card_or_vault_id
-        else
-          parameters[:customer].merge!(
-            :first_name => credit_card_or_vault_id.first_name,
-            :last_name => credit_card_or_vault_id.last_name
-          )
-          parameters[:credit_card] = {
-            :number => credit_card_or_vault_id.number,
-            :cvv => credit_card_or_vault_id.verification_value,
-            :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
-            :expiration_year => credit_card_or_vault_id.year.to_s
-          }
-        end
-        parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address]
-        parameters[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
+        transaction_params = create_transaction_parameters(money, credit_card_or_vault_id, options)
+
         commit do
-          result = Braintree::Transaction.send(transaction_type, parameters)
+          result = Braintree::Transaction.send(transaction_type, transaction_params)
           response_params, response_options, avs_result, cvv_result = {}, {}, {}, {}
           if result.success?
             response_params[:braintree_transaction] = transaction_hash(result.transaction)
@@ -201,7 +175,7 @@ module ActiveMerchant #:nodoc:
               :postal_match => result.transaction.avs_postal_code_response_code
             }
             response_options[:cvv_result] = result.transaction.cvv_response_code
-            message = result.transaction.processor_response_code + " " + result.transaction.processor_response_text
+            message = "#{result.transaction.processor_response_code} #{result.transaction.processor_response_text}"
           else
             message = message_from_result(result)
           end
@@ -279,13 +253,49 @@ module ActiveMerchant #:nodoc:
         }
 
         {
-          "order_id"         => transaction.order_id,
-          "status"           => transaction.status,
-          "customer_details" => customer_details,
-          "billing_details"  => billing_details,
-          "shipping_details" => shipping_details,
-          "vault_customer"   => vault_customer
+          "order_id"            => transaction.order_id,
+          "status"              => transaction.status,
+          "customer_details"    => customer_details,
+          "billing_details"     => billing_details,
+          "shipping_details"    => shipping_details,
+          "vault_customer"      => vault_customer,
+          "merchant_account_id" => transaction.merchant_account_id
         }
+      end
+
+      def create_transaction_parameters(money, credit_card_or_vault_id, options)
+        parameters = {
+          :amount => amount(money).to_s,
+          :order_id => options[:order_id],
+          :customer => {
+            :id => options[:store] == true ? "" : options[:store],
+            :email => options[:email]
+          },
+          :options => {
+            :store_in_vault => options[:store] ? true : false,
+            :submit_for_settlement => options[:submit_for_settlement]
+          }
+        }
+        if options.has_key?(:merchant_account_id)
+          parameters[:merchant_account_id] = options[:merchant_account_id]
+        end
+        if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
+          parameters[:customer_id] = credit_card_or_vault_id
+        else
+          parameters[:customer].merge!(
+            :first_name => credit_card_or_vault_id.first_name,
+            :last_name => credit_card_or_vault_id.last_name
+          )
+          parameters[:credit_card] = {
+            :number => credit_card_or_vault_id.number,
+            :cvv => credit_card_or_vault_id.verification_value,
+            :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
+            :expiration_year => credit_card_or_vault_id.year.to_s
+          }
+        end
+        parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address]
+        parameters[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
+        parameters
       end
     end
   end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -30,6 +30,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '123', response.params["braintree_transaction"]["order_id"]
   end
 
+  def test_successful_authorize_with_merchant_account_id
+    assert response = @gateway.authorize(@amount, @credit_card, :merchant_account_id => 'sandbox_credit_card_non_default')
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'sandbox_credit_card_non_default', response.params["braintree_transaction"]["merchant_account_id"]
+  end
+
   def test_successful_purchase_using_vault_id
     assert response = @gateway.store(@credit_card)
     assert_success response
@@ -270,6 +277,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_credit
     assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '1002 Processed', response.message
+    assert_equal 'submitted_for_settlement', response.params["braintree_transaction"]["status"]
+  end
+
+  def test_successful_credit_with_merchant_account_id
+    assert response = @gateway.credit(@amount, @credit_card, :merchant_account_id => 'sandbox_credit_card_non_default')
     assert_success response
     assert_equal '1002 Processed', response.message
     assert_equal 'submitted_for_settlement', response.params["braintree_transaction"]["status"]

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -11,26 +11,53 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_refund_legacy_method_signature
-    Braintree::Transaction.expects(:refund).with('transaction_id', nil).returns(braintree_result)
+    Braintree::Transaction.expects(:refund).
+      with('transaction_id', nil).
+      returns(braintree_result(:id => "refund_transaction_id"))
     response = @gateway.refund('transaction_id', :test => true)
     assert_equal "refund_transaction_id", response.authorization
   end
 
   def test_refund_method_signature
-    Braintree::Transaction.expects(:refund).with('transaction_id', '10.00').returns(braintree_result)
+    Braintree::Transaction.expects(:refund).
+      with('transaction_id', '10.00').
+      returns(braintree_result(:id => "refund_transaction_id"))
     response = @gateway.refund(1000, 'transaction_id', :test => true)
     assert_equal "refund_transaction_id", response.authorization
   end
 
   def test_void_transaction
-    Braintree::Transaction.expects(:void).with('transaction_id').returns(braintree_result(:id => "void_transaction_id"))
+    Braintree::Transaction.expects(:void).
+      with('transaction_id').
+      returns(braintree_result(:id => "void_transaction_id"))
+
     response = @gateway.void('transaction_id', :test => true)
     assert_equal "void_transaction_id", response.authorization
+  end
+
+  def test_user_agent_includes_activemerchant_version
+    assert Braintree::Configuration.instantiate.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
+  end
+
+  def test_merchant_account_id_present_when_provided
+    Braintree::Transaction.expects(:sale).
+      with(has_entries(:merchant_account_id => "present")).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :merchant_account_id => "present")
+  end
+
+  def test_merchant_account_id_absent_if_not_provided
+    Braintree::Transaction.expects(:sale).with do |params|
+      not params.has_key?(:merchant_account_id)
+    end.returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"))
   end
 
   private
 
   def braintree_result(options = {})
-    Braintree::SuccessfulResult.new(:transaction => Braintree::Transaction._new(nil, {:id => "refund_transaction_id"}.merge(options)))
+    Braintree::SuccessfulResult.new(:transaction => Braintree::Transaction._new(nil, {:id => "transaction_id"}.merge(options)))
   end
 end


### PR DESCRIPTION
Adding ability to specify non-default merchant_account_id when creating a transaction for BraintreeBlueGateway
