### PR TITLE
Added validation_mode option to AuthorizeNetCimGateway#create_customer_profile_request

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -466,6 +466,8 @@ module ActiveMerchant #:nodoc:
       def build_create_customer_profile_request(xml, options)
         add_profile(xml, options[:profile])
 
+        xml.tag!('validationMode', CIM_VALIDATION_MODES[options[:validation_mode]]) if options[:validation_mode]
+
         xml.target!
       end
 


### PR DESCRIPTION
Added the validation_mode option to the create_customer_profile_request, so Authorize.net can validate the credit card before creating the customer profile.
