### PR TITLE
updated sagepay sanitize to truncate description field. fixes #370

### DIFF
--- a/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
+++ b/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
@@ -107,6 +107,8 @@ module ActiveMerchant #:nodoc:
               exact = /^[A-Z]{3}$/
             when /State$/
               exact = /^[A-Z]{2}$/
+            when 'Description'
+              value = value.truncate(100)
             else
               reject = /&+/
             end

--- a/test/unit/integrations/helpers/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/helpers/sage_pay_form_helper_test.rb
@@ -110,6 +110,16 @@ class SagePayFormHelperTest < Test::Unit::TestCase
       assert plain.include?('&DeliveryState=IL')
     end
   end
+
+  def test_description_should_truncate
+    description = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut la'
+    assert_equal 101, description.size
+    @helper.add_field('Description', description)
+
+    with_crypt_plaintext do |plain|
+      assert plain.include?('Description=Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt u...')
+    end
+  end
   
   def test_set_shipping_address_wont_be_overridden_by_billing_address
     @helper.billing_address(


### PR DESCRIPTION
Updates SagePay form helper sanitization to truncate description field to 100 characters. fixes #370.

@Soleone @wisq 
