### PR TITLE
Bug fix #230 - Add rubigen to the gemspec

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('braintree', '>= 2.0.0')
   s.add_dependency('json', '>= 1.5.1') if RUBY_VERSION =~ /^1\.8\./
   s.add_dependency('active_utils', '>= 1.0.1')
+  s.add_dependency('rubigen')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
Rubigen is required for `script/generate gateway foobar_stream`, when generating a gateway skeleton. From step 2 of the [Contributing wiki page](https://github.com/Shopify/active_merchant/wiki/contributing).
