### PR TITLE
Paybox Direct: Treat all response codes besides '00000' as hard failures...

### DIFF
--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -37,7 +37,6 @@ module ActiveMerchant #:nodoc:
 
       SUCCESS_CODES = ['00000']
       UNAVAILABILITY_CODES = ['00001', '00097', '00098']
-      FRAUD_CODES = ['00102','00104','00134','00138','00141','00143','00157','00159']
       SUCCESS_MESSAGE = 'The transaction was approved'
       FAILURE_MESSAGE = 'The transaction failed'
 
@@ -148,17 +147,13 @@ module ActiveMerchant #:nodoc:
           :timestamp => parameters[:dateq]),
           :test => test?,
           :authorization => response[:numappel].to_s + response[:numtrans].to_s,
-          :fraud_review => fraud_review?(response),
+          :fraud_review => false,
           :sent_params => parameters.delete_if{|key,value| ['porteur','dateval','cvv'].include?(key.to_s)}
         )
       end
 
       def success?(response)
         SUCCESS_CODES.include?(response[:codereponse])
-      end
-
-      def fraud_review?(response)
-        FRAUD_CODES.include?(response[:codereponse])
       end
 
       def service_unavailable?(response)

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -59,12 +59,12 @@ class PayboxDirectTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_fraudulent_request
+  def test_keep_the_card_code_not_considered_fraudulent
     @gateway.expects(:ssl_post).returns(purchase_response("00104"))
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert response.fraud_review?
+    assert !response.fraud_review?
   end
 
   def test_do_not_honour_code_not_considered_fraudulent


### PR DESCRIPTION
... and never as fraud.

Currently ActiveMerchant implicitly assumes that if a response has the `fraud_review` flag set that it still can be processed further but just needs to add a fraud warning for the merchant. This is not the case with Paybox, even if a response code signals fraud, it will not be able to get captured.

Merchant double checked with Paybox support that all response codes besides `00000` will not be able to go through with the processing bank.

Please review @jduff 
