### PR TITLE
Add more options to Paypal Express

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -150,6 +150,7 @@ module ActiveMerchant #:nodoc:
                 add_items_xml(xml, options, currency_code) if options[:items]
 
                 xml.tag! 'n2:PaymentAction', action
+                xml.tag! 'n2:Custom', options[:custom] unless options[:custom].blank?
               end
 
               if options[:shipping_options]

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -136,6 +136,18 @@ class PaypalExpressTest < Test::Unit::TestCase
 
     assert_equal 'SetExpressCheckout', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentAction').text
   end
+
+  def test_includes_custom_tag_if_specified
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:custom => 'Foo'}))
+
+    assert_equal 'Foo', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:Custom').text
+  end
+
+  def test_does_not_include_custom_tag_if_not_specified
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {}))
+
+    assert_nil REXML::XPath.first(xml, '//n2:PaymentDetails/n2:Custom')
+  end
   
   def test_does_not_include_items_if_not_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {}))


### PR DESCRIPTION
This patch adds `:brand_name` and `:custom` options in Paypal Express API.

Following https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_soap_r_SetExpressCheckout.
