### PR TITLE
 payment_service_for don't work with Quickpay

### DIFF
--- a/lib/active_merchant/billing/integrations/quickpay/helper.rb
+++ b/lib/active_merchant/billing/integrations/quickpay/helper.rb
@@ -5,12 +5,13 @@ module ActiveMerchant #:nodoc:
         class Helper < ActiveMerchant::Billing::Integrations::Helper
 
           def initialize(order, account, options = {})
+            md5secret options.delete(:credential2)
             super
             add_field('protocol', '3')
             add_field('msgtype', 'authorize')
             add_field('language', 'da')
             add_field('autocapture', 0)
-            add_field('testmode', 0)
+            add_field('testmode', test? ? 1 : 0)
             add_field('ordernumber', format_order_number(order))
           end
               
@@ -58,8 +59,6 @@ module ActiveMerchant #:nodoc:
           mapping :description, 'description'
           mapping :ipaddress, 'ipaddress'
           mapping :testmode, 'testmode'
-
-          mapping :credential2, 'md5secret'
 
           mapping :customer, ''
           mapping :billing_address, {}

--- a/test/unit/integrations/helpers/quickpay_helper_test.rb
+++ b/test/unit/integrations/helpers/quickpay_helper_test.rb
@@ -18,12 +18,12 @@ class QuickpayHelperTest < Test::Unit::TestCase
   end
   
   def test_generate_md5string
-    assert_equal '3authorize24352435daorder500500USDhttp://example.com/okhttp://example.com/cancelhttp://example.com/notify00mysecretmd5string', 
+    assert_equal '3authorize24352435daorder500500USDhttp://example.com/okhttp://example.com/cancelhttp://example.com/notify01mysecretmd5string', 
                  @helper.generate_md5string
   end
   
   def test_generate_md5check
-    assert_equal '31a0a94ce953208d05f3f3d255fff31f', @helper.generate_md5check
+    assert_equal '3dc7b51567c4911cc38511f796773366', @helper.generate_md5check
   end
   
   def test_unknown_mapping


### PR DESCRIPTION
When you use the "ActionViewHelper" method  `payment_service_for` with the service `:quickpay`, you get the following error:

``` rails
TypeError: can't convert nil into String
    from /Users/johanfrolich/.rvm/gems/ruby-1.9.2-p180@boxerwine/gems/activemerchant-1.21.0/lib/active_merchant/billing/integrations/quickpay/helper.rb:26:in `+'
    from /Users/johanfrolich/.rvm/gems/ruby-1.9.2-p180@boxerwine/gems/activemerchant-1.21.0/lib/active_merchant/billing/integrations/quickpay/helper.rb:26:in `generate_md5string'
    from /Users/johanfrolich/.rvm/gems/ruby-1.9.2-p180@boxerwine/gems/activemerchant-1.21.0/lib/active_merchant/billing/integrations/quickpay/helper.rb:30:in `generate_md5check'
    from /Users/johanfrolich/.rvm/gems/ruby-1.9.2-p180@boxerwine/gems/activemerchant-1.21.0/lib/active_merchant/billing/integrations/quickpay/helper.rb:22:in `form_fields'
```

The method `generate_md5string` that is being called, needs a instance variable `@md5secret` to generate the md5check field. This variable must be set though its own setter method (`md5secret(value)`), but `payment_service_for` never call this method, so `@md5secret` is nil. 
Setting the credentials2 options which get mapped to the field md5secret does not works as the field md5secret is not the same as `@md5secret`

I have made a hack by writing the following in a initializer :

``` ruby
ActiveMerchant::Billing::Integrations::Quickpay::Helper.class_eval do
  def initialize(order, account, options = {})
    @md5secret = options.delete(:credential2)
    super
    add_field('protocol', '3')
    add_field('msgtype', 'authorize')
    add_field('language', 'da')
    add_field('autocapture', 0)
    add_field('testmode', 0)
    add_field('ordernumber', format_order_number(order))
  end
end
```

I could make this to a pull request, i would just be sure that i understood the problem correctly?
