### PR TITLE
Support recurring purchases in BogusGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -18,9 +18,9 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://example.com'
       self.display_name = 'Bogus'
       
-      def authorize(money, creditcard, options = {})
+      def authorize(money, credit_card_or_reference, options = {})
         money = amount(money)
-        case creditcard.number
+        case normalize(credit_card_or_reference)
         when '1'
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         when '2'
@@ -30,9 +30,21 @@ module ActiveMerchant #:nodoc:
         end      
       end
   
-      def purchase(money, creditcard, options = {})
+      def purchase(money, credit_card_or_reference, options = {})
         money = amount(money)
-        case creditcard.number
+        case normalize(credit_card_or_reference)
+        when '1', AUTHORIZATION
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+        when '2'
+          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
+        else
+          raise Error, ERROR_MESSAGE
+        end
+      end
+ 
+      def recurring(money, credit_card_or_reference, options = {})
+        money = amount(money)
+        case normalize(credit_card_or_reference)
         when '1'
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         when '2'
@@ -42,26 +54,14 @@ module ActiveMerchant #:nodoc:
         end
       end
  
-      def recurring(money, creditcard, options = {})
-        money = amount(money)
-        case creditcard.number
-        when '1'
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-        when '2'
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
-        else
-          raise Error, ERROR_MESSAGE
-        end
-      end
- 
-      def credit(money, creditcard, options = {})
-        if creditcard.is_a?(String)
+      def credit(money, credit_card_or_reference, options = {})
+        if credit_card_or_reference.is_a?(String)
           deprecated CREDIT_DEPRECATION_MESSAGE
-          return refund(money, creditcard, options)
+          return refund(money, credit_card_or_reference, options)
         end
 
         money = amount(money)
-        case creditcard.number
+        case normalize(credit_card_or_reference)
         when '1'
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true )
         when '2'
@@ -71,9 +71,9 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def refund(money, ident, options = {})
+      def refund(money, reference, options = {})
         money = amount(money)
-        case ident
+        case reference
         when '1'
           raise Error, REFUND_ERROR_MESSAGE
         when '2'
@@ -83,9 +83,9 @@ module ActiveMerchant #:nodoc:
         end
       end
  
-      def capture(money, ident, options = {})
+      def capture(money, reference, options = {})
         money = amount(money)
-        case ident
+        case reference
         when '1'
           raise Error, CAPTURE_ERROR_MESSAGE
         when '2'
@@ -95,21 +95,21 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def void(ident, options = {})
-        case ident
+      def void(reference, options = {})
+        case reference
         when '1'
           raise Error, VOID_ERROR_MESSAGE
         when '2'
-          Response.new(false, FAILURE_MESSAGE, {:authorization => ident, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:authorization => ident}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
         end
       end
       
-      def store(creditcard, options = {})
-        case creditcard.number
+      def store(credit_card_or_reference, options = {})
+        case normalize(credit_card_or_reference)
         when '1'
-          Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION )
+          Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
         when '2'
           Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true)
         else
@@ -117,14 +117,24 @@ module ActiveMerchant #:nodoc:
         end              
       end
       
-      def unstore(identification, options = {})
-        case identification
+      def unstore(reference, options = {})
+        case reference
         when '1'
           Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
         when '2'
           Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE },:test => true)
         else
           raise Error, UNSTORE_ERROR_MESSAGE
+        end
+      end
+
+      private
+
+      def normalize(credit_card_or_reference)
+        if credit_card_or_reference.respond_to?(:number)
+          credit_card_or_reference.number
+        else
+          credit_card_or_reference.to_s
         end
       end
     end

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -86,6 +86,11 @@ class BogusTest < Test::Unit::TestCase
   def test_unstore
     @gateway.unstore('1')
   end
+
+  def test_store_then_purchase
+    reference = @gateway.store(@creditcard)
+    assert @gateway.purchase(1000, reference.authorization).success?
+  end
   
   def test_supported_countries
     assert_equal ['US'], BogusGateway.supported_countries


### PR DESCRIPTION
Adds support for calling `BogusGateway#purchase` with the authorization returned
from `#store`.

@jduff: this is a writeup of an old patch from @phpfog. This one should apply cleanly on `master` - can I get you to merge it in, please?
