### PR TITLE
Update Securepay AU to include usable credentials for running remote tests

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -126,7 +126,8 @@ module ActiveMerchant #:nodoc:
       def build_reference_request(money, reference)
         xml = Builder::XmlMarkup.new
 
-        transaction_id, order_id, preauth_id, original_amount = reference.split("*")
+        transaction_id, order_id, preauth_id, original_amount = reference.split('*')
+
         xml.tag! 'amount', (money ? amount(money) : original_amount)
         xml.tag! 'currency', options[:currency] || currency(money)
         xml.tag! 'txnID', transaction_id

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -464,8 +464,8 @@ secure_pay_tech:
   password: d557591484cb2cd12bba445aba420d2c69cd6a88
 
 secure_pay_au:
-  login:
-  password:
+  login: ABC0030
+  password: abc123
 
 #  Replace with your serial numbers for the skipjack test environment
 skipjack:

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -6,10 +6,10 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     @gateway = SecurePayAuGateway.new(fixtures(:secure_pay_au))
 
     @amount = 100
-    @credit_card = credit_card('4444333322221111', {:month => 9, :year => 15})
+    @credit_card = credit_card('4242424242424242', {:month => 9, :year => 15})
 
     @options = {
-      :order_id => '1',
+      :order_id => '2',
       :billing_address => address,
       :description => 'Store Purchase'
     }
@@ -76,11 +76,13 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   def test_successful_void
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
+
     authorization = response.authorization
 
-    assert response = @gateway.void(authorization)
-    assert_success response
-    assert_equal 'Approved', response.message
+    assert result = @gateway.void(authorization)
+
+    assert_success result
+    assert_equal 'Approved', result.message
   end
 
   def test_failed_void
@@ -102,13 +104,12 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert_equal 'Successful', response.message
   end
 
-  def test_failed_unstore
+  def test_repeat_unstore
     @gateway.unstore('test1234') rescue nil #Ensure it is already missing
 
-    assert response = @gateway.unstore('test1234')
-    assert_failure response
+    response = @gateway.unstore('test1234')
 
-    assert_equal 'Normal', response.message
+    assert_success response
   end
 
   def test_successful_store
@@ -155,6 +156,6 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
               )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal "Fatal Unknown Error", response.message
+    assert_equal "Invalid merchant ID", response.message
   end
 end


### PR DESCRIPTION
As requested : 

There is one fail due to db issue on testing server for remote tests, this shouldn't happen after securepay resolve the issue. The request and response is valid.

```
bundle exec rake test:remote TEST=test/remote/gateways/remote_secure_pay_au_test.rb
```
