### PR TITLE
Added Paypal Recurring API module

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -1,10 +1,12 @@
 require File.dirname(__FILE__) + '/paypal/paypal_common_api'
+require File.dirname(__FILE__) + '/paypal/paypal_recurring_api'
 require File.dirname(__FILE__) + '/paypal_express'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PaypalGateway < Gateway
       include PaypalCommonAPI
+      include PaypalRecurringApi
       
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
       self.supported_countries = ['US']

--- a/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
@@ -1,0 +1,245 @@
+require File.dirname(__FILE__) + '/paypal_common_api'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # This module is included in both PaypalGateway and PaypalExpressGateway
+    module PaypalRecurringApi
+      PAYPAL_NAMESPACE = ActiveMerchant::Billing::PaypalCommonAPI::PAYPAL_NAMESPACE
+      API_VERSION = ActiveMerchant::Billing::PaypalCommonAPI::API_VERSION
+      EBAY_NAMESPACE = ActiveMerchant::Billing::PaypalCommonAPI::EBAY_NAMESPACE
+      # Create a recurring payment.
+      #
+      # This transaction creates a recurring payment profile
+      # ==== Parameters
+      #
+      # * <tt>money</tt> -- The amount to be charged to the customer at each interval as an Integer value in cents.
+      # * <tt>credit_card</tt> -- The CreditCard details for the transaction.
+      # * <tt>options</tt> -- A hash of parameters.
+      #
+      # ==== Options
+      #
+      # * <tt>:period</tt> -- [Day, Week, SemiMonth, Month, Year] default: Month
+      # * <tt>:frequency</tt> -- a number
+      # * <tt>:cycles</tt> -- Limit to certain # of cycles (OPTIONAL)
+      # * <tt>:start_date</tt> -- When does the charging starts (REQUIRED)
+      # * <tt>:description</tt> -- The description to appear in the profile (REQUIRED)
+      
+      def recurring(amount, credit_card, options = {})
+        options[:credit_card] = credit_card
+        options[:amount] = amount
+        requires!(options, :description, :start_date, :period, :frequency, :amount)
+        commit 'CreateRecurringPaymentsProfile', build_create_profile_request(options)
+      end
+
+      # Update a recurring payment's details.
+      #
+      # This transaction updates an existing Recurring Billing Profile
+      # and the subscription must have already been created previously 
+      # by calling +recurring()+. The ability to change certain
+      # details about a recurring payment is dependent on transaction history
+      # and the type of plan you're subscribed with paypal. Web Payment Pro
+      # seems to have the ability to update the most field.
+      #
+      # ==== Parameters
+      #
+      # * <tt>options</tt> -- A hash of parameters.
+      #
+      # ==== Options
+      #
+      # * <tt>:profile_id</tt> -- A string containing the <tt>:profile_id</tt>
+      # of the recurring payment already in place for a given credit card. (REQUIRED)
+      def update_recurring(options={})
+        requires!(options, :profile_id)
+        opts = options.dup
+        commit 'UpdateRecurringPaymentsProfile', build_change_profile_request(opts.delete(:profile_id), opts)
+      end
+
+      # Cancel a recurring payment.
+      #
+      # This transaction cancels an existing recurring billing profile. Your account must have recurring billing enabled
+      # and the subscription must have already been created previously by calling recurring()
+      #
+      # ==== Parameters
+      #
+      # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
+      # recurring payment already in place for a given credit card. (REQUIRED)
+      # * <tt>options</tt> -- A hash with extra info ('note' for ex.)
+      def cancel_recurring(profile_id, options = {})
+        raise_error_if_blank('profile_id', profile_id)
+        commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Cancel', options)
+      end
+
+      # Get Subscription Status of a recurring payment profile.
+      #
+      # ==== Parameters
+      #
+      # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
+      # recurring payment already in place for a given credit card. (REQUIRED)
+      def status_recurring(profile_id)
+        raise_error_if_blank('profile_id', profile_id)
+        commit 'GetRecurringPaymentsProfileDetails', build_get_profile_details_request(profile_id)
+      end
+
+      # Suspends a recurring payment profile.
+      #
+      # ==== Parameters
+      #
+      # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
+      # recurring payment already in place for a given credit card. (REQUIRED)
+      def suspend_recurring(profile_id, options = {})
+        raise_error_if_blank('profile_id', profile_id)
+        commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Suspend', options)
+      end
+
+      # Reactivates a suspended recurring payment profile.
+      #
+      # ==== Parameters
+      #
+      # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
+      # recurring payment already in place for a given credit card. (REQUIRED)
+      def reactivate_recurring(profile_id, options = {})
+        raise_error_if_blank('profile_id', profile_id)
+commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Reactivate', options)
+      end
+
+      # Bills outstanding amount to a recurring payment profile.
+      #
+      # ==== Parameters
+      #
+      # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
+      # recurring payment already in place for a given credit card. (REQUIRED)
+      def bill_outstanding_amount(profile_id, options = {})
+        raise_error_if_blank('profile_id', profile_id)
+        commit 'BillOutstandingAmount', build_bill_outstanding_amount(profile_id, options)
+      end
+
+      private
+      def raise_error_if_blank(field_name, field)
+        raise ArgumentError.new("Missing required parameter: #{field_name}") if field.blank?
+      end
+      def build_create_profile_request(options)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'CreateRecurringPaymentsProfileReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'CreateRecurringPaymentsProfileRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:CreateRecurringPaymentsProfileRequestDetails' do
+              xml.tag! 'Token', options[:token] unless options[:token].blank?
+              if options[:credit_card]
+                add_credit_card(xml, options[:credit_card], (options[:billing_address] || options[:address]), options)
+              end
+              xml.tag! 'n2:RecurringPaymentsProfileDetails' do
+                xml.tag! 'n2:BillingStartDate', (options[:start_date].is_a?(Date) ? options[:start_date].to_time : options[:start_date]).utc.iso8601
+                xml.tag! 'n2:ProfileReference', options[:profile_reference] unless options[:profile_reference].blank?
+              end
+              xml.tag! 'n2:ScheduleDetails' do
+                xml.tag! 'n2:Description', options[:description]
+                xml.tag! 'n2:PaymentPeriod' do
+                  xml.tag! 'n2:BillingPeriod', options[:period] || 'Month'
+                  xml.tag! 'n2:BillingFrequency', options[:frequency]
+                  xml.tag! 'n2:TotalBillingCycles', options[:total_billing_cycles] unless options[:total_billing_cycles].blank?
+                  xml.tag! 'n2:Amount', amount(options[:amount]), 'currencyID' => options[:currency] || 'USD'
+                  xml.tag! 'n2:TaxAmount', amount(options[:tax_amount] || 0), 'currencyID' => options[:currency] || 'USD' unless options[:tax_amount].blank?
+                  xml.tag! 'n2:ShippingAmount', amount(options[:shipping_amount] || 0), 'currencyID' => options[:currency] || 'USD' unless options[:shipping_amount].blank?
+                end
+                if !options[:trial_amount].blank?
+                  xml.tag! 'n2:TrialPeriod' do
+                    xml.tag! 'n2:BillingPeriod', options[:trial_period] || 'Month'
+                    xml.tag! 'n2:BillingFrequency', options[:trial_frequency]
+                    xml.tag! 'n2:TotalBillingCycles', options[:trial_cycles] || 1
+                    xml.tag! 'n2:Amount', amount(options[:trial_amount]), 'currencyID' => options[:currency] || 'USD'
+                    xml.tag! 'n2:TaxAmount', amount(options[:trial_tax_amount] || 0), 'currencyID' => options[:currency] || 'USD' unless options[:trial_tax_amount].blank?
+                    xml.tag! 'n2:ShippingAmount', amount(options[:trial_shipping_amount] || 0), 'currencyID' => options[:currency] || 'USD' unless options[:trial_shipping_amount].blank?
+                  end
+                end
+                if !options[:initial_amount].blank?
+                  xml.tag! 'n2:ActivationDetails' do
+                    xml.tag! 'n2:InitialAmount', amount(options[:initial_amount]), 'currencyID' => options[:currency] || 'USD'
+                    xml.tag! 'n2:FailedInitialAmountAction', options[:continue_on_failure] ? 'ContinueOnFailure' : 'CancelOnFailure'
+                  end
+                end
+                xml.tag! 'n2:MaxFailedPayments', options[:max_failed_payments] unless options[:max_failed_payments].blank?
+                xml.tag! 'n2:AutoBillOutstandingAmount', options[:auto_bill_outstanding] ? 'AddToNextBilling' : 'NoAutoBill'
+              end
+            end
+          end
+        end
+        xml.target!
+      end
+
+      def build_get_profile_details_request(profile_id)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'GetRecurringPaymentsProfileDetailsReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'GetRecurringPaymentsProfileDetailsRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'ProfileID', profile_id
+          end
+        end
+        xml.target!
+      end
+
+      def build_change_profile_request(profile_id, options)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'UpdateRecurringPaymentsProfileReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'UpdateRecurringPaymentsProfileRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:UpdateRecurringPaymentsProfileRequestDetails' do
+              xml.tag! 'ProfileID', profile_id
+              if options[:credit_card]
+                add_credit_card(xml, options[:credit_card], options[:address], options)
+              end
+              xml.tag! 'n2:Note', options[:note] unless options[:note].blank?
+              xml.tag! 'n2:Description', options[:description] unless options[:description].blank?
+              xml.tag! 'n2:ProfileReference', options[:reference] unless options[:reference].blank?
+              xml.tag! 'n2:AdditionalBillingCycles', options[:additional_billing_cycles] unless options[:additional_billing_cycles].blank?
+              xml.tag! 'n2:MaxFailedPayments', options[:max_failed_payments] unless options[:max_failed_payments].blank?
+              xml.tag! 'n2:AutoBillOutstandingAmount', options[:auto_bill_outstanding] ? 'AddToNextBilling' : 'NoAutoBill'
+              if options.has_key?(:amount)
+                xml.tag! 'n2:Amount', amount(options[:amount]), 'currencyID' => options[:currency] || 'USD'
+              end
+              if options.has_key?(:tax_amount)
+                xml.tag! 'n2:TaxAmount', amount(options[:tax_amount] || 0), 'currencyID' => options[:currency] || 'USD'
+              end
+              if options.has_key?(:start_date)
+                xml.tag! 'n2:BillingStartDate', (options[:start_date].is_a?(Date) ? options[:start_date].to_time : options[:start_date]).utc.iso8601
+              end
+            end
+          end
+        end
+        xml.target!
+      end
+
+      def build_manage_profile_request(profile_id, action, options)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'ManageRecurringPaymentsProfileStatusReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'ManageRecurringPaymentsProfileStatusRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:ManageRecurringPaymentsProfileStatusRequestDetails' do
+              xml.tag! 'ProfileID', profile_id
+              xml.tag! 'n2:Action', action
+              xml.tag! 'n2:Note', options[:note] unless options[:note].blank?
+            end
+          end
+        end
+        xml.target!
+      end
+
+      def build_bill_outstanding_amount(profile_id, options)
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'BillOutstandingAmountReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'BillOutstandingAmountRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:BillOutstandingAmountRequestDetails' do
+              xml.tag! 'ProfileID', profile_id
+              if options.has_key?(:amount)
+                xml.tag! 'n2:Amount', amount(options[:amount]), 'currencyID' => options[:currency] || 'USD'
+              end
+              xml.tag! 'n2:Note', options[:note] unless options[:note].blank?
+            end
+          end
+        end
+        xml.target!
+      end
+
+    end
+  end
+end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -14,12 +14,53 @@ class PaypalTest < Test::Unit::TestCase
     
     @credit_card = credit_card('4242424242424242')
     @options = { :billing_address => address, :ip => '127.0.0.1' }
+    @recurring_required_fields = {:start_date => Date.today, :frequency => :Month, :period => 'Month', :description => 'A description'}
   end 
 
   def test_no_ip_address
     assert_raise(ArgumentError){ @gateway.purchase(@amount, @credit_card, :billing_address => address)}
   end
-  
+
+  def test_recurring_requires_description
+    @recurring_required_fields.delete(:description)
+    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+  end
+
+  def test_recurring_requires_start_date
+    @recurring_required_fields.delete(:start_date)
+    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+  end
+
+  def test_recurring_requires_frequency
+    @recurring_required_fields.delete(:frequency)
+    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+  end
+
+  def test_recurring_requires_period
+    @recurring_required_fields.delete(:period)
+    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+  end
+
+  def test_update_recurring_requires_profile_id
+    assert_raise(ArgumentError){ @gateway.update_recurring(:amount => 100)}
+  end
+
+  def test_cancel_recurring_requires_profile_id
+    assert_raise(ArgumentError){ @gateway.cancel_recurring(nil, :note => 'Note')}
+  end
+
+  def test_status_recurring_requires_profile_id
+    assert_raise(ArgumentError){ @gateway.status_recurring(nil, :note => 'Note')}
+  end
+
+  def test_suspend_recurring_requires_profile_id
+    assert_raise(ArgumentError){ @gateway.suspend_recurring(nil, :note => 'Note')}
+  end
+
+  def test_reactivate_recurring_requires_profile_id
+    assert_raise(ArgumentError){ @gateway.reactivate_recurring(nil, :note => 'Note')}
+  end
+
   def test_successful_purchase_with_auth_signature
     @gateway = PaypalGateway.new(:login => 'cody', :password => 'test', :pem => 'PEM', :auth_signature => 123)
     expected_header = {'X-PP-AUTHORIZATION' => 123, 'X-PAYPAL-MESSAGE-PROTOCOL' => 'SOAP11'}
@@ -259,7 +300,86 @@ class PaypalTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_purchase_response)
     response = @gateway.purchase(100, @credit_card, @options.merge(:currency => 'JPY'))
     assert response.success?
-  end  
+  end
+
+  def test_successful_create_profile
+    @gateway.expects(:ssl_post).returns(successful_create_profile_paypal_response)
+    response = @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    assert_instance_of Response, response
+    assert response.success?
+    assert response.test?
+    assert_equal 'I-G7A2FF8V75JY', response.params['profile_id']
+    assert_equal 'ActiveProfile', response.params['profile_status']
+  end
+
+  def test_failed_create_profile
+    @gateway.expects(:ssl_post).returns(failed_create_profile_paypal_response)
+    response = @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    assert_instance_of Response, response
+    assert !response.success?
+    assert response.test?
+    assert_equal 'I-G7A2FF8V75JY', response.params['profile_id']
+    assert_equal 'ActiveProfile', response.params['profile_status']
+  end
+
+  def test_update_recurring_delegation
+    @gateway.expects(:build_change_profile_request).with('I-G7A2FF8V75JY', :amount => 200)
+    @gateway.stubs(:commit)
+    @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+  end
+
+  def test_update_recurring_response
+    @gateway.expects(:ssl_post).returns(successful_update_recurring_payment_profile_response)
+    response = @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+    assert response.success?
+  end
+
+  def test_cancel_recurring_delegation
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Cancel', :note => 'A Note').returns(:cancel_request)
+    @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :cancel_request)
+    @gateway.cancel_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+  end
+
+  def test_suspend_recurring_delegation
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Suspend', :note => 'A Note').returns(:request)
+    @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
+    @gateway.suspend_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+  end
+
+  def test_reactivate_recurring_delegation
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Reactivate', :note => 'A Note').returns(:request)
+    @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
+    @gateway.reactivate_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+  end
+
+  def test_status_recurring_delegation
+    @gateway.expects(:build_get_profile_details_request).with('I-G7A2FF8V75JY').returns(:request)
+    @gateway.expects(:commit).with('GetRecurringPaymentsProfileDetails', :request)
+    @gateway.status_recurring('I-G7A2FF8V75JY')
+  end
+
+  def test_status_recurring_response
+    @gateway.expects(:ssl_post).returns(succesful_get_recurring_payments_profile_response)
+    response = @gateway.status_recurring('I-M1L3RX91DPDD')
+    assert response.success?
+    assert_equal 'I-M1L3RX91DPDD', response.params['profile_id']
+  end
+
+  def test_bill_outstanding_amoung_delegation
+    @gateway.expects(:build_bill_outstanding_amount).with('I-G7A2FF8V75JY', :amount => 400).returns(:request)
+    @gateway.expects(:commit).with('BillOutstandingAmount', :request)
+    @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+  end
+
+  def test_bill_outstanding_amoung_response
+    @gateway.expects(:ssl_post).returns(successful_bill_outstanding_amount)
+    response = @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+    assert response.success?
+  end
+
+
+
+
   private
   def successful_purchase_response
     <<-RESPONSE
@@ -586,6 +706,201 @@ class PaypalTest < Test::Unit::TestCase
     </DoDirectPaymentResponse>
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_create_profile_paypal_response
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\">
+     <SOAP-ENV:Header>
+       <Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security>
+       <RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\">
+          <Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\">
+            <Username xsi:type=\"xs:string\"></Username>
+            <Password xsi:type=\"xs:string\"></Password>
+            <Signature xsi:type=\"xs:string\"></Signature>
+            <Subject xsi:type=\"xs:string\"></Subject></Credentials>
+       </RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\">
+       <CreateRecurringPaymentsProfileResponse xmlns=\"urn:ebay:api:PayPalAPI\">
+         <Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2011-08-28T18:59:40Z</Timestamp>
+         <Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack>
+         <CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">4b8eaecc084b</CorrelationID>
+         <Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">59.0</Version>
+         <Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2085867</Build>
+       <CreateRecurringPaymentsProfileResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:CreateRecurringPaymentsProfileResponseDetailsType\">
+         <ProfileID xsi:type=\"xs:string\">I-G7A2FF8V75JY</ProfileID>
+         <ProfileStatus xsi:type=\"ebl:RecurringPaymentsProfileStatusType\">ActiveProfile</ProfileStatus>
+         <TransactionID xsi:type=\"xs:string\"></TransactionID></CreateRecurringPaymentsProfileResponseDetails>
+       </CreateRecurringPaymentsProfileResponse>
+      </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def failed_create_profile_paypal_response
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\">
+    <SOAP-ENV:Header>
+      <Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security>
+      <RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\">
+        <Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\">
+          <Username xsi:type=\"xs:string\"></Username>
+          <Password xsi:type=\"xs:string\"></Password>
+          <Signature xsi:type=\"xs:string\"></Signature>
+          <Subject xsi:type=\"xs:string\"></Subject>
+        </Credentials>
+      </RequesterCredentials>
+     </SOAP-ENV:Header>
+    <SOAP-ENV:Body id=\"_0\">
+    <CreateRecurringPaymentsProfileResponse xmlns=\"urn:ebay:api:PayPalAPI\">
+      <Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2011-08-28T18:59:40Z</Timestamp>
+      <Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">This is a test failure</Ack>
+      <CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">4b8eaecc084b</CorrelationID>
+      <Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">59.0</Version>
+      <Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2085867</Build>
+      <CreateRecurringPaymentsProfileResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:CreateRecurringPaymentsProfileResponseDetailsType\">
+        <ProfileID xsi:type=\"xs:string\">I-G7A2FF8V75JY</ProfileID>
+        <ProfileStatus xsi:type=\"ebl:RecurringPaymentsProfileStatusType\">ActiveProfile</ProfileStatus>
+        <TransactionID xsi:type=\"xs:string\"></TransactionID>
+      </CreateRecurringPaymentsProfileResponseDetails>
+     </CreateRecurringPaymentsProfileResponse>
+    </SOAP-ENV:Body>
+   </SOAP-ENV:Envelope>"
+   RESPONSE
+  end
+
+  def successful_details_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"/>
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string"/>
+        <Password xsi:type="xs:string"/>
+        <Subject xsi:type="xs:string"/>
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <GetExpressCheckoutDetailsResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2011-03-01T20:19:35Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">84aff0e17b6f</CorrelationID>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">62.0</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">1741654</Build>
+      <GetExpressCheckoutDetailsResponseDetails xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:GetExpressCheckoutDetailsResponseDetailsType">
+        <Token xsi:type="ebl:ExpressCheckoutTokenType">EC-2XE90996XX9870316</Token>
+        <PayerInfo xsi:type="ebl:PayerInfoType">
+          <Payer xsi:type="ebl:EmailAddressType">buyer@jadedpallet.com</Payer>
+          <PayerID xsi:type="ebl:UserIDType">FWRVKNRRZ3WUC</PayerID>
+          <PayerStatus xsi:type="ebl:PayPalUserStatusCodeType">verified</PayerStatus>
+          <PayerName xsi:type='ebl:PersonNameType'>
+            <Salutation xmlns='urn:ebay:apis:eBLBaseComponents'/>
+            <FirstName xmlns='urn:ebay:apis:eBLBaseComponents'>Fred</FirstName>
+            <MiddleName xmlns='urn:ebay:apis:eBLBaseComponents'/>
+            <LastName xmlns='urn:ebay:apis:eBLBaseComponents'>Brooks</LastName>
+            <Suffix xmlns='urn:ebay:apis:eBLBaseComponents'/>
+          </PayerName>
+          <PayerCountry xsi:type="ebl:CountryCodeType">US</PayerCountry>
+          <PayerBusiness xsi:type="xs:string"/>
+          <Address xsi:type="ebl:AddressType">
+            <Name xsi:type="xs:string">Fred Brooks</Name>
+            <Street1 xsi:type="xs:string">1 Infinite Loop</Street1>
+            <Street2 xsi:type="xs:string"/>
+            <CityName xsi:type="xs:string">Cupertino</CityName>
+            <StateOrProvince xsi:type="xs:string">CA</StateOrProvince>
+            <Country xsi:type="ebl:CountryCodeType">US</Country>
+            <CountryName>United States</CountryName>
+            <PostalCode xsi:type="xs:string">95014</PostalCode>
+            <AddressOwner xsi:type="ebl:AddressOwnerCodeType">PayPal</AddressOwner>
+            <AddressStatus xsi:type="ebl:AddressStatusCodeType">Confirmed</AddressStatus>
+          </Address>
+        </PayerInfo>
+        <InvoiceID xsi:type="xs:string">1230123</InvoiceID>
+        <ContactPhone>416-618-9984</ContactPhone>
+        <PaymentDetails xsi:type="ebl:PaymentDetailsType">
+          <OrderTotal xsi:type="cc:BasicAmountType" currencyID="USD">19.00</OrderTotal>
+          <ItemTotal xsi:type="cc:BasicAmountType" currencyID="USD">19.00</ItemTotal>
+          <ShippingTotal xsi:type="cc:BasicAmountType" currencyID="USD">0.00</ShippingTotal>
+          <HandlingTotal xsi:type="cc:BasicAmountType" currencyID="USD">0.00</HandlingTotal>
+          <TaxTotal xsi:type="cc:BasicAmountType" currencyID="USD">0.00</TaxTotal>
+          <ShipToAddress xsi:type="ebl:AddressType">
+            <Name xsi:type="xs:string">Fred Brooks</Name>
+            <Street1 xsi:type="xs:string">1234 Penny Lane</Street1>
+            <Street2 xsi:type="xs:string"/>
+            <CityName xsi:type="xs:string">Jonsetown</CityName>
+            <StateOrProvince xsi:type="xs:string">NC</StateOrProvince>
+            <Country xsi:type="ebl:CountryCodeType">US</Country>
+            <CountryName>United States</CountryName>
+            <Phone xsi:type="xs:string">123-456-7890</Phone>
+            <PostalCode xsi:type="xs:string">23456</PostalCode>
+            <AddressID xsi:type="xs:string"/>
+            <AddressOwner xsi:type="ebl:AddressOwnerCodeType">PayPal</AddressOwner>
+            <ExternalAddressID xsi:type="xs:string"/>
+            <AddressStatus xsi:type="ebl:AddressStatusCodeType">Confirmed</AddressStatus>
+          </ShipToAddress>
+          <PaymentDetailsItem xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:PaymentDetailsItemType">
+            <Name xsi:type="xs:string">Shopify T-Shirt</Name>
+            <Quantity>1</Quantity>
+            <Tax xsi:type="cc:BasicAmountType" currencyID="USD">0.00</Tax>
+            <Amount xsi:type="cc:BasicAmountType" currencyID="USD">19.00</Amount>
+            <EbayItemPaymentDetailsItem xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:EbayItemPaymentDetailsItemType"/>
+          </PaymentDetailsItem>
+          <InsuranceTotal xsi:type="cc:BasicAmountType" currencyID="USD">0.00</InsuranceTotal>
+          <ShippingDiscount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</ShippingDiscount>
+          <InsuranceOptionOffered xsi:type="xs:string">false</InsuranceOptionOffered>
+          <SellerDetails xsi:type="ebl:SellerDetailsType"/>
+          <PaymentRequestID xsi:type="xs:string"/>
+          <OrderURL xsi:type="xs:string"/>
+          <SoftDescriptor xsi:type="xs:string"/>
+        </PaymentDetails>
+        <CheckoutStatus xsi:type="xs:string">PaymentActionNotInitiated</CheckoutStatus>
+      </GetExpressCheckoutDetailsResponseDetails>
+    </GetExpressCheckoutDetailsResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+
+  def successful_update_recurring_payment_profile_response
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\">
+    <UpdateRecurringPaymentsProfileResponse xmlns=\"urn:ebay:api:PayPalAPI\">
+      <Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2012-03-19T20:30:02Z</Timestamp>
+      <Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack>
+      <CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">9ad0f67c1127c</CorrelationID>
+      <Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version>
+      <Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2649250</Build>
+      <UpdateRecurringPaymentsProfileResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UpdateRecurringPaymentsProfileResponseDetailsType\">
+        <ProfileID xsi:type=\"xs:string\">I-M1L3RX91DPDD</ProfileID>
+      </UpdateRecurringPaymentsProfileResponseDetails>
+    </UpdateRecurringPaymentsProfileResponse>
+  </SOAP-ENV:Body></SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_manage_recurring_payment_profile_response 
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header>
+    <SOAP-ENV:Body id=\"_0\">
+    <ManageRecurringPaymentsProfileStatusResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2012-03-19T20:41:03Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">3c02ea62138c4</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2649250</Build><ManageRecurringPaymentsProfileStatusResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:ManageRecurringPaymentsProfileStatusResponseDetailsType\"><ProfileID xsi:type=\"xs:string\">I-M1L3RX91DPDD</ProfileID></ManageRecurringPaymentsProfileStatusResponseDetails></ManageRecurringPaymentsProfileStatusResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_bill_outstanding_amount
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><BillOutstandingAmountResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2012-03-19T20:50:49Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">2c1cbe06d718e</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2649250</Build><BillOutstandingAmountResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:BillOutstandingAmountResponseDetailsType\"><ProfileID xsi:type=\"xs:string\">I-M1L3RX91DPDD</ProfileID></BillOutstandingAmountResponseDetails></BillOutstandingAmountResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def succesful_get_recurring_payments_profile_response
+    <<-RESPONSE
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><GetRecurringPaymentsProfileDetailsResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2012-03-19T21:34:40Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">6f24b53c49232</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2649250</Build><GetRecurringPaymentsProfileDetailsResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:GetRecurringPaymentsProfileDetailsResponseDetailsType\"><ProfileID xsi:type=\"xs:string\">I-M1L3RX91DPDD</ProfileID><ProfileStatus xsi:type=\"ebl:RecurringPaymentsProfileStatusType\">CancelledProfile</ProfileStatus><Description xsi:type=\"xs:string\">A description</Description><AutoBillOutstandingAmount xsi:type=\"ebl:AutoBillType\">NoAutoBill</AutoBillOutstandingAmount><MaxFailedPayments>0</MaxFailedPayments><RecurringPaymentsProfileDetails xsi:type=\"ebl:RecurringPaymentsProfileDetailsType\"><SubscriberName xsi:type=\"xs:string\">Ryan Bates</SubscriberName><SubscriberShippingAddress xsi:type=\"ebl:AddressType\"><Name xsi:type=\"xs:string\"></Name><Street1 xsi:type=\"xs:string\"></Street1><Street2 xsi:type=\"xs:string\"></Street2><CityName xsi:type=\"xs:string\"></CityName><StateOrProvince xsi:type=\"xs:string\"></StateOrProvince><CountryName></CountryName><Phone xsi:type=\"xs:string\"></Phone><PostalCode xsi:type=\"xs:string\"></PostalCode><AddressID xsi:type=\"xs:string\"></AddressID><AddressOwner xsi:type=\"ebl:AddressOwnerCodeType\">PayPal</AddressOwner><ExternalAddressID xsi:type=\"xs:string\"></ExternalAddressID><AddressStatus xsi:type=\"ebl:AddressStatusCodeType\">Unconfirmed</AddressStatus></SubscriberShippingAddress><BillingStartDate xsi:type=\"xs:dateTime\">2012-03-19T11:00:00Z</BillingStartDate></RecurringPaymentsProfileDetails><CurrentRecurringPaymentsPeriod xsi:type=\"ebl:BillingPeriodDetailsType\"><BillingPeriod xsi:type=\"ebl:BillingPeriodTypeType\">Month</BillingPeriod><BillingFrequency>1</BillingFrequency><TotalBillingCycles>0</TotalBillingCycles><Amount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</Amount><ShippingAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</ShippingAmount><TaxAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TaxAmount></CurrentRecurringPaymentsPeriod><RecurringPaymentsSummary xsi:type=\"ebl:RecurringPaymentsSummaryType\"><NumberCyclesCompleted>1</NumberCyclesCompleted><NumberCyclesRemaining>-1</NumberCyclesRemaining><OutstandingBalance xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</OutstandingBalance><FailedPaymentCount>1</FailedPaymentCount></RecurringPaymentsSummary><CreditCard xsi:type=\"ebl:CreditCardDetailsType\"><CreditCardType xsi:type=\"ebl:CreditCardTypeType\">Visa</CreditCardType><CreditCardNumber xsi:type=\"xs:string\">3576</CreditCardNumber><ExpMonth>1</ExpMonth><ExpYear>2013</ExpYear><CardOwner xsi:type=\"ebl:PayerInfoType\"><PayerStatus xsi:type=\"ebl:PayPalUserStatusCodeType\">unverified</PayerStatus><PayerName xsi:type=\"ebl:PersonNameType\"><FirstName xmlns=\"urn:ebay:apis:eBLBaseComponents\">Ryan</FirstName><LastName xmlns=\"urn:ebay:apis:eBLBaseComponents\">Bates</LastName></PayerName><Address xsi:type=\"ebl:AddressType\"><AddressOwner xsi:type=\"ebl:AddressOwnerCodeType\">PayPal</AddressOwner><AddressStatus xsi:type=\"ebl:AddressStatusCodeType\">Unconfirmed</AddressStatus></Address></CardOwner><StartMonth>0</StartMonth><StartYear>0</StartYear><ThreeDSecureRequest xsi:type=\"ebl:ThreeDSecureRequestType\"></ThreeDSecureRequest></CreditCard><RegularRecurringPaymentsPeriod xsi:type=\"ebl:BillingPeriodDetailsType\"><BillingPeriod xsi:type=\"ebl:BillingPeriodTypeType\">Month</BillingPeriod><BillingFrequency>1</BillingFrequency><TotalBillingCycles>0</TotalBillingCycles><Amount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</Amount><ShippingAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</ShippingAmount><TaxAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TaxAmount></RegularRecurringPaymentsPeriod><TrialAmountPaid xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TrialAmountPaid><RegularAmountPaid xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</RegularAmountPaid><AggregateAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</AggregateAmount><AggregateOptionalAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</AggregateOptionalAmount><FinalPaymentDueDate xsi:type=\"xs:dateTime\">1970-01-01T00:00:00Z</FinalPaymentDueDate></GetRecurringPaymentsProfileDetailsResponseDetails></GetRecurringPaymentsProfileDetailsResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
     RESPONSE
   end
 end


### PR DESCRIPTION
I took @ginettev code from https://github.com/Shopify/active_merchant/pull/246 as a starting point and made a module out of it, added a few needed tests & fixed a bug.
With this pull adding recurring payment api to PaypalExpressGateway should be just a matter of including PaypalRecurringApi.

Squashed commits
