### PR TITLE
Added in Support for CardSave 

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -78,7 +78,6 @@ module ActiveMerchant #:nodoc:
           card_companies.reject { |c,p| c == 'maestro' }.each do |company, pattern|
             return company.dup if number =~ pattern 
           end
-          
           return 'maestro' if number =~ card_companies['maestro']
 
           return nil

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -1,0 +1,27 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class CardSaveGateway < IridiumGateway
+      #CardSave lets you handle failovers on payments by providing 3 gateways in case one happens to be down
+      #URLS = ['https://gw1.cardsaveonlinepayments.com:4430/','https://gw2.cardsaveonlinepayments.com:4430/','https://gw3.cardsaveonlinepayments.com:4430/']
+      class << self
+        attr_accessor :test_url
+        attr_accessor :live_url
+        def test_url
+          @test_url ||= 'https://gw1.cardsaveonlinepayments.com:4430/'
+        end
+        def live_url
+          @live_url ||= 'https://gw1.cardsaveonlinepayments.com:4430/'
+        end
+      end
+      
+      self.money_format = :cents
+      self.default_currency = 'GBP'
+      self.supported_cardtypes = [ :visa, :switch, :maestro, :master, :solo, :american_express, :jcb ]
+      self.supported_countries = [ 'GB' ]
+      self.homepage_url = 'http://www.cardsave.net/'
+      self.display_name = 'CardSave'
+      
+    end
+  end
+end
+

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -7,8 +7,16 @@ module ActiveMerchant #:nodoc:
     # login to the Iridium Merchant Management System. Instead, you will 
     # use the API username and password you were issued separately.
     class IridiumGateway < Gateway
-      TEST_URL = 'https://gw1.iridiumcorp.net/'
-      LIVE_URL = 'https://gw1.iridiumcorp.net/'
+      class << self
+        attr_accessor :test_url
+        attr_accessor :live_url
+        def test_url
+          @test_url ||= 'https://gw1.iridiumcorp.net/'
+        end
+        def live_url
+          @live_url ||= 'https://gw1.iridiumcorp.net/'
+        end
+      end
       
       # The countries the gateway supports merchants from as 2 digit ISO country codes
       self.supported_countries = ['GB', 'ES']
@@ -172,7 +180,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(request, options)
         requires!(options, :action)
-        response = parse(ssl_post(test? ? TEST_URL : LIVE_URL, request,
+        response = parse(ssl_post(test? ? self.class.test_url : self.class.live_url, request,
                               {"SOAPAction" => "https://www.thepaymentgateway.net/#{options[:action]}",
                                "Content-Type" => "text/xml; charset=utf-8" }))
   

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -42,6 +42,11 @@ braintree_blue:
   merchant_id: X
   public_key: Y
   private_key: Z
+  
+#Username/Password given in sign up email. Not MMS credentials
+card_save:
+  login:
+  password:
 
 card_stream:
   login: X

--- a/test/remote/gateways/remote_card_save_test.rb
+++ b/test/remote/gateways/remote_card_save_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class RemoteCardSaveTest < Test::Unit::TestCase  
+
+  def setup
+    @gateway = CardSaveGateway.new(fixtures(:card_save))
+    
+    @amount = 100
+    @credit_card = credit_card('4976000000003436', :verification_value => '452')
+    @declined_card = credit_card('4221690000004963', :verification_value => '125')
+    @addresses = {'4976000000003436' => { :name => 'John Watson', :address1 => '32 Edward Street', :city => 'Camborne,', :state => 'Cornwall', :country => 'GB', :zip => 'TR14 8PA' },
+                  '4221690000004963' => { :name => 'Ian Lee', :address1 => '274 Lymington Avenue', :city => 'London', :state => 'London', :country => 'GB', :zip => 'N22 6JN' }}
+    
+    @options = { 
+      :order_id => '1',
+      :billing_address => @addresses[@credit_card.number],
+      :description => 'Store Purchase'
+    }
+  end
+  
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.message =~ /AuthCode: ([0-9]+)/
+  end
+
+  def test_unsuccessful_purchase
+    @options.merge!(:billing_address => @addresses[@declined_card.number])
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Card declined', response.message
+  end
+
+  def test_authorize_and_capture
+    amount = @amount+10
+    assert auth = @gateway.authorize(amount, @credit_card, @options)
+    assert_success auth
+    assert auth.message =~ /AuthCode: ([0-9]+)/
+    assert auth.authorization
+    assert capture = @gateway.capture(amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    assert response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'Input variable errors', response.message
+  end
+
+  def test_invalid_login
+    gateway = CardSaveGateway.new(
+    :login => '',
+    :password => ''
+    )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Input variable errors', response.message
+  end
+end

--- a/test/unit/gateways/card_save_test.rb
+++ b/test/unit/gateways/card_save_test.rb
@@ -1,0 +1,277 @@
+require 'test_helper'
+
+class CardSaveTest < Test::Unit::TestCase
+  def setup
+    Base.gateway_mode = :test
+    @gateway = CardSaveGateway.new(login:'login', password:'password')
+    @credit_card = credit_card
+    @amount = 100    
+    @options = {order_id:'1', billing_address:address, description:'Store Purchase'}
+  end
+  
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_visa_no_3d_purchase_response)
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    
+    # Replace with authorization number from the successful response
+    assert_equal '1;110706093540191601939772;939772', response.authorization
+    assert response.test?
+  end
+
+  def test_unsuccessful_request
+    @gateway.expects(:ssl_post).returns(declined_switch_no_3d_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_nil response.authorization
+    assert response.test?
+  end
+  
+  def test_referred_request_is_a_failure
+    @gateway.expects(:ssl_post).returns(referred_mastercard_no_3d_secure_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_nil response.authorization
+    assert response.test?
+  end
+  
+  def test_referred_request_is_a_failure
+    @gateway.expects(:ssl_post).returns(failed_due_to_unsupported_card_currency_combination)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_nil response.authorization
+    assert response.test?
+  end
+  
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(authorization_successful)
+    
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response    
+    assert_equal('1;110706124418747501702211;702211', response.authorization)
+    assert response.test?
+  end
+  
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(capture_successful)
+    
+    assert response = @gateway.capture(1111, "1;110706124418747501702211;702211")
+    assert_success response    
+    assert_equal('110706124418747501702211', response.authorization)
+    assert response.test?
+  end
+  
+  def test_default_currency
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/CurrencyCode="826"/), anything).returns(successful_visa_no_3d_purchase_response)
+    assert_success @gateway.purchase(@amount, @credit_card, @options)
+  end
+  
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund)
+    assert response = @gateway.refund(@amount, '123456789')
+    assert_success response
+    assert_equal 'Refund successful', response.message
+  end
+  
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund)
+    
+    assert response = @gateway.refund(@amount, '123456789')
+    assert_failure response
+    assert_equal 'Amount exceeds that available for refund [1000]', response.message
+  end
+
+  private
+  
+  # Place raw successful response from gateway here
+  def successful_visa_no_3d_purchase_response
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CardDetailsTransactionResult AuthorisationAttempted="True">
+            <StatusCode>0</StatusCode>
+            <Message>AuthCode: 939772</Message>
+          </CardDetailsTransactionResult>
+          <TransactionOutputData CrossReference="110706093540191601939772">
+            <AuthCode>939772</AuthCode>
+            <AddressNumericCheckResult>PASSED</AddressNumericCheckResult>
+            <PostCodeCheckResult>PASSED</PostCodeCheckResult>
+            <CV2CheckResult>PASSED</CV2CheckResult>
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CardDetailsTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def declined_switch_no_3d_purchase_response
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CardDetailsTransactionResult AuthorisationAttempted="True">
+            <StatusCode>5</StatusCode>
+            <Message>Card declined</Message>
+          </CardDetailsTransactionResult>
+          <TransactionOutputData CrossReference="110706102619764701991133">
+            <AddressNumericCheckResult>NOT_SUBMITTED</AddressNumericCheckResult>
+            <PostCodeCheckResult>NOT_SUBMITTED</PostCodeCheckResult>
+            <CV2CheckResult>NOT_SUBMITTED</CV2CheckResult>
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CardDetailsTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def referred_mastercard_no_3d_secure_purchase_response
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CardDetailsTransactionResult AuthorisationAttempted="True">
+            <StatusCode>4</StatusCode>
+            <Message>Card referred</Message>
+          </CardDetailsTransactionResult>
+          <TransactionOutputData CrossReference="110706105145862601596515">
+            <AddressNumericCheckResult>NOT_SUBMITTED</AddressNumericCheckResult>
+            <PostCodeCheckResult>NOT_SUBMITTED</PostCodeCheckResult>
+            <CV2CheckResult>NOT_SUBMITTED</CV2CheckResult>
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CardDetailsTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def failed_due_to_unsupported_card_currency_combination
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CardDetailsTransactionResult AuthorisationAttempted="False">
+            <StatusCode>30</StatusCode>
+            <Message>No routes found for American Express/GBP</Message>
+          </CardDetailsTransactionResult>
+          <TransactionOutputData>
+            <AddressNumericCheckResult>NOT_SUBMITTED</AddressNumericCheckResult>
+            <PostCodeCheckResult>NOT_SUBMITTED</PostCodeCheckResult>
+            <CV2CheckResult>NOT_SUBMITTED</CV2CheckResult>
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CardDetailsTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def authorization_successful
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CardDetailsTransactionResult AuthorisationAttempted="True">
+            <StatusCode>0</StatusCode>
+            <Message>AuthCode: 702211</Message>
+          </CardDetailsTransactionResult>
+          <TransactionOutputData CrossReference="110706124418747501702211">
+            <AuthCode>702211</AuthCode>
+            <AddressNumericCheckResult>PASSED</AddressNumericCheckResult>
+            <PostCodeCheckResult>PASSED</PostCodeCheckResult>
+            <CV2CheckResult>PASSED</CV2CheckResult>
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CardDetailsTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def capture_successful
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CrossReferenceTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CrossReferenceTransactionResult AuthorisationAttempted="True">
+            <StatusCode>0</StatusCode>
+            <Message>Collection successful</Message>
+          </CrossReferenceTransactionResult>
+          <TransactionOutputData CrossReference="110706124418747501702211">
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CrossReferenceTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>
+    )
+  end
+  
+  def successful_refund
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CrossReferenceTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CrossReferenceTransactionResult AuthorisationAttempted="True">
+            <StatusCode>0</StatusCode>
+            <Message>Refund successful</Message>
+          </CrossReferenceTransactionResult>
+          <TransactionOutputData CrossReference="110706132015423601247790">
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CrossReferenceTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+  def failed_refund
+    %(<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <CrossReferenceTransactionResponse xmlns="https://www.thepaymentgateway.net/">
+          <CrossReferenceTransactionResult AuthorisationAttempted="False">
+            <StatusCode>30</StatusCode>
+            <Message>Amount exceeds that available for refund [1000]</Message>
+          </CrossReferenceTransactionResult>
+          <TransactionOutputData CrossReference="110706132233872701536706">
+            <GatewayEntryPoints>
+              <GatewayEntryPoint EntryPointURL="https://gw1.cardsaveonlinepayments.com:4430/" Metric="100"/>
+              <GatewayEntryPoint EntryPointURL="https://gw2.cardsaveonlinepayments.com:4430/" Metric="200"/>
+              <GatewayEntryPoint EntryPointURL="https://gw3.cardsaveonlinepayments.com:4430/" Metric="300"/>
+            </GatewayEntryPoints>
+          </TransactionOutputData>
+        </CrossReferenceTransactionResponse>
+      </soap:Body>
+    </soap:Envelope>)
+  end
+  
+end


### PR DESCRIPTION
Hi,

I've added in support for a GB gateway called CardSave which underneath is the same as Iridium, which already existed, except for the urls. So I've altered how the gateway urls are used and subclassed the Iridium Gateway to create one for CardSave. Hope that's ok, it seemed to be the most sensible course of action. I've added in extra tests to cover it too. 

Let me know if you need anything else for this submission!

Thanks

Tom
