### PR TITLE
Create abstract method definitions for the gateway methods

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -99,6 +99,38 @@ module ActiveMerchant #:nodoc:
       self.application_id = 'ActiveMerchant'
       
       attr_reader :options
+
+      def purchase(money, creditcard, options = {})
+        raise NotImplementedError
+      end
+
+      def authorize(money, creditcard, options = {})
+        raise NotImplementedError
+      end
+
+      def capture(money, authorization, options = {})
+        raise NotImplementedError
+      end
+
+      def void(identification, options = {})
+        raise NotImplementedError
+      end
+
+      def credit(money, identification, options = {})
+        raise NotImplementedError
+      end
+
+      def recurring(money, creditcard, options = {})
+        raise NotImplementedError
+      end
+
+      def store(creditcard, options = {})
+        raise NotImplementedError
+      end
+
+      def unstore(identification, options = {})
+        raise NotImplementedError
+      end
       
       # Use this method to check if your gateway of interest supports a credit card of some type
       def self.supports?(card_type)

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -45,4 +45,11 @@ class GatewayTest < Test::Unit::TestCase
     
     assert_equal SimpleTestGateway.application_id, SubclassGateway.application_id
   end
+
+  def test_defines_abstract_methods
+    methods = %w[purchase authorize capture void credit recurring store unstore]
+    methods.each do |method|
+      assert_raise(NotImplementedError) { Gateway.new.__send__(method, nil, nil) }
+    end
+  end
 end


### PR DESCRIPTION
The abstract implementations simply raise `NotImplementedError`.

The primary purpose of this is to have a default place for documentation. Furthermore, I find it better that gateway implementations that do not support some features raise `NotImplementedError` instead of `NoMethodError`.

There is one downside though -- since the methods are public, `#respond_to?` returns `true` for the methods, causing a few tests to fail.

A custom `#respond_to?` implementation would solve this. `Gateway` subclasses would register which functionality they supported through a class method call, e.g. `supports :authorize, :capture, :purchase, :credit`, and `#respond_to?` would respond accordingly.

If this plan is accepted, I'll add extensive documentation to all the abstract methods. This will be inherited to the concrete implementations.
