### PR TITLE
Adding 'order' details when appropriate while creating transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -451,6 +451,8 @@ module ActiveMerchant #:nodoc:
           add_merchant_authentication(xml)
           # Merchant-assigned reference ID for the request
           xml.tag!('refId', options[:ref_id]) if options[:ref_id]
+          # Order options
+          add_order(xml, options[:order]) if options[:order]
           send("build_#{action}_request", xml, options)
         end
       end


### PR DESCRIPTION
Whenever authorize.net receives two similar requests from the same payment profile in less than two minutes it will deny the second one in order to avoid double-triggering. 

In my project, particularly, I would prefer to deal with the logic to prevent this on our end, this patch adds the order information to the xml when the order argument is passed. Please let me know if you think it's appropriate to merge it to active_merchant/master.

Cheers!

P.
