### PR TITLE
Ogone: Add store method to create an alias without making a purchase

### DIFF
--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -22,6 +22,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
     assert_equal '7', response.params['ECI']
     assert_equal @options[:currency], response.params["currency"]
+    assert_equal @options[:order_id], reponse.order_id
   end
 
   def test_successful_purchase_with_utf8_encoding_1
@@ -144,6 +145,20 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert_equal OgoneGateway::SUCCESS_MESSAGE, auth.message
     assert_success void
   end
+  
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
+    assert_success response
+    assert purchase = @gateway.purchase(@amount, 'test_alias')
+    assert_success purchase
+  end
+  
+  def test_successful_store_generated_alias
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert purchase = @gateway.purchase(@amount, response.billing_id)
+    assert_success purchase
+  end
 
   def test_successful_referenced_credit
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)
@@ -172,11 +187,11 @@ class RemoteOgoneTest < Test::Unit::TestCase
 
   def test_reference_transactions
     # Setting an alias
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(:store => "awesomeman", :order_id=>Time.now.to_i.to_s+"1"))
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"1"))
     assert_success response
     assert_equal '7', response.params['ECI']
     # Updating an alias
-    assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(:store => "awesomeman", :order_id=>Time.now.to_i.to_s+"2"))
+    assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"2"))
     assert_success response
     assert_equal '7', response.params['ECI']
     # Using an alias (i.e. don't provide the credit card)

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -12,6 +12,7 @@ class OgoneTest < Test::Unit::TestCase
     @credit_card = credit_card
     @amount = 100
     @identification = "3014726"
+    @billing_id = "myalias"
     @options = {
       :order_id => '1',
       :billing_address => address,
@@ -124,6 +125,29 @@ class OgoneTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_store
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'ECI', '7')
+    @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
+    assert response = @gateway.store(@credit_card, :billing_id => @billing_id)
+    assert_success response
+    assert_equal '3014726;RES', response.authorization
+    assert_equal '2', response.billing_id
+    assert response.test?
+  end
+
+  def test_deprecated_store_option
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'ECI', '7')
+    @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
+    assert_deprecation_warning(OgoneGateway::OGONE_STORE_OPTION_DEPRECATION_MESSAGE, @gateway) do
+      assert response = @gateway.store(@credit_card, :store => @billing_id)
+      assert_success response
+      assert_equal '3014726;RES', response.authorization
+      assert response.test?
+    end
+  end
+
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -184,6 +208,18 @@ class OgoneTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
     assert_equal 'P', response.cvv_result['code']
+  end
+
+  def test_billing_id
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_equal '2', response.billing_id
+  end
+
+  def test_order_id
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_equal '1233680882919266242708828', response.order_id
   end
 
   def test_production_mode
@@ -298,7 +334,8 @@ class OgoneTest < Test::Unit::TestCase
         amount="1"
         currency="EUR"
         PM="CreditCard"
-        BRAND="VISA">
+        BRAND="VISA"
+        ALIAS="2">
       </ncresponse>
     END
   end
@@ -322,7 +359,8 @@ class OgoneTest < Test::Unit::TestCase
         amount="1"
         currency="EUR"
         PM="CreditCard"
-        BRAND="VISA">
+        BRAND="VISA"
+        ALIAS="2">
       </ncresponse>
     END
   end
@@ -341,7 +379,8 @@ class OgoneTest < Test::Unit::TestCase
       amount=""
       currency="EUR"
       PM=""
-      BRAND="">
+      BRAND=""
+      ALIAS="2">
       </ncresponse>
     END
   end
@@ -359,7 +398,8 @@ class OgoneTest < Test::Unit::TestCase
       ACCEPTANCE=""
       STATUS="91"
       amount="1"
-      currency="EUR">
+      currency="EUR"
+      ALIAS="2">
       </ncresponse>
     END
   end
@@ -377,7 +417,8 @@ class OgoneTest < Test::Unit::TestCase
     ACCEPTANCE=""
     STATUS="61"
     amount="1"
-    currency="EUR">
+    currency="EUR"
+    ALIAS="2">
     </ncresponse>
     END
   end
@@ -395,7 +436,8 @@ class OgoneTest < Test::Unit::TestCase
     ACCEPTANCE=""
     STATUS="81"
     amount="1"
-    currency="EUR">
+    currency="EUR"
+    ALIAS="2">
     </ncresponse>
     END
   end
@@ -419,7 +461,8 @@ class OgoneTest < Test::Unit::TestCase
     amount="1"
     currency="EUR"
     PM="CreditCard"
-    BRAND="VISA">
+    BRAND="VISA"
+    ALIAS="2">
     </ncresponse>
     END
   end
@@ -438,7 +481,8 @@ class OgoneTest < Test::Unit::TestCase
     amount=""
     currency="EUR"
     PM=""
-    BRAND="">
+    BRAND=""
+    ALIAS="2">
     </ncresponse>
     END
   end


### PR DESCRIPTION
This is a squashed version of https://github.com/Shopify/active_merchant/pull/282

This fork gives the possibility to create an Alias in Ogone without doing a real payment.
It does so by authorizing a €0.01 transaction then voiding it.

Unit and remote tests are included.
