### PR TITLE
[bugfix] Authorize.net CIM refund with :order => {} generates XSD validation error

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -624,7 +624,7 @@ module ActiveMerchant #:nodoc:
                 xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
                 xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
             end
-            add_order(xml, transaction[:order]) if transaction[:order]
+            add_order(xml, transaction[:order]) if transaction[:order].present?
           end
         end
       end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -536,6 +536,28 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal 'The referenced transaction does not meet the criteria for issuing a credit.', response.params['direct_response']['message']
   end
 
+  def test_should_create_customer_profile_transaction_auth_capture_and_then_refund_using_profile_ids_request_with_empty_order
+    response = get_and_validate_auth_capture_response
+
+    assert response = @gateway.create_customer_profile_transaction(
+      :transaction => {
+        :type => :refund,
+        :amount => 1,
+        :customer_profile_id => @customer_profile_id,
+        :customer_payment_profile_id => @customer_payment_profile_id,
+        :trans_id => response.params['direct_response']['transaction_id'],
+        :order => {}
+      }
+    )
+    assert_instance_of Response, response
+    # You can't test refunds in TEST MODE.  If you authorize or capture
+    # a transaction, and the transaction is not yet settled by the payment
+    # gateway, you cannot issue a refund. You get an error message
+    # saying "The referenced transaction does not meet the criteria for issuing a credit.".
+    assert_failure response
+    assert_equal 'The referenced transaction does not meet the criteria for issuing a credit.', response.message
+  end
+
   def test_should_create_customer_profile_transaction_auth_capture_and_then_refund_using_masked_credit_card_request
     response = get_and_validate_auth_capture_response
 


### PR DESCRIPTION
Fix bug where passing an empty hash to the order attribute would create an XSD validation error. If the order attribute is empty, it should simply be omitted.
