### PR TITLE
[Code Review] More useful results for ePay authorization errors

### DIFF
--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -192,7 +192,9 @@ module ActiveMerchant #:nodoc:
         else
           return {
             'accept' => '0',
-            'errortext' => 'No Location header returned.'
+            'errortext' => 'ePay did not respond as expected. Please try again.',
+            'response_code' => response.code,
+            'response_message' => response.message
           }
         end
 

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -29,6 +29,15 @@ class EpayTest < Test::Unit::TestCase
                  response.message
   end
 
+  def test_failed_response_on_purchase
+    @gateway.expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 400,'Bad Request'))
+
+    assert response = @gateway.authorize(100, @credit_card)
+    assert_equal 400, response.params['response_code']
+    assert_equal 'Bad Request', response.params['response_message']
+    assert_equal 'ePay did not respond as expected. Please try again.', response.message
+  end
+
   def test_successful_capture
     @gateway.expects(:soap_post).returns(REXML::Document.new(valid_capture_response))
 


### PR DESCRIPTION
Users were getting an ambiguous error message when using ePay: "Location header not included." Upon further investigation, it was discovered to be an error on the ePay site. In many cases, trying to process the payment again corrected this problem This patch will change the error message to "ePay did not respond as expected. Please try again.", and the response code and message from ePay will be added to the result.

Please Review:
@jduff @csaunders
