### PR TITLE
[Enhancement] Secure Pay AU gateway updated to handle periodic payments....

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -4,30 +4,33 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class SecurePayAuGateway < Gateway
       API_VERSION = 'xml-4.2'
-      
+      PERIODIC_API_VERSION = 'spxml-3.0'
+
       TEST_URL = 'https://www.securepay.com.au/test/payment'
       LIVE_URL = 'https://www.securepay.com.au/xmlapi/payment'
-      
+      TEST_PERIODIC_URL = "https://test.securepay.com.au/xmlapi/periodic"
+      LIVE_PERIODIC_URL = "https://api.securepay.com.au/xmlapi/periodic"
+
       self.supported_countries = ['AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
-      
+
       # The homepage URL of the gateway
       self.homepage_url = 'http://securepay.com.au'
-      
+
       # The name of the gateway
       self.display_name = 'SecurePay'
-      
+
       class_attribute :request_timeout
       self.request_timeout = 60
-      
+
       self.money_format = :cents
       self.default_currency = 'AUD'
-      
+
       # 0 Standard Payment
-      # 4 Refund 
-      # 6 Client Reversal (Void) 
-      # 10 Preauthorise 
-      # 11 Preauth Complete (Advice)        
+      # 4 Refund
+      # 6 Client Reversal (Void)
+      # 10 Preauthorise
+      # 11 Preauth Complete (Advice)
       TRANSACTIONS = {
         :purchase => 0,
         :authorization => 10,
@@ -35,33 +38,50 @@ module ActiveMerchant #:nodoc:
         :void => 6,
         :refund => 4
       }
-      
+
+      PERIODIC_ACTIONS = {
+        :add_triggered    => "add",
+        :remove_triggered => "delete",
+        :trigger          => "trigger"
+      }
+
+      PERIODIC_TYPES = {
+        :add_triggered    => 4,
+        :remove_triggered => nil,
+        :trigger          => nil
+      }
+
       SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
-      
+
       def initialize(options = {})
         requires!(options, :login, :password)
         @options = options
         super
       end
-      
+
       def test?
         @options[:test] || super
       end
-      
-      def purchase(money, credit_card, options = {})
-        requires!(options, :order_id)
-        commit :purchase, build_purchase_request(money, credit_card, options)
-      end                       
-    
+
+      def purchase(money, credit_card_or_stored_id, options = {})
+        if credit_card_or_stored_id.is_a?(ActiveMerchant::Billing::CreditCard)
+          requires!(options, :order_id)
+          commit :purchase, build_purchase_request(money, credit_card_or_stored_id, options)
+        else
+          options[:billing_id] = credit_card_or_stored_id.to_s
+          commit_periodic(build_periodic_item(:trigger, money, nil, options))
+        end
+      end
+
       def authorize(money, credit_card, options = {})
         requires!(options, :order_id)
         commit :authorization, build_purchase_request(money, credit_card, options)
       end
-      
+
       def capture(money, reference, options = {})
         commit :capture, build_reference_request(money, reference)
       end
-      
+
       def refund(money, reference, options = {})
         commit :refund, build_reference_request(money, reference)
       end
@@ -74,54 +94,64 @@ module ActiveMerchant #:nodoc:
       def void(reference, options = {})
         commit :void, build_reference_request(nil, reference)
       end
-      
+
+      def store(creditcard, options = {})
+        requires!(options, :billing_id, :amount)
+        commit_periodic(build_periodic_item(:add_triggered, options[:amount], creditcard, options))
+      end
+
+      def unstore(identification, options = {})
+        options[:billing_id] = identification
+        commit_periodic(build_periodic_item(:remove_triggered, options[:amount], nil, options))
+      end
+
       private
-      
+
       def build_purchase_request(money, credit_card, options)
         xml = Builder::XmlMarkup.new
-        
+
         xml.tag! 'amount', amount(money)
-        xml.tag! 'currency', options[:currency] || currency(money)              
+        xml.tag! 'currency', options[:currency] || currency(money)
         xml.tag! 'purchaseOrderNo', options[:order_id].to_s.gsub(/[ ']/, '')
-        
+
         xml.tag! 'CreditCardInfo' do
           xml.tag! 'cardNumber', credit_card.number
           xml.tag! 'expiryDate', expdate(credit_card)
           xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
         end
-        
+
         xml.target!
       end
-      
+
       def build_reference_request(money, reference)
         xml = Builder::XmlMarkup.new
-        
+
         transaction_id, order_id, preauth_id, original_amount = reference.split("*")
         xml.tag! 'amount', (money ? amount(money) : original_amount)
         xml.tag! 'currency', options[:currency] || currency(money)
         xml.tag! 'txnID', transaction_id
         xml.tag! 'purchaseOrderNo', order_id
         xml.tag! 'preauthID', preauth_id
-        
+
         xml.target!
       end
-      
+
       def build_request(action, body)
         xml = Builder::XmlMarkup.new
         xml.instruct!
         xml.tag! 'SecurePayMessage' do
           xml.tag! 'MessageInfo' do
-            xml.tag! 'messageID', Utils.generate_unique_id.slice(0, 30)
+            xml.tag! 'messageID', ActiveMerchant::Utils.generate_unique_id.slice(0, 30)
             xml.tag! 'messageTimestamp', generate_timestamp
             xml.tag! 'timeoutValue', request_timeout
             xml.tag! 'apiVersion', API_VERSION
           end
-          
+
           xml.tag! 'MerchantInfo' do
             xml.tag! 'merchantID', @options[:login]
             xml.tag! 'password', @options[:password]
           end
-          
+
           xml.tag! 'RequestType', 'Payment'
           xml.tag! 'Payment' do
             xml.tag! 'TxnList', "count" => 1 do
@@ -133,40 +163,98 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
-        
+
         xml.target!
       end
-         
+
       def commit(action, request)
         response = parse(ssl_post(test? ? TEST_URL : LIVE_URL, build_request(action, request)))
-        
-        Response.new(success?(response), message_from(response), response, 
-          :test => test?, 
+
+        Response.new(success?(response), message_from(response), response,
+          :test => test?,
           :authorization => authorization_from(response)
         )
       end
-      
+
+      def build_periodic_item(action, money, credit_card, options)
+        xml = Builder::XmlMarkup.new
+
+        xml.tag! 'actionType', PERIODIC_ACTIONS[action]
+        xml.tag! 'clientID', options[:billing_id].to_s
+
+        if credit_card
+          xml.tag! 'CreditCardInfo' do
+            xml.tag! 'cardNumber', credit_card.number
+            xml.tag! 'expiryDate', expdate(credit_card)
+            xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
+          end
+        end
+        xml.tag! 'amount', amount(money)
+        xml.tag! 'periodicType', PERIODIC_TYPES[action] if PERIODIC_TYPES[action]
+
+        xml.target!
+      end
+
+      def build_periodic_request(body)
+        xml = Builder::XmlMarkup.new
+        xml.instruct!
+        xml.tag! 'SecurePayMessage' do
+          xml.tag! 'MessageInfo' do
+            xml.tag! 'messageID', ActiveMerchant::Utils.generate_unique_id.slice(0, 30)
+            xml.tag! 'messageTimestamp', generate_timestamp
+            xml.tag! 'timeoutValue', request_timeout
+            xml.tag! 'apiVersion', PERIODIC_API_VERSION
+          end
+
+          xml.tag! 'MerchantInfo' do
+            xml.tag! 'merchantID', @options[:login]
+            xml.tag! 'password', @options[:password]
+          end
+
+          xml.tag! 'RequestType', 'Periodic'
+          xml.tag! 'Periodic' do
+            xml.tag! 'PeriodicList', "count" => 1 do
+              xml.tag! 'PeriodicItem', "ID" => 1 do
+                xml << body
+              end
+            end
+          end
+        end
+        xml.target!
+      end
+
+      def commit_periodic(request)
+        my_request = build_periodic_request(request)
+        #puts my_request
+        response = parse(ssl_post(test? ? TEST_PERIODIC_URL : LIVE_PERIODIC_URL, my_request))
+
+        Response.new(success?(response), message_from(response), response,
+          :test => test?,
+          :authorization => authorization_from(response)
+        )
+      end
+
       def success?(response)
         SUCCESS_CODES.include?(response[:response_code])
       end
-      
+
       def authorization_from(response)
         [response[:txn_id], response[:purchase_order_no], response[:preauth_id], response[:amount]].join('*')
       end
-          
+
       def message_from(response)
         response[:response_text] || response[:status_description]
       end
-      
+
       def expdate(credit_card)
         "#{format(credit_card.month, :two_digits)}/#{format(credit_card.year, :two_digits)}"
       end
-      
+
       def parse(body)
         xml = REXML::Document.new(body)
 
         response = {}
-        
+
         xml.root.elements.to_a.each do |node|
           parse_element(response, node)
         end
@@ -181,13 +269,12 @@ module ActiveMerchant #:nodoc:
           response[node.name.underscore.to_sym] = node.text
         end
       end
-      
+
       # YYYYDDMMHHNNSSKKK000sOOO
       def generate_timestamp
         time = Time.now.utc
         time.strftime("%Y%d%m%H%M%S#{time.usec}+000")
-      end  
+      end
     end
   end
 end
-

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
 class RemoteSecurePayAuTest < Test::Unit::TestCase
-  
+
   def setup
     @gateway = SecurePayAuGateway.new(fixtures(:secure_pay_au))
-    
-    @amount = 100
-    @credit_card = credit_card('4444333322221111')
 
-    @options = { 
+    @amount = 100
+    @credit_card = credit_card('4444333322221111', {:month => 9, :year => 15})
+
+    @options = {
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase'
     }
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -36,7 +36,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
   end
-  
+
   def test_failed_authorize
     @amount = 151
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
@@ -62,7 +62,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Approved', response.message
   end
-  
+
   def test_failed_refund
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -72,7 +72,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Only $1.0 available for refund', response.message
   end
-  
+
   def test_successful_void
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -91,6 +91,61 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert response = @gateway.void(authorization+'1')
     assert_failure response
     assert_equal 'Unable to retrieve original FDR txn', response.message
+  end
+
+  def test_successful_unstore
+    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil
+
+    assert response = @gateway.unstore('test1234')
+    assert_success response
+
+    assert_equal 'Successful', response.message
+  end
+
+  def test_failed_unstore
+    @gateway.unstore('test1234') rescue nil #Ensure it is already missing
+
+    assert response = @gateway.unstore('test1234')
+    assert_failure response
+
+    assert_equal 'Normal', response.message
+  end
+
+  def test_successful_store
+    @gateway.unstore('test1234') rescue nil
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000})
+    assert_success response
+
+    assert_equal 'Successful', response.message
+  end
+
+  def test_failed_store
+    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil #Ensure it already exists
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000})
+    assert_failure response
+
+    assert_equal 'Duplicate Client ID Found', response.message
+  end
+
+  def test_successful_triggered_payment
+    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil #Ensure it already exists
+
+    assert response = @gateway.purchase(12300, 'test1234', @options)
+    assert_success response
+    assert_equal response.params['amount'], '12300'
+
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failure_triggered_payment
+    @gateway.unstore('test1234') rescue nil #Ensure its no longer there
+
+    assert response = @gateway.purchase(12300, 'test1234', @options)
+    assert_failure response
+
+    assert_equal 'Payment not found', response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -9,226 +9,375 @@ class SecurePayAuTest < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
-    
-    @options = { 
+
+    @options = {
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase'
     }
   end
-  
+
+  def test_supported_countries
+    assert_equal ['AU'], SecurePayAuGateway.supported_countries
+  end
+
+  def test_supported_card_types
+    assert_equal [:visa, :master, :american_express, :diners_club, :jcb], SecurePayAuGateway.supported_cardtypes
+  end
+
+
   def test_successful_purchase_with_live_data
     @gateway.expects(:ssl_post).returns(successful_live_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_success response
-    
+
     assert_equal '000000*#1047.5**211700', response.authorization
     assert response.test?
   end
-  
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_success response
-    
+
     assert_equal '024259*test**1000', response.authorization
     assert response.test?
   end
 
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
     assert response.test?
     assert_equal "CARD EXPIRED", response.message
   end
-  
+
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
-    
+
     assert_equal '269057*1*369057*100', response.authorization
   end
-  
+
   def test_failed_authorization
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
-    
+
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal "Insufficient Funds", response.message
   end
-  
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    
+
     assert response = @gateway.capture(@amount, "crazy*reference*thingy*100", {})
     assert_success response
     assert_equal "Approved", response.message
   end
-  
+
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_capture_response)
-    
+
     assert response = @gateway.capture(@amount, "crazy*reference*thingy*100")
     assert_failure response
     assert_equal "Preauth was done for smaller amount", response.message
   end
-  
+
   def test_successful_refund
     @gateway.expects(:ssl_post).returns(successful_refund_response)
     assert_success @gateway.refund(@amount, "crazy*reference*thingy*100", {})
   end
-  
+
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
-    
+
     assert response = @gateway.refund(@amount, "crazy*reference*thingy*100")
     assert_failure response
     assert_equal "Only $1.00 available for refund", response.message
   end
-  
+
   def test_deprecated_credit
     @gateway.expects(:ssl_post).returns(successful_refund_response)
-    
+
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE, @gateway) do
       assert_success @gateway.credit(@amount, "crazy*reference*thingy*100", {})
     end
   end
-  
+
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
-    
+
     assert response = @gateway.void("crazy*reference*thingy*100", {})
     assert_success response
   end
-  
+
   def test_failed_void
     @gateway.expects(:ssl_post).returns(failed_void_response)
-    
+
     assert response = @gateway.void("crazy*reference*thingy*100")
     assert_failure response
     assert_equal "Transaction was done for different amount", response.message
   end
-  
+
   def test_failed_login
     @gateway.expects(:ssl_post).returns(failed_login_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
     assert_equal "Invalid merchant ID", response.message
   end
 
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 'test3', :amount => 123})
+    assert_instance_of Response, response
+    assert_equal "Successful", response.message
+    assert_equal 'test3', response.params['client_id']
+  end
+
+  def test_successful_unstore
+    @gateway.expects(:ssl_post).returns(successful_unstore_response)
+
+    assert response = @gateway.unstore('test2')
+    assert_instance_of Response, response
+    assert_equal "Successful", response.message
+    assert_equal 'test2', response.params['client_id']
+  end
+
+  def test_successful_triggered_payment
+    @gateway.expects(:ssl_post).returns(successful_triggered_payment_response)
+
+    assert response = @gateway.purchase(@amount, 'test3', @options)
+    assert_instance_of Response, response
+    assert_equal "Approved", response.message
+    assert_equal 'test3', response.params['client_id']
+  end
+
   private
-  
+
+  def successful_store_response
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SecurePayMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0ecd7eff71b37ef</messageID>
+        <messageTimestamp>20040710144410220000+600</messageTimestamp>
+        <apiVersion>spxml-3.0</apiVersion>
+      </MessageInfo>
+      <RequestType>Periodic</RequestType>
+      <MerchantInfo>
+        <merchantID>ABC0001</merchantID>
+      </MerchantInfo>
+      <Status>
+        <statusCode>0</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Periodic>
+        <PeriodicList count="1">
+          <PeriodicItem ID="1">
+            <actionType>add</actionType>
+            <clientID>test3</clientID>
+            <responseCode>00</responseCode>
+            <responseText>Successful</responseText>
+            <successful>yes</successful>
+            <CreditCardInfo>
+              <pan>444433...111</pan>
+              <expiryDate>09/15</expiryDate>
+              <recurringFlag>no</recurringFlag>
+            </CreditCardInfo>
+            <amount>1100</amount>
+            <periodicType>4</periodicType>
+          </PeriodicItem>
+        </PeriodicList>
+      </Periodic>
+    </SecurePayMessage>
+    XML
+  end
+
+  def successful_unstore_response
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SecurePayMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0ecd7eff71c3ef1</messageID>
+        <messageTimestamp>20040710150207549000+600</messageTimestamp>
+        <apiVersion>spxml-3.0</apiVersion>
+      </MessageInfo>
+      <RequestType>Periodic</RequestType>
+      <MerchantInfo>
+        <merchantID>ABC0001</merchantID>
+      </MerchantInfo>
+      <Status>
+        <statusCode>0</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Periodic>
+        <PeriodicList count="1">
+          <PeriodicItem ID="1">
+            <actionType>delete</actionType>
+            <clientID>test2</clientID>
+            <responseCode>00</responseCode>
+            <responseText>Successful</responseText>
+            <successful>yes</successful>
+          </PeriodicItem>
+        </PeriodicList>
+      </Periodic>
+    </SecurePayMessage>
+    XML
+  end
+
+  def successful_triggered_payment_response
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SecurePayMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0ecd7eff71c94d6</messageID>
+        <messageTimestamp>20040710150808428000+600</messageTimestamp>
+        <apiVersion>spxml-3.0</apiVersion>
+      </MessageInfo>
+      <RequestType>Periodic</RequestType>
+      <MerchantInfo>
+        <merchantID>ABC0001</merchantID>
+      </MerchantInfo>
+      <Status>
+        <statusCode>0</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Periodic>
+        <PeriodicList count="1">
+          <PeriodicItem ID="1">
+            <actionType>trigger</actionType>
+            <clientID>test3</clientID>
+            <responseCode>00</responseCode>
+            <responseText>Approved</responseText>
+            <successful>yes</successful>
+            <amount>1400</amount>
+            <txnID>011700</txnID>
+            <CreditCardInfo>
+              <pan>424242...242</pan>
+              <expiryDate>09/08</expiryDate>
+              <recurringFlag>no</recurringFlag>
+              <cardType>6</cardType>
+              <cardDescription>Visa</cardDescription>
+            </CreditCardInfo>
+            <settlementDate>20041007</settlementDate>
+          </PeriodicItem>
+        </PeriodicList>
+      </Periodic>
+    </SecurePayMessage>
+    XML
+  end
+
   def failed_login_response
     '<SecurePayMessage><Status><statusCode>504</statusCode><statusDescription>Invalid merchant ID</statusDescription></Status></SecurePayMessage>'
   end
-  
+
   def successful_purchase_response
-    <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<SecurePayMessage>
-  <MessageInfo>
-    <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
-    <messageTimestamp>20080802041625665000+660</messageTimestamp>
-    <apiVersion>xml-4.2</apiVersion>
-  </MessageInfo>
-  <RequestType>Payment</RequestType>
-  <MerchantInfo>
-    <merchantID>XYZ0001</merchantID>
-  </MerchantInfo>
-  <Status>
-    <statusCode>000</statusCode>
-    <statusDescription>Normal</statusDescription>
-  </Status>
-  <Payment>
-    <TxnList count="1">
-      <Txn ID="1">
-        <txnType>0</txnType>
-        <txnSource>0</txnSource>
-        <amount>1000</amount>
-        <currency>AUD</currency>
-        <purchaseOrderNo>test</purchaseOrderNo>
-        <approved>Yes</approved>
-        <responseCode>00</responseCode>
-        <responseText>Approved</responseText>
-        <thinlinkResponseCode>100</thinlinkResponseCode>
-        <thinlinkResponseText>000</thinlinkResponseText>
-        <thinlinkEventStatusCode>000</thinlinkEventStatusCode>
-        <thinlinkEventStatusText>Normal</thinlinkEventStatusText>
-        <settlementDate>20080208</settlementDate>
-        <txnID>024259</txnID>
-        <CreditCardInfo>
-          <pan>424242...242</pan>
-          <expiryDate>07/11</expiryDate>
-          <cardType>6</cardType>
-          <cardDescription>Visa</cardDescription>
-        </CreditCardInfo>
-      </Txn>
-    </TxnList>
-  </Payment>
-</SecurePayMessage>
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SecurePayMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
+        <messageTimestamp>20080802041625665000+660</messageTimestamp>
+        <apiVersion>xml-4.2</apiVersion>
+      </MessageInfo>
+      <RequestType>Payment</RequestType>
+      <MerchantInfo>
+        <merchantID>XYZ0001</merchantID>
+      </MerchantInfo>
+      <Status>
+        <statusCode>000</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Payment>
+        <TxnList count="1">
+          <Txn ID="1">
+            <txnType>0</txnType>
+            <txnSource>0</txnSource>
+            <amount>1000</amount>
+            <currency>AUD</currency>
+            <purchaseOrderNo>test</purchaseOrderNo>
+            <approved>Yes</approved>
+            <responseCode>00</responseCode>
+            <responseText>Approved</responseText>
+            <thinlinkResponseCode>100</thinlinkResponseCode>
+            <thinlinkResponseText>000</thinlinkResponseText>
+            <thinlinkEventStatusCode>000</thinlinkEventStatusCode>
+            <thinlinkEventStatusText>Normal</thinlinkEventStatusText>
+            <settlementDate>20080208</settlementDate>
+            <txnID>024259</txnID>
+            <CreditCardInfo>
+              <pan>424242...242</pan>
+              <expiryDate>07/11</expiryDate>
+              <cardType>6</cardType>
+              <cardDescription>Visa</cardDescription>
+            </CreditCardInfo>
+          </Txn>
+        </TxnList>
+      </Payment>
+    </SecurePayMessage>
     XML
   end
-  
+
   def failed_purchase_response
-    <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<SecurePayMessage>
-  <MessageInfo>
-    <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
-    <messageTimestamp>20080802040346380000+660</messageTimestamp>
-    <apiVersion>xml-4.2</apiVersion>
-  </MessageInfo>
-  <RequestType>Payment</RequestType>
-  <MerchantInfo>
-    <merchantID>XYZ0001</merchantID>
-  </MerchantInfo>
-  <Status>
-    <statusCode>000</statusCode>
-    <statusDescription>Normal</statusDescription>
-  </Status>
-  <Payment>
-    <TxnList count="1">
-      <Txn ID="1">
-        <txnType>0</txnType>
-        <txnSource>0</txnSource>
-        <amount>1000</amount>
-        <currency>AUD</currency>
-        <purchaseOrderNo>test</purchaseOrderNo>
-        <approved>No</approved>
-        <responseCode>907</responseCode>
-        <responseText>CARD EXPIRED</responseText>
-        <thinlinkResponseCode>300</thinlinkResponseCode>
-        <thinlinkResponseText>000</thinlinkResponseText>
-        <thinlinkEventStatusCode>981</thinlinkEventStatusCode>
-        <thinlinkEventStatusText>Error - Expired Card</thinlinkEventStatusText>
-        <settlementDate>        </settlementDate>
-        <txnID>000000</txnID>
-        <CreditCardInfo>
-          <pan>424242...242</pan>
-          <expiryDate>07/06</expiryDate>
-          <cardType>6</cardType>
-          <cardDescription>Visa</cardDescription>
-        </CreditCardInfo>
-      </Txn>
-    </TxnList>
-  </Payment>
-</SecurePayMessage>
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SecurePayMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
+        <messageTimestamp>20080802040346380000+660</messageTimestamp>
+        <apiVersion>xml-4.2</apiVersion>
+      </MessageInfo>
+      <RequestType>Payment</RequestType>
+      <MerchantInfo>
+        <merchantID>XYZ0001</merchantID>
+      </MerchantInfo>
+      <Status>
+        <statusCode>000</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Payment>
+        <TxnList count="1">
+          <Txn ID="1">
+            <txnType>0</txnType>
+            <txnSource>0</txnSource>
+            <amount>1000</amount>
+            <currency>AUD</currency>
+            <purchaseOrderNo>test</purchaseOrderNo>
+            <approved>No</approved>
+            <responseCode>907</responseCode>
+            <responseText>CARD EXPIRED</responseText>
+            <thinlinkResponseCode>300</thinlinkResponseCode>
+            <thinlinkResponseText>000</thinlinkResponseText>
+            <thinlinkEventStatusCode>981</thinlinkEventStatusCode>
+            <thinlinkEventStatusText>Error - Expired Card</thinlinkEventStatusText>
+            <settlementDate>        </settlementDate>
+            <txnID>000000</txnID>
+            <CreditCardInfo>
+              <pan>424242...242</pan>
+              <expiryDate>07/06</expiryDate>
+              <cardType>6</cardType>
+              <cardDescription>Visa</cardDescription>
+            </CreditCardInfo>
+          </Txn>
+        </TxnList>
+      </Payment>
+    </SecurePayMessage>
     XML
   end
-  
+
   def successful_live_purchase_response
-    <<-XML
+    <<-XML.gsub(/^\s{4}/,'')
     <?xml version="1.0" encoding="UTF-8"?>
     <SecurePayMessage>
       <MessageInfo>
@@ -273,35 +422,35 @@ class SecurePayAuTest < Test::Unit::TestCase
     </SecurePayMessage>
     XML
   end
-  
+
   def successful_authorization_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>18071a6170073a7ef231ef048217be</messageID><messageTimestamp>20102807071229455000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>10</txnType><txnSource>23</txnSource><amount>100</amount><currency>AUD</currency><purchaseOrderNo>1</purchaseOrderNo><approved>Yes</approved><responseCode>00</responseCode><responseText>Approved</responseText><thinlinkResponseCode>100</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>000</thinlinkEventStatusCode><thinlinkEventStatusText>Normal</thinlinkEventStatusText><settlementDate>20100728</settlementDate><txnID>269057</txnID><preauthID>369057</preauthID><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def failed_authorization_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>97991d10eda9ae47d684ae21089b97</messageID><messageTimestamp>20102807071237345000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>10</txnType><txnSource>23</txnSource><amount>151</amount><currency>AUD</currency><purchaseOrderNo>1</purchaseOrderNo><approved>No</approved><responseCode>51</responseCode><responseText>Insufficient Funds</responseText><thinlinkResponseCode>200</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>000</thinlinkEventStatusCode><thinlinkEventStatusText>Normal</thinlinkEventStatusText><settlementDate>20100728</settlementDate><txnID>269059</txnID><preauthID>269059</preauthID><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def successful_capture_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>1e3b82037a228c237cbc89db8a5e8a</messageID><messageTimestamp>20102807071233509000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>11</txnType><txnSource>23</txnSource><amount>100</amount><currency>AUD</currency><purchaseOrderNo>1</purchaseOrderNo><approved>Yes</approved><responseCode>00</responseCode><responseText>Approved</responseText><thinlinkResponseCode>100</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>000</thinlinkEventStatusCode><thinlinkEventStatusText>Normal</thinlinkEventStatusText><settlementDate>20100728</settlementDate><txnID>269058</txnID><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def failed_capture_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>9ac0da93c0ea7a2d74c2430a078995</messageID><messageTimestamp>20102807071243261000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>11</txnType><txnSource>23</txnSource><amount>101</amount><currency>AUD</currency><purchaseOrderNo>1</purchaseOrderNo><approved>No</approved><responseCode>142</responseCode><responseText>Preauth was done for smaller amount</responseText><thinlinkResponseCode>300</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>999</thinlinkEventStatusCode><thinlinkEventStatusText>Error - Pre-auth Was Done For Smaller Amount</thinlinkEventStatusText><settlementDate/><txnID/><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def successful_void_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>2207c9396eb7005639edcbae9bfb46</messageID><messageTimestamp>20102807071317401000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>6</txnType><txnSource>23</txnSource><amount>100</amount><currency>AUD</currency><purchaseOrderNo>269069</purchaseOrderNo><approved>Yes</approved><responseCode>00</responseCode><responseText>Approved</responseText><thinlinkResponseCode>100</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>000</thinlinkEventStatusCode><thinlinkEventStatusText>Normal</thinlinkEventStatusText><settlementDate>20100728</settlementDate><txnID>269070</txnID><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def failed_void_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>5ae52d17168291fff92d0c45933eb5</messageID><messageTimestamp>20102807071257719000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>6</txnType><txnSource>23</txnSource><amount>1001</amount><currency>AUD</currency><purchaseOrderNo>269063</purchaseOrderNo><approved>No</approved><responseCode>100</responseCode><responseText>Transaction was done for different amount</responseText><thinlinkResponseCode>300</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>990</thinlinkEventStatusCode><thinlinkEventStatusText>Error - Invalid amount</thinlinkEventStatusText><settlementDate/><txnID/><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def successful_refund_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>feaedbe87239a005729aece8efa48b</messageID><messageTimestamp>20102807071306650000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>4</txnType><txnSource>23</txnSource><amount>100</amount><currency>AUD</currency><purchaseOrderNo>269065</purchaseOrderNo><approved>Yes</approved><responseCode>00</responseCode><responseText>Approved</responseText><thinlinkResponseCode>100</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>000</thinlinkEventStatusCode><thinlinkEventStatusText>Normal</thinlinkEventStatusText><settlementDate>20100728</settlementDate><txnID>269067</txnID><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end
-  
+
   def failed_refund_response
     %(<?xml version="1.0" encoding="UTF-8" standalone="no"?><SecurePayMessage><MessageInfo><messageID>6bacab2b7ae1200d8099e0873e25bc</messageID><messageTimestamp>20102807071248484000+600</messageTimestamp><apiVersion>xml-4.2</apiVersion></MessageInfo><RequestType>Payment</RequestType><MerchantInfo><merchantID>CAX0001</merchantID></MerchantInfo><Status><statusCode>000</statusCode><statusDescription>Normal</statusDescription></Status><Payment><TxnList count="1"><Txn ID="1"><txnType>4</txnType><txnSource>23</txnSource><amount>101</amount><currency>AUD</currency><purchaseOrderNo>269061</purchaseOrderNo><approved>No</approved><responseCode>134</responseCode><responseText>Only $1.00 available for refund</responseText><thinlinkResponseCode>300</thinlinkResponseCode><thinlinkResponseText>000</thinlinkResponseText><thinlinkEventStatusCode>999</thinlinkEventStatusCode><thinlinkEventStatusText>Error - Transaction Already Fully Refunded/Only $x.xx Available for Refund</thinlinkEventStatusText><settlementDate/><txnID/><CreditCardInfo><pan>444433...111</pan><expiryDate>09/11</expiryDate><cardType>6</cardType><cardDescription>Visa</cardDescription></CreditCardInfo></Txn></TxnList></Payment></SecurePayMessage>)
   end


### PR DESCRIPTION
Following suggestion on : https://github.com/Shopify/active_merchant/pull/124

This is enhancements to the existing SecurePay AU gateway for handling periodic payments (including triggers), with unit tests and remote tests.
