### PR TITLE
Braintree: handle gateway_rejected transactions gracefully

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
         Braintree::Configuration.merchant_id = options[:merchant_id]
         Braintree::Configuration.public_key = options[:public_key]
         Braintree::Configuration.private_key = options[:private_key]
-        Braintree::Configuration.environment = test? ? :sandbox : :production
+        Braintree::Configuration.environment = (options[:environment] || (test? ? :sandbox : :production)).to_sym
         Braintree::Configuration.logger.level = Logger::ERROR if Braintree::Configuration.logger
         Braintree::Configuration.custom_user_agent = "ActiveMerchant #{ActiveMerchant::VERSION}"
         super
@@ -175,7 +175,11 @@ module ActiveMerchant #:nodoc:
               :postal_match => result.transaction.avs_postal_code_response_code
             }
             response_options[:cvv_result] = result.transaction.cvv_response_code
-            message = "#{result.transaction.processor_response_code} #{result.transaction.processor_response_text}"
+            if result.transaction.status == "gateway_rejected"
+              message = "Transaction declined - gateway rejected"
+            else
+              message = "#{result.transaction.processor_response_code} #{result.transaction.processor_response_text}"
+            end
           else
             message = message_from_result(result)
           end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -43,6 +43,11 @@ braintree_blue:
   public_key: Y
   private_key: Z
   
+braintree_blue_with_processing_rules:
+  merchant_id: X
+  public_key: Y
+  private_key: Z
+
 #Username/Password given in sign up email. Not MMS credentials
 card_save:
   login: merchant_id


### PR DESCRIPTION
We made a change to the Braintree Blue integration.  Previously, transactions that were accepted by the processor but rejected at the gateway (due to processing rules) were returning the processor's response code (1000 - Approved).  This patch sets a message on such transactions indicating that the transaction was declined at the gateway.  Please let us know if you have any questions.  Thank you!
