### PR TITLE
Added line items to authorize.net cim gateway for auth_capture

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -620,6 +620,7 @@ module ActiveMerchant #:nodoc:
                 xml.tag!('transId', transaction[:trans_id])
               else
                 xml.tag!('amount', transaction[:amount])
+                add_line_items(xml, transaction[:line_items]) if transaction[:line_items]
                 xml.tag!('customerProfileId', transaction[:customer_profile_id])
                 xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
                 xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
@@ -634,6 +635,19 @@ module ActiveMerchant #:nodoc:
           xml.tag!('invoiceNumber', order[:invoice_number]) if order[:invoice_number]
           xml.tag!('description', order[:description]) if order[:description]
           xml.tag!('purchaseOrderNumber', order[:purchase_order_number]) if order[:purchase_order_number]
+        end
+      end
+
+      def add_line_items(xml, line_items)
+        line_items.each do |line_item|
+          xml.tag!('lineItems') do
+            xml.tag!('itemId', line_item[:item_id])
+            xml.tag!('name', line_item[:name])
+            xml.tag!('description', line_item[:description])
+            xml.tag!('quantity', line_item[:quantity])
+            xml.tag!('unitPrice', line_item[:unit_price])
+            xml.tag!('taxable', line_item[:taxable])
+          end
         end
       end
       

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -143,6 +143,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           :description => 'Test Order Description',
           :purchase_order_number => '4321'
         },
+        :line_items => [
+          {:item_id => '1', :name => 'item 1', :description => 'desc', :quantity => '1', :unit_price => '1.00', :taxable => 'false'},
+          {:item_id => '2', :name => 'item 2', :description => 'desc', :quantity => '1', :unit_price => '2.00', :taxable => 'false'}
+        ],
         :amount => @amount
       }
     )

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -185,6 +185,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           :description => 'Test Order Description',
           :purchase_order_number => '4321'
         },
+        :line_items => [
+          {:item_id => '1', :name => 'item 1', :description => 'desc', :quantity => '1', :unit_price => '1.00', :taxable => 'false'},
+          {:item_id => '2', :name => 'item 2', :description => 'desc', :quantity => '1', :unit_price => '2.00', :taxable => 'false'}
+        ],
         :amount => @amount
       }
     )


### PR DESCRIPTION
Authorize.net CIM supports line items (which are useful for tracking, matching up orders, etc.) but activemerchant does not. I added the necessary methods to accept and convert line items to xml. The line items should be passed as an array of hashes within the transaction hash. 

I've also added line items to the authorize.net gateway tests for auth_capture. The line items are not returned in the response, however.
