### PR TITLE
Ogone: Add support for custom currency at Gateway level. Helped by @rymai

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -195,7 +195,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_money(post, money, options)
-        add_pair post, 'currency', options[:currency] || currency(money)
+        add_pair post, 'currency', options[:currency] || @options[:currency] || currency(money)
         add_pair post, 'amount',   amount(money)
       end
 

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -10,7 +10,8 @@ class RemoteOgoneTest < Test::Unit::TestCase
     @options = {
       :order_id => generate_unique_id[0...30],
       :billing_address => address,
-      :description => 'Store Purchase'
+      :description => 'Store Purchase',
+      :currency => fixtures(:ogone)[:currency] || 'EUR'
     }
   end
 
@@ -18,8 +19,9 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert_equal @options[:currency], response.params["currency"]
   end
-  
+
   def test_successful_with_non_numeric_order_id
     @options[:order_id] = "##{@options[:order_id][0...26]}.12"
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -32,6 +34,26 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+  end
+
+  # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
+  #       section of your account admin on https://secure.ogone.com/ncol/test/frame_ogone.asp before running this test
+  def test_successful_purchase_with_custom_currency_at_the_gateway_level
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(:currency => 'USD'))
+    assert response = gateway.purchase(@amount, @credit_card)
+    assert_success response
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert_equal "USD", response.params["currency"]
+  end
+
+  # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
+  #       section of your account admin on https://secure.ogone.com/ncol/test/frame_ogone.asp before running this test
+  def test_successful_purchase_with_custom_currency
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(:currency => 'EUR'))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
+    assert_success response
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert_equal "USD", response.params["currency"]
   end
 
   def test_unsuccessful_purchase

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -17,7 +17,7 @@ class OgoneTest < Test::Unit::TestCase
       :description => 'Store Purchase'
     }
   end
-  
+
   def teardown
     Base.mode = :test
   end
@@ -93,16 +93,16 @@ class OgoneTest < Test::Unit::TestCase
     assert_failure response
     assert response.test?
   end
-  
+
   def test_create_readable_error_message_upon_failure
     @gateway.expects(:ssl_post).returns(test_failed_authorization_due_to_unknown_order_number)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert response.test?
-    
+
     assert_equal "Unknown order", response.message
   end
-  
+
   def test_supported_countries
     assert_equal ['BE', 'DE', 'FR', 'NL', 'AT', 'CH'], OgoneGateway.supported_countries
   end
@@ -113,6 +113,28 @@ class OgoneTest < Test::Unit::TestCase
 
   def test_default_currency
     assert_equal 'EUR', OgoneGateway.default_currency
+
+    gateway = OgoneGateway.new(@credentials)
+    gateway.expects(:add_pair).at_least(1)
+    gateway.expects(:add_pair).with(anything, 'currency', 'EUR')
+    gateway.expects(:ssl_post).returns(successful_purchase_response)
+    gateway.purchase(@amount, @credit_card, @options)
+  end
+
+  def test_custom_currency_at_gateway_level
+    gateway = OgoneGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway.expects(:add_pair).at_least(1)
+    gateway.expects(:add_pair).with(anything, 'currency', 'USD')
+    gateway.expects(:ssl_post).returns(successful_purchase_response)
+    gateway.purchase(@amount, @credit_card, @options)
+  end
+
+  def test_local_custom_currency_overwrite_gateway_level
+    gateway = OgoneGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway.expects(:add_pair).at_least(1)
+    gateway.expects(:add_pair).with(anything, 'currency', 'EUR')
+    gateway.expects(:ssl_post).returns(successful_purchase_response)
+    gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'EUR'))
   end
 
   def test_avs_result
@@ -126,7 +148,7 @@ class OgoneTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card)
     assert_equal 'P', response.cvv_result['code']
   end
-  
+
   def test_production_mode
     Base.mode = :production
     gateway = OgoneGateway.new(@credentials)
@@ -139,19 +161,19 @@ class OgoneTest < Test::Unit::TestCase
     gateway = OgoneGateway.new(@credentials)
     assert gateway.test?
   end
-  
+
   def test_format_error_message_with_slash_separator
     @gateway.expects(:ssl_post).returns('<ncresponse NCERRORPLUS="unknown order/1/i/67.192.100.64" STATUS="0" />')
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal "Unknown order", response.message
   end
-  
+
   def test_format_error_message_with_pipe_separator
     @gateway.expects(:ssl_post).returns('<ncresponse NCERRORPLUS=" no card no|no exp date|no brand" STATUS="0" />')
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal "No card no, no exp date, no brand", response.message
   end
-  
+
   def test_format_error_message_with_no_separator
     @gateway.expects(:ssl_post).returns('<ncresponse NCERRORPLUS=" unknown order " STATUS="0" />')
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -163,7 +185,7 @@ class OgoneTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Hash, response.params
   end
-  
+
   private
 
   def successful_authorize_response
@@ -310,7 +332,7 @@ class OgoneTest < Test::Unit::TestCase
     </ncresponse>
     END
   end
-  
+
   def test_failed_authorization_due_to_unknown_order_number
     <<-END
     <?xml version="1.0"?>
@@ -326,7 +348,7 @@ class OgoneTest < Test::Unit::TestCase
     currency="EUR"
     PM=""
     BRAND="">
-    </ncresponse>    
+    </ncresponse>
     END
   end
 


### PR DESCRIPTION
Following the pull request #198 here is the second patch, adding support for custom currency at Gateway level. For Ogone gateway.
