### PR TITLE
Payflow improvements: don't auto-set start_date and allow modification of RetryNumDays

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -207,8 +207,13 @@ module ActiveMerchant #:nodoc:
                     xml.tag! 'OptionalTrans', TRANSACTIONS[initial_tx[:type]]
                     xml.tag! 'OptionalTransAmt', amount(initial_tx[:amount]) unless initial_tx[:amount].blank?
                   end
-                
-                  xml.tag! 'Start', format_rp_date(options[:starting_at] || Date.today + 1 )
+                  
+                  if action == :add
+                    xml.tag! 'Start', format_rp_date(options[:starting_at] || Date.today + 1 )
+                  else
+                    xml.tag! 'Start', format_rp_date(options[:starting_at]) unless options[:starting_at].nil?
+                  end
+                  
                   xml.tag! 'EMail', options[:email] unless options[:email].nil?
                   
                   billing_address = options[:billing_address] || options[:address]


### PR DESCRIPTION
These two commits add the following (with tests):
- starting_at date is no longer defaulted to Date.tomorrow when modifying recurring profiles. Modifying profiles does not require starting_at date, and we were bit by this when we modified a bunch of recurring profiles only to find that the starting_at date had been reset to tomorrow for all of them because we had omitted the starting_at parameter.
- RetryNumDays, which sets how many days payflow retries a declined transaction, can now be set when modifying or creating a recurring profile.
