### PR TITLE
Expired cards should have only one error on year.

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -236,7 +236,7 @@ module ActiveMerchant #:nodoc:
         else
           errors.add :month,      "is not a valid month" unless valid_month?(@month)
           errors.add :year,       "expired"              if expired?
-          errors.add :year,       "is not a valid year"  unless valid_expiry_year?(@year)
+          errors.add :year,       "is not a valid year"  unless expired? || valid_expiry_year?(@year)
         end
       end
 

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -153,6 +153,12 @@ class CreditCardTest < Test::Unit::TestCase
     assert_valid @visa
   end
 
+  def test_expired_card_should_have_one_error_on_year
+    @visa.year = Time.now.year - 1
+    assert_not_valid @visa
+    assert_equal 1, @visa.errors['year'].length
+    assert /expired/ =~ @visa.errors['year'].first
+  end
 
   def test_should_be_valid_with_start_month_and_year_as_string
     @solo.start_month = '2'


### PR DESCRIPTION
Previously, an expired card would have two errors, "expired" and "is not valid year". But the second error is redundant and less precise. This commit adds a clause to prevent the "is not valid year" error from being added if the card is simply just expired.
