### PR TITLE
[Gateway] Add new NABTransact(AU) Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [MerchantWare](http://merchantwarehouse.com/merchantware) - US
 * [Modern Payments](http://www.modpay.com) - US
 * [Moneris](http://www.moneris.com/) - CA
+* [NABTransact](http://www.nab.com.au/nabtransact/) - AU
 * [Netaxept](http://www.betalingsterminal.no/Netthandel-forside) - NO, DK, SE, FI
 * [NetRegistry](http://www.netregistry.com.au) - AU
 * [NELiX TransaX Gateway](http://www.nelixtransax.com) - US

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -1,0 +1,244 @@
+require 'rexml/document'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # The National Australia Bank provide a payment gateway that seems to
+    # be a rebadged Securepay Australia service, though some differences exist.
+    class NabTransactGateway < Gateway
+      API_VERSION = 'xml-4.2'
+      PERIODIC_API_VERSION = "spxml-4.2"
+
+      TEST_URL = 'https://transact.nab.com.au/test/xmlapi/payment'
+      LIVE_URL = 'https://transact.nab.com.au/live/xmlapi/payment'
+      TEST_PERIODIC_URL = "https://transact.nab.com.au/xmlapidemo/periodic"
+      LIVE_PERIODIC_URL = "https://transact.nab.com.au/xmlapi/periodic"
+
+      self.supported_countries = ['AU']
+
+      # The card types supported by the payment gateway
+      # Note that support for Diners, Amex, and JCB require extra
+      # steps in setting up your account, as detailed in the NAB Transact API
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
+
+      self.homepage_url = 'http://transact.nab.com.au'
+      self.display_name = 'NAB Transact'
+
+      cattr_accessor :request_timeout
+      self.request_timeout = 60
+
+      self.money_format = :cents
+      self.default_currency = 'AUD'
+
+      #Transactions currently accepted by NAB Transact XML API
+      TRANSACTIONS = {
+        :purchase => 0,         #Standard Payment
+        :credit => 4,           #Refund
+        :void => 6,             #Client Reversal (Void)
+        :authorization => 10,   #Preauthorise
+        :capture => 11          #Preauthorise Complete (Advice)
+      }
+
+      PERIODIC_TYPES = {
+        :addcrn    => 5,
+        :editcrn   => 5,
+        :deletecrn => 5,
+        :trigger   => 8
+      }
+
+      SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
+
+
+      def initialize(options = {})
+        requires!(options, :login, :password)
+        @options = options
+        super
+      end
+
+      def test?
+        @options[:test] || super
+      end
+
+      def purchase(money, credit_card_or_stored_id, options = {})
+        if credit_card_or_stored_id.is_a?(ActiveMerchant::Billing::CreditCard)
+          #Credit card for instant payment
+          commit :purchase, build_purchase_request(money, credit_card_or_stored_id, options)
+        else
+          #Triggered payment for an existing stored credit card
+          options[:billing_id] = credit_card_or_stored_id.to_s
+          commit_periodic build_periodic_item(:trigger, money, nil, options)
+        end
+      end
+
+      def store(creditcard, options = {})
+        requires!(options, :billing_id, :amount)
+        commit_periodic(build_periodic_item(:addcrn, options[:amount], creditcard, options))
+      end
+
+      def unstore(identification, options = {})
+        options[:billing_id] = identification
+        commit_periodic(build_periodic_item(:deletecrn, options[:amount], nil, options))
+      end
+
+      private
+
+      def build_purchase_request(money, credit_card, options)
+        xml = Builder::XmlMarkup.new
+        xml.tag! 'amount', amount(money)
+        xml.tag! 'currency', options[:currency] || currency(money)
+        xml.tag! 'purchaseOrderNo', options[:order_id].to_s.gsub(/[ ']/, '')
+
+        xml.tag! 'CreditCardInfo' do
+          xml.tag! 'cardNumber', credit_card.number
+          xml.tag! 'expiryDate', expdate(credit_card)
+          xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
+        end
+
+        xml.target!
+      end
+
+      #Generate payment request XML
+      # - API is set to allow multiple Txn's but currentlu only allows one
+      # - txnSource = 23 - (XML)
+
+      def build_request(action, body)
+        xml = Builder::XmlMarkup.new
+        xml.instruct!
+        xml.tag! 'NABTransactMessage' do
+          xml.tag! 'MessageInfo' do
+            xml.tag! 'messageID', Utils.generate_unique_id.slice(0, 30)
+            xml.tag! 'messageTimestamp', generate_timestamp
+            xml.tag! 'timeoutValue', request_timeout
+            xml.tag! 'apiVersion', API_VERSION
+          end
+
+          xml.tag! 'MerchantInfo' do
+            xml.tag! 'merchantID', @options[:login]
+            xml.tag! 'password', @options[:password]
+          end
+
+          xml.tag! 'RequestType', 'Payment'
+          xml.tag! 'Payment' do
+            xml.tag! 'TxnList', "count" => 1 do
+              xml.tag! 'Txn', "ID" => 1 do
+                xml.tag! 'txnType', TRANSACTIONS[action]
+                xml.tag! 'txnSource', 23
+                xml << body
+              end
+            end
+          end
+        end
+
+        xml.target!
+      end
+
+      def build_periodic_item(action, money, credit_card, options)
+        xml = Builder::XmlMarkup.new
+
+        xml.tag! 'actionType', action.to_s
+        xml.tag! 'periodicType', PERIODIC_TYPES[action] if PERIODIC_TYPES[action]
+        xml.tag! 'currency', options[:currency] || currency(money)
+        xml.tag! 'crn', options[:billing_id]
+
+        if credit_card
+          xml.tag! 'CreditCardInfo' do
+            xml.tag! 'cardNumber', credit_card.number
+            xml.tag! 'expiryDate', expdate(credit_card)
+            xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
+          end
+        end
+        xml.tag! 'amount', amount(money)
+
+        xml.target!
+      end
+
+      def build_periodic_request(body)
+        xml = Builder::XmlMarkup.new
+        xml.instruct!
+        xml.tag! 'NABTransactMessage' do
+          xml.tag! 'MessageInfo' do
+            xml.tag! 'messageID', ActiveMerchant::Utils.generate_unique_id.slice(0, 30)
+            xml.tag! 'messageTimestamp', generate_timestamp
+            xml.tag! 'timeoutValue', request_timeout
+            xml.tag! 'apiVersion', PERIODIC_API_VERSION
+          end
+
+          xml.tag! 'MerchantInfo' do
+            xml.tag! 'merchantID', @options[:login]
+            xml.tag! 'password', @options[:password]
+          end
+
+          xml.tag! 'RequestType', 'Periodic'
+          xml.tag! 'Periodic' do
+            xml.tag! 'PeriodicList', "count" => 1 do
+              xml.tag! 'PeriodicItem', "ID" => 1 do
+                xml << body
+              end
+            end
+          end
+        end
+
+        xml.target!
+      end
+
+      def commit(action, request)
+        response = parse(ssl_post(test? ? TEST_URL : LIVE_URL, build_request(action, request)))
+
+        Response.new(success?(response), message_from(response), response,
+          :test => test?,
+          :authorization => authorization_from(response)
+        )
+      end
+
+      def commit_periodic(request)
+        response = parse(ssl_post(test? ? TEST_PERIODIC_URL : LIVE_PERIODIC_URL, build_periodic_request(request)))
+        Response.new(success?(response), message_from(response), response,
+          :test => test?,
+          :authorization => authorization_from(response)
+        )
+      end
+
+      def success?(response)
+        SUCCESS_CODES.include?(response[:response_code])
+      end
+
+      def authorization_from(response)
+        response[:txn_id]
+      end
+
+      def message_from(response)
+        response[:response_text] || response[:status_description]
+      end
+
+      def expdate(credit_card)
+        "#{format(credit_card.month, :two_digits)}/#{format(credit_card.year, :two_digits)}"
+      end
+
+      def parse(body)
+        xml = REXML::Document.new(body)
+
+        response = {}
+
+        xml.root.elements.to_a.each do |node|
+          parse_element(response, node)
+        end
+
+        response
+      end
+
+      def parse_element(response, node)
+        if node.has_elements?
+          node.elements.each{|element| parse_element(response, element) }
+        else
+          response[node.name.underscore.to_sym] = node.text
+        end
+      end
+
+      # YYYYDDMMHHNNSSKKK000sOOO
+      def generate_timestamp
+        time = Time.now.utc
+        time.strftime("%Y%d%m%H%M%S#{time.usec}+000")
+      end
+
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -157,6 +157,11 @@ modern_payments:
 moneris:
   login: store1
   password: yesguy
+
+#Working credentials, no need to replace
+nab_transact:
+  login: ABC0001
+  password: changeit
   
 netaxept:
   login: LOGIN

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -1,0 +1,137 @@
+require 'test_helper'
+class RemoteNabTransactTest < Test::Unit::TestCase
+
+  def setup
+    @gateway = NabTransactGateway.new(fixtures(:nab_transact))
+
+    @amount = 200
+    @credit_card = credit_card('4444333322221111')
+
+    @declined_card = credit_card('4111111111111234')
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'NAB Transact Purchase'
+    }
+  end
+
+  # Order totals to simulate approved transactions:
+  #   $1.00 $1.08 $105.00 $105.08 (or any total ending in 00, 08, 11 or 16)
+
+  # Order totals to simulate declined transactions:
+  #   $1.51 $1.05 $105.51 $105.05 (or any total not ending in 00, 08, 11 or 16)
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase_insufficient_funds
+    #Any total not ending in 00/08/11/16
+    failing_amount = 151 #Specifically tests 'Insufficient Funds'
+    assert response = @gateway.purchase(failing_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+  end
+
+  def test_unsuccessful_purchase_do_not_honour
+    #Any total not ending in 00/08/11/16
+    failing_amount = 105 #Specifically tests 'do not honour'
+    assert response = @gateway.purchase(failing_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Do Not Honour', response.message
+  end
+
+  def test_unsuccessful_purchase_bad_credit_card
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Invalid Credit Card Number', response.message
+  end
+
+  def test_invalid_login
+    gateway = NabTransactGateway.new(
+                :login => 'ABCFAKE',
+                :password => 'changeit'
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid merchant ID', response.message
+  end
+
+  def test_successful_store
+    @gateway.unstore(1234)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 1234, :amount => 150})
+    assert_success response
+    assert_equal 'Successful', response.message
+  end
+
+  def test_unsuccessful_store
+    @gateway.unstore(1235)
+
+    assert response = @gateway.store(@declined_card, {:billing_id => 1235, :amount => 150})
+    assert_failure response
+    assert_equal 'Invalid Credit Card Number', response.message
+  end
+
+  def test_duplicate_store
+    @gateway.unstore(1236)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 1236, :amount => 150})
+    assert_success response
+    assert_equal 'Successful', response.message
+
+    assert response = @gateway.store(@credit_card, {:billing_id => 1236, :amount => 150})
+    assert_failure response
+    assert_equal 'Duplicate CRN Found', response.message
+  end
+
+  def test_unstore
+    gateway_id = '1234'
+    @gateway.unstore(gateway_id)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => gateway_id, :amount => 150})
+    assert_success response
+    assert_equal 'Successful', response.message
+
+    assert gateway_id = response.params["crn"]
+    assert unstore_response = @gateway.unstore(gateway_id)
+    assert_success unstore_response
+  end
+
+  def test_successful_trigger_purchase
+    gateway_id = '1234'
+    trigger_amount = 12000
+    @gateway.unstore(gateway_id)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => gateway_id, :amount => 150})
+    assert_success response
+    assert_equal 'Successful', response.message
+
+    purchase_response = @gateway.purchase(trigger_amount, gateway_id)
+
+    assert gateway_id = purchase_response.params["crn"]
+    assert trigger_amount = purchase_response.params["amount"]
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+  end
+
+  def test_failure_trigger_purchase
+    gateway_id = '1234'
+    trigger_amount = 0
+    @gateway.unstore(gateway_id)
+
+    assert response = @gateway.store(@credit_card, {:billing_id => gateway_id, :amount => 150})
+    assert_success response
+    assert_equal 'Successful', response.message
+
+    purchase_response = @gateway.purchase(trigger_amount, gateway_id)
+
+    assert gateway_id = purchase_response.params["crn"]
+    assert_failure purchase_response
+    assert_equal 'Invalid Amount', purchase_response.message
+  end
+
+end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -1,0 +1,151 @@
+require 'test_helper'
+
+class NabTransactTest < Test::Unit::TestCase
+  def setup
+    @gateway = NabTransactGateway.new(
+                 :login => 'login',
+                 :password => 'password'
+               )
+    @credit_card = credit_card
+    @amount = 200
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Test NAB Purchase'
+    }
+  end
+
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal '009887', response.authorization
+    assert response.test?
+  end
+
+  def test_unsuccessful_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+    assert response.test?
+    assert_equal "Expired Card", response.message
+  end
+
+  def test_failed_login
+    @gateway.expects(:ssl_post).returns(failed_login_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+    assert_equal "Invalid merchant ID", response.message
+  end
+
+  def test_supported_countries
+    assert_equal ['AU'], NabTransactGateway.supported_countries
+  end
+
+  def test_supported_card_types
+    assert_equal [:visa, :master, :american_express, :diners_club, :jcb], NabTransactGateway.supported_cardtypes
+  end
+
+
+  private
+
+  def failed_login_response
+    '<NABTransactMessage><Status><statusCode>504</statusCode><statusDescription>Invalid merchant ID</statusDescription></Status></NABTransactMessage>'
+  end
+
+  def successful_purchase_response
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <NABTransactMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0cf40f5fb750f64</messageID>
+        <messageTimestamp>20042303111226938000+660</messageTimestamp>
+        <apiVersion>xml-4.2</apiVersion>
+      </MessageInfo>
+      <MerchantInfo>
+        <merchantID>ABC0001</merchantID>
+      </MerchantInfo>
+      <RequestType>Payment</RequestType>
+      <Status>
+        <statusCode>000</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Payment>
+        <TxnList count="1">
+          <Txn ID="1">
+            <txnType>0</txnType>
+            <txnSource>23</txnSource>
+            <amount>200</amount>
+            <currency>AUD</currency>
+            <purchaseOrderNo>test</purchaseOrderNo>
+            <approved>Yes</approved>
+            <responseCode>00</responseCode>
+            <responseText>Approved</responseText>
+            <settlementDate>20040323</settlementDate>
+            <txnID>009887</txnID>
+            <CreditCardInfo>
+              <pan>444433...111</pan>
+              <expiryDate>08/12</expiryDate>
+              <cardType>6</cardType>
+              <cardDescription>Visa</cardDescription>
+            </CreditCardInfo>
+          </Txn>
+        </TxnList>
+      </Payment>
+    </NABTransactMessage>
+    XML
+  end
+
+  def failed_purchase_response
+    <<-XML.gsub(/^\s{4}/,'')
+    <?xml version="1.0" encoding="UTF-8"?>
+    <NABTransactMessage>
+      <MessageInfo>
+        <messageID>8af793f9af34bea0cf40f5fb5c630c</messageID>
+        <messageTimestamp>20042303111226938000+660</messageTimestamp>
+        <apiVersion>xml-4.2</apiVersion>
+      </MessageInfo>
+      <MerchantInfo>
+        <merchantID>ABC0001</merchantID>
+      </MerchantInfo>
+      <RequestType>Payment</RequestType>
+      <Status>
+        <statusCode>000</statusCode>
+        <statusDescription>Normal</statusDescription>
+      </Status>
+      <Payment>
+        <TxnList count="1">
+          <Txn ID="1">
+            <txnType>0</txnType>
+            <txnSource>23</txnSource>
+            <amount>200</amount>
+            <currency>AUD</currency>
+            <purchaseOrderNo>test</purchaseOrderNo>
+            <approved>No</approved>
+            <responseCode>54</responseCode>
+            <responseText>Expired Card</responseText>
+            <settlementDate>20040323</settlementDate>
+            <txnID>000000</txnID>
+            <CreditCardInfo>
+              <pan>444433...111</pan>
+              <expiryDate>08/12</expiryDate>
+              <cardType>6</cardType>
+              <cardDescription>Visa</cardDescription>
+            </CreditCardInfo>
+          </Txn>
+        </TxnList>
+      </Payment>
+    </NABTransactMessage>
+    XML
+  end
+
+end


### PR DESCRIPTION
Following suggestion on : https://github.com/Shopify/active_merchant/pull/124
And : https://github.com/Shopify/active_merchant/pull/285

This is new gateway NAB Transact, with unit tests and remote tests.

Thanks for the check, oversight on the currency code. Everything is working as expected on both unit and remote tests : 

```
bundle exec rake test:units TEST=test/unit/gateways/nab_transact_test.rb 
Loaded suite /Users/tom/.rvm/gems/ruby-1.8.7-p352/gems/rake-0.9.0/lib/rake/rake_test_loader
Started
.....
Finished in 0.014051 seconds.

```

```
bundle exec rake test:remote TEST=test/remote/gateways/remote_nab_transact_test.rb
Loaded suite /Users/tom/.rvm/gems/ruby-1.8.7-p352/gems/rake-0.9.0/lib/rake/rake_test_loader
Started
...........
Finished in 15.225441 seconds.

11 tests, 46 assertions, 0 failures, 0 errors
```
