### PR TITLE
Authorize.net CIM: adds support for get_customer_profile_ids

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
         :create_customer_payment_profile => 'createCustomerPaymentProfile',
         :create_customer_shipping_address => 'createCustomerShippingAddress',
         :get_customer_profile => 'getCustomerProfile',
+        :get_customer_profile_ids => 'getCustomerProfileIds',
         :get_customer_payment_profile => 'getCustomerPaymentProfile',
         :get_customer_shipping_address => 'getCustomerShippingAddress',
         :delete_customer_profile => 'deleteCustomerProfile',
@@ -201,6 +202,11 @@ module ActiveMerchant #:nodoc:
 
         request = build_request(:get_customer_profile, options)
         commit(:get_customer_profile, request)
+      end
+
+      def get_customer_profile_ids(options = {})
+        request = build_request(:get_customer_profile_ids, options)
+        commit(:get_customer_profile_ids, request)
       end
 
       # Retrieve a customer payment profile for an existing customer profile.
@@ -510,6 +516,10 @@ module ActiveMerchant #:nodoc:
 
       def build_get_customer_profile_request(xml, options)
         xml.tag!('customerProfileId', options[:customer_profile_id])
+        xml.target!
+      end
+
+      def build_get_customer_profile_ids_request(xml, options)
         xml.target!
       end
 

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -230,6 +230,14 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal @customer_profile_id, response.authorization
   end
 
+  def test_should_get_customer_profile_ids_request
+    @gateway.expects(:ssl_post).returns(successful_get_customer_profile_ids_response)
+
+    assert response = @gateway.get_customer_profile_ids
+    assert_instance_of Response, response
+    assert_success response
+  end
+
   def test_should_get_customer_profile_request_with_multiple_payment_profiles
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response_with_multiple_payment_profiles)
 
@@ -657,6 +665,27 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           </paymentProfiles>
         </profile>
       </getCustomerProfileResponse>
+    XML
+  end
+
+  def successful_get_customer_profile_ids_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8"?>
+      <getCustomerProfileIdsResponse xmlns="AnetApi/xml/v1/schema/
+      AnetApiSchema.xsd">
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+        <ids>
+          <numericString>10000</numericString>
+          <numericString>10001</numericString>
+          <numericString>10002</numericString>
+        </ids>
+      </getCustomerProfileIdsResponse>
     XML
   end
 


### PR DESCRIPTION
This change adds support for getCustomerProfileIdsRequest, which retrieves all customer profile IDs you have previously created.
