### PR TITLE
[Code Review]Added support for Visa Dankort for ePay

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -18,6 +18,7 @@ module ActiveMerchant #:nodoc:
     # * Switch
     # * Solo
     # * Dankort
+    # * Visa/Dankort
     # * Maestro
     # * Forbrugsforeningen
     # * Laser
@@ -81,6 +82,7 @@ module ActiveMerchant #:nodoc:
       # * +'switch'+
       # * +'solo'+
       # * +'dankort'+
+      # * +'visa_dankort'+
       # * +'maestro'+
       # * +'forbrugsforeningen'+
       # * +'laser'+

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -3,7 +3,8 @@ module ActiveMerchant #:nodoc:
     # Convenience methods that can be included into a custom Credit Card object, such as an ActiveRecord based Credit Card object.
     module CreditCardMethods
       CARD_COMPANIES = { 
-        'visa'               => /^4\d{12}(\d{3})?$/,
+        'visa_dankort'       => /^45711\d{11}$/,
+        'visa'               => /^4(?!5711)\d{12}(\d{3})?$/,
         'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
         'discover'           => /^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/,
         'american_express'   => /^3[47]\d{13}$/,

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'DKK'
       self.money_format = :cents
-      self.supported_cardtypes = [:dankort, :forbrugsforeningen, :visa, :master,
+      self.supported_cardtypes = [:dankort, :visa_dankort, :forbrugsforeningen, :visa, :master,
                                   :american_express, :diners_club, :jcb, :maestro]
       self.supported_countries = ['DK', 'SE', 'NO']
       self.homepage_url = 'http://epay.dk/'

--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -25,6 +25,20 @@ class RemoteEpayTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_authorization_dankort_visa
+    card = credit_card('4444444444444000')
+    card.type = 'visa_dankort'
+    assert response = @gateway.authorize(@amount, card , @options)
+    assert_equal "1", response.params['accept']
+    assert_not_nil response.params['tid']
+    assert_not_nil response.params['cur']
+    assert_not_nil response.params['amount']
+    assert_not_nil response.params['orderid']
+    assert !response.authorization.blank?
+    assert_success response
+    assert response.test?
+  end
+
   def test_failed_authorization
     assert response = @gateway.authorize(@amount, @credit_card_declined, @options)
     assert_equal '1', response.params['decline']

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -78,8 +78,8 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'dankort', CreditCard.type?('5019717010103742')
   end
   
-  def test_should_detect_visa_dankort_as_visa
-    assert_equal 'visa', CreditCard.type?('4571100000000000')
+  def test_should_be_visa_dankort_card_type
+    assert_equal 'visa_dankort', CreditCard.type?('4571100000000000')
   end
   
   def test_should_detect_electron_dk_as_visa


### PR DESCRIPTION
Visa Dankort cards were being classified as Visa cards, which meant they could not be processed by ePay. This fixes the problem.

Ticket: https://shopify.desk.com/agent/case/130446

Please Review:
@Soleone @csaunders
