### PR TITLE
Use the same name for the password in Quickpay

### DIFF
--- a/lib/active_merchant/billing/integrations/quickpay/notification.rb
+++ b/lib/active_merchant/billing/integrations/quickpay/notification.rb
@@ -55,7 +55,7 @@ module ActiveMerchant #:nodoc:
           ]
 
           def generate_md5string
-            MD5_CHECK_FIELDS.map { |key| params[key.to_s] } * "" + @options[:credential2]
+            MD5_CHECK_FIELDS.map { |key| params[key.to_s] } * "" + @options[:password]
           end
           
           def generate_md5check

--- a/test/unit/integrations/notifications/quickpay_notification_test.rb
+++ b/test/unit/integrations/notifications/quickpay_notification_test.rb
@@ -4,7 +4,7 @@ class QuickpayNotificationTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
   def setup
-    @quickpay = Quickpay::Notification.new(http_raw_data, :credential2 => "mysecretmd5string")
+    @quickpay = Quickpay::Notification.new(http_raw_data, :password => "mysecretmd5string")
   end
 
   def test_accessors
@@ -27,12 +27,12 @@ class QuickpayNotificationTest < Test::Unit::TestCase
   end
   
   def test_failed_acknnowledgement
-    @quickpay = Quickpay::Notification.new(http_raw_data, :credential2 => "badmd5string")
+    @quickpay = Quickpay::Notification.new(http_raw_data, :password => "badmd5string")
     assert !@quickpay.acknowledge
   end
 
   def test_acknowledgement_with_cardnumber
-    @quickpay = Quickpay::Notification.new(http_raw_data_with_cardnumber, :credential2 => "mysecretmd5string")
+    @quickpay = Quickpay::Notification.new(http_raw_data_with_cardnumber, :password => "mysecretmd5string")
     assert @quickpay.acknowledge
   end
   


### PR DESCRIPTION
The secret used in notifications and gateway interaction are the same. This commit renames the one in `Quickpay::Notification` from `:credential2` to `:password`.

If you wish I can retain backwards compatibility by allowing the secret to be given in both ways. Just let me know and I'll amend the commit.
