### PR TITLE
[Code Review] Added visa_dankort? to CreditCardMethods

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -83,6 +83,10 @@ module ActiveMerchant #:nodoc:
 
           return nil
         end
+
+        def visa_dankort?(number)
+          number =~ /^4571\d{12}$/
+        end
         
         def first_digits(number)
           number.to_s.slice(0,6) 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -192,4 +192,12 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 19, number.length
     assert_equal 'switch', CreditCard.type?(number)
   end
+
+  def test_visa_dankort_returns_true_when_card_is_visa_dankort
+    assert CreditCard.visa_dankort?('4571029326925773')
+  end
+
+  def test_visa_dankort_returns_false_when_card_is_not_visa_dankort
+    assert_false CreditCard.visa_dankort?('4012888888881881')
+  end
 end


### PR DESCRIPTION
The visa_dankort? method returns true if the card_number parameter is a Visa Dankort number. 

This is needed to fix Shopify's Visa Dankort support.

Please Review
@Soleone @odorcicd
