### PR TITLE
SecurePayAu: fix credit card check

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, credit_card_or_stored_id, options = {})
-        if credit_card_or_stored_id.is_a?(ActiveMerchant::Billing::CreditCard)
+        if credit_card_or_stored_id.respond_to?(:number)
           #Credit card for instant payment
           commit :purchase, build_purchase_request(money, credit_card_or_stored_id, options)
         else

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, credit_card_or_stored_id, options = {})
-        if credit_card_or_stored_id.is_a?(ActiveMerchant::Billing::CreditCard)
+        if credit_card_or_stored_id.respond_to?(:number)
           requires!(options, :order_id)
           commit :purchase, build_purchase_request(money, credit_card_or_stored_id, options)
         else

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -58,6 +58,18 @@ class SecurePayAuTest < Test::Unit::TestCase
     assert_equal "CARD EXPIRED", response.message
   end
 
+  def test_purchase_with_stored_id_calls_commit_periodic
+    @gateway.expects(:commit_periodic)
+
+    @gateway.purchase(@amount, "123", @options)
+  end
+
+  def test_purchase_with_creditcard_calls_commit_with_purchase
+    @gateway.expects(:commit).with(:purchase, anything)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
 


### PR DESCRIPTION
- Some ActiveMerchant users have their own credit card object that they
  pass to ActiveMerchant so we shouldn't be checking for
  ActiveMerchant::Billing::CreditCard explicitly but check that it looks
  like a credit card instead (having a number method is a good check).

@Soleone @ntalbott for review
