### PR TITLE
Update eWAY gateway implementation

### DIFF
--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -40,21 +40,6 @@ class EwayTest < Test::Unit::TestCase
     assert_equal EwayGateway::MESSAGES["00"], response.message
   end
 
-  def test_invalid_expiration_date
-    @credit_card_success.year = 2005 
-    assert response = @gateway.purchase(100, @credit_card_success, @params)
-    assert_failure response
-    assert response.test?
-  end
-  
-  def test_purchase_with_invalid_verification_value
-    @credit_card_success.verification_value = 'AAA' 
-    assert response = @gateway.purchase(100, @credit_card_success, @params)
-    assert_nil response.authorization
-    assert_failure response
-    assert response.test?
-  end
-
   def test_purchase_success_without_verification_value
     @credit_card_success.verification_value = nil
     

--- a/test/unit/gateways/eway_test.rb
+++ b/test/unit/gateways/eway_test.rb
@@ -21,6 +21,15 @@ class EwayTest < Test::Unit::TestCase
       },
       :description => 'purchased items'
     } 
+
+    @options_without_address = @options.reject { |k,v| k == :billing_address }
+
+  end
+
+  def test_purchase_without_billing_address
+    assert_raise(ArgumentError) do
+      @gateway.purchase(@amount, @credit_card, @options_without_address)
+    end
   end
   
   def test_successful_purchase
@@ -114,5 +123,3 @@ class EwayTest < Test::Unit::TestCase
     XML
   end
 end
-
-


### PR DESCRIPTION
#### Docs:
1. Removed old copy&paste about TrustCommerce
2. Added info about transaction results
3. Added test credit card number, provided by eway docs (http://www.eway.com.au/developers/sandbox/direct-payments.html)
#### Code:
1. `:order_id` is not a required parameter, so removed it
2. Added `:address` and `:billing_address` to required parameres, because if you don't pass address to gateway, you'll get:

``` ruby
@message="Error: Required XML tag(s) missing, or incorrect case used. Required tag Name(s): ewayCustomerAddress, ewayCustomerPostcode"
```
1. Removed tests for invalid expiration date and verification value. Seems like Test eWay Gateway doesn't care about validity of them and returning success code (so both tests failing).
