### PR TITLE
Authorize.net CIM Fixes

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -94,6 +94,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:login</tt> -- The Authorize.Net API Login ID (REQUIRED)
       # * <tt>:password</tt> -- The Authorize.Net Transaction Key. (REQUIRED)
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server. 
+      # * <tt>:delimiter</tt> -- The delimiter used in the direct response.  Default is ',' (comma).
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
         requires!(options, :login, :password)
@@ -108,11 +109,28 @@ module ActiveMerchant #:nodoc:
       # It is *CRITICAL* that you save this ID. There is no way to retrieve this through the API. You will not 
       # be able to create another Customer Profile with the same information.
       #
-      # ==== Options
+      # 
       #
-      # TODO
+      # ==== Options
+      # 
+      # * <tt>:profile</tt> -- A hash containing at least one of the CONDITIONAL profile options below (REQUIRED)
+      #
+      # ==== Profile
+      #
+      # * <tt>:email</tt> -- Email address associated with the customer profile (CONDITIONAL)
+      # * <tt>:description</tt> -- Description of the customer or customer profile (CONDITIONAL)
+      # * <tt>:merchant_customer_id</tt> -- Merchant assigned ID for the customer (CONDITIONAL)
+      # * <tt>:payment_profile</tt> -- A hash containing the elements of the new payment profile (optional)
+      #
+      # ==== Payment Profile
+      #
+      # * <tt>:payment</tt> -- A hash containing information on payment. Either :credit_card or :bank_account (optional)
       def create_customer_profile(options)
-        # TODO Add requires
+        requires!(options, :profile)
+        requires!(options[:profile], :email) unless options[:profile][:merchant_customer_id] || options[:profile][:description]
+        requires!(options[:profile], :description) unless options[:profile][:email] || options[:profile][:merchant_customer_id]
+        requires!(options[:profile], :merchant_customer_id) unless options[:profile][:description] || options[:profile][:email]
+          
         request = build_request(:create_customer_profile, options)
         commit(:create_customer_profile, request)
       end
@@ -469,6 +487,12 @@ module ActiveMerchant #:nodoc:
 
         xml.tag!('validationMode', CIM_VALIDATION_MODES[options[:validation_mode]]) if options[:validation_mode]
 
+        if options.has_key?(:payment_profile)
+          xml.tag!('paymentProfile') do
+            add_payment_profile(xml, options[:payment_profile])
+          end
+        end
+        
         xml.target!
       end
 
@@ -759,24 +783,23 @@ module ActiveMerchant #:nodoc:
         message = response_params['messages']['message']['text']
         test_mode = test? || message =~ /Test Mode/
         success = response_params['messages']['result_code'] == 'Ok'
+        response_params['direct_response'] = parse_direct_response(response_params['direct_response']) if response_params['direct_response']
+        transaction_id = response_params['direct_response']['transaction_id'] if response_params['direct_response']
 
-        response = Response.new(success, message, response_params,
+        Response.new(success, message, response_params,
           :test => test_mode,
-          :authorization => response_params['customer_profile_id'] || (response_params['profile'] ? response_params['profile']['customer_profile_id'] : nil)
+          :authorization => transaction_id || response_params['customer_profile_id'] || (response_params['profile'] ? response_params['profile']['customer_profile_id'] : nil)
         )
-        
-        response.params['direct_response'] = parse_direct_response(response) if response.params['direct_response']
-        response
       end
       
       def tag_unless_blank(xml, tag_name, data)
         xml.tag!(tag_name, data) unless data.blank? || data.nil?
       end
 
-      def parse_direct_response(response)
-        direct_response = {'raw' => response.params['direct_response']}
-        direct_response_fields = response.params['direct_response'].split(',')
-
+      def parse_direct_response(params)
+        delimiter = @options[:delimiter] || ','
+        direct_response = {'raw' => params}
+        direct_response_fields = params.split(delimiter)
         direct_response.merge(
           {
             'response_code' => direct_response_fields[0],
@@ -818,7 +841,14 @@ module ActiveMerchant #:nodoc:
             'purchase_order_number' => direct_response_fields[36],
             'md5_hash' => direct_response_fields[37],
             'card_code' => direct_response_fields[38],
-            'cardholder_authentication_verification_response' => direct_response_fields[39]
+            'cardholder_authentication_verification_response' => direct_response_fields[39],
+            # The following direct response fields are only available in version 3.1 of the
+            # transaction response.  Check your merchant account settings for details.
+            'account_number' => direct_response_fields[50] || '',
+            'card_type' => direct_response_fields[51] || '',
+            'split_tender_id' => direct_response_fields[52] || '',
+            'requested_amount' => direct_response_fields[53] || '',
+            'balance_on_card' => direct_response_fields[54] || '',
           }
         )
       end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -96,7 +96,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal "This transaction has been approved.", response.params['direct_response']['message']
     assert response.params['direct_response']['approval_code'] =~ /\w{6}/
     assert_equal "auth_only", response.params['direct_response']['transaction_type']
@@ -119,7 +119,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal "This transaction has been approved.", response.params['direct_response']['message']
     assert_equal approval_code, response.params['direct_response']['approval_code']
     assert_equal "capture_only", response.params['direct_response']['transaction_type']
@@ -149,7 +149,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal "This transaction has been approved.", response.params['direct_response']['message']
     assert response.params['direct_response']['approval_code'] =~ /\w{6}/
     assert_equal "auth_capture", response.params['direct_response']['transaction_type']
@@ -454,7 +454,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal "This transaction has been approved.", response.params['direct_response']['message']
   end
 
@@ -511,7 +511,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
@@ -568,7 +568,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
     return response
   end
@@ -638,7 +638,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal "This transaction has been approved.", response.params['direct_response']['message']
     assert response.params['direct_response']['approval_code'] =~ /\w{6}/
     assert_equal "auth_capture", response.params['direct_response']['transaction_type']
@@ -673,7 +673,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert response.params['direct_response']['approval_code'] =~ /\w{6}/
     assert_equal "auth_only", response.params['direct_response']['transaction_type']
     assert_equal "100.00", response.params['direct_response']['amount']

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -112,7 +112,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
     assert_equal 'auth_only', response.params['direct_response']['transaction_type']
     assert_equal 'Gw4NGI', approval_code = response.params['direct_response']['approval_code']
@@ -168,7 +168,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
@@ -190,8 +190,75 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
+  end
+
+  def test_should_create_customer_profile_transaction_auth_capture_request_for_version_3_1
+    @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_capture_version_3_1))
+
+    assert response = @gateway.create_customer_profile_transaction(
+      :transaction => {
+        :customer_profile_id => @customer_profile_id,
+        :customer_payment_profile_id => @customer_payment_profile_id,
+        :type => :auth_capture,
+        :order => {
+          :invoice_number => '1234',
+          :description => 'Test Order Description',
+          :purchase_order_number => '4321'
+        },
+        :amount => @amount
+      }
+    )
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
+    assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
+    assert_equal 'auth_capture', response.params['direct_response']['transaction_type']
+    assert_equal 'CSYM0K', approval_code = response.params['direct_response']['approval_code']
+    assert_equal '2163585627', response.params['direct_response']['transaction_id']
+
+    assert_equal '1', response.params['direct_response']['response_code']
+    assert_equal '1', response.params['direct_response']['response_subcode']
+    assert_equal '1', response.params['direct_response']['response_reason_code']
+    assert_equal 'Y', response.params['direct_response']['avs_response']
+    assert_equal '1234', response.params['direct_response']['invoice_number']
+    assert_equal 'Test Order Description', response.params['direct_response']['order_description']
+    assert_equal '100.00', response.params['direct_response']['amount']
+    assert_equal 'CC', response.params['direct_response']['method']
+    assert_equal 'Up to 20 chars', response.params['direct_response']['customer_id']
+    assert_equal '', response.params['direct_response']['first_name']
+    assert_equal '', response.params['direct_response']['last_name']
+    assert_equal 'Widgets Inc', response.params['direct_response']['company']
+    assert_equal '1234 My Street', response.params['direct_response']['address']
+    assert_equal 'Ottawa', response.params['direct_response']['city']
+    assert_equal 'ON', response.params['direct_response']['state']
+    assert_equal 'K1C2N6', response.params['direct_response']['zip_code']
+    assert_equal 'CA', response.params['direct_response']['country']
+    assert_equal '', response.params['direct_response']['phone']
+    assert_equal '', response.params['direct_response']['fax']
+    assert_equal 'Up to 255 Characters', response.params['direct_response']['email_address']
+    assert_equal '', response.params['direct_response']['ship_to_first_name']
+    assert_equal '', response.params['direct_response']['ship_to_last_name']
+    assert_equal '', response.params['direct_response']['ship_to_company']
+    assert_equal '', response.params['direct_response']['ship_to_address']
+    assert_equal '', response.params['direct_response']['ship_to_city']
+    assert_equal '', response.params['direct_response']['ship_to_state']
+    assert_equal '', response.params['direct_response']['ship_to_zip_code']
+    assert_equal '', response.params['direct_response']['ship_to_country']
+    assert_equal '', response.params['direct_response']['tax']
+    assert_equal '', response.params['direct_response']['duty']
+    assert_equal '', response.params['direct_response']['freight']
+    assert_equal '', response.params['direct_response']['tax_exempt']
+    assert_equal '4321', response.params['direct_response']['purchase_order_number']
+    assert_equal '02DFBD7934AD862AB16688D44F045D31', response.params['direct_response']['md5_hash']
+    assert_equal '', response.params['direct_response']['card_code']
+    assert_equal '2', response.params['direct_response']['cardholder_authentication_verification_response']
+    assert_equal 'XXXX4242', response.params['direct_response']['account_number']
+    assert_equal 'Visa', response.params['direct_response']['card_type']
+    assert_equal '', response.params['direct_response']['split_tender_id']
+    assert_equal '', response.params['direct_response']['requested_amount']
+    assert_equal '', response.params['direct_response']['balance_on_card']
   end
 
   def test_should_delete_customer_profile_request
@@ -321,7 +388,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
@@ -367,7 +434,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
     return response
   end
@@ -445,7 +512,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
@@ -461,7 +528,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
@@ -505,7 +572,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     )
     assert_instance_of Response, response
     assert_success response
-    assert_nil response.authorization
+    assert_equal response.authorization, response.params['direct_response']['transaction_id']
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
     return response
   end
@@ -816,7 +883,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     :auth_capture => '1,1,1,This transaction has been approved.,d1GENk,Y,508223661,32968c18334f16525227,Store purchase,1.00,CC,auth_capture,,Longbob,Longsen,,,,,,,,,,,,,,,,,,,,,,,269862C030129C1173727CC10B1935ED,P,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
     :void => '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,void,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
     :refund => '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,refund,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :prior_auth_capture => '1,1,1,This transaction has been approved.,VR0lrD,P,2149227870,1245958544,,1.00,CC,prior_auth_capture,1245958544,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,0B8BFE0A0DE6FDB69740ED20F79D04B0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,'
+    :prior_auth_capture => '1,1,1,This transaction has been approved.,VR0lrD,P,2149227870,1245958544,,1.00,CC,prior_auth_capture,1245958544,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,0B8BFE0A0DE6FDB69740ED20F79D04B0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    :auth_capture_version_3_1 => '1,1,1,This transaction has been approved.,CSYM0K,Y,2163585627,1234,Test Order Description,100.00,CC,auth_capture,Up to 20 chars,,,Widgets Inc,1234 My Street,Ottawa,ON,K1C2N6,CA,,,Up to 255 Characters,,,,,,,,,,,,,4321,02DFBD7934AD862AB16688D44F045D31,,2,,,,,,,,,,,XXXX4242,Visa,,,,,,,,,,,,,,,,'
   }
   UNSUCCESSUL_DIRECT_RESPONSE = {
     :refund => '3,2,54,The referenced transaction does not meet the criteria for issuing a credit.,,P,0,,,1.00,CC,credit,1245952682,,,Widgets Inc,1245952682 My Street,Ottawa,ON,K1C2N6,CA,,,bob1245952682@email.com,,,,,,,,,,,,,,207BCBBF78E85CF174C87AE286B472D2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,447250,406104'


### PR DESCRIPTION
I've done some maintenance and added some documentation to make the Authorize.net CIM gateway a bit more usable for me and can hopefully benefit others as well.  Here are the things I have added in these commits:
- Added an option when initializing the gateway to optionally override the default direct_response delimiter of ',' (comma)
- Added additional fields to be parsed in the direct response for Authorize.net's Transaction Version 3.1.  These fields include things such as card_type and account_number (masked) to be returned with the response.  It is completely backwards compatible to version 3.0 (all tests still pass with additional tests added for new direct_response type).
- Added requires to create_customer_profile as previously marked by a "TODO add requires" in accordance with the Authorize.net CIM XML Guide.  Added documentation to match.
- Refactored Response.authorization to not be nil when returning a processed transaction response and a gateway transaction_id exists.  It now returns that transaction_id as the authorization in the response.  Modified tests to account for this response.
