### PR TITLE
Add option to retain payment methods once stored

### DIFF
--- a/lib/active_merchant/billing/gateways/samurai.rb
+++ b/lib/active_merchant/billing/gateways/samurai.rb
@@ -76,6 +76,7 @@ module ActiveMerchant #:nodoc:
           :zip          => address[:zip],
           :sandbox      => test?
         })
+        result.retain if options[:retain] && result.is_sensitive_data_valid && result.payment_method_token
 
         Response.new(result.is_sensitive_data_valid,
                      message_from_result(result),

--- a/test/remote/gateways/remote_samurai_test.rb
+++ b/test/remote/gateways/remote_samurai_test.rb
@@ -50,6 +50,10 @@ class RemoteSamuraiTest < Test::Unit::TestCase
     assert_success @gateway.void(authorize.authorization)
   end
 
+  def test_successful_store_and_retain
+    assert_success @gateway.store(@credit_card, :retain => true)
+  end
+
   def test_invalid_login
     assert_raise(ArgumentError) do
       SamuraiGateway.new( :login => '', :password => '' )

--- a/test/unit/gateways/samurai_test.rb
+++ b/test/unit/gateways/samurai_test.rb
@@ -134,6 +134,42 @@ class SamuraiTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_retain
+    card_to_store = valid_credit_card
+    payment_method = successful_create_payment_method_response
+    Samurai::PaymentMethod.expects(:create).
+                           with(card_to_store).
+                           returns(payment_method)
+    payment_method.expects(:retain)
+    response = @gateway.store(@successful_credit_card, :retain => true)
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_no_retain_on_failed_store
+    card_to_store = valid_credit_card
+    payment_method = successful_create_payment_method_response
+    payment_method.is_sensitive_data_valid = false
+    payment_method.payment_method_token = nil
+    Samurai::PaymentMethod.expects(:create).
+                           with(card_to_store).
+                           returns(payment_method)
+    payment_method.expects(:retain).never
+    response = @gateway.store(@successful_credit_card, :retain => true)
+  end
+
+  def test_no_retain_options
+    card_to_store = valid_credit_card
+    payment_method = successful_create_payment_method_response
+    Samurai::PaymentMethod.expects(:create).
+                           with(card_to_store).
+                           returns(payment_method).
+                           twice
+    payment_method.expects(:retain).never
+    response = @gateway.store(@successful_credit_card, :retain => false)
+    response = @gateway.store(@successful_credit_card)
+  end
+
   def test_passing_optional_processor_options
     Samurai::Processor.expects(:purchase).
                        with(@successful_payment_method_token, @amount, {:billing_reference => 'billing_reference'}).
@@ -158,6 +194,22 @@ class SamuraiTest < Test::Unit::TestCase
   end
 
   private
+
+  def valid_credit_card
+    {
+      :card_number  => "4242424242424242",
+      :expiry_month => "09",
+      :expiry_year  => (Time.now.year + 1).to_s,
+      :cvv          => "123",
+      :first_name   => "Longbob",
+      :last_name    => "Longsen",
+      :address_1    => nil,
+      :address_2    => nil,
+      :city         => nil,
+      :zip          => nil,
+      :sandbox      => true
+    }
+  end
 
   def successful_purchase_response
     successful_response("Purchase")


### PR DESCRIPTION
Currently, if a credit card is stored with Samurai and there is no subsequent auth/payment, then the card is purged from their system within 24-48 hours. Using the new `:retain` option will request that Samurai retain the payment method for future use.

See the Samurai docs here: https://samurai.feefighters.com/developers/ruby/api-reference#retaining-a-payment-method
