### PR TITLE
Added metadata fields for dynamic card descriptors with NAB Transact

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -81,6 +81,17 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_metadata(options)
+        xml = Builder::XmlMarkup.new
+        if options[:merchant_name] || options[:merchant_location]
+          xml.tag! 'metadata' do
+            xml.tag! 'meta', :name => 'ca_name', :value => options[:merchant_name] if options[:merchant_name]
+            xml.tag! 'meta', :name => 'ca_location', :value => options[:merchant_location] if options[:merchant_location]
+          end
+        end
+        xml.target!
+      end
+
       def build_purchase_request(money, credit_card, options)
         xml = Builder::XmlMarkup.new
         xml.tag! 'amount', amount(money)
@@ -93,6 +104,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
         end
 
+        xml << add_metadata(options)
+        
         xml.target!
       end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -200,10 +200,15 @@ moneris_us:
   login: monusqa002
   password: qatoken
 
-#Working credentials, no need to replace
+# Working credentials, no need to replace
 nab_transact:
   login: ABC0001
   password: changeit
+
+# Working credentials, no need to replace
+nab_transact_card_acceptor:
+  login: XYZ0010
+  password: abcd1234
   
 netaxept:
   login: LOGIN

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -3,6 +3,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
 
   def setup
     @gateway = NabTransactGateway.new(fixtures(:nab_transact))
+    @card_acceptor_gateway = NabTransactGateway.new(fixtures(:nab_transact_card_acceptor))
 
     @amount = 200
     @credit_card = credit_card('4444333322221111')
@@ -26,6 +27,33 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
+  end
+  
+  # Unfortunately there is no "real" way to test the dynamic card acceptor,
+  # however the "Integration Guide - XML API for Payments" documentation states:
+  #   If enabled on your NAB Transact account, the Dynamic Card Acceptor details
+  #   will be accepted via metadata tags added to your XML request. Note that 
+  #   permission for this feature must be enabled on your account or you will
+  #   receive a response of “555 – Permission denied”.
+  #
+  # I couldn't find any other reference to this error code, so we can set the
+  # fields on an account with the dynamic card acceptor feature disabled and
+  # ensure we get the error.
+  def test_successful_purchase_with_card_acceptor
+    card_acceptor_options = {
+      :merchant_name => 'ActiveMerchant',
+      :merchant_location => 'Melbourne'
+    }
+    card_acceptor_options.each do |key, value|
+      options = @options.merge({key => value})
+      assert response = @gateway.purchase(@amount, @credit_card, options)
+      assert_failure response
+      assert_equal 'Permission denied', response.message
+
+      assert response = @card_acceptor_gateway.purchase(@amount, @credit_card, options)
+      assert_success response
+      assert_equal 'Approved', response.message
+    end
   end
 
   def test_unsuccessful_purchase_insufficient_funds


### PR DESCRIPTION
Some code to enable dynamic card acceptor (text displayed on a customer's bank statement) for the NAB Transact gateway.

Open to changing the option names from merchant_name and merchant_location to something different - couldn't really find any cohesion between the few gateways that support card acceptors.

I've only added it for direct, once-off payments. NAB only has it documented there. Will have to get in touch with the bank to see if it can be done through "trigger" payments as well.
