### PR TITLE
Barclays epdq gateway updates

### DIFF
--- a/lib/active_merchant/billing/gateways/barclays_epdq.rb
+++ b/lib/active_merchant/billing/gateways/barclays_epdq.rb
@@ -260,7 +260,6 @@ module ActiveMerchant #:nodoc:
               else
                 xml.Cvv2Indicator 5
               end
-              xml.IssueNum(creditcard.issue_number) if creditcard.issue_number.present?
             end
           end
         end
@@ -304,4 +303,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-


### PR DESCRIPTION
Should no longer deal with Solo/Switch or collect start date / issue number for UK maestro cards.
