### PR TITLE
eWay ManagedPayment Payment response

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -188,6 +188,7 @@ private
         reply[:message]=REXML::XPath.first(node, '//ewayTrxnError').text
         reply[:success]=(REXML::XPath.first(node, '//ewayTrxnStatus').text == 'True')
         reply[:auth_code]=REXML::XPath.first(node, '//ewayAuthCode').text
+        reply[:transaction_number]=REXML::XPath.first(node, '//ewayTrxnNumber').text        
         reply
       end
       

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -79,6 +79,7 @@ class EwayManagedTest < Test::Unit::TestCase
     assert_equal "00,Transaction Approved(Test Gateway)", response.message
     assert_success response
     assert_equal "123456", response.authorization
+    assert_equal "123456", response.params['transaction_number']
     assert response.test?
   end
   


### PR DESCRIPTION
The eWay ManagedPayment Payment response also sends a transaction number in the field "ewayTrxnNumber" as per token API docs: http://www.eway.com.au/_Files/documentation/Token%20Payments%20Field%20Description.pdf

Let's send this back with the response so we can record it.
