### PR TITLE
Paypal Express: Support specifying :brand_name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 = ActiveMerchant CHANGELOG
 
+== Not released yet ==
+
+* Paypal Express: Support specifying :brand_name [Olek Janiszewski]
+
 == Version 1.20.1 (December 22, 2011)
 
 * PayflowExpressUk: Fix parsing street2 from response [odorcicd]

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -152,6 +152,7 @@ module ActiveMerchant #:nodoc:
               end
               
               xml.tag! 'n2:LocaleCode', options[:locale] unless options[:locale].blank?
+              xml.tag! 'n2:BrandName', options[:brand_name] unless options[:brand_name].blank?
             end
           end
         end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -285,7 +285,18 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
-  
+
+  def test_not_adds_brand_name_if_not_specified
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
+
+    assert_nil REXML::XPath.first(xml, '//n2:BrandName')
+  end
+
+  def test_adds_brand_name_if_specified
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:brand_name => 'Acme'}))
+    assert_equal 'Acme', REXML::XPath.first(xml, '//n2:BrandName').text
+  end
+
   def test_get_phone_number_from_address_if_contact_phone_not_sent
     response = successful_details_response.sub(%r{<ContactPhone>416-618-9984</ContactPhone>\n}, '')
     @gateway.expects(:ssl_post).returns(response)


### PR DESCRIPTION
Following https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_soap_r_SetExpressCheckout
