### PR TITLE
Added support for MyGate payment gateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/my_gate.rb
+++ b/lib/active_merchant/billing/gateways/my_gate.rb
@@ -1,0 +1,497 @@
+require File.dirname(__FILE__) + '/my_gate/security_pre_auth_response'
+require File.dirname(__FILE__) + '/my_gate/security_auth_response'
+require File.dirname(__FILE__) + '/my_gate/response'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # MyGate is a South African payment solutions company providing a Payment Gateway.
+    # 
+    # For more information on the MyGate Payment Gateway please visit the {product page}[http://mygate.co.za/products/payment-gateway].
+    # 
+    # The process for transacting with MyGate is as follows:
+    # 
+    # * Once you receive the credit card details run a <tt>security_pre_auth</tt> on the MyGateGateway instance.
+    #   This will tell you whether the user is registered for 3D-Secure and if so, where to redirect them
+    #   in order for them to enter their PIN.
+    # * If they are enrolled redirect them to the <tt>acs_url</tt> provided by POSTing the paramaters
+    #   documented in +MyGate::SecurityPreAuthResponse+.
+    # * Once they successfully enter their PIN they will be redirected to the URL you provided which
+    #   should point to a controller that passes the params directly to <tt>process_acs</tt>. This will
+    #   authenticate what they entered into 3D-Secure with MyGate.
+    # * If this is successful or if they weren't enrolled you should now have a valid <tt>transaction_index</tt>
+    #   in order to submit the <tt>purchase</tt> or other transaction much like other gateways.
+    # 
+    # Please take note that some of the responses have slightly modified behaviour, e.g. <tt>purchase</tt>
+    # returns an <tt>Array</tt> of authorizations as it effectively does an <tt>authorize</tt> and <tt>capture</tt>
+    # on the MyGate platform. Also the <tt>transaction_index</tt> is used as the authorization for captures, 
+    # not the <tt>authorization</tt> Array.
+    class MyGateGateway < Gateway
+      
+      # This is the version of the API the gateway is implemented against
+      API_VERSION = '5.0.0'
+      def self.api_version; API_VERSION.gsub '.', 'x'; end #:nodoc:
+      
+      # # # # # # # # # # # # # # # # # # # # # #
+      #                Constants                #
+      # # # # # # # # # # # # # # # # # # # # # #
+      
+      # The location of the web services required to interact with MyGate
+      URLS = {
+        :three_d_secure => 'https://www.mygate.co.za/3dsecure/3DSecure.cfc',
+        :transaction => "https://www.mygate.co.za/enterprise/#{api_version}/ePayService.cfc",
+        :immediate_settlement => "https://www.mygate.co.za/enterprise/#{api_version}/ePayWebService.cfc"
+      }
+      
+      # Used to map actions to the various Web Services
+      SERVICES = {
+        :security_pre_auth => :three_d_secure,
+        :security_auth     => :three_d_secure,
+        :authorize         => :transaction,
+        :void              => :transaction,
+        :capture           => :transaction,
+        :refund            => :transaction,
+        :purchase          => :immediate_settlement
+      }
+      
+      # Used to list the supported cards and map them to the codes used by MyGate
+      CARD_TYPES = {
+        :american_express => '1',
+        :discover         => '2',
+        :master           => '3',
+        :visa             => '4',
+        :diners_club      => '5'
+      }
+      
+      # Used to map the bank name where the merchant account is kept to a code for use by MyGate
+      MERCHANT_GATEWAYS = {
+        :fnb_live       => '21',
+        :absa           => '22',
+        :nedbank        => '23',
+        :standard_bank  => '24'
+      }
+      
+      # Used to map the transaction types to codes used by MyGate
+      ACTIONS = {
+        :authorize          => '1',
+        :reverse_authorize  => '2',
+        :settlement         => '3',
+        :refund             => '4'
+      }
+      SOAP_ACTIONS = {
+        :security_pre_auth  => 'lookup',
+        :security_auth      => 'authenticate',
+        :authorize          => 'fProcess',
+        :capture            => 'fProcess',
+        :reverse_authorize  => 'fProcess',
+        :settlement         => 'fProcess',
+        :refund             => 'fProcess',
+        :purchase           => ''
+      }
+      
+      # # # # # # # # # # # # # # # # # # # # # #
+      #              Configuration              #
+      # # # # # # # # # # # # # # # # # # # # # #
+      
+      self.supported_countries = ['ZA']
+      self.supported_cardtypes = CARD_TYPES.keys
+      self.homepage_url = 'http://mygate.co.za/'
+      self.display_name = 'MyGate'
+      self.default_currency = 'ZAR'
+      
+      # Creates a new MyGateGateway
+      #
+      # Unlike other gateways you are required to pass the following in the options hash:
+      # 
+      # ==== Options
+      #
+      # * <tt>:gateway_id</tt> -- The bank where the merchant account is kept. Must be one of the following: 
+      #                           <tt><:fnb_live/tt>, <tt>:absa</tt>, <tt>:nedbank</tt> or <tt>:standard_bank</tt> (REQUIRED)
+      # * <tt>:application_id</tt> -- The MyGate Application ID. Looks like: +4b775479-a264-444c-b774-22d5521852d8+ (REQUIRED)
+      # * <tt>:merchant_id</tt> -- The MyGate Merchant ID. Looks like: +79958a8d-0c7b-4038-8e2e-8948e1d678e1+ (REQUIRED)
+      # 
+      def initialize(options = {})
+        requires!(options, :merchant_id, :application_id, :gateway)
+        @options = options
+        super
+      end
+      
+      # # # # # # # # # # # # # # # # # # # # # #
+      # Specialized Methods for Authentication  #
+      # # # # # # # # # # # # # # # # # # # # # #
+      
+      # This method is called to initiate the 3D-Secure verification process. It is the
+      # first in a 3 step process to obtain a TransactionIndex which MyGate requires
+      # for the regular gateway actions.
+      # 
+      # This method returns a <tt>MyGate::SecurityPreAuthResponse</tt> object which will
+      # contain the parameters which should be used when posted to the 3D-Secure server.
+      # See that class for documentation.
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>money</tt> -- The amount to be purchased as an Integer value in cents.
+      # * <tt>creditcard</tt> -- The CreditCard details for the transaction.
+      # * <tt>options</tt> -- A hash of optional parameters.
+      # 
+      # ==== Required Options
+      # 
+      # * <tt>:user_agent</tt> -- The user agent of the user's browser.
+      # * <tt>:http_accept</tt> -- The HTTPAccept header sent by the user's browser. (use '*/*' if unsure)
+      # 
+      def security_pre_auth(money, creditcard, options = {})
+        requires!(options, :user_agent, :http_accept)
+        
+        options.reverse_merge(:recurring => 'N') # defaults
+        
+        xml = Builder::XmlMarkup.new(:indent => 2, :margin => 3)
+        
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        add_field_to xml, 'Mode', test? ? '0' : '1'
+        
+        add_field_to xml, 'PAN', creditcard.number
+        add_field_to xml, 'PANExpr', "#{format(creditcard.year, :two_digits)}#{format(creditcard.month, :two_digits)}"
+        add_field_to xml, 'PurchaseAmount', amount(money)
+        
+        add_field_to xml, 'UserAgent', options[:user_agent]
+        add_field_to xml, 'BrowserHeader', options[:http_accept]
+        
+        add_field_to xml, 'OrderNumber', options[:order_id]
+        add_field_to xml, 'OrderDesc', options[:description]
+        
+        add_field_to xml, 'Recurring', options[:recurring]
+        add_field_to xml, 'RecurringFrequency', options[:recurring_day]
+        add_field_to xml, 'RecurringEnd', options[:recurring_end]
+        add_field_to xml, 'Installment', options[:installment]
+        
+        MyGate::SecurityPreAuthResponse.new commit(:security_pre_auth, xml.target!)
+      end
+      
+      # Process the response from the ACS service and verify it with MyGate
+      # 
+      # This method should be called in an action to which the ACS service posted
+      # its response. This action should have access to the original order information
+      # in order to retrieve the details of the transaction and process the transaction
+      # once the authentication has completed.
+      # 
+      # It returns a <tt>MyGate::SecurityAuthResponse</tt>.
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>params</tt> -- The params hash that the controller action received.
+      # * <tt>options</tt> -- Should contain the <tt>:transaction_index</tt> from the <tt>SecurityPreAuthResponse</tt>.
+      # 
+      def security_auth(params, options = {})
+        requires!(params, 'PaRes')
+        requires!(options, :transaction_index)
+        
+        xml = Builder::XmlMarkup.new(:indent => 2, :margin => 3)
+        
+        add_field_to xml, 'TransactionID', options[:transaction_index]
+        add_field_to xml, 'PAResPayload', params['PaRes']
+        
+        MyGate::SecurityAuthResponse.new commit(:security_auth, xml.target!)
+      end
+      
+      # # # # # # # # # # # # # # # # # # # # # #
+      #        Standard Gateway Functions       #
+      # # # # # # # # # # # # # # # # # # # # # #
+      
+      # Perform a purchase, which is essentially an authorization and capture in a single operation.
+      #
+      # ==== Parameters
+      # 
+      # * <tt>money</tt> -- the Integer amount to be purchased in cents
+      # * <tt>creditcard</tt> -- the CreditCard details for the transaction
+      # * <tt>options</tt> -- a Hash of optional parameters
+      # 
+      # ==== Required Options
+      # 
+      # <tt>transaction_index</tt> -- provided by 3D-Secure operation (required)
+      # 
+      def purchase(money, creditcard, options = {})
+        requires!(options, :transaction_index)
+        address = options[:shipping_address] || options[:address]
+        
+        xml = Builder::XmlMarkup.new :indent => 2, :margin => 3
+        
+        add_field_to xml, 'GatewayID', MERCHANT_GATEWAYS[@options[:gateway].to_sym]
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        
+        add_field_to xml, 'TransactionIndex', options[:transaction_index]
+        add_field_to xml, 'Terminal', options[:merchant] || application_id
+        add_field_to xml, 'Mode', test? ? 0 : 1
+        add_field_to xml, 'MerchantReference', options[:order_id]
+        add_field_to xml, 'Amount', amount(money)
+        add_field_to xml, 'Currency', options[:currency] || currency(money)
+        add_field_to xml, 'CashBackAmount'
+        add_field_to xml, 'CardType', CARD_TYPES[creditcard.type.to_sym]
+        add_field_to xml, 'AccountType'
+        add_field_to xml, 'CardNumber', creditcard.number
+        add_field_to xml, 'CardHolder', creditcard.name || options[:customer]
+        add_field_to xml, 'CVVNumber', creditcard.verification_value
+        add_field_to xml, 'ExpiryMonth', format(creditcard.month, :two_digits)
+        add_field_to xml, 'ExpiryYear', format(creditcard.year, :four_digits)
+        add_field_to xml, 'Budget'
+        add_field_to xml, 'BudgetPeriod'
+        add_field_to xml, 'AuthorisationNumber'
+        add_field_to xml, 'PIN'
+        add_field_to xml, 'DebugMode'
+        add_field_to xml, 'eCommerceIndicator'
+        add_field_to xml, 'verifiedByVisaXID', options[:xid]
+        add_field_to xml, 'verifiedByVisaCAFF', options[:caff]
+        add_field_to xml, 'secureCodeUCAF'
+        add_field_to xml, 'UCI'
+        add_field_to xml, 'IPAddress', options[:ip]
+        add_field_to xml, 'ShippingCountryCode', address && address[:country]
+        add_field_to xml, 'PurchaseItemsID'
+        
+        MyGate::Response.new(commit(:purchase, xml.target!), :test => test?)
+      end
+      
+      # Perform an authorization (see if the funds are available)
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>money</tt> -- the Integer amount to be purchased in cents
+      # * <tt>creditcard</tt> -- the CreditCard details for the transaction
+      # * <tt>options</tt> -- a Hash of optional parameters
+      # 
+      # ==== Required Options
+      # 
+      # <tt>transaction_index</tt> -- provided by 3D-Secure operation (required)
+      # 
+      def authorize(money, creditcard, options = {})
+        requires!(options, :transaction_index)
+        address = options[:shipping_address] || options[:address]
+        
+        xml = Builder::XmlMarkup.new :indent => 2, :margin => 3
+        
+        add_field_to xml, 'GatewayID', MERCHANT_GATEWAYS[@options[:gateway].to_sym]
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        
+        add_field_to xml, 'Action', ACTIONS[:authorize]
+        add_field_to xml, 'TransactionIndex', options[:transaction_index]
+        add_field_to xml, 'Terminal', options[:merchant] || application_id
+        add_field_to xml, 'Mode', (test? ? '0' : '1')
+        add_field_to xml, 'MerchantReference', options[:order_id]
+        add_field_to xml, 'Amount', amount(money)
+        add_field_to xml, 'Currency', options[:currency] || currency(money)
+        add_field_to xml, 'CashBackAmount'
+        add_field_to xml, 'CardType', CARD_TYPES[creditcard.type.to_sym]
+        add_field_to xml, 'AccountType'
+        add_field_to xml, 'CardNumber', creditcard.number
+        add_field_to xml, 'CardHolder', creditcard.name || options[:customer]
+        add_field_to xml, 'CVVNumber', creditcard.verification_value
+        add_field_to xml, 'ExpiryMonth', format(creditcard.month, :two_digits)
+        add_field_to xml, 'ExpiryYear', format(creditcard.year, :four_digits)
+        add_field_to xml, 'Budget'
+        add_field_to xml, 'BudgetPeriod'
+        add_field_to xml, 'AuthorisationNumber'
+        add_field_to xml, 'PIN'
+        add_field_to xml, 'DebugMode'
+        add_field_to xml, 'eCommerceIndicator'
+        add_field_to xml, 'verifiedByVisaXID', options[:xid]
+        add_field_to xml, 'verifiedByVisaCAFF', options[:caff]
+        add_field_to xml, 'secureCodeUCAF'
+        add_field_to xml, 'UCI', options[:uci]
+        add_field_to xml, 'IPAddress', options[:ip]
+        add_field_to xml, 'ShippingCountryCode', address && address[:country]
+        add_field_to xml, 'PurchaseItemsID'
+        
+        MyGate::Response.new(commit(:authorize, xml.target!), :test => test?)
+      end
+      
+      # Reverse an authorization
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>amount</tt> -- the (currently optional) amount previously authorized
+      # * <tt>authorize_transaction_index</tt> -- the <tt>transaction_index</tt> from the authorization call
+      # * <tt>options</tt> -- a Hash of optional parameters
+      # 
+      def void(amount, authorize_transaction_index, options = {})
+        xml = Builder::XmlMarkup.new :indent => 2, :margin => 3
+        
+        add_field_to xml, 'GatewayID', MERCHANT_GATEWAYS[@options[:gateway].to_sym]
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        
+        add_field_to xml, 'Action', ACTIONS[:reverse_authorize]
+        add_field_to xml, 'TransactionIndex', authorize_transaction_index
+        add_field_to xml, 'Terminal', options[:merchant] || application_id
+        add_field_to xml, 'Mode' #, (test? ? '0' : '1') # Test mode causes warnings
+        add_field_to xml, 'MerchantReference', options[:order_id]
+        add_field_to xml, 'Amount'
+        
+        add_unused_action_fields_to xml, options[:ip]
+        
+        MyGate::Response.new(commit(:capture, xml.target!), :test => test?)
+      end
+      
+      # Perform a capture (transfer the funds)
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>money</tt> -- the Integer amount to be captured in cents
+      # * <tt>authorize_transaction_index</tt> -- the <tt>transaction_index</tt> from the <tt>authorize</tt> response
+      # * <tt>options</tt> -- a Hash of optional parameters
+      # 
+      def capture(money, authorize_transaction_index, options = {})
+        xml = Builder::XmlMarkup.new :indent => 2, :margin => 3
+        
+        add_field_to xml, 'GatewayID', MERCHANT_GATEWAYS[@options[:gateway].to_sym]
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        
+        add_field_to xml, 'Action', ACTIONS[:settlement]
+        add_field_to xml, 'TransactionIndex', authorize_transaction_index
+        add_field_to xml, 'Terminal', options[:merchant] || application_id
+        add_field_to xml, 'Mode' #, (test? ? '0' : '1') # Test mode causes warnings
+        add_field_to xml, 'MerchantReference', options[:order_id]
+        add_field_to xml, 'Amount', amount(money)
+        
+        add_unused_action_fields_to xml, options[:ip]
+        
+        MyGate::Response.new(commit(:capture, xml.target!), :test => test?)
+      end
+      
+      # Refund a customer for a specific capture
+      # 
+      # ==== Parameters
+      # 
+      # * <tt>money</tt> -- the Integer amount to be refunded in cents
+      # * <tt>capture_transaction_index</tt> -- the <tt>transaction_index</tt> that was returned by the <tt>capture</tt> and the <tt>authorize</tt> calls
+      # * <tt>options</tt> -- a Hash of optional parameters
+      # 
+      def refund(money, capture_transaction_index, options = {})
+        xml = Builder::XmlMarkup.new :indent => 2, :margin => 3
+        
+        add_field_to xml, 'GatewayID', MERCHANT_GATEWAYS[@options[:gateway].to_sym]
+        add_field_to xml, 'MerchantID', @options[:merchant_id]
+        add_field_to xml, 'ApplicationID', @options[:application_id]
+        
+        add_field_to xml, 'Action', ACTIONS[:refund]
+        add_field_to xml, 'TransactionIndex', capture_transaction_index
+        add_field_to xml, 'Terminal', options[:merchant] || application_id
+        add_field_to xml, 'Mode' #, (test? ? '0' : '1') # Test mode causes warnings
+        add_field_to xml, 'MerchantReference', options[:order_id]
+        add_field_to xml, 'Amount' #, amount(money) # Amount causes warnings
+        
+        add_unused_action_fields_to xml, options[:ip]
+        
+        MyGate::Response.new(commit(:capture, xml.target!), :test => test?)
+      end
+      
+      private
+      
+      # To remove some duplication that is semantically irrelevant
+      def add_unused_action_fields_to(xml, ip_address = nil)
+        add_field_to xml, 'Currency'
+        add_field_to xml, 'CashBackAmount'
+        add_field_to xml, 'CardType'
+        add_field_to xml, 'AccountType'
+        add_field_to xml, 'CardNumber'
+        add_field_to xml, 'CardHolder'
+        add_field_to xml, 'CVVNumber'
+        add_field_to xml, 'ExpiryMonth'
+        add_field_to xml, 'ExpiryYear'
+        add_field_to xml, 'Budget'
+        add_field_to xml, 'BudgetPeriod'
+        add_field_to xml, 'AuthorisationNumber'
+        add_field_to xml, 'PIN'
+        add_field_to xml, 'DebugMode'
+        add_field_to xml, 'eCommerceIndicator'
+        add_field_to xml, 'verifiedByVisaXID'
+        add_field_to xml, 'verifiedByVisaCAFF'
+        add_field_to xml, 'secureCodeUCAF'
+        add_field_to xml, 'UCI'
+        add_field_to xml, 'IPAddress', ip_address
+        add_field_to xml, 'ShippingCountryCode'
+        add_field_to xml, 'PurchaseItemsID'
+      end
+      
+      # This wraps the parameters for all the transactions into a SOAP wrapper to be sent to the web service
+      # 
+      # ==== Parameters
+      #
+      # * <tt>action</tt> -- The transaction type to build (matching the gateway actions) as a symbol.
+      # * <tt>body</tt> -- A Builder::XmlMarkup instance containing the tags to wrap in a SOAP envelope.
+      # 
+      def build_request(action, body)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.instruct!
+        xml.tag! 's:Envelope', { 'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/',
+                                 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 
+                                 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' } do
+          xml.tag! 's:Body', { 'xmlns:api' => namespace_from(action) } do
+            
+            xml.tag! "api:#{root_node_from(action)}" do
+              xml << body
+            end
+          end
+        end
+      end
+      
+      # Used internally to DRY up the process of adding parameters to the SOAP request.
+      # Calling it without a value will cause opening and closing tags to be present,
+      # but without any content. Many parameters are required to be sent in this way.
+      # 
+      # ==== Parameters
+      #
+      # * <tt>xml</tt> -- The Builder::XmlMarkup instance to add the tag to. (required)
+      # * <tt>field</tt> -- The name of the parameter as a string or symbol. (required)
+      # * <tt>value</tt> -- Optional String content of the tag.
+      # 
+      def add_field_to(xml, field, value = '')
+        xml.tag! field.to_s, { }, value
+      end
+      
+      # # # # # # # # # # # # # # # # # # # # # #
+      #           Gateway Communication         #
+      # # # # # # # # # # # # # # # # # # # # # #
+      
+      # Send the request to MyGate and parse a response
+      # 
+      # ==== Parameters
+      #
+      # * <tt>action</tt> -- The transaction type to build (matching the gateway actions) as a symbol.
+      # * <tt>body</tt> -- A Builder::XmlMarkup instance containing the tags to insert into the SOAP request.
+      # 
+      def commit(action, body, verbose_mode = false)
+        request = build_request(action, body)
+        puts "\n\n#{request}\n\n" if verbose_mode
+        url = URLS[SERVICES[action]]
+        response = ssl_post(url, request, {'Content-Type' => 'text/xml; charset=utf-8', 'SOAPAction' => SOAP_ACTIONS[action]})
+        puts "\n\n#{response}\n\n" if verbose_mode
+        response
+      end
+      
+      def root_node_from(action)
+        case action
+        when :purchase
+          'fProcessAndSettle'
+        when :security_pre_auth
+          'lookup'
+        when :security_auth
+          'authenticate'
+        else
+          'fProcess'
+        end
+      end
+      
+      def namespace_from(action)
+        case action
+        when :security_pre_auth, :security_auth
+          'http://_3dsecure'
+        else
+          "http://_#{self.class.api_version}.enterprise"
+        end
+      end
+      
+    end
+  end
+end
+

--- a/lib/active_merchant/billing/gateways/my_gate/response.rb
+++ b/lib/active_merchant/billing/gateways/my_gate/response.rb
@@ -1,0 +1,56 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module MyGate #:nodoc:
+      
+      # The MyGateGateway::Response class contains the result of an actual transaction response. 
+      # An object of this class is returned from MyGateGateway#authorize, MyGateGateway#capture 
+      # and MyGateGateway#purchase.
+      # 
+      # This class handles the XML parsing for the API request.
+      # 
+      # ==== Properties
+      # 
+      # <tt>success</tt>            : <tt>true</tt> if the service returned a Result of 0, <tt>false</tt> otherwise
+      # <tt>message</tt>            : a <tt>String</tt> message indicating the error or success message
+      # <tt>transaction_index</tt>  : the transaction index that MyGate returned as an uppercase <tt>String</tt>
+      # <tt>authorization</tt>      : an <tt>Array</tt> containing the AuthorisationIDs reutrned by the gateway
+      # <tt>xml</tt>                : the <tt>REXML::Document</tt> parsed from the response available for debugging
+      class Response < Billing::Response
+        
+        # The message that will be retrieved from the <tt>message</tt> attribute when successful.
+        SUCCESS = 'Transaction processed successfully'
+        
+        attr_reader :xml, :transaction_index
+        
+        def initialize(raw_xml, options = {})
+          @xml = REXML::Document.new(raw_xml)
+          
+          # Behave consistent with Billing::Response where possible
+          @test = options[:test] || false
+          @authorization = []
+          
+          # Parse both responses with the same class, since they are so similar
+          @xml.elements.each('//fProcessAndSettleReturn | //fProcessReturn') do |node|
+            key, *values = node.text.split '||'
+            case key
+            when 'Result'
+              @success = (values[0].to_i >= 0)
+              @message = SUCCESS if @success
+            when 'TransactionIndex'
+              @transaction_index = values[0].upcase
+            when 'AuthorisationID'
+              @authorization << values[0]
+            when 'Error'
+              @message = values.last
+            when 'Warning'
+              @message = "Warning: #{values.last}"
+            end
+          end unless xml.root.nil?
+          
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/my_gate/security_auth_response.rb
+++ b/lib/active_merchant/billing/gateways/my_gate/security_auth_response.rb
@@ -1,0 +1,65 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module MyGate #:nodoc:
+      
+      # An object of this class is returned from <tt>MyGateGateway#security_auth</tt>.
+      # This class handles the XML parsing for the API request.
+      # 
+      # ==== Properties
+      # 
+      # <tt>success</tt>                : <tt>true</tt> if the service returned a Result of 0
+      # <tt>pa_response_status</tt>     : <tt>true</tt> if the cardholder is enrolled for 3D-Secure, 
+      #                                   <tt>false</tt> if they are not enrolled and 
+      #                                   <tt>nil</tt> if the service returns 'undefined'
+      # <tt>signature_verfication</tt>  : a hash that needs to be POSTed to the ACS URL as PaReq
+      # <tt>eci</tt>                    : the ECI code
+      # <tt>xid</tt>                    : the XID code
+      # <tt>cavv</tt>                   : the CAVV code
+      # <tt>error_number</tt>           : the integer error code returned from MyGate if <tt>success</tt> is <tt>false</tt>
+      # <tt>error_description</tt>      : a description of the error associated with <tt>error_number</tt>
+      # 
+      # ==== Usage
+      # 
+      # Primarily used to confirm that the authentication was processed, but attributes 
+      # from this object is also used in the transaction request that follows it.
+      class SecurityAuthResponse
+        
+        attr_reader :success, :pa_response_status, :signature_verification, 
+                    :eci, :xid, :cavv, 
+                    :error_number, :error_description
+        
+        alias :success? :success # to make it behave a bit more like Billing::Response
+        
+        def initialize(raw_xml)
+          xml = REXML::Document.new raw_xml
+          
+          xml.elements.each('//authenticateReturn') do |node|
+            key, value = node.text.split '||'
+            case key
+            when 'Result'
+              @success = (value == '0')
+            when 'PAResStatus'
+              @pa_response_status = true  if value == 'Y'
+              @pa_response_status = false if value == 'N'
+              @pa_response_status = nil   if value == 'U'
+            when 'SignatureVerification'
+              @signature_verification = (value == 'Y')
+            when 'ECI'
+              @eci = value
+            when 'XID'
+              @xid = value
+            when 'Cavv'
+              @cavv = value
+            when 'ErrorNo'
+              @error_number = value.to_i
+            when 'ErrorDesc'
+              @error_description = value
+            end
+          end unless xml.root.nil?
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/my_gate/security_pre_auth_response.rb
+++ b/lib/active_merchant/billing/gateways/my_gate/security_pre_auth_response.rb
@@ -1,0 +1,71 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module MyGate #:nodoc:
+      
+      # An object of this class is returned from MyGateGateway#security_pre_auth.
+      # This class handles the XML parsing for the API request.
+      # 
+      # ==== Properties
+      # 
+      # <tt>success</tt>            : <tt>true</tt> if the service returned a Result of 0
+      # <tt>enrolled</tt>           : <tt>true</tt> if the cardholder is enrolled for 3D-Secure, 
+      #                               <tt>false</tt> if they are not enrolled and 
+      #                               <tt>nil</tt> if the service returns 'undefined'
+      # <tt>eci</tt>                : the ECI code (only present if thy are not enrolled)
+      # <tt>acs_url</tt>            : the URL to which the user should be redirected with a POST
+      # <tt>transaction_index</tt>  : the transaction index that needs to be POSTed to the ACS URL as TransactionIndex
+      # <tt>pa_request_message</tt> : a hash that needs to be POSTed to the ACS URL as PaReq
+      # <tt>error_number</tt>       : The integer error code returned from MyGate if <tt>success</tt> is <tt>false</tt>
+      # <tt>error_description</tt>  : A description of the error associated with <tt>error_number</tt>
+      # 
+      # ==== Usage
+      # 
+      # Once this object is obtained by calling MyGateGateway#security_pre_auth
+      # the user should be redirected to the <tt>acs_url</tt> with an HTTP POST
+      # containing the following paramters as per {the documentation}[http://mygate.co.za/images/PDFs/myenterprise_userguide.pdf]:
+      # 
+      # <tt>PaReq</tt> -- The <tt>pa_request_message</tt> received.
+      # <tt>TermUrl</tt> -- The URL where you want the user to be redirected to after authenticating.
+      #                     Configure a controller to receive the POST at this URL and pass the 
+      #                     params back into MyGateGateway#process_acs.
+      # <tt>TransactionIndex</tt> -- The <tt>transaction_index</tt> received.
+      class SecurityPreAuthResponse
+        
+        attr_reader :success, :enrolled, :transaction_index, :acs_url, :pa_request_message, :eci,
+                    :error_number, :error_description
+        
+        alias :success? :success # to make it behave a bit more like Billing::Response
+        
+        def initialize(raw_xml)
+          xml = REXML::Document.new raw_xml
+          
+          xml.elements.each('//lookupReturn') do |node|
+            key, value = node.text.split '||'
+            case key
+            when 'Result'
+              @success = (value == '0')
+            when 'Enrolled'
+              @enrolled = true  if value == 'Y'
+              @enrolled = false if value == 'N'
+              @enrolled = nil   if value == 'U'
+            when 'TransactionIndex'
+              @transaction_index = value
+            when 'ACSUrl'
+              @acs_url = value
+            when 'PAReqMsg'
+              @pa_request_message = value
+            when 'ECI'
+              @eci = value
+            when 'ErrorNo'
+              @error_number = value.to_i
+            when 'ErrorDesc'
+              @error_description = value
+            end
+          end unless xml.root.nil?
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -177,6 +177,12 @@ nab_transact:
   login: ABC0001
   password: changeit
   
+# Working credentials, no need to replace
+my_gate:
+  gateway: fnb_live
+  merchant_id: 79958a8d-0c7b-4038-8e2e-8948e1d678e1
+  application_id: 4b775479-a264-444c-b774-22d5521852d8
+  
 netaxept:
   login: LOGIN
   password: PASSWORD

--- a/test/remote/gateways/remote_my_gate_test.rb
+++ b/test/remote/gateways/remote_my_gate_test.rb
@@ -1,0 +1,158 @@
+require 'mechanize'
+require 'test_helper'
+
+class RemoteMyGateTest < Test::Unit::TestCase
+  
+  def setup
+    @gateway = MyGateGateway.new(fixtures(:my_gate))
+    
+    @amount = 65476 # ZAR 654.76
+    
+    # Modify this to your own PostBin to separate out the 3DS test
+    @postbin_url = 'http://www.postbin.org/znycpi'
+    
+    # Cards as per the document found {here}[http://mygate.co.za/images/PDFs/myenterprise_userguide.pdf].
+    @credit_card   = credit_card('4111111111111111', :first_name => 'Joe', :last_name => 'Soap', :verification_value => '123')
+    @declined_card = credit_card('4242424242424242', :first_name => 'Joe', :last_name => 'Soap', :verification_value => '123')
+    @enrolled_card = credit_card('4341792000000044', :first_name => 'Joe', :last_name => 'Soap', :verification_value => '123', :month => 10, :year => 2012)
+    
+    @options = { 
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase',
+      :user_agent => "ActiveMerchant v#{ActiveMerchant::VERSION}", 
+      :http_accept => '*/*'
+    }
+    
+  end
+  
+  def test_3d_secure_authorization
+    pre_auth_response = @gateway.security_pre_auth(@amount, @enrolled_card, @options)
+    assert_success pre_auth_response
+    assert pre_auth_response.enrolled
+    
+    # Now we need to manually reset the password to be able to verify our identity.
+    # The process is pretty convoluted and requires quite a few form submissions.
+    # For testing purposes I am posting to PostBin and retrieving the values there.
+    browser = Mechanize.new
+    verification_page = browser.post(pre_auth_response.acs_url, {
+      'PaReq' => pre_auth_response.pa_request_message, 
+      'TermUrl' => @postbin_url, # Replace with your own PostBin to filter test results
+      'TransactionIndex' => pre_auth_response.transaction_index
+    })
+    # puts "\nVerification page: #{verification_page.title}"    
+    password_reset_page = browser.click(verification_page.link_with(:text => /change my password/))
+    # puts "Password reset page: #{password_reset_page.title}"
+    confirm_new_password_page = set_password(password_reset_page.forms.first)
+    # puts "Confirm new password page: #{confirm_new_password_page.title}"
+    verification_after_reset_page = set_password(confirm_new_password_page.forms.first)
+    # puts "Verification after reset page #{verification_after_reset_page.title}"
+    javascript_warning_page = set_password(verification_after_reset_page.forms.first)
+    javascript_warning_page.forms.last.click_button # posts to PostBin
+    
+    sleep(1) # to give PostBin a chance to process the post
+    
+    # Get the PaRes value - normally you would do this with
+    postbin = browser.get(@postbin_url)
+    pa_response_message = REXML::Document.new(postbin.body).root.get_elements("//tr[td/@title = 'PaRes']/td/pre").first.text
+    assert pa_response_message.size > 20
+    
+    # Authenticate the result with MyGate
+    assert auth_response = @gateway.security_auth(
+      { 'PaRes' => pa_response_message }, # params from controller
+      { :transaction_index => pre_auth_response.transaction_index } # transaction_index from order
+    )
+    assert_success auth_response
+    assert auth_response.eci.present?
+    assert auth_response.xid.present?
+    assert auth_response.cavv.present?
+  end
+  
+  def test_successful_purchase
+    # 3D-Secure lookup is required, cardholder should not be enrolled, thus avoiding 3DS redirecting
+    pre_auth @credit_card
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_unsuccessful_purchase
+    pre_auth @declined_card
+    
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert response.message.present?
+  end
+  
+  def test_successful_authorize
+    pre_auth @credit_card
+    
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_authorize_and_capture_and_refund
+    pre_auth @credit_card
+    
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal MyGate::Response::SUCCESS, auth.message
+    
+    assert auth.transaction_index
+    assert capture = @gateway.capture(@amount, auth.transaction_index)
+    assert_success capture
+    assert_equal MyGate::Response::SUCCESS, capture.message
+    
+    assert capture.transaction_index
+    assert refund = @gateway.refund(@amount, capture.transaction_index)
+    assert_success refund
+    assert_equal MyGate::Response::SUCCESS, refund.message
+  end
+  
+  def test_authorize_and_void
+    pre_auth @credit_card
+    
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal MyGate::Response::SUCCESS, auth.message
+    
+    assert auth.authorization
+    assert void = @gateway.void(auth.transaction_index, @options)
+    assert_success void
+    assert_equal MyGate::Response::SUCCESS, void.message
+  end
+  
+  def test_failed_capture
+    pre_auth @credit_card
+    
+    assert response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'This transaction requires a TransactionIndex.  Please specify a correct transaction index.  If this problem persists, please contact MyGate at support@mygate.co.za', response.message
+  end
+  
+  def test_invalid_login
+    gateway = MyGateGateway.new :merchant_id => '', :application_id => '', :gateway => :fnb_live
+    
+    @options.update :transaction_index => ''
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'A Merchant ID was not specified.  Please check that you have entered a Merchant ID.  If this problem persists, please contact MyGate at support@mygate.co.za', response.message
+  end
+  
+  private
+  
+  def pre_auth(credit_card, enrolled = false)
+    pre_auth_response = @gateway.security_pre_auth(@amount, credit_card, @options)
+    assert_success pre_auth_response
+    assert_equal enrolled, pre_auth_response.enrolled
+    
+    @options.update :transaction_index => pre_auth_response.transaction_index
+  end
+  
+  def set_password(form, password = 'fnbtest')
+    form['newpassword'] = password
+    form.click_button(form.buttons.last)
+  end
+end

--- a/test/unit/gateways/my_gate_test.rb
+++ b/test/unit/gateways/my_gate_test.rb
@@ -1,0 +1,347 @@
+require 'test_helper'
+
+class MyGateTest < Test::Unit::TestCase
+  def setup
+    @gateway = MyGateGateway.new(
+      :merchant_id => '79958a8d-0c7b-4038-8e2e-8948e1d678e1', 
+      :application_id => '4b775479-a264-444c-b774-22d5521852d8', 
+      :gateway => :fnb_live
+    )
+    
+    @credit_card = credit_card
+    @amount = 100
+    
+    @options = { 
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase',
+      :transaction_index => '25868639-5344-4A62-A722-FB0C22B72658'
+    }
+  end
+  
+  def test_security_pre_auth_response
+    @gateway.expects(:ssl_post).returns(enrolled_3d_secure_response)
+    @options.update :user_agent => '', :http_accept => '*/*'
+    
+    assert response = @gateway.security_pre_auth(@amount, @credit_card, @options)
+    
+    assert_instance_of MyGate::SecurityPreAuthResponse, response
+    assert_success response
+    assert response.enrolled == true
+    assert response.transaction_index == 'EFAD257A-C705-4776-9BF9-E7BE5941ACA8'
+    assert response.acs_url == 'https://visatest.3dsecure.com/mdpayacs/pareq'
+    assert response.pa_request_message == 'eJxVUttuwjAM/ZWK12lN0tILyEQqsDEeQAy2vaIqNdBpvZC2FPb1JKWFLU8+vhzbx4GPg0ScblBUEjkssCjCPRpxNOqdd4mz9bbUZH7f8u0eh1WwxiOHE8oizlLOTGpaQDqoiqU4hGnJIRTH8XzJ+96AOhRICyFBOZ9yen++a7uK4OaGNEyQLy6zsEQgDQCRVWkpL9xjiqUDUMkffijLfEhIXddmctmrElNk5m8IRAeBPEZZVdoqFNk5jvjT92Q3tb8+jy+zfH06vS7ZLhnUQTAO3kdAdAZEioxblKlnU4N5Q4cObQ9I44cw0VNw1+mbnqs2u0HIdZfgHtOhvy5Q6kpMRbdJhwDPeZaiylAy3G2IsBCcGc/GpswkGt0KagYdAPLYafKmxRal0o8xz7cbsRuoqWOlFrN0xxYA0QWkvSNpr62sf7/gCljrrbw='
+  end
+  
+  def test_security_pre_auth_error_response
+    @gateway.expects(:ssl_post).returns(error_3d_secure_response)
+    @options.update :user_agent => '', :http_accept => '*/*'
+    
+    assert response = @gateway.security_pre_auth(@amount, @credit_card, @options)
+    
+    assert_instance_of MyGate::SecurityPreAuthResponse, response
+    assert_failure response
+    assert response.error_number == 9001
+    assert response.error_description == 'Unexpected Error -'
+  end
+  
+  def test_security_auth_response
+    @gateway.expects(:ssl_post).returns(successful_security_auth_response)
+    
+    params  = { 'PaRes' => 'eJzNmFmvozoSgP9Kq+cxus2ehKv0kcxOEgj7kpcRW9ghCQQIv36cpM/pc1ut0Z15mUGKgEq5XLarvjLeWNk1STgziW7X5G2jJF0XpMmXPP7+dTrV1D9X/0S/YeslRi6/vm00YCTd8z8CWy5pbA1lQ3Lt8rZ5w76h3/AN8v4KLV2jLGj6t00QXRhZfSNXNEqhG+TH66ZOrjL3hn5c6yWxhAZe4g3ys712ezx10Lspj99ExroElzEnUVZylGAcfRL4KQAM0L9vkIfGJg765A1HMQzD0eUXjPwTx/4kVxvkKd+cH+ZA3d6g7SVFrpYb5LNoAyfimjTR/W2FQW8/3jbJdG6bBGpAJz+eN8hP785B82k4j4skoW0o3Vje26bP689eoQ+vqPUGeco3XR/0t+7N3yA/njZRMAxv4DEw88Cw4HXxPi//eISjfapskih/QynoFLw/W4Eqba95n9UPV/8q2CAPV5DnQr5tzDxtYGfX5MtUV033/WvW9+c/EWQcx28j8a29pggOh4GgNAIV4i5P//H11SqJ5ebUvm3YoGmbPAqqfA56uO5K0mdt/OWjw9+ZtIyHVQwxePYPaPaPCCObPx4SlMAoaB/5vdFP7v6dXn51/NoFf3RZgD06+MXQ28ZITsljmZMvtiF///qPn+HN5WnS9f9Nh++dfbbwbs8JqlvyNhHxMrJKtwlXlYgT2i71zmmYN3yVfn9v99LcIB8e/nD/fQE+hvJS9M7LKxtLUkVqSWI1nqpQiCze+fBE7K7ghsLI3fO4MvaR2i6We0E6bxejOI5G57IyRwsR354Cnj8VrFHIt2mnaJLH5YM/lWGRGbWHAFkL3LC3ysugm6QZauI5kx0kvhe+HcZdKTaNWnGtJ+6Pye64Xa2FsVqOO1aqCDY9W+7NKCfjMN1Q/vundfgxyl1yf43Ko1CaC/rg9cQm1z4/wYCA6avIMlfOLAuGewpGmQGpbICDMIx0KJ7xyRXCZn8LHSWP0ZHT/e2uPcrZEKlA5wVGB6M383sFlCLAbJ7JFNZxlImzwJ5JVYcBrcUIx62N8pPCgdtL1llb7HiOcD41XQo9etub7xnnEKeykGUs+I4HrlrJvDBHOF0EroAGLn2LZl5TAPrsB0yKeDQxN/DUTGFIj7P4UbH4u1LwFLzPKtY+ZPfPsoPQju6vvtrdxFtAe/eVffn68KtQDHKUgM85ur7nJ+dw9KLUFgUqdJ1bDP0M8QmLxWoIG2USLeC9bMCehGMV1VUduE4pi1tKFp5jHdPj+tf5Y+D8camPAgUqglZkwP58SUTGyKiuL3FuOfSDoLSCoPdDznUX6TjcFFUQuMZy7wQyJyVykInSQLzsXN7446pftCo1waBY7IZTHrLLmNH4bYmMTehcZO2C3qT1SfV7RKjyBb8jWFwObKO/poWcD7FI3WXucO2Mw7md6W2JL3iRtcVLR1Quw2F8IfvN9bBHfOBqIwFShQFALNJUMGAMMdaPeZT0NQNOa57RFY4hAVCY9WO+Y3nUfYUJgHCwO73uvJ0Uc7aNaOXVkU+m1WDKdFPA+NTlR55BRp1VABgPOlwDA00ZTh5fMeQ0qQ77tkClsIrIsp0IdFtgYOwKWdzGkjEe8vUQEzGxb55zf/Nxut8TzDWwWKYDT3snRhZbOO/QxiXd7UCd5cZHW8Ol7nB9u1d7ofBNqghxdDg6j/gQOB2+R/U4xksGa6WDGLlT6Xtgub/TMF22QyiOt7iuZt9Vs32tDqHVzgeuHHycpN/jdi+uaaesLN2chth6yWS+usWicw/rV8z77pjauHOHtoqjyTARoUIbVfaMu4IuYK5AvePZxwX06GyruKaLH7mkQHuowjzzJeZS3YXBhu1dvhjVbGGDsZzx9MwxuKAZrI5xQGXS8pKVuUiPKPOYTwAOTKpz3KBLfmF33WpZ9O5CGo1rGbvqNVg60+xh68LZ2TYfngVqh5v2DVXCY2WlwFCSigT3FY/ilQSxO8cMNrnlNknrpeaMeXYQmWqrbJtUokrxmBDCYXk5jU5XEkx5EDF0QKctIdz2Jj2d2BuB81vePNRIYd/9UF9ynHPlkeNaPOH9llqlZ8FHwHcIwF/p9jvc8ZkFcYfjP3GnsXbiLURwoDSh8c8iwdI3Uf4t7oK/ibv9DPoP3FX/Oe4UYxzF9Ikfjp/UV3iIDhfiWA/bPMLBDHEafeEPYAqnjE/UcfoEUffA30tmfcj+96iWxdNDzpoX0ZRDgoMIhKEGACmqgGOZXN89Qs7yHSkjZN928AFdKTfXb285ddkfyP7GtokmAfWgXtt+wjKOpSPW3YLjchWu2H4xausOWJUuUo55lhBvqukWLK5hXpTRblYHu6gc0VkExaFD+zVosdIRqMhiZCrFToIUyCaVrGOCVYkGT4v6ooyeL7QXCh1EFHSL0ipQjQPyziwnOlR6XeaADpiWlJmugDEVwJIxPvFSMEw6Ci2wBSvnuHndaQSYpQ4TkTRR5APnjato5NOnrgV0CYGBODLpA3vyA23UE6Um4JUCjApLioybMABiUWHtUR59eTf6MKNtCaS8K+AZGktP/EDoRS/0/EBWJPbnB57Z8R170H7BMsgM8JYzU6X1x0Ay0Ihrhz3q3KKa7kKWwh/r5b+j8xkDEHvup/hzIOYI/eYT207h7unhAsisOP4Vv/UDZ7+g0KQf6Bych8xWmaMNZS4GS6Za2TU9xOwLrakfpKl/gD9WPNV/H69PuyZT6dBvWKrvPm6nL7vToD3xzXchYb/rbcPGgH1TL6TWQicLahU1D6Taqe6pc4ir51fMk4j/QLH4KO0q1HfMo3ccHuh9xLwlVnPMPZj5qQQChQW6P0qvEnZgGJ//9+Xvr7nBPHMDrpfOCq5x6IgLmmb7mM8ztKHLiyMyen+xnVjKJTASJcnVhHmgbYlhh/nElY1eEEmJhW0LZacs9gRnuSgTWFDMxXLbZqZF8CsqFPGwPG8NTuwbVF3YVcfmsx7P1FIreiTsVjLCOMZeXDT2rt55pBDnu4NHLsixYwW6vvG87yfSAmN2iLyylNLMr8l6Favn86n0ZgSc7wFx18XKNpdDW8lkU1ChEa6Qi7nu+3BBZXVFmIxn9WPrDpM93jEkOht+1wrjuj4WaYbsRed6Fld1w20jIna9VZkfF/t1nnM6FhDCwE12SsSkPV1jcXXn9bkIJARbmPzuHomnUqDMOV/ax4Qn+TOXMojQt6qzmD3075ULrn2kdnt5Lxc6T/qYZaAIM+yZhWsL2BFEfvGbCsoxV0XvRlZ/Ylzkx61jz7yqgO6JRjZT+OcOwOIHhX3hkp2U+r8IzUniQPCxA/2B7M+pJQvPdB2lLFIVuJNSCxmH9+nAKbj7kBVPGQrRP6kFf3eL/z/f05TPf18+ZIYbweP/HWif6TI4NOVK9TLDa3aq2NNeoDtJI1nBWudR33NoiCJaHRcZvt7KHnfpDpYmSfhlvy3Qq3py5O4oMaAk+eosrDpOGzvDOPDuAtN369AInN2KWOJX+H0pYSnCl8dUk/GMlAjNmclZGnppHbRONcbO8eJie3Plp0J9P484YdzGzEfW2GVps/P9iloataKPRpzxeLuuWQ0fyUrb0nMULWwCvV5wmr4f5HmursQkrGbzVvSC2wUN3flePooxwtTtrlXcG3eWkZJctLtOFJPKWpPAYhZoP8zrnSbY6cEcOyBWaGVf1vJ+d04S28+PYkswk7qC3w3q2MdIUVe5sFOAOHeiNDHDKdjHXrL0tzhPIWT/vuPXC7hSYP15py4ocJ8PkTdyr5KmvUqazsHyJP6yC3UOsqJp9xGJOCWZ7XDBkGNKqieun3+7C4UI5YGHCMzJmyJ2X15J1TUN5Nx4O9saRyWr772S26Hm2sQWuTigrzWV8Pi2ciNjZs0ORY0uCki44e+4tl37/b1cnhLb9QWV1BR2EHyNKDB53u6xsqROtxw5heIu66NQI/bMSY9Z50wj1FXbmgvL7pmCX+URzRUlu531NTGvFud5Lt1dBz/PEXSiG0+UJ8mPS6GLVwOh0IsV7e/cKcmOE2qEOqzB61CsPXxJnQ7H87gf7bVo+3xtAhwVmZuvByuh3CmRFo2LBRceL/A7KCTqvXoxvCUj5ih2aTiUJnRHRJoAaUG7pgBXb1cnJGOJ5JbLTZUx0/K+7wl6PTcKUsD9+gGTV7WFiYNw3qee5kvc+NsdM/LzrAD5OD/4ebLwPEl8nmk+zr4+n3X+C6Ro39A=' }
+    options = { :transaction_index => 'EFAD257A-C705-4776-9BF9-E7BE5941ACA8' }
+    assert response = @gateway.security_auth(params, options)
+    
+    assert_success response
+    assert response.pa_response_status == true
+    assert response.signature_verification == true
+    assert response.eci == '05'
+    assert response.xid == 'GBTqaqwi40CHVMawwY4AYgAABAQ='
+    assert response.cavv == 'AAABASOBCAAAAAAAEYEIAAAAAAA='
+  end
+  
+  def test_security_auth_error_response
+    @gateway.expects(:ssl_post).returns(failed_security_auth_response)
+    
+    params  = { 'PaRes' => '' }
+    options = { :transaction_index => 'EFAD257A-C705-4776-9BF9-E7BE5941ACA8' }
+    assert response = @gateway.security_auth(params, options)
+    
+    assert_failure response
+    assert response.error_number == 9999
+    assert response.error_description == 'Unexpected Error - null'
+  end
+  
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+    
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_instance_of MyGate::Response, response
+    assert_success response
+    assert response.test?
+    
+    assert_equal ['483952'], response.authorization
+    assert_equal '50E2B171-BE1F-42FE-B378-DB594DFC3BB0', response.transaction_index
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+    
+    assert response = @gateway.void(@amount, '50E2B171-BE1F-42FE-B378-DB594DFC3BB0')
+    assert_instance_of MyGate::Response, response
+    assert_success response
+    assert response.test?
+    
+    assert_equal ['657193'], response.authorization
+    assert_equal '9485CA92-5032-43F3-99A6-8D842EF90D90', response.transaction_index
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    
+    assert response = @gateway.capture(@amount, '50E2B171-BE1F-42FE-B378-DB594DFC3BB0')
+    assert_instance_of MyGate::Response, response
+    assert_success response
+    assert response.test?
+    
+    assert_equal ['951280'], response.authorization
+    assert_equal 'CD57C91A-0D30-4CCA-8043-9285B0F7FBE0', response.transaction_index
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    
+    assert response = @gateway.refund(@amount, 'CE4778AD-3B7C-4AE7-ABDC-4670B75B5460')
+    assert_instance_of MyGate::Response, response
+    assert_success response
+    assert response.test?
+    
+    assert_equal ['346030'], response.authorization
+    assert_equal 'CE4778AD-3B7C-4AE7-ABDC-4670B75B5460', response.transaction_index
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of MyGate::Response, response
+    assert_success response
+    assert response.test?
+    
+    # Two transactions happen at once, thus we get two Authorization IDs
+    assert_equal ['222471', '984095'], response.authorization
+    assert_equal 'DAF69F3C-05A4-4C6F-8066-ECB0C037E465', response.transaction_index
+    assert_equal MyGate::Response::SUCCESS, response.message
+  end
+  
+  def test_unsuccessful_request
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'BC70050D-8662-4D5B-B04E-31E56087B99A', response.transaction_index
+    assert_equal 'An error occurred while processing the credit card', response.message
+  end
+  
+  def test_warning_capture
+    @gateway.expects(:ssl_post).returns(warning_capture_result)
+    
+    assert response = @gateway.capture(@amount, '50E2B171-BE1F-42FE-B378-DB594DFC3BB0')
+    assert_success response
+    assert_equal '43CDCDFF-9BB2-4474-91A5-0CF8CFE6D03E', response.transaction_index
+    assert_equal 'Warning: Mode was ignored', response.message
+  end
+  
+  private
+  
+  # This is the response to the call initiated from ActiveMerchant to MyGate for 3D-Secure
+  def enrolled_3d_secure_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:lookupResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_3dsecure">
+       <lookupReturn soapenc:arrayType="xsd:anyType[5]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <lookupReturn xsi:type="soapenc:string">TransactionIndex||EFAD257A-C705-4776-9BF9-E7BE5941ACA8</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">Result||0</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">Enrolled||Y</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">ACSUrl||https://visatest.3dsecure.com/mdpayacs/pareq</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">PAReqMsg||eJxVUttuwjAM/ZWK12lN0tILyEQqsDEeQAy2vaIqNdBpvZC2FPb1JKWFLU8+vhzbx4GPg0ScblBUEjkssCjCPRpxNOqdd4mz9bbUZH7f8u0eh1WwxiOHE8oizlLOTGpaQDqoiqU4hGnJIRTH8XzJ+96AOhRICyFBOZ9yen++a7uK4OaGNEyQLy6zsEQgDQCRVWkpL9xjiqUDUMkffijLfEhIXddmctmrElNk5m8IRAeBPEZZVdoqFNk5jvjT92Q3tb8+jy+zfH06vS7ZLhnUQTAO3kdAdAZEioxblKlnU4N5Q4cObQ9I44cw0VNw1+mbnqs2u0HIdZfgHtOhvy5Q6kpMRbdJhwDPeZaiylAy3G2IsBCcGc/GpswkGt0KagYdAPLYafKmxRal0o8xz7cbsRuoqWOlFrN0xxYA0QWkvSNpr62sf7/gCljrrbw=</lookupReturn>
+       </lookupReturn>
+      </ns1:lookupResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  # An example of a response when a required field is missing
+  def error_3d_secure_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:lookupResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_3dsecure">
+       <lookupReturn soapenc:arrayType="xsd:anyType[3]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <lookupReturn xsi:type="soapenc:string">Result||-1</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">ErrorNo||9001</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">ErrorDesc||Unexpected Error -</lookupReturn>
+       </lookupReturn>
+      </ns1:lookupResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def not_enrolled_3d_secure_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:lookupResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_3dsecure">
+       <lookupReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <lookupReturn xsi:type="soapenc:string">TransactionIndex||EEA3E083-4A46-4F8B-B819-6C5B1621052F</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">Result||0</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">Enrolled||N</lookupReturn>
+        <lookupReturn xsi:type="soapenc:string">ECI||06</lookupReturn>
+       </lookupReturn>
+      </ns1:lookupResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_purchase_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessAndSettleResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessAndSettleReturn soapenc:arrayType="xsd:anyType[5]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessAndSettleReturn xsi:type="soapenc:string">Result||0</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">TransactionIndex||daf69f3c-05a4-4c6f-8066-ecb0c037e465</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/02 11:19:41 AM</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">AuthorisationID||222471</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">AuthorisationID||984095</fProcessAndSettleReturn>
+       </fProcessAndSettleReturn>
+      </ns1:fProcessAndSettleResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_security_auth_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:authenticateResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_3dsecure">
+       <authenticateReturn soapenc:arrayType="xsd:anyType[6]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <authenticateReturn xsi:type="soapenc:string">Result||0</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">PAResStatus||Y</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">SignatureVerification||Y</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">XID||GBTqaqwi40CHVMawwY4AYgAABAQ=</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">Cavv||AAABASOBCAAAAAAAEYEIAAAAAAA=</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">ECI||05</authenticateReturn>
+       </authenticateReturn>
+      </ns1:authenticateResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def failed_security_auth_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:authenticateResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_3dsecure">
+       <authenticateReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <authenticateReturn xsi:type="soapenc:string">Result||-1</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">ErrorNo||9999</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">ErrorDesc||Unexpected Error - null</authenticateReturn>
+        <authenticateReturn xsi:type="soapenc:string">ECI||07</authenticateReturn>
+       </authenticateReturn>
+      </ns1:authenticateResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def failed_purchase_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessAndSettleResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessAndSettleReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessAndSettleReturn xsi:type="soapenc:string">Result||-1</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">TransactionIndex||bc70050d-8662-4d5b-b04e-31e56087b99a</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">Error||5001||Service.Processing||Processing Error||An error occurred while processing the credit card</fProcessAndSettleReturn>
+        <fProcessAndSettleReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/02 12:11:38 PM</fProcessAndSettleReturn>
+       </fProcessAndSettleReturn>
+      </ns1:fProcessAndSettleResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_authorize_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessReturn xsi:type="soapenc:string">Result||0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">TransactionIndex||50e2b171-be1f-42fe-b378-db594dfc3bb0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/05 11:38:44 AM</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AuthorisationID||483952</fProcessReturn>
+       </fProcessReturn>
+      </ns1:fProcessResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_capture_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessReturn xsi:type="soapenc:string">Result||0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">TransactionIndex||cd57c91a-0d30-4cca-8043-9285b0f7fbe0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/08 01:46:47 PM</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AuthorisationID||951280</fProcessReturn>
+       </fProcessReturn>
+      </ns1:fProcessResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_refund_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessReturn xsi:type="soapenc:string">Result||0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">TransactionIndex||ce4778ad-3b7c-4ae7-abdc-4670b75b5460</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/09 11:34:57 AM</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AuthorisationID||346030</fProcessReturn>
+       </fProcessReturn>
+      </ns1:fProcessResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def successful_void_response
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessReturn soapenc:arrayType="xsd:anyType[4]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessReturn xsi:type="soapenc:string">Result||0</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">TransactionIndex||9485ca92-5032-43f3-99a6-8d842ef90d90</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/09 10:45:54 AM</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AuthorisationID||657193</fProcessReturn>
+       </fProcessReturn>
+      </ns1:fProcessResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+  
+  def warning_capture_result
+    %(<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+     <soapenv:Body>
+      <ns1:fProcessResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://_5x0x0.enterprise">
+       <fProcessReturn soapenc:arrayType="xsd:anyType[5]" xsi:type="soapenc:Array" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+        <fProcessReturn xsi:type="soapenc:string">Result||1</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">TransactionIndex||43cdcdff-9bb2-4474-91a5-0cf8cfe6d03e</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">Warning||8001||Service.Validate||Mode was ignored||</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AcquirerDateTime||2011/12/08 01:46:20 PM</fProcessReturn>
+        <fProcessReturn xsi:type="soapenc:string">AuthorisationID||417224</fProcessReturn>
+       </fProcessReturn>
+      </ns1:fProcessResponse>
+     </soapenv:Body>
+    </soapenv:Envelope>)
+  end
+end


### PR DESCRIPTION
It has a slightly different flow as it is required to do a 3D-Secure check beforehand, but everything is fully tested both remotely and with unit tests so it should be easy to see how to use it.

I couldn't find a reference implementation of how an established flow for 3D-Secure would work so I've left it up to the application that ActiveMerchant is embedded in. In the tests I tell the 3D-Secure service to redirect to PostBin and then I parse the results from that page using Mechanize as it would have no way to post to the machine running the tests reliably.

There is a slight concern where MyGate doesn't reference their own AuthorisationIDs, they reference a transaction_index. I've used the authorization parameter as other gateway implementations do, but I've renamed it to make it clear what to pass.

I've also tried to keep documentation plentiful and verbose so everything should be clear, but please get in touch if anything needs explanation or amending.
