### PR TITLE
Add mode mapping to two checkout integration helper

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout/helper.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout/helper.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
           # a unique order id from your program. (128 characters max)
           mapping :order, 'cart_order_id'
 
+          mapping :mode, 'mode'
 
           mapping :customer, :email      => 'email',
                              :phone      => 'phone'
@@ -51,6 +52,20 @@ module ActiveMerchant #:nodoc:
             add_field(mappings[:customer][:email], params[:email])
             add_field(mappings[:customer][:phone], params[:phone])
             add_field('card_holder_name', "#{params[:first_name]} #{params[:last_name]}")
+          end
+          
+          def line_item(params = {})
+            max_existing_line_item_id = form_fields.keys.map do |key| 
+              match = key.to_s.match(/li_(\d+)_/)
+              if match
+                match[1]
+              end
+            end.reject(&:nil?).max.to_i
+            
+            line_item_id = max_existing_line_item_id + 1
+            params.each do |key, value|
+              add_field("li_#{line_item_id}_#{key}", value)
+            end
           end
         end
       end

--- a/test/unit/integrations/helpers/two_checkout_helper_test.rb
+++ b/test/unit/integrations/helpers/two_checkout_helper_test.rb
@@ -24,7 +24,18 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     assert_field 'email', 'cody@example.com'
     assert_field 'phone', '(555)555-5555'
   end
-
+  
+  def test_line_item_fields
+    @helper.line_item :quantity => 1, :recurrence => '1 Week'
+    @helper.line_item :description => 'Test Product', :price => '15.0'
+    
+    assert_field 'li_1_quantity', '1'
+    assert_field 'li_1_recurrence', '1 Week'
+    
+    assert_field 'li_2_description', 'Test Product'
+    assert_field 'li_2_price', '15.0'
+  end
+  
   def test_address_mapping
     @helper.billing_address :address1 => '1 My Street',
                             :address2 => 'Apt. 1',


### PR DESCRIPTION
Added

```
mapping :mode, 'mode'
```

It is a required param for the Pass Through Product Parameter Set, see:
https://www.2checkout.com/blog/knowledge-base/merchants/tech-support/3rd-party-carts/parameter-sets/pass-through-product-parameter-set/
