### PR TITLE
NoChex: Update the URL that payment requests are posted to.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 = ActiveMerchant CHANGELOG
 
+* NoChex: Update the URL that payment requests are posted to [caseywhalen]
+
 == Version 1.17.0 (August 23, 2011)
 
 * Add Payflow Link integration [jduff]

--- a/lib/active_merchant/billing/integrations/nochex.rb
+++ b/lib/active_merchant/billing/integrations/nochex.rb
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
         
        
         mattr_accessor :service_url
-        self.service_url = 'https://www.nochex.com/nochex.dll/checkout'
+        self.service_url = 'https://secure.nochex.com'
 
         mattr_accessor :notification_confirmation_url
         self.notification_confirmation_url = 'https://www.nochex.com/nochex.dll/apc/apc'


### PR DESCRIPTION
This patch addresses recent changes made to NoChex.

Assistly Case:
https://shopify.assistly.com/agent/case/54825

@jduff
