### PR TITLE
New gateway: NMI 3-Step Redirect

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi_three_step.rb
+++ b/lib/active_merchant/billing/gateways/nmi_three_step.rb
@@ -1,0 +1,92 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class NmiThreeStepGateway < Gateway
+      LIVE_URL = 'https://secure.nmi.com/api/v2/three-step'
+      
+      # The countries the gateway supports merchants from as 2 digit ISO country codes
+      self.supported_countries = ['US']
+      
+      # The card types supported by the payment gateway
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      
+      # The homepage URL of the gateway
+      self.homepage_url = 'http://nmi.com/'
+      
+      # The name of the gateway
+      self.display_name = 'NMI Three Step Redirect'
+      
+      def initialize(options = {})
+        requires!(options, :login)
+        @options = options
+        super
+      end
+      
+      def setup_purchase(money, options = {})
+        requires!(options, :return_url)
+        commit build_setup_request(money, options)
+      end
+
+      # A helper to get the 2nd step form URL from the 1st step response
+      def form_url_for(response)
+        response.params["form_url"]
+      end
+
+      # Now that the Payment Gateway has collected the sensitive customer data, you 
+      # must submit another behind-the-scenes direct POST to complete the trasanction 
+      # using the token-id
+      def purchase(token)
+        commit build_sale_request(token)
+      end
+    
+      private
+      
+      def build_response(r)
+        success = r["result"] == "1"
+        message = r["result_text"]
+        options = {
+          :authorization => r["transaction_id"],
+          :fraud_review => false,
+          :avs_result => {code: r["avs_result"]},
+          :cvv_result => r["cvv_result"]
+        }
+        Response.new(success, message, r, options)
+      end
+
+      def commit(request_body)
+        data = ssl_post(LIVE_URL, request_body, {"content-type" => "text/xml"})
+        hash = Hash.from_xml(data)["response"]
+        build_response(hash)
+      end
+
+      def build_setup_request(money, options)
+        builder = Builder::XmlMarkup.new
+        builder.instruct!
+        builder.tag!( "sale") do |sale|
+          sale.tag!("api-key", @options[:login])
+          sale.tag!("redirect-url", options[:return_url])
+          sale.tag!("amount", amount(money))
+          sale.tag!("ip-address", options[:ip]) if options[:ip]
+          sale.tag!("order-description", options[:description]) if options[:description]
+          sale.tag!("customer-id", options[:customer]) if options[:customer]
+          sale.tag!("merchant-receipt-email", options[:merchant_email]) if options[:merchant_email]
+          sale.tag!("customer-receipt", true)
+          sale.tag!("merchant-defined-field-1", options[:custom_1]) if options[:custom_1]
+          sale.tag!("merchant-defined-field-2", options[:custom_2]) if options[:custom_2]
+          sale.tag!("tax-amount", amount(options[:tax])) if options[:tax]
+          sale.tag!("shipping-amount", amount(options[:shipping])) if options[:shipping]
+        end
+      end
+
+      def build_sale_request(token)
+        builder = Builder::XmlMarkup.new
+        builder.instruct!
+        builder.tag! "complete-action" do |c|
+          c.tag! "api-key", @options[:login]
+          c.tag! "token-id", token
+        end
+      end
+     
+    end # NmiThreeStepGateway
+  end # Billing
+end # ActiveMerchant
+

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -169,7 +169,10 @@ net_registry:
 nmi:
   login: demo
   password: password
-  
+
+nmi_three_step:
+  login: 2F822Rw39fx762MaV7Yy86jXGTC7sCDy
+
 ogone:
   login: LOGIN
   user: USER

--- a/test/remote/gateways/remote_nmi_three_step_test.rb
+++ b/test/remote/gateways/remote_nmi_three_step_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+#require "net/http"
+
+class RemoteNmiThreeStepTest < Test::Unit::TestCase
+  
+
+  def setup
+    @gateway = NmiThreeStepGateway.new(fixtures(:nmi_three_step))
+    
+    @amount = 101
+    @declined_amount = 42
+    #@credit_card = credit_card('4111111111111111') # Visa
+    
+    @options = { 
+      #:order_id => '1',
+      #:billing_address => address,
+      #:description => 'Store Purchase',
+      :return_url => 'http://example.com'
+    }
+
+    @step_two_form_data = {
+      "billing-cc-number" => "4111111111111111", # Visa
+      "billing-cc-exp" => "1010", # 10/2010
+    }
+  end
+  
+  def test_successful_purchase
+    # Step 1: submit amount and get form URL for sensitive payment information
+    assert response = @gateway.setup_purchase(@amount, @options)
+    assert_success response
+    assert_equal "Step 1 completed", response.message
+    assert @gateway.form_url_for(response).present?
+
+    # Step 2: send credit card number, etc to remote form
+    endpoint = URI.parse(@gateway.form_url_for(response))
+    z = Net::HTTP.start(endpoint.host, endpoint.port, :use_ssl => true) do |http|
+      req = Net::HTTP::Post.new(endpoint.path)
+      req.set_form_data(@step_two_form_data)
+      http.request(req)
+    end
+
+    # Step 3: use token to make purchase
+    token = CGI.parse(URI.parse(z["Location"]).query)["token-id"][0]
+    assert token.present?, z["Location"]
+    assert response = @gateway.purchase(token)
+    assert_success response
+    assert_equal "SUCCESS", response.message
+  end
+
+  def test_unsuccessful_setup_purchase
+    assert response = @gateway.setup_purchase(nil, @options)
+    assert_failure response
+  end
+
+  def test_invalid_login
+    gateway = NmiThreeStepGateway.new(:login => 'abc123')
+    assert response = gateway.setup_purchase(@amount, @options)
+    assert_failure response
+    assert response.message.include?("Specified API key not found"), response.inspect
+  end
+end


### PR DESCRIPTION
Implements this:

http://www.planetauthorize.net/assets/Planetauthorize-Three-Step-Redirect-API.pdf

Note that this NMI API is different than the Authorize.net-compatible one included already.

Many of the supported fields such as billing and shipping address can be sent in either step one or step two. I elected, for this first release, to have those optional fields be sent in the step two phase and out of the codebase.

I would also like feedback on Hash key names for all the custom fields...
