### PR TITLE
Added handling :items when purchase() when using PaypalExpress gateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -80,6 +80,8 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'n2:ButtonSource', application_id.to_s.slice(0,32) unless application_id.blank?
                 xml.tag! 'n2:InvoiceID', options[:order_id]
                 xml.tag! 'n2:OrderDescription', options[:description]
+
+                add_items_xml(xml, options, currency_code) if options[:items]
               end
             end
           end
@@ -115,20 +117,8 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'n2:OrderDescription', options[:description]
                 xml.tag! 'n2:InvoiceID', options[:order_id]
 
-                if options[:items]
-                  options[:items].each do |item|
-                    xml.tag! 'n2:PaymentDetailsItem' do
-                      xml.tag! 'n2:Name', item[:name]
-                      xml.tag! 'n2:Number', item[:number]
-                      xml.tag! 'n2:Quantity', item[:quantity]
-                      if item[:amount]
-                        xml.tag! 'n2:Amount', localized_amount(item[:amount], currency_code), 'currencyID' => currency_code
-                      end
-                      xml.tag! 'n2:Description', item[:description]
-                      xml.tag! 'n2:ItemURL', item[:url]
-                    end
-                  end
-                end
+                add_items_xml(xml, options, currency_code) if options[:items]
+
                 add_address(xml, 'n2:ShipToAddress', options[:shipping_address] || options[:address])
 
                 xml.tag! 'n2:PaymentAction', action
@@ -171,6 +161,23 @@ module ActiveMerchant #:nodoc:
       
       def build_response(success, message, response, options = {})
         PaypalExpressResponse.new(success, message, response, options)
+      end
+
+      private
+
+      def add_items_xml(xml, options, currency_code)
+        options[:items].each do |item|
+          xml.tag! 'n2:PaymentDetailsItem' do
+            xml.tag! 'n2:Name', item[:name]
+            xml.tag! 'n2:Number', item[:number]
+            xml.tag! 'n2:Quantity', item[:quantity]
+            if item[:amount]
+              xml.tag! 'n2:Amount', localized_amount(item[:amount], currency_code), 'currencyID' => currency_code
+            end
+            xml.tag! 'n2:Description', item[:description]
+            xml.tag! 'n2:ItemURL', item[:url]
+          end
+        end
       end
     end
   end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -142,7 +142,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_nil REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem')
   end
 
-  def test_items_are_included_if_specified
+  def test_items_are_included_if_specified_in_build_setup_request
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:currency => 'GBP', :items => [
                                             {:name => 'item one', :description => 'item one description', :amount => 10000, :number => 1, :quantity => 3},
                                             {:name => 'item two', :description => 'item two description', :amount => 20000, :number => 2, :quantity => 4}
@@ -228,6 +228,26 @@ class PaypalExpressTest < Test::Unit::TestCase
     
     xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Test', 100, {}))
     assert_equal 'ActiveMerchant_EC', REXML::XPath.first(xml, '//n2:ButtonSource').text
+  end
+
+  def test_items_are_included_if_specified_in_build_sale_or_authorization_request
+    xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Sale', 100, {:items => [
+                                            {:name => 'item one', :description => 'item one description', :amount => 10000, :number => 1, :quantity => 3},
+                                            {:name => 'item two', :description => 'item two description', :amount => 20000, :number => 2, :quantity => 4}
+    ]}))
+
+
+    assert_equal 'item one', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name').text
+    assert_equal 'item one description', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Description').text
+    assert_equal '100.00', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Amount').text
+    assert_equal '1', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Number').text
+    assert_equal '3', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Quantity').text
+
+    assert_equal 'item two', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name')[1].text
+    assert_equal 'item two description', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Description')[1].text
+    assert_equal '200.00', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Amount')[1].text
+    assert_equal '2', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Number')[1].text
+    assert_equal '4', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Quantity')[1].text
   end
   
   def test_error_code_for_single_error 


### PR DESCRIPTION
With this modification, :items will be captured when the purchase() method is called.
