### PR TITLE
use securerandom from stdlib not active_support

### DIFF
--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -30,8 +30,8 @@ require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/base64'
-require 'active_support/secure_random'
 
+require 'securerandom'
 require 'builder'
 require 'cgi'
 require 'rexml/document'
@@ -41,7 +41,7 @@ require 'active_merchant/billing'
 require 'active_merchant/version'
 
 module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:    
+  module Billing #:nodoc:
     autoload :Integrations, 'active_merchant/billing/integrations'
   end
 end

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class QbmsGateway < Gateway
@@ -118,7 +116,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
-      
+
       def hosted?
         @options[:pem]
       end


### PR DESCRIPTION
Hello,

This patch makes active_merchant compatible with rails 3.2 and should not negatively impact other versions. All of the tests pass on the latest 1.8.7 and 1.9.2 for me.
