### PR TITLE
Paypal Express: Validate generated XML against paypal xsd's

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -313,8 +313,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'n2:CityName', address[:city]
           xml.tag! 'n2:StateOrProvince', address[:state].blank? ? 'N/A' : address[:state]
           xml.tag! 'n2:Country', address[:country]
-          xml.tag! 'n2:PostalCode', address[:zip]
           xml.tag! 'n2:Phone', address[:phone]
+          xml.tag! 'n2:PostalCode', address[:zip]
         end
       end
       

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -98,9 +98,34 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'SetExpressCheckoutRequest', 'xmlns:n2' => EBAY_NAMESPACE do
             xml.tag! 'n2:Version', API_VERSION
             xml.tag! 'n2:SetExpressCheckoutRequestDetails' do
+              xml.tag! 'n2:ReturnURL', options[:return_url]
+              xml.tag! 'n2:CancelURL', options[:cancel_return_url]
               if options[:max_amount]
                 xml.tag! 'n2:MaxAmount', localized_amount(options[:max_amount], currency_code), 'currencyID' => currency_code
               end
+              xml.tag! 'n2:NoShipping', options[:no_shipping] ? '1' : '0'
+              xml.tag! 'n2:AddressOverride', options[:address_override] ? '1' : '0'
+              xml.tag! 'n2:LocaleCode', options[:locale] unless options[:locale].blank?
+              # Customization of the payment page
+              xml.tag! 'n2:PageStyle', options[:page_style] unless options[:page_style].blank?
+              xml.tag! 'n2:cpp-header-image', options[:header_image] unless options[:header_image].blank?
+              xml.tag! 'n2:cpp-header-border-color', options[:header_border_color] unless options[:header_border_color].blank?
+              xml.tag! 'n2:cpp-header-back-color', options[:header_background_color] unless options[:header_background_color].blank?
+              xml.tag! 'n2:cpp-payflow-color', options[:background_color] unless options[:background_color].blank?
+              if options[:allow_guest_checkout]
+                xml.tag! 'n2:SolutionType', 'Sole'
+                xml.tag! 'n2:LandingPage', 'Billing'
+              end
+              xml.tag! 'n2:BuyerEmail', options[:email] unless options[:email].blank?
+
+              if options[:billing_agreement]
+                xml.tag! 'n2:BillingAgreementDetails' do
+                  xml.tag! 'n2:BillingType', options[:billing_agreement][:type]
+                  xml.tag! 'n2:BillingAgreementDescription', options[:billing_agreement][:description]
+                  xml.tag! 'n2:PaymentType', options[:billing_agreement][:payment_type] || 'InstantOnly'
+                end
+              end
+
               if !options[:allow_note].nil?
                 xml.tag! 'n2:AllowNote', options[:allow_note] ? '1' : '0'
               end
@@ -117,41 +142,12 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'n2:OrderDescription', options[:description]
                 xml.tag! 'n2:InvoiceID', options[:order_id]
 
-                add_items_xml(xml, options, currency_code) if options[:items]
-
                 add_address(xml, 'n2:ShipToAddress', options[:shipping_address] || options[:address])
+
+                add_items_xml(xml, options, currency_code) if options[:items]
 
                 xml.tag! 'n2:PaymentAction', action
               end
-
-              xml.tag! 'n2:AddressOverride', options[:address_override] ? '1' : '0'
-              xml.tag! 'n2:NoShipping', options[:no_shipping] ? '1' : '0'
-              xml.tag! 'n2:ReturnURL', options[:return_url]
-              xml.tag! 'n2:CancelURL', options[:cancel_return_url]
-              xml.tag! 'n2:IPAddress', options[:ip] unless options[:ip].blank?
-              xml.tag! 'n2:BuyerEmail', options[:email] unless options[:email].blank?
-              
-              if options[:billing_agreement]
-                xml.tag! 'n2:BillingAgreementDetails' do
-                  xml.tag! 'n2:BillingType', options[:billing_agreement][:type]
-                  xml.tag! 'n2:BillingAgreementDescription', options[:billing_agreement][:description]
-                  xml.tag! 'n2:PaymentType', options[:billing_agreement][:payment_type] || 'InstantOnly'
-                end
-              end
-        
-              # Customization of the payment page
-              xml.tag! 'n2:PageStyle', options[:page_style] unless options[:page_style].blank?
-              xml.tag! 'n2:cpp-header-image', options[:header_image] unless options[:header_image].blank?
-              xml.tag! 'n2:cpp-header-back-color', options[:header_background_color] unless options[:header_background_color].blank?
-              xml.tag! 'n2:cpp-header-border-color', options[:header_border_color] unless options[:header_border_color].blank?
-              xml.tag! 'n2:cpp-payflow-color', options[:background_color] unless options[:background_color].blank?
-              
-              if options[:allow_guest_checkout]
-                xml.tag! 'n2:SolutionType', 'Sole'
-                xml.tag! 'n2:LandingPage', 'Billing'
-              end
-              
-              xml.tag! 'n2:LocaleCode', options[:locale] unless options[:locale].blank?
             end
           end
         end

--- a/test/schema/paypal/CoreComponentTypes.xsd
+++ b/test/schema/paypal/CoreComponentTypes.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:ebay:apis:CoreComponentTypes" elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:apis:CoreComponentTypes" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:import namespace="urn:ebay:apis:eBLBaseComponents" schemaLocation="eBLBaseComponents.xsd"/>
+	<!-- Definition of AmountType -->
+	<xs:complexType name="AmountType">
+		<xs:simpleContent>
+			<xs:extension base="xs:double">
+				<xs:attribute name="currencyID" type="ebl:CurrencyCodeType" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="BasicAmountType">
+	<xs:annotation><xs:documentation>On requests, you must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies. 
+<br/><br/>
+Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</xs:documentation></xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="currencyID" type="ebl:CurrencyCodeType" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- Definition of MeasureType -->
+	<xs:complexType name="MeasureType">
+		<xs:simpleContent>
+			<xs:extension base="xs:double">
+				<xs:attribute name="unit" type="xs:token" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- Definition of QuantityType -->
+	<xs:complexType name="QuantityType">
+		<xs:simpleContent>
+			<xs:extension base="xs:double">
+				<xs:attribute name="unit" type="xs:token" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- Definition of UUIDType (as a simpleType)-->
+	<xs:simpleType name="UUIDType">
+		<xs:annotation>
+			<xs:documentation>
+			    Specifies a universally unique identifier. The UUID can 
+			    only contain digits from 0-9 and letters from A-F. The 
+			    UUID must be 32 characters long.  For example, 
+			    1FB02B2-9D27-3acb-ABA2-9D539C374228       
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:length value="36"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/test/schema/paypal/EnhancedDataTypes.xsd
+++ b/test/schema/paypal/EnhancedDataTypes.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="urn:ebay:apis:EnhancedDataTypes" elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:ns="urn:ebay:apis:EnhancedDataTypes" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="EnhancedCheckoutDataType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedPaymentDataType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedItemDataType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedPaymentInfoType">
+	</xs:complexType>
+	<xs:element name="EnhancedInitiateRecoupRequestDetails" type="ns:EnhancedInitiateRecoupRequestDetailsType"/>
+	<xs:element name="EnhancedCompleteRecoupRequestDetails" type="ns:EnhancedCompleteRecoupRequestDetailsType"/>
+	<xs:element name="EnhancedCompleteRecoupResponseDetails" type="ns:EnhancedCompleteRecoupResponseDetailsType"/>
+	<xs:element name="EnhancedCancelRecoupRequestDetails" type="ns:EnhancedCancelRecoupRequestDetailsType"/>
+	<xs:complexType name="EnhancedInitiateRecoupRequestDetailsType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedCompleteRecoupRequestDetailsType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedCompleteRecoupResponseDetailsType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedCancelRecoupRequestDetailsType">
+	</xs:complexType>
+	<xs:complexType name="EnhancedPayerInfoType">
+	</xs:complexType>
+</xs:schema>

--- a/test/schema/paypal/eBLBaseComponents.xsd
+++ b/test/schema/paypal/eBLBaseComponents.xsd
@@ -1,0 +1,14402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ns="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:ebay:apis:eBLBaseComponents" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<import namespace="urn:ebay:apis:CoreComponentTypes" schemaLocation="test/schema/paypal/CoreComponentTypes.xsd"/>
+	<import namespace="urn:ebay:apis:EnhancedDataTypes" schemaLocation="test/schema/paypal/EnhancedDataTypes.xsd"/>
+	<simpleType name="AccountStateCodeType">
+		<annotation>
+			<documentation>
+			     AccountStateCodeType
+			     These are the possible codes to describe the state of an account of an 
+			     eBay user.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Active">
+				<annotation>
+					<documentation>
+						    Amex					
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Pending">
+				<annotation>
+					<documentation>
+						   Visa
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Inactive">
+				<annotation>
+					<documentation>
+						  Mastercard
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="AckCodeType">
+		<annotation>
+			<documentation>
+			   AckCodeType
+			   This code identifies the acknowledgement code types that 
+			   could be used to communicate the status of processing a 
+			   (request) message to an application. This code would be used 
+			   as part of a response message that contains an application 
+			   level acknowledgement element.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Success">
+				<annotation>
+					<documentation>
+					   Request processing succeeded.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Failure">
+				<annotation>
+					<documentation> 
+					   Request processing failed.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Warning">
+				<annotation>
+					<documentation>
+					     Request processing completed with warning information
+					     being included in the response message.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SuccessWithWarning">
+				<annotation>
+					<documentation>
+					     Request processing completed successful with some
+					     with some warning information that could be useful for
+					     the requesting application to process and/or record.
+					 </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="FailureWithWarning">
+				<annotation>
+					<documentation>
+					     Request processing failed with some error and warnining
+					     information that requesting application should process to
+					     determine cause(s) of failure.
+					 </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PartialSuccess">
+				<annotation>
+					<documentation>
+					    Request processing completed with Partial Success.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="AddressOwnerCodeType">
+		<annotation>
+			<documentation>
+			   AddressOwnerCodeType
+			   This code identifies the AddressOwner code types which indicates
+			   who owns the user'a address.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="PayPal">
+				<annotation>
+					<documentation>
+					   PayPal owns address.
+				      </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="eBay">
+				<annotation>
+					<documentation> 
+					   eBay owns address.										
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="AuctionTypeCodeType">
+		<annotation>
+			<documentation>
+			     AuctionTypeCodeType - Type declaration to be used 
+			     by other schema's. This includes codes indicating the
+			     type of auction for the listed item.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown">
+				<annotation>
+					<documentation>
+						    Unknown auction type
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Chinese">
+				<annotation>
+					<documentation>
+						   Chinese auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Dutch">
+				<annotation>
+					<documentation>
+						   Dutch auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Live">
+				<annotation>
+					<documentation>
+						   Live Auctions-type auction						
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Ad type">
+				<annotation>
+					<documentation>
+						   Ad type auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Stores Fixed-price">
+				<annotation>
+					<documentation>
+						   Stores Fixed-price auction (US only)
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Personal Offer">
+				<annotation>
+					<documentation>
+						   Personal Offer auction 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Fixed Price Item">
+				<annotation>
+					<documentation>
+						   Fixed Price item ("BIN only").
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="BalanceCodeType">
+		<annotation>
+			<documentation>
+			   BalanceCodeType
+			   This code identifies the types of balances in an account, e.g., a PayPal 
+			   account.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+				<annotation>
+					<documentation>Custom Code</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="BuyerPaymentMethodCodeType">
+		<annotation>
+			<documentation>
+			     BuyerPaymentMethodCodeType - Type declaration to be used 
+			     by other schema. The includes the codes for payment methods 
+			     used by buyers to pay sellers.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						    No payment method specified
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MOCC">
+				<annotation>
+					<documentation>
+						  Money order/cashiers check
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="AmEx">
+				<annotation>
+					<documentation>
+						  American Express
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PaymentSeeDescription">
+				<annotation>
+					<documentation>
+						  Payment See Description
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CCAccepted">
+				<annotation>
+					<documentation>
+						  American Express
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PersonalCheck">
+				<annotation>
+					<documentation>
+						  Personal check
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="COD">
+				<annotation>
+					<documentation>
+						   COD
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="VisaMC">
+				<annotation>
+					<documentation>
+						  Visa/Mastercard
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Other">
+				<annotation>
+					<documentation>
+						  Other forms of payment.
+						  Some custom method is accepted by seller 
+						  as payment method in the transaction. For 
+						  Motors vehicle items, this field refers to the 
+						  Deposit payment method.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PayPal">
+				<annotation>
+					<documentation>
+						  PayPal
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Discover">
+				<annotation>
+					<documentation>
+						  Discover
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CashOnPickup">
+				<annotation>
+					<documentation>
+						    Payment on delivery acceptable payment term. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MoneyXferAccepted">
+				<annotation>
+					<documentation>
+						    Direct transfer of money acceptable payment term. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MoneyXferAcceptedinCheckout">
+				<annotation>
+					<documentation>
+						    If the seller has bank account information on file, 
+						    and MoneyXferAcceptedinCheckout = true, then 
+						    the bank account information will be displayed in 
+						    Checkout. Applicable to German site only.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="OtherOnlinePayments">
+				<annotation>
+					<documentation>
+						    Online Escrow paid for by seller. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="BuyerProtectionCodeType">
+		<annotation>
+			<documentation>
+			     BuyerProtectionCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="ItemIneligible">
+				<annotation>
+					<documentation>
+						    Item is ineligible (e.g., category not applicable).
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemEligible">
+				<annotation>
+					<documentation>
+						     Item is eligible per standard criteria. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemMarkedIneligible">
+				<annotation>
+					<documentation>
+						   Item marked ineligible per special criteria (e.g., seller's account closed).
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemMarkedEligible">
+				<annotation>
+					<documentation>
+						  Item marked eligible per other criteria.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="CheckoutStatusCodeType">
+		<annotation>
+			<documentation>
+			     CheckoutStatusCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="CheckoutComplete">
+				<annotation>
+					<documentation>
+						    Checkout complete.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CheckoutIncomplete">
+				<annotation>
+					<documentation>
+						    Checkout incomplete. No details specified.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BuyerRequestsTotal">
+				<annotation>
+					<documentation>
+						   Buyer requests total.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SellerResponded">
+				<annotation>
+					<documentation>
+						  Seller responded to buyer's request. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="CountryCodeType">
+		<annotation>
+			<documentation>
+			  CountryCodeType
+			  This code list module defines the enumerated types
+			   of standard 2-letter ISO 3166 country codes. This codelist
+			   contains some additional country code not defined in
+			   the ISO 3166 country code set. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="AF"/>
+			<enumeration value="AL"/>
+			<enumeration value="DZ"/>
+			<enumeration value="AS"/>
+			<enumeration value="AD"/>
+			<enumeration value="AO"/>
+			<enumeration value="AI"/>
+			<enumeration value="AQ"/>
+			<enumeration value="AG"/>
+			<enumeration value="AR"/>
+			<enumeration value="AM"/>
+			<enumeration value="AW"/>
+			<enumeration value="AU"/>
+			<enumeration value="AT"/>
+			<enumeration value="AZ"/>
+			<enumeration value="BS"/>
+			<enumeration value="BH"/>
+			<enumeration value="BD"/>
+			<enumeration value="BB"/>
+			<enumeration value="BY"/>
+			<enumeration value="BE"/>
+			<enumeration value="BZ"/>
+			<enumeration value="BJ"/>
+			<enumeration value="BM"/>
+			<enumeration value="BT"/>
+			<enumeration value="BO"/>
+			<enumeration value="BA"/>
+			<enumeration value="BW"/>
+			<enumeration value="BV"/>
+			<enumeration value="BR"/>
+			<enumeration value="IO"/>
+			<enumeration value="BN"/>
+			<enumeration value="BG"/>
+			<enumeration value="BF"/>
+			<enumeration value="BI"/>
+			<enumeration value="KH"/>
+			<enumeration value="CM"/>
+			<enumeration value="CA"/>
+			<enumeration value="CV"/>
+			<enumeration value="KY"/>
+			<enumeration value="CF"/>
+			<enumeration value="TD"/>
+			<enumeration value="CL"/>
+			<enumeration value="C2"/>
+			<enumeration value="CN"/>
+			<enumeration value="CX"/>
+			<enumeration value="CC"/>
+			<enumeration value="CO"/>
+			<enumeration value="KM"/>
+			<enumeration value="CG"/>
+			<enumeration value="CD"/>
+			<enumeration value="CK"/>
+			<enumeration value="CR"/>
+			<enumeration value="CI"/>
+			<enumeration value="HR"/>
+			<enumeration value="CU"/>
+			<enumeration value="CY"/>
+			<enumeration value="CZ"/>
+			<enumeration value="DK"/>
+			<enumeration value="DJ"/>
+			<enumeration value="DM"/>
+			<enumeration value="DO"/>
+			<enumeration value="TP"/>
+			<enumeration value="EC"/>
+			<enumeration value="EG"/>
+			<enumeration value="SV"/>
+			<enumeration value="GQ"/>
+			<enumeration value="ER"/>
+			<enumeration value="EE"/>
+			<enumeration value="ET"/>
+			<enumeration value="FK"/>
+			<enumeration value="FO"/>
+			<enumeration value="FJ"/>
+			<enumeration value="FI"/>
+			<enumeration value="FR"/>
+			<enumeration value="GF"/>
+			<enumeration value="PF"/>
+			<enumeration value="TF"/>
+			<enumeration value="GA"/>
+			<enumeration value="GM"/>
+			<enumeration value="GE"/>
+			<enumeration value="DE"/>
+			<enumeration value="GH"/>
+			<enumeration value="GI"/>
+			<enumeration value="GR"/>
+			<enumeration value="GL"/>
+			<enumeration value="GD"/>
+			<enumeration value="GP"/>
+			<enumeration value="GU"/>
+			<enumeration value="GT"/>
+			<enumeration value="GN"/>
+			<enumeration value="GW"/>
+			<enumeration value="GY"/>
+			<enumeration value="HT"/>
+			<enumeration value="HM"/>
+			<enumeration value="VA"/>
+			<enumeration value="HN"/>
+			<enumeration value="HK"/>
+			<enumeration value="HU"/>
+			<enumeration value="IS"/>
+			<enumeration value="IN"/>
+			<enumeration value="ID"/>
+			<enumeration value="IR"/>
+			<enumeration value="IQ"/>
+			<enumeration value="IE"/>
+			<enumeration value="IL"/>
+			<enumeration value="IT"/>
+			<enumeration value="JM"/>
+			<enumeration value="JP"/>
+			<enumeration value="JO"/>
+			<enumeration value="KZ"/>
+			<enumeration value="KE"/>
+			<enumeration value="KI"/>
+			<enumeration value="KP"/>
+			<enumeration value="KR"/>
+			<enumeration value="KW"/>
+			<enumeration value="KG"/>
+			<enumeration value="LA"/>
+			<enumeration value="LV"/>
+			<enumeration value="LB"/>
+			<enumeration value="LS"/>
+			<enumeration value="LR"/>
+			<enumeration value="LY"/>
+			<enumeration value="LI"/>
+			<enumeration value="LT"/>
+			<enumeration value="LU"/>
+			<enumeration value="MO"/>
+			<enumeration value="MK"/>
+			<enumeration value="MG"/>
+			<enumeration value="MW"/>
+			<enumeration value="MY"/>
+			<enumeration value="MV"/>
+			<enumeration value="ML"/>
+			<enumeration value="MT"/>
+			<enumeration value="MH"/>
+			<enumeration value="MQ"/>
+			<enumeration value="MR"/>
+			<enumeration value="MU"/>
+			<enumeration value="YT"/>
+			<enumeration value="MX"/>
+			<enumeration value="FM"/>
+			<enumeration value="MD"/>
+			<enumeration value="MC"/>
+			<enumeration value="MN"/>
+			<enumeration value="MS"/>
+			<enumeration value="MA"/>
+			<enumeration value="MZ"/>
+			<enumeration value="MM"/>
+			<enumeration value="NA"/>
+			<enumeration value="NR"/>
+			<enumeration value="NP"/>
+			<enumeration value="NL"/>
+			<enumeration value="AN"/>
+			<enumeration value="NC"/>
+			<enumeration value="NZ"/>
+			<enumeration value="NI"/>
+			<enumeration value="NE"/>
+			<enumeration value="NG"/>
+			<enumeration value="NU"/>
+			<enumeration value="NF"/>
+			<enumeration value="MP"/>
+			<enumeration value="NO"/>
+			<enumeration value="OM"/>
+			<enumeration value="PK"/>
+			<enumeration value="PW"/>
+			<enumeration value="PS"/>
+			<enumeration value="PA"/>
+			<enumeration value="PG"/>
+			<enumeration value="PY"/>
+			<enumeration value="PE"/>
+			<enumeration value="PH"/>
+			<enumeration value="PN"/>
+			<enumeration value="PL"/>
+			<enumeration value="PT"/>
+			<enumeration value="PR"/>
+			<enumeration value="QA"/>
+			<enumeration value="RE"/>
+			<enumeration value="RO"/>
+			<enumeration value="RU"/>
+			<enumeration value="RW"/>
+			<enumeration value="SH"/>
+			<enumeration value="KN"/>
+			<enumeration value="LC"/>
+			<enumeration value="PM"/>
+			<enumeration value="VC"/>
+			<enumeration value="WS"/>
+			<enumeration value="SM"/>
+			<enumeration value="ST"/>
+			<enumeration value="SA"/>
+			<enumeration value="SN"/>
+			<enumeration value="SC"/>
+			<enumeration value="SL"/>
+			<enumeration value="SG"/>
+			<enumeration value="SK"/>
+			<enumeration value="SI"/>
+			<enumeration value="SB"/>
+			<enumeration value="SO"/>
+			<enumeration value="ZA"/>
+			<enumeration value="GS"/>
+			<enumeration value="ES"/>
+			<enumeration value="LK"/>
+			<enumeration value="SD"/>
+			<enumeration value="SR"/>
+			<enumeration value="SJ"/>
+			<enumeration value="SZ"/>
+			<enumeration value="SE"/>
+			<enumeration value="CH"/>
+			<enumeration value="SY"/>
+			<enumeration value="TW"/>
+			<enumeration value="TJ"/>
+			<enumeration value="TZ"/>
+			<enumeration value="TH"/>
+			<enumeration value="TG"/>
+			<enumeration value="TK"/>
+			<enumeration value="TO"/>
+			<enumeration value="TT"/>
+			<enumeration value="TN"/>
+			<enumeration value="TR"/>
+			<enumeration value="TM"/>
+			<enumeration value="TC"/>
+			<enumeration value="TV"/>
+			<enumeration value="UG"/>
+			<enumeration value="UA"/>
+			<enumeration value="AE"/>
+			<enumeration value="GB"/>
+			<enumeration value="US"/>
+			<enumeration value="UM"/>
+			<enumeration value="UY"/>
+			<enumeration value="UZ"/>
+			<enumeration value="VU"/>
+			<enumeration value="VE"/>
+			<enumeration value="VN"/>
+			<enumeration value="VG"/>
+			<enumeration value="VI"/>
+			<enumeration value="WF"/>
+			<enumeration value="EH"/>
+			<enumeration value="YE"/>
+			<enumeration value="YU"/>
+			<enumeration value="ZM"/>
+			<enumeration value="ZW"/>
+			<enumeration value="AA">
+				<annotation>
+					<documentation>
+		                NOTE: APO/FPO was defined in eBay list previously 
+		                but they are not defined in ISO 3166. This country 
+		                will remain on eBay country code list for backward 
+		                compatibility.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="QM">
+				<annotation>
+					<documentation>
+		                NOTE: Guernsey was defined in eBay list previously 
+		                but they are not defined in ISO 3166. This country 
+		                will remain on eBay country list for backward 
+		                compatibility.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="QN">
+				<annotation>
+					<documentation>
+		                 NOTE: Jan Mayen was defined in eBay list previously 
+		                 but they are not defined in ISO 3166. This country 
+		                 will remain on eBay country list for backward 
+		                 compatibility.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="QO">
+				<annotation>
+					<documentation>
+		                 NOTE: Jersey was defined in eBay list previously 
+		                 but they are not defined in ISO 3166. This country 
+		                 will remain on eBay country list for backward 
+		                 compatibility.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="QP">
+				<annotation>
+					<documentation>
+		                 NOTE: Tahiti was defined in eBay list previously 
+		                 but they are not defined in ISO 3166. This country 
+		                 will remain on eBay country list for backward 
+		                 compatibility.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CS">
+				<annotation>
+					<documentation>
+		                 NOTE: Serbia and Montenegro was not defined in the list previously
+							  but now an ISO 3166 code has been defined. As of 41.0 this
+							  country is supported in PayPal PRO.
+		             </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GG"/>
+			<enumeration value="IM"/>
+			<enumeration value="JE"/>
+			<enumeration value="TL"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="CurrencyCodeType">
+		<annotation>
+			<documentation>
+		   		ISO 4217 standard 3-letter currency code. 
+<br/>
+				<br/>
+The following currencies are supported by PayPal.
+<table>
+					<th>Code</th>
+					<th>Currency<th/>Maximum Transaction Amount</th>
+					<tr>
+						<td>AUD</td>
+						<td>Australian Dollar </td>
+						<td>12,500 AUD</td>
+					</tr>
+					<tr>
+						<td>CAD</td>
+						<td>Canadian Dollar<td/>12,500 CAD</td>
+					</tr>
+					<tr>
+						<td>EUR</td>
+						<td>Euro</td>
+						<td> 8,000 EUR</td>
+					</tr>
+					<tr>
+						<td>GBP</td>
+						<td>Pound Sterling</td>
+						<td>  5,500 GBP</td>
+					</tr>
+					<tr>
+						<td>JPY</td>
+						<td>Japanese Yen</td>
+						<td>1,000,000 JPY</td>
+					</tr>
+					<tr>
+						<td>USD</td>
+						<td> U.S. Dollar</td>
+						<td>10,000 USD</td>
+					</tr>
+					<tr>
+						<td>CHF</td>
+						<td> Czech Koruna</td>
+						<td>70,000 CHF</td>
+					</tr>
+					<tr>
+						<td>SEK</td>
+						<td> Swedish Krona</td>
+						<td>3,50,000 SEK</td>
+					</tr>
+					<tr>
+						<td>NOK</td>
+						<td> Norwegian Krone</td>
+						<td>4,00,000 NOK</td>
+					</tr>
+					<tr>
+						<td>DKK</td>
+						<td> Danish Krone</td>
+						<td>3,00,000 DKK</td>
+					</tr>
+					<tr>
+						<td>PLN</td>
+						<td> Poland Zloty</td>
+						<td>1,60,000 PLN</td>
+					</tr>
+					<tr>
+						<td>HUF</td>
+						<td> Hungary Forint</td>
+						<td>110,00,000 HUF</td>
+					</tr>
+					<tr>
+						<td>SGD</td>
+						<td> Singapore Dollar</td>
+						<td>80,000 SGD</td>
+					</tr>
+					<tr>
+						<td>HKD</td>
+						<td> HongKong Dollar</td>
+						<td>3,80,000 HKD</td>
+					</tr>
+					<tr>
+						<td>NZD</td>
+						<td> New Zealand Dollar</td>
+						<td>77,000 NZD</td>
+					</tr>
+					<tr>
+						<td>CZK</td>
+						<td> Czech Koruna</td>
+						<td>1,20,000 CZK</td>
+					</tr>
+				</table>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="AFA"/>
+			<enumeration value="ALL"/>
+			<enumeration value="DZD"/>
+			<enumeration value="ADP"/>
+			<enumeration value="AOA"/>
+			<enumeration value="ARS"/>
+			<enumeration value="AMD"/>
+			<enumeration value="AWG"/>
+			<enumeration value="AZM"/>
+			<enumeration value="BSD"/>
+			<enumeration value="BHD"/>
+			<enumeration value="BDT"/>
+			<enumeration value="BBD"/>
+			<enumeration value="BYR"/>
+			<enumeration value="BZD"/>
+			<enumeration value="BMD"/>
+			<enumeration value="BTN"/>
+			<enumeration value="INR"/>
+			<enumeration value="BOV"/>
+			<enumeration value="BOB"/>
+			<enumeration value="BAM"/>
+			<enumeration value="BWP"/>
+			<enumeration value="BRL"/>
+			<enumeration value="BND"/>
+			<enumeration value="BGL"/>
+			<enumeration value="BGN"/>
+			<enumeration value="BIF"/>
+			<enumeration value="KHR"/>
+			<enumeration value="CAD"/>
+			<enumeration value="CVE"/>
+			<enumeration value="KYD"/>
+			<enumeration value="XAF"/>
+			<enumeration value="CLF"/>
+			<enumeration value="CLP"/>
+			<enumeration value="CNY"/>
+			<enumeration value="COP"/>
+			<enumeration value="KMF"/>
+			<enumeration value="CDF"/>
+			<enumeration value="CRC"/>
+			<enumeration value="HRK"/>
+			<enumeration value="CUP"/>
+			<enumeration value="CYP"/>
+			<enumeration value="CZK"/>
+			<enumeration value="DKK"/>
+			<enumeration value="DJF"/>
+			<enumeration value="DOP"/>
+			<enumeration value="TPE"/>
+			<enumeration value="ECV"/>
+			<enumeration value="ECS"/>
+			<enumeration value="EGP"/>
+			<enumeration value="SVC"/>
+			<enumeration value="ERN"/>
+			<enumeration value="EEK"/>
+			<enumeration value="ETB"/>
+			<enumeration value="FKP"/>
+			<enumeration value="FJD"/>
+			<enumeration value="GMD"/>
+			<enumeration value="GEL"/>
+			<enumeration value="GHC"/>
+			<enumeration value="GIP"/>
+			<enumeration value="GTQ"/>
+			<enumeration value="GNF"/>
+			<enumeration value="GWP"/>
+			<enumeration value="GYD"/>
+			<enumeration value="HTG"/>
+			<enumeration value="HNL"/>
+			<enumeration value="HKD"/>
+			<enumeration value="HUF"/>
+			<enumeration value="ISK"/>
+			<enumeration value="IDR"/>
+			<enumeration value="IRR"/>
+			<enumeration value="IQD"/>
+			<enumeration value="ILS"/>
+			<enumeration value="JMD"/>
+			<enumeration value="JPY"/>
+			<enumeration value="JOD"/>
+			<enumeration value="KZT"/>
+			<enumeration value="KES"/>
+			<enumeration value="AUD"/>
+			<enumeration value="KPW"/>
+			<enumeration value="KRW"/>
+			<enumeration value="KWD"/>
+			<enumeration value="KGS"/>
+			<enumeration value="LAK"/>
+			<enumeration value="LVL"/>
+			<enumeration value="LBP"/>
+			<enumeration value="LSL"/>
+			<enumeration value="LRD"/>
+			<enumeration value="LYD"/>
+			<enumeration value="CHF"/>
+			<enumeration value="LTL"/>
+			<enumeration value="MOP"/>
+			<enumeration value="MKD"/>
+			<enumeration value="MGF"/>
+			<enumeration value="MWK"/>
+			<enumeration value="MYR"/>
+			<enumeration value="MVR"/>
+			<enumeration value="MTL"/>
+			<enumeration value="EUR"/>
+			<enumeration value="MRO"/>
+			<enumeration value="MUR"/>
+			<enumeration value="MXN"/>
+			<enumeration value="MXV"/>
+			<enumeration value="MDL"/>
+			<enumeration value="MNT"/>
+			<enumeration value="XCD"/>
+			<enumeration value="MZM"/>
+			<enumeration value="MMK"/>
+			<enumeration value="ZAR"/>
+			<enumeration value="NAD"/>
+			<enumeration value="NPR"/>
+			<enumeration value="ANG"/>
+			<enumeration value="XPF"/>
+			<enumeration value="NZD"/>
+			<enumeration value="NIO"/>
+			<enumeration value="NGN"/>
+			<enumeration value="NOK"/>
+			<enumeration value="OMR"/>
+			<enumeration value="PKR"/>
+			<enumeration value="PAB"/>
+			<enumeration value="PGK"/>
+			<enumeration value="PYG"/>
+			<enumeration value="PEN"/>
+			<enumeration value="PHP"/>
+			<enumeration value="PLN"/>
+			<enumeration value="USD"/>
+			<enumeration value="QAR"/>
+			<enumeration value="ROL"/>
+			<enumeration value="RUB"/>
+			<enumeration value="RUR"/>
+			<enumeration value="RWF"/>
+			<enumeration value="SHP"/>
+			<enumeration value="WST"/>
+			<enumeration value="STD"/>
+			<enumeration value="SAR"/>
+			<enumeration value="SCR"/>
+			<enumeration value="SLL"/>
+			<enumeration value="SGD"/>
+			<enumeration value="SKK"/>
+			<enumeration value="SIT"/>
+			<enumeration value="SBD"/>
+			<enumeration value="SOS"/>
+			<enumeration value="LKR"/>
+			<enumeration value="SDD"/>
+			<enumeration value="SRG"/>
+			<enumeration value="SZL"/>
+			<enumeration value="SEK"/>
+			<enumeration value="SYP"/>
+			<enumeration value="TWD"/>
+			<enumeration value="TJS"/>
+			<enumeration value="TZS"/>
+			<enumeration value="THB"/>
+			<enumeration value="XOF"/>
+			<enumeration value="TOP"/>
+			<enumeration value="TTD"/>
+			<enumeration value="TND"/>
+			<enumeration value="TRL"/>
+			<enumeration value="TMM"/>
+			<enumeration value="UGX"/>
+			<enumeration value="UAH"/>
+			<enumeration value="AED"/>
+			<enumeration value="GBP"/>
+			<enumeration value="USS"/>
+			<enumeration value="USN"/>
+			<enumeration value="UYU"/>
+			<enumeration value="UZS"/>
+			<enumeration value="VUV"/>
+			<enumeration value="VEB"/>
+			<enumeration value="VND"/>
+			<enumeration value="MAD"/>
+			<enumeration value="YER"/>
+			<enumeration value="YUM"/>
+			<enumeration value="ZMK"/>
+			<enumeration value="ZWD"/>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="DepositTypeCodeType">
+		<annotation>
+			<documentation>
+			   DepositTypeCodeType - Type declaration to be used by other schema's.
+			   This code identifies the DepositType codes used to specify deposit
+			   types for Motors items. If the ietm listed is not a Motors item, then always
+			   return DepositType value to be "None".
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None">
+				<annotation>
+					<documentation>None</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="OtherMethod">
+				<annotation>
+					<documentation>
+					   Other Method
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="FastDeposit">
+				<annotation>
+					<documentation> 
+					   Fast Deposit.																			</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="DetailLevelCodeType">
+		<annotation>
+			<documentation>
+			     DetailLevelCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="ReturnAll">
+				<annotation>
+					<documentation>
+						    Return in response message all detail levels.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemReturnDescription">
+				<annotation>
+					<documentation>
+						    Return item description. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemReturnAttributes">
+				<annotation>
+					<documentation>
+						  Return attributes as part of the item.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<annotation>
+		<documentation>
+			This file defines re-useable base and aggregate components of the 
+			eBay Business Lanaguage (eBL) that would be used to compose 
+			message payloads for eBay APIs.
+ 		</documentation>
+	</annotation>
+    <simpleType name="IncentiveSiteAppliedOnType">
+        <annotation>
+            <documentation>
+                This defines if the incentive is applied on Ebay or PayPal.
+            </documentation>
+        </annotation>
+        <restriction base="xs:token">
+            <enumeration value="INCENTIVE-SITE-APPLIED-ON-UNKNOWN"/>
+            <enumeration value="INCENTIVE-SITE-APPLIED-ON-MERCHANT"/>
+            <enumeration value="INCENTIVE-SITE-APPLIED-ON-PAYPAL"/>
+        </restriction>
+    </simpleType>
+    <simpleType name="IncentiveAppliedStatusType">
+        <annotation>
+            <documentation>
+                This defines if the incentive is applied successfully or not.
+            </documentation>
+        </annotation>
+        <restriction base="xs:token">
+            <enumeration value="INCENTIVE-APPLIED-STATUS-SUCCESS"/>
+            <enumeration value="INCENTIVE-APPLIED-STATUS-ERROR"/>
+        </restriction>
+    </simpleType>
+	<simpleType name="ItemIDType">
+		<annotation>
+			<documentation>
+			    Represents the unique identifier for an item. To be used to specify the
+			    elements that represents an ItemID.
+			</documentation>
+		</annotation>
+		<restriction base="xs:string"/>
+	</simpleType>
+	<complexType name="AccountEntryType">
+		<sequence>
+			<element ref="ns:Balance">
+				<annotation>
+					<documentation>
+			          Balance as of a given entry, can be 0.00.
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="Credit" type="cc:AmountType">
+				<annotation>
+					<documentation>
+			          Credit Amount for a detail entry, can be 0.00. 
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="Date" type="xs:dateTime">
+				<annotation>
+					<documentation>
+			           Date entry was posted, in GMT. 
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="Debit" type="cc:AmountType">
+				<annotation>
+					<documentation>
+			           Debit Amount for this detail entry, can be 0.00.      
+			       </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ItemID">
+				<annotation>
+					<documentation>
+			           Item number if transaction is associated with an auction or 0 
+			           if no item is associated with an account entry.      
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="Memo" type="xs:string">
+				<annotation>
+					<documentation>
+			           Memo line for an account entry, can be empty string.
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="RefNumber" type="xs:int">
+				<annotation>
+					<documentation>
+			           eBay reference number for an account entry.    
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="AccountEntryDetailsType" type="xs:int">
+				<annotation>
+					<documentation>
+			           Integer code for account details entry type. This element
+			           element specifies an index to a table of explanations for 
+			           accounting charges. 
+			       </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AdditionalAccountType">
+		<annotation>
+			<documentation>
+	          The AdditionalAccount component represents historical data related to 
+	          accounts that the user held with a country of residency other than 
+	          the current one. eBay users can have one active account at a time. 
+	          For users who change their country of residency and modify their 
+	          eBay registration to reflect this change, the new country of residence 
+	          becomes the currently active account. Any account associated with 
+	          a previous country is treated as an additional account. Because the 
+	          currency for these additional accounts are different than the active 
+	          account, each additional account includes an indicator of the currency 
+	          for that account. Users who never change their country of residence 
+	          will not have any additional accounts.
+	        </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:Balance"/>
+			<element ref="ns:Currency"/>
+			<element ref="ns:AccountCode"/>
+		</sequence>
+	</complexType>
+	<complexType name="PromotedItemType">
+		<annotation>
+			<documentation>
+				Merchandizing info for an Item. This contains a list of crosssell
+				or upsell items.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ItemID" type="ns:ItemIDType">
+				<annotation>
+					<documentation> 
+						Item ID for the base item. Based on this item other items are 
+						promoted. it is teh only tag that would show up in all calls that use promoted item type. 
+						some are not in soap yet, such as get and ser promotion rules
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PictureURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						URL for the picture of the promoted item.           
+					</documentation>
+				</annotation>
+			</element>
+			<element name="position" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation>
+						Where to display in the list of items.currentl y even forget and set does not have to be minoccur =0 
+						but if we ever were to do revise promotion tems, it can be omitted
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PromotionPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+						Promotion Price. Price at which the buyer can buy the item now.
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="PromotionPriceType" type="ns:PromotionItemPriceTypeCodeType" minOccurs="0"/>
+			<element name="SelectionType" type="ns:PromotionItemSelectionCodeType" minOccurs="0"/>
+			<element name="Title" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+                    	Item Title for the promoted item.           
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="ListingType" type="ns:ListingTypeCodeType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="CrossPromotionsType">
+		<annotation>
+			<documentation>
+				Merchandizing info for an Item. This contains a list of crosssell
+				or upsell items.
+				PrimaryScheme, PromotionMethod,SellerId,ItemId, ShippingDiscount
+				do not have be min occur 0
+	        </documentation>
+		</annotation>
+		<sequence>
+			<element name="ItemID" type="ns:ItemIDType">
+				<annotation>
+					<documentation> 
+						Item ID for the base item. Based on this item other items are 
+						promoted.
+                 	</documentation>
+				</annotation>
+			</element>
+			<element name="PrimaryScheme" type="ns:PromotionSchemeCodeType"/>
+			<element name="PromotionMethod" type="ns:PromotionMethodCodeType"/>
+			<element name="SellerID" type="xs:string">
+				<annotation>
+					<documentation>
+                    	Id of the Seller who is promoting this item.           
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="ShippingDiscount" type="xs:boolean">
+				<annotation>
+					<documentation>
+                    	Shipping Discount offered or not by the seller.
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="SellerKey" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+                    	Key of the Seller who is promoting this item.           
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="StoreName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+                    	Store Name for the seller.
+                    </documentation>
+				</annotation>
+			</element>
+			<element name="PromotedItem" type="ns:PromotedItemType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="AccountSummaryType" mixed="true">
+		<annotation>
+			<documentation>
+                     Includes account summary for the user. 
+             </documentation>
+		</annotation>
+		<choice minOccurs="0" maxOccurs="unbounded">
+			<element name="AccountState" type="ns:AccountStateCodeType" minOccurs="0"/>
+			<element name="AdditionalAccount" type="ns:AdditionalAccountType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="AdditionalAccountsCount" type="xs:int">
+				<annotation>
+					<documentation>
+                                     Number of additional accounts.
+                           	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:AmountPastDue" minOccurs="0">
+				<annotation>
+					<documentation>
+                                Amount past due, 0.00 if not past due. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="BankAccountInfo" type="xs:string">
+				<annotation>
+					<documentation>
+                                First four digits (with remainder Xed-out). This may be an empty 
+                                string depending upon the value of the payment type for the 
+                                user account (e.g, if no debit-card specified).
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="BankModifyDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Last time/day BankAccountInfo and/or BankRoutingInfo was 
+                                modified, in GMT. This may be an empty string depending 
+                                upon the value of the payment type for the user account 
+                                (e.g, if no debit-card specified).
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="BillingCycleDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Indicates the billing cycle in which eBay sends a billing 
+                                invoice to the specified user. Possible values:
+    						0 = On the last day of the month.
+    						15 = On the 15th day of the month. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="CCExp" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Expiration date for the credit card selected as payment method, 
+                                in GMT. Empty string if no credit card is on file or if account is
+                                inactive -- even if there is a credit card on file.
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="CCInfo" type="xs:string">
+				<annotation>
+					<documentation>
+                                Last four digits of user's credit card selected as payment
+                                type. Empty string if no credit is on file. This may be an empty 
+                                string depending upon the value of the payment type for the 
+                                user account (e.g, if no debit-card specified).
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="CCModifyDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Last date credit card or credit card expiration date was 
+                                modified, in GMT. This may be an empty string depending 
+                                upon the value of the payment type for the user account 
+                                (e.g, Empty string if no credit card is on file.
+                           </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:CurrentBalance">
+				<annotation>
+					<documentation>
+                                User's current balance. Can be 0.00, positive, or negative. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="LastAmountPaid" type="cc:AmountType">
+				<annotation>
+					<documentation>
+                                Amount of last payment posted, 0.00 if no payments posted. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="LastInvoiceAmount" type="cc:AmountType">
+				<annotation>
+					<documentation>
+                                Amount of last invoice. 0.00 if account not yet invoiced. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="LastInvoiceDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Date of last invoice sent by eBay to the user, in GMT. 
+                                Empty string if this account has not been invoiced yet. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="LastPaymentDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+                                Date of last payment by specified user to eBay, in GMT. 
+                                Empty string if no payments posted. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="PastDue" type="xs:boolean">
+				<annotation>
+					<documentation>
+                                Indicates whether the account has past due amounts 
+                                outstanding. Possible values:
+    						true = Account is past due.
+    						false = Account is current. 
+                           </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentMethod" type="ns:SellerPaymentMethodCodeType">
+				<annotation>
+					<documentation>
+                               Indicates the method the specified user selected for paying 
+                               eBay. The values for PaymentType vary for each SiteID. 
+                           </documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="BuyerType">
+		<annotation>
+			<documentation>
+				Information about user used by buying applications
+	        </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:ShippingAddress" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="SellerType">
+		<annotation>
+			<documentation>
+				Information about user used by selling applications
+				there are number of required elements - they will always show up for seller node
+				there is not such a call to do revise seller info. only added minoccur=0 to elements that will not show up in every 
+				type of request/responce
+	        </documentation>
+		</annotation>
+		<sequence>
+			<element name="AllowPaymentEdit" type="xs:boolean"/>
+			<element name="BillingCurrency" type="ns:CurrencyCodeType" minOccurs="0"/>
+			<element ref="ns:CheckoutEnabled"/>
+			<element name="CIPBankAccountStored" type="xs:boolean"/>
+			<element name="GoodStanding" type="xs:boolean"/>
+			<element name="LiveAuctionAuthorized" type="xs:boolean"/>
+			<element name="MerchandizingPref" type="ns:MerchandizingPrefCodeType">
+				<annotation>
+					<documentation>
+					            		Indicates whether the user has elected to participate 
+					            		as a seller in the Merchandising Manager feature. 
+    					         	</documentation>
+				</annotation>
+			</element>
+			<element name="QualifiesForB2BVAT" type="xs:boolean"/>
+			<element ref="ns:SellerLevel"/>
+			<element ref="ns:SellerPaymentAddress" minOccurs="0"/>
+			<element name="SchedulingInfo" type="ns:SchedulingInfoType" minOccurs="0"/>
+			<element ref="ns:StoreOwner"/>
+			<element name="StoreURL" type="xs:anyURI" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="FeeType">
+		<annotation>
+			<documentation>
+			     Definition of an eBay Fee type.
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="Name" type="xs:string" minOccurs="0"/>
+			<element name="Fee" type="cc:AmountType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="FeesType">
+		<annotation>
+			<documentation>
+			      Following are the current set of eBay fee types
+					AuctionLengthFee
+					BoldFee
+					BuyItNowFee
+					CategoryFeaturedFee
+					FeaturedFee
+					FeaturedGalleryFee
+					FixedPriceDurationFee
+					GalleryFee
+					GiftIconFee
+					HighLightFee
+					InsertionFee
+					ListingDesignerFee
+					ListingFee
+					PhotoDisplayFee
+					PhotoFee
+					ReserveFee
+					SchedulingFee
+					ThirtyDaysAucFee
+				Instances of this type could hold one or more supported types of fee.
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="Fee" type="ns:FeeType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ShippingCarrierDetailsType">
+		<sequence>
+			<element name="CarrierShippingFee" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Calculated cost of shipping, based on shipping parameters and 
+                                    selected shipping service. Only returned if ShippingType = 2
+                                    (i.e., calculated shipping rate).
+                             	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:InsuranceFee" minOccurs="0"/>
+			<element ref="ns:InsuranceOption" minOccurs="0"/>
+			<element name="PackagingHandlingCosts" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                               	  Optional fees a seller might assess for the shipping of the item. 
+                         		</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingRateErrorMessage" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                              	  Describes any error message associated with the attempt 
+                                   to calculate shipping rates. If there was no error, returns 
+                              	  "No Error" (without the quotation marks).
+                           </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ShippingService">
+				<annotation>
+					<documentation> 
+                              	is unique identified of shipping carrier, without this element the whole node makes no sence
+                           </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="CalculatedShippingRateType">
+		<sequence>
+			<element name="OriginatingPostalCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Potal/zip code from where package will be shipped.
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingIrregular" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+                              	  Indicates an item that cannot go through the stamping machine 
+                              	  at the shipping service office (a value of True) and requires 
+                              	  special or fragile handling. Only returned if ShippingType = 2. 
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="CarrierDetails" type="ns:ShippingCarrierDetailsType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+                               	 contains information about shipping fees per each shipping service chosen by the seller
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="ShippingPackage" type="ns:ShippingPackageCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                               	  May need to be moved into details - wait for George! The size of the package to be shipped. Possible values are:
+    					  None
+    					  Letter
+    					  Large envelope
+    					  USPS flat rate envelope
+   	 				  Package/thick envelope
+    					  USPS large package/oversize 1
+    					  Very large package/oversize 2
+    					  UPS Letter
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="WeightMajor" type="cc:MeasureType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                              	  Shipping weight unit of measure (major). If unit of weight is kilogram 
+                              	  (i.e., metric system) this would be the exact weight value in kilogram 
+                              	  (i.e., complete decimal number, e.g., 2.23 kg). Only returned if 
+                              	  ShippingType is 2. 
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="WeightMinor" type="cc:MeasureType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                              	  Shipping weight unit of measure (minor). If unit of weight is  in pounds and/or
+                              	  ounces, this would be the exact weight value in ounces (i.e., complete 
+                              	  decimal number, e.g., 8.2 or 8.0 ounces). Only returned if ShippingType is 2. 
+                               </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="FlatShippingRateType">
+		<sequence>
+			<element name="AdditionalShippingCosts" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                     Any additional shipping costs for the item. 
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="FlatShippingHandlingCosts" type="cc:AmountType" minOccurs="0"/>
+			<element ref="ns:InsuranceFee" minOccurs="0"/>
+			<element ref="ns:InsuranceOption" minOccurs="0"/>
+			<element ref="ns:ShippingService" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="SalesTaxType">
+		<sequence>
+			<element name="SalesTaxPercent" type="xs:float" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                   Amount of the sales tax to be collected for the transaction. 
+                                   Sales tax is only for US. 
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="SalesTaxState" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Sales tax for the transaction, expressed as a percentage. Should 
+                                    be empty for items listed on international sites (hence, this is 
+                                    US-only element).
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="ShippingIncludedInTax" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                   Indicates whether shipping is included in the tax. Applicable if 
+                                   ShippingType = 1 or 2. This element is used for US-only.
+                             </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ShippingDetailsType">
+		<annotation>
+			<documentation> 
+                       Specifies the shipping payment details.
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="AllowPaymentEdit" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+                               	  Indicates whether the buyer edited the payment amount. 
+                           	</documentation>
+				</annotation>
+			</element>
+			<element name="CalculatedShippingRate" type="ns:CalculatedShippingRateType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Calculated shipping rate details.  If present, then the calculated shipping rate option was used. 
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="ChangePaymentInstructions" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+                               	  Indicates whether the payment instructions are included (e.g., for updating the
+                               	  details of a transaction).
+                           	</documentation>
+				</annotation>
+			</element>
+			<element name="FlatShippingRate" type="ns:FlatShippingRateType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+                                    Flat shipping rate details. If present, then the flat shipping rate option was used. 
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="InsuranceTotal" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Total cost of insurance for the transaction.
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="InsuranceWanted" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Indicates whether buyer selected to have insurance. 
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInstructions" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Payment instuctions.   
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="SalesTax" type="ns:SalesTaxType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Sales tax details. Sales tax applicable for only US sites.
+                                    For non-US sites this sub-element should not be used.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="SellerPostalCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    Postal/Zip code from where the seller will ship the item.
+                                 </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="SiteHostedPictureType">
+		<sequence>
+			<element name="PictureURL" type="xs:anyURI" minOccurs="0" maxOccurs="6">
+				<annotation>
+					<documentation> 
+                                    URLs for item picture that are stored/hosted at eBay site.
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="PhotoDisplay" type="ns:PhotoDisplayCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                   Type of display for photos used for PhotoHosting slide show. 
+			                   Here are display options:
+    							None = No special Picture Services features.
+    							SlideShow = Slideshow of multiple pictures.
+    							SuperSize = Super-size format picture.
+    							PicturePack = Picture Pack.
+    				             		Default is 'None'. 
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="GalleryType" type="ns:GalleryTypeCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  This will be either "Featured" or "Gallery".
+                              	</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="VendorHostedPictureType">
+		<sequence>
+			<element name="PictureURL" type="xs:anyURI" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                    URLs for item picture that are stored/hosted at eBay site.
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="GalleryURL" type="xs:anyURI" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             		URL for a picture for the gallery. If the GalleryFeatured 
+			             		argument is true, a value must be supplied for either 
+			             		the GalleryURL or the PictureURL argument. 
+						In either case:
+							(a) If a URL is provided for only PictureURL, it is used 
+							as the Gallery thumbnail. 
+							(b) If a URL is provided for both GalleryURL and 
+							PictureURL, then the picture indicated in GalleryURL 
+							is used as the thumbnail. 
+						The image used for the Gallery thumbnail (specified 
+						in the GalleryURL or PictureURL argument) must be 
+						in one of the graphics formats JPEG, BMP, TIF, or GIF. 
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="GalleryType" type="ns:GalleryTypeCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  This will be either "Featured" or "Gallery".
+                              	</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ValType">
+		<sequence>
+			<element name="ValueLiteral" type="xs:string"/>
+		</sequence>
+		<attribute name="ValueID" type="xs:string" use="optional"/>
+	</complexType>
+	<complexType name="AttributeType">
+		<annotation>
+			<documentation> 
+   				Specific physical attribute of an item.
+   	             </documentation>
+		</annotation>
+		<sequence>
+			<element name="Value" type="ns:ValType" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+				   ValueList of the Attribute being described by the AttributeID.
+			       </documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="AttributeID" type="xs:string">
+			<annotation>
+				<documentation>
+					Constant name of the attribute that identifies a 
+				     	physical attribute within a set of characteristics 
+				     	that describe something in a formalised way. 
+			       </documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="AttributeSetType">
+		<annotation>
+			<documentation> 
+			AttributeSet.
+               </documentation>
+		</annotation>
+		<sequence>
+			<element name="Attribute" type="ns:AttributeType" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="AttributeSetID" type="xs:string"/>
+	</complexType>
+	<complexType name="ListOfAttributeSetType">
+		<sequence>
+			<element name="AttributeSet" type="ns:AttributeSetType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="CategoryType">
+		<annotation>
+			<documentation>
+ 			  Container for data on the primary category of listing.
+ 	           </documentation>
+		</annotation>
+		<sequence>
+			<element name="AutoPayEnabled" type="xs:boolean" minOccurs="0"/>
+			<element name="B2BVATEnabled" type="xs:boolean" minOccurs="0"/>
+			<element name="CatalogEnabled" type="xs:boolean" minOccurs="0"/>
+			<element name="CategoryID" type="xs:string"/>
+			<element name="CategoryLevel" type="xs:int" minOccurs="0"/>
+			<element name="CategoryName" type="xs:string" minOccurs="0"/>
+			<element name="CategoryParentID" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="CategoryParentName" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="CSIDList" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+ 			  		CSIDList is not present if Attributes enabled.
+ 	           		 </documentation>
+				</annotation>
+			</element>
+			<element name="Expired" type="xs:boolean" minOccurs="0"/>
+			<element name="IntlAutosFixedCat" type="xs:boolean" minOccurs="0"/>
+			<element name="LeafCategory" type="xs:boolean" minOccurs="0"/>
+			<element name="Virtual" type="xs:boolean" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="StorefrontType">
+		<annotation>
+			<documentation> 
+	       		Contains the eBay Stores-specific item attributes 
+	       		department number and store location. StorefrontInfo 
+	       		is shown for any item that belongs to an eBay Store 
+	       		owner, regardless of whether it is fixed price or 
+	       		auction type. Returned as null for international 
+	       		fixed price items.
+     			</documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:StoreCategoryID">
+				<annotation>
+					<documentation> 
+			      			assumed this type is specific to add/get/revise item, then each StorefrontType nust have category id, for store details this node makes no sense to use
+			        	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:StoreURL" minOccurs="0">
+				<annotation>
+					<documentation> 
+			      			in case or revise item for example - to change store category (department) you do not need to change store URL, so it will notbe in request
+			      		</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ListingDesignerType">
+		<annotation>
+			<documentation> 
+  				Identifies the Layout and the Theme template 
+	       		associated with the item. in case of revision - all data can be min occur = 0
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="LayoutID" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			      			Identifies the Layout template associated with the item.
+			  		</documentation>
+				</annotation>
+			</element>
+			<element name="OptimalPictureSize" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+						A value of true for OptimalPictureSize indicates that the picture 
+						URL will be enlarged to fit description of the item.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ThemeID" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			      			Identifies the Theme template associated with the item.
+			 		</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="CharityType">
+		<annotation>
+			<documentation> 
+                       Contains information about a Charity listing.in case of revision - all data can be min occur = 0
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="CharityName" type="xs:string" minOccurs="0"/>
+			<element name="CharityNumber" type="xs:int" minOccurs="0"/>
+			<element name="DonationPercent" type="xs:float" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="SellingStatusType">
+		<annotation>
+			<documentation> 
+			Contains the listed items price details which consists of
+			following information: BuyItNowPrice, ConvertedBuyItNowPrice,
+			ConvertedPrice, ConvertedStartPrice, CurrentPrice, MinimumToBid, 
+			ReservePrice, and StartPrice.  need to take in account get seller events when defining minoccurs = 0       
+                </documentation>
+		</annotation>
+		<sequence>
+			<element name="BidCount" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               Number of bids placed so far against the item. Not
+			               returned for International Fixed Price items.
+                          </documentation>
+				</annotation>
+			</element>
+			<element name="BidIncrement" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               Smallest amount a bid must be above the current high 
+			               bid. Not returned International Fixed Price items.
+                          </documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedCurrentPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+					   Converted current price of listed item.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="CurrentPrice" type="cc:AmountType">
+				<annotation>
+					<documentation> 
+					For auction-format listings, current minimum asking price 
+					or the current highest bid for the item if bids have been 
+					placed. Shows minimum bid if no bids have been placed 
+					against the item. This field does not reflect the actual current 
+					price of the item if it's a Type=7 or Type=9 (Fixed Price) 
+					item and the price has been revised. (See StartPrice for 
+					revised asking price.) 
+                              </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:HighBidder" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                 Contains one User node representing the current high 
+			                 bidder. GetItem returns a high bidder for auctions that have 
+			                 ended and have a winning bidder. For Fixed Price listings, 
+			                 in-progress auctions, or auction items that received no 
+			                 bids, GetItem returns a HighBidder node with empty tags. 
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="LeadCount" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  Applicable to ad-format items only. Indicates how many 
+			                  leads to potential buyers are associated with this item. 
+			                  For other item types (other than ad-format items), returns
+			                  a value of 0 (zero).
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="MinimumToBid" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  Minimum acceptable bid for the item. Not returned for 
+			                  International Fixed Price items.     
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="QuantitySold" type="xs:int">
+				<annotation>
+					<documentation> 
+					     Number of items purchased so far. (Subtract from the value
+					     returned in the Quantity field to calculate the number of items
+					     remaining.)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReserveMet" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+						Returns true if the reserve price was met or no reserve
+						price was specified.  
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SecondChanceEligible" type="xs:boolean" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="ReviseStatusType">
+		<annotation>
+			<documentation> 
+			Contains the revise status information details (e.g., item properties 
+			information). ths node contains system set data only - always output and always all data. no minccurs needed,
+			except for motors specific data, since it wil lnot be retruned for non motors items
+                </documentation>
+		</annotation>
+		<sequence>
+			<element name="ItemRevised" type="xs:boolean">
+				<annotation>
+					<documentation> 
+			              	Indicates whether the item was revised since the auction started. 
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="BuyItNowAdded" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	If true, indicates that a Buy It Now Price was added for
+			              	the item. Only returned for Motors items.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="BuyItNowLowered" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             		Replaces BinLowered as of API version 305. If true,
+			             		indicates that the Buy It Now Price was lowered for the
+			             		item. Only returned for Motors items. 
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="ReserveLowered" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+			                  If true, indicates that the Reserve Price was lowered for
+			                  the item. Only returned for Motors items.
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="ReserveRemoved" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  If true, indicates that the Reserve Price was removed
+			                  from the item. Only returned for eBay Motors items.
+                              </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ListingDetailsType">
+		<annotation>
+			<documentation> 
+			Contains the listed item details which consists of following information: .         
+                </documentation>
+		</annotation>
+		<sequence>
+			<element name="Adult" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="BindingAuction" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="CheckoutEnabled" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedBuyItNowPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               Converted value of the BuyItNowPrice in the currency 
+			               indicated by SiteCurrency. This value must be refreshed 
+			               every 24 hours to pick up the current conversion rates.
+                          </documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedStartPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               Converted value of the StartPrice field in the currency 
+			               indicated by SiteCurrency. This value must be refreshed 
+			               every 24 hours to pick up the current conversion rates.
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedReservePrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+					 Indicates the converted reserve price for a reserve auction. Returned 
+					 only if DetailLevel = 4. ReservePrice is only returned for auctions with 
+					 a reserve price where the user calling GetItem is the item's seller. 
+					 Returned as null for International Fixed Price items. For more information 
+					 on reserve price auctions, see http://pages.ebay.com/help/basics/f-format.html#1. 
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="HasReservePrice" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="RegionName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="RelistedItemID" type="ns:ItemIDType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Indicates the new ItemID for a relisted item. When an item is 
+			               	relisted, the old (expired) listing is annotated with the new 
+			               	(relist) ItemID. This field only appears when the old listing is 
+			               	retrieved.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="SecondChanceOriginalItemID" type="ns:ItemIDType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               The ItemID for the original listing (i.e., OriginalItemID specific 
+			               to Second Chance Offer items). 
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="StartTime" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              Time stamp for the start of the listing (in GMT). For regular items, 
+			              StartTime is not sent in at listing time.
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="EndTime" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              Time stamp for the end of the listing (in GMT).
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="ViewItemURL" type="xs:anyURI" minOccurs="0">
+				<annotation>
+					<documentation>
+                              </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ItemType">
+		<sequence>
+			<element name="ApplicationData" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Returns custom, application-specific data associated 
+			               	with the item. The data in this field is stored with the item 
+			               	in the items table at eBay, but is not used in any way by 
+			               	eBay. Use ApplicationData to store such special information 
+			               	as a part or SKU number. Maximum 32 characters in length.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="ListOfAttributeSets" type="ns:ListOfAttributeSetType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Carries one or more instances of the AttributeSet in a list.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="AutoPay" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	If true (1), indicates that the seller requested immediate 
+			               	payment for the item. False (0) if immediate payment was 
+			               	not requested. (Does not indicate whether the item is 
+			               	still a candidate for puchase via immediate payment.) 
+			               	Only applicable for items listed on US and UK sites in 
+			               	categories that support immediate payment, when seller 
+			              	has a Premier or Business PayPal account.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerProtection" type="ns:BuyerProtectionCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Indicates the status of the item's eligibility for the Buyer 
+			               	Protection Program. Possible values:
+    							ItemIneligible - Item is ineligible (e.g., category not applicable)
+    						 	ItemEligible - Item is eligible per standard criteria 
+    							ItemMarkedIneligible - Item marked ineligible per special criteria (e.g., seller's account closed)
+    							ItemMarkedIneligible - Item marked elegible per other criteria
+						Applicable for items listed to the US site and for the Parts 
+						and Accessories category (6028) or Everything Else category 
+						(10368) (or their subcategories) on the eBay Motors site.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="BuyItNowPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Amount a Buyer would need to bid to take advantage 
+			               	of the Buy It Now feature. Not applicable to Fixed-Price 
+			               	items (Type = 7 or 9) or AdFormat-type listings. For 
+			               	Fixed-Price items, see StartPrice instead. 
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="Charity" type="ns:CharityType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Charity listing container. 
+                                 </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:Country" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	2-letter ISO 3166 Country Code.   
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="CrossPromotion" type="ns:CrossPromotionsType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	CrossPromotions container, if applicable shows promoted items
+                                 </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:Currency" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                	3-letter ISO Currency Code.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="Description" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Item Description.
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="Escrow" type="ns:EscrowCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	Online Escrow paid for by buyer or seller. Cannot use 
+			              	with real estate auctions. Escrow is recommended for 
+			              	for transactions over $500. Escrow service, 
+			              	available via Escrow.com, protects both buyer and 
+			              	seller by acting as a trusted third-party during the 
+			              	transaction and managing the payment process
+			              	from start to finish. Also, if escrow by seller option used,
+			              	then for Motors, this means that Escrow will be 
+			              	negotiated at the end of the auction.
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="GiftIcon" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	If set, a generic gift icon displays in the listing's 
+			              	Title. GiftIcon must be set to to be able to use 
+			              	GiftServices options (e.g., GiftExpressShipping, 
+			              	GiftShipToRecipient, or GiftWrap).
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="GiftServices" type="ns:GiftServicesCodeType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+			              	Gift service options offered by the seller of 
+			              	the listed item.    
+                              </documentation>
+				</annotation>
+			</element>
+			<element name="HitCounter" type="ns:HitCounterCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Optional hit counter for the item's listing page. Possible 
+			               	values are:
+			               		"NoHitCounter"  
+							"HonestyStyle"  
+							"GreenLED"  
+							"Hidden"  
+                          		</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ItemID" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                	The ID that uniquely identifies the item listing.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="ListingDetails" type="ns:ListingDetailsType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Includes listing details in terms of start and 
+			               	end time of listing (in GMT) as well as other 
+			               	details (e.g., orginal item for second chance,
+			               	converted start price, etc.).
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="ListingDesigner" type="ns:ListingDesignerType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	When an item is first listed (using AddItem), a Layout template 
+			              	or a Theme template (or both) can be assigned to the item. 
+			              	A Layout template is assigned to a new item by specifying 
+			              	the Layout template ID (in the AddItem input argument 
+			              	LayoutID). Similarly, a Theme template is assigned to the 
+			              	item using the ThemeID argument.      
+                             	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ListingDuration" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             		Describes the number of days the auction will be active.      
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="ListingEnhancement" type="ns:ListingEnhancementsCodeType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+			             		Describes the types of enhancment supported
+			               	for the item's listing.   
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="ListingType" type="ns:ListingTypeCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Describes the type of listing for the item a seller 
+			               	has chosen (e.g., Chinese, Dutch, FixedPrice, etc.).    
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="Location" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             		Indicates the geographical location of the item.    
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="PartnerCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  	Needed for add item only for partners.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="PartnerName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  	Needed for add item only for partners.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:PaymentMethods" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+			               	List of payment methods accepted by a seller from a buyer for 
+			               	a (checkout) transaction.
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="PayPalEmailAddress" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                	Valid PayPal e-mail address if seller has chosen PayPal 
+			                	as a payment method for the listed item.
+                                </documentation>
+				</annotation>
+			</element>
+			<element name="PrimaryCategory" type="ns:CategoryType" minOccurs="0">
+				<annotation>
+					<documentation>
+			            		Container for data on the primary category of listing. 
+			         	</documentation>
+				</annotation>
+			</element>
+			<element name="PrivateListing" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  	Private auction. Not applicable to Fixed Price items.
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="Quantity" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                 	Number of items being sold in the auction.
+                              	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:RegionID" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Region where the item is listed. See Region Table for values. 
+			               	If the item is listed with a Region of 0 (zero), then this return 
+			               	field denotes no region association with the item, meaning 
+			               	that it is not listing the item regionally.
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="RelistLink" type="xs:boolean" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	If true, creates a link from the old listing for the item to the new 
+			               	relist page, which accommodates users who might still look for 
+			               	the item under its old item ID. Also adds the relist ID to the old 
+			               	listing's record in the eBay database, which can be returned by 
+			               	calling GetItem for the old ItemId. If your application creates the 
+			               	listing page for the user, you need to add the relist link option to 
+			              	your application for your users.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="ReservePrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+					 	Indicates the reserve price for a reserve auction. Returned 
+					 	only if DetailLevel = 4. ReservePrice is only returned for 
+					 	auctions with a reserve price where the user calling GetItem 
+					 	is the item's seller. Returned as null for International Fixed 
+					 	Price items. For more information on reserve price auctions, 
+					 	see http://pages.ebay.com/help/basics/f-format.html#1. 
+                              </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ReviseStatus" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  Revise Status contains information about the item being
+			                  revised.
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="ScheduleTime" type="xs:dateTime" minOccurs="0"/>
+			<element name="SecondaryCategory" type="ns:CategoryType" minOccurs="0">
+				<annotation>
+					<documentation>
+			            		Container for data on the secondary category of listing. 
+			            		Secondary category is optional.
+			          	</documentation>
+				</annotation>
+			</element>
+			<element name="SiteHostedPicture" type="ns:SiteHostedPictureType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  	Item picture information for pictures hosted at eBay site.
+                             	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:Seller" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Seller user.     
+                             	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:SellingStatus" minOccurs="0">
+				<annotation>
+					<documentation>
+			            		Container for for selling status information (e.g., BidCount,
+			            		BidIncrement, HighBidder, MinimimumToBid, etc).
+			         	</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingOption" type="ns:ShippingOptionCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	Specifies where the seller is willing to ship the item. 
+			               		Default "SiteOnly". Valid values are: 
+			               	 	SiteOnly (the default)
+    						 	WorldWide
+    						 	SitePlusRegions
+    							 WillNotShip
+					 	If SitePlusRegions is selected, then at least one 
+					 	regions argument (ShipToNorthAmerica, ShipToEurope, 
+					 	etc.) must also be set.
+                             </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ShippingDetails" minOccurs="0">
+				<annotation>
+					<documentation> 
+                              	  	Contains the shipping payment related information for the 
+                              	  	listed item.
+                         		</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ShippingRegions" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+			               	Regions that seller will ship to.     
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingTerms" type="ns:ShippingTermsCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             	  	Describes who pays for the delivery of an item (e.g., buyer 
+			               	or seller). 
+                              	</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:Site" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                	eBay site on which item is listed.
+                          		</documentation>
+				</annotation>
+			</element>
+			<element name="StartPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			            		Starting price for the item. For Type=7 or Type=9 (Fixed Price) 
+			            		items, if the item price (MinimumBid) is revised, this field 
+			            		returns the new price. 
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="Storefront" type="ns:StorefrontType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			             		Storefront is shown for any item that 
+			             		belongs to an eBay Store owner, regardless of 
+			             		whether it is fixed price or auction type.  Not 
+			             		returned for International Fixed Price items.     
+                             	</documentation>
+				</annotation>
+			</element>
+			<element name="SubTitle" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                 Subtitle to use in addition to the title. Provides more keywords when buyers search in titles and descriptions.
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="TimeLeft" type="xs:duration" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	Time until the the end of the listing (e.g., the amount of time left 
+			              	in an active auction).
+                              	</documentation>
+				</annotation>
+			</element>
+			<element name="Title" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                 Name of the item as it appears for auctions. 
+                               </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:UUID" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	Universally unique constraint tag. The UUID is unique to a category.
+                               	</documentation>
+				</annotation>
+			</element>
+			<element name="VATDetails" type="ns:VATDetailsType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			               	VAT info container. 
+                                 </documentation>
+				</annotation>
+			</element>
+			<element name="VendorHostedPicture" type="ns:VendorHostedPictureType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                  	Item picture information for pictures hosted at vendor (i.e., remote) site.
+                             	</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="TransactionsType">
+		<annotation>
+			<documentation> 
+                       Contains information about multiple individual transations.
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:Transaction" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransactionType">
+		<annotation>
+			<documentation> 
+                       Contains information about a single transaction. A transaction contains information 
+                       about the sale of a particular item. The system creates a transaction when a buyer 
+                       has made a purchase (Fixed Price items) or is the winning bidder (BIN and auction 
+                       items). A listing can be associated with one or more transactions in these cases:
+                           	Multi-Item Fixed Price Listings
+                           	Dutch Auction Listings
+                      A listing is associated with a single transaction in these cases:
+                           	Single-Item Fixed Price Listings
+                           	Single-Item Auction Listings
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:AmountPaid" minOccurs="0">
+				<annotation>
+					<documentation> 
+						The amount the buyer paid for the item or agreed to pay, 
+						depending on how far into the checkout process the item is. 
+						If the seller allowed the buyer to change the item total, the buyer 
+						is able to change the total until the time that the transaction's 
+						status moves to Complete. Determine whether the buyer 
+						changed the amount by calling GetSellerTransactions or 
+						GetSellerTransactions and comparing the AmountPaid value 
+						to what the seller expected. For Motors items, AmountPaid is 
+						the amount paid by the buyer for the deposit.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Buyer" type="ns:UserType" minOccurs="0">
+				<annotation>
+					<documentation> 
+						Container for buyer data. 
+					</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ShippingDetails" minOccurs="0">
+				<annotation>
+					<documentation>
+						Includes shipping payment data.  
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedAmountPaid" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			        		Value returned in the Transaction/AmountPaid element, converted 
+			         		to the currency indicated by SiteCurrency.
+			     		</documentation>
+				</annotation>
+			</element>
+			<element name="ConvertedTransactionPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			        		Value returned in the Transaction/TransactionPrice element, 
+			        		converted to the currency indicated by SiteCurrency.
+			     		</documentation>
+				</annotation>
+			</element>
+			<element name="CreatedDate" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation> 
+			        		For fixed-price, Stores, and BIN items indicates when the 
+			        		purchase (or BIN) occurred. For all other item types indicates 
+			        		when the transaction was created (the time when checkout 
+			        		was initiated).
+			     		</documentation>
+				</annotation>
+			</element>
+			<element name="DepositType" type="ns:DepositTypeCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                    Deposit type for Motors items. If item is not a Motors item, 
+			                    then returns a DepositType of None. Possible values:
+    							None
+    							Other Method
+    							Fast Deposit
+			     		</documentation>
+				</annotation>
+			</element>
+			<element name="Item" type="ns:ItemType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                	Item info associated with the transaction. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="QuantityPurchased" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                   Contains the number of individual items the buyer purchased in 
+			                   the transaction. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingHandlingTotal" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                    Shipping cost totals shown to user (for both flat and calculated 
+			                    rates).		
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Status" type="ns:TransactionStatusType" minOccurs="0">
+				<annotation>
+					<documentation> 
+			                    Container node for transaction status data.      		
+					</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:TransactionID" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	Unique identifier for a transaction. Returns 0 when Type=1 
+			             		(Chinese auction). Typically, an ItemID and a TransactionID 
+			             		uniquely identify a checkout  transaction.
+					</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:AuthorizationID">
+				<annotation>
+					<documentation> 
+			              	Unique identifier for an authorization.
+                              		</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionPrice" type="cc:AmountType" minOccurs="0">
+				<annotation>
+					<documentation> 
+	                    		Price of the item, before shipping and sales tax. For Motors, 
+	                    		TransactionPrice is the deposit amount.
+	                 		</documentation>
+				</annotation>
+			</element>
+			<element name="VATPercent" type="xs:decimal" minOccurs="0">
+				<annotation>
+					<documentation> 
+			              	VAT rate for the item, if the item price includes the VAT rate. 
+			              	Specify the VATPercent if you want include the net price in 
+			              	addition to the gross price in the listing. VAT rates vary 
+			              	depending on the item and on the user's country of residence; 
+			              	therefore a business seller is responsible for entering the 
+			              	correct VAT rate (it will not be calculated by eBay).
+                               	</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="UserIDType">
+		<restriction base="xs:string">
+			<maxLength value="127"/>
+		</restriction>
+	</simpleType>
+	<complexType name="PaymentMeansType">
+		<sequence>
+			<element name="TypeCodeID" type="ns:SellerPaymentMethodCodeType"/>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentType">
+		<sequence>
+			<element name="PaymentMeans" type="ns:PaymentMeansType"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransactionStatusType">
+		<sequence>
+			<element name="eBayPaymentStatus" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+						Indicates the success or failure of an eBay Online Payment for 
+						the transaction. If the payment failed, the value returned indicates 
+						the reason for the failure. Possible values:
+    							0 = No payment failure.
+    							3 = Buyer's eCheck bounced.
+    							4 = Buyer's credit card failed.
+    							5 = Buyer failed payment as reported by seller.
+    							7 = Payment from buyer to seller is in PayPal process, but has not yet been completed.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="IncompleteState" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+                       			Indicates the current state of the checkout process for the transaction. Possible values:
+    						0 = Checkout complete.
+    						1 = Checkout incomplete. No details specified.
+    						2 = Buyer requests total.
+    						3 = Seller responded to buyer's request.
+                   			</documentation>
+				</annotation>
+			</element>
+			<element name="LastTimeModified" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation> 
+                       			Indicates last date and time checkout status or incomplete state was updated 
+                       			(in GMT). 
+                   			</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentMethodUsed" type="ns:BuyerPaymentMethodCodeType" minOccurs="0">
+				<annotation>
+					<documentation> 
+                       			Payment method used by the buyer. (See BuyerPaymentCodeList/Type).
+                   			</documentation>
+				</annotation>
+			</element>
+			<element name="StatusIs" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation> 
+                       			Indicates whether the transaction process complete or incomplete. 
+                       			Possible values:
+    							1 = Incomplete
+    							2 = Complete
+                   			</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="UserType">
+		<sequence>
+			<element name="AboutMePage" type="xs:boolean" minOccurs="0"/>
+			<element name="EAISToken" type="xs:string" minOccurs="0"/>
+			<element ref="ns:Email"/>
+			<element ref="ns:FeedbackScore" minOccurs="0">
+				<annotation>
+					<documentation>
+			  		Feedback scores are a quantitative expression of the desirability of dealing 
+			  		with that person as a Buyer or a Seller in auction transactions. Each 
+			  		auction transaction can result in one feedback entry for a given user 
+			  		(the Buyer can leave one feedback about the Seller and the Seller can leave 
+			  		one feedback about the Buyer). That one feedback can be positive, negative, 
+			  		or neutral. The aggregated feedback counts for a particular user represent 
+			  		that user's overall feedback score (referred to as a "feedback rating" on the 
+			  		eBay site). This rating is commonly expressed as the eBay Feedback score
+			  		for the user. 
+			       </documentation>
+				</annotation>
+			</element>
+			<element name="FeedbackPrivate" type="xs:boolean" minOccurs="0"/>
+			<element name="FeedbackRatingStar" type="ns:FeedbackRatingStarCodeType" minOccurs="0"/>
+			<element name="IDVerified" type="xs:boolean" minOccurs="0"/>
+			<element name="NewUser" type="xs:boolean" minOccurs="0"/>
+			<element ref="ns:RegistrationAddress" minOccurs="0"/>
+			<element name="RegistrationDate" type="xs:dateTime" minOccurs="0"/>
+			<element ref="ns:Site" minOccurs="0"/>
+			<element name="Status" type="ns:UserStatusCodeType" minOccurs="0"/>
+			<element ref="ns:UserID" minOccurs="0"/>
+			<element name="UserIDChanged" type="xs:boolean" minOccurs="0"/>
+			<element name="UserIDLastChanged" type="xs:dateTime" minOccurs="0"/>
+			<element name="VATStatus" type="ns:VATStatusCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			              If present, indicates whether or not the user is subject to VAT. 
+			              Users who have registered with eBay as VAT-exempt are not 
+			              subject to VAT. See Value-Added Tax (VAT). Not returned for 
+			              users whose country of residence is outside the EU. 
+			              Possible values for the user's status:
+    						2 = Residence in an EU country but user registered as VAT-exempt
+    						3 = Residence in an EU country and user not registered as VAT-exempt 
+                          </documentation>
+				</annotation>
+			</element>
+			<element name="BuyerInfo" type="ns:BuyerType" minOccurs="0"/>
+			<element name="SellerInfo" type="ns:SellerType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="VATDetailsType">
+		<annotation>
+			<documentation> 
+                       Contains information required To list a business item.
+                       BusinessSeller - only for add item, the RestrictedToBusiness and VATPercent for both get and add,
+                       for revise all must be optional
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="BusinessSeller" type="xs:boolean" minOccurs="0"/>
+			<element name="RestrictedToBusiness" type="xs:boolean" minOccurs="0"/>
+			<element name="VATPercent" type="xs:float" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="SchedulingInfoType">
+		<annotation>
+			<documentation> 
+                       Contains information for Scheduling limits for the user. All dtails must be present,unless we will have revise call one day,
+                       just in case we might let's make min occur = 0
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="MaxScheduledMinutes" type="xs:int" minOccurs="0"/>
+			<element name="MinScheduledMinutes" type="xs:int" minOccurs="0"/>
+			<element name="MaxScheduledItems" type="xs:int" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<element name="AccountCode" type="xs:string"/>
+	<element name="AccountSummary" type="ns:AccountSummaryType"/>
+	<element name="AmountPaid" type="cc:AmountType"/>
+	<element name="AmountPastDue" type="cc:AmountType"/>
+	<element name="Balance" type="cc:AmountType"/>
+	<element name="Buyer" type="ns:UserType"/>
+	<element name="Category" type="ns:CategoryType"/>
+	<element name="CheckoutEnabled" type="xs:boolean"/>
+	<element name="CurrentBalance" type="cc:AmountType"/>
+	<element name="FeedbackScore" type="xs:int"/>
+	<element name="Fees" type="ns:FeesType"/>
+	<element name="HighBidder" type="ns:UserType"/>
+	<element name="InsuranceFee" type="cc:AmountType">
+		<annotation>
+			<documentation> 
+                        Amount of insurance. Applicable if ShippingType is
+                        Flat shipping rate orCalculated shipping rate. 
+                    </documentation>
+		</annotation>
+	</element>
+	<element name="InsuranceOption" type="ns:InsuranceOptionCodeType">
+		<annotation>
+			<documentation> 
+                                    Indicates whether insurance fee is required. Possible values:
+				      Insurance not offered.
+   					      Insurance optional.
+   					      Insurance required. 
+   					      Insurance included in Shipping and Handling costs.
+			         Applicable if ShippingType is Flat shipping rate or 
+			         Calculated shipping rate. 
+                              </documentation>
+		</annotation>
+	</element>
+	<element name="Item" type="ns:ItemType"/>
+	<element name="ItemID" type="ns:ItemIDType"/>
+	<element name="ListingDuration" type="ns:ListingDurationCodeType"/>
+	<element name="PaymentMeans" type="ns:PaymentMeansType"/>
+	<element name="PaymentMethods" type="ns:BuyerPaymentMethodCodeType"/>
+	<element name="PaymentType" type="ns:PaymentType"/>
+	<element name="Region" type="xs:string"/>
+	<element name="RegionID" type="xs:string"/>
+	<element name="RegistrationAddress" type="ns:AddressType"/>
+	<element name="ReviseStatus" type="ns:ReviseStatusType"/>
+	<element name="Seller" type="ns:UserType"/>
+	<element name="SellerLevel" type="ns:SellerLevelCodeType"/>
+	<element name="SellingStatus" type="ns:SellingStatusType"/>
+	<element name="ShippingService" type="ns:ShippingServiceCodeType">
+		<annotation>
+			<documentation> 
+                              	  Shipping carrier for the item. Possible values are:
+    					   UPS Ground
+    					   UPS 3rd Day
+    					   UPS 2nd Day
+    					   UPS Next Day
+    					   USPS Priority
+    					   USPS Parcel
+    					   USPS Media
+    					   USPS First Class 
+                         		</documentation>
+		</annotation>
+	</element>
+	<element name="Site" type="ns:SiteCodeType"/>
+	<element name="StoreCategoryID" type="xs:int">
+		<annotation>
+			<documentation> 
+	       		Custom categories for subdividing the items 
+	       		within an eBay Store. Store owners can create 
+	       		up to 12 custom categories for their stores. 
+	       		(One Store category cannot be customized 
+	       		and retains the value of "Other") If specified, 
+	       		must be number between 0 and 12.
+    					0=Not an eBay Store item
+    					1=Other
+    					2=Category 1
+    					3=Category 2
+    					...
+    					11=Category 10
+    					12=Category 11
+ 				Returned as null for international fixed priced 
+ 				item.
+     	             </documentation>
+		</annotation>
+	</element>
+	<element name="StoreOwner" type="xs:boolean"/>
+	<element name="StoreURL" type="xs:anyURI">
+		<annotation>
+			<documentation> 
+	       		URL pointing to the seller's eBay Store page. 
+	       		Returned as null for International Fixed Price items. 
+	       		This URL follows the format below, where "####" 
+	       		is replaced by the seller's eBay Stores ID (that 
+	       		uniquely identifies the eBay Store).
+    					http://www.ebaystores.com/id=####
+     	             </documentation>
+		</annotation>
+	</element>
+	<complexType name="ItemArrayType">
+		<sequence>
+			<element ref="ns:Item" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<element name="ItemArray" type="ns:ItemArrayType"/>
+	<complexType name="CategoryArrayType">
+		<sequence>
+			<element ref="ns:Category" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<element name="CategoryArray" type="ns:CategoryArrayType"/>
+	<complexType name="PaginationType">
+		<sequence>
+			<element name="EntriesPerPage" type="xs:int" minOccurs="0"/>
+			<element name="PageNumber" type="xs:int" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="ModifiedFieldType">
+		<sequence>
+			<element name="Field" type="xs:string" minOccurs="0"/>
+			<element name="ModifyType" type="ns:ModifyCodeType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="PaginationResultType">
+		<sequence>
+			<element name="TotalNumberOfPages" type="xs:int" minOccurs="0"/>
+			<element name="TotalNumberOfEntries" type="xs:int" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<element name="Pagination" type="ns:PaginationType"/>
+	<element name="PaginationResult" type="ns:PaginationResultType"/>
+	<element name="ShippingAddress" type="ns:AddressType"/>
+	<element name="ShippingInfo" type="ns:ShippingInfoType"/>
+	<element name="TaxInfo" type="ns:TaxInfoType"/>
+	<element name="Error" type="ns:ErrorType"/>
+    <element name="ThreeDSecureRequest" type="ns:ThreeDSecureRequestType"/>
+	<element name="CreditCardInfo" type="ns:CreditCardDetailsType"/>
+	<element name="SellerPaymentAddress" type="ns:AddressType"/>
+	<element name="ShippingRegions" type="ns:ShippingRegionCodeType"/>
+	<element name="ShippingDetails" type="ns:ShippingDetailsType"/>
+	<element name="ShippingTerm" type="ns:ShippingTermsCodeType"/>
+	<element name="Transaction" type="ns:TransactionType"/>
+	<element name="Transactions" type="ns:TransactionsType"/>
+	<element name="TransactionID" type="xs:string"/>
+	<element name="EbayTransactionID" type="xs:string"/>
+	<element name="AuthorizationID" type="xs:string"/>
+	<element name="UserID" type="ns:UserIDType"/>
+	<element name="User" type="ns:UserType"/>
+	<annotation>
+		<documentation xml:lang="en">
+            Inclusion of all supported eBay Business Language (eBL) Code Lists.            
+			This schema definition file contains specification for:
+			1) eBay Business Langauge (eBL) Abstract Request and Response Message
+			    which will be used to construct payloads for various applications;
+			2) Re-useable error components of the eBL that would be used to communicate 
+			    application-level error messages back to the client application. These application 
+			    error messages may be due to a problem detected while processing the 
+			    request message.
+			3) Other utility components needed by various eBay buying, selling, and payment
+			    applications, e.g., address type and element.
+ 		</documentation>
+	</annotation>
+	<complexType name="ErrorParameterType">
+		<sequence>
+			<element name="Value" type="xs:string">
+				<annotation>
+					<documentation>
+		                    Value of the application-specific error parameter.
+	                      </documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="ParamID" type="xs:string">
+			<annotation>
+				<documentation>
+		             Specifies application-specific error parameter name.
+	               </documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ErrorType">
+		<sequence>
+			<element name="ShortMessage" type="xs:string"/>
+			<element name="LongMessage" type="xs:string" minOccurs="0"/>
+			<element name="ErrorCode" type="xs:token">
+				<annotation>
+					<documentation>
+		       		Error code can be used by a receiving application to debugging a response 
+		       		message. These codes will need to be uniquely defined for each application. 
+		    		 </documentation>
+				</annotation>
+			</element>
+			<element name="SeverityCode" type="ns:SeverityCodeType">
+				<annotation>
+					<documentation>
+		                   SeverityCode indicates whether the error is an application
+		                   level error or if it is informational error, i.e., warning.
+	                     </documentation>
+				</annotation>
+			</element>
+			<element name="ErrorParameters" type="ns:ErrorParameterType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+		                   This optional element may carry additional application-specific error variables 
+		                   that indicate specific information about the error condition particularly in the 
+		                   cases where there are multiple instances of the ErrorType which require 
+		                   additional context.
+	                     </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="FaultDetailsType">
+		<sequence>
+			<element name="ErrorCode" type="xs:string">
+				<annotation>
+					<documentation>
+		       		Error code can be used by a receiving application to debugging a SOAP response 
+		       		message that contain one or more SOAP Fault detail objects, i.e., fault detail sub-elements. 
+		       		These codes will need to be uniquely defined for each fault scenario.
+		    		 </documentation>
+				</annotation>
+			</element>
+			<element name="Severity" type="xs:string">
+				<annotation>
+					<documentation>
+		                   Severity indicates whether the error is a serious fault
+		                   or if it is informational error, i.e., warning.
+	                     </documentation>
+				</annotation>
+			</element>
+			<element name="DetailedMessage" type="xs:string" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="AbstractRequestType" abstract="true">
+		<annotation>
+			<documentation> 
+                       Base type definition of request payload that can carry any type 
+                       of payload content with optional versioning information and detail level
+                       requirements.
+                   </documentation>
+		</annotation>
+		<sequence>
+			<element name="DetailLevel" type="ns:DetailLevelCodeType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+                                 This specifies the required detail level that is needed by a client application pertaining to
+                                 a particular data component (e.g., Item, Transaction, etc.). The detail level is specified in
+                                 the DetailLevelCodeType which has all the enumerated values of the detail level for 
+                                 each component.  
+                            </documentation>
+				</annotation>
+			</element>
+			<element name="ErrorLanguage" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                 This should be the standard RFC 3066 language identification tag, e.g., en_US.
+                            </documentation>
+				</annotation>
+			</element>
+			<element name="Version" type="xs:string">
+				<annotation>
+					<documentation> 
+                               This refers to the version of the request payload schema.
+                           </documentation>
+				</annotation>
+			</element>
+			<any namespace="##local" processContents="lax" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="AbstractResponseType" abstract="true">
+		<annotation>
+			<documentation> 
+                    Base type definition of a response payload that can carry any 
+                    type of payload content with following optional elements:
+                    	- timestamp of response message, 
+                    	- application level acknowledgement, and 
+                    	- application-level errors and warnings.
+                    </documentation>
+		</annotation>
+		<sequence>
+			<element name="Timestamp" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation> 
+  				        This value represents the date and time (GMT) when the response 
+  				        was generated by a service provider (as a result of processing 
+  				        of a request). 
+  	                        </documentation>
+				</annotation>
+			</element>
+			<element name="Ack" type="ns:AckCodeType">
+				<annotation>
+					<documentation> 
+                                   Application level acknowledgement code.
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="CorrelationID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+                                   CorrelationID may be used optionally with an application 
+                                   level acknowledgement.
+                               </documentation>
+				</annotation>
+			</element>
+			<element name="Errors" type="ns:ErrorType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="Version" type="xs:string">
+				<annotation>
+					<documentation> 
+                                 This refers to the version of the response payload schema.
+                             </documentation>
+				</annotation>
+			</element>
+			<element name="Build" type="xs:string">
+				<annotation>
+					<documentation> 
+                               This refers to the specific software build that was used in the deployment 
+                               for processing the request and generating the response.
+                             </documentation>
+				</annotation>
+			</element>
+			<any namespace="##local" processContents="lax" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="PhoneNumberType">
+		<sequence>
+			<element name="CountryCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Country code associated with this phone number.  
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PhoneNumber" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Phone number associated with this phone.  
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Extension" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Extension associated with this phone number.  
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AddressType">
+		<sequence>
+			<element name="Name" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Person's name associated with this address. 
+<br/>Character length and limitations: 32 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Street1" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			First street address. 
+<br/>Character length and limitations: 300 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Street2" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Second street address. 
+<br/>Character length and limitations: 300 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="CityName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Name of city. 
+<br/>Character length and limitations: 120 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="StateOrProvince" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			State or province. 
+<br/>Character length and limitations: 120 single-byte alphanumeric characters
+<br/>
+						<br/>
+			For Canada and the USA, StateOrProvince must be the standard 2-character abbreviation of a state or province.
+<br/>
+						<br/>
+						<b>Canadian Provinces</b>
+						<table>
+							<tr>
+								<td>Alberta</td>
+								<td>AB </td>
+							</tr>
+							<tr>
+								<td>British_Columbia</td>
+								<td>BC</td>
+							</tr>
+							<tr>
+								<td>Manitoba</td>
+								<td>MB</td>
+							</tr>
+							<tr>
+								<td>New_Brunswick</td>
+								<td>NB</td>
+							</tr>
+							<tr>
+								<td>Newfoundland</td>
+								<td>NF</td>
+							</tr>
+							<tr>
+								<td>Northwest_Territories</td>
+								<td>NT</td>
+							</tr>
+							<tr>
+								<td>Nova_Scotia</td>
+								<td>NS </td>
+							</tr>
+							<tr>
+								<td>Nunavut</td>
+								<td>NU</td>
+							</tr>
+							<tr>
+								<td>Ontario</td>
+								<td>ON</td>
+							</tr>
+							<tr>
+								<td>Prince_Edward_Island</td>
+								<td>PE</td>
+							</tr>
+							<tr>
+								<td>Quebec</td>
+								<td>QC</td>
+							</tr>
+							<tr>
+								<td>Saskatchewan</td>
+								<td>SK</td>
+							</tr>
+							<tr>
+								<td>Yukon</td>
+								<td>YK</td>
+							</tr>
+						</table>
+						<br/>
+						<br/>
+						<b>United States</b>
+						<table>
+							<tr>
+								<td>Alabama</td>
+								<td/>
+							</tr> AL 
+<tr>
+								<td>Alaska</td>
+								<td>AK</td>
+							</tr>
+							<tr>
+								<td>American_Samoa</td>
+								<td>AS</td>
+							</tr>
+							<tr>
+								<td>Arizona</td>
+								<td>AZ</td>
+							</tr>
+							<tr>
+								<td>Arkansas</td>
+								<td>AR</td>
+							</tr>
+							<tr>
+								<td>California</td>
+								<td>CA</td>
+							</tr>
+							<tr>
+								<td>Colorado</td>
+								<td>CO</td>
+							</tr>
+							<tr>
+								<td>Connecticut</td>
+								<td>CT</td>
+							</tr>
+							<tr>
+								<td>Delaware</td>
+								<td>DE</td>
+							</tr>
+							<tr>
+								<td>District_Of_Columbia</td>
+								<td>DC</td>
+							</tr>
+							<tr>
+								<td>Federated_States_Of_Micronesia</td>
+								<td>FM</td>
+							</tr>
+							<tr>
+								<td>Florida</td>
+								<td>FL</td>
+							</tr>
+							<tr>
+								<td>Georgia</td>
+								<td>GA</td>
+							</tr>
+							<tr>
+								<td>Guam</td>
+								<td>GU</td>
+							</tr>
+							<tr>
+								<td>Hawaii</td>
+								<td>HI</td>
+							</tr>
+							<tr>
+								<td>Idaho</td>
+								<td>ID </td>
+							</tr>
+							<tr>
+								<td>Illinois</td>
+								<td>IL</td>
+							</tr>
+							<tr>
+								<td>Indiana</td>
+								<td>IN</td>
+							</tr>
+							<tr>
+								<td>Iowa</td>
+								<td>IA</td>
+							</tr>
+							<tr>
+								<td>Kansas</td>
+								<td>KS</td>
+							</tr>
+							<tr>
+								<td>Kentucky</td>
+								<td>KY</td>
+							</tr>
+							<tr>
+								<td>Louisiana</td>
+								<td>LA</td>
+							</tr>
+							<tr>
+								<td>Maine</td>
+								<td>ME</td>
+							</tr>
+							<tr>
+								<td>Marshall_Islands</td>
+								<td>MH</td>
+							</tr>
+							<tr>
+								<td>Maryland</td>
+								<td>MD</td>
+							</tr>
+							<tr>
+								<td>Massachusetts</td>
+								<td>MA</td>
+							</tr>
+							<tr>
+								<td>Michigan</td>
+								<td>MI</td>
+							</tr>
+							<tr>
+								<td>Minnesota</td>
+								<td>MN</td>
+							</tr>
+							<tr>
+								<td>Mississippi</td>
+								<td>MS</td>
+							</tr>
+							<tr>
+								<td>Missouri</td>
+								<td>MO</td>
+							</tr>
+							<tr>
+								<td>Montana</td>
+								<td>MT</td>
+							</tr>
+							<tr>
+								<td>Nebraska</td>
+								<td>NE</td>
+							</tr>
+							<tr>
+								<td>Nevada</td>
+								<td>NV</td>
+							</tr>
+							<tr>
+								<td>New_Hampshire</td>
+								<td>NH</td>
+							</tr>
+							<tr>
+								<td>New_Jersey</td>
+								<td>NJ</td>
+							</tr>
+							<tr>
+								<td>New_Mexico</td>
+								<td>NM</td>
+							</tr>
+							<tr>
+								<td>New_York</td>
+								<td>NY</td>
+							</tr>
+							<tr>
+								<td>North_Carolina</td>
+								<td>NC</td>
+							</tr>
+							<tr>
+								<td>North_Dakota</td>
+								<td>ND</td>
+							</tr>
+							<tr>
+								<td>Northern_Mariana_Islands</td>
+								<td>MP</td>
+							</tr>
+							<tr>
+								<td>Ohio</td>
+								<td>OH </td>
+							</tr>
+							<tr>
+								<td>Oklahoma</td>
+								<td>OK</td>
+							</tr>
+							<tr>
+								<td>Oregon</td>
+								<td>OR</td>
+							</tr>
+							<tr>
+								<td>Palau</td>
+								<td>PW</td>
+							</tr>
+							<tr>
+								<td>Pennsylvania</td>
+								<td>PA</td>
+							</tr>
+							<tr>
+								<td>Puerto_Rico</td>
+								<td>PR</td>
+							</tr>
+							<tr>
+								<td>Rhode_Island</td>
+								<td>RI</td>
+							</tr>
+							<tr>
+								<td>South_Carolina</td>
+								<td>SC</td>
+							</tr>
+							<tr>
+								<td>South_Dakota</td>
+								<td>SD</td>
+							</tr>
+							<tr>
+								<td>Tennessee</td>
+								<td>TN </td>
+							</tr>
+							<tr>
+								<td>Texas</td>
+								<td>TX</td>
+							</tr>
+							<tr>
+								<td>Utah</td>
+								<td>UT</td>
+							</tr>
+							<tr>
+								<td>Vermont</td>
+								<td>VT</td>
+							</tr>
+							<tr>
+								<td>Virgin_Islands</td>
+								<td>VI</td>
+							</tr>
+							<tr>
+								<td>Virginia</td>
+								<td>VA</td>
+							</tr>
+							<tr>
+								<td>Washington</td>
+								<td>WA</td>
+							</tr>
+							<tr>
+								<td>West_Virginia</td>
+								<td>WV</td>
+							</tr>
+							<tr>
+								<td>Wisconsin</td>
+								<td>WI</td>
+							</tr>
+							<tr>
+								<td>Wyoming</td>
+								<td>WY</td>
+							</tr>
+							<tr>
+								<td>Armed_Forces_Americas</td>
+								<td>AA</td>
+							</tr>
+							<tr>
+								<td>Armed_Forces</td>
+								<td>AE</td>
+							</tr>
+							<tr>
+								<td>Armed_Forces_Pacific</td>
+								<td>AP</td>
+							</tr>
+						</table>
+					</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:Country" minOccurs="0">
+				<annotation>
+					<documentation>
+			ISO 3166 standard country code
+			<br/>Character limit: Two single-byte characters. </documentation>
+				</annotation>
+			</element>
+			<element ref="ns:CountryName" minOccurs="0">
+				<annotation>
+					<documentation> 
+					IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+					<br/>
+						<br/>
+			           This element should only be used in response elements and typically
+			           should not be used in creating request messages which specify the 
+			           name of a country using the Country element (which refers to a
+			           2-letter country code).      
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Phone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Telephone number associated with this address</documentation>
+				</annotation>
+			</element>
+			<element name="PostalCode" type="xs:string" minOccurs="0"/>
+			<element name="AddressID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile, or UpdateRecurringPaymentsProfile.
+</documentation>
+				</annotation>
+			</element>
+			<element name="AddressOwner" type="ns:AddressOwnerCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+</documentation>
+				</annotation>
+			</element>
+			<element name="ExternalAddressID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+</documentation>
+				</annotation>
+			</element>
+			<element name="InternationalName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+					IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+<br/>
+						<br/>
+			           Only applicable to SellerPaymentAddress today. Seller's international name that is associated with the payment address. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="InternationalStateAndCity" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			           					IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+<br/>
+						<br/>
+Only applicable to SellerPaymentAddress today. International state and city for the seller's payment address. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="InternationalStreet" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation> 
+			           					IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+<br/>
+						<br/>
+Only applicable to SellerPaymentAddress today. Seller's international street address that is associated with the payment address.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AddressStatus" type="ns:AddressStatusCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Status of the address on file with PayPal.
+<br/>
+						<br/>								IMPORTANT: Do not set this element for SetExpressCheckout, DoExpressCheckoutPayment, DoDirectPayment, CreateRecurringPaymentsProfile or UpdateRecurringPaymentsProfile.
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<element name="Country" type="ns:CountryCodeType"/>
+	<element name="CountryName" type="xs:string"/>
+	<element name="Currency" type="ns:CurrencyCodeType"/>
+	<element name="Email" type="xs:string"/>
+	<element name="StateOrProvince" type="xs:string"/>
+	<element name="UUID" type="cc:UUIDType"/>
+	<simpleType name="EscrowCodeType">
+		<annotation>
+			<documentation>
+			     EscrowCodeType
+			     These are the possible codes to describe Escrow options. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="ByBuyer">
+				<annotation>
+					<documentation>
+						    By Buyer
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BySeller">
+				<annotation>
+					<documentation>
+						   By Seller.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						   None.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="FeedbackRatingStarCodeType">
+		<annotation>
+			<documentation>
+			     FeedbackRatingStarCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						No graphic displayed
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Yellow">
+				<annotation>
+					<documentation>
+						Yellow Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Turquoise">
+				<annotation>
+					<documentation>
+						Turquoise Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Purple">
+				<annotation>
+					<documentation>
+						Purple Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Red">
+				<annotation>
+					<documentation>
+						Red Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Green">
+				<annotation>
+					<documentation>
+						Green Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="YellowShooting">
+				<annotation>
+					<documentation>
+						Yellow Shooting Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="TurquoiseShooting">
+				<annotation>
+					<documentation>
+						Turquoise Shooting Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PurpleShooting">
+				<annotation>
+					<documentation>
+						Purple Shooting Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="RedShooting">
+				<annotation>
+					<documentation>
+						Red Shooting Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Blue">
+				<annotation>
+					<documentation>
+						Blue Star
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="GalleryTypeCodeType">
+		<annotation>
+			<documentation>
+			     GalleryTypeCodeType
+			     Specifies the codes for various properties of an item. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Featured">
+				<annotation>
+					<documentation>
+						   Indicates whether it is a featured item. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Gallery">
+				<annotation>
+					<documentation>
+						   Include in the gallery. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="GeneralPaymentMethodCodeType">
+		<annotation>
+			<documentation>
+			     GeneralPaymentMethodCodeType - Type declaration to be used 
+			     by other schema. This code identifies the general types of payment means, 
+			     e.g., used by payment service provider applications.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+				<annotation>
+					<documentation>Custom Code</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Echeck">
+				<annotation>
+					<documentation>Electronic check.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ACH">
+				<annotation>
+					<documentation> ACH.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Creditcard">
+				<annotation>
+					<documentation>
+					     Credit-card.
+					 </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PayPalBalance">
+				<annotation>
+					<documentation>
+					     Pay balance.
+					 </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="GiftServicesCodeType">
+		<annotation>
+			<documentation>
+			     GiftServicesCodeType - Type declaration to be used by other schema's.
+			     Specifies the codes for the various Gift Services offered by sellers. If 
+			     any of the Gift Services are offered by the seller, the generic gift icon 
+			     should be used to display the item:
+			     		http://pics.ebay.com/aw/pics/gift/gift.gif 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="GiftExpressShipping">
+				<annotation>
+					<documentation>
+						    indicates that the seller is offering to ship the item via 
+						    an express shipping method as described in the item 
+						    description. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GiftShipToRecipient">
+				<annotation>
+					<documentation>
+						    indicates that the seller is offering to ship to the gift recipient, 
+						    not the buyer, when payment clears.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GiftWrap">
+				<annotation>
+					<documentation>
+						   indicates that the seller is offering to wrap the item (and 
+						   optionally include a card) as described in the item 
+						   description.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="HitCounterCodeType">
+		<annotation>
+			<documentation>
+			   HitCounterCodeType
+			   This code identifies the HitCounter codes used to specify whether 
+			   a hit counter is used for the item's listing page and, if so, what type.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NoHitCounter">
+				<annotation>
+					<documentation>No hit counter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="HonestyStyle">
+				<annotation>
+					<documentation>
+					   Honesty Style Hit Counter
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GreenLED">
+				<annotation>
+					<documentation> 
+					   Green LED counter.																	</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Hidden">
+				<annotation>
+					<documentation>
+					     Hidden counter.
+					 </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="InsuranceOptionCodeType">
+		<annotation>
+			<documentation>
+			     InsuranceOptionCodeType
+			     These are the possible codes to describe insurance option as part of shipping
+			     service.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Optional">
+				<annotation>
+					<documentation>
+						    Insurance optional.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Required">
+				<annotation>
+					<documentation>
+						   Insurance required. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="NotOffered">
+				<annotation>
+					<documentation>
+						   Insurance not offered.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="IncludedInShippingHandling">
+				<annotation>
+					<documentation>
+						   Insurance included in Shipping and Handling costs.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ListingDurationCodeType">
+		<annotation>
+			<documentation>
+			     ListingDurationCodeType
+			     These are the possible codes to describe the number of days the 
+			     auction will be active. Must be one of the values 3, 5, 7, or 10 
+			     for auction and basic Fixed-Price (Type 9) listings. Must be 30, 
+			     60, 90, 120, or GTC for Stores Fixed-Price (Type 7) listings. 
+			     Specify GTC for the Good 'Til Cancel feature (eBay Stores 
+			     items only).
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Days_1">
+				<annotation>
+					<documentation>
+						    1 Day
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_3">
+				<annotation>
+					<documentation>
+						    3 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_5">
+				<annotation>
+					<documentation>
+						   5 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_7">
+				<annotation>
+					<documentation>
+						  7 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_10">
+				<annotation>
+					<documentation>
+						  10 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_30">
+				<annotation>
+					<documentation>
+						  30 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_60">
+				<annotation>
+					<documentation>
+						    60 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_90">
+				<annotation>
+					<documentation>
+						  90 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days_120">
+				<annotation>
+					<documentation>
+						  120 Days
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GTC">
+				<annotation>
+					<documentation>
+						  GTC
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ListingEnhancementsCodeType">
+		<annotation>
+			<documentation>
+			     ListingEnhancementsCodeType
+			     Specifies the codes for various properties of an item. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Border">
+				<annotation>
+					<documentation>
+						    Indicates whether an item will be displayed with a  border 
+						    that will go around the item (e.g., for category-based search 
+						    result page or store search that brings up multiple items) 
+						    to differentiate it from the rest of list.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BoldTitle">
+				<annotation>
+					<documentation>
+						   Indicates whether the bolding option was used. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Featured">
+				<annotation>
+					<documentation>
+						   Indicates whether it is a featured item. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Highlight">
+				<annotation>
+					<documentation>
+						    Indicates item's listing is highlighted. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="HomePageFeatured">
+				<annotation>
+					<documentation>
+						    Indicates item's listing is home page featured. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<annotation>
+		<documentation>eBay Listing Enhancements Codes</documentation>
+	</annotation>
+	<annotation>
+		<documentation>Code List Agency - eBay, Inc.</documentation>
+	</annotation>
+	<annotation>
+		<documentation>Code List Version - 1.0</documentation>
+	</annotation>
+	<simpleType name="ListingTypeCodeType">
+		<annotation>
+			<documentation>
+			     ListingTypeCodeType - Type declaration to be used 
+			     by other schema. This includes codes indicating the
+			     type of auction for the listed item.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown">
+				<annotation>
+					<documentation>
+						    Unknown Listing Type
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Chinese">
+				<annotation>
+					<documentation>
+						   Chinese auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Dutch">
+				<annotation>
+					<documentation>
+						   Dutch auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Live">
+				<annotation>
+					<documentation>
+						   Live Auctions-type auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="AdType">
+				<annotation>
+					<documentation>
+						   Ad type auction
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="StoresFixedPrice">
+				<annotation>
+					<documentation>
+						   Stores Fixed-price auction (US only)
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PersonalOffer">
+				<annotation>
+					<documentation>
+						   Personal Offer auction 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="FixedPriceItem">
+				<annotation>
+					<documentation>
+						   Fixed Price item ("BIN only").
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="MerchandizingPrefCodeType">
+		<annotation>
+			<documentation>
+			     MerchandizingPrefCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="OptIn">
+				<annotation>
+					<documentation>
+						OptIn
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="OptOut">
+				<annotation>
+					<documentation>
+						OptOut
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ModifyCodeType">
+		<annotation>
+			<documentation>
+			   ModifyCodeType
+			   This code identifies the types of modification you can make on an object.
+			   account.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Dropped">
+				<annotation>
+					<documentation>Indicate filed is to be dropped.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Modify">
+				<annotation>
+					<documentation>Indicate filed is to be modified.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PhotoDisplayCodeType">
+		<annotation>
+			<documentation>
+			     PhotoDisplayCodeType
+			     These are types of display for photos used for PhotoHosting slide show. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						      No special Picture Services features.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SlideShow">
+				<annotation>
+					<documentation>
+						    Slideshow of multiple pictures.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SuperSize">
+				<annotation>
+					<documentation>
+						   Super-size format picture.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PicturePack">
+				<annotation>
+					<documentation>
+						  Picture Pack. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PromotionItemPriceTypeCodeType">
+		<annotation>
+			<documentation>
+				Cross Promotion Method.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="AuctionPrice">
+				<annotation>
+					<documentation>
+						    Auction Item
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BuyItNowPrice">
+				<annotation>
+					<documentation>
+						  Buy It Now
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved. Do not use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PromotionItemSelectionCodeType">
+		<annotation>
+			<documentation>
+				Cross Promotion Method.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Manual">
+				<annotation>
+					<documentation>
+						    Manual Selection
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Automatic">
+				<annotation>
+					<documentation>
+						  Automatic Selection
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved. Do not use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PromotionMethodCodeType">
+		<annotation>
+			<documentation>
+				Cross Promotion Method.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="CrossSell">
+				<annotation>
+					<documentation>
+						    Cross Sell
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UpSell">
+				<annotation>
+					<documentation>
+						  Up Sell
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved. Do not use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PromotionSchemeCodeType">
+		<annotation>
+			<documentation>
+				Cross Promotion Context Promotion Scheme.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="ItemToItem">
+				<annotation>
+					<documentation>
+						    Item to Item Promotional Scheme
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ItemToStoreCat">
+				<annotation>
+					<documentation>
+						  Item to Item Store Scheme
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="StoreToStoreCat">
+				<annotation>
+					<documentation>
+						  Store to Store Scheme
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved. Do not use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="PurchasePurposeTypeCodeType">
+		<annotation>
+			<documentation>
+			   PurchasePurposeTypeCodeType - Type declaration to be used by other 
+			   schema. This code identifies the purpose of purchases, e.g.,  
+			   by a PayPal application.                
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+				<annotation>
+					<documentation>Custom Code</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BuyNowItem">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="ShoppingCart">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="AuctionItem">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="GiftCertificates">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="Subscription">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="Donation">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="eBayBilling">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="SellerLevelCodeType">
+		<annotation>
+			<documentation>
+			     SellerLevelCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Bronze">
+				<annotation>
+					<documentation>
+						Bronze
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Silver">
+				<annotation>
+					<documentation>
+						Silver
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Gold">
+				<annotation>
+					<documentation>
+						Gold
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Platinum">
+				<annotation>
+					<documentation>
+						Platinum
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Titanium">
+				<annotation>
+					<documentation>
+						Titanium
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						None
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="SellerPaymentMethodCodeType">
+		<annotation>
+			<documentation>
+			     SellerPaymentMethodCodeType
+			     These are payment methods that sellers can use to pay eBay.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+				<annotation>
+					<documentation>
+						    No payment method specified - some other payment method.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Amex">
+				<annotation>
+					<documentation>
+						    Amex
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Visa">
+				<annotation>
+					<documentation>
+						   Visa
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Mastercard">
+				<annotation>
+					<documentation>
+						  Mastercard
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Discover">
+				<annotation>
+					<documentation>
+						  Discover
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="JCB">
+				<annotation>
+					<documentation>
+						   JCB
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Diners">
+				<annotation>
+					<documentation>
+						   Diners
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="SeverityCodeType">
+		<annotation>
+			<documentation>
+			   SeverityCodeType
+			   This code identifies the Severity code types in terms of whether
+			   there is an API-level error or warning that needs to be communicated
+			   to the client.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Warning">
+				<annotation>
+					<documentation>
+					   Warning or informational error.
+				      </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Error">
+				<annotation>
+					<documentation> 
+					   Application-level error.										
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PartialSuccess">
+				<annotation>
+					<documentation>
+					   Partial Success.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingOptionCodeType">
+		<annotation>
+			<documentation>
+			     ShippingOptionCodeType
+			     These are the possible codes to describe shipping options in terms
+			     of where the seller is willing to ship the item. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="SiteOnly">
+				<annotation>
+					<documentation>
+						    Site only.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="WorldWide">
+				<annotation>
+					<documentation>
+						   WorldWide.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SitePlusRegions">
+				<annotation>
+					<documentation>
+						   SitePlusRegions.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="WillNotShip">
+				<annotation>
+					<documentation>
+						   WillNotShip.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingPackageCodeType">
+		<annotation>
+			<documentation>
+			     ShippingPackageCodeType
+			     These are the possible codes to describe shipping package options.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None">
+				<annotation>
+					<documentation>
+						    None.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Letter">
+				<annotation>
+					<documentation>
+						   Letter.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="LargeEnvelope">
+				<annotation>
+					<documentation>
+						   LargeEnvelope
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSLargePack">
+				<annotation>
+					<documentation>
+						   USPS Large Package/Oversize 1
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="VeryLargePack">
+				<annotation>
+					<documentation>
+						   Very Large Package/Oversize 2
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UPSLetter">
+				<annotation>
+					<documentation>
+						   UPS Letter
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSFlatRateEnvelope">
+				<annotation>
+					<documentation>
+						   USPS Flat Rate Envelope
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="PackageThickEnvelope">
+				<annotation>
+					<documentation>
+						    Package/thick envelope
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingRatesTypeCodeType">
+		<annotation>
+			<documentation>
+			     ShippingRatesTypeCodeType - Type declaration to be used 
+			     by other schema. The includes the codes for shipping types
+			     supported by sellers to transport items sold to buyers.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Flat">
+				<annotation>
+					<documentation>
+						    Flat shipping rate.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Calculated">
+				<annotation>
+					<documentation>
+						  Calculated shipping rate.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingRegionCodeType">
+		<annotation>
+			<documentation>
+			     ShippingRegion CodeType
+			     This code list module defines the enumerated types of regions for 
+			     shipping items (i.e., a seller may support shipment of an item). 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Africa">
+				<annotation>
+					<documentation>
+						Africa
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Asia">
+				<annotation>
+					<documentation>
+						Asia
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Caribbean">
+				<annotation>
+					<documentation>
+						Carribbean
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Europe">
+				<annotation>
+					<documentation>
+						Europe
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="LatinAmerica">
+				<annotation>
+					<documentation>
+						LatinAmerica
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MiddleEast">
+				<annotation>
+					<documentation>
+						MiddleEast
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="NorthAmerica">
+				<annotation>
+					<documentation>
+						NorthAmerica
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Oceania">
+				<annotation>
+					<documentation>
+						Oceania (i.e., Pacific region other than Asia)
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="SouthAmerica">
+				<annotation>
+					<documentation>
+						SouthAmerica
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingServiceCodeType">
+		<annotation>
+			<documentation>
+			     ShippingServiceCodeType
+			     These are the possible codes to describe insurance option as part of shipping
+			     service.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="UPSGround">
+				<annotation>
+					<documentation>
+						    UPS Ground
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UPS3rdDay">
+				<annotation>
+					<documentation>
+						   UPS 3rd Day
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UPS2ndDay">
+				<annotation>
+					<documentation>
+						   UPS 2nd Day
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UPSNextDay">
+				<annotation>
+					<documentation>
+						   UPS Next Day.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSPriority">
+				<annotation>
+					<documentation>
+						   USPS Priority.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSParcel">
+				<annotation>
+					<documentation>
+						   USPS Parcel.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSMedia">
+				<annotation>
+					<documentation>
+						   USPS Media.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSFirstClass">
+				<annotation>
+					<documentation>
+						   USPS First Class
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ShippingMethodStandard">
+				<annotation>
+					<documentation>
+						    ShippingMethodStandard - used by merchant tool only
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ShippingMethodExpress">
+				<annotation>
+					<documentation>
+						  ShippingMethodExpress- used by merchant tool only
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ShippingMethodNextDay">
+				<annotation>
+					<documentation>
+						    ShippingMethodNextDay- used by merchant tool only
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSExpressMail">
+				<annotation>
+					<documentation>
+						    USPS Express Mail
+				</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="USPSGround">
+				<annotation>
+					<documentation>
+						    USPS Ground
+			</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Download">
+			    <annotation><documentation> Download. </documentation> </annotation>
+			</enumeration>
+			<enumeration value="WillCall_Or_Pickup">
+			    <annotation><documentation> Will Call Or Pick Up. </documentation> </annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShippingTermsCodeType">
+		<annotation>
+			<documentation>
+			     ShippingTermsCodeType - Type declaration to be used by other schema's.
+			     Shipping terms code describes who pays for the shipping of an item.
+			     These are the standard shipping terms, i.e.,  terms of delivery of an item. 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="SellerPays">
+				<annotation>
+					<documentation>
+						    Seller pays all shipping costs. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="BuyerPays">
+				<annotation>
+					<documentation>
+						    Buyer pays all shipping costs. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="SiteCodeType">
+		<annotation>
+			<documentation>
+			     SiteCodeType
+			     These are site codes that buyers and sellers can use to identify 
+			     their sites.   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="US">
+				<annotation>
+					<documentation>
+						USA
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Canada">
+				<annotation>
+					<documentation>
+						Canada
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UK">
+				<annotation>
+					<documentation>
+						United Kingdom
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Australia">
+				<annotation>
+					<documentation>
+						Australia
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Austria">
+				<annotation>
+					<documentation>
+						Austria
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Belgium_French">
+				<annotation>
+					<documentation>
+						Belgium (French)
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="France">
+				<annotation>
+					<documentation>
+						France
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Germany">
+				<annotation>
+					<documentation>
+						Germany
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Italy">
+				<annotation>
+					<documentation>
+						Italy
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Belgium_Dutch">
+				<annotation>
+					<documentation>
+						Belgium (Dutch)
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Netherlands">
+				<annotation>
+					<documentation>
+						Netherlands
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Spain">
+				<annotation>
+					<documentation>
+						Spain
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Switzerland">
+				<annotation>
+					<documentation>
+						Switzerland
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Taiwan">
+				<annotation>
+					<documentation>
+						Taiwan
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="eBayMotors">
+				<annotation>
+					<documentation>
+						eBay Motors
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="HongKong">
+				<annotation>
+					<documentation>
+						Hong Kong
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Singapore">
+				<annotation>
+					<documentation>
+						Singapore
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="UnitCodeType">
+		<annotation>
+			<documentation>
+			     UnitCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="kg">
+				<annotation>
+					<documentation>
+						    Kilogram.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="lbs">
+				<annotation>
+					<documentation>
+						    Pounds.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="oz">
+				<annotation>
+					<documentation>
+						   Ounces						
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="cm">
+				<annotation>
+					<documentation>
+						  Centimeter. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="inches">
+				<annotation>
+					<documentation>
+						  Inches. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ft">
+				<annotation>
+					<documentation>
+						  Feet.
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="UserStatusCodeType">
+		<annotation>
+			<documentation>
+			     UserStatusCodeType
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown">
+				<annotation>
+					<documentation>
+						     User properties have never been set. 
+						     This value should seldom, if ever, be returned 
+						     and typically represents a problem. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Suspended">
+				<annotation>
+					<documentation>
+						    User has been suspended from selling and buying, 
+						    such as for violations of eBay terms or agreement. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Confirmed">
+				<annotation>
+					<documentation>
+						   User has completed online registration and has 
+						   properly responded to confirmation email. Most 
+						   users should fall in this category. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Unconfirmed">
+				<annotation>
+					<documentation>
+						    User has completed online registration, but 
+						    has either not responded to confirmation email 
+						    or has not yet been sent the confirmation email. . 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Ghost">
+				<annotation>
+					<documentation>
+						    Registered users of AuctionWeb (pre-eBay) 
+						    who never re-registered on eBay.  
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="InMaintenance">
+				<annotation>
+					<documentation>
+						    Temporary user record state indicating the 
+						    record is in the process of being changed by 
+						    eBay. Query user information again to get new 
+						    status.   
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Deleted">
+				<annotation>
+					<documentation>
+						    Records for the specified user have been deleted.  
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CreditCardVerify">
+				<annotation>
+					<documentation>
+						    User has completed registration and confirmation, 
+						    but is pending a verification of credit card information. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="AccountOnHold">
+				<annotation>
+					<documentation>
+						    User's account is on hold, such as for non-payment 
+						    of amounts due eBay. User cannot sell or buy items.   
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Merged">
+				<annotation>
+					<documentation>
+						      User record has been merged with another account 
+						      record for the same user. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="RegistrationCodeMailOut">
+				<annotation>
+					<documentation>
+						    User has completed online registration and has 
+						    been sent the confirmation email, but has not yet 
+						    responded to the confirmation email. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="TermPending">
+				<annotation>
+					<documentation>
+						      User has been scheduled for account closure 
+						      (typically when a user has requested to have 
+						      their account closed.) A user in this state should 
+						      not be considered an active user. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UnconfirmedHalfOptIn">
+				<annotation>
+					<documentation>
+						      User has completed the registration for 
+						      Half.com and opted to automatically also be 
+						      registered with eBay, but the registration 
+						      confirmation is still pending. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CreditCardVerifyHalfOptIn">
+				<annotation>
+					<documentation>
+						      User has completed the registration for 
+						      Half.com and opted to automatically also be 
+						      registered with eBay, but the verification of 
+						      credit card information is still pending. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UnconfirmedPassport">
+				<annotation>
+					<documentation>
+						      Passport User. User has completed the registration process, but the registration confirmation is still pending. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CreditCardVerifyPassport">
+				<annotation>
+					<documentation>
+						     Passport User Requiring Credit Card Verification. User has completed the registration process with credit card verification, but the registration confirmation is still pending. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UnconfirmedExpress">
+				<annotation>
+					<documentation>
+						     Half.com User. User has completed the registration for Half.com and opted to automatically also be registered with eBay, but the registration confirmation is still pending. 
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="VATStatusCodeType">
+		<annotation>
+			<documentation>
+			     VATStatusCodeType   
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NoVATTax">
+				<annotation>
+					<documentation>
+						No VAT Tax
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="VATTax">
+				<annotation>
+					<documentation>
+						VAT Tax
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="VATExempt">
+				<annotation>
+					<documentation>
+						VAT Exempt
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CustomCode">
+				<annotation>
+					<documentation>
+						  Reserved for internal or future use.
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="CreditCardTypeType">
+		<annotation>
+			<documentation>
+				Type declaration to be used by other schemas.
+				This is the credit card type
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Visa"/>
+			<enumeration value="MasterCard"/>
+			<enumeration value="Discover"/>
+			<enumeration value="Amex"/>
+			<enumeration value="Switch"/>
+			<enumeration value="Solo"/>
+			<enumeration value="Maestro"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="NameType">
+		<restriction base="xs:string">
+			<length value="25"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SalutationType">
+		<restriction base="xs:string">
+			<length value="20"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SuffixType">
+		<restriction base="xs:string">
+			<length value="12"/>
+		</restriction>
+	</simpleType>
+	<complexType name="PersonNameType">
+		<sequence>
+			<element name="Salutation" type="ns:SalutationType" minOccurs="0"/>
+			<element name="FirstName" type="ns:NameType" minOccurs="0"/>
+			<element name="MiddleName" type="ns:NameType" minOccurs="0"/>
+			<element name="LastName" type="ns:NameType" minOccurs="0"/>
+			<element name="Suffix" type="ns:SuffixType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<simpleType name="TransactionId">
+		<annotation>
+			<documentation>
+				TransactionId - Type for a PayPal Transaction ID.
+			</documentation>
+		</annotation>
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="AuthorizationId">
+		<annotation>
+			<documentation>
+				AuthorizationId - Type for a PayPal Authorization ID.
+			</documentation>
+		</annotation>
+		<restriction base="xs:string"/>
+	</simpleType>
+	<!-- new eBL types -->
+	<simpleType name="MerchantPullIDType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="EmailAddressType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="ExpressCheckoutTokenType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="AuthFlowTokenType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="LanguageCodeType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<!-- For China Postbacks -->
+	<simpleType name="PaymentNotificationServiceCodeType">
+		<annotation>
+			<documentation>
+				PaymentNotificationService 
+				For SetPaymentStatus API, this value should always be eBayCN.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="eBayCN"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="OrderID">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<simpleType name="BankIDCodeType">
+		<annotation>
+			<documentation>
+				BankID 
+				The various banks supported for China postbacks.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="CMB"/>
+			<enumeration value="ICBC"/>
+			<enumeration value="CCB"/>
+			<enumeration value="ChinaPay"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentStatusIDCodeType">
+		<annotation>
+			<documentation>
+				PaymentStatus 
+				The payment statuses supported for China postbacks.
+				0 - None
+				1 - Success
+				2 - Pending or Suspicious
+				3 - Failure
+			</documentation>
+		</annotation>
+		<restriction base="xs:integer">
+			<minInclusive value="0"/>
+			<maxInclusive value="3"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="RefundType">
+		<annotation>
+			<documentation>
+				RefundType - Type declaration to be used by other 
+				schema. This code identifies the types of refund transactions 
+				supported.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+				<annotation>
+					<documentation/>
+				</annotation>
+			</enumeration>
+			<enumeration value="Full">
+				<annotation>
+					<documentation>Full Refund</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Partial">
+				<annotation>
+					<documentation>Partial Refund</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ExternalDispute">
+				<annotation>
+					<documentation>External Dispute</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+
+	<simpleType name="UnitOfMeasure">
+		<annotation>
+			<documentation>
+				Based on NRF-ARTS Specification for Units of Measure
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="EA">
+				<annotation>
+					<documentation>Each</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Hours">
+				<annotation>
+					<documentation>Hours</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Days">
+				<annotation>
+					<documentation>Days</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Seconds">
+				<annotation>
+					<documentation>Seconds</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CrateOf12">
+				<annotation>
+					<documentation>Crate of 12 bottles of beer</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="6Pack">
+				<annotation>
+					<documentation>6Pack</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GLI">
+				<annotation>
+					<documentation>Gallon (UK)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GLL">
+				<annotation>
+					<documentation>Gallon (US)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="LTR">
+				<annotation>
+					<documentation>Litre</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="INH">
+				<annotation>
+					<documentation>Inch</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="FOT">
+				<annotation>
+					<documentation>Foot</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MMT">
+				<annotation>
+					<documentation>Millimeter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CMQ">
+				<annotation>
+					<documentation>Centimeter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MTR">
+				<annotation>
+					<documentation>Meter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MTK">
+				<annotation>
+					<documentation>Square Meter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="MTQ">
+				<annotation>
+					<documentation>Cubic Meter</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="GRM">
+				<annotation>
+					<documentation>Gram</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="KGM">
+				<annotation>
+					<documentation>Kilogram</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="KG">
+				<annotation>
+					<documentation>Kilogram</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="LBR">
+				<annotation>
+					<documentation>Pound</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ANN">
+				<annotation>
+					<documentation>Annual</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CEL">
+				<annotation>
+					<documentation>Degree Celcius</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="FAH">
+				<annotation>
+					<documentation>Degree Fahrenheit</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="RESERVED">
+				<annotation>
+					<documentation>RESERVED</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="RedeemedOfferType">
+		<restriction base="xs:token">
+			<enumeration value="MERCHANT_COUPON"/>
+			<enumeration value="LOYALTY_CARD"/>
+			<enumeration value="MANUFACTURER_COUPON"/>
+			<enumeration value="RESERVED"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="APIType">
+		<annotation>
+			<documentation>Supported API Types for DoCancel operation</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="CHECKOUT_AUTHORIZATION">
+				<annotation>
+					<documentation>POS CHECKOUT AUTHORIZATION</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="CHECKOUT_SALE">
+				<annotation>
+					<documentation>POS CHECKOUT SALE</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+
+	<!-- eBLPaymentsPP in the reusable section -->
+	<element name="APIType" type="ns:APIType"/>
+	<element name="RefundType" type="ns:RefundType"/>
+	<element name="ReceiptID" type="xs:string"/>
+	<element name="SubscriptionID" type="xs:string"/>
+	<element name="OptionTrackingDetails" type="ns:OptionTrackingDetailsType"/>
+	<element name="ItemTrackingDetails" type="ns:ItemTrackingDetailsType"/>
+	<element name="ButtonSearchResult" type="ns:ButtonSearchResultType"/>
+	<element name="PaymentTransactions" type="ns:PaymentTransactionSearchResultType"/>
+	<element name="PaymentTransactionDetails" type="ns:PaymentTransactionType"/>
+	<element name="ThreeDSecureDetails" type="ns:ThreeDSecureInfoType"/>
+	<element name="MerchantPullPaymentDetails" type="ns:MerchantPullPaymentType"/>
+	<element name="BillUserResponseDetails" type="ns:MerchantPullPaymentResponseType"/>
+	<element name="BAUpdateResponseDetails" type="ns:BAUpdateResponseDetailsType"/>
+	<element name="SetAuthFlowParamRequestDetails" type="ns:SetAuthFlowParamRequestDetailsType"/>
+	<element name="GetAuthDetailsResponseDetails" type="ns:GetAuthDetailsResponseDetailsType"/>
+	<element name="SetAccessPermissionsRequestDetails" type="ns:SetAccessPermissionsRequestDetailsType"/>
+	<element name="GetAccessPermissionDetailsResponseDetails" type="ns:GetAccessPermissionDetailsResponseDetailsType"/>
+	<element name="SetExpressCheckoutRequestDetails" type="ns:SetExpressCheckoutRequestDetailsType"/>
+	<element name="ExecuteCheckoutOperationsRequestDetails" type="ns:ExecuteCheckoutOperationsRequestDetailsType"/>
+	<element name="ExecuteCheckoutOperationsResponseDetails" type="ns:ExecuteCheckoutOperationsResponseDetailsType"/>
+	<element name="GetExpressCheckoutDetailsResponseDetails" type="ns:GetExpressCheckoutDetailsResponseDetailsType"/>
+	<element name="DoExpressCheckoutPaymentResponseDetails" type="ns:DoExpressCheckoutPaymentResponseDetailsType"/>
+	<element name="DoExpressCheckoutPaymentRequestDetails" type="ns:DoExpressCheckoutPaymentRequestDetailsType"/>
+	<element name="DoCaptureResponseDetails" type="ns:DoCaptureResponseDetailsType"/>
+	<element name="DoDirectPaymentRequestDetails" type="ns:DoDirectPaymentRequestDetailsType"/>
+	<element name="CreateMobilePaymentRequestDetails" type="ns:CreateMobilePaymentRequestDetailsType"/>
+	<element name="GetMobileStatusRequestDetails" type="ns:GetMobileStatusRequestDetailsType"/>
+	<element name="SetCustomerBillingAgreementRequestDetails" type="ns:SetCustomerBillingAgreementRequestDetailsType"/>
+	<element name="GetBillingAgreementCustomerDetailsResponseDetails" type="ns:GetBillingAgreementCustomerDetailsResponseDetailsType"/>
+	<element name="DoReferenceTransactionRequestDetails" type="ns:DoReferenceTransactionRequestDetailsType"/>
+	<element name="DoReferenceTransactionResponseDetails" type="ns:DoReferenceTransactionResponseDetailsType"/>
+    <element name="DoNonReferencedCreditRequestDetails" type="ns:DoNonReferencedCreditRequestDetailsType"/>
+	<element name="DoNonReferencedCreditResponseDetails" type="ns:DoNonReferencedCreditResponseDetailsType"/>
+	<element name="UATPDetails" type="ns:UATPDetailsType"/>
+	<element name="CreateRecurringPaymentsProfileResponseDetails" type="ns:CreateRecurringPaymentsProfileResponseDetailsType"/>
+	<element name="CreateRecurringPaymentsProfileRequestDetails" type="ns:CreateRecurringPaymentsProfileRequestDetailsType"/>
+	<element name="EnhancedData" type="ns:EnhancedDataType"/>
+	<element name="AirlineItinerary" type="ns:AirlineItineraryType"/>
+	<element name="InstrumentDetails" type="ns:InstrumentDetailsType"/>
+        <element name="OfferDetails" type="ns:OfferDetailsType"/>
+	<element name="GetRecurringPaymentsProfileDetailsResponseDetails" type="ns:GetRecurringPaymentsProfileDetailsResponseDetailsType"/>
+	<element name="ManageRecurringPaymentsProfileStatusRequestDetails" type="ns:ManageRecurringPaymentsProfileStatusRequestDetailsType"/>
+	<element name="ManageRecurringPaymentsProfileStatusResponseDetails" type="ns:ManageRecurringPaymentsProfileStatusResponseDetailsType"/>
+	<element name="BillOutstandingAmountRequestDetails" type="ns:BillOutstandingAmountRequestDetailsType"/>
+	<element name="BillOutstandingAmountResponseDetails" type="ns:BillOutstandingAmountResponseDetailsType"/>
+	<element name="UpdateRecurringPaymentsProfileRequestDetails" type="ns:UpdateRecurringPaymentsProfileRequestDetailsType"/>
+	<element name="UpdateRecurringPaymentsProfileResponseDetails" type="ns:UpdateRecurringPaymentsProfileResponseDetailsType"/>
+	<element name="AuthorizationInfo" type="ns:AuthorizationInfoType"/>
+	<element name="GetIncentiveEvaluationRequestDetails" type="ns:GetIncentiveEvaluationRequestDetailsType"/>
+	<element name="GetIncentiveEvaluationResponseDetails" type="ns:GetIncentiveEvaluationResponseDetailsType"/>
+	<element name="MerchantStoreDetails" type="ns:MerchantStoreDetailsType"/>
+	<element name="RefundItemDetails" type="ns:InvoiceItemType"/>
+	<simpleType name="IncentiveRequestCodeType">
+		<annotation>
+			<documentation>
+				IncentiveRequestType 
+				This identifies the type of request for the API call. The type of request may be used to determine whether the request is for evaluating incentives in pre-checkout or in-checkout phase.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="InCheckout"/>
+			<enumeration value="PreCheckout"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="IncentiveRequestDetailLevelCodeType">
+		<annotation>
+			<documentation>
+				IncentiveRequestDetailLevelType 
+				This identifies the granularity of information requested by the client application. This information will be used to define the contents and details of the response.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Aggregated"/>
+			<enumeration value="Detail"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="IncentiveTypeCodeType">
+		<annotation>
+			<documentation>
+				IncentiveType 
+				This identifies the type of INCENTIVE for the redemption code.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Coupon"/>
+			<enumeration value="eBayGiftCertificate"/>
+			<enumeration value="eBayGiftCard"/>
+			<enumeration value="PayPalRewardVoucher"/>
+			<enumeration value="MerchantGiftCertificate"/>
+			<enumeration value="eBayRewardVoucher"/>
+		</restriction>
+	</simpleType>
+	<complexType name="IncentiveAppliedToType">
+		<sequence>
+			<element name="BucketId" type="xs:string" minOccurs="0"/>
+			<element name="ItemId" type="xs:string" minOccurs="0"/>
+			<element name="IncentiveAmount" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="SubType" type="xs:string" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="IncentiveDetailType">
+		<sequence>
+			<element name="RedemptionCode" type="xs:string" minOccurs="0"/>
+			<element name="DisplayCode" type="xs:string" minOccurs="0"/>
+			<element name="ProgramId" type="xs:string" minOccurs="0"/>
+			<element name="IncentiveType" type="ns:IncentiveTypeCodeType" minOccurs="0"/>
+			<element name="IncentiveDescription" type="xs:string" minOccurs="0"/>
+			<element name="AppliedTo" type="ns:IncentiveAppliedToType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="Status" type="xs:string" minOccurs="0"/>
+			<element name="ErrorCode" type="xs:string" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="IncentiveItemType">
+		<sequence>
+			<element name="ItemId" type="xs:string" minOccurs="0"/>
+			<element name="PurchaseTime" type="xs:dateTime" minOccurs="0"/>
+			<element name="ItemCategoryList" type="xs:string" minOccurs="0"/>
+			<element name="ItemPrice" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="ItemQuantity" type="xs:integer" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="IncentiveBucketType">
+		<sequence>
+			<element name="Items" type="ns:IncentiveItemType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="BucketId" type="xs:string" minOccurs="0"/>
+			<element name="SellerId" type="xs:string" minOccurs="0"/>
+			<element name="ExternalSellerId" type="xs:string" minOccurs="0"/>
+			<element name="BucketSubtotalAmt" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="BucketShippingAmt" type="cc:BasicAmountType" minOccurs="0"/>
+            <element name="BucketInsuranceAmt" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="BucketSalesTaxAmt" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="BucketTotalAmt" type="cc:BasicAmountType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="IncentiveRequestDetailsType">
+		<sequence>
+			<element name="RequestId" type="xs:string" minOccurs="0"/>
+			<element name="RequestType" type="ns:IncentiveRequestCodeType" minOccurs="0"/>
+			<element name="RequestDetailLevel" type="ns:IncentiveRequestDetailLevelCodeType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="GetIncentiveEvaluationRequestDetailsType">
+		<sequence>
+			<element name="ExternalBuyerId" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="IncentiveCodes" type="xs:string" minOccurs="0" maxOccurs="1000"/>
+			<element name="ApplyIndication" type="ns:IncentiveApplyIndicationType" minOccurs="0" maxOccurs="1000"/>
+			<element name="Buckets" type="ns:IncentiveBucketType" minOccurs="0" maxOccurs="100"/>
+			<element name="CartTotalAmt" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1"/>
+			<element name="RequestDetails" type="ns:IncentiveRequestDetailsType" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="GetIncentiveEvaluationResponseDetailsType">
+		<sequence>
+			<element name="IncentiveDetails" type="ns:IncentiveDetailType" minOccurs="0" maxOccurs="1000"/>
+			<element name="RequestId" type="xs:string" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="SetExpressCheckoutRequestDetailsType">
+		<sequence>
+			<element name="OrderTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>The total cost of the order to the customer. If shipping cost and tax charges are known, include them in OrderTotal; if not, OrderTotal should be the current sub-total of the order. 
+<br/>
+						<br/>
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies. 
+<br/>
+						<br/>
+Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReturnURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after choosing to pay with PayPal. PayPal recommends that the value of ReturnURL be the final review page on which the customer confirms the order and payment. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit. </documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer is returned if he does not approve the use of PayPal to pay you. PayPal recommends that the value of CancelURL be the original page on which the customer chose to pay with PayPal. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit
+</documentation>
+				</annotation>
+			</element>
+			<element name="TrackingImageURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Tracking URL for ebay. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit
+</documentation>
+				</annotation>
+			</element>
+            <element name="giropaySuccessURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after paying with giropay online. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: no limit.
+</documentation>
+				</annotation>
+			</element>
+            <element name="giropayCancelURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after fail to pay with giropay online. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: no limit.
+</documentation>
+				</annotation>
+			</element>
+            <element name="BanktxnPendingURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer's browser can be returned in the mEFT done page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: no limit.
+</documentation>
+				</annotation>
+			</element>
+			<element name="Token" type="ns:ExpressCheckoutTokenType" minOccurs="0">
+				<annotation>
+					<documentation>On your first invocation of SetExpressCheckoutRequest, the value of this token is returned by SetExpressCheckoutResponse. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Include this element and its value only if you want to modify an existing checkout session with another invocation of SetExpressCheckoutRequest; for example, if you want the customer to edit his shipping address on PayPal. 
+<br/>
+						<br/>
+Character length and limitations: 20 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="MaxAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>The expected maximum total amount of the complete order, including shipping cost and tax charges. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies. 
+<br/>
+						<br/>
+Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="OrderDescription" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Description of items the customer is purchasing. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>A free-form field for your own use, such as a tracking number or other value you want PayPal to return on GetExpressCheckoutDetailsResponse and DoExpressCheckoutPaymentResponse. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Your own unique invoice or tracking number. PayPal returns this value to you on DoExpressCheckoutPaymentResponse. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReqConfirmShipping" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that you require that the customer's shipping address on file with PayPal be a confirmed address. Any value other than 1 indicates that the customer's shipping address on file with PayPal need NOT be a confirmed address. Setting this element overrides the setting you have specified in the recipient's Merchant Account Profile. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: One single-byte numeric character.
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReqBillingAddress" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that you require that the customer's billing address on file. Setting this element overrides the setting you have specified in Admin.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: One single-byte numeric character.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+						The billing address for the buyer.
+							<br/>
+						Optional
+							<br/>
+							<br/>
+						If you include the BillingAddress element, the AddressType elements are required:
+							<br/>
+							<br/>
+						Name
+							<br/>
+							<br/>
+						Street1
+							<br/>
+							<br/>
+						CityName
+							<br/>
+							<br/>
+						CountryCode
+							<br/>
+							<br/>
+						<b>Do not set set the CountryName element.</b>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="NoShipping" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that on the PayPal pages, no shipping address fields should be displayed whatsoever. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: Four single-byte numeric characters.
+</documentation>
+				</annotation>
+			</element>
+			<element name="AddressOverride" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that the PayPal pages should display the shipping address set by you in the Address element on this SetExpressCheckoutRequest, not the shipping address on file with PayPal for this customer. Displaying the PayPal street address on file does not allow the customer to edit that address. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: Four single-byte numeric characters.
+</documentation>
+				</annotation>
+			</element>
+			<element name="LocaleCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Locale of pages displayed by PayPal during Express Checkout. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: Five single-byte alphabetic characters, upper- or lowercase. 
+<br/>
+						<br/>
+Allowable values: 
+<br/>
+AU or en_AU
+<br/>
+DE or de_DE
+<br/>
+FR or fr_FR
+<br/>
+GB or en_GB
+<br/>
+IT or it_IT
+<br/>
+JP or ja_JP
+<br/>
+US or en_US
+</documentation>
+				</annotation>
+			</element>
+			<element name="PageStyle" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Sets the Custom Payment Page Style for payment pages associated with this button/link. PageStyle corresponds to the HTML variable page_style for customizing payment pages. The value is the same as the Page Style Name you chose when adding or editing the page style from the Profile subtab of the My Account tab of your PayPal account. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 30 single-byte alphabetic characters.
+			</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-image" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			A URL for the image you want to appear at the top left of the payment page. The image has a maximum size of 750 pixels wide by 90 pixels high. PayPal recommends that you provide an image that is stored on a secure (https) server. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 127
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-border-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the border color around the header of the payment page. The border is a 2-pixel perimeter around the header space, which is 750 pixels wide by 90 pixels high. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-back-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the background color for the header of the payment page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-payflow-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the background color for the payment page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+            <element name="cpp-cart-border-color" type="xs:string" minOccurs="0">
+                <annotation>
+                    <documentation>
+            Sets the cart gradient color for the Mini Cart on 1X flow. 
+<br/>
+                        <br/>
+Optional
+<br/>
+                        <br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+                </annotation>
+            </element>
+			<element name="cpp-logo-image" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			A URL for the image you want to appear above the mini-cart. The image has a maximum size of 190 pixels wide by 60 pixels high. PayPal recommends that you provide an image that is stored on a secure (https) server. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 127
+</documentation>
+				</annotation>
+			</element>
+			<element name="Address" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>Customer's shipping address. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+If you include a shipping address and set the AddressOverride element on the request, PayPal returns this same address in GetExpressCheckoutDetailsResponse. 
+</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			How you want to obtain payment. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Authorization indicates that this payment is a basic authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Order indicates that this payment is is an order authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Sale indicates that this is a final sale for which you are requesting payment.
+<br/>
+						<br/>
+IMPORTANT: You cannot set PaymentAction to Sale or Order on SetExpressCheckoutRequest and then change PaymentAction to Authorization on the final Express Checkout API, DoExpressCheckoutPaymentRequest.
+<br/>
+						<br/>
+Character length and limit: Up to 13 single-byte alphabetic characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="SolutionType" type="ns:SolutionTypeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			This will indicate which flow you are choosing (expresschecheckout or expresscheckout optional)
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+None
+<br/>
+						<br/>
+Sole indicates that you are in the ExpressO flow
+<br/>
+						<br/>
+Mark indicates that you are in the old express flow.
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LandingPage" type="ns:LandingPageType" minOccurs="0">
+				<annotation>
+					<documentation>
+			This indicates Which page to display for ExpressO (Billing or Login) 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+None
+<br/>
+						<br/>
+Billing indicates that you are not a paypal account holder
+<br/>
+						<br/>
+Login indicates that you are a paypal account holder
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerEmail" type="ns:EmailAddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Email address of the buyer as entered during checkout. PayPal uses this value to pre-fill the PayPal membership sign-up portion of the PayPal login page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limit: 127 single-byte alphanumeric characters 
+</documentation>
+				</annotation>
+			</element>
+			<element name="ChannelType" type="ns:ChannelType" minOccurs="0"/>
+			<element name="BillingAgreementDetails" type="ns:BillingAgreementDetailsType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="PromoCodes" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Promo Code<br/>
+						<br/>
+						Optional<br/>
+						<br/>
+						List of promo codes supplied by merchant. These promo codes enable the Merchant Services Promotion Financing feature.
+					</documentation>
+				</annotation>
+			</element>	
+			<element name="PayPalCheckOutBtnType" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Default Funding option for PayLater Checkout button.
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ProductCategory" type="ns:ProductCategoryType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="ShippingMethod" type="ns:ShippingServiceCodeType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="ProfileAddressChangeDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        Date and time (in GMT in the format yyyy-MM-ddTHH:mm:ssZ) at which address was changed by the user. 
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="AllowNote" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+			The value 1 indicates that the customer may enter a note to the merchant on the PayPal page during checkout. The note is returned in the GetExpressCheckoutDetails response and the DoExpressCheckoutPayment response.<br/>
+			Optional<br/>
+			Character length and limitations: One single-byte numeric character.<br/>
+			Allowable values: 0,1 
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="FundingSourceDetails" type="ns:FundingSourceDetailsType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+					    Funding source preferences. 
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="BrandName" type="xs:string" minOccurs="0" maxOccurs="1"> 
+                <annotation> 
+                    <documentation>
+			The label that needs to be displayed on the cancel links in the PayPal hosted checkout pages. <br/> 
+			Optional <br/> 
+			Character length and limit: 127 single-byte alphanumeric characters 
+                    </documentation>
+		       	</annotation>
+            </element>
+            <element name="CallbackURL" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+			URL for PayPal to use to retrieve shipping, handling, insurance, and tax details from your website.<br/>
+			Optional<br/>
+			Character length and limitations: 2048 characters.<br/>
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="EnhancedCheckoutData" type="ed:EnhancedCheckoutDataType" minOccurs="0" maxOccurs="1"> 
+                <annotation>
+                    <documentation>
+            Enhanced data for different industry segments.<br/> 
+			Optional<br/>
+                    </documentation> 
+                </annotation>
+            </element>
+            <element name="OtherPaymentMethods" type="ns:OtherPaymentMethodDetailsType" minOccurs="0" maxOccurs="unbounded" >
+                <annotation>
+                    <documentation>
+			List of other payment methods the user can pay with.
+			Optional
+			Refer to the OtherPaymentMethodDetailsType for more details.
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="BuyerDetails" type="ns:BuyerDetailsType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+			Details about the buyer's account.<br/> 
+			Optional<br/>
+			Refer to the BuyerDetailsType for more details. <br/>
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="PaymentDetails" type="ns:PaymentDetailsType" minOccurs="0" maxOccurs="10">
+                <annotation>
+                    <documentation>
+			Information about the payment.
+                    </documentation>
+                </annotation>
+            </element>
+			<element name="FlatRateShippingOptions" type="ns:ShippingOptionType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						List of Fall Back Shipping options provided by merchant.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CallbackTimeout" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the call back timeout override.
+					</documentation>
+				</annotation>
+			</element>
+			
+			<element name="CallbackVersion" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the call back version.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CustomerServiceNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Customer service number.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftMessageEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift message enable.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftReceiptEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift receipt enable.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftWrapEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift Wrap enable.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftWrapName" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift Wrap name.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftWrapAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift Wrap amount.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerEmailOptInEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Buyer email option enable .
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SurveyEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the survey enable.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SurveyQuestion" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the survey question.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SurveyChoice" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Information about the survey choices for survey question.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TotalType" type="ns:TotalType" minOccurs="0"/>
+			<element name="NoteToBuyer" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Any message the seller would like to be displayed in the Mini Cart for UX.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Incentives" type="ns:IncentiveInfoType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Incentive Code<br/>
+						<br/>
+						Optional<br/>
+						<br/>
+						List of incentive codes supplied by ebay/merchant.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReqInstrumentDetails" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Merchant specified flag which indicates whether to return Funding Instrument Details in DoEC or not.
+						<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ExternalRememberMeOptInDetails" type="ns:ExternalRememberMeOptInDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						This element contains information that allows the merchant to request to
+						opt into external remember me on behalf of the buyer or to request login
+						bypass using external remember me.  Note the opt-in details are silently
+						ignored if the ExternalRememberMeID is present.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FlowControlDetails" type="ns:FlowControlDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						An optional set of values related to flow-specific details.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="DisplayControlDetails" type="ns:DisplayControlDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						An optional set of values related to display-specific details.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ExternalPartnerTrackingDetails" type="ns:ExternalPartnerTrackingDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						An optional set of values related to tracking for external partner.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+  <complexType name="ExecuteCheckoutOperationsRequestDetailsType">
+    <sequence>
+      <element name="Token" type="ns:ExpressCheckoutTokenType" minOccurs="0">
+        <annotation>
+          <documentation>
+            On your first invocation of ExecuteCheckoutOperationsRequest, the value of this token is returned by ExecuteCheckoutOperationsResponse.
+            <br/>
+            <br/>
+            Optional
+            <br/>
+            <br/>
+            Include this element and its value only if you want to modify an existing checkout session with another invocation of ExecuteCheckoutOperationsRequest; for example, if you want the customer to edit his shipping address on PayPal.
+            <br/>
+            <br/>
+            Character length and limitations: 20 single-byte characters
+          </documentation>
+        </annotation>
+      </element>
+      <element name="SetDataRequest" type="ns:SetDataRequestType" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            All the Data required to initiate the checkout session is passed in this element.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="AuthorizationRequest" type="ns:AuthorizationRequestType" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            If auto authorization is required, this should be passed in with IsRequested set to yes.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="SetDataRequestType">
+    <sequence>
+      <element name="BillingApprovalDetails" type="ns:BillingApprovalDetailsType" minOccurs="0" maxOccurs="unbounded">
+        <annotation>
+          <documentation>
+            Details about Billing Agreements requested to be created.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="BuyerDetail" type="ns:BuyerDetailType" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Only needed if Auto Authorization is requested. The authentication session token will be passed in here.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="InfoSharingDirectives" type="ns:InfoSharingDirectivesType" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Requests for specific buyer information like Billing Address to be returned through GetExpressCheckoutDetails should be specified under this.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="AuthorizationRequestType">
+    <sequence>
+      <element name="IsRequested" type="xs:boolean" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="BillingApprovalDetailsType">
+    <sequence>
+      <element name="ApprovalType" type="ns:ApprovalTypeType" minOccurs="1">
+        <annotation>
+          <documentation>The Type of Approval requested - Billing Agreement or Profile</documentation>
+        </annotation>
+      </element>
+      <element name="ApprovalSubType" type="ns:ApprovalSubTypeType" minOccurs="0">
+        <annotation>
+          <documentation>The Approval subtype - Must be MerchantInitiatedBilling for BillingAgreement ApprovalType</documentation>
+        </annotation>
+      </element>
+      <element name="OrderDetails" type="ns:OrderDetailsType" minOccurs="0">
+        <annotation>
+          <documentation>Description about the Order</documentation>
+        </annotation>
+      </element>
+      <element name="PaymentDirectives" type="ns:PaymentDirectivesType" minOccurs="0">
+        <annotation>
+          <documentation>Directives about the type of payment</documentation>
+        </annotation>
+      </element>
+      <element name="Custom" type="xs:string" minOccurs="0">
+        <annotation>
+          <documentation>Client may pass in its identification of this Billing Agreement. It used for the client's tracking purposes.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="InfoSharingDirectivesType">
+    <sequence>
+      <element name="ReqBillingAddress" type="xs:string" minOccurs="0">
+        <annotation>
+          <documentation>If Billing Address should be returned in GetExpressCheckoutDetails response, this parameter should be set to yes here</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="OrderDetailsType">
+    <sequence>
+      <element name="Description" type="xs:string" minOccurs="0">
+        <annotation>
+          <documentation>Description of the Order.</documentation>
+        </annotation>
+      </element>
+      <element name="MaxAmount" type="cc:BasicAmountType" minOccurs="0">
+        <annotation>
+          <documentation>Expected maximum amount that the merchant may pull using DoReferenceTransaction</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="PaymentDirectivesType">
+    <sequence>
+      <element name="PaymentType" type="ns:MerchantPullPaymentCodeType" minOccurs="0">
+        <annotation>
+          <documentation>Type of the Payment is it Instant or Echeck or Any.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="BuyerDetailType">
+    <sequence>
+      <element name="IdentificationInfo" type="ns:IdentificationInfoType" minOccurs="0">
+        <annotation>
+          <documentation>Information that is used to indentify the Buyer. This is used for auto authorization. Mandatory if Authorization is requested.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="IdentificationInfoType">
+    <sequence>
+      <element name="MobileIDInfo" type="ns:MobileIDInfoType" minOccurs="0">
+        <annotation>
+          <documentation>Mobile specific buyer identification.</documentation>
+        </annotation>
+      </element>
+      <element name="RememberMeIDInfo" type="ns:RememberMeIDInfoType" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Contains login bypass information.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="MobileIDInfoType">
+    <sequence>
+      <element name="SessionToken" type="xs:string">
+        <annotation>
+          <documentation>The Session token returned during buyer authentication.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="RememberMeIDInfoType">
+    <sequence>
+      <element name="ExternalRememberMeID" type="xs:string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            External remember-me ID returned by GetExpressCheckoutDetails on successful opt-in. The
+            ExternalRememberMeID is a 17-character alphanumeric (encrypted) string that identifies
+            the buyer's remembered login with a merchant and has meaning only to the merchant.  If
+            present, requests that the web flow attempt bypass of login.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+	<complexType name="FundingSourceDetailsType">
+	<sequence>
+		<element name="AllowPushFunding" type="xs:string" minOccurs="0" maxOccurs="1">
+			<annotation>
+				<documentation>
+					Allowable values: 0,1 <br/> 
+					The value 1 indicates that the customer can accept push funding, and 0 means they cannot.<br/>
+					Optional<br/>
+					Character length and limitations: One single-byte numeric character.<br/>
+				</documentation>
+			</annotation>
+		</element>
+		<element name="UserSelectedFundingSource" type="ns:UserSelectedFundingSourceType"  minOccurs="0" maxOccurs="1">
+			<annotation>
+				<documentation>
+					Allowable values: ELV, CreditCard, ChinaUnionPay, BML <br/>
+					This element could be used to specify the perered funding option <br/>
+					for a guest users. It has effect only if LandingPage element is set to Billing. <br/>
+					Otherwise it will be ignored. 
+				</documentation>
+			</annotation>
+		</element>
+	</sequence>
+	</complexType>
+	<complexType name="BillingAgreementDetailsType">
+		<sequence>
+			<element name="BillingType" type="ns:BillingCodeType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementDescription" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Only needed for AutoBill billinng type.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentType" type="ns:MerchantPullPaymentCodeType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementCustom" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Custom annotation field for your exclusive use.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GetExpressCheckoutDetailsResponseDetailsType">
+		<sequence>
+			<element name="Token" type="ns:ExpressCheckoutTokenType">
+				<annotation>
+					<documentation>
+			The timestamped token value that was returned by SetExpressCheckoutResponse and passed on GetExpressCheckoutDetailsRequest. 
+<br/>
+						<br/>Character length and limitations: 20 single-byte characters</documentation>
+				</annotation>
+			</element>
+			<element name="PayerInfo" type="ns:PayerInfoType">
+				<annotation>
+					<documentation>
+			Information about the payer</documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			A free-form field for your own use, as set by you in the Custom element of SetExpressCheckoutRequest. 
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Your own invoice or tracking number, as set by you in the InvoiceID element of SetExpressCheckoutRequest. 
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ContactPhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Payer's contact telephone number. PayPal returns a contact telephone number only if your Merchant account profile settings require that the buyer enter one.</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementAcceptedStatus" type="xs:boolean" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RedirectRequired" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>Customer's billing address.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+If you have credit card mapped in your account then billing address of the credit card is returned otherwise your primary address is returned , PayPal returns this address in GetExpressCheckoutDetailsResponse.
+</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			Text note entered by the buyer in PayPal flow.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CheckoutStatus" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			Returns the status of the EC checkout session.<br/>
+			Values include 'PaymentActionNotInitiated', 'PaymentActionFailed', 'PaymentActionInProgress', 'PaymentCompleted'.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PayPalAdjustment" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			PayPal may offer a discount or gift certificate to the buyer, which will be represented by a negativeamount. If the buyer has a negative balance, PayPal will add that amount to the current charges, which will be represented as a positive amount.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentDetails" type="ns:PaymentDetailsType" minOccurs="0" maxOccurs="10">
+				<annotation>
+					<documentation>
+			Information about the individual purchased items.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="UserSelectedOptions" type="ns:UserSelectedOptionType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the user selected options.
+					</documentation>
+				</annotation>
+			</element>
+ 			<element name="IncentiveDetails" type="ns:IncentiveDetailsType" minOccurs="0" maxOccurs="unbounded">
+                <annotation>  
+                        <documentation>  
+			                Information about the incentives that were applied from Ebay RYP page and PayPal RYP page.
+                        </documentation>  
+                </annotation>  
+ 			</element>
+			<element name="GiftMessage" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift message.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftReceiptEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift receipt enable.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftWrapName" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift Wrap name.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="GiftWrapAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Gift Wrap amount.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerMarketingEmail" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Buyer marketing email.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SurveyQuestion" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the survey question.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SurveyChoiceSelected" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Information about the survey choice selected by the user.
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="PaymentRequestInfo" type="ns:PaymentRequestInfoType" minOccurs="0" maxOccurs="10">
+				<annotation>
+					<documentation>
+						Contains payment request information about each bucket in the cart.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ExternalRememberMeStatusDetails" type="ns:ExternalRememberMeStatusDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Response information resulting from opt-in operation or current login bypass status.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+  <complexType name="ExecuteCheckoutOperationsResponseDetailsType">
+    <sequence>
+      <element name="SetDataResponse" type="ns:SetDataResponseType" minOccurs="1" />
+      <element name="AuthorizationResponse" type="ns:AuthorizationResponseType" minOccurs="0" />
+    </sequence>
+  </complexType>
+  <complexType name="SetDataResponseType">
+        <xs:sequence>
+			<element name="Token" type="ns:ExpressCheckoutTokenType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						If Checkout session was initialized successfully, the corresponding token is returned in this element.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SetDataError" type="ns:ErrorType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+  </complexType>
+  <complexType name="AuthorizationResponseType">
+	<xs:sequence>
+		<element name="Status" type="ns:AckCodeType" minOccurs="1">
+			<annotation>
+				<documentation>
+					Status will denote whether Auto authorization was successful or not.
+				</documentation>
+			</annotation>
+		</element>
+		<element name="AuthorizationError" type="ns:ErrorType" minOccurs="0" maxOccurs="unbounded"/>
+	</xs:sequence>
+  </complexType>
+
+	<complexType name="DoExpressCheckoutPaymentRequestDetailsType">
+		<sequence>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			How you want to obtain payment. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Authorization indicates that this payment is a basic authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Order indicates that this payment is is an order authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Sale indicates that this is a final sale for which you are requesting payment.
+<br/>
+						<br/>
+IMPORTANT: You cannot set PaymentAction to Sale on SetExpressCheckoutRequest and then change PaymentAction to Authorization on the final Express Checkout API, DoExpressCheckoutPaymentRequest.
+<br/>
+						<br/>
+Character length and limit: Up to 13 single-byte alphabetic characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Token" type="ns:ExpressCheckoutTokenType">
+				<annotation>
+					<documentation>
+			The timestamped token value that was returned by SetExpressCheckoutResponse and passed on GetExpressCheckoutDetailsRequest. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: 20 single-byte characters</documentation>
+				</annotation>
+			</element>
+			<element name="PayerID" type="ns:UserIDType">
+				<annotation>
+					<documentation>
+			Encrypted PayPal customer account identification number as returned by GetExpressCheckoutDetailsResponse. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: 127 single-byte characters.
+</documentation>
+				</annotation>
+			</element>
+			<element name="OrderURL" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			URL on Merchant site pertaining to this invoice. 
+<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentDetails" type="ns:PaymentDetailsType" minOccurs="0" maxOccurs="10">
+				<annotation>
+					<documentation>
+			Information about the payment 
+<br/>
+						<br/>
+						<b>Required</b>
+					</documentation>
+				</annotation>
+			</element>
+			    <element name="PromoOverrideFlag" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+				    <documentation>
+					Flag to indicate if previously set promoCode shall be overriden. Value 1 indicates overriding.
+				    </documentation>
+				</annotation>
+			    </element>
+			<element name="PromoCode" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Promotional financing code for item. Overrides any previous PromoCode setting.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EnhancedData" type="ns:EnhancedDataType"  minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Contains data for enhanced data like Airline Itinerary Data.
+				</documentation>
+				</annotation>
+			</element>
+			<element name="SoftDescriptor" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Soft Descriptor supported for Sale and Auth in DEC only. For Order this will be ignored.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="UserSelectedOptions" type="ns:UserSelectedOptionType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the user selected options.
+					</documentation>
+				</annotation>
+			</element>
+	              <element name="GiftMessage" type="xs:string" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the Gift message.
+                       </documentation>
+                   </annotation>
+               </element>
+               <element name="GiftReceiptEnable" type="xs:string" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the Gift receipt enable.
+                       </documentation>
+                   </annotation>
+               </element>
+               <element name="GiftWrapName" type="xs:string" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the Gift Wrap name.
+                       </documentation>
+                   </annotation>
+               </element>
+               <element name="GiftWrapAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the Gift Wrap amount.
+                       </documentation>
+                  </annotation>
+               </element>
+               <element name="BuyerMarketingEmail" type="xs:string" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the Buyer marketing email.
+                       </documentation>
+                   </annotation>
+               </element>
+               <element name="SurveyQuestion" type="xs:string" minOccurs="0" maxOccurs="1">
+                   <annotation>
+                       <documentation>
+                           Information about the survey question.
+                       </documentation>
+                   </annotation>
+               </element>
+               <element name="SurveyChoiceSelected" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                   <annotation>
+                       <documentation>
+                           Information about the survey choice selected by the user.
+                       </documentation>
+                   </annotation>
+               </element>
+
+			<element name="ButtonSource" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>An identification code for use by third-party applications to identify transactions. 
+						<br/>
+							<br/>
+								Optional
+							<br/>
+						<br/>
+						Character length and limitations: 32 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SkipBACreation" type="xs:boolean" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Merchant specified flag which indicates whether to create billing agreement as part of DoEC or not.
+<br/>
+					<br/>
+					<b>Optional</b>
+					<br/>
+					<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DoExpressCheckoutPaymentResponseDetailsType">
+		<sequence>
+			<element name="Token" type="ns:ExpressCheckoutTokenType">
+				<annotation>
+					<documentation>
+			The timestamped token value that was returned by SetExpressCheckoutResponse and passed on GetExpressCheckoutDetailsRequest. 
+<br/>
+						<br/>
+Character length and limitations:20 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType" minOccurs="0" maxOccurs="10">
+				<annotation>
+					<documentation>Information about the transaction </documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementID" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RedirectRequired" type="xs:string" minOccurs="0" maxOccurs="1">
+				 <annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0" maxOccurs="1">
+				 <annotation>
+					<documentation>Memo entered by sender in PayPal Review Page note field.
+						<br/>
+						<br/>
+							Optional
+						<br/>
+						<br/>
+						Character length and limitations: 255 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SuccessPageRedirectRequested" type="xs:string" minOccurs="0" maxOccurs="1"> 
+			    <annotation>
+				    <documentation>
+				        Redirect back to PayPal, PayPal can host the success page. 	          
+				    </documentation>
+				</annotation>
+			</element>
+			<element name="UserSelectedOptions" type="ns:UserSelectedOptionType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the user selected options.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DoCaptureResponseDetailsType">
+		<sequence>
+			<element ref="ns:AuthorizationID">
+				<annotation>
+					<documentation>The authorization identification number you specified in the request. 
+<br/>Character length and limits: 19 single-byte characters maximum
+</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType">
+				<annotation>
+					<documentation>Information about the transaction </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DoDirectPaymentRequestDetailsType">
+		<sequence>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType">
+				<annotation>
+					<documentation>
+			How you want to obtain payment. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Authorization indicates that this payment is a basic authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Sale indicates that this is a final sale for which you are requesting payment.
+<br/>
+						<br/>
+NOTE: Order is not allowed for Direct Payment.
+<br/>
+						<br/>
+Character length and limit: Up to 13 single-byte alphabetic characters</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentDetails" type="ns:PaymentDetailsType">
+				<annotation>
+					<documentation>
+			Information about the payment 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CreditCard" type="ns:CreditCardDetailsType">
+				<annotation>
+					<documentation>
+			Information about the credit card to be charged. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="IPAddress" type="xs:string">
+				<annotation>
+					<documentation>
+			IP address of the payer's browser as recorded in its HTTP request to your website. PayPal records this IP addresses as a means to detect possible fraud. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>Character length and limitations: 15 single-byte characters, including periods, in dotted-quad format: ???.???.???.???
+</documentation>
+				</annotation>
+			</element>
+			<element name="MerchantSessionId" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Your customer session identification token. PayPal records this optional session identification token as an additional means to detect possible fraud. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 64 single-byte numeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="ReturnFMFDetails" type="xs:boolean" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="CreateMobilePaymentRequestDetailsType">
+		<sequence>
+			<element name="PaymentType" type="ns:MobilePaymentCodeType">
+				<annotation>
+					<documentation>Type of the payment
+<br/>
+						<br/>
+						<b>Required</b>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType">
+				<annotation>
+					<documentation>
+						How you want to obtain payment.  Defaults to Sale.
+<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+Authorization indicates that this payment is a basic authorization subject to settlement with PayPal Authorization and Capture.
+<br/>
+						<br/>
+Sale indicates that this is a final sale for which you are requesting payment.
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SenderPhone" type="ns:PhoneNumberType">
+				<annotation>
+					<documentation>Phone number of the user making the payment.
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecipientType" type="ns:MobileRecipientCodeType">
+				<annotation>
+					<documentation>Type of recipient specified, i.e., phone number or email address
+<br/>
+						<br/>
+						<b>Required</b>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecipientEmail" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Email address of the recipient
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecipientPhone" type="ns:PhoneNumberType" minOccurs="0">
+				<annotation>
+					<documentation>Phone number of the recipipent
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemAmount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>Amount of item before tax and shipping
+<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Tax" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>The tax charged on the transaction
+Tax
+<br/>
+						<br/>
+Optional
+<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Shipping" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>Per-transaction shipping charge
+<br/>
+						<br/>
+Optional
+<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Name of the item being ordered
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemNumber" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>SKU of the item being ordered
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Memo entered by sender in PayPal Website Payments note field.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CustomID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Unique ID for the order.  Required for non-P2P transactions
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SharePhoneNumber" type="xs:integer" minOccurs="0">
+				<annotation>
+					<documentation>Indicates whether the sender's phone number will be shared with recipient
+<br/>
+						<br/>
+Optional
+<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShareHomeAddress" type="xs:integer" minOccurs="0">
+				<annotation>
+					<documentation>Indicates whether the sender's home address will be shared with recipient
+<br/>
+						<br/>
+Optional
+<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GetMobileStatusRequestDetailsType">
+		<sequence>
+			<element name="Phone" type="ns:PhoneNumberType">
+				<annotation>
+					<documentation>Phone number for status inquiry </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="SetAuthFlowParamRequestDetailsType">
+		<sequence>
+			<element name="ReturnURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after choosing to login with PayPal.
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit. </documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer is returned if he does not approve the use of PayPal login. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit
+</documentation>
+				</annotation>
+			</element>
+			<element name="LogoutURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after user logs out from PayPal. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit. </documentation>
+				</annotation>
+			</element>
+			<element name="InitFlowType" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The type of the flow.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="SkipLoginPage" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The used to decide SkipLogin allowed or not.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ServiceName1" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The name of the field Merchant requires from PayPal after user's login.
+					<br/>
+						<br/>
+						Optional
+						<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+						</documentation>
+				</annotation>
+			</element>
+			<element name="ServiceDefReq1" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Whether the field is required, opt-in or opt-out.
+					<br/>    
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ServiceName2" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The name of the field Merchant requires from PayPal after user's login.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ServiceDefReq2" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Whether the field is required, opt-in or opt-out.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="LocaleCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Locale of pages displayed by PayPal during Authentication Login.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: Five single-byte alphabetic characters, upper- or lowercase. 
+<br/>
+						<br/>
+Allowable values: 
+<br/>
+AU or en_AU
+<br/>
+DE or de_DE
+<br/>
+FR or fr_FR
+<br/>
+GB or en_GB
+<br/>
+IT or it_IT
+<br/>
+JP or ja_JP
+<br/>
+US or en_US
+</documentation>
+				</annotation>
+			</element>
+			<element name="PageStyle" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Sets the Custom Payment Page Style for flow pages associated with this button/link. PageStyle corresponds to the HTML variable page_style for customizing flow pages. The value is the same as the Page Style Name you chose when adding or editing the page style from the Profile subtab of the My Account tab of your PayPal account. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 30 single-byte alphabetic characters.
+			</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-image" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			A URL for the image you want to appear at the top left of the flow page. The image has a maximum size of 750 pixels wide by 90 pixels high. PayPal recommends that you provide an image that is stored on a secure (https) server. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 127
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-border-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the border color around the header of the flow page. The border is a 2-pixel perimeter around the header space, which is 750 pixels wide by 90 pixels high. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-back-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the background color for the header of the flow page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-payflow-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sets the background color for the payment page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="FirstName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>First Name of the user, this information is used if user chooses to signup with PayPal.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="LastName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Last Name of the user, this information is used if user chooses to signup with PayPal.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+</documentation>
+				</annotation>
+			</element>
+			<element name="Address" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>User address, this information is used when user chooses to signup for PayPal.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+If you include a shipping address and set the AddressOverride element on the request, PayPal returns this same address in GetExpressCheckoutDetailsResponse. 
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GetAuthDetailsResponseDetailsType">
+		<sequence>
+			<element name="FirstName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The first name of the User.
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="LastName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The Last name of the user.
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Email" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The email address of the user.
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PayerID" type="ns:UserIDType">
+				<annotation>
+					<documentation>
+			Encrypted PayPal customer account identification number.
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: 127 single-byte characters.
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<complexType name="SetAccessPermissionsRequestDetailsType">
+		<sequence>
+			<element name="ReturnURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after choosing to login with PayPal.
+					<br/>
+					<br/>
+					<b>Required</b>
+					<br/>
+					<br/>
+					Character length and limitations: no limit. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer is returned if he does not approve the use of PayPal login. 
+					<br/>
+					<br/>
+					<b>Required</b>
+					<br/>
+					<br/>
+					Character length and limitations: no limit
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LogoutURL" type="xs:string">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after user logs out from PayPal. 
+					<br/>
+					<br/>
+					<b>Required</b>
+					<br/>
+					<br/>
+					Character length and limitations: no limit. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="InitFlowType" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The type of the flow.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="SkipLoginPage" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The used to decide SkipLogin allowed or not.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="RequiredAccessPermissions" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+									 contains information about API Services
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="OptionalAccessPermissions" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+									 contains information about API Services
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="LocaleCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+				Locale of pages displayed by PayPal during Authentication Login.
+				<br/>
+				<br/>
+				Optional
+				<br/>
+				<br/>
+					Character length and limitations: Five single-byte alphabetic characters, upper- or lowercase. 
+					<br/>
+					<br/>
+Allowable values: 
+<br/>
+AU or en_AU
+<br/>
+DE or de_DE
+<br/>
+FR or fr_FR
+<br/>
+GB or en_GB
+<br/>
+IT or it_IT
+<br/>
+JP or ja_JP
+<br/>
+US or en_US
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PageStyle" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Sets the Custom Payment Page Style for flow pages associated with this button/link. PageStyle corresponds to the HTML variable page_style for customizing flow pages. The value is the same as the Page Style Name you chose when adding or editing the page style from the Profile subtab of the My Account tab of your PayPal account. 
+					<br/>
+					<br/>
+				Optional
+				<br/>
+				<br/>Character length and limitations: 30 single-byte alphabetic characters.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-image" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+				A URL for the image you want to appear at the top left of the flow page. The image has a maximum size of 750 pixels wide by 90 pixels high. PayPal recommends that you provide an image that is stored on a secure (https) server. 
+				<br/>
+				<br/>
+				Optional
+				<br/>
+				<br/>
+				Character length and limitations: 127
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-border-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+				Sets the border color around the header of the flow page. The border is a 2-pixel perimeter around the header space, which is 750 pixels wide by 90 pixels high. 
+				<br/>
+				<br/>
+				Optional
+				<br/>
+				<br/>Character length and limitations: Six character HTML hexadecimal color code in ASCII
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-back-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+				Sets the background color for the header of the flow page. 
+				<br/>
+				<br/>
+				Optional
+				<br/>
+				<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-payflow-color" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+				Sets the background color for the payment page. 
+				<br/>
+				<br/>
+				Optional
+				<br/>
+				<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FirstName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>First Name of the user, this information is used if user chooses to signup with PayPal.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LastName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Last Name of the user, this information is used if user chooses to signup with PayPal.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitation: Six character HTML hexadecimal color code in ASCII
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Address" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>User address, this information is used when user chooses to signup for PayPal.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>
+					If you include a shipping address and set the AddressOverride element on the request, PayPal returns this same address in GetExpressCheckoutDetailsResponse. 
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<complexType name="GetAccessPermissionDetailsResponseDetailsType">
+		<sequence>
+			<element name="FirstName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The first name of the User.
+						<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="LastName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The Last name of the user.
+						<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Email" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The email address of the user.
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AccessPermissionName" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+									 contains information about API Services
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AccessPermissionStatus" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation> 
+									 contains information about API Services
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PayerID" type="ns:UserIDType">
+				<annotation>
+					<documentation>
+						Encrypted PayPal customer account identification number.
+						<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+						Character length and limitations: 127 single-byte characters.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<complexType name="BAUpdateResponseDetailsType">
+		<sequence>
+			<element name="BillingAgreementID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementDescription" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementStatus" type="ns:MerchantPullStatusCodeType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementCustom" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PayerInfo" type="ns:PayerInfoType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAgreementMax" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>Customer's billing address.
+					<br/>
+					<br/>Optional
+					<br/>
+					If you have credit card mapped in your account then billing address of the 
+					credit card is returned otherwise your primary address is returned , PayPal 
+					returns this address in BAUpdateResponseDetails.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="MerchantPullPaymentResponseType">
+		<annotation>
+			<documentation>
+				MerchantPullPaymentResponseType
+				Response data from the merchant pull.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="PayerInfo" type="ns:PayerInfoType">
+				<annotation>
+					<documentation>
+			information about the customer</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType">
+				<annotation>
+					<documentation>Information about the transaction </documentation>
+				</annotation>
+			</element>
+			<element name="MerchantPullInfo" type="ns:MerchantPullInfoType">
+				<annotation>
+					<documentation>
+			Specific information about the preapproved payment </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="MerchantPullInfoType">
+		<annotation>
+			<documentation>
+				MerchantPullInfoType 
+				Information about the merchant pull.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="MpStatus" type="ns:MerchantPullStatusCodeType">
+				<annotation>
+					<documentation>
+					Current status of billing agreement 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="MpMax" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>Monthly maximum payment amount</documentation>
+				</annotation>
+			</element>
+			<element name="MpCustom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value of the mp_custom variable that you specified in a FORM submission to PayPal during the creation or updating of a customer billing agreement 
+</documentation>
+				</annotation>
+			</element>
+			<element name="Desc" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value of the mp_desc variable (description of goods or services) associated with the billing agreement 
+</documentation>
+				</annotation>
+			</element>
+			<element name="Invoice" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Invoice value as set by BillUserRequest API call </documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Custom field as set by BillUserRequest API call </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentSourceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Note: This field is no longer used and is always empty.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentTransactionSearchResultType">
+		<annotation>
+			<documentation>
+				PaymentTransactionSearchResultType 
+				Results from a PaymentTransaction search
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Timestamp" type="xs:dateTime">
+				<annotation>
+					<documentation>The date and time (in UTC/GMT format) the transaction occurred</documentation>
+				</annotation>
+			</element>
+			<element name="Timezone" type="xs:string">
+				<annotation>
+					<documentation>The time zone of the transaction </documentation>
+				</annotation>
+			</element>
+			<element name="Type" type="xs:string">
+				<annotation>
+					<documentation>The type of the transaction</documentation>
+				</annotation>
+			</element>
+			<element name="Payer" type="ns:EmailAddressType">
+				<annotation>
+					<documentation>The email address of the payer</documentation>
+				</annotation>
+			</element>
+			<element name="PayerDisplayName" type="xs:string">
+				<annotation>
+					<documentation>Display name of the payer</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:TransactionID">
+				<annotation>
+					<documentation>The transaction ID of the seller</documentation>
+				</annotation>
+			</element>
+			<element name="Status" type="xs:string">
+				<annotation>
+					<documentation>The status of the transaction</documentation>
+				</annotation>
+			</element>
+			<element name="GrossAmount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>The total gross amount charged, including any profile shipping cost and taxes</documentation>
+				</annotation>
+			</element>
+			<element name="FeeAmount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>The fee that PayPal charged for the transaction </documentation>
+				</annotation>
+			</element>
+			<element name="NetAmount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>The net amount of the transaction </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ShippingInfoType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ShippingMethod" type="xs:string"/>
+			<element name="ShippingCarrier" type="xs:string"/>
+			<element name="ShippingAmount" type="cc:BasicAmountType"/>
+			<element name="HandlingAmount" type="cc:BasicAmountType"/>
+			<element name="InsuranceAmount" type="cc:BasicAmountType"/>
+		</sequence>
+	</complexType>
+	<complexType name="TaxInfoType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="TaxAmount" type="cc:BasicAmountType"/>
+			<element name="SalesTaxPercentage" type="xs:string"/>
+			<element name="TaxState" type="xs:string"/>
+		</sequence>
+	</complexType>
+	<complexType name="MerchantPullPaymentType">
+		<annotation>
+			<documentation>
+				MerchantPullPayment 
+				Parameters to make initiate a pull payment
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Amount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>
+			The amount to charge to the customer. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Only numeric characters and a decimal separator are allowed. Limit: 10 single-byte characters, including two for decimals You must set the currencyID attribute to one of the three-character currency code for any of the supported PayPal currencies. 
+</documentation>
+				</annotation>
+			</element>
+			<element name="MpID" type="ns:MerchantPullIDType">
+				<annotation>
+					<documentation>
+			Preapproved Payments billing agreement identification number between the PayPal customer and you. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character limit: 19 single-byte alphanumeric characters.
+<br/>
+						<br/>
+The format of a billing agreement identification number is the single-character prefix B, followed by a hyphen and an alphanumeric character string: 
+<br/>
+						<br/>
+B-unique_alphanumeric_string
+</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentType" type="ns:MerchantPullPaymentCodeType" minOccurs="0">
+				<annotation>
+					<documentation>Specifies type of PayPal payment you require 
+<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="Memo" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Text entered by the customer in the Note field during enrollment 
+<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="EmailSubject" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Subject line of confirmation email sent to recipient
+			<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="Tax" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>The tax charged on the transaction
+						<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="Shipping" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>Per-transaction shipping charge 
+						<br/>
+						<br/>
+Optional</documentation>
+				</annotation>
+			</element>
+			<element name="Handling" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>Per-transaction handling charge
+									<br/>
+						<br/>
+Optional</documentation>
+				</annotation>
+			</element>
+			<element name="ItemName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Name of purchased item
+				<br/>
+						<br/>
+Optional</documentation>
+				</annotation>
+			</element>
+			<element name="ItemNumber" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Reference number of purchased item
+			<br/>
+						<br/>
+Optional</documentation>
+				</annotation>
+			</element>
+			<element name="Invoice" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Your invoice number  
+	<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Custom annotation field for tracking or other use
+				<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="ButtonSource" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>An identification code for use by third-party applications to identify transactions. 
+	<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 32 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="SoftDescriptor" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Passed in soft descriptor string to be appended. 
+	<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentTransactionType">
+		<annotation>
+			<documentation>
+				PaymentTransactionType 
+				Information about a PayPal payment from the seller side
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ReceiverInfo" type="ns:ReceiverInfoType">
+				<annotation>
+					<documentation>Information about the recipient of the payment </documentation>
+				</annotation>
+			</element>
+			<element name="PayerInfo" type="ns:PayerInfoType">
+				<annotation>
+					<documentation>Information about the payer </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType">
+				<annotation>
+					<documentation>Information about the transaction </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentItemInfo" type="ns:PaymentItemInfoType" minOccurs="0">
+				<annotation>
+					<documentation>Information about an individual item in the transaction</documentation>
+				</annotation>
+			</element>
+			<element name="UserSelectedOptions" type="ns:UserSelectedOptionType" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the user selected options.
+	  </documentation>
+  </annotation>
+</element>
+<element name="GiftMessage" type="xs:string" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the Gift message.
+	  </documentation>
+  </annotation>
+</element>
+<element name="GiftReceipt" type="xs:string" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the Gift receipt.
+	  </documentation>
+  </annotation>
+</element>
+<element name="GiftWrapName" type="xs:string" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the Gift Wrap name.
+	  </documentation>
+  </annotation>
+</element>
+<element name="GiftWrapAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the Gift Wrap amount.
+	  </documentation>
+  </annotation>
+</element>
+<element name="BuyerEmailOptIn" type="xs:string" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the Buyer email.
+	  </documentation>
+  </annotation>
+</element>
+<element name="SurveyQuestion" type="xs:string" minOccurs="0" maxOccurs="1">
+  <annotation>
+	  <documentation>
+		  Information about the survey question.
+	  </documentation>
+  </annotation>
+</element>
+<element name="SurveyChoiceSelected" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+  <annotation>
+	  <documentation>
+		  Information about the survey choice selected by the user.
+	  </documentation>
+  </annotation>
+</element>
+		</sequence>
+	</complexType>
+	<complexType name="ReceiverInfoType">
+		<annotation>
+			<documentation>
+				ReceiverInfoType 
+				Receiver information.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Business" type="ns:EmailAddressType">
+				<annotation>
+					<documentation>
+			Email address or account ID of the payment recipient (the seller). Equivalent to Receiver if payment is sent to primary account. 
+<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Receiver" type="ns:EmailAddressType">
+				<annotation>
+					<documentation>Primary email address of the payment recipient (the seller). If you are the recipient of the payment and the payment is sent to your non-primary email address, the value of Receiver is still your primary email address. 
+<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReceiverID" type="ns:UserIDType">
+				<annotation>
+					<documentation>Unique account ID of the payment recipient (the seller). This value is the same as the value of the recipient's referral ID. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PayerInfoType">
+		<annotation>
+			<documentation>
+				PayerInfoType 
+				Payer information
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Payer" type="ns:EmailAddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Email address of payer 
+<br/>Character length and limitations: 127 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="PayerID" type="ns:UserIDType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Unique customer ID 
+<br/>Character length and limitations: 17 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="PayerStatus" type="ns:PayPalUserStatusCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Status of payer's email address
+			</documentation>
+				</annotation>
+			</element>
+			<element name="PayerName" type="ns:PersonNameType">
+				<annotation>
+					<documentation>
+			Name of payer </documentation>
+				</annotation>
+			</element>
+			<element name="PayerCountry" type="ns:CountryCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Payment sender's country of residence using standard two-character ISO 3166 country codes. 
+Character length and limitations: Two single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="PayerBusiness" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Payer's business name. 
+<br/>Character length and limitations: 127 single-byte characters</documentation>
+				</annotation>
+			</element>
+			<element name="Address" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Payer's business address</documentation>
+				</annotation>
+			</element>
+			<element name="ContactPhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Business contact telephone number</documentation>
+				</annotation>
+			</element>
+			<element name="TaxIdDetails" type="ns:TaxIdDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Details about payer's tax info.<br/>
+						Refer to the TaxIdDetailsType for more details.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EnhancedPayerInfo" type="ed:EnhancedPayerInfoType" minOccurs="0" maxOccurs="1">
+				<annotation>
+                                          <documentation>Holds any enhanced information about the payer</documentation>
+                                </annotation>
+                        </element>
+		</sequence>
+	</complexType>
+
+
+	<complexType name="InstrumentDetailsType">
+		<annotation>
+			<documentation>
+				InstrumentDetailsType
+				Promotional Instrument Information.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="InstrumentCategory" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						This field holds the category of the instrument only when it is promotional. Return value 1 represents BML.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<complexType name="BMLOfferInfoType">
+		<annotation>
+			<documentation>
+				BMLOfferInfoType
+				Specific information for BML.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="OfferTrackingID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Unique identification for merchant/buyer/offer combo.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<complexType name="OfferDetailsType">
+		<annotation>
+			<documentation>
+				OfferDetailsType
+				Specific information for an offer.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="OfferCode" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Code used to identify the promotion offer.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BMLOfferInfo" type="ns:BMLOfferInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+						Specific infromation for BML, Similar structure could be added for sepcific
+						<br/> promotion needs like CrossPromotions
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+
+	<complexType name="PaymentInfoType">
+		<annotation>
+			<documentation>
+				PaymentInfoType 
+				Payment information.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:TransactionID">
+				<annotation>
+					<documentation>A transaction identification number. 
+<br/>Character length and limits: 19 single-byte characters maximum
+</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:EbayTransactionID" minOccurs="0">
+				<annotation>
+					<documentation>Its Ebay transaction id.
+					<br/>EbayTransactionID will returned for immediate pay item transaction in ECA 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ParentTransactionID" type="ns:TransactionId" minOccurs="0">
+				<annotation>
+					<documentation>
+			Parent or related transaction identification number. This field is populated for the following transaction types: 
+<br/>
+						<br/>
+Reversal
+<br/>
+Capture of an authorized transaction.
+<br/>
+Reauthorization of a transaction.
+<br/>
+Capture of an order. The value of ParentTransactionID is the original OrderID.
+<br/>
+Authorization of an order. The value of ParentTransactionID is the original OrderID.
+<br/>
+Capture of an order authorization.
+<br/>
+Void of an order. The value of ParentTransactionID is the original OrderID.
+<br/>
+						<br/>
+Character length and limits: 19 single-byte characters maximum</documentation>
+				</annotation>
+			</element>
+			<element ref="ns:ReceiptID" minOccurs="0">
+				<annotation>
+					<documentation>
+			Receipt ID 
+<br/>
+						<br/>
+Character length and limitations: 16 digits in xxxx-xxxx-xxxx-xxxx format</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionType" type="ns:PaymentTransactionCodeType">
+				<annotation>
+					<documentation>
+			The type of transaction 
+<br/>
+						<br/>
+cart: Transaction created via the PayPal Shopping Cart feature or by Express Checkout with multiple purchased item
+<br/>
+						<br/>
+express-checkout: Transaction created by Express Checkout with a single purchased items
+<br/>
+						<br/>
+send-money: Transaction created by customer from the Send Money tab on the PayPal website.
+<br/>
+						<br/>
+web-accept: Transaction created by customer via Buy Now, Donation, or Auction Smart Logos.
+<br/>
+						<br/>
+subscr-*: Transaction created by customer via Subscription. eot means "end of subscription term."
+<br/>
+						<br/>
+merch-pmt: preapproved payment.
+<br/>
+						<br/>
+mass-pay: Transaction created via MassPay.
+<br/>
+						<br/>
+virtual-terminal: Transaction created via merchant virtual terminal.
+<br/>
+						<br/>
+credit: Transaction created via merchant virtual terminal or API to credit a customer.
+</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentType" type="ns:PaymentCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			The type of payment</documentation>
+				</annotation>
+			</element>
+			<element name="RefundSourceCodeType" type="ns:RefundSourceCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			The type of funding source</documentation>
+				</annotation>
+			</element>
+			    <element name="ExpectedeCheckClearDate" type="xs:dateTime">
+				    <annotation>
+					    <documentation>
+			    eCheck latest expected clear date </documentation>
+				    </annotation>
+			    </element>
+			<element name="PaymentDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+			Date and time of payment </documentation>
+				</annotation>
+			</element>
+			<element name="GrossAmount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>
+			Full amount of the customer's payment, before transaction fee is subtracted</documentation>
+				</annotation>
+			</element>
+			<element name="FeeAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Transaction fee associated with the payment </documentation>
+				</annotation>
+			</element>
+			<element name="SettleAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>Amount deposited into the account's primary balance after a currency conversion from automatic conversion through your Payment Receiving Preferences or manual conversion through manually accepting a payment. This amount is calculated after fees and taxes have been assessed. </documentation>
+				</annotation>
+			</element>
+			<element name="TaxAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of tax for transaction </documentation>
+				</annotation>
+			</element>
+			<element name="ExchangeRate" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Exchange rate for transaction </documentation>
+				</annotation>
+			</element>
+			<element name="PaymentStatus" type="ns:PaymentStatusCodeType">
+				<annotation>
+					<documentation>
+			The status of the payment:
+<br/>
+						<br/>
+None: No status
+<br/>
+                        <br/>
+Created: A giropay payment has been initiated.
+<br/>
+						<br/>
+Canceled-Reversal: A reversal has been canceled. For example, you won a dispute with the customer, and the funds for the transaction that was reversed have been returned to you.
+<br/>
+						<br/>
+Completed: The payment has been completed, and the funds have been added successfully to your account balance.
+<br/>
+						<br/>
+Denied: You denied the payment. This happens only if the payment was previously pending because of possible reasons described for the PendingReason element.
+<br/>
+						<br/>
+Expired: This authorization has expired and cannot be captured.
+<br/>
+						<br/>
+Failed: The payment has failed. This happens only if the payment was made from your customer's bank account.
+<br/>
+						<br/>
+In-Progress: The transaction is in process of authorization and capture.
+<br/>
+						<br/>
+Partially-Refunded: The transaction has been partially refunded.
+<br/>
+						<br/>
+Pending: The payment is pending. See "PendingReason" for more information.
+<br/>
+						<br/>
+Refunded: You refunded the payment.
+<br/>
+						<br/>
+Reversed: A payment was reversed due to a chargeback or other type of reversal. The funds have been removed from your account balance and returned to the buyer. The reason for the reversal is specified in the ReasonCode element.
+<br/>
+						<br/>
+Processed: A payment has been accepted.
+<br/>
+						<br/>
+Voided: This authorization has been voided.
+<br/>
+						<br/>
+Completed-Funds-Held: The payment has been completed, and the funds have been added successfully to your pending balance. See the "HoldDecision" field for more information.
+</documentation>
+				</annotation>
+			</element>
+			<element name="PendingReason" type="ns:PendingStatusCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			The reason the payment is pending: 
+none: No pending reason
+<br/>
+						<br/>
+address: The payment is pending because your customer did not include a confirmed shipping address and your Payment Receiving Preferences is set such that you want to manually accept or deny each of these payments. To change your preference, go to the Preferences section of your Profile.
+<br/>
+						<br/>
+authorization: You set PaymentAction to Authorization on SetExpressCheckoutRequest and have not yet captured funds.
+<br/>
+						<br/>
+echeck: The payment is pending because it was made by an eCheck that has not yet cleared.
+<br/>
+						<br/>
+intl: The payment is pending because you hold a non-U.S. account and do not have a withdrawal mechanism. You must manually accept or deny this payment from your Account Overview.
+<br/>
+						<br/>
+multi-currency: You do not have a balance in the currency sent, and you do not have your Payment Receiving Preferences set to automatically convert and accept this payment. You must manually accept or deny this payment.
+<br/>
+						<br/>
+unilateral: The payment is pending because it was made to an email address that is not yet registered or confirmed.
+<br/>
+						<br/>
+upgrade: The payment is pending because it was made via credit card and you must upgrade your account to Business or Premier status in order to receive the funds. upgrade can also mean that you have reached the monthly limit for transactions on your account.
+<br/>
+						<br/>
+verify: The payment is pending because you are not yet verified. You must verify your account before you can accept this payment.
+<br/>
+						<br/>
+other: The payment is pending for a reason other than those listed above. For more information, contact PayPal Customer Service.
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReasonCode" type="ns:ReversalReasonCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			The reason for a reversal if TransactionType is reversal: 
+none: No reason code
+<br/>
+						<br/>
+chargeback: A reversal has occurred on this transaction due to a chargeback by your customer.
+<br/>
+						<br/>
+guarantee: A reversal has occurred on this transaction due to your customer triggering a money-back guarantee.
+<br/>
+						<br/>
+buyer-complaint: A reversal has occurred on this transaction due to a complaint about the transaction from your customer.
+<br/>
+						<br/>
+refund: A reversal has occurred on this transaction because you have given the customer a refund.
+<br/>
+						<br/>
+other: A reversal has occurred on this transaction due to a reason not listed above.
+</documentation>
+				</annotation>
+			</element>
+			<element name="HoldDecision" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			HoldDecision is returned in the response only if PaymentStatus is Completed-Funds-Held. The reason the funds are kept in pending balance: 
+newsellerpaymenthold: The seller is new.
+<br/>
+						<br/>
+paymenthold: A hold is placed on your transaction due to a reason not listed above.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingMethod" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Shipping method selected by the user during check-out.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProtectionEligibility" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Protection Eligibility for this Transaction - None, SPP or ESPP
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProtectionEligibilityType" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Protection Eligibility details  for this Transaction
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShipAmount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of shipping charged on transaction</documentation>
+				</annotation>
+			</element>
+			<element name="ShipHandleAmount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of ship handling charged on transaction</documentation>
+				</annotation>
+			</element>
+			<element name="ShipDiscount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of shipping discount on transaction</documentation>
+				</annotation>
+			</element>
+			<element name="InsuranceAmount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of Insurance amount on transaction</documentation>
+				</annotation>
+			</element>
+			<element name="Subject" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Subject as entered in the transaction</documentation>
+				</annotation>
+			</element>
+			<element name="SellerDetails" type="ns:SellerDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Details about the seller.<br/>
+						Optional <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentRequestID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Unique identifier and mandatory for each bucket in case of split payement
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FMFDetails" type="ns:FMFDetailsType"  minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Thes are filters that could result in accept/deny/pending action.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EnhancedPaymentInfo" type="ed:EnhancedPaymentInfoType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						This will be enhanced info for the payment: Example: UATP details
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentError" type="ns:ErrorType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						This will indicate the payment status for individual payment request in case of split payment
+					</documentation>
+				</annotation>
+			</element>
+			<element name="InstrumentDetails" type="ns:InstrumentDetailsType" minOccurs="0">
+				<annotation>
+					<documentation>
+						Type of the payment instrument.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OfferDetails" type="ns:OfferDetailsType" minOccurs="0">
+				<annotation>
+					<documentation>
+						Offer Details.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="SubscriptionTermsType">
+		<annotation>
+			<documentation>
+				SubscriptionTermsType 
+				Terms of a PayPal subscription.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Amount" type="cc:BasicAmountType"/>
+		</sequence>
+		<attribute name="period" type="xs:string" use="required"/>
+	</complexType>
+	<complexType name="SubscriptionInfoType">
+		<annotation>
+			<documentation>
+				SubscriptionInfoType 
+				Information about a PayPal Subscription.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element ref="ns:SubscriptionID">
+				<annotation>
+					<documentation>
+			ID generated by PayPal for the subscriber. 
+Character length and limitations: no limit</documentation>
+				</annotation>
+			</element>
+			<element name="SubscriptionDate" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+			Subscription start date </documentation>
+				</annotation>
+			</element>
+			<element name="EffectiveDate" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+			Date when the subscription modification will be effective </documentation>
+				</annotation>
+			</element>
+			<element name="RetryTime" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+			Date PayPal will retry a failed subscription payment </documentation>
+				</annotation>
+			</element>
+			<element name="Username" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Username generated by PayPal and given to subscriber to access the subscription. 
+Character length and limitations: 64 alphanumeric single-byte characters</documentation>
+				</annotation>
+			</element>
+			<element name="Password" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Password generated by PayPal and given to subscriber to access the subscription. For security, the value of the password is hashed. 
+Character length and limitations: 128 alphanumeric single-byte characters</documentation>
+				</annotation>
+			</element>
+			<element name="Recurrences" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			The number of payment installments that will occur at the regular rate. 
+Character length and limitations: no limit</documentation>
+				</annotation>
+			</element>
+			<element name="Terms" type="ns:SubscriptionTermsType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+			Subscription duration and charges</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="reattempt" type="xs:string" use="required"/>
+		<attribute name="recurring" type="xs:string" use="required"/>
+	</complexType>
+	<complexType name="AuctionInfoType">
+		<annotation>
+			<documentation>
+				AuctionInfoType 
+				Basic information about an auction.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="BuyerID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+		Customer's auction ID	</documentation>
+				</annotation>
+			</element>
+			<element name="ClosingDate" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+			Auction's close date </documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="multiItem" type="xs:string" use="required"/>
+	</complexType>
+	<complexType name="OptionType">
+		<annotation>
+			<documentation>
+				OptionType 
+				PayPal item options for shopping cart.
+			</documentation>
+			<!-- add more documentation here -->
+		</annotation>
+		<sequence/>
+		<attribute name="name" type="xs:string" use="required"/>
+		<attribute name="value" type="xs:string" use="required"/>
+	</complexType>
+	<complexType name="EbayItemPaymentDetailsItemType">
+		<annotation>
+			<documentation>
+				EbayItemPaymentDetailsItemType - Type declaration to be used by other schemas.
+				Information about an Ebay Payment Item.
+			</documentation>
+			<!-- add more documentation here -->
+		</annotation>
+		<sequence>
+			<element name="ItemNumber" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Auction ItemNumber. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 765 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="AuctionTransactionId" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Auction Transaction ID. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="OrderId" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Ebay Order ID. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 64 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="CartID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Ebay Cart ID.
+						<br/>
+						<br/>
+							Optional
+						<br/>
+						<br/>
+							Character length and limitations: 64 single-byte characters
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentDetailsItemType">
+		<annotation>
+			<documentation>
+				PaymentDetailsItemType 
+				Information about a Payment Item.
+			</documentation>
+			<!-- add more documentation here -->
+		</annotation>
+		<sequence>
+			<element name="Name" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item name. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 127 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Number" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item number. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 127 single-byte characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Quantity" type="xs:integer" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item quantity. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: Any positive integer</documentation>
+				</annotation>
+			</element>
+			<element name="Tax" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item sales tax. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: any valid currency amount; currency code is set the same as for OrderTotal.
+</documentation>
+				</annotation>
+			</element>
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Cost of item 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="EbayItemPaymentDetailsItem" type="ns:EbayItemPaymentDetailsItemType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Ebay specific details.
+<br/>
+						<br/>
+Optional
+<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PromoCode" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Promotional financing code for item. Part of the Merchant Services Promotion Financing feature.
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ProductCategory" type="ns:ProductCategoryType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                    </documentation>
+                </annotation>
+            </element>
+			<element name="Description" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Item description. <br/>
+						Optional<br/>
+						Character length and limitations: 127 single-byte characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemWeight" type="cc:MeasureType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Item weight.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemLength" type="cc:MeasureType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Item length.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemWidth" type="cc:MeasureType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Item width.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemHeight" type="cc:MeasureType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Item height.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemURL" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						URL for the item.<br/>
+						Optional<br/>
+						Character length and limitations: no limit.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EnhancedItemData" type="ed:EnhancedItemDataType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Enhanced data for each item in the cart.<br/>
+						Optional<br/>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ItemCategory" type="ns:ItemCategoryType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                        <documentation>
+                                Item category - physical or digital. <br/>
+                                Optional<br/>
+                        </documentation>
+                </annotation>
+            </element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentItemType">
+		<annotation>
+			<documentation>
+				PaymentItemType 
+				Information about a Payment Item.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="EbayItemTxnId" type="xs:string" minOccurs="0" >
+				<annotation>
+					<documentation>
+						eBay Auction Transaction ID of the Item 
+						<br/>Optional<br/>
+						<br/>Character length and limitations: 255 single-byte characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Name" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item name set by you or entered by the customer. 
+<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Number" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Item number set by you. 
+<br/>
+Character length and limitations: 127 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Quantity" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Quantity set by you or entered by the customer. 
+<br/>
+Character length and limitations: no limit</documentation>
+				</annotation>
+			</element>
+			<element name="SalesTax" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of tax charged on payment </documentation>
+				</annotation>
+			</element>
+			<element name="ShippingAmount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of shipping charged on payment </documentation>
+				</annotation>
+			</element>
+			<element name="HandlingAmount" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of handling charged on payment </documentation>
+				</annotation>
+			</element>
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Cost of item </documentation>
+				</annotation>
+			</element>
+			<element name="Options" type="ns:OptionType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+			Item options selected in PayPal shopping cart </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentItemInfoType">
+		<annotation>
+			<documentation>
+				PaymentItemInfoType 
+				Information about a PayPal item.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Invoice number you set in the original transaction.
+			<br/>
+						<br/>
+			Character length and limitations: 127 single-byte alphanumeric characters </documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Custom field you set in the original transaction. 
+<br/>
+						<br/>
+Character length and limitations: 127 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Memo" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Memo entered by your customer in PayPal Website Payments note field. 
+<br/>
+						<br/>
+Character length and limitations: 255 single-byte alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="SalesTax" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Amount of tax charged on transaction</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentItem" type="ns:PaymentItemType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+			Details about the indivudal purchased item</documentation>
+				</annotation>
+			</element>
+			<element name="Subscription" type="ns:SubscriptionInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Information about the transaction if it was created via PayPal Subcriptions</documentation>
+				</annotation>
+			</element>
+			<element name="Auction" type="ns:AuctionInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Information about the transaction if it was created via an auction</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PaymentDetailsType">
+		<annotation>
+			<documentation>
+				PaymentDetailsType 
+				Information about a payment.  Used by DCC and Express Checkout.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="OrderTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Total of order, including shipping, handling, and tax. 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+						<br/>Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,). </documentation>
+				</annotation>
+			</element>
+			<element name="ItemTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sum of cost of all items in this order. 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Total shipping costs for this order. 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="HandlingTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Total handling costs for this order. 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="TaxTotal" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Sum of tax for all items in this order. 
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Limitations: Must not exceed $10,000 USD in any currency. No currency symbol. Decimal separator must be a period (.), and the thousands separator must be a comma (,).
+</documentation>
+				</annotation>
+			</element>
+			<element name="OrderDescription" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Description of items the customer is purchasing. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			A free-form field for your own use. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Your own invoice or tracking number. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ButtonSource" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			An identification code for use by third-party applications to identify transactions. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 32 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="NotifyURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Your URL for receiving Instant Payment Notification (IPN) about this transaction. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>If you do not specify NotifyURL in the request, the notification URL from your Merchant Profile is used, if one exists. 
+<br/>
+						<br/>Character length and limitations: 2,048 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ShipToAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Address the order will be shipped to. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+If you include the ShipToAddress element, the AddressType elements are required: 
+<br/>
+						<br/>Name
+<br/>
+						<br/>
+Street1
+<br/>
+						<br/>
+CityName
+<br/>
+						<br/>
+CountryCode
+<br/>
+						<br/>
+						<b>Do not set set the CountryName element.</b>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ShippingMethod" type="ns:ShippingServiceCodeType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="ProfileAddressChangeDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        Date and time (in GMT in the format yyyy-MM-ddTHH:mm:ssZ) at which address was changed by the user. 
+                    </documentation>
+                </annotation>
+            </element>
+			<element name="PaymentDetailsItem" type="ns:PaymentDetailsItemType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+			Information about the individual purchased items</documentation>
+				</annotation>
+			</element>
+			<element name="InsuranceTotal" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Total shipping insurance costs for this order.<br/>
+						Optional<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingDiscount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Shipping discount for this order, specified as a negative number.<br/>
+						Optional<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="InsuranceOptionOffered" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the Insurance options.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AllowedPaymentMethod" type="ns:AllowedPaymentMethodType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Allowed payment methods for this transaction.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EnhancedPaymentData" type="ed:EnhancedPaymentDataType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Enhanced Data section to accept channel specific data.<br/>
+						Optional<br/>
+						Refer to EnhancedPaymentDataType for details.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SellerDetails" type="ns:SellerDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Details about the seller.<br/>
+						Optional <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="NoteText" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Note to recipient/seller.<br/> 
+						Optional <br/>
+						Character length and limitations: 127 single-byte alphanumeric characters.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionId" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+			PayPal Transaction Id, returned once DoExpressCheckout is completed. <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						How you want to obtain payment.
+						<br/>
+						<br/>
+						This payment action input will be used for split payments
+						<br/>
+						<br/>
+							Authorization indicates that this payment is a basic authorization subject to settlement with PayPal Authorization and Capture.
+						<br/>
+						<br/>
+							Order indicates that this payment is is an order authorization subject to settlement with PayPal Authorization and Capture.
+						<br/>
+						<br/>
+							Sale indicates that this is a final sale for which you are requesting payment.
+						<br/>
+						<br/>
+							IMPORTANT: You cannot set PaymentAction to Sale on SetExpressCheckoutRequest and then change PaymentAction to Authorization on the final Express Checkout API, DoExpressCheckoutPaymentRequest.
+						<br/>
+						<br/>
+							Character length and limit: Up to 13 single-byte alphabetic characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentRequestID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Unique identifier and mandatory for the particular payment request in case of multiple payment
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OrderURL" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						URL on Merchant site pertaining to this invoice. 
+						<br/>
+						<br/>
+							<b>Optional</b>
+						<br/>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SoftDescriptor" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Soft Descriptor supported for Sale and Auth in DEC only. For Order this will be ignored.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BranchLevel" type="xs:integer" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						BranchLevel is used to identify chain payment.
+						If BranchLevel is 0 or 1, this payment is where money moves to.
+						If BranchLevel greater than 1, this payment contains the actual seller info.	
+						<br/>
+						<br/>
+						Optional
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OfferDetails" type="ns:OfferDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Soft Descriptor supported for Sale and Auth in DEC only. For Order this will be ignored.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Recurring" type="ns:RecurringFlagType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Flag to indicate the recurring transaction
+					</documentation>
+				</annotation>
+			</element>
+		    </sequence>
+	    </complexType>
+
+    <complexType name="IncentiveDetailsType">
+        <annotation>
+            <documentation>
+                Information about the incentives that were applied from Ebay RYP page and PayPal RYP page.
+            </documentation>
+        </annotation>
+        <sequence>
+            <element name="UniqueIdentifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        Unique Identifier consisting of redemption code, user friendly descripotion, incentive type, campaign code, incenitve application order and site redeemed o
+n.
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="SiteAppliedOn" type="ns:IncentiveSiteAppliedOnType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        Defines if the incentive has been applied on Ebay or PayPal.
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="TotalDiscountAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        The total discount amount for the incentive, summation of discounts up across all the buckets/items.
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="Status" type="ns:IncentiveAppliedStatusType" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>
+                        Status of incentive processing. Sussess or Error.
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="ErrorCode" type="xs:integer" minOccurs="0" maxOccurs="1">
+                <annotation>  
+                    <documentation>  
+                        Error code if there are any errors. Zero otherwise.
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="IncentiveAppliedDetails" type="ns:IncentiveAppliedDetailsType" minOccurs="0" maxOccurs="unbounded">
+                <annotation>  
+                    <documentation>  
+                        Details of incentive application on individual bucket/item.  
+                    </documentation>  
+                </annotation>  
+            </element>
+        </sequence>  
+    </complexType>  
+
+    <complexType name="IncentiveAppliedDetailsType">  
+        <annotation>  
+            <documentation>  
+                Details of incentive application on individual bucket/item.  
+            </documentation>  
+        </annotation>  
+        <sequence>  
+            <element name="PaymentRequestID" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>  
+                    <documentation>  
+                        PaymentRequestID uniquely identifies a bucket. It is the "bucket id" in the world of EC API.
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="ItemId" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>  
+                    <documentation>  
+                        The item id passed through by the merchant. 
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="ExternalTxnId" type="xs:string" minOccurs="0" maxOccurs="1">
+                <annotation>  
+                    <documentation>  
+                        The item transaction id passed through by the merchant. 
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="DiscountAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+                <annotation>  
+                    <documentation>  
+                        Discount offerred for this bucket or item. 
+                    </documentation>  
+                </annotation>  
+            </element>  
+            <element name="SubType" type="xs:string" minOccurs="0" >
+                <annotation>  
+                    <documentation>  
+                        SubType for coupon. 
+                    </documentation>  
+                </annotation>  
+            </element>  
+        </sequence>  
+    </complexType>  
+
+	<complexType name="SellerDetailsType">
+		<annotation>
+			<documentation>
+				Details about the seller.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="SellerId" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Unique identifier for the seller.<br/>
+						Optional <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SellerUserName" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The user name of the user at the marketplaces site.<br/>
+						Optional <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SellerRegistrationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Date when the user registered with the marketplace.<br/>
+						Optional <br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PayPalAccountID" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Seller Paypal Account Id contains the seller EmailId or PayerId or PhoneNo passed during the Request. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SecureMerchantAccountID" type="ns:UserIDType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Unique PayPal customer account identification number (of the seller). This feild is meant for Response. This field is ignored, if passed in the Request.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>	
+	<complexType name="OtherPaymentMethodDetailsType">
+		<annotation>
+			<documentation>
+				Lists the Payment Methods (other than PayPal) that the use can pay with e.g. Money Order. <br/>
+				Optional.<br/>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="OtherPaymentMethodId" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The identifier of the Payment Method.
+                   	</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodType" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Valid values are 'Method', 'SubMethod'.
+           			</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodLabel" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The name of the Payment Method.
+           			</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodLabelDescription" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The short description of the Payment Method, goes along with the label.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodLongDescriptionTitle" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The title for the long description.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodLongDescription" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The long description of the Payment Method.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodIcon" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The icon of the Payment Method.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OtherPaymentMethodHideLabel" type="xs:boolean" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						If this flag is true, then OtherPaymentMethodIcon is required to have a valid value; the label will be hidden and only ICON will be shown.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="BuyerDetailsType">
+		<annotation>
+			<documentation>
+				Details about the buyer's account passed in by the merchant or partner.<br/>
+				Optional.<br/>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="BuyerId"	type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The client's unique ID for this user.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerUserName" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The user name of the user at the marketplaces site.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerRegistrationDate" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+						Date when the user registered with the marketplace.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TaxIdDetails" type="ns:TaxIdDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Details about payer's tax info.<br/>
+						Refer to the TaxIdDetailsType for more details.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="IdentificationInfo" type="ns:IdentificationInfoType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Contains information that identifies the buyer. e.g. email address or the external remember me id.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="TaxIdDetailsType">
+		<annotation>
+			<documentation>
+				Details about the payer's tax info passed in by the merchant or partner.<br/>
+				Optional.<br/>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="TaxIdType" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The payer's Tax ID type; CNPJ/CPF for BR country.<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TaxId" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						The payer's Tax ID<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+    <complexType name="ThreeDSecureRequestType">
+        <annotation>
+            <documentation>
+                The Common 3DS fields. Common for both GTD and DCC API's.
+            </documentation>
+        </annotation>
+        <sequence>
+            <element name="Eci3ds" type="xs:string" minOccurs="0"/>
+            <element name="Cavv" type="xs:string" minOccurs="0"/>
+            <element name="Xid" type="xs:string" minOccurs="0"/>
+            <element name="MpiVendor3ds" type="xs:string" minOccurs="0"/>
+            <element name="AuthStatus3ds" type="xs:string" minOccurs="0"/>
+        </sequence>
+    </complexType>
+    <complexType name="ThreeDSecureResponseType">
+        <annotation>
+            <documentation>
+                3DS remaining fields.
+            </documentation>
+        </annotation>
+        <sequence>
+            <element name="Vpas" type="xs:string" minOccurs="0"/>
+            <element name="EciSubmitted3DS" type="xs:string" minOccurs="0"/>
+        </sequence>
+    </complexType>
+    <complexType name="ThreeDSecureInfoType">
+        <annotation>
+            <documentation>
+                3DSecureInfoType
+                Information about 3D Secure parameters.
+            </documentation>
+            <!-- add more documentation here -->
+        </annotation>
+        <sequence>
+            <element name="ThreeDSecureRequest" type="ns:ThreeDSecureRequestType" minOccurs="0"/>
+            <element name="ThreeDSecureResponse" type="ns:ThreeDSecureResponseType" minOccurs="0"/>
+        </sequence>
+    </complexType>
+    <complexType name="CreditCardDetailsType">
+        <annotation>
+            <documentation>
+                CreditCardDetailsType 
+                Information about a Credit Card.
+            </documentation>
+            <!-- add more documentation here -->
+        </annotation>
+        <sequence>
+            <element name="CreditCardType" type="ns:CreditCardTypeType" minOccurs="0"/>
+            <element name="CreditCardNumber" type="xs:string" minOccurs="0"/>
+            <element name="ExpMonth" type="xs:int" minOccurs="0"/>
+            <element name="ExpYear" type="xs:int" minOccurs="0"/>
+            <element name="CardOwner" type="ns:PayerInfoType" minOccurs="0"/>
+            <element name="CVV2" type="xs:string" minOccurs="0"/>
+            <element name="StartMonth" type="xs:int" minOccurs="0"/>
+            <element name="StartYear" type="xs:int" minOccurs="0"/>
+            <element name="IssueNumber" type="xs:string" minOccurs="0"/>
+            <element name="ThreeDSecureRequest" type="ns:ThreeDSecureRequestType" minOccurs="0"/>
+        </sequence>
+    </complexType>
+	<complexType name="ShippingOptionType">
+		<annotation>
+			<documentation>
+				Fallback shipping options type.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ShippingOptionIsDefault" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ShippingOptionAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1"/>
+			<element name="ShippingOptionName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="UserSelectedOptionType">
+		<annotation>
+			<documentation>
+				Information on user selected options
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ShippingCalculationMode" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="InsuranceOptionSelected" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ShippingOptionIsDefault" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ShippingOptionAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1"/>
+			<element name="ShippingOptionName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="CreditCardNumberTypeType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="CreditCardType" type="ns:CreditCardTypeType" minOccurs="0" maxOccurs="1"/>
+			<element name="CreditCardNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="ReferenceCreditCardDetailsType">
+		<annotation>
+			<documentation>
+				CreditCardDetailsType for DCC Reference Transaction
+				Information about a Credit Card.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="CreditCardNumberType" type="ns:CreditCardNumberTypeType" minOccurs="0" maxOccurs="1"/>
+			<element name="ExpMonth" type="xs:int" minOccurs="0" maxOccurs="1"/>
+			<element name="ExpYear" type="xs:int" minOccurs="0" maxOccurs="1"/>
+			<element name="CardOwnerName" type="ns:PersonNameType" minOccurs="0" maxOccurs="1"/>
+			<element name="BillingAddress" type="ns:AddressType" minOccurs="0" maxOccurs="1"/>
+			<element name="CVV2" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="StartMonth" type="xs:int" minOccurs="0" maxOccurs="1"/>
+			<element name="StartYear" type="xs:int" minOccurs="0" maxOccurs="1"/>
+			<element name="IssueNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<!-- new CodeTypes -->
+	<simpleType name="PaymentTransactionCodeType">
+		<annotation>
+			<documentation>
+				PaymentTransactionCodeType 
+				This is the type of a PayPal of which matches the output from IPN
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="none"/>
+			<enumeration value="web-accept"/>
+			<enumeration value="cart"/>
+			<enumeration value="send-money"/>
+			<enumeration value="subscr-failed"/>
+			<enumeration value="subscr-cancel"/>
+			<enumeration value="subscr-payment"/>
+			<enumeration value="subscr-signup"/>
+			<enumeration value="subscr-eot"/>
+			<enumeration value="subscr-modify"/>
+			<enumeration value="mercht-pmt"/>
+			<enumeration value="mass-pay"/>
+			<enumeration value="virtual-terminal"/>
+            <enumeration value="integral-evolution"/>
+            <enumeration value="express-checkout"/>
+            <enumeration value="pro-hosted"/>
+            <enumeration value="pro-api"/> 
+			<enumeration value="credit"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentStatusCodeType">
+		<annotation>
+			<documentation>
+				PaymentStatusCodeType 
+				This is the status of a PayPal Payment which matches the output from IPN
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Completed"/>
+			<enumeration value="Failed"/>
+			<enumeration value="Pending"/>
+			<enumeration value="Denied"/>
+			<enumeration value="Refunded"/>
+			<enumeration value="Reversed"/>
+			<enumeration value="Canceled-Reversal"/>
+			<enumeration value="Processed"/>
+			<enumeration value="Partially-Refunded"/>
+			<enumeration value="Voided"/>
+			<enumeration value="Expired"/>
+			<enumeration value="In-Progress"/>
+            <enumeration value="Created"/>
+			<enumeration value="Completed-Funds-Held"/>
+			<enumeration value="Instant"/>
+			<enumeration value="Delayed"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="AddressStatusCodeType">
+		<annotation>
+			<documentation>
+				AddressStatusCodeType 
+				This is the PayPal address status
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Confirmed"/>
+			<enumeration value="Unconfirmed"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentActionCodeType">
+		<annotation>
+			<documentation>
+				PaymentDetailsCodeType 
+				This is the PayPal payment details type (used by DCC and Express Checkout)
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Authorization"/>
+			<enumeration value="Sale"/>
+			<enumeration value="Order"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="FMFPendingTransactionActionType">
+		<annotation>
+			<documentation>
+				This is various actions that a merchant can take on a FMF Pending Transaction.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Accept"/>
+			<enumeration value="Deny"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ChannelType">
+		<annotation>
+			<documentation>
+				ChannelType - Type declaration to be used by other schemas.
+				This is the PayPal Channel type (used by Express Checkout)
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Merchant"/>
+			<enumeration value="eBayItem"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TotalType">
+		<annotation>
+			<documentation>
+				TotalType - Type declaration for the label to be displayed
+				in MiniCart for UX.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Total"/>
+			<enumeration value="EstimatedTotal"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SolutionTypeType">
+		<annotation>
+			<documentation>
+				SolutionTypeType 
+				This is the PayPal payment Solution details type (used by Express Checkout)
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Mark"/>
+			<enumeration value="Sole"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="AllowedPaymentMethodType">
+		<annotation>
+			<documentation>
+				AllowedPaymentMethodType
+				This is the payment Solution merchant needs to specify for Autopay (used by Express Checkout)
+				<br/>Optional
+				<br/>Default indicates that its merchant supports all funding source
+				<br/>InstantPaymentOnly indicates that its merchant only supports instant payment
+				<br/>AnyFundingSource allow all funding methods to be chosen by the buyer irrespective of merchant's profile setting
+				<br/>InstantFundingSource allow only instant funding methods, block echeck, meft, elevecheck. This will override any merchant profile setting
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Default"/>
+			<enumeration value="InstantPaymentOnly"/>
+			<enumeration value="AnyFundingSource"/>
+			<enumeration value="InstantFundingSource"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="LandingPageType">
+		<annotation>
+			<documentation>
+				LandingPageType 
+				This is the PayPal payment Landing Page details type (used by Express Checkout)
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Login"/>
+			<enumeration value="Billing"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="BillingCodeType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="MerchantInitiatedBilling"/>
+			<enumeration value="RecurringPayments"/>
+			<enumeration value="MerchantInitiatedBillingSingleAgreement"/>
+			<enumeration value="ChannelInitiatedBilling"/>
+		</restriction>
+	</simpleType>
+  <simpleType name="ApprovalTypeType">
+    <annotation>
+      <documentation>
+      </documentation>
+    </annotation>
+    <restriction base="xs:token">
+      <enumeration value="BillingAgreement"/>
+      <enumeration value="Profile"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="ApprovalSubTypeType">
+    <annotation>
+      <documentation>
+      </documentation>
+    </annotation>
+    <restriction base="xs:token">
+      <enumeration value="None"/>
+      <enumeration value="MerchantInitiatedBilling"/>
+    </restriction>
+  </simpleType>
+
+	<simpleType name="PendingStatusCodeType">
+		<annotation>
+			<documentation>
+				PendingStatusCodeType 
+				The pending status for a PayPal Payment transaction which matches the output from IPN
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="none"/>
+			<enumeration value="echeck"/>
+			<enumeration value="intl"/>
+			<enumeration value="verify"/>
+			<enumeration value="address"/>
+			<enumeration value="unilateral"/>
+			<enumeration value="other"/>
+			<enumeration value="upgrade"/>
+			<enumeration value="multi-currency"/>
+			<enumeration value="authorization"/>
+			<enumeration value="order"/>
+			<enumeration value="payment-review"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ReceiverInfoCodeType">
+		<annotation>
+			<documentation>
+				ReceiverInfoCodeType 
+				Payee identifier type for MassPay API
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="EmailAddress"/>
+			<enumeration value="UserID"/>
+			<enumeration value="PhoneNumber"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ReversalReasonCodeType">
+		<annotation>
+			<documentation>
+				ReversalReasonCodeType 
+				Reason for a reversal on a PayPal transaction which matches the output from IPN
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="none"/>
+			<enumeration value="chargeback"/>
+			<enumeration value="guarantee"/>
+			<enumeration value="buyer-complaint"/>
+			<enumeration value="refund"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentCodeType">
+		<annotation>
+			<documentation>
+				PaymentCodeType 
+				This is the type of PayPal payment which matches the output from IPN.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="none"/>
+			<enumeration value="echeck"/>
+			<enumeration value="instant"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="RefundSourceCodeType">
+		<annotation>
+			<documentation>
+				RefundSourceCodeType
+				This is the type of PayPal funding source that can be used for auto refund.
+					any - Means Merchant doesn't have any preference. PayPal can use any available funding source (Balance or eCheck)
+					default - Means merchant's preferred funding source as configured in his profile. (Balance or eCheck)
+					instant - Only Balance
+					echeck - Merchant prefers echeck. If PayPal balance can cover the refund amount, we will use PayPal balance. (balance or eCheck)
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="any"/>
+			<enumeration value="default"/>
+			<enumeration value="instant"/>
+			<enumeration value="echeck"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PayPalUserStatusCodeType">
+		<annotation>
+			<documentation>
+				PayPalUserStatusCodeType 
+				PayPal status of a user Address
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="verified"/>
+			<enumeration value="unverified"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="MerchantPullPaymentCodeType">
+		<annotation>
+			<documentation>
+				MerchantPullPaymentCodeType 
+				Type of Payment to be initiated by the merchant
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Any"/>
+			<enumeration value="InstantOnly"/>
+			<enumeration value="EcheckOnly"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="MerchantPullStatusCodeType">
+		<annotation>
+			<documentation>
+				MerchantPullStatusCodeType 
+				Status of the merchant pull
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Active"/>
+			<enumeration value="Canceled"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentTransactionStatusCodeType">
+		<annotation>
+			<documentation>
+				PaymentTransactionStatusCodeType 
+				The status of the PayPal payment.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Pending"/>
+			<enumeration value="Processing"/>
+			<enumeration value="Success"/>
+			<enumeration value="Denied"/>
+			<enumeration value="Reversed"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PaymentTransactionClassCodeType">
+		<annotation>
+			<documentation>
+				PaymentTransactionClassCodeType 
+				The Type of PayPal payment.
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="All"/>
+			<enumeration value="Sent"/>
+			<enumeration value="Received"/>
+			<enumeration value="MassPay"/>
+			<enumeration value="MoneyRequest"/>
+			<enumeration value="FundsAdded"/>
+			<enumeration value="FundsWithdrawn"/>
+			<enumeration value="PayPalDebitCard"/>
+			<enumeration value="Referral"/>
+			<enumeration value="Fee"/>
+			<enumeration value="Subscription"/>
+			<enumeration value="Dividend"/>
+			<enumeration value="Billpay"/>
+			<enumeration value="Refund"/>
+			<enumeration value="CurrencyConversions"/>
+			<enumeration value="BalanceTransfer"/>
+			<enumeration value="Reversal"/>
+			<enumeration value="Shipping"/>
+			<enumeration value="BalanceAffecting"/>
+			<enumeration value="ECheck"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="MatchStatusCodeType">
+		<annotation>
+			<documentation>
+				MatchStatusCodeType 
+				This is the PayPal (street/zip) match code
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Matched"/>
+			<enumeration value="Unmatched"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="CompleteCodeType">
+		<annotation>
+			<documentation>
+				CompleteCodeType 
+				This is the PayPal DoCapture CompleteType code
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NotComplete"/>
+			<enumeration value="Complete"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TransactionEntityType">
+		<annotation>
+			<documentation>
+				TransactionEntityType 
+				This is the PayPal DoAuthorization TransactionEntityType code
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="None"/>
+			<enumeration value="Auth"/>
+			<enumeration value="Reauth"/>
+			<enumeration value="Order"/>
+			<enumeration value="Payment"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="MobileRecipientCodeType">
+		<annotation>
+			<documentation>
+				MobileRecipientCodeType 
+				These are the accepted types of recipients for mobile-originated transactions
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="PhoneNumber"/>
+			<enumeration value="EmailAddress"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="MobilePaymentCodeType">
+		<annotation>
+			<documentation>
+				MobilePaymentCodeType 
+				These are the accepted types of mobile payments
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="P2P"/>
+			<enumeration value="HardGoods"/>
+			<enumeration value="Donation"/>
+			<enumeration value="TopUp"/>
+		</restriction>
+	</simpleType>
+	<!-- Custom Security Header -->
+	<complexType name="CustomSecurityHeaderType">
+		<annotation>
+			<documentation>
+      			    Custom Securiy Header.
+      			</documentation>
+		</annotation>
+		<sequence>
+			<element name="eBayAuthToken" type="xs:string" minOccurs="0"/>
+			<element name="HardExpirationWarning" type="xs:string" minOccurs="0"/>
+			<element name="Credentials" type="ns:UserIdPasswordType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="UserIdPasswordType">
+		<sequence>
+			<element name="AppId" type="xs:string" minOccurs="0"/>
+			<element name="DevId" type="xs:string" minOccurs="0"/>
+			<element name="AuthCert" type="xs:string" minOccurs="0"/>
+			<element name="Username" type="xs:string">
+				<annotation>
+					<documentation>
+						The username is the identifier for an account.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Password" type="xs:string">
+				<annotation>
+					<documentation>
+						Password contains the current password associated with the username.  
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Signature" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Signature for Three Token authentication.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Subject" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						This field identifies an account (e.g., payment) on whose behalf the operation is being performed. 
+						For instance one account holder may delegate the abililty to perform certain operations 
+						to another account holder.  This delegation is done through a separate mechanism.  
+						If the base username has not been authorized by the subject the request will be rejected.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AuthToken" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Authentication Session Token for authentication and authorization.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="SetCustomerBillingAgreementRequestDetailsType">
+		<sequence>
+			<element name="BillingAgreementDetails" type="ns:BillingAgreementDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReturnURL" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LocaleCode" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PageStyle" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-image" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-border-color" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-header-back-color" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="cpp-payflow-color" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerEmail" type="ns:EmailAddressType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReqBillingAddress" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that you require that the customer's billing address on file. Setting this element overrides the setting you have specified in Admin.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: One single-byte numeric character.
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GetBillingAgreementCustomerDetailsResponseDetailsType">
+		<sequence>
+			<element name="PayerInfo" type="ns:PayerInfoType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>Customer's billing address.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+If you have a credit card mapped in your PayPal account, PayPal returns the billing address of the credit billing address otherwise your primary address as billing address in GetBillingAgreementCustomerDetails.
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+        <complexType name="DeviceDetailsType">
+	        <sequence>
+		        <element name="DeviceID" type="xs:string" minOccurs="0">
+			        <annotation>
+			                <documentation>Device ID <br/><br/>Optional<br/><br/>
+					    Character length and limits: 256 single-byte characters <br/>
+                                            DeviceID length morethan 256 is truncated
+				         </documentation>
+					 </annotation>
+                        </element>
+	        </sequence>
+        </complexType>
+        <complexType name="SenderDetailsType">
+                <sequence>
+                        <element name="DeviceDetails" type="ns:DeviceDetailsType" minOccurs="0">
+                                <annotation>
+                                        <documentation>
+                                         </documentation>
+                                 </annotation>
+                        </element>
+                </sequence>
+        </complexType>
+	<complexType name="DoReferenceTransactionRequestDetailsType">
+		<sequence>
+			<element name="ReferenceID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentAction" type="ns:PaymentActionCodeType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentType" type="ns:MerchantPullPaymentCodeType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentDetails" type="ns:PaymentDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CreditCard" type="ns:ReferenceCreditCardDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="IPAddress" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="MerchantSessionId" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReqConfirmShipping" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SoftDescriptor" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+                        <element name="SenderDetails" type="ns:SenderDetailsType" minOccurs="0" maxOccurs="1">
+	                        <annotation>
+		                        <documentation>
+	                        	</documentation>
+	                        </annotation>
+                        </element>
+		</sequence>
+	</complexType>
+	<complexType name="DoReferenceTransactionResponseDetailsType">
+		<sequence>
+			<element name="BillingAgreementID" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AVSCode" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CVV2Code" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionID" type="ns:TransactionId" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentAdviceCode" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Response code from the processor when a recurring transaction is declined
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+    <complexType name="DoNonReferencedCreditRequestDetailsType">
+		<sequence>
+            <element name="Amount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="NetAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="TaxAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ShippingAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="CreditCard" type="ns:CreditCardDetailsType">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+            <element name="ReceiverEmail" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Comment" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DoNonReferencedCreditResponseDetailsType">
+		<sequence>
+			<element name="Amount" type="cc:BasicAmountType">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionID" type="ns:TransactionId">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+	<!-- BOARDING DATA TYPES -->
+	<element name="EnterBoardingRequestDetails" type="ns:EnterBoardingRequestDetailsType"/>
+	<element name="GetBoardingDetailsResponseDetails" type="ns:GetBoardingDetailsResponseDetailsType"/>
+	<complexType name="EnterBoardingRequestDetailsType">
+		<sequence>
+			<element name="ProgramCode" type="xs:string">
+				<annotation>
+					<documentation>
+			Onboarding program code given to you by PayPal.
+			<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: 64 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="ProductList" type="xs:string">
+				<annotation>
+					<documentation>
+			A list of comma-separated values that indicate the PayPal products you are implementing for this merchant:
+			<br/>
+						<br/>
+Direct Payment (dp) allows payments by credit card without requiring the customer to have a PayPal account. 
+<br/>
+						<br/>
+Express Checkout (ec) allows customers to fund transactions with their PayPal account. 
+<br/>
+						<br/>
+Authorization and Capture (auth_settle) allows merchants to verify availability of funds in a PayPal account, but capture them at a later time. 
+<br/>
+						<br/>
+Administrative APIs (admin_api) is a collection of the PayPal APIs for transaction searching, getting transaction details, refunding, and mass payments. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: 64 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="PartnerCustom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Any custom information you want to store for this partner
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="ImageUrl" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			The URL for the logo displayed on the PayPal Partner Welcome Page.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>
+Character length and limitations: 2,048 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="MarketingCategory" type="ns:MarketingCategoryType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Marketing category tha configures the graphic displayed n the PayPal Partner Welcome page.</documentation>
+				</annotation>
+			</element>
+			<element name="BusinessInfo" type="ns:BusinessInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Information about the merchant’s business</documentation>
+				</annotation>
+			</element>
+			<element name="OwnerInfo" type="ns:BusinessOwnerInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Information about the merchant (the business owner)</documentation>
+				</annotation>
+			</element>
+			<element name="BankAccount" type="ns:BankAccountDetailsType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Information about the merchant's bank account</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="MarketingCategoryType">
+		<annotation>
+			<documentation>
+                        MarketingCategoryType 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Marketing-Category-Default"/>
+			<enumeration value="Marketing-Category1"/>
+			<enumeration value="Marketing-Category2"/>
+			<enumeration value="Marketing-Category3"/>
+			<enumeration value="Marketing-Category4"/>
+			<enumeration value="Marketing-Category5"/>
+			<enumeration value="Marketing-Category6"/>
+			<enumeration value="Marketing-Category7"/>
+			<enumeration value="Marketing-Category8"/>
+			<enumeration value="Marketing-Category9"/>
+			<enumeration value="Marketing-Category10"/>
+			<enumeration value="Marketing-Category11"/>
+			<enumeration value="Marketing-Category12"/>
+			<enumeration value="Marketing-Category13"/>
+			<enumeration value="Marketing-Category14"/>
+			<enumeration value="Marketing-Category15"/>
+			<enumeration value="Marketing-Category16"/>
+			<enumeration value="Marketing-Category17"/>
+			<enumeration value="Marketing-Category18"/>
+			<enumeration value="Marketing-Category19"/>
+			<enumeration value="Marketing-Category20"/>
+		</restriction>
+	</simpleType>
+	<complexType name="BusinessInfoType">
+		<annotation>
+			<documentation>
+				BusinessInfoType 
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Type" type="ns:BusinessTypeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Type of business, such as corporation or sole proprietorship</documentation>
+				</annotation>
+			</element>
+			<element name="Name" type="ns:NameType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Official name of business
+<br/>
+						<br/>
+Character length and limitations: 75 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Address" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Merchant’s business postal address</documentation>
+				</annotation>
+			</element>
+			<element name="WorkPhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Business’s primary telephone number
+<br/>
+						<br/>
+Character length and limitations: 20 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Category" type="ns:BusinessCategoryType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Line of business, as defined in the enumerations</documentation>
+				</annotation>
+			</element>
+			<element name="SubCategory" type="ns:BusinessSubCategoryType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Business sub-category, as defined in the enumerations</documentation>
+				</annotation>
+			</element>
+			<element name="AveragePrice" type="ns:AverageTransactionPriceType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Average transaction price, as defined by the enumerations.
+			<table>
+							<tr>
+								<th>Enumeration</th>
+								<th>Meaning</th>
+							</tr>
+							<tr>
+								<td/>
+								<td/>
+							</tr>AverageTransactionPrice-Not-Applicable	
+<tr>
+								<td>AverageTransactionPrice-Range1</td>
+								<td>Less than $25 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range2</td>
+								<td>$25 USD to $50 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range3</td>
+								<td>$50 USD to $100 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range4</td>
+								<td>$100 USD to $250 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range5</td>
+								<td>$250 USD to $500 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range6</td>
+								<td>$500 USD to $1,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range7</td>
+								<td>	$1,000 USD to $2,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range8</td>
+								<td>$2,000 USD to $5,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range9</td>
+								<td>$5,000 USD to $10,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageTransactionPrice-Range10</td>
+								<td>More than $10,000 USD</td>
+							</tr>
+						</table>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AverageMonthlyVolume" type="ns:AverageMonthlyVolumeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Average monthly sales volume, as defined by the enumerations.
+			<table>
+							<tr>
+								<th>Enumeration</th>
+								<th>Meaning</th>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Not-Applicable</td>
+								<td/>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range1</td>
+								<td>Less than $1,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range2</td>
+								<td>$1,000 USD to $5,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range3</td>
+								<td>$5,000 USD to $25,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range4</td>
+								<td>$25,000 USD to $100,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range5</td>
+								<td>$100,000 USD to $1,000,000 USD</td>
+							</tr>
+							<tr>
+								<td>AverageMonthlyVolume-Range6</td>
+								<td>More than $1,000,000 USD</td>
+							</tr>
+						</table>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SalesVenue" type="ns:SalesVenueType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Main sales venue, such as eBay</documentation>
+				</annotation>
+			</element>
+			<element name="Website" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Primary URL of business
+			<br/>
+						<br/>Character length and limitations: 2,048 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="RevenueFromOnlineSales" type="ns:PercentageRevenueFromOnlineSalesType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Percentage of revenue attributable to online sales, as defined by the enumerations
+			<br/>
+						<br/>
+						<table>
+							<tr>
+								<th>Enumeration</th>
+								<th>Meaning</th>
+							</tr>
+							<tr>
+								<td/>
+								<td/>
+							</tr>PercentageRevenueFromOnlineSales-Not-Applicable	
+<tr>
+								<td>PercentageRevenueFromOnlineSales-Range1</td>
+								<td>Less than 25%</td>
+							</tr>
+							<tr>
+								<td>PercentageRevenueFromOnlineSales-Range2</td>
+								<td>25% to 50%</td>
+							</tr>
+							<tr>
+								<td>PercentageRevenueFromOnlineSales-Range3</td>
+								<td>50% to 75%</td>
+							</tr>
+							<tr>
+								<td>PercentageRevenueFromOnlineSales-Range4</td>
+								<td>75% to 100%</td>
+							</tr>
+						</table>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BusinessEstablished" type="xs:dateTime" minOccurs="0">
+				<annotation>
+					<documentation>
+			Date the merchant’s business was established</documentation>
+				</annotation>
+			</element>
+			<element name="CustomerServiceEmail" type="ns:EmailAddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Email address to contact business’s customer service
+<br/>
+						<br/>
+Character length and limitations: 127 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="CustomerServicePhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Telephone number to contact business’s customer service
+<br/>
+						<br/>Character length and limitations: 32 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="BusinessTypeType">
+		<annotation>
+			<documentation>
+				BusinessTypeType
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown"/>
+			<enumeration value="Individual"/>
+			<enumeration value="Proprietorship"/>
+			<enumeration value="Partnership"/>
+			<enumeration value="Corporation"/>
+			<enumeration value="Nonprofit"/>
+			<enumeration value="Government"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="BusinessCategoryType">
+		<annotation>
+			<documentation>
+				BusinessCategoryType 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Category-Unspecified"/>
+			<enumeration value="Antiques"/>
+			<enumeration value="Arts"/>
+			<enumeration value="Automotive"/>
+			<enumeration value="Beauty"/>
+			<enumeration value="Books"/>
+			<enumeration value="Business"/>
+			<enumeration value="Cameras-and-Photography"/>
+			<enumeration value="Clothing"/>
+			<enumeration value="Collectibles"/>
+			<enumeration value="Computer-Hardware-and-Software"/>
+			<enumeration value="Culture-and-Religion"/>
+			<enumeration value="Electronics-and-Telecom"/>
+			<enumeration value="Entertainment"/>
+			<enumeration value="Entertainment-Memorabilia"/>
+			<enumeration value="Food-Drink-and-Nutrition"/>
+			<enumeration value="Gifts-and-Flowers"/>
+			<enumeration value="Hobbies-Toys-and-Games"/>
+			<enumeration value="Home-and-Garden"/>
+			<enumeration value="Internet-and-Network-Services"/>
+			<enumeration value="Media-and-Entertainment"/>
+			<enumeration value="Medical-and-Pharmaceutical"/>
+			<enumeration value="Money-Service-Businesses"/>
+			<enumeration value="Non-Profit-Political-and-Religion"/>
+			<enumeration value="Not-Elsewhere-Classified"/>
+			<enumeration value="Pets-and-Animals"/>
+			<enumeration value="Real-Estate"/>
+			<enumeration value="Services"/>
+			<enumeration value="Sports-and-Recreation"/>
+			<enumeration value="Travel"/>
+			<enumeration value="Other-Categories"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="BusinessSubCategoryType">
+		<annotation>
+			<documentation>
+				BusinessSubCategoryType 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="SubCategory-Unspecified"/>
+			<enumeration value="ANTIQUES-General"/>
+			<enumeration value="ANTIQUES-Antiquities"/>
+			<enumeration value="ANTIQUES-Decorative"/>
+			<enumeration value="ANTIQUES-Books-Manuscripts"/>
+			<enumeration value="ANTIQUES-Furniture"/>
+			<enumeration value="ANTIQUES-Glass"/>
+			<enumeration value="ANTIQUES-RugsCarpets"/>
+			<enumeration value="ANTIQUES-Pottery"/>
+			<enumeration value="ANTIQUES-Cultural"/>
+			<enumeration value="ANTIQUES-Artifacts-Grave-related-and-Native-American-Crafts"/>
+			<enumeration value="ARTSANDCRAFTS-General"/>
+			<enumeration value="ARTSANDCRAFTS-Art-Dealer-and-Galleries"/>
+			<enumeration value="ARTSANDCRAFTS-Prints"/>
+			<enumeration value="ARTSANDCRAFTS-Painting"/>
+			<enumeration value="ARTSANDCRAFTS-Photography"/>
+			<enumeration value="ARTSANDCRAFTS-Reproductions"/>
+			<enumeration value="ARTSANDCRAFTS-Sculptures"/>
+			<enumeration value="ARTSANDCRAFTS-Woodworking"/>
+			<enumeration value="ARTSANDCRAFTS-Art-and-Craft-Supplies"/>
+			<enumeration value="ARTSANDCRAFTS-Fabrics-and-Sewing"/>
+			<enumeration value="ARTSANDCRAFTS-Quilting"/>
+			<enumeration value="ARTSANDCRAFTS-Scrapbooking"/>
+			<enumeration value="AUTOMOTIVE-General"/>
+			<enumeration value="AUTOMOTIVE-Autos"/>
+			<enumeration value="AUTOMOTIVE-Aviation"/>
+			<enumeration value="AUTOMOTIVE-Motorcycles"/>
+			<enumeration value="AUTOMOTIVE-Parts-and-Supplies"/>
+			<enumeration value="AUTOMOTIVE-Services"/>
+			<enumeration value="AUTOMOTIVE-Vintage-and-Collectible-Vehicles"/>
+			<enumeration value="BEAUTY-General"/>
+			<enumeration value="BEAUTY-Body-Care-Personal-Hygiene"/>
+			<enumeration value="BEAUTY-Fragrances-and-Perfumes"/>
+			<enumeration value="BEAUTY-Makeup"/>
+			<enumeration value="BOOKS-General"/>
+			<enumeration value="BOOKS-Audio-Books"/>
+			<enumeration value="BOOKS-Children-Books"/>
+			<enumeration value="BOOKS-Computer-Books"/>
+			<enumeration value="BOOKS-Educational-and-Textbooks"/>
+			<enumeration value="BOOKS-Magazines"/>
+			<enumeration value="BOOKS-Fiction-and-Literature"/>
+			<enumeration value="BOOKS-NonFiction"/>
+			<enumeration value="BOOKS-Vintage-and-Collectibles"/>
+			<enumeration value="BUSINESS-General"/>
+			<enumeration value="BUSINESS-Agricultural"/>
+			<enumeration value="BUSINESS-Construction"/>
+			<enumeration value="BUSINESS-Educational"/>
+			<enumeration value="BUSINESS-Industrial"/>
+			<enumeration value="BUSINESS-Office-Supplies-and-Equipment"/>
+			<enumeration value="BUSINESS-GeneralServices"/>
+			<enumeration value="BUSINESS-Advertising"/>
+			<enumeration value="BUSINESS-Employment"/>
+			<enumeration value="BUSINESS-Marketing"/>
+			<enumeration value="BUSINESS-Meeting-Planners"/>
+			<enumeration value="BUSINESS-Messaging-and-Paging-Services"/>
+			<enumeration value="BUSINESS-Seminars"/>
+			<enumeration value="BUSINESS-Publishing"/>
+			<enumeration value="BUSINESS-Shipping-and-Packaging"/>
+			<enumeration value="BUSINESS-Wholesale"/>
+			<enumeration value="BUSINESS-Industrial-Solvents"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-General"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-Accessories"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-Cameras"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-Video-Equipment"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-Film"/>
+			<enumeration value="CAMERASANDPHOTOGRAPHY-Supplies"/>
+			<enumeration value="CLOTHING-Accessories"/>
+			<enumeration value="CLOTHING-Babies-Clothing-and-Supplies"/>
+			<enumeration value="CLOTHING-Childrens-Clothing"/>
+			<enumeration value="CLOTHING-Mens-Clothing"/>
+			<enumeration value="CLOTHING-Shoes"/>
+			<enumeration value="CLOTHING-Wedding-Clothing"/>
+			<enumeration value="CLOTHING-Womens-Clothing"/>
+			<enumeration value="CLOTHING-General"/>
+			<enumeration value="CLOTHING-Jewelry"/>
+			<enumeration value="CLOTHING-Watches-and-Clocks"/>
+			<enumeration value="CLOTHING-Rings"/>
+			<enumeration value="COLLECTIBLES-General"/>
+			<enumeration value="COLLECTIBLES-Advertising"/>
+			<enumeration value="COLLECTIBLES-Animals"/>
+			<enumeration value="COLLECTIBLES-Animation"/>
+			<enumeration value="COLLECTIBLES-Coin-Operated-Banks-and-Casinos"/>
+			<enumeration value="COLLECTIBLES-Coins-and-Paper-Money"/>
+			<enumeration value="COLLECTIBLES-Comics"/>
+			<enumeration value="COLLECTIBLES-Decorative"/>
+			<enumeration value="COLLECTIBLES-Disneyana"/>
+			<enumeration value="COLLECTIBLES-Holiday"/>
+			<enumeration value="COLLECTIBLES-Knives-and-Swords"/>
+			<enumeration value="COLLECTIBLES-Militaria"/>
+			<enumeration value="COLLECTIBLES-Postcards-and-Paper"/>
+			<enumeration value="COLLECTIBLES-Stamps"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-General"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Desktop-PCs"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Monitors"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Hardware"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Peripherals"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Laptops-Notebooks-PDAs"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Networking-Equipment"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Parts-and-Accessories"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-GeneralSoftware"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Oem-Software"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Academic-Software"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Beta-Software"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Game-Software"/>
+			<enumeration value="COMPUTERHARDWAREANDSOFTWARE-Data-Processing-Svc"/>
+			<enumeration value="CULTUREANDRELIGION-General"/>
+			<enumeration value="CULTUREANDRELIGION-Christianity"/>
+			<enumeration value="CULTUREANDRELIGION-Metaphysical"/>
+			<enumeration value="CULTUREANDRELIGION-New-Age"/>
+			<enumeration value="CULTUREANDRELIGION-Organizations"/>
+			<enumeration value="CULTUREANDRELIGION-Other-Faiths"/>
+			<enumeration value="CULTUREANDRELIGION-Collectibles"/>
+			<enumeration value="ELECTRONICSANDTELECOM-GeneralTelecom"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Cell-Phones-and-Pagers"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Telephone-Cards"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Telephone-Equipment"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Telephone-Services"/>
+			<enumeration value="ELECTRONICSANDTELECOM-GeneralElectronics"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Car-Audio-and-Electronics"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Home-Electronics"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Home-Audio"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Gadgets-and-other-electronics"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Batteries"/>
+			<enumeration value="ELECTRONICSANDTELECOM-ScannersRadios"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Radar-Dectors"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Radar-Jamming-Devices"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Satellite-and-Cable-TV-Descramblers"/>
+			<enumeration value="ELECTRONICSANDTELECOM-Surveillance-Equipment"/>
+			<enumeration value="ENTERTAINMENT-General"/>
+			<enumeration value="ENTERTAINMENT-Movies"/>
+			<enumeration value="ENTERTAINMENT-Music"/>
+			<enumeration value="ENTERTAINMENT-Concerts"/>
+			<enumeration value="ENTERTAINMENT-Theater"/>
+			<enumeration value="ENTERTAINMENT-Bootleg-Recordings"/>
+			<enumeration value="ENTERTAINMENT-Promotional-Items"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-General"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Autographs"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Limited-Editions"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Movie"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Music"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Novelties"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Photos"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Posters"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Sports-and-Fan-Shop"/>
+			<enumeration value="ENTERTAINMENTMEMORABILIA-Science-Fiction"/>
+			<enumeration value="FOODDRINKANDNUTRITION-General"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Coffee-and-Tea"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Food-Products"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Gourmet-Items"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Health-and-Nutrition"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Services"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Vitamins-and-Supplements"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Weight-Management-and-Health-Products"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Restaurant"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Tobacco-and-Cigars"/>
+			<enumeration value="FOODDRINKANDNUTRITION-Alcoholic-Beverages"/>
+			<enumeration value="GIFTSANDFLOWERS-General"/>
+			<enumeration value="GIFTSANDFLOWERS-Flowers"/>
+			<enumeration value="GIFTSANDFLOWERS-Greeting-Cards"/>
+			<enumeration value="GIFTSANDFLOWERS-Humorous-Gifts-and-Novelties"/>
+			<enumeration value="GIFTSANDFLOWERS-Personalized-Gifts"/>
+			<enumeration value="GIFTSANDFLOWERS-Products"/>
+			<enumeration value="GIFTSANDFLOWERS-Services"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-General"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Action-Figures"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Bean-Babies"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Barbies"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Bears"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Dolls"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Games"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Model-Kits"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Diecast-Toys-Vehicles"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Video-Games-and-Systems"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Vintage-and-Antique-Toys"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-BackupUnreleased-Games"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Game-copying-hardwaresoftware"/>
+			<enumeration value="HOBBIESTOYSANDGAMES-Mod-Chips"/>
+			<enumeration value="HOMEANDGARDEN-General"/>
+			<enumeration value="HOMEANDGARDEN-Appliances"/>
+			<enumeration value="HOMEANDGARDEN-Bed-and-Bath"/>
+			<enumeration value="HOMEANDGARDEN-Furnishing-and-Decorating"/>
+			<enumeration value="HOMEANDGARDEN-Garden-Supplies"/>
+			<enumeration value="HOMEANDGARDEN-Hardware-and-Tools"/>
+			<enumeration value="HOMEANDGARDEN-Household-Goods"/>
+			<enumeration value="HOMEANDGARDEN-Kitchenware"/>
+			<enumeration value="HOMEANDGARDEN-Rugs-and-Carpets"/>
+			<enumeration value="HOMEANDGARDEN-Security-and-Home-Defense"/>
+			<enumeration value="HOMEANDGARDEN-Plants-and-Seeds"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-General"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-Bulletin-board"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-online-services"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-Auction-management-tools"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-ecommerce-development"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-training-services"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-Online-Malls"/>
+			<enumeration value="INTERNETANDNETWORKSERVICES-Web-hosting-and-design"/>
+			<enumeration value="MEDIAANDENTERTAINMENT-General"/>
+			<enumeration value="MEDIAANDENTERTAINMENT-Concerts"/>
+			<enumeration value="MEDIAANDENTERTAINMENT-Theater"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-General"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-Medical"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-Dental"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-Opthamalic"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-Prescription-Drugs"/>
+			<enumeration value="MEDICALANDPHARMACEUTICAL-Devices"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-General"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Remittance"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Wire-Transfer"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Money-Orders"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Electronic-Cash"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Currency-DealerExchange"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Check-Cashier"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Travelers-Checks"/>
+			<enumeration value="MONEYSERVICEBUSINESSES-Stored-Value-Cards"/>
+			<enumeration value="NONPROFITPOLITICALANDRELIGION-General"/>
+			<enumeration value="NONPROFITPOLITICALANDRELIGION-Charities"/>
+			<enumeration value="NONPROFITPOLITICALANDRELIGION-Political"/>
+			<enumeration value="NONPROFITPOLITICALANDRELIGION-Religious"/>
+			<enumeration value="PETSANDANIMALS-General"/>
+			<enumeration value="PETSANDANIMALS-Supplies-and-Toys"/>
+			<enumeration value="PETSANDANIMALS-Wildlife-Products"/>
+			<enumeration value="REALESTATE-General"/>
+			<enumeration value="REALESTATE-Commercial"/>
+			<enumeration value="REALESTATE-Residential"/>
+			<enumeration value="REALESTATE-Time-Shares"/>
+			<enumeration value="SERVICES-GeneralGovernment"/>
+			<enumeration value="SERVICES-Legal"/>
+			<enumeration value="SERVICES-Medical"/>
+			<enumeration value="SERVICES-Dental"/>
+			<enumeration value="SERVICES-Vision"/>
+			<enumeration value="SERVICES-General"/>
+			<enumeration value="SERVICES-Child-Care-Services"/>
+			<enumeration value="SERVICES-Consulting"/>
+			<enumeration value="SERVICES-ImportingExporting"/>
+			<enumeration value="SERVICES-InsuranceDirect"/>
+			<enumeration value="SERVICES-Financial-Services"/>
+			<enumeration value="SERVICES-Graphic-and-Commercial-Design"/>
+			<enumeration value="SERVICES-Landscaping"/>
+			<enumeration value="SERVICES-Locksmith"/>
+			<enumeration value="SERVICES-Online-Dating"/>
+			<enumeration value="SERVICES-Event-and-Wedding-Planning"/>
+			<enumeration value="SERVICES-Schools-and-Colleges"/>
+			<enumeration value="SERVICES-Entertainment"/>
+			<enumeration value="SERVICES-Aggregators"/>
+			<enumeration value="SPORTSANDRECREATION-General"/>
+			<enumeration value="SPORTSANDRECREATION-Bicycles-and-Accessories"/>
+			<enumeration value="SPORTSANDRECREATION-Boating-Sailing-and-Accessories"/>
+			<enumeration value="SPORTSANDRECREATION-Camping-and-Survival"/>
+			<enumeration value="SPORTSANDRECREATION-Exercise-Equipment"/>
+			<enumeration value="SPORTSANDRECREATION-Fishing"/>
+			<enumeration value="SPORTSANDRECREATION-Golf"/>
+			<enumeration value="SPORTSANDRECREATION-Hunting"/>
+			<enumeration value="SPORTSANDRECREATION-Paintball"/>
+			<enumeration value="SPORTSANDRECREATION-Sporting-Goods"/>
+			<enumeration value="SPORTSANDRECREATION-Swimming-Pools-and-Spas"/>
+			<enumeration value="TRAVEL-General"/>
+			<enumeration value="TRAVEL-Accommodations"/>
+			<enumeration value="TRAVEL-Agencies"/>
+			<enumeration value="TRAVEL-Airlines"/>
+			<enumeration value="TRAVEL-Auto-Rentals"/>
+			<enumeration value="TRAVEL-Cruises"/>
+			<enumeration value="TRAVEL-Other-Transportation"/>
+			<enumeration value="TRAVEL-Services"/>
+			<enumeration value="TRAVEL-Supplies"/>
+			<enumeration value="TRAVEL-Tours"/>
+			<enumeration value="TRAVEL-AirlinesSpirit-Air"/>
+			<enumeration value="Other-SubCategories"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="AverageTransactionPriceType">
+		<annotation>
+			<documentation>
+				AverageTransactionPriceType
+				<br/>
+				<br/>
+				<table>
+					<tr>
+						<th>Enumeration</th>
+						<th>Meaning</th>
+					</tr>
+					<tr>
+						<td/>
+						<td/>
+					</tr>AverageTransactionPrice-Not-Applicable	
+<tr>
+						<td>AverageTransactionPrice-Range1</td>
+						<td>Less than $25 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range2</td>
+						<td>$25 USD to $50 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range3</td>
+						<td>$50 USD to $100 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range4</td>
+						<td>$100 USD to $250 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range5</td>
+						<td>$250 USD to $500 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range6</td>
+						<td>$500 USD to $1,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range7</td>
+						<td>	$1,000 USD to $2,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range8</td>
+						<td>$2,000 USD to $5,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range9</td>
+						<td>$5,000 USD to $10,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageTransactionPrice-Range10</td>
+						<td>More than $10,000 USD</td>
+					</tr>
+				</table>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="AverageTransactionPrice-Not-Applicable"/>
+			<enumeration value="AverageTransactionPrice-Range1"/>
+			<enumeration value="AverageTransactionPrice-Range2"/>
+			<enumeration value="AverageTransactionPrice-Range3"/>
+			<enumeration value="AverageTransactionPrice-Range4"/>
+			<enumeration value="AverageTransactionPrice-Range5"/>
+			<enumeration value="AverageTransactionPrice-Range6"/>
+			<enumeration value="AverageTransactionPrice-Range7"/>
+			<enumeration value="AverageTransactionPrice-Range8"/>
+			<enumeration value="AverageTransactionPrice-Range9"/>
+			<enumeration value="AverageTransactionPrice-Range10"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="AverageMonthlyVolumeType">
+		<annotation>
+			<documentation>
+				AverageMonthlyVolumeType 
+				<table>
+					<tr>
+						<th>Enumeration</th>
+						<th>Meaning</th>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Not-Applicable</td>
+						<td/>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range1</td>
+						<td>Less than $1,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range2</td>
+						<td>$1,000 USD to $5,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range3</td>
+						<td>$5,000 USD to $25,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range4</td>
+						<td>$25,000 USD to $100,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range5</td>
+						<td>$100,000 USD to $1,000,000 USD</td>
+					</tr>
+					<tr>
+						<td>AverageMonthlyVolume-Range6</td>
+						<td>More than $1,000,000 USD</td>
+					</tr>
+				</table>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="AverageMonthlyVolume-Not-Applicable"/>
+			<enumeration value="AverageMonthlyVolume-Range1"/>
+			<enumeration value="AverageMonthlyVolume-Range2"/>
+			<enumeration value="AverageMonthlyVolume-Range3"/>
+			<enumeration value="AverageMonthlyVolume-Range4"/>
+			<enumeration value="AverageMonthlyVolume-Range5"/>
+			<enumeration value="AverageMonthlyVolume-Range6"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SalesVenueType">
+		<annotation>
+			<documentation>
+				SalesVenueType 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Venue-Unspecified"/>
+			<enumeration value="eBay"/>
+			<enumeration value="AnotherMarketPlace"/>
+			<enumeration value="OwnWebsite"/>
+			<enumeration value="Other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PercentageRevenueFromOnlineSalesType">
+		<annotation>
+			<documentation>
+				PercentageRevenueFromOnlineSalesType
+				<br/>
+				<br/>
+				<table>
+					<tr>
+						<th>Enumeration</th>
+						<th>Meaning</th>
+					</tr>
+					<tr>
+						<td/>
+						<td/>
+					</tr>PercentageRevenueFromOnlineSales-Not-Applicable	
+<tr>
+						<td>PercentageRevenueFromOnlineSales-Range1</td>
+						<td>Less than 25%</td>
+					</tr>
+					<tr>
+						<td>PercentageRevenueFromOnlineSales-Range2</td>
+						<td>25% to 50%</td>
+					</tr>
+					<tr>
+						<td>PercentageRevenueFromOnlineSales-Range3</td>
+						<td>50% to 75%</td>
+					</tr>
+					<tr>
+						<td>PercentageRevenueFromOnlineSales-Range4</td>
+						<td>75% to 100%</td>
+					</tr>
+				</table>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="PercentageRevenueFromOnlineSales-Not-Applicable"/>
+			<enumeration value="PercentageRevenueFromOnlineSales-Range1"/>
+			<enumeration value="PercentageRevenueFromOnlineSales-Range2"/>
+			<enumeration value="PercentageRevenueFromOnlineSales-Range3"/>
+			<enumeration value="PercentageRevenueFromOnlineSales-Range4"/>
+		</restriction>
+	</simpleType>
+	<complexType name="BusinessOwnerInfoType">
+		<annotation>
+			<documentation>
+				BusinessOwnerInfoType 
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Owner" type="ns:PayerInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Details about the business owner</documentation>
+				</annotation>
+			</element>
+			<element name="HomePhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Business owner’s home telephone number
+<br/>
+						<br/>Character length and limitations: 32 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="MobilePhone" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Business owner’s mobile telephone number
+<br/>
+						<br/>
+Character length and limitations: 32 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="SSN" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Business owner’s social security number
+<br/>
+						<br/>
+Character length and limitations: 9 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="BankAccountDetailsType">
+		<annotation>
+			<documentation>
+				BankAccountDetailsType 
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Name" type="xs:string">
+				<annotation>
+					<documentation>
+			Name of bank
+			<br/>
+						<br/>
+			Character length and limitations: 192 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Type" type="ns:BankAccountTypeType">
+				<annotation>
+					<documentation>
+			Type of bank account: Checking or Savings</documentation>
+				</annotation>
+			</element>
+			<element name="RoutingNumber" type="xs:string">
+				<annotation>
+					<documentation>
+			Merchant’s bank routing number
+<br/>
+						<br/>
+Character length and limitations: 23 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="AccountNumber" type="xs:string">
+				<annotation>
+					<documentation>
+			Merchant’s bank account number
+<br/>
+						<br/>
+Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="BankAccountTypeType">
+		<annotation>
+			<documentation>
+				BankAccountTypeType 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Checking"/>
+			<enumeration value="Savings"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="EnterBoardingTokenType">
+		<restriction base="xs:string"/>
+	</simpleType>
+	<complexType name="GetBoardingDetailsResponseDetailsType">
+		<sequence>
+			<element name="Status" type="ns:BoardingStatusType">
+				<annotation>
+					<documentation>
+			Status of merchant's onboarding process:
+			<br/>
+						<br/>
+			Completed
+<br/>Cancelled
+<br/>Pending
+<br/>
+						<br/>Character length and limitations: Eight alphabetic characters</documentation>
+				</annotation>
+			</element>
+			<element name="StartDate" type="xs:dateTime">
+				<annotation>
+					<documentation>
+			Date the boarding process started</documentation>
+				</annotation>
+			</element>
+			<element name="LastUpdated" type="xs:dateTime">
+				<annotation>
+					<documentation>
+			Date the merchant’s status or progress was last updated</documentation>
+				</annotation>
+			</element>
+			<element name="Reason" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Reason for merchant’s cancellation of sign-up.
+<br/>
+						<br/>
+Character length and limitations: 1,024 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="ProgramName" type="xs:string"/>
+			<element name="ProgramCode" type="xs:string"/>
+			<element name="CampaignID" type="xs:string" minOccurs="0"/>
+			<element name="UserWithdrawalLimit" type="ns:UserWithdrawalLimitTypeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Indicates if there is a limitation on the amount of money the business can withdraw from PayPal</documentation>
+				</annotation>
+			</element>
+			<element name="PartnerCustom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Custom information you set on the EnterBoarding API call
+<br/>
+						<br/>Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="AccountOwner" type="ns:PayerInfoType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Details about the owner of the account</documentation>
+				</annotation>
+			</element>
+			<element name="Credentials" type="ns:APICredentialsType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API credentials</documentation>
+				</annotation>
+			</element>
+			<element name="ConfigureAPIs" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			The APIs that this merchant has granted the business partner permission to call on his behalf.
+<br/>
+						<br/>
+						For example:
+						<br/>
+SetExpressCheckout,GetExpressCheckoutDetails,DoExpressCheckoutPayment
+</documentation>
+				</annotation>
+			</element>
+			<element name="EmailVerificationStatus" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Primary email verification status. Confirmed, Unconfirmed</documentation>
+				</annotation>
+			</element>
+			<element name="VettingStatus" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Gives VettingStatus - Pending, Cancelled, Approved, UnderReview
+<br/>
+						<br/>Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="BankAccountVerificationStatus" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Gives BankAccountVerificationStatus - Added, Confirmed
+<br/>
+						<br/>Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="BoardingStatusType">
+		<annotation>
+			<documentation>
+				Boarding Status 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown"/>
+			<enumeration value="Completed"/>
+			<enumeration value="Cancelled"/>
+			<enumeration value="Pending"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="UserWithdrawalLimitTypeType">
+		<annotation>
+			<documentation>
+				User Withdrawal Limit Type Type 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Unknown"/>
+			<enumeration value="Limited"/>
+			<enumeration value="Unlimited"/>
+		</restriction>
+	</simpleType>
+	<complexType name="APICredentialsType">
+		<annotation>
+			<documentation>
+				APICredentialsType 
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Username" type="xs:string">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API username
+Character length and limitations: 128 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Password" type="xs:string">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API password
+Character length and limitations: 40 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Signature" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API signature, if one exists.
+<br/>
+						<br/>Character length and limitations: 256 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Certificate" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API certificate in PEM format, if one exists
+			<br/>
+						<br/>
+			The certificate consists of two parts: the private key (2,048 bytes) and the certificate proper (4,000 bytes).
+<br/>
+						<br/>
+						<br/>Character length and limitations: 6,048 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+			<element name="Type" type="ns:APIAuthenticationType">
+				<annotation>
+					<documentation>
+			Merchant’s PayPal API authentication mechanism.
+			<br/>
+						<br/>
+Auth-None: no authentication mechanism on file
+<br/>
+						<br/>Cert: API certificate
+<br/>
+						<br/>Sign: API signature
+<br/>
+						<br/>Character length and limitations: 9 alphanumeric characters</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="APIAuthenticationType">
+		<annotation>
+			<documentation>
+				API Authentication Type 
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Auth-None"/>
+			<enumeration value="Cert"/>
+			<enumeration value="Sign"/>
+		</restriction>
+	</simpleType>
+
+	<element name="SetMobileCheckoutRequestDetails" type="ns:SetMobileCheckoutRequestDetailsType"/>
+	<complexType name="SetMobileCheckoutRequestDetailsType">
+		<sequence>
+			<element name="BuyerPhone" type="ns:PhoneNumberType" minOccurs="0">
+				<annotation>
+					<documentation>The phone number of the buyer's mobile device, if available.
+<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="ItemAmount" type="cc:BasicAmountType" minOccurs="1">
+				<annotation>
+					<documentation>
+			Cost of this item before tax and shipping.
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Required
+<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="Tax" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Tax amount for this item.
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="Shipping" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Shipping amount for this item.
+You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.
+<br/>
+						<br/>
+Optional
+<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="ItemName" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>Description of the item that the customer is purchasing. 
+<br/>
+						<br/>
+Required
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ItemNumber" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Reference number of the item that the customer is purchasing. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>A free-form field for your own use, such as a tracking number or other value you want returned to you in IPN.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Your own unique invoice or tracking number.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="ReturnURL" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after choosing to pay with PayPal. PayPal recommends that the value of ReturnURL be the final review page on which the customer confirms the order and payment. 
+<br/>
+						<br/>
+						<b>Required</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit. </documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer is returned if he does not approve the use of PayPal to pay you. PayPal recommends that the value of CancelURL be the original page on which the customer chose to pay with PayPal. 
+<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+Character length and limitations: no limit
+</documentation>
+				</annotation>
+			</element>
+			<element name="AddressDisplayOptions" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that you require that the customer's shipping address on file with PayPal be a confirmed address. Setting this element overrides the setting you have specified in your Merchant Account Profile. 
+<br/>
+						<br/>
+Optional
+<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="SharePhone" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation>The value 1 indicates that you require that the customer specifies a contact phone for the transactxion.  Default is 0 / none required.
+<br/>
+						<br/>
+Optional
+</documentation>
+				</annotation>
+			</element>
+			<element name="ShipToAddress" type="ns:AddressType" minOccurs="0">
+				<annotation>
+					<documentation>Customer's shipping address. 
+<br/>
+						<br/>
+Optional
+<br/>
+</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerEmail" type="ns:EmailAddressType" minOccurs="0">
+				<annotation>
+					<documentation>
+			Email address of the buyer as entered during checkout. PayPal uses this value to pre-fill the login portion of the PayPal login page. 
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limit: 127 single-byte alphanumeric characters 
+</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<element name="DoMobileCheckoutPaymentResponseDetails" type="ns:DoMobileCheckoutPaymentResponseDetailsType"/>
+	<complexType name="DoMobileCheckoutPaymentResponseDetailsType">
+		<sequence>
+			<element name="Custom" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>A free-form field for your own use, such as a tracking number or other value you want returned to you in IPN.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 256 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="InvoiceID" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>Your own unique invoice or tracking number.
+<br/>
+						<br/>
+Optional
+<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+</documentation>
+				</annotation>
+			</element>
+			<element name="PayerInfo" type="ns:PayerInfoType">
+				<annotation>
+					<documentation>Information about the payer</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentInfo" type="ns:PaymentInfoType">
+				<annotation>
+					<documentation>Information about the transaction</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+
+  <xs:simpleType name="EbayCheckoutType">
+   <restriction base="xs:token">							
+	<enumeration value="none"/>	
+	<enumeration value="Auction"/>
+	<enumeration value="BuyItNow"/>
+	<enumeration value="FixedPriceItem"/>
+	<enumeration value="Autopay"/>
+   </restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DyneticClientType">
+   <restriction base="xs:token">
+	<enumeration value="none"/>
+	<enumeration value="WAP"/>
+	<enumeration value="J2MEClient"/>
+   </restriction>
+  </xs:simpleType>
+	<element name="SetEbayMobileCheckoutRequestDetails" type="ns:SetEbayMobileCheckoutRequestDetailsType"/>
+	<complexType name="SetEbayMobileCheckoutRequestDetailsType">
+		<sequence>
+			<element name="CheckoutType" type="ns:EbayCheckoutType" minOccurs="1">
+				<annotation>
+					<documentation>The value 'Auction' indicates that user is coming to checkout after an auction ended. A value of 'BuyItNow' indicates if the user is coming to checkout by clicking on the 'buy it now' button in a chinese auction. A value of 'FixedPriceItem' indicates that user clicked on 'Buy it now' on  a fixed price item. A value of Autopay indicates autopay (or immediate pay) which is not supported at the moment.
+					<br/>
+					<br/>
+					Required
+					<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemId" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>An item number assigned to the item in eBay database. 
+						<br/>
+						<br/>
+						Required
+						<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionId" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>An Transaction id assigned to the item in eBay database. In case of Chinese auction Item Id itself indicates Transaction Id. Transaction Id in this case is Zero.
+						<br/>
+						<br/>
+						Required
+						<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SiteId" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>An id indicating the site on which the item was listed. 
+						<br/>
+						<br/>
+						Required
+						<br/>
+						<br/>Character length and limitations: 2 alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerId" type="xs:string" minOccurs="1">
+				<annotation>
+					<documentation>Buyers ebay Id. 
+						<br/>
+						<br/>
+						Required
+						<br/>
+						<br/>Character length and limitations: 127 single-byte alphanumeric characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ClientType" type="ns:DyneticClientType" minOccurs="1">
+				<annotation>
+					<documentation>Indicating the client type. Weather it is WAP or J2ME. A value of 'WAP' indicates WAP. A value of 'J2MEClient' indicates J2ME client. 
+						<br/>
+						<br/>
+						Required
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BuyerPhone" type="ns:PhoneNumberType" minOccurs="0">
+				<annotation>
+					<documentation>The phone number of the buyer's mobile device, if available.
+						<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ReturnURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer's browser is returned after choosing to pay with PayPal. PayPal recommends that the value of ReturnURL be the final review page on which the customer confirms the order and payment. 
+						<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+						Character length and limitations: no limit. 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CancelURL" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>URL to which the customer is returned if he does not approve the use of PayPal to pay you. PayPal recommends that the value of CancelURL be the original page on which the customer chose to pay with PayPal. 
+<br/>
+						<br/>
+						<b>Optional</b>
+						<br/>
+						<br/>
+						Character length and limitations: no limit
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Quantity" type="xs:int" minOccurs="0">
+				<annotation>
+					<documentation>Specify quantity in case it is an immediate pay (or autopay) item. 
+						<br/>
+						<br/>
+						Optional
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemAmount" type="cc:BasicAmountType" minOccurs="0">
+				<annotation>
+					<documentation>Cost of this item before tax and shipping.You must set the currencyID attribute to one of the three-character currency codes for any of the supported PayPal currencies.Used only for autopay items.
+						<br/>
+						<br/>
+						Optional
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	
+	<complexType name="UATPDetailsType">
+		<annotation>
+			<documentation>
+				UATP Card Details Type 
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="UATPNumber" type="xs:string">
+				<annotation>
+					<documentation>UATP Card Number</documentation>
+				</annotation>
+			</element>
+			<element name="ExpMonth" type="xs:int">
+				<annotation>
+					<documentation>  UATP Card expirty month</documentation>
+				</annotation>
+			</element>
+			<element name="ExpYear" type="xs:int">
+				<annotation>
+					<documentation>  UATP Card expirty year</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="RecurringPaymentsProfileStatusType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="ActiveProfile"/>
+			<enumeration value="PendingProfile"/>
+			<enumeration value="CancelledProfile"/>
+			<enumeration value="ExpiredProfile"/>
+			<enumeration value="SuspendedProfile"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="FailedPaymentActionType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="CancelOnFailure"/>
+			<enumeration value="ContinueOnFailure"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="AutoBillType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NoAutoBill"/>
+			<enumeration value="AddToNextBilling"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="StatusChangeActionType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Cancel"/>
+			<enumeration value="Suspend"/>
+			<enumeration value="Reactivate"/>
+		</restriction>
+	</simpleType>
+	<complexType name="RecurringPaymentsSummaryType">
+		<sequence>
+			<element name="NextBillingDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="NumberCyclesCompleted" type="xs:int" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="NumberCyclesRemaining" type="xs:int" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OutstandingBalance" type="cc:BasicAmountType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FailedPaymentCount" type="xs:int" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LastPaymentDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LastPaymentAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ActivationDetailsType">
+		<sequence>
+			<element name="InitialAmount" type="cc:BasicAmountType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FailedInitialAmountAction" type="ns:FailedPaymentActionType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="BillingPeriodType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NoBillingPeriodType"/>
+			<enumeration value="Day"/>
+			<enumeration value="Week"/>
+			<enumeration value="SemiMonth"/>
+			<enumeration value="Month"/>
+			<enumeration value="Year"/>
+		</restriction>
+	</simpleType>
+	<complexType name="BillingPeriodDetailsType">
+		<sequence>
+			<element name="BillingPeriod" type="ns:BillingPeriodType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Unit of meausre for billing cycle
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingFrequency" type="xs:int" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Number of BillingPeriod that make up one billing cycle
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TotalBillingCycles" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Total billing cycles in this portion of the schedule
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Amount to charge
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Additional shipping amount to charge
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TaxAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Additional tax amount to charge
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	
+	<complexType name="BillingPeriodDetailsType_Update">
+		<sequence>
+			<element name="BillingPeriod" type="ns:BillingPeriodType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Unit of meausre for billing cycle
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingFrequency" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Number of BillingPeriod that make up one billing cycle
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TotalBillingCycles" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Total billing cycles in this portion of the schedule
+					</documentation>
+				</annotation>
+			</element>
+
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Amount to charge
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Additional shipping amount to charge
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TaxAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Additional tax amount to charge
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ScheduleDetailsType">
+		<sequence>
+			<element name="Description" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Schedule details for the Recurring Payment
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TrialPeriod" type="ns:BillingPeriodDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Trial period of this schedule
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentPeriod" type="ns:BillingPeriodDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="MaxFailedPayments" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						The max number of payments the buyer can fail before this Recurring Payments profile is cancelled
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ActivationDetails" type="ns:ActivationDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AutoBillOutstandingAmount" type="ns:AutoBillType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="RecurringPaymentsProfileDetailsType">
+		<sequence>
+			<element name="SubscriberName" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Subscriber name - if missing, will use name in buyer's account 
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SubscriberShippingAddress" type="ns:AddressType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Subscriber address - if missing, will use address in buyer's account
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingStartDate" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						When does this Profile begin billing?
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProfileReference" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+				<documentation>Your own unique invoice or tracking number.
+					<br/>
+					<br/>
+					Optional
+					<br/>
+					<br/>Character length and limitations: 127 single-byte alphanumeric characters
+				</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+       <complexType name="CreateRecurringPaymentsProfileRequestDetailsType">
+		<sequence>
+			<element name="Token" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Billing Agreement token (required if Express Checkout)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CreditCard" type="ns:CreditCardDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Information about the credit card to be charged (required if Direct Payment)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecurringPaymentsProfileDetails" type="ns:RecurringPaymentsProfileDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Customer Information for this Recurring Payments
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ScheduleDetails" type="ns:ScheduleDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Schedule Information for this Recurring Payments
+					</documentation>
+				</annotation>
+			</element>
+			<element name="PaymentDetailsItem" type="ns:PaymentDetailsItemType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Information about the Item Details.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="CreateRecurringPaymentsProfileResponseDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Recurring Billing Profile ID
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProfileStatus" type="ns:RecurringPaymentsProfileStatusType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Recurring Billing Profile Status
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TransactionID" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                         Transaction id from DCC initial payment
+                                        </documentation>
+                                </annotation>
+                        </element>
+			<element name="DCCProcessorResponse" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                        Response from DCC initial payment
+                                        </documentation>
+                                </annotation>
+                        </element>
+			<element name="DCCReturnCode" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                        Return code if DCC initial payment fails
+                                        </documentation>
+                                </annotation>
+                        </element>
+		</sequence>
+	</complexType>
+	<complexType name="GetRecurringPaymentsProfileDetailsResponseDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Recurring Billing Profile ID
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProfileStatus" type="ns:RecurringPaymentsProfileStatusType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Description" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AutoBillOutstandingAmount" type="ns:AutoBillType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="MaxFailedPayments" type="xs:int" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecurringPaymentsProfileDetails" type="ns:RecurringPaymentsProfileDetailsType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CurrentRecurringPaymentsPeriod" type="ns:BillingPeriodDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RecurringPaymentsSummary" type="ns:RecurringPaymentsSummaryType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CreditCard" type="ns:CreditCardDetailsType" minOccurs="0" maxOccurs="1"> 
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TrialRecurringPaymentsPeriod" type="ns:BillingPeriodDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RegularRecurringPaymentsPeriod" type="ns:BillingPeriodDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TrialAmountPaid" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="RegularAmountPaid" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AggregateAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AggregateOptionalAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="FinalPaymentDueDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ManageRecurringPaymentsProfileStatusRequestDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Action" type="ns:StatusChangeActionType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ManageRecurringPaymentsProfileStatusResponseDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="BillOutstandingAmountRequestDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="BillOutstandingAmountResponseDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="UpdateRecurringPaymentsProfileRequestDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Note" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Description" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SubscriberName" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="SubscriberShippingAddress" type="ns:AddressType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProfileReference" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AdditionalBillingCycles" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Amount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ShippingAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TaxAmount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OutstandingBalance" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="AutoBillOutstandingAmount" type="ns:AutoBillType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="MaxFailedPayments" type="xs:int" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="CreditCard" type="ns:CreditCardDetailsType" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+                        Information about the credit card to be charged (required if Direct Payment)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="BillingStartDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                                When does this Profile begin billing?
+                                        </documentation>
+                                </annotation>
+                        </element>
+			<element name="TrialPeriod" type="ns:BillingPeriodDetailsType_Update" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                                Trial period of this schedule
+                                        </documentation>
+                                </annotation>
+                        </element>
+                        <element name="PaymentPeriod" type="ns:BillingPeriodDetailsType_Update" minOccurs="0" maxOccurs="1">
+                                <annotation>
+                                        <documentation>
+                                        </documentation>
+                                </annotation>
+                        </element>
+
+		</sequence>
+	</complexType>
+	<complexType name="UpdateRecurringPaymentsProfileResponseDetailsType">
+		<sequence>
+			<element name="ProfileID" type="xs:string" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="RiskFilterDetailsType">
+		<annotation>
+			<documentation>
+				Details of Risk Filter.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Id" type="xs:int" minOccurs="1" maxOccurs="1"> </element>
+			<element name="Name" type="xs:string" minOccurs="1" maxOccurs="1"> </element>
+			<element name="Description" type="xs:string" minOccurs="1" maxOccurs="1"> </element>
+		</sequence>
+	</complexType>
+	<complexType name="RiskFilterListType">
+		<annotation>
+			<documentation>
+				Details of Risk Filter.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Filters" type="ns:RiskFilterDetailsType" minOccurs="1" maxOccurs="unbounded"> </element>
+		</sequence>
+	</complexType>
+	<complexType name="FMFDetailsType">
+		<annotation>
+			<documentation>Thes are filters that could result in accept/deny/pending action.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="AcceptFilters" type="ns:RiskFilterListType" minOccurs="0" maxOccurs="1"> </element>
+			<element name="PendingFilters" type="ns:RiskFilterListType" minOccurs="0" maxOccurs="1"> </element>
+			<element name="DenyFilters" type="ns:RiskFilterListType" minOccurs="0" maxOccurs="1"> </element>
+			<element name="ReportFilters" type="ns:RiskFilterListType" minOccurs="0" maxOccurs="1"> </element>
+		</sequence>
+	</complexType>
+	<simpleType name="ProductCategoryType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="Other">
+                <annotation><documentation> Other</documentation> </annotation>
+			</enumeration>
+			<enumeration value="Airlines">
+                <annotation><documentation> Airlines</documentation> </annotation>
+			</enumeration>
+			<enumeration value="Antiques">
+                <annotation><documentation> Antiques</documentation> </annotation>
+			</enumeration>
+			<enumeration value="Art">
+                <annotation><documentation> Art</documentation> </annotation>
+			</enumeration>
+			<enumeration value="Cameras_Photos">
+                <annotation><documentation> Cameras &amp; Photos</documentation> </annotation>
+			</enumeration>
+            <enumeration value="Cars_Boats_Vehicles_Parts">
+                <annotation><documentation> Cars, Boats, Vehicles &amp; Parts</documentation> </annotation>
+            </enumeration>
+            <enumeration value="CellPhones_Telecom">
+                <annotation><documentation> Cell Phones &amp; Telecom</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Coins_PaperMoney">
+                <annotation><documentation> Coins &amp; Paper Money</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Collectibles">
+                <annotation><documentation> Collectibles</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Computers_Networking">
+                <annotation><documentation> Computers &amp; Networking</documentation> </annotation>
+            </enumeration>
+            <enumeration value="ConsumerElectronics">
+                <annotation><documentation> Consumer Electronics</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Jewelry_Watches">
+                <annotation><documentation> Jewelry &amp; Watches</documentation> </annotation>
+            </enumeration>
+            <enumeration value="MusicalInstruments">
+                <annotation><documentation> Musical Instruments</documentation> </annotation>
+            </enumeration>
+            <enumeration value="RealEstate">
+                <annotation><documentation> Real Estate</documentation> </annotation>
+            </enumeration>
+            <enumeration value="SportsMemorabilia_Cards_FanShop">
+                <annotation><documentation> Sports Memorabilia, Cards &amp; Fan Shop</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Stamps">
+                <annotation><documentation> Stamps</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Tickets">
+                <annotation><documentation> Tickets</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Travels">
+                <annotation><documentation> Travels</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Gambling">
+                <annotation><documentation> Gambling</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Alcohol">
+                <annotation><documentation> Alcohol</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Tobacco">
+                <annotation><documentation> Tobacco</documentation> </annotation>
+            </enumeration>
+            <enumeration value="MoneyTransfer">
+                <annotation><documentation> Money Transfer</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Software">
+                <annotation><documentation> Software</documentation> </annotation>
+            </enumeration>
+		</restriction>
+	</simpleType>
+
+	<complexType name="EnhancedDataType">
+		<annotation>
+			<documentation>
+				Enhanced Data Information. Example: AID for Airlines
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="AirlineItinerary"   type="ns:AirlineItineraryType" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>
+	<complexType name="AirlineItineraryType">
+		<annotation>
+			<documentation>
+				AID for Airlines
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="PassengerName" type="xs:string" minOccurs="0"/>
+			<element name="IssueDate" type="xs:string" minOccurs="0"/>
+			<element name="TravelAgencyName" type="xs:string" minOccurs="0"/>
+			<element name="TravelAgencyCode" type="xs:string" minOccurs="0"/>
+			<element name="TicketNumber" type="xs:string" minOccurs="0"/>
+			<element name="IssuingCarrierCode" type="xs:string" minOccurs="0"/>
+			<element name="CustomerCode" type="xs:string" minOccurs="0"/>
+			<element name="TotalFare" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="TotalTaxes" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="TotalFee" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="RestrictedTicket" type="xs:string" minOccurs="0"/>
+			<element name="ClearingSequence" type="xs:string" minOccurs="0"/>
+			<element name="ClearingCount" type="xs:string" minOccurs="0"/>
+			<element name="FlightDetails" type="ns:FlightDetailsType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="FlightDetailsType">
+		<annotation>
+			<documentation>
+				Details of leg information
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="ConjuctionTicket" type="xs:string" minOccurs="0"/>
+			<element name="ExchangeTicket" type="xs:string" minOccurs="0"/>
+			<element name="CouponNumber" type="xs:string" minOccurs="0"/>
+			<element name="ServiceClass" type="xs:string" minOccurs="0"/>
+			<element name="TravelDate" type="xs:string" minOccurs="0"/>
+			<element name="CarrierCode" type="xs:string" minOccurs="0"/>
+			<element name="StopOverPermitted" type="xs:string" minOccurs="0"/>
+			<element name="DepartureAirport" type="xs:string" minOccurs="0"/>
+			<element name="ArrivalAirport" type="xs:string" minOccurs="0"/>
+			<element name="FlightNumber" type="xs:string" minOccurs="0"/>
+			<element name="DepartureTime" type="xs:string" minOccurs="0"/>
+			<element name="ArrivalTime" type="xs:string" minOccurs="0"/>
+			<element name="FareBasisCode" type="xs:string" minOccurs="0"/>
+			<element name="Fare" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="Taxes" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="Fee" type="cc:BasicAmountType" minOccurs="0"/>
+			<element name="EndorsementOrRestrictions" type="xs:string" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="AuthorizationInfoType">
+		<annotation>
+			<documentation>
+				Authorization details
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="PaymentStatus" type="ns:PaymentStatusCodeType">
+				<annotation>
+					<documentation>
+			The status of the payment:
+<br/>
+						<br/>
+Pending: The payment is pending. See "PendingReason" for more information.
+</documentation>
+				</annotation>
+			</element>
+			<element name="PendingReason" type="ns:PendingStatusCodeType" minOccurs="0">
+				<annotation>
+					<documentation>
+			The reason the payment is pending:
+none: No pending reason
+<br/>
+						<br/>
+address: The payment is pending because your customer did not include a confirmed shipping address and your Payment Receiving Preferences is set such that you want to manually accept or deny each of these payments. To change your preference, go to the Preferences section of your Profile.
+<br/>
+						<br/>
+authorization: The authorization is pending at time of creation if payment is not under review
+<br/>
+						<br/>
+echeck: The payment is pending because it was made by an eCheck that has not yet cleared.
+<br/>
+						<br/>
+intl: The payment is pending because you hold a non-U.S. account and do not have a withdrawal mechanism. You must manually accept or deny this payment from your Account Overview.
+<br/>
+						<br/>
+multi-currency: You do not have a balance in the currency sent, and you do not have your Payment Receiving Preferences set to automatically convert and accept this payment. You must manually accept or deny this payment.
+<br/>
+						<br/>
+unilateral: The payment is pending because it was made to an email address that is not yet registered or confirmed.
+<br/>
+						<br/>
+upgrade: The payment is pending because it was made via credit card and you must upgrade your account to Business or Premier status in order to receive the funds. upgrade can also mean that you have reached the monthly limit for transactions on your account.
+<br/>
+						<br/>
+verify: The payment is pending because you are not yet verified. You must verify your account before you can accept this payment.
+<br/>
+						<br/>
+payment_review: The payment is pending because it is under payment review.
+<br/>
+						<br/>
+other: The payment is pending for a reason other than those listed above. For more information, contact PayPal Customer Service.
+</documentation>
+				</annotation>
+			</element>
+			<element name="ProtectionEligibility" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Protection Eligibility for this Transaction - None, SPP or ESPP
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ProtectionEligibilityType" type="xs:string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Protection Eligibility Type  for this Transaction
+					</documentation>
+
+				 </annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="ButtonCodeType">
+		<annotation>
+			<documentation>
+				Types of button coding
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+  		<enumeration value="HOSTED">
+        <annotation><documentation> Creates Hosted Button</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="ENCRYPTED">
+        <annotation><documentation> Creates Encrypted Button</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="CLEARTEXT">
+        <annotation><documentation> Creates Cleartext Button</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="TOKEN">
+        <annotation><documentation> Creates Token or temporary Button</documentation> </annotation>
+      </enumeration>
+ 		</restriction>
+	</simpleType>
+	<simpleType name="ButtonTypeType">
+		<annotation>
+			<documentation>
+				Types of buttons
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+  		<enumeration value="BUYNOW">
+        <annotation><documentation>  button type is BUYNOW</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="CART">
+        <annotation><documentation>  button type is CART</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="GIFTCERTIFICATE">
+        <annotation><documentation>  button type is GIFTCERTIFICATE</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="SUBSCRIBE">
+        <annotation><documentation>  button type is SUBSCRIBE</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="DONATE">
+        <annotation><documentation>  button type is DONATE</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="UNSUBSCRIBE">
+        <annotation><documentation>  button type is UNSUBSCRIBE</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="VIEWCART">
+        <annotation><documentation> button type is VIEWCART</documentation> </annotation>
+      </enumeration>
+        <enumeration value="PAYMENTPLAN">
+        <annotation><documentation> button type is PAYMENTPLAN</documentation> </annotation>
+      </enumeration>
+        <enumeration value="AUTOBILLING">
+        <annotation><documentation> button type is AUTOBILLING</documentation> </annotation>
+      </enumeration>
+  	<enumeration value="PAYMENT">
+        <annotation><documentation>  button type is PAYMENT</documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ButtonSubTypeType">
+		<annotation>
+			<documentation>
+				Types of button sub types
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+  		<enumeration value="PRODUCTS">
+        <annotation><documentation>  button subtype is PRODUCTS</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="SERVICES">
+        <annotation><documentation> button subtype is SERVICES</documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ButtonImageType">
+		<annotation>
+			<documentation>
+				Types of button images
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="REG">
+        <annotation><documentation>  button image type is REG</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="SML">
+        <annotation><documentation>  button image type is SML</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="CC">
+        <annotation><documentation> button image type is CC</documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="BuyNowTextType">
+		<annotation>
+			<documentation>
+				values for buynow button text
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+	 		<enumeration value="BUYNOW">
+        <annotation><documentation>  button wording is BUYNOW</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="PAYNOW">
+        <annotation><documentation> button wording is PAYNOW</documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="SubscribeTextType">
+		<annotation>
+			<documentation>
+				values for subscribe button text
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+	 		<enumeration value="BUYNOW">
+        <annotation><documentation>  button wording is BUYNOW</documentation> </annotation>
+      </enumeration>
+  		<enumeration value="SUBSCRIBE">
+        <annotation><documentation> button wording is SUBSCRIBE</documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ButtonStatusType">
+		<annotation>
+			<documentation>
+				values for subscribe button text
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+	 		<enumeration value="DELETE">
+        <annotation><documentation>  Changes Button Status to DELETE </documentation> </annotation>
+      </enumeration>
+		</restriction>
+	</simpleType>
+	<complexType name="OptionTrackingDetailsType">
+		<sequence>
+			<element name="OptionNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Number.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OptionQty" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Quantity.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OptionSelect" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Select Name.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OptionQtyDelta" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Quantity Delta.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OptionAlert" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Alert.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="OptionCost" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Cost.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ItemTrackingDetailsType">
+		<sequence>
+			<element name="ItemNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Item Number.
+						<br/>
+						<b>Required</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemQty" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Option Quantity.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemQtyDelta" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Item Quantity Delta.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemAlert" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Item Alert.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+			<element name="ItemCost" type="xs:string" minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+						Item Cost.
+						<br/>
+						<b>Optional</b>
+						<br/>
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ButtonSearchResultType">
+		<sequence>
+			<element name="HostedButtonID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ButtonType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ItemName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			<element name="ModifyDate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+	</complexType>	
+    <simpleType name="OptionTypeListType">
+		<annotation>
+			<documentation>
+			</documentation>
+		</annotation>
+		<restriction base="xs:token">
+			<enumeration value="NoOptionType"/>
+			<enumeration value="FULL"/>
+			<enumeration value="EMI"/>
+			<enumeration value="VARIABLE"/>
+		</restriction>
+	</simpleType>
+    <complexType name="ReverseTransactionRequestDetailsType">
+        <sequence>
+            <element name="TransactionID" type="ns:TransactionId" minOccurs="0" maxOccurs="1">
+                <annotation>
+                    <documentation>Identifier of the transaction to reverse.
+                        <br/>
+                        <br/>
+                        <b>Required</b>
+                        <br/>
+                        <br/>
+                        Character length and limitations: 17 single-byte alphanumeric characters
+                    </documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <complexType name="ReverseTransactionResponseDetailsType">
+        <sequence>
+            <element name="ReverseTransactionID" type="ns:TransactionId" minOccurs="0" maxOccurs="1" nillable="true">
+                <annotation>
+                    <documentation>Unique transaction identifier of the reversal transaction created.
+                        <br/>
+                        <br/>
+                        Character length and limitations:17 single-byte characters
+                    </documentation>
+                </annotation>
+            </element>
+            <element name="Status" type="xs:string" minOccurs="1" maxOccurs="1">
+                <annotation>
+                    <documentation>Status of reversal request.
+                        <br/>
+                        <br/>
+                        <b>Required</b>
+                        <br/>
+                        <br/>
+                    </documentation>
+                </annotation>
+            </element>
+        </sequence>
+    </complexType>
+    <element name="ReverseTransactionRequestDetails" type="ns:ReverseTransactionRequestDetailsType"/>
+    <element name="ReverseTransactionResponseDetails" type="ns:ReverseTransactionResponseDetailsType"/>
+    <simpleType name="UserSelectedFundingSourceType">
+	<annotation>
+		<documentation>
+			UserSelectedFundingSourceType
+			User Selected Funding Source (used by Express Checkout)
+		</documentation>
+	</annotation>
+	<restriction base="xs:token">
+		<enumeration value="ELV"/>
+		<enumeration value="CreditCard"/>
+		<enumeration value="ChinaUnionPay"/>
+		<enumeration value="BML"/>
+	</restriction>
+    </simpleType>
+    <simpleType name="ItemCategoryType">
+        <annotation>
+            <documentation>
+            </documentation>
+        </annotation>
+        <restriction base="xs:token">
+            <enumeration value="Physical">
+                <annotation><documentation>Physical</documentation> </annotation>
+            </enumeration>
+            <enumeration value="Digital">
+                <annotation><documentation>Digital</documentation> </annotation>
+            </enumeration>
+        </restriction>
+    </simpleType>
+    <simpleType name="RecurringFlagType">
+	<annotation>
+		<documentation>
+		</documentation>
+	</annotation>
+	<restriction base="xs:token">
+		<enumeration value="Y"/>
+		<enumeration value="y"/>
+	</restriction>
+    </simpleType>
+		<complexType name="IncentiveInfoType">  
+			<annotation>  
+				<documentation>  
+		    		Details of incentive application on individual bucket.  
+				</documentation>  
+	    	</annotation>  
+	    	<sequence>  
+				<element name="IncentiveCode" type="xs:string" minOccurs="0" maxOccurs="1">
+		    		<annotation>  
+						<documentation>  
+			    			Incentive redemption code.
+						</documentation>  
+		    		</annotation>  
+				</element>
+				<element name="ApplyIndication" type="ns:IncentiveApplyIndicationType" minOccurs="0" maxOccurs="unbounded">
+		    		<annotation>  
+						<documentation>  
+			    			Defines which bucket or item that the incentive should be applied to. 
+						</documentation>  
+		    		</annotation>  
+				</element>  
+	    	</sequence>  
+		</complexType>  
+		<complexType name="IncentiveApplyIndicationType">  
+	    	<annotation>  
+				<documentation>  
+		    		Defines which bucket or item that the incentive should be applied to.  
+				</documentation>  
+	    	</annotation>  
+	    	<sequence>  
+            	<element name="PaymentRequestID" type="xs:string" minOccurs="0" maxOccurs="1">
+		    		<annotation>  
+						<documentation>  
+			    			The Bucket ID that the incentive is applied to.
+						</documentation>  
+		    		</annotation>  
+				</element>
+            	<element name="ItemId" type="xs:string" minOccurs="0" maxOccurs="1">
+		    		<annotation>  
+						<documentation>  
+			    			The item that the incentive is applied to. 
+						</documentation>  
+		    		</annotation>  
+				</element>  
+		    </sequence>
+	    </complexType>
+	    <complexType name="PaymentRequestInfoType">
+		    <sequence>
+			    <annotation>
+				    <documentation>
+					    Contains payment request information for each bucket in the cart.
+				    </documentation>
+			    </annotation>
+			    <element name="TransactionId" type="xs:string" minOccurs="0" maxOccurs="1">
+				    <annotation>
+					    <documentation>
+						    Contains the transaction id of the bucket.
+					    </documentation>
+				    </annotation>
+			    </element>
+			    <element name="PaymentRequestID" type="xs:string" minOccurs="0" maxOccurs="1">
+				    <annotation>
+					    <documentation>
+						    Contains the bucket id.
+					    </documentation>
+				    </annotation>
+			    </element>
+			    <element name="PaymentError" type="ns:ErrorType" minOccurs="0" maxOccurs="1">
+				    <annotation>
+					    <documentation>
+						    Contains the error details.
+					    </documentation>
+				    </annotation>
+			    </element>
+		    </sequence>
+	    </complexType>
+			<complexType name="ExternalRememberMeOwnerDetailsType">
+				<sequence>
+					<annotation>
+						<documentation>
+							E-mail address or secure merchant account ID of merchant to associate with new external remember-me.
+						</documentation>
+					</annotation>
+					<element name="ExternalRememberMeOwnerIDType" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								A discriminant that tells SetEC what kind of data the ExternalRememberMeOwnerID parameter contains.
+								Currently, the owner must be either the API actor or omitted/none.  In the future, we may allow the
+								owner to be a 3rd party merchant account.
+								Possible values are:
+								None, ignore the ExternalRememberMeOwnerID.  An empty value for this field also signifies None.
+								Email, the owner ID is an email address
+								SecureMerchantAccountID, the owner id is a string representing the secure merchant account ID
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ExternalRememberMeOwnerID" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								When opting in to bypass login via remember me, this parameter specifies the merchant account
+								associated with the remembered login.  Currentl, the owner must be either the API actor or omitted/none.
+								In the future, we may allow the owner to be a 3rd party merchant account.
+								If the Owner ID Type field is not present or "None", this parameter is ignored.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="ExternalRememberMeOptInDetailsType">
+				<sequence>
+					<annotation>
+						<documentation>
+							This element contains information that allows the merchant to request to
+							opt into external remember me on behalf of the buyer or to request login
+							bypass using external remember me.
+						</documentation>
+					</annotation>
+					<element name="ExternalRememberMeOptIn" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								1 = opt in to external remember me.
+								0 or omitted = no opt-in
+								Other values are invalid
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ExternalRememberMeOwnerDetails" type="ns:ExternalRememberMeOwnerDetailsType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								E-mail address or secure merchant account ID of merchant to associate with new external remember-me. Currently,
+								the owner must be either the API actor or omitted/none.  In the future, we may allow the owner to be a 3rd party
+								merchant account.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="FlowControlDetailsType">
+				<sequence>
+					<annotation>
+						<documentation>
+							An optional set of values related to flow-specific details.
+						</documentation>
+					</annotation>
+					<element name="ErrorURL" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								The URL to redirect to for an unpayable transaction.  This field is currently used only
+								for the inline checkout flow.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="InContextReturnURL" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								The URL to redirect to after a user clicks the "Pay" or "Continue" button on the merchant's
+								site.  This field is currently used only for the inline checkout flow.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="ExternalRememberMeStatusDetailsType">
+				<sequence>
+					<annotation>
+						<documentation>
+							Response information resulting from opt-in operation or current login bypass status.
+						</documentation>
+					</annotation>
+					<element name="ExternalRememberMeStatus" type="xs:integer" minOccurs="1" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Required field that reports status of opt-in or login bypass attempt.
+								0 = Success - successful opt-in or ExternalRememberMeID specified in SetExpressCheckout
+									is valid.
+								1 = Invalid ID - ExternalRememberMeID specified in SetExpressCheckout is invalid.
+								2 = Internal Error - System error or outage during opt-in or login bypass.  Can retry
+									opt-in or login bypass next time.  Flow will force full authentication and allow buyer
+									to complete transaction.
+								-1 = None - the return value does not signify any valid remember me status.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ExternalRememberMeID" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Identifier returned on external-remember-me-opt-in to allow the merchant to request
+								bypass of PayPal login through external remember me on behalf of the buyer in future
+								transactions.  The ExternalRememberMeID is a 17-character alphanumeric (encrypted)
+								string.  This field has meaning only to the merchant.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="DisplayControlDetailsType">
+				<sequence>
+					<annotation>
+						<documentation>
+							Contains elements that allows customization of display (user interface) elements.
+						</documentation>
+					</annotation>
+					<element name="InContextPaymentButtonImage" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Optional URL to pay button image for the inline checkout flow.  Currently applicable
+								only to the inline checkout flow when the FlowControlDetails/InlineReturnURL is present.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+            <complexType name="ExternalPartnerTrackingDetailsType">
+                <sequence>
+                    <annotation>
+                        <documentation>
+                            Contains elements that allow tracking for an external partner.
+                        </documentation>
+                    </annotation>
+                    <element name="ExternalPartnerSegmentID" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <annotation>
+                            <documentation>
+                                PayPal will just log this string. There will NOT be any business logic around it, nor any decisions made based on the value of the string that is passed in.
+                                From a tracking/analytical perspective, PayPal would not infer any meaning to any specific value.
+                                We would just segment the traffic based on the value passed (Cart and None as an example) and track different
+                                metrics like risk/conversion etc based on these segments.
+                                The external partner would control the value of what gets passed and we take that value as is and generate data based on it. <br/>
+                                Optional <br/>
+                            </documentation>
+                        </annotation>
+                    </element>
+                </sequence>
+            </complexType>
+			<complexType name="MerchantStoreDetailsType">
+				<sequence>
+					<element name="StoreID" type="xs:string" minOccurs="1" maxOccurs="1">
+						<annotation>
+							<documentation>Store ID<br/><br/>Optional<br/><br/>
+								Character length and limits: 50 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="TerminalID" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>Terminal ID<br/><br/>Optional<br/><br/>
+								Character length and limits: 50 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="AdditionalFeeType">
+				<sequence>
+					<element name="Type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+					<element name="Amount" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="DiscountType">
+				<annotation>
+					<documentation>
+						Describes discount information
+					</documentation>
+				</annotation>
+				<sequence>
+					<element name="Name" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>Item name<br/><br/>Optional<br/><br/>
+								Character length and limits: 127 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Description" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>description of the discount<br/><br/>Optional<br/><br/>
+								Character length and limits: 127 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Amount" type="cc:BasicAmountType"
+						minOccurs="1" maxOccurs="1">
+						<annotation>
+							<documentation>amount discounted<br/><br/>Optional<br/><br/>
+							</documentation>
+						</annotation>
+					</element>
+					<element name="RedeemedOfferType" type="ns:RedeemedOfferType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>offer type<br/><br/>Optional<br/><br/>
+							</documentation>
+						</annotation>
+					</element>
+					<element name="RedeemedOfferID" type="xs:string"
+						minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>offer ID<br/><br/>Optional<br/><br/>
+								Character length and limits: 64 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+
+			<complexType name="InvoiceItemType">
+				<annotation>
+					<documentation>
+						Describes an individual item for an invoice.
+					</documentation>
+				</annotation>
+				<sequence>
+					<element name="Name" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>a human readable item name<br/><br/>Optional<br/><br/>
+								Character length and limits: 127 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Description" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>a human readable item description<br/><br/>Optional<br/><br/>
+								Character length and limits: 127 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="EAN" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								The International Article Number or 
+								Universal Product Code (UPC) for the item.
+								Empty string is allowed.
+								Character length and limits: 17 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="SKU" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								The Stock-Keeping Unit or other identification 
+								code assigned to the item.
+								Character length and limits: 64 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ReturnPolicyIdentifier" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								A retailer could apply different return policies on different items.
+								Each return policy would be identified using a label or identifier.
+								This return policy identifier should be set here.  
+								This identifier will be displayed next to the item in the e-Receipt.
+								Character length and limits: 8 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Price" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								total price of this item
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ItemPrice" type="cc:BasicAmountType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								price per item quantity
+							</documentation>
+						 </annotation>
+					</element>
+					<element name="ItemCount" type="xs:double" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								quantity of the item (non-negative)
+							</documentation>
+						 </annotation>
+					</element>
+					<element name="ItemCountUnit" type="ns:UnitOfMeasure" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Unit of measure for the itemCount
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Discount" type="ns:DiscountType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>
+								discount applied to this item
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Taxable" type="xs:boolean" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								identifies whether this item is taxable or not.  
+								If not passed, this will be assumed to be true.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="TaxRate" type="xs:double" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								The tax percentage applied to the item.
+								This is only used for displaying in the receipt, it is not used in pricing calculations.
+								Note: we have totalTax at invoice level. It's up to the caller to do the calculations for setting that other element.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="AdditionalFees" type="ns:AdditionalFeeType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>
+								Additional fees to this item
+							</documentation>
+						</annotation>
+					</element>
+					<element name="Reimbursable" type="xs:boolean" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								identifies whether this is reimbursable or not.
+								If not pass, this will be assumed to be true.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="MPN" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Manufacturer part number.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ISBN" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								International Standard Book Number.
+								Reference http://en.wikipedia.org/wiki/ISBN
+								Character length and limits: 32 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="PLU" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Price Look-Up code
+								Reference http://en.wikipedia.org/wiki/Price_Look-Up_code
+								Character length and limits: 5 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="ModelNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Character length and limits: 32 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+					<element name="StyleNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Character length and limits: 32 single-byte characters
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<complexType name="RefundInfoType">
+				<sequence>
+					<annotation>
+						<documentation>
+							Holds refunds payment status information
+						</documentation>
+					</annotation>
+					<element name="RefundStatus" type="ns:PaymentStatusCodeType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Refund status whether it is Instant or Delayed.
+							</documentation>
+						</annotation>
+					</element>
+					<element name="PendingReason" type="ns:PendingStatusCodeType" minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>
+								Tells us the reason when refund payment status is Delayed.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</complexType>
+			<element name="RefundInfo" type="ns:RefundInfoType"/>
+</schema>


### PR DESCRIPTION
Paypal isn't always very exacting about the order of it's elements, but some features won't work unless the order is correct.  This change verifies the xml generated is valid against the paypal's xsd's.   I'm not sure where to put the xsd's in the file structure, let me know if there is another preferred place for them.
