### PR TITLE
Tidy up gateway lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,16 @@ For more in-depth documentation and tutorials, see {file:GettingStarted.md} and 
 
 The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) contains a [table of features supported by each gateway](http://github.com/Shopify/active_merchant/wikis/gatewayfeaturematrix).
 
-* [Authorize.Net CIM](http://www.authorize.net/) - US
 * [Authorize.Net](http://www.authorize.net/) - US
+* [Authorize.Net CIM](http://www.authorize.net/) - US
 * [Barclays ePDQ](http://www.barclaycard.co.uk/business/accepting-payments/epdq-mpi/) - UK
 * [Beanstream.com](http://www.beanstream.com/) - CA
 * [BluePay](http://www.bluepay.com/) - US
 * [Braintree](http://www.braintreepaymentsolutions.com) - US
-* [CardStream](http://www.cardstream.com/) - GB
+* [CardStream](http://www.cardstream.com/) - UK
 * [CertoDirect](http://www.certodirect.com/) - BE, BG, CZ, DK, DE, EE, IE, EL, ES, FR, IT, CY, LV, LT, LU, HU, MT, NL, AT, PL, PT, RO, SI, SK, FI, SE, UK
 * [CyberSource](http://www.cybersource.com) - US
-* [DataCash](http://www.datacash.com/) - GB
+* [DataCash](http://www.datacash.com/) - UK
 * [Efsnet](http://www.concordefsnet.com/) - US
 * [Elavon MyVirtualMerchant](http://www.elavon.com) - US, CA
 * [ePay](http://www.epay.dk/) - DK, SE, NO
@@ -113,33 +113,33 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Moneris](http://www.moneris.com/) - CA
 * [Moneris US](http://www.monerisusa.com/) - US
 * [NABTransact](http://www.nab.com.au/nabtransact/) - AU
-* [Netaxept](http://www.betalingsterminal.no/Netthandel-forside) - NO, DK, SE, FI
-* [NetRegistry](http://www.netregistry.com.au) - AU
 * [NELiX TransaX Gateway](http://www.nelixtransax.com) - US
+* [Netaxept](http://www.betalingsterminal.no/Netthandel-forside) - NO, DK, SE, FI
 * [NETbilling](http://www.netbilling.com) - US
+* [NetRegistry](http://www.netregistry.com.au) - AU
 * [NMI](http://nmi.com/) - US
 * [Ogone DirectLink](http://www.ogone.com) - BE, DE, FR, NL, AT, CH
-* [Optimal Payments](http://www.optimalpayments.com/) - CA, US, GB
+* [Optimal Payments](http://www.optimalpayments.com/) - CA, US, UK
 * [Orbital Paymentech](http://chasepaymentech.com/) - CA, US
 * [PayBox Direct](http://www.paybox.com) - FR
 * [PayJunction](http://www.payjunction.com/) - US
-* [PaySecure](http://www.commsecure.com.au/paysecure.shtml) - AU
+* [PaymentExpress](http://www.paymentexpress.com/) - AU, MY, NZ, SG, ZA, UK, US
 * [PayPal Express Checkout](https://www.paypal.com/cgi-bin/webscr?cmd=xpt/merchant/ExpressCheckoutIntro-outside) - US, CA, SG, AU
 * [PayPal Payflow Pro](https://www.paypal.com/cgi-bin/webscr?cmd=_payflow-pro-overview-outside) - US, CA, SG, AU
-* [PayPal Website Payments Pro (UK)](https://www.paypal.com/uk/cgi-bin/webscr?cmd=_wp-pro-overview-outside) - GB
-* [PaymentExpress](http://www.paymentexpress.com/) - AU, MY, NZ, SG, ZA, GB, US
+* [PayPal Website Payments Pro (UK)](https://www.paypal.com/uk/cgi-bin/webscr?cmd=_wp-pro-overview-outside) - UK
 * [PayPal Website Payments Pro (CA)](https://www.paypal.com/cgi-bin/webscr?cmd=_wp-pro-overview-outside) - CA
 * [PayPal Express Checkout](https://www.paypal.com/cgi-bin/webscr?cmd=xpt/merchant/ExpressCheckoutIntro-outside) - US
 * [PayPal Website Payments Pro (US)](https://www.paypal.com/cgi-bin/webscr?cmd=_wp-pro-overview-outside) - US
+* [PaySecure](http://www.commsecure.com.au/paysecure.shtml) - AU
 * [Plug'n Pay](http://www.plugnpay.com/) - US
 * [Psigate](http://www.psigate.com/) - CA
-* [PSL Payment Solutions](http://www.paymentsolutionsltd.com/) - GB
+* [PSL Payment Solutions](http://www.paymentsolutionsltd.com/) - UK
 * [Quantum](http://www.quantumgateway.com) - US
 * [QuickBooks Merchant Services](http://payments.intuit.com/) - US
 * [Quickpay](http://quickpay.dk/) - DK, SE
 * [Rabobank Nederland](http://www.rabobank.nl/) - NL
-* [Realex](http://www.realexpayments.com/) - IE, GB
-* [SagePay](http://www.sagepay.com) - GB
+* [Realex](http://www.realexpayments.com/) - IE, UK
+* [SagePay](http://www.sagepay.com) - UK
 * [Sage Payment Solutions](http://www.sagepayments.com) - US, CA
 * [Sallie Mae](http://www.salliemae.com) - US
 * [SecureNet](http://www.securenet.com) - US
@@ -154,7 +154,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Verifi](http://www.verifi.com/) - US
 * [ViaKLIX](http://viaklix.com) - US
 * [Wirecard](http://www.wirecard.com) - DE
-* [WorldPay](http://www.worldpay.com) - AU, HK, GB, US
+* [WorldPay](http://www.worldpay.com) - AU, HK, UK, US
 
 ## Supported Offsite Payment Gateways
 
@@ -162,8 +162,8 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Authorize.Net SIM](http://developer.authorize.net/api/sim/) - US
 * [Banca Sella GestPay](https://www.sella.it/banca/ecommerce/gestpay/gestpay.jsp)
 * [Chronopay](http://www.chronopay.com)
-* [Direct-eBanking / sofortueberweisung.de by Payment-Networks AG](https://www.payment-network.com/deb_com_en/merchantarea/home) - DE, AT, CH, BE, UK, NL
 * [DirecPay](http://www.timesofmoney.com/direcpay/jsp/home.jsp)
+* [Direct-eBanking / sofortueberweisung.de by Payment-Networks AG](https://www.payment-network.com/deb_com_en/merchantarea/home) - DE, AT, CH, BE, UK, NL
 * [Dotpay](http://dotpay.pl)
 * [Dwolla](https://www.dwolla.com/default.aspx)
 * [HiTRUST](http://www.hitrust.com.hk/)


### PR DESCRIPTION
Hope this seems reasonable. When looking for supported gateways in the UK, I was initially tripped up that some were 'GB' and some 'UK'. Also, they're in a slightly funny order.

Put gateway lists in alphabetical order.
(Ignoring punctuation and case; shorter-first.)

Pick a consistent country code for the UK; I don't think this doc
cares about the fine distinctions between UK of GB & NI and GB.
