### PR TITLE
Don't fail expiration date parsing on leading zeros. 

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -161,8 +161,8 @@ module ActiveMerchant #:nodoc:
       end
       
       def expdate(creditcard)
-        year  = sprintf("%.4i", creditcard.year)
-        month = sprintf("%.2i", creditcard.month)
+        year  = sprintf("%.4i", creditcard.year.to_s.sub(/^0+/, ''))
+        month = sprintf("%.2i", creditcard.month.to_s.sub(/^0+/, ''))
 
         "#{year}#{month}"
       end


### PR DESCRIPTION
Passing in an expiration month of say "09" no longer raises the following exception: ArgumentError: invalid value for Integer(): "09".
