### PR TITLE
The md5 check actually needs to be done against all the params in the no...

### DIFF
--- a/lib/active_merchant/billing/integrations/quickpay/notification.rb
+++ b/lib/active_merchant/billing/integrations/quickpay/notification.rb
@@ -48,14 +48,11 @@ module ActiveMerchant #:nodoc:
             end
           end
 
-          MD5_CHECK_FIELDS = [
-            :msgtype, :ordernumber, :amount, :currency, :time, :state,
-            :chstat, :chstatmsg, :qpstat, :qpstatmsg, :merchant, :merchantemail,
-            :transaction, :cardtype, :cardnumber, :testmode
-          ]
-
           def generate_md5string
-            MD5_CHECK_FIELDS.map { |key| params[key.to_s] } * "" + @options[:credential2]
+            @raw.split('&').map do |line|
+              key, value = *line.scan( %r{^([A-Za-z0-9_.]+)\=(.*)$} ).flatten
+              CGI.unescape(value) unless key == 'md5check'
+            end.join("") + @options[:credential2]
           end
           
           def generate_md5check


### PR DESCRIPTION
...tification, except the md5check field itself, in the order in which they were received. That is the bullet-proof (and future-proof) way of doing it.
