### PR TITLE
Introduced payment_routine method for better service_url handling

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout.rb
@@ -6,9 +6,31 @@ module ActiveMerchant #:nodoc:
         autoload 'Return', File.dirname(__FILE__) + '/two_checkout/return'
         autoload 'Notification', File.dirname(__FILE__) + '/two_checkout/notification'
        
-        mattr_accessor :service_url
-        self.service_url = 'https://www.2checkout.com/checkout/purchase'
-
+        mattr_accessor :payment_routine
+        self.payment_routine = :multi_page
+        
+        def self.service_url
+          case self.payment_routine
+          when :multi_page
+            'https://www.2checkout.com/checkout/purchase'  
+          when :single_page
+            'https://www.2checkout.com/checkout/spurchase'
+          else
+            raise StandardError, "Integration payment routine set to an invalid value: #{self.payment_routine}"
+          end
+        end
+        
+        def self.service_url=(service_url)
+          # Note: do not use this method, it is here for backward compatibility
+          # Use the payment_routine method to change service_url
+          if service_url =~ /spurchase/
+            self.payment_routine = :single_page
+          else
+            self.payment_routine = :multi_page
+          end
+        end
+        
+        
         def self.notification(post, options = {})
           Notification.new(post)
         end  

--- a/test/unit/integrations/two_checkout_module_test.rb
+++ b/test/unit/integrations/two_checkout_module_test.rb
@@ -3,6 +3,25 @@ require 'test_helper'
 class TwoCheckoutModuleTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
   
+  def test_default_service_url
+    assert_equal 'https://www.2checkout.com/checkout/purchase', TwoCheckout.service_url
+  end
+  
+  def test_legacy_service_url_writer
+    TwoCheckout.service_url = 'https://www.2checkout.com/checkout/spurchase'
+    assert_equal :single_page, TwoCheckout.payment_routine
+  end
+  
+  def test_single_page_payment_routine_service_url
+    TwoCheckout.payment_routine = :single_page
+    assert_equal 'https://www.2checkout.com/checkout/spurchase', TwoCheckout.service_url
+  end
+  
+  def test_multi_page_payment_routine_service_url
+    TwoCheckout.payment_routine = :multi_page
+    assert_equal 'https://www.2checkout.com/checkout/purchase', TwoCheckout.service_url
+  end
+  
   def test_notification_method
     assert_instance_of TwoCheckout::Notification, TwoCheckout.notification('name=cody', {})
   end


### PR DESCRIPTION
2checkout supports two service urls (see the source link at the end):

Multi-page Payment Routine: https://www.2checkout.com/checkout/purchase

Single Page Payment Routine: https://www.2checkout.com/checkout/spurchase

I added the `payment_routine` method to be able to switch between these service urls.

```
def test_single_page_payment_routine_service_url
  TwoCheckout.payment_routine = :single_page
  assert_equal 'https://www.2checkout.com/checkout/spurchase', TwoCheckout.service_url
end

def test_multi_page_payment_routine_service_url
  TwoCheckout.payment_routine = :multi_page
  assert_equal 'https://www.2checkout.com/checkout/purchase', TwoCheckout.service_url
end
```

I also modified `service_url=` for backward compatibility so that similar code would keep working (in case someone was doing this):

```
ActiveMerchant::Billing::Integrations::TwoCheckout.service_url = "https://www.2checkout.com/checkout/spurchase"
```

Source: https://www.2checkout.com/blog/knowledge-base/merchants/tech-support/3rd-party-carts/parameter-sets/pass-through-product-parameter-set/
