### PR TITLE
AuthorizeNetCimGateway x_duplicate_window support

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -94,6 +94,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>:password</tt> -- The Authorize.Net Transaction Key. (REQUIRED)
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server. 
       #   Otherwise, perform transactions against the production server.
+      # * <tt>:duplicate_window</tt> -- Number of seconds following submission during which processing
+      #    of duplicate transactions will be prevented.  Valid range is 0 - 28800, default is 120.
       def initialize(options = {})
         requires!(options, :login, :password)
         @options = options


### PR DESCRIPTION
Authorize.net supports a extra option _x_duplicate_window_, which controls how long in the future it'll check for and reject duplicate transactions (if you need to submit them relatively frequently, the ability to set this to zero is rather important).  The AuthorizeNetGateway has been extended to allow setting this, but the AuthorizeNetCimGateway is currently missing support.  This pull request fixes that.

No tests, as there weren't tests for duplicate_window in AuthorizeNetGateway, but I've confirmed it's functional in production usage.
