### PR TITLE
Adding WEB echeck_type

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -75,7 +75,8 @@ module ActiveMerchant #:nodoc:
       
       ECHECK_TYPES = {
         :ccd => 'CCD',
-        :ppd => 'PPD'
+        :ppd => 'PPD',
+        :web => 'WEB'
       }
       
       self.homepage_url = 'http://www.authorize.net/'


### PR DESCRIPTION
The existing echeck_types, PPD and CCD are not suitable for e-commerce applications.

In particular, http://www.authorize.net/files/echecknetuserguide.pdf states
    "For PPD transactions, the customer’s payment authorization may NOT be received via telephone or the Internet. "

and CCD is for corporate accounts only, requiring "An authorization agreement from the corporate customer is required for CCD transactions. " where the authorization agreement requires a signature.

So the only echeck_type that is suitable for personal accounts, initiated online, is WEB.  
