### PR TITLE
Fixed USA Epay's handling of AVS.

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -175,11 +175,7 @@ module ActiveMerchant #:nodoc:
           :test => @options[:test] || test?,
           :authorization => response[:ref_num],
           :cvv_result => response[:cvv2_result_code],
-          :avs_result => {
-            :street_match => response[:avs_result_code].to_s[0,1],
-            :postal_match => response[:avs_result_code].to_s[1,1],
-            :code => response[:avs_result_code].to_s[2,1]
-          }
+          :avs_result => { :code => response[:avs_result_code] }
         )
       end
 

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -127,10 +127,10 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   end
   
   def successful_purchase_response
-    "UMversion=2.9&UMstatus=Approved&UMauthCode=001716&UMrefNum=55074409&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=YYY&UMcvv2Result=Match&UMcvv2ResultCode=M&UMresult=A&UMvpasResultCode=&UMerror=Approved&UMerrorcode=00000&UMcustnum=&UMbatch=596&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMfiller=filled"
+    "UMversion=2.9&UMstatus=Approved&UMauthCode=001716&UMrefNum=55074409&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=Y&UMcvv2Result=Match&UMcvv2ResultCode=M&UMresult=A&UMvpasResultCode=&UMerror=Approved&UMerrorcode=00000&UMcustnum=&UMbatch=596&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMfiller=filled"
   end
   
   def unsuccessful_purchase_response
-    "UMversion=2.9&UMstatus=Declined&UMauthCode=000000&UMrefNum=55076060&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=YYY&UMcvv2Result=Not%20Processed&UMcvv2ResultCode=P&UMvpasResultCode=&UMresult=D&UMerror=Card%20Declined&UMerrorcode=10127&UMbatch=596&UMfiller=filled"
+    "UMversion=2.9&UMstatus=Declined&UMauthCode=000000&UMrefNum=55076060&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=Y&UMcvv2Result=Not%20Processed&UMcvv2ResultCode=P&UMvpasResultCode=&UMresult=D&UMerror=Card%20Declined&UMerrorcode=10127&UMbatch=596&UMfiller=filled"
   end
 end


### PR DESCRIPTION
In production, we're receiving a 1 character code rather than a 3
character code.  The fix actually makes this gateway more
consistent with the other gateways and handles all of the
possible AVS result codes.
