### PR TITLE
Refactor to avoid camelize

### DIFF
--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         requires!(options, :order_id)
         original_transaction_id, original_transaction_amount = identification.split(";")
-        commit(:void_transaction, {:reference_number => format_reference_number(options[:order_id]), :transaction_ID => original_transaction_id})
+        commit(:void_transaction, {:reference_number => format_reference_number(options[:order_id]), :transaction_id => original_transaction_id})
       end
       
       def voice_authorize(money, authorization_code, creditcard, options = {})
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
           :reference_number => format_reference_number(options[:order_id]),
           :transaction_amount => amount(money),
           :original_transaction_amount => original_transaction_amount,
-          :original_transaction_ID => original_transaction_id,
+          :original_transaction_id => original_transaction_id,
           :client_ip_address => options[:ip]
         }
       end
@@ -191,7 +191,7 @@ module ActiveMerchant #:nodoc:
         transaction = root.add_element(action.to_s.camelize)
 
         actions[action].each do |key|
-          transaction.add_element(key.to_s.camelize).text = parameters[key] unless parameters[key].blank?
+          transaction.add_element(key).text = parameters[key.underscore.to_sym] unless parameters[key.underscore.to_sym].blank?
         end
 
         xml.to_s
@@ -217,18 +217,18 @@ module ActiveMerchant #:nodoc:
         ACTIONS
       end
 
-      CREDIT_CARD_FIELDS =  [:authorization_number, :client_ip_address, :billing_address, :billing_city, :billing_state, :billing_postal_code, :billing_country, :billing_name, :card_verification_value, :expiration_month, :expiration_year, :reference_number, :transaction_amount, :account_number ]
+      CREDIT_CARD_FIELDS =  %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber )
 
       ACTIONS = {
            :credit_card_authorize		=> CREDIT_CARD_FIELDS,
            :credit_card_charge			=> CREDIT_CARD_FIELDS,
            :credit_card_voice_authorize		=> CREDIT_CARD_FIELDS,
            :credit_card_capture			=> CREDIT_CARD_FIELDS,
-           :credit_card_credit			=> CREDIT_CARD_FIELDS << :original_transaction_amount,
-           :credit_card_refund			=> [:reference_number, :transaction_amount, :original_transaction_amount, :original_transaction_ID, :client_ip_address],
-           :void_transaction			=> [:reference_number, :transaction_ID],
-           :credit_card_settle			=> [:reference_number, :transaction_amount, :original_transaction_amount, :original_transaction_ID, :client_ip_address],
-           :system_check			=> [:system_check],
+           :credit_card_credit			=> CREDIT_CARD_FIELDS << "OriginalTransactionAmount",
+           :credit_card_refund			=> %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
+           :void_transaction			=> %w(ReferenceNumber TransactionID),
+           :credit_card_settle			=> %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
+           :system_check			=> %w(SystemCheck),
       }    
     end
   end


### PR DESCRIPTION
@Soleone for review

`ActiveSupport` has changed the way `camelize` works in 3.2. I haven't been able to find exactly what has changed, but the output is different for `:original_transaction_ID.to_s.camelize` between the two versions.

This is a refactor so that we can avoid calling `camelize` and, in my opinion, makes it more obvious what the attributes should be.
