### PR TITLE
Update the Braintree Blue gateway to include billing address options

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -137,8 +137,10 @@ module ActiveMerchant #:nodoc:
         options.each do |key, value|
           valid_options[key] = value if [:verify_card, :verification_merchant_account_id].include?(key)
         end
+
         parameters[:credit_card] ||= {}
         parameters[:credit_card].merge!(:options => valid_options)
+        parameters[:credit_card][:billing_address] = map_address(options[:billing_address]) if options[:billing_address]
         parameters
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -99,6 +99,34 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'OK', response.message
   end
 
+  def test_successful_store_with_billing_address
+    billing_address = {
+      :address1 => "1 E Main St",
+      :address2 => "Suite 403",
+      :city => "Chicago",
+      :state => "Illinois",
+      :zip => "60622",
+      :country_name => "US"
+    }
+    credit_card = credit_card('5105105105105100')
+    assert response = @gateway.store(credit_card, :billing_address => billing_address)
+    assert_success response
+    assert_equal 'OK', response.message
+
+    vault_id = response.params['customer_vault_id']
+    purchase_response = @gateway.purchase(@amount, vault_id)
+    response_billing_details = {
+      "country_name"=>nil,
+      "region"=>"Illinois",
+      "company"=>nil,
+      "postal_code"=>"60622",
+      "extended_address"=>"Suite 403",
+      "street_address"=>"1 E Main St",
+      "locality"=>"Chicago"
+    }
+    assert_equal purchase_response.params['braintree_transaction']['billing_details'], response_billing_details
+  end
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -121,6 +121,34 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.store(credit_card("41111111111111111111"), :verify_card => false)
   end
 
+  def test_store_with_billing_address_options
+    customer_attributes = {
+      :credit_cards => [],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :id => "123"
+    }
+    billing_address = {
+      :address1 => "1 E Main St",
+      :address2 => "Suite 403",
+      :city => "Chicago",
+      :state => "Illinois",
+      :zip => "60622",
+      :country_name => "US"
+    }
+    result = Braintree::SuccessfulResult.new(:customer => mock(customer_attributes))
+    Braintree::Customer.expects(:create).with do |params|
+      assert_not_nil params[:credit_card][:billing_address]
+      [:street_address, :extended_address, :locality, :region, :postal_code, :country_name].each do |billing_attribute|
+        params[:credit_card][:billing_address].has_key?(billing_attribute) if params[:billing_address]
+      end
+      params
+    end.returns(result)
+    
+    @gateway.store(credit_card("41111111111111111111"), :billing_address => billing_address)
+  end
+
   def test_merge_credit_card_options_ignores_bad_option
     params = {:first_name => 'John', :credit_card => {:cvv => '123'}}
     options = {:verify_card => true, :bogus => 'ignore me'}
@@ -135,6 +163,46 @@ class BraintreeBlueTest < Test::Unit::TestCase
     merged_params = @gateway.send(:merge_credit_card_options, params, options)
     expected_params = {:first_name => 'John', :credit_card => {:options => {:verify_card => true}}}
     assert_equal expected_params, merged_params
+  end
+
+  def test_merge_credit_card_options_handles_billing_address
+    billing_address = {
+      :address1 => "1 E Main St",
+      :city => "Chicago",
+      :state => "Illinois",
+      :zip => "60622",
+      :country => "US"
+    }
+    params = {:first_name => 'John'}
+    options = {:billing_address => billing_address}
+    expected_params = {
+      :first_name => 'John',
+      :credit_card => {
+        :billing_address => {
+          :street_address => "1 E Main St",
+          :extended_address => nil,
+          :company => nil,
+          :locality => "Chicago",
+          :region => "Illinois",
+          :postal_code => "60622",
+          :country_name => "US"
+        },
+        :options => {}
+      }
+    }
+    assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
+  end
+
+  def test_merge_credit_card_options_only_includes_billing_address_when_present
+    params = {:first_name => 'John'}
+    options = {}
+    expected_params = {
+      :first_name => 'John',
+      :credit_card => {
+        :options => {}
+      }
+    }
+    assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
   end
 
   private


### PR DESCRIPTION
when storing a customer/card. See the Braintree docs here:
http://www.braintreepayments.com/docs/ruby/customers/create#customer_with_credit_card_with_billing_address
