### PR TITLE
Orbital: Don't send AVS address details for any country besides

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -77,6 +77,8 @@ module ActiveMerchant #:nodoc:
         "EUR" => '978'
       }
 
+      AVS_SUPPORTED_COUNTRIES = ['US', 'CA', 'UK', 'GB']
+
       def initialize(options = {})
         requires!(options, :merchant_id)
         requires!(options, :login, :password) unless options[:ip_authentication]
@@ -148,12 +150,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, creditcard, options)      
         if address = options[:billing_address] || options[:address]
-          xml.tag! :AVSzip, address[:zip]
-          xml.tag! :AVSaddress1, address[:address1]
-          xml.tag! :AVSaddress2, address[:address2]
-          xml.tag! :AVScity, address[:city]
-          xml.tag! :AVSstate, address[:state]
-          xml.tag! :AVSphoneNum, address[:phone] ? address[:phone].scan(/\d/).join.to_s : nil
+          add_avs_details(xml, address)
           xml.tag! :AVSname, creditcard.name
           xml.tag! :AVScountryCode, address[:country]
         end
@@ -177,6 +174,18 @@ module ActiveMerchant #:nodoc:
         xml.tag! :CurrencyExponent, '2' # Will need updating to support currencies such as the Yen.
       end
       
+      def add_avs_details(xml, address)
+        return unless AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s)
+
+        xml.tag! :AVSzip, address[:zip]
+        xml.tag! :AVSaddress1, address[:address1]
+        xml.tag! :AVSaddress2, address[:address2]
+        xml.tag! :AVScity, address[:city]
+        xml.tag! :AVSstate, address[:state]
+        xml.tag! :AVSphoneNum, address[:phone] ? address[:phone].scan(/\d/).join.to_s : nil
+      end
+
+
       def parse(body)
         response = {}
         xml = REXML::Document.new(body)


### PR DESCRIPTION
## Problem

A few selected transactions from e.g. Netherlands failed with the error "Request does not adhere to the DTD. Please correct and send again."

After brining it up with Chase support they said that:

> Most likely it is the address.  AVS verification occurs only for transactions in the U.S., Canada, and Great Britain.  Outside of these no address verification is present.
> Additionally special characters in the address field outside those specified in the schema along with length limits could cause this error. 
> While a customer can process transactions using a card from many countries the merchant is limited in what information they submit to us.
> We recommend not submitting address information for transactions outside of those countries, our system does not use the information and it could cause issues like this.
## Solution

Only send name and country code for all addresses outside of US, CA, GB and UK

Based off the XML Schema file called Request_PTI54.psd from the zip file http://download.chasepaymentech.com/docs/orbital/online_xml_api_schema_xsd_only.zip, line 829:
https://img.skitch.com/20120515-j9fk1mqak6ifxr8y676sdeyb8j.jpg (screenshot)

Please review @jduff @odorcicd 
