### PR TITLE
Ogone: Alias creation without payment

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -151,6 +151,13 @@ module ActiveMerchant #:nodoc:
       def refund(money, reference, options = {})
         perform_reference_credit(money, reference, options)
       end
+      
+      # Create an alias for a credit_card
+      def create_alias(payment_source, aliaz, options = {})
+        res = authorize(1, payment_source, :store => aliaz)
+        void(res.params['PAYID'])
+        res
+      end
 
       def test?
         @options[:test] || super

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -144,6 +144,13 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert_equal OgoneGateway::SUCCESS_MESSAGE, auth.message
     assert_success void
   end
+  
+  def test_successful_alias_creation
+    assert response = @gateway.create_alias(@credit_card, 'test_alias')
+    assert_success response
+    assert response = @gateway.purchase(@amount, 'test_alias')
+    assert_success response
+  end
 
   def test_successful_referenced_credit
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
This fork gives the possibility to create an Alias in Ogone without doing a real payment.
It does so by authorizing a €0.01 transaction then voiding it.

A remote test is included.

Yannick Schutz & Joel Cogen
Belighted
