### PR TITLE
Removing money version restriction, newer version now work with 1.9

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   
   s.add_dependency('activesupport', '>= 2.3.11')
   s.add_dependency('i18n')
-  s.add_dependency('money', '<= 3.7.1')
+  s.add_dependency('money')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('json', '>= 1.5.1')
   s.add_dependency('active_utils', '>= 1.0.2')


### PR DESCRIPTION
I have a conflict with some other gems in my application that want to use money > 3.7.1, but I can't with activemerchant version > 1.18.1. 

I tested activemerchant with the newest version of the money gem and it passes all test in my computer using ruby 1.9.2p290. 

Is it possible to remove the <= 3.7.1 restriction?

Thanks,
