### PR TITLE
Removes trailing spaces from generator templates

### DIFF
--- a/generators/gateway/templates/gateway.rb
+++ b/generators/gateway/templates/gateway.rb
@@ -3,72 +3,72 @@ module ActiveMerchant #:nodoc:
     class <%= class_name %>Gateway < Gateway
       TEST_URL = 'https://example.com/test'
       LIVE_URL = 'https://example.com/live'
-      
+
       # The countries the gateway supports merchants from as 2 digit ISO country codes
       self.supported_countries = ['US']
-      
+
       # The card types supported by the payment gateway
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
-      
+
       # The homepage URL of the gateway
       self.homepage_url = 'http://www.example.net/'
-      
+
       # The name of the gateway
       self.display_name = 'New Gateway'
-      
+
       def initialize(options = {})
         #requires!(options, :login, :password)
         @options = options
         super
-      end  
-      
+      end
+
       def authorize(money, creditcard, options = {})
         post = {}
         add_invoice(post, options)
-        add_creditcard(post, creditcard)        
-        add_address(post, creditcard, options)        
+        add_creditcard(post, creditcard)
+        add_address(post, creditcard, options)
         add_customer_data(post, options)
-        
+
         commit('authonly', money, post)
       end
-      
+
       def purchase(money, creditcard, options = {})
         post = {}
         add_invoice(post, options)
-        add_creditcard(post, creditcard)        
-        add_address(post, creditcard, options)   
+        add_creditcard(post, creditcard)
+        add_address(post, creditcard, options)
         add_customer_data(post, options)
-             
+
         commit('sale', money, post)
-      end                       
-    
+      end
+
       def capture(money, authorization, options = {})
         commit('capture', money, post)
       end
-    
-      private                       
-      
+
+      private
+
       def add_customer_data(post, options)
       end
 
-      def add_address(post, creditcard, options)      
+      def add_address(post, creditcard, options)
       end
 
       def add_invoice(post, options)
       end
-      
-      def add_creditcard(post, creditcard)      
+
+      def add_creditcard(post, creditcard)
       end
-      
+
       def parse(body)
-      end     
-      
+      end
+
       def commit(action, money, parameters)
       end
 
       def message_from(response)
       end
-      
+
       def post_data(action, parameters = {})
       end
     end

--- a/generators/gateway/templates/gateway_test.rb
+++ b/generators/gateway/templates/gateway_test.rb
@@ -9,21 +9,21 @@ class <%= class_name %>Test < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
-    
-    @options = { 
+
+    @options = {
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase'
     }
   end
-  
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_instance_of 
+    assert_instance_of
     assert_success response
-    
+
     # Replace with authorization number from the successful response
     assert_equal '', response.authorization
     assert response.test?
@@ -31,18 +31,18 @@ class <%= class_name %>Test < Test::Unit::TestCase
 
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert response.test?
   end
 
   private
-  
+
   # Place raw successful response from gateway here
   def successful_purchase_response
   end
-  
+
   # Place raw failed response from gateway here
   def failed_purchase_response
   end

--- a/generators/gateway/templates/remote_gateway_test.rb
+++ b/generators/gateway/templates/remote_gateway_test.rb
@@ -1,22 +1,22 @@
 require 'test_helper'
 
 class Remote<%= class_name %>Test < Test::Unit::TestCase
-  
+
 
   def setup
     @gateway = <%= class_name %>Gateway.new(fixtures(:<%= class_name.underscore %>))
-    
+
     @amount = 100
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
-    
-    @options = { 
+
+    @options = {
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase'
     }
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/generators/integration/templates/integration.rb
+++ b/generators/integration/templates/integration.rb
@@ -4,14 +4,14 @@ require File.dirname(__FILE__) + '/<%= name %>/notification.rb'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module Integrations #:nodoc:
-      module <%= class_name %> 
-       
+      module <%= class_name %>
+
         mattr_accessor :service_url
         self.service_url = 'https://www.example.com'
 
         def self.notification(post)
           Notification.new(post)
-        end  
+        end
       end
     end
   end

--- a/generators/integration/templates/module_test.rb
+++ b/generators/integration/templates/module_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class <%= class_name %>ModuleTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
-  
+
   def test_notification_method
     assert_instance_of <%= class_name %>::Notification, <%= class_name %>.notification('name=cody')
   end
-end 
+end

--- a/generators/integration/templates/notification.rb
+++ b/generators/integration/templates/notification.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
         class Notification < ActiveMerchant::Billing::Integrations::Notification
           def complete?
             params['']
-          end 
+          end
 
           def item_id
             params['']
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
             params['']
           end
 
-          # When was this payment received by the client. 
+          # When was this payment received by the client.
           def received_at
             params['']
           end
@@ -25,10 +25,10 @@ module ActiveMerchant #:nodoc:
           def payer_email
             params['']
           end
-         
+
           def receiver_email
             params['']
-          end 
+          end
 
           def security_key
             params['']
@@ -48,21 +48,21 @@ module ActiveMerchant #:nodoc:
             params['']
           end
 
-          # Acknowledge the transaction to <%= class_name %>. This method has to be called after a new 
-          # apc arrives. <%= class_name %> will verify that all the information we received are correct and will return a 
-          # ok or a fail. 
-          # 
+          # Acknowledge the transaction to <%= class_name %>. This method has to be called after a new
+          # apc arrives. <%= class_name %> will verify that all the information we received are correct and will return a
+          # ok or a fail.
+          #
           # Example:
-          # 
+          #
           #   def ipn
           #     notify = <%= class_name %>Notification.new(request.raw_post)
           #
-          #     if notify.acknowledge 
+          #     if notify.acknowledge
           #       ... process order ... if notify.complete?
           #     else
           #       ... log possible hacking attempt ...
           #     end
-          def acknowledge      
+          def acknowledge
             payload = raw
 
             uri = URI.parse(<%= class_name %>.notification_confirmation_url)
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
 
             request['Content-Length'] = "#{payload.size}"
             request['User-Agent'] = "Active Merchant -- http://home.leetsoft.com/am"
-            request['Content-Type'] = "application/x-www-form-urlencoded" 
+            request['Content-Type'] = "application/x-www-form-urlencoded"
 
             http = Net::HTTP.new(uri.host, uri.port)
             http.verify_mode    = OpenSSL::SSL::VERIFY_NONE unless @ssl_strict

--- a/generators/integration/templates/notification_test.rb
+++ b/generators/integration/templates/notification_test.rb
@@ -23,7 +23,7 @@ class <%= class_name %>NotificationTest < Test::Unit::TestCase
   end
 
   # Replace with real successful acknowledgement code
-  def test_acknowledgement    
+  def test_acknowledgement
 
   end
 
@@ -37,5 +37,5 @@ class <%= class_name %>NotificationTest < Test::Unit::TestCase
   private
   def http_raw_data
     ""
-  end  
+  end
 end


### PR DESCRIPTION
Noticed that the generator was creating code with trailing spaces and decided to fix it
