### PR TITLE
Updated service URL

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout.rb
@@ -1,4 +1,3 @@
-
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module Integrations #:nodoc:
@@ -8,7 +7,7 @@ module ActiveMerchant #:nodoc:
         autoload 'Notification', File.dirname(__FILE__) + '/two_checkout/notification'
        
         mattr_accessor :service_url
-        self.service_url = 'https://www.2checkout.com/2co/buyer/purchase'
+        self.service_url = 'https://www.2checkout.com/checkout/purchase'
 
         def self.notification(post, options = {})
           Notification.new(post)


### PR DESCRIPTION
The service URL was not the direct 2Checkout.com purchase URL but rather a very old one that works by virtue of a redirect.
