### PR TITLE
Add Support for Reference Transactions using BAIDs in Paypal Express Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
         base.cattr_accessor :signature
       end
       
-      API_VERSION = '62.0'
+      API_VERSION = '72'
       
       URLS = {
         :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -327,6 +327,57 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '2', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Number')[1].text
     assert_equal '4', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Quantity')[1].text
   end
+
+  def test_build_reference_transaction_test
+    xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000, {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' }))
+
+    assert_equal '72', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
+    assert_equal 'ref_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
+    assert_equal 'Sale', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentAction').text
+    assert_equal 'Any', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentType').text
+    assert_equal '20.00', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:OrderTotal').text
+    assert_equal 'Description', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:OrderDescription').text
+    assert_equal 'invoice_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:InvoiceID').text
+    assert_equal 'ActiveMerchant', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:PaymentDetails/n2:ButtonSource').text
+    assert_equal '127.0.0.1', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text
+  end
+
+  def test_reference_transaction
+    @gateway.expects(:ssl_post).returns(successful_reference_transaction_response)
+    
+    response = @gateway.reference_transaction(2000,  {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' })
+      
+    assert_equal "Success", response.params['ack']
+    assert_equal "Success", response.message
+    assert_equal "9R43552341412482K", response.authorization
+  end
+
+  def test_reference_transaction_requires_fields
+    valid_options = {
+      :reference_id => "ref_id", 
+      :payment_type => 'Any', 
+      :invoice_id   => 'invoice_id',
+      :description  => 'Description',
+      :ip           => '127.0.0.1' }
+
+    [:reference_id, :payment_type, :invoice_id, :description, :ip].each do |field|
+      options = valid_options.dup
+      options.delete(field)
+      assert_raise ArgumentError do
+        @gateway.reference_transaction(2000, options)
+      end
+    end
+  end
   
   def test_error_code_for_single_error 
     @gateway.expects(:ssl_post).returns(response_with_error)
@@ -433,6 +484,55 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
   
   private
+  def successful_reference_transaction_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+	<SOAP-ENV:Header>
+		<Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+		<RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+			<Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+				<Username xsi:type="xs:string"></Username>
+				<Password xsi:type="xs:string"></Password>
+				<Signature xsi:type="xs:string">OMGOMGOMG</Signature>
+				<Subject xsi:type="xs:string"></Subject>
+				</Credentials>
+			</RequesterCredentials>
+		</SOAP-ENV:Header>
+	<SOAP-ENV:Body id="_0">
+		<DoReferenceTransactionResponse xmlns="urn:ebay:api:PayPalAPI">
+			<Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2011-05-23T21:36:32Z</Timestamp>
+			<Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+			<CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">4d6d3af55369b</CorrelationID>
+			<Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+			<Build xmlns="urn:ebay:apis:eBLBaseComponents">1863577</Build>
+			<DoReferenceTransactionResponseDetails xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:DoReferenceTransactionResponseDetailsType">
+				<BillingAgreementID xsi:type="xs:string">B-3R788221G4476823M</BillingAgreementID>
+				<PaymentInfo xsi:type="ebl:PaymentInfoType">
+					<TransactionID>9R43552341412482K</TransactionID>
+					<ParentTransactionID xsi:type="ebl:TransactionId"></ParentTransactionID>
+					<ReceiptID></ReceiptID>
+					<TransactionType xsi:type="ebl:PaymentTransactionCodeType">mercht-pmt</TransactionType>
+					<PaymentType xsi:type="ebl:PaymentCodeType">instant</PaymentType>
+					<PaymentDate xsi:type="xs:dateTime">2011-05-23T21:36:32Z</PaymentDate>
+					<GrossAmount xsi:type="cc:BasicAmountType" currencyID="USD">190.00</GrossAmount>
+					<FeeAmount xsi:type="cc:BasicAmountType" currencyID="USD">5.81</FeeAmount>
+					<TaxAmount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</TaxAmount>
+					<ExchangeRate xsi:type="xs:string"></ExchangeRate>
+					<PaymentStatus xsi:type="ebl:PaymentStatusCodeType">Completed</PaymentStatus>
+					<PendingReason xsi:type="ebl:PendingStatusCodeType">none</PendingReason>
+					<ReasonCode xsi:type="ebl:ReversalReasonCodeType">none</ReasonCode>
+					<ProtectionEligibility xsi:type="xs:string">Ineligible</ProtectionEligibility>
+					<ProtectionEligibilityType xsi:type="xs:string">None</ProtectionEligibilityType>
+					</PaymentInfo>
+				</DoReferenceTransactionResponseDetails>
+			</DoReferenceTransactionResponse>
+		</SOAP-ENV:Body>
+	</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+
   def successful_details_response
     <<-RESPONSE
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This is a pull request, with only the commit that adds the reference transaction from this pull request:

https://github.com/Shopify/active_merchant/pull/122

See that pull request for more details.
## Implement Action for DoReferenceTransaction

After making a purchase with BillingAgreementDetails a BillingAgreementID is returned. This ID can be passed along to the DoReferenceTransaction action to bill a user without redirecting them to a PayPal site (it's like storing a credit card).

Changes
- Adjust the version of PayPal API to be 72 (I also did this in my prior pull request).
- Add new function, reference_transaction, to the gateway
- Add private method, build_reference_transaction_request, to build the xml to send the PayPal
- Add unit tests for both reference_transaction and the private build_reference_transaction request method

If there are any changes I need to make to this in order to get this integrated let me know.
