### PR TITLE
Separate "demo accounts" from "test transactions" for Elavon/Viaklix

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -59,6 +59,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard(form, creditcard)        
         add_address(form, options)   
         add_customer_data(form, options)
+        add_test_mode(form, options)
         commit(:authorize, money, form)
       end
       
@@ -77,6 +78,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(form, options)
         add_creditcard(form, options[:credit_card])
         add_customer_data(form, options)
+        add_test_mode(form, options)
         commit(:capture, money, form)
       end
       

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -43,6 +43,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard(form, creditcard)        
         add_address(form, options)   
         add_customer_data(form, options)
+        add_test_mode(form, options)
         commit(:purchase, money, form)
       end
       
@@ -58,10 +59,15 @@ module ActiveMerchant #:nodoc:
         add_creditcard(form, creditcard)        
         add_address(form, options)   
         add_customer_data(form, options)
+        add_test_mode(form, options)
         commit(:credit, money, form)
       end
       
       private
+      def add_test_mode(form, options)
+        form[:test_mode] = 'TRUE' if options[:test_mode]
+      end
+      
       def add_customer_data(form, options)
         form[:email] = options[:email].to_s.slice(0, 100) unless options[:email].blank?
         form[:customer_code] = options[:customer].to_s.slice(0, 10) unless options[:customer].blank?
@@ -129,8 +135,7 @@ module ActiveMerchant #:nodoc:
           'merchant_id'   => @options[:login],
           'pin'           => @options[:password],
           'show_form'     => 'false',
-          'test_mode'     => test? ? 'TRUE' : 'FALSE',
-          'result_format' => 'ASCII',          
+          'result_format' => 'ASCII'          
         }
         
         result['user_id'] = @options[:user] unless @options[:user].blank?


### PR DESCRIPTION
A fix for this issue: https://github.com/Shopify/active_merchant/issues/319
(not sure how to attach it... if that's possible)

This commit makes it so Base.gateway_mode (gateway.test?) determines what URL to send the request to, while @options[:test] determines what type of transaction to send (real vs. test).  This may create compatibility issues for anybody using the previous code, which allows you to submit to a demo account using the @options[:test] parameter, so it should probably not go in a minor version update I suppose, although it shouldn't create any problems in production environments.

It's a fairly minor change, but I haven't been able to test this yet, because my project uses dm-types 1.1.0 which is incompatible with the current HEAD of active_merchant.  Need to get up to date :)
