### PR TITLE
adding c_prod parameter support

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
         autoload 'Notification', File.dirname(__FILE__) + '/two_checkout/notification'
        
         mattr_accessor :payment_routine
-        self.payment_routine = :multi_page
+        self.payment_routine = :single_page
         
         def self.service_url
           case self.payment_routine

--- a/lib/active_merchant/billing/integrations/two_checkout/helper.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout/helper.rb
@@ -6,65 +6,86 @@ module ActiveMerchant #:nodoc:
           def initialize(order, account, options = {})
             super
             add_field('fixed', 'Y')
-            
+
             if ActiveMerchant::Billing::Base.integration_mode == :test || options[:test]
               add_field('demo', 'Y')
-            end 
+            end
           end
-          
+
           # The 2checkout vendor account number
           mapping :account, 'sid'
-          
-          # he total amount to be billed, in decimal form, without a currency symbol. (8 characters, decimal, 2 characters: Example: 99999999.99)
+
+          # The total amount to be billed, in decimal form, without a currency symbol. (8 characters, decimal, 2 characters: Example: 99999999.99)
           mapping :amount, 'total'
-        
-          # a unique order id from your program. (128 characters max)
+
+          # Pass your order id if you are using Third Part Cart Parameters. (128 characters max)
           mapping :order, 'cart_order_id'
 
+          # Pass your order id if you are using the Pass Through Products Parameters.  (50 characters max)
+          mapping :invoice, 'merchant_order_id'
+
+          # Left here for backward compatibility, do not use. The line_item method will add automatically.
           mapping :mode, 'mode'
 
           mapping :customer, :email      => 'email',
-                             :phone      => 'phone'
+                  :phone      => 'phone'
 
           mapping :billing_address, :city     => 'city',
-                                    :address1 => 'street_address',
-                                    :address2 => 'street_address2',
-                                    :state    => 'state',
-                                    :zip      => 'zip',
-                                    :country  => 'country'
-          
+                  :address1 => 'street_address',
+                  :address2 => 'street_address2',
+                  :state    => 'state',
+                  :zip      => 'zip',
+                  :country  => 'country'
+
           mapping :shipping_address, :city     => 'ship_city',
-                                     :address1 => 'ship_street_address',
-                                     :state    => 'ship_state',
-                                     :zip      => 'ship_zip',
-                                     :country  => 'ship_country'
-          
-          mapping :invoice, 'merchant_order_id'
-          
+                  :address1 => 'ship_street_address',
+                  :state    => 'ship_state',
+                  :zip      => 'ship_zip',
+                  :country  => 'ship_country'
+
           # Does nothing, since we've disabled the Continue Shopping button by using the fixed = Y field
           mapping :return_url, 'return_url'
-          
-          #mapping :description, ''
-          #mapping :tax, ''
-          #mapping :shipping, ''
-          
+
+          # Approved URL path
+          mapping :notification_url, 'x_receipt_link_url'
+
           def customer(params = {})
             add_field(mappings[:customer][:email], params[:email])
             add_field(mappings[:customer][:phone], params[:phone])
             add_field('card_holder_name', "#{params[:first_name]} #{params[:last_name]}")
           end
-          
+
+          # Uses Pass Through Product Parameters to pass in lineitems.
+          # (must mark tanigble sales as shipped to settle the transaction)
           def line_item(params = {})
-            max_existing_line_item_id = form_fields.keys.map do |key| 
+            add_field('mode', '2CO')
+            max_existing_line_item_id = form_fields.keys.map do |key|
               match = key.to_s.match(/li_(\d+)_/)
               if match
                 match[1]
               end
             end.reject(&:nil?).max.to_i
-            
+
             line_item_id = max_existing_line_item_id + 1
             params.each do |key, value|
               add_field("li_#{line_item_id}_#{key}", value)
+            end
+          end
+
+          # Uses Third Party Cart parameter set to pass in lineitem details.
+          # (sales settle automatically)
+          def c_prod(params = {})
+            add_field('id_type', '1')
+            max_existing_line_item_id = form_fields.keys.map do |key|
+              match = key.to_s.match(/c_prod_(\d+)/)
+              if match
+                match[1]
+              end
+            end.reject(&:nil?).max.to_i
+
+            line_item_id = max_existing_line_item_id + 1
+            params.each do |key, value|
+              add_field("c_#{key}_#{line_item_id}", value)
             end
           end
         end

--- a/lib/active_merchant/billing/integrations/two_checkout/notification.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout/notification.rb
@@ -7,44 +7,65 @@ module ActiveMerchant #:nodoc:
     module Integrations #:nodoc:
       module TwoCheckout
         class Notification < ActiveMerchant::Billing::Integrations::Notification
-        #  order_number	2Checkout.com order number
-        #   	card_holder_name	Card holder's name
-        #   	street_address	Card holder's address
-        #   	city	Card holder's city
-        #   	state	Card holder's state
-        #   	zip	Card holder's zip
-        #   	country	Card holder's country
-        #   	email	Card holder's email
-        #   	phone	Card holder's phone
-        #   	credit_card_processed	Y if successful, K if waiting for approval
-        #   	total	 Total purchase amount
-        #   	ship_name	Shipping information
-        #   	ship_street_address	Shipping information
-        #   	ship_city	Shipping information
-        #   	ship_state	Shipping information
-        #   	ship_zip	 Shipping information
-        #   	ship_country	Shipping information
-        #   	product_id	2Checkout product ID for purchased items will append a number if more than one item. 
-        #  ex. product_id,product_id1,product_id2
-        #   	quantity	quantity of corresponding product will append a number if more than one item.
-        #  ex. quantity,quantity1,quantity2
-        #   	merchant_product_id	 your product ID for purchased items will append a number if more than one item.
-        #  ex. merchant_product_id,merchant_product_id1,merchant_product_id2
-        #   	product_description	your description for purchased items will append a number if more than one item.
-        #  ex. product_description,product_description1,product_description2
-          
+          # card_holder_name - Provides the customer’s name.
+          # city - Provides the customer’s city.
+          # country - Provides the customer’s country.
+          # credit_card_processed - This parameter will always be passed back as Y.
+          # demo - Defines if an order was live, or if the order was a demo order. If the order was a demo, the MD5 hash will fail.
+          # email - Provides the email address the customer provided when placing the order.
+          # fixed - This parameter will only be passed back if it was passed into the purchase routine.
+          # ip_country - Provides the customer’s IP location.
+          # key - An MD5 hash used to confirm the validity of a sale.
+          # lang - Customer language
+          # merchant_order_id - The order ID you had assigned to the order.
+          # order_number - The 2Checkout order number associated with the order.
+          # invoice_id - The 2Checkout invoice number.
+          # pay_method - Provides seller with the customer’s payment method. CC for Credit Card, PPI for PayPal.
+          # phone - Provides the phone number the customer provided when placing the order.
+          # ship_name - Provides the ship to name for the order.
+          # ship_street_address - Provides ship to address.
+          # ship_street_address2 - Provides more detailed shipping address if this information was provided by the customer.
+          # ship_city - Provides ship to city.
+          # ship_state - Provides ship to state.
+          # ship_zip - Ship Zip
+
+          # Pass Through Products Only
+          # li_#_name - Name of the corresponding lineitem.
+          # li_#_quantity - Quantity of the corresponding lineitem.
+          # li_#_price - Price of the corresponding lineitem.
+          # li_#_tangible - Specifies if the corresponding li_#_type is a tangible or intangible. ‘Y’ OR ‘N’
+          # li_#_product_id - ID of the corresponding lineitem.
+          # li_#_product_description - Description of the corresponding lineitem.
+          # li_#_recurrence - # WEEK | MONTH | YEAR – always singular.
+          # li_#_duration - Forever or # WEEK | MONTH | YEAR – always singular, defaults to Forever.
+          # li_#_startup_fee - Amount in account pricing currency.
+          # li_#_option_#_name - Name of option. 64 characters max – cannot include '<' or '>'.
+          # li_#_option_#_value - Name of option. 64 characters max – cannot include '<' or '>'.
+          # li_#_option_#_surcharge - Amount in account pricing currency.
+
+          #Third Party Cart Only
+          # cart_order_id - The order ID you had assigned to the order.
+
+          # Allow seller to define default currency (should match 2Checkout account pricing currency)
           def currency
-            'USD'
+              'USD'
           end
-          
+
           def complete?
             status == 'Completed'
-          end 
-
-          def item_id
-            params['cart_order_id']
           end
 
+          # Third Party Cart parameters will return 'card_order_id'
+          # Pass Through Product parameters will only return 'merchant_order_id'
+          def item_id
+            if (params['cart_order_id'].nil?)
+              params['merchant_order_id']
+            else
+              params['cart_order_id']
+            end
+          end
+
+          # 2Checkout Sale ID
           def transaction_id
             params['order_number']
           end
@@ -53,60 +74,64 @@ module ActiveMerchant #:nodoc:
             params['']
           end
 
+          #Customer Email
           def payer_email
             params['email']
           end
-         
+
           def receiver_email
             params['']
-          end 
+          end
 
           # The MD5 Hash
           def security_key
             params['key']
           end
 
-          # the money amount we received in X.2 decimal.
+          # The money amount we received in X.2 decimal.
           def gross
             params['total']
           end
 
           # Was this a test transaction? # Use the hash
+          # Please note 2Checkout forces the order number computed in the hash to '1' on demo sales.
           def test?
             params['demo'] == 'Y'
           end
 
+          # 2Checkout only returns 'Y' for this parameter. If the sale is not authorized, no passback occurs.
           def status
             case params['credit_card_processed']
-            when 'Y'
-              'Completed'
-            when 'K'
-              'Pending'
-            else
-              'Failed'
+              when 'Y'
+                'Completed'
+              else
+                'Failed'
             end
           end
-          
+
+          # Secret Word defined in 2Checkout account
           def secret
             @options[:credential2]
           end
-          
+
+          # Checks against MD5 Hash
           def acknowledge
             return false if security_key.blank?
-            
+
             Digest::MD5.hexdigest("#{secret}#{params['sid']}#{transaction_id}#{gross}").upcase == security_key.upcase
           end
-          
+
           private
-          
+
+          # Parses Header Redirect Query String
           def parse(post)
             @raw = post.to_s
-            for line in @raw.split('&')    
+            for line in @raw.split('&')
               key, value = *line.scan( %r{^(\w+)\=(.*)$} ).flatten
               params[key] = CGI.unescape(value || '')
             end
           end
-          
+
         end
       end
     end

--- a/test/unit/integrations/helpers/two_checkout_helper_test.rb
+++ b/test/unit/integrations/helpers/two_checkout_helper_test.rb
@@ -13,7 +13,6 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
  
   def test_basic_helper_fields
     assert_field 'sid', 'cody@example.com'
-
     assert_field 'total', '5.00'
     assert_field 'cart_order_id', 'order-500'
   end
@@ -34,6 +33,17 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     
     assert_field 'li_2_description', 'Test Product'
     assert_field 'li_2_price', '15.0'
+  end
+
+  def test_c_prod_fields
+    @helper.c_prod :prod => "1,1", :name => 'Example Product Name'
+    @helper.c_prod :description => 'Example Product Description', :price => '15.0'
+    
+    assert_field 'c_prod_1', '1,1'
+    assert_field 'c_name_1', 'Example Product Name'
+    
+    assert_field 'c_description_2', 'Example Product Description'
+    assert_field 'c_price_2', '15.0'
   end
   
   def test_address_mapping

--- a/test/unit/integrations/notifications/two_checkout_notification_test.rb
+++ b/test/unit/integrations/notifications/two_checkout_notification_test.rb
@@ -39,10 +39,10 @@ class TwoCheckoutNotificationTest < Test::Unit::TestCase
 
   private
   def test_http_raw_data
-    "sid=1232919&fixed=Y&key=B5446FF1061F5522C29CCCA0F95EA375&state=ON&email=cody%40example.com&city=Ottawa&street_address=1+-+8+Clarence+St%2C+Apartment+5&product_id=&cart_order_id=10&tcoid=8032992fe053170efb7e58de35b07d39&country=Canada&order_number=3644445821&merchant_order_id=%231010&option-=&cart_id=10&Product_description=&lang=&demo=Y&pay_method=CC&quantity=1&total=31.66&phone=(555)555-5555&return_url=&credit_card_processed=Y&zip=K1M+3G7&merchant_product_id=10&card_holder_name=Cody+Fauser"
+    "sid=1232919&fixed=Y&key=B5446FF1061F5522C29CCCA0F95EA375&state=ON&email=cody%40example.com&city=Ottawa&street_address=1+-+8+Clarence+St%2C+Apartment+5&product_id=&cart_order_id=10&tcoid=8032992fe053170efb7e58de35b07d39&country=Canada&order_number=3644445821&merchant_order_id=10&option-=&cart_id=10&Product_description=&lang=&demo=Y&pay_method=CC&quantity=1&total=31.66&phone=(555)555-5555&return_url=&credit_card_processed=Y&zip=K1M+3G7&merchant_product_id=10&card_holder_name=Cody+Fauser"
   end
   
   def live_http_raw_data
-    "sid=1232919&fixed=Y&key=0ee5cd112a9d34952167399c6b55d14f&state=ON&email=cody%40example.com&city=Ottawa&street_address=1+-+8+Clarence+St%2C+Apartment+5&product_id=&cart_order_id=10&tcoid=8032992fe053170efb7e58de35b07d39&country=Canada&order_number=3644445821&merchant_order_id=%231010&option-=&cart_id=10&Product_description=&lang=&pay_method=CC&quantity=1&total=31.66&phone=(555)555-5555&return_url=&credit_card_processed=Y&zip=K1M+3G7&merchant_product_id=10&card_holder_name=Cody+Fauser"
+    "sid=1232919&fixed=Y&key=0ee5cd112a9d34952167399c6b55d14f&state=ON&email=cody%40example.com&city=Ottawa&street_address=1+-+8+Clarence+St%2C+Apartment+5&product_id=&cart_order_id=10&tcoid=8032992fe053170efb7e58de35b07d39&country=Canada&order_number=3644445821&merchant_order_id=10&option-=&cart_id=10&Product_description=&lang=&pay_method=CC&quantity=1&total=31.66&phone=(555)555-5555&return_url=&credit_card_processed=Y&zip=K1M+3G7&merchant_product_id=10&card_holder_name=Cody+Fauser"
   end
 end

--- a/test/unit/integrations/two_checkout_module_test.rb
+++ b/test/unit/integrations/two_checkout_module_test.rb
@@ -4,12 +4,12 @@ class TwoCheckoutModuleTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
   
   def test_default_service_url
-    assert_equal 'https://www.2checkout.com/checkout/purchase', TwoCheckout.service_url
+    assert_equal 'https://www.2checkout.com/checkout/spurchase', TwoCheckout.service_url
   end
   
   def test_legacy_service_url_writer
-    TwoCheckout.service_url = 'https://www.2checkout.com/checkout/spurchase'
-    assert_equal :single_page, TwoCheckout.payment_routine
+    TwoCheckout.service_url = 'https://www.2checkout.com/checkout/purchase'
+    assert_equal :multi_page, TwoCheckout.payment_routine
   end
   
   def test_single_page_payment_routine_service_url


### PR DESCRIPTION
The current branch only supported the 2Checkout Pass Through Products parameter set which requires that the seller mark tangible sales as shipped before they will charge the customer. A new method c_prod method was added to allow support for 2Checkout Third Party Cart Parameters which charge automatically.

The default purchase routine URL was changed from the multi-page checkout to the more popular single page checkout.

The notification took the item_id from the cart_order_id parameter returned by 2Checkout. On sales using the Pass Through Products parameters, 2Checkout does not return this parameter causing this method to return nil. The method now falls back to the merchant_order_id when cart_order_id is not passed back so that both the Third Party Cart parameters and Pass Through Product Parameters can be used.

Unit tests were updated to reflect the changes and are all passing.

All changes have been tested on live sales to insure backward compatibility with current version. 
