### PR TITLE
Add email to stripe customer details

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -89,6 +89,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
+        post[:email] = options[:email]
         post[:description] = options[:email] || options[:description]
       end
 


### PR DESCRIPTION
Currently we store 'email' in the description field, and nothing in the email field.

When you visit the stripe admin console, you see:

email: <blank>
description: jeff@foo.com

This pull requests adds 'email' to the email field.
