### PR TITLE
Fix Stripe's purchase method.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         add_creditcard(post, creditcard, options)
         add_customer(post, options)
-        add_customer_data(post, options)
+        post[:description] = options[:description] || options[:email]
         add_flags(post, options)
 
         raise ArgumentError.new("Customer or Credit Card required.") if !post[:card] && !post[:customer]
@@ -79,7 +79,8 @@ module ActiveMerchant #:nodoc:
       def store(creditcard, options = {})
         post = {}
         add_creditcard(post, creditcard, options)
-        add_customer_data(post, options)
+        post[:description] = options[:description]
+        post[:email] = options[:email]
 
         if options[:customer]
           commit("customers/#{CGI.escape(options[:customer])}", post)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -14,7 +14,8 @@ class RemoteStripeTest < Test::Unit::TestCase
     @new_credit_card = credit_card('5105105105105100')
 
     @options = {
-      :description => 'ActiveMerchant Test Purchase'
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com'
     }
   end
 
@@ -23,6 +24,17 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert_equal "charge", response.params["object"]
     assert response.params["paid"]
+  end
+
+  def test_purchase_description
+    assert response = @gateway.purchase(@amount, @credit_card, { :description => "TheDescription", :email => "email@example.com" })
+    assert_equal "TheDescription", response.params["description"], "Use the description if it's specified."
+
+    assert response = @gateway.purchase(@amount, @credit_card, { :email => "email@example.com" })
+    assert_equal "email@example.com", response.params["description"], "Use the email if no description is specified."
+
+    assert response = @gateway.purchase(@amount, @credit_card, { })
+    assert_nil response.params["description"], "No description or email specified."
   end
 
   def test_unsuccessful_purchase
@@ -68,10 +80,11 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer"})
+    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
     assert_success response
     assert_equal "customer", response.params["object"]
     assert_equal "Active Merchant Test Customer", response.params["description"]
+    assert_equal "email@example.com", response.params["email"]
     assert_equal @credit_card.last_digits, response.params["active_card"]["last4"]
   end
 


### PR DESCRIPTION
Their purchase API call doesn't allow an email parameter.  The
create customer api call allows both the email and the
description to be specified.
