### PR TITLE
Remove double declaration of `void' method in CertoDirect.

### DIFF
--- a/lib/active_merchant/billing/gateways/certo_direct.rb
+++ b/lib/active_merchant/billing/gateways/certo_direct.rb
@@ -94,16 +94,6 @@ module ActiveMerchant #:nodoc:
         commit(build_void_request(money, identification))
       end
 
-      # Void a previous transaction
-      #
-      # ==== Parameters
-      #
-      # * <tt>money</tt> -- The amount to be captured as an Integer value in cents.
-      # * <tt>identification</tt> - The authorization returned from the previous authorize request.
-      def void(money, identification, options = {})
-        commit(build_void_request(money, identification))
-      end
-
       # Create a recurring payment.
       #
       # ==== Parameters


### PR DESCRIPTION
I am sorry I just noticed that `void' method was defined twice in CertoDirect gateway. This commit fixes it.

Thank you and sorry for this typo. ;)
