### PR TITLE
Add migs gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -1,0 +1,259 @@
+require File.dirname(__FILE__) + '/migs/migs_codes'
+
+require 'digest/md5' # Used in add_secure_hash
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class MigsGateway < Gateway
+      include MigsCodes
+
+      API_VERSION = 1
+
+      SERVER_HOSTED_URL = 'https://migs.mastercard.com.au/vpcpay'
+      MERCHANT_HOSTED_URL = 'https://migs.mastercard.com.au/vpcdps'
+
+      # MiGS is supported throughout Asia Pacific, Middle East and Africa
+      # MiGS is used in Australia (AU) by ANZ (eGate), CBA (CommWeb) and more
+      # Source of Country List: http://www.scribd.com/doc/17811923
+      self.supported_countries = %w(AU AE BD BN EG HK ID IN JO KW LB LK MU MV MY NZ OM PH QA SA SG TT VN)
+
+      # The card types supported by the payment gateway
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
+
+      self.money_format = :cents
+
+      # The homepage URL of the gateway
+      self.homepage_url = 'http://mastercard.com/mastercardsps'
+
+      # The name of the gateway
+      self.display_name = 'MasterCard Internet Gateway Service (MiGS)'
+
+      # Creates a new MigsGateway
+      # The advanced_login/advanced_password fields are needed for
+      # advanced methods such as the capture, refund and status methods
+      #
+      # ==== Options
+      #
+      # * <tt>:login</tt> -- The MiGS Merchant ID (REQUIRED)
+      # * <tt>:password</tt> -- The MiGS Access Code (REQUIRED)
+      # * <tt>:secure_hash</tt> -- The MiGS Secure Hash
+      # (Required for Server Hosted payments)
+      # * <tt>:advanced_login</tt> -- The MiGS AMA User
+      # * <tt>:advanced_password</tt> -- The MiGS AMA User's password
+      def initialize(options = {})
+        requires!(options, :login, :password)
+        @test = options[:login].start_with?('TEST')
+        @options = options
+        super
+      end
+
+      # ==== Options
+      #
+      # * <tt>:order_id</tt> -- A reference for tracking the order (REQUIRED)
+      # * <tt>:unique_id</tt> -- A unique id for this request (Max 40 chars).
+      # If not supplied one will be generated.
+      def purchase(money, creditcard, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        post[:Amount] = amount(money)
+        add_invoice(post, options)
+        add_creditcard(post, creditcard)
+        add_standard_parameters('pay', post, options[:unique_id])
+
+        commit(post)
+      end
+
+      # MiGS works by merchants being either purchase only or authorize/capture
+      # So authorize is the same as purchase when in authorize mode
+      alias_method :authorize, :purchase
+
+      # ==== Options
+      #
+      # * <tt>:unique_id</tt> -- A unique id for this request (Max 40 chars).
+      # If not supplied one will be generated.
+      def capture(money, authorization, options = {})
+        requires!(@options, :advanced_login, :advanced_password)
+
+        post = options.merge(:TransNo => authorization)
+        post[:Amount] = amount(money)
+        add_advanced_user(post)
+        add_standard_parameters('capture', post, options[:unique_id])
+
+        commit(post)
+      end
+
+      # ==== Options
+      #
+      # * <tt>:unique_id</tt> -- A unique id for this request (Max 40 chars).
+      # If not supplied one will be generated.
+      def refund(money, authorization, options = {})
+        requires!(@options, :advanced_login, :advanced_password)
+
+        post = options.merge(:TransNo => authorization)
+        post[:Amount] = amount(money)
+        add_advanced_user(post)
+        add_standard_parameters('refund', post, options[:unique_id])
+
+        commit(post)
+      end
+
+      def credit(money, authorization, options = {})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, authorization, options)
+      end
+
+      # Checks the status of a previous transaction
+      # This can be useful when a response is not received due to network issues
+      #
+      # ==== Parameters
+      #
+      # * <tt>unique_id</tt> -- Unique id of transaction to find.
+      #   This is the value of the option supplied in other methods or
+      #   if not supplied is returned with key :MerchTxnRef
+      def status(unique_id)
+        requires!(@options, :advanced_login, :advanced_password)
+
+        post = {}
+        add_advanced_user(post)
+        add_standard_parameters('queryDR', post, unique_id)
+
+        commit(post)
+      end
+
+      # Generates a URL to redirect user to MiGS to process payment
+      # Once user is finished MiGS will redirect back to specified URL
+      # With a response hash which can be turned into a Response object
+      # with purchase_offsite_response
+      #
+      # ==== Options
+      #
+      # * <tt>:order_id</tt> -- A reference for tracking the order (REQUIRED)
+      # * <tt>:locale</tt> -- Change the language of the redirected page
+      #   Values are 2 digit locale, e.g. en, es
+      # * <tt>:return_url</tt> -- the URL to return to once the payment is complete
+      # * <tt>:card_type</tt> -- Providing this skips the card type step.
+      #   Values are ActiveMerchant formats: e.g. master, visa, american_express, diners_club
+      # * <tt>:unique_id</tt> -- Unique id of transaction to find.
+      #   If not supplied one will be generated.
+      def purchase_offsite_url(money, options = {})
+        requires!(options, :order_id, :return_url)
+        requires!(@options, :secure_hash)
+
+        post = {}
+        post[:Amount] = amount(money)
+        add_invoice(post, options)
+        add_creditcard_type(post, options[:card_type]) if options[:card_type]
+
+        post.merge!(
+          :Locale => options[:locale] || 'en',
+          :ReturnURL => options[:return_url]
+        )
+
+        add_standard_parameters('pay', post, options[:unique_id])
+
+        add_secure_hash(post)
+
+        SERVER_HOSTED_URL + '?' + post_data(post)
+      end
+
+      # Parses a response from purchase_offsite_url once user is redirected back
+      #
+      # ==== Parameters
+      #
+      # * <tt>data</tt> -- All params when offsite payment returns
+      # e.g. returns to http://company.com/return?a=1&b=2, then input "a=1&b=2"
+      def purchase_offsite_response(data)
+        requires!(@options, :secure_hash)
+
+        response_hash = parse(data)
+
+        expected_secure_hash = calculate_secure_hash(response_hash.reject{|k, v| k == :SecureHash}, @options[:secure_hash])
+        unless response_hash[:SecureHash] == expected_secure_hash
+          raise SecurityError, "Secure Hash mismatch, response may be tampered with"
+        end
+
+        response_object(response_hash)
+      end
+
+      private
+
+      def add_advanced_user(post)
+        post[:User] = @options[:advanced_login]
+        post[:Password] = @options[:advanced_password]
+      end
+
+      def add_invoice(post, options)
+        post[:OrderInfo] = options[:order_id]
+      end
+
+      def add_creditcard(post, creditcard)
+        post[:CardNum] = creditcard.number
+        post[:CardSecurityCode] = creditcard.verification_value if creditcard.verification_value?
+        post[:CardExp] = format(creditcard.year, :two_digits) + format(creditcard.month, :two_digits)
+      end
+
+      def add_creditcard_type(post, card_type)
+        post[:Gateway]  = 'ssl'
+        post[:card] = CARD_TYPES.detect{|ct| ct.am_code == card_type}.migs_long_code
+      end
+
+      def parse(body)
+        params = CGI::parse(body)
+        hash = {}
+        params.each do |key, value|
+          hash[key.gsub('vpc_', '').to_sym] = value[0]
+        end
+        hash
+      end
+
+      def commit(post)
+        data = ssl_post MERCHANT_HOSTED_URL, post_data(post)
+        response_hash = parse(data)
+        response_object(response_hash)
+      end
+
+      def response_object(response)
+        Response.new(success?(response), response[:Message], response,
+          :test => @test,
+          :authorization => response[:TransactionNo],
+          :fraud_review => fraud_review?(response),
+          :avs_result => { :code => response[:AVSResultCode] },
+          :cvv_result => response[:CSCResultCode]
+        )
+      end
+
+      def success?(response)
+        response[:TxnResponseCode] == '0'
+      end
+
+      def fraud_review?(response)
+        ISSUER_RESPONSE_CODES[response[:AcqResponseCode]] == 'Suspected Fraud'
+      end
+
+      def add_standard_parameters(action, post, unique_id = nil)
+        post.merge!(
+          :Version     => API_VERSION,
+          :Merchant    => @options[:login],
+          :AccessCode  => @options[:password],
+          :Command     => action,
+          :MerchTxnRef => unique_id || generate_unique_id.slice(0, 40)
+        )
+      end
+
+      def post_data(post)
+        post.collect { |key, value| "vpc_#{key}=#{CGI.escape(value.to_s)}" }.join("&")
+      end
+
+      def add_secure_hash(post)
+        post[:SecureHash] = calculate_secure_hash(post, @options[:secure_hash])
+      end
+
+      def calculate_secure_hash(post, secure_hash)
+        sorted_values = post.sort_by(&:to_s).map(&:last)
+        input = secure_hash + sorted_values.join
+        Digest::MD5.hexdigest(input).upcase
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/migs/migs_codes.rb
+++ b/lib/active_merchant/billing/gateways/migs/migs_codes.rb
@@ -1,0 +1,100 @@
+module ActiveMerchant
+  module Billing
+    module MigsCodes
+      TXN_RESPONSE_CODES = {
+        '?' => 'Response Unknown',
+        '0' => 'Transaction Successful',
+        '1' => 'Transaction Declined - Bank Error',
+        '2' => 'Bank Declined Transaction',
+        '3' => 'Transaction Declined - No Reply from Bank',
+        '4' => 'Transaction Declined - Expired Card',
+        '5' => 'Transaction Declined - Insufficient funds',
+        '6' => 'Transaction Declined - Error Communicating with Bank',
+        '7' => 'Payment Server Processing Error - Typically caused by invalid input data such as an invalid credit card number. Processing errors can also occur',
+        '8' => 'Transaction Declined - Transaction Type Not Supported',
+        '9' => 'Bank Declined Transaction (Do not contact Bank)',
+        'A' => 'Transaction Aborted',
+        'C' => 'Transaction Cancelled',
+        'D' => 'Deferred Transaction',
+        'E' => 'Issuer Returned a Referral Response',
+        'F' => '3D Secure Authentication Failed',
+        'I' => 'Card Security Code Failed',
+        'L' => 'Shopping Transaction Locked (This indicates that there is another transaction taking place using the same shopping transaction number)',
+        'N' => 'Cardholder is not enrolled in 3D Secure (Authentication Only)',
+        'P' => 'Transaction is Pending',
+        'R' => 'Retry Limits Exceeded, Transaction Not Processed',
+        'S' => 'Duplicate OrderInfo used. (This is only relevant for Payment Servers that enforce the uniqueness of this field)',
+        'U' => 'Card Security Code Failed'
+      }
+
+      ISSUER_RESPONSE_CODES = {
+        '00' => 'Approved',
+        '01' => 'Refer to Card Issuer',
+        '02' => 'Refer to Card Issuer',
+        '03' => 'Invalid Merchant',
+        '04' => 'Pick Up Card',
+        '05' => 'Do Not Honor',
+        '07' => 'Pick Up Card',
+        '12' => 'Invalid Transaction',
+        '14' => 'Invalid Card Number (No such Number)',
+        '15' => 'No Such Issuer',
+        '33' => 'Expired Card',
+        '34' => 'Suspected Fraud',
+        '36' => 'Restricted Card',
+        '39' => 'No Credit Account',
+        '41' => 'Card Reported Lost',
+        '43' => 'Stolen Card',
+        '51' => 'Insufficient Funds',
+        '54' => 'Expired Card',
+        '57' => 'Transaction Not Permitted',
+        '59' => 'Suspected Fraud',
+        '62' => 'Restricted Card',
+        '65' => 'Exceeds withdrawal frequency limit',
+        '91' => 'Cannot Contact Issuer'
+      }
+
+      VERIFIED_3D_CODES = {
+        'Y' => 'The cardholder was successfully authenticated.',
+        'E' => 'The cardholder is not enrolled.',
+        'N' => 'The cardholder was not verified.',
+        'U' => 'The cardholder\'s Issuer was unable to authenticate due to a system error at the Issuer.',
+        'F' => 'An error exists in the format of the request from the merchant. For example, the request did not contain all required fields, or the format of some fields was invalid.',
+        'A' => 'Authentication of your Merchant ID and Password to the Directory Server Failed (see "What does a Payment Authentication Status of "A" mean?" on page 85).',
+        'D' => 'Error communicating with the Directory Server, for example, the Payment Server could not connect to the directory server or there was a versioning mismatch.',
+        'C' => 'The card type is not supported for authentication.',
+        'M' => 'This indicates that attempts processing was used. Verification is marked with status M - ACS attempts processing used. Payment is performed with authentication. Attempts is when a cardholder has successfully passed the directory server but decides not to continue with the authentication process and cancels.',
+        'S' => 'The signature on the response received from the Issuer could not be validated. This should be considered a failure.',
+        'T' => 'ACS timed out. The Issuer\'s ACS did not respond to the Authentication request within the time out period.',
+        'P' => 'Error parsing input from Issuer.',
+        'I' => 'Internal Payment Server system error. This could be caused by a temporary DB failure or an error in the security module or by some error in an internal system.'
+      }
+
+      class CreditCardType
+        attr_accessor :am_code, :migs_code, :migs_long_code, :name
+        def initialize(am_code, migs_code, migs_long_code, name)
+          @am_code        = am_code
+          @migs_code      = migs_code
+          @migs_long_code = migs_long_code
+          @name           = name
+        end
+      end
+
+      CARD_TYPES = [
+        # The following are 4 different representations of credit card types
+        # am_code: The active merchant code
+        # migs_code: Used in response for purchase/authorize/status
+        # migs_long_code: Used to pre-select card for server_purchase_url
+        # name: The nice display name
+        %w(american_express AE Amex             American\ Express),
+        %w(diners_club      DC Dinersclub       Diners\ Club),
+        %w(jcb              JC JCB              JCB\ Card),
+        %w(maestro          MS Maestro          Maestro\ Card),
+        %w(master           MC Mastercard       MasterCard),
+        %w(na               PL PrivateLabelCard Private\ Label\ Card),
+        %w(visa             VC Visa             Visa\ Card')
+      ].map do |am_code, migs_code, migs_long_code, name|
+        CreditCardType.new(am_code, migs_code, migs_long_code, name)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -159,6 +159,22 @@ merchant_ware:
  password: 
  name: 
 
+# Working credentials, no need to replace
+migs_purchase: # MiGS gateway for purchase mode
+  login: TESTANZTEST3
+  password: '6447E199'
+  secure_hash: '76AF3392002D202A60D0AB5F9D81653C'
+  advanced_login: noack_ama
+  advanced_password: test1234
+
+# Working credentials, no need to replace
+migs_capture: # MiGS gateway for auth/capture mode
+  login: TESTANZTEST2
+  password: '8ED23813'
+  secure_hash: '5816DF2E29819E43EA7C1F6E0DC2F1B5'
+  advanced_login: noack_ama
+  advanced_password: test1234
+
 modern_payments:
   login: login
   password: password

--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+require 'net/http'
+
+class RemoteMigsTest < Test::Unit::TestCase
+  def setup
+    @gateway = MigsGateway.new(fixtures(:migs_purchase))
+    @capture_gateway = MigsGateway.new(fixtures(:migs_capture))
+
+    @amount = 100
+    @declined_amount = 105
+    @visa   = credit_card('4005550000000001', :month => 5, :year => 2013, :type => 'visa')
+    @master = credit_card('5123456789012346', :month => 5, :year => 2013, :type => 'master')
+    @amex   = credit_card('371449635311004',  :month => 5, :year => 2013, :type => 'american_express')
+    @diners = credit_card('30123456789019',   :month => 5, :year => 2013, :type => 'diners_club')
+    @credit_card = @visa
+
+    @options = {
+      :order_id => '1'
+    }
+  end
+
+  def test_server_purchase_url
+    options = {
+      :order_id   => 1,
+      :unique_id  => 9,
+      :return_url => 'http://localhost:8080/payments/return'
+    }
+
+    choice_url = @gateway.purchase_offsite_url(@amount, options)
+    assert_response_contains 'Pay securely by clicking on the card logo below', choice_url
+
+    responses = {
+      'visa'             => 'You have chosen <B>VISA</B>',
+      'master'           => 'You have chosen <B>MasterCard</B>',
+      'diners_club'      => 'You have chosen <B>Diners Club</B>',
+      'american_express' => 'You have chosen <B>American Express</B>'
+    }
+
+    responses.each_pair do |card_type, response_text|
+      url = @gateway.purchase_offsite_url(@amount, options.merge(:card_type => card_type))
+      assert_response_contains response_text, url
+    end
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase
+    assert response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_authorize_and_capture
+    assert auth = @capture_gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert capture = @capture_gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+  end
+
+  def test_failed_authorize
+    assert response = @capture_gateway.authorize(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_refund
+    assert payment_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success payment_response
+    assert response = @gateway.refund(@amount, payment_response.authorization, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_status
+    purchase_response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    assert response = @gateway.status(purchase_response.params['MerchTxnRef'])
+    assert_equal 'Y', response.params['DRExists']
+    assert_equal 'N', response.params['FoundMultipleDRs']
+  end
+
+  def test_invalid_login
+    gateway = MigsGateway.new(:login => '', :password => '')
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Required field vpc_Merchant was not present in the request', response.message
+  end
+
+  private
+
+  include ActiveMerchant::PostsData
+  def assert_response_contains(text, url)
+    response = https_response(url)
+    assert response.body.include?(text)
+  end
+
+  def https_response(url, cookie = nil)
+    headers = cookie ? {'Cookie' => cookie} : {}
+    response = raw_ssl_request(:get, url, nil, headers)
+    if response.is_a?(Net::HTTPRedirection)
+      new_cookie = [cookie, response['Set-Cookie']].compact.join(';')
+      response = https_response(response['Location'], new_cookie)
+    end
+    response
+  end
+end

--- a/test/unit/gateways/migs_test.rb
+++ b/test/unit/gateways/migs_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class MigsTest < Test::Unit::TestCase
+  def setup
+    @gateway = MigsGateway.new(
+                 :login => 'login',
+                 :password => 'password',
+                 :secure_hash => '76AF3392002D202A60D0AB5F9D81653C'
+               )
+
+    @credit_card = credit_card
+    @amount = 100
+    
+    @options = { 
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase'
+    }
+  end
+  
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+    
+    # Replace with authorization number from the successful response
+    assert_equal '123456', response.authorization
+  end
+
+  def test_unsuccessful_request
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+    
+    assert_equal '654321', response.authorization
+  end
+
+  def test_secure_hash
+    params = {
+      :MerchantId => 'MER123',
+      :OrderInfo  => 'A48cvE28',
+      :Amount     => 2995
+    }
+    ordered_values = "#{@gateway.options[:secure_hash]}2995MER123A48cvE28"
+
+    @gateway.send(:add_secure_hash, params)
+    assert_equal Digest::MD5.hexdigest(ordered_values).upcase, params[:SecureHash]
+  end
+
+  def test_purchase_offsite_response
+    # Below response from instance running remote test
+    response_params = "vpc_3DSXID=a1B8UcW%2BKYqkSinLQohGmqQd9uY%3D&vpc_3DSenrolled=U&vpc_AVSResultCode=Unsupported&vpc_AcqAVSRespCode=Unsupported&vpc_AcqCSCRespCode=Unsupported&vpc_AcqResponseCode=00&vpc_Amount=100&vpc_AuthorizeId=367739&vpc_BatchNo=20120421&vpc_CSCResultCode=Unsupported&vpc_Card=MC&vpc_Command=pay&vpc_Locale=en&vpc_MerchTxnRef=9&vpc_Merchant=TESTANZTEST3&vpc_Message=Approved&vpc_OrderInfo=1&vpc_ReceiptNo=120421367739&vpc_SecureHash=8794D9478D030B65F3092282E76283F8&vpc_TransactionNo=2000025183&vpc_TxnResponseCode=0&vpc_VerSecurityLevel=06&vpc_VerStatus=U&vpc_VerType=3DS&vpc_Version=1"
+
+    response_hash = @gateway.send(:parse, response_params)
+    response_hash.delete(:SecureHash)
+    calculated_hash = @gateway.send(:calculate_secure_hash, response_hash, @gateway.options[:secure_hash])
+    assert_equal '8794D9478D030B65F3092282E76283F8', calculated_hash
+
+    response = @gateway.purchase_offsite_response(response_params)
+    assert_success response
+
+    tampered_response1 = response_params.gsub('83F8', '93F8')
+    assert_raise(SecurityError){@gateway.purchase_offsite_response(tampered_response1)}
+
+    tampered_response2 = response_params.gsub('Locale=en', 'Locale=es')
+    assert_raise(SecurityError){@gateway.purchase_offsite_response(tampered_response2)}
+  end
+
+  private
+  
+  # Place raw successful response from gateway here
+  def successful_purchase_response
+    build_response(
+      :TxnResponseCode => '0',
+      :TransactionNo   => '123456'
+    )
+  end
+  
+  # Place raw failed response from gateway here
+  def failed_purchase_response
+    build_response(
+      :TxnResponseCode => '3',
+      :TransactionNo   => '654321'
+    )
+  end
+  
+  def build_response(options)
+    options.collect { |key, value| "vpc_#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+  end
+end


### PR DESCRIPTION
_Introduction_
MasterCard Internet Gateway Service (MiGS) is a gateway used in Asia, Oceania, the Middle East and Africa. It's especially popular in Australia where it's used by 2 of the "Big 4" Australian banks where it's branded ANZ eGate and CommWeb

_The code_
- Covers the purchase mode and auth/capture mode
- Handles offsite payments
- Working test accounts for above scenarios
- Tests all public methods
- Non standard arguments/options (e.g. not creditcard, money, authorization arguments) are documented
