### PR TITLE
Moved CyberSource email requirement under add_address, as it is not required when using subscriptions

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
       #
       # You must supply an :order_id in the options hash 
       def authorize(money, creditcard_or_reference, options = {})
-        requires!(options,  :order_id, :email)
+        requires!(options,  :order_id)
         setup_address_hash(options)
         commit(build_auth_request(money, creditcard_or_reference, options), options )
       end
@@ -125,7 +125,7 @@ module ActiveMerchant #:nodoc:
       # Purchase is an auth followed by a capture
       # You must supply an order_id in the options hash  
       def purchase(money, creditcard_or_reference, options = {})
-        requires!(options, :order_id, :email)
+        requires!(options, :order_id)
         setup_address_hash(options)
         commit(build_purchase_request(money, creditcard_or_reference, options), options)
       end
@@ -350,7 +350,9 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_address(xml, creditcard, address, options, shipTo = false)      
+      def add_address(xml, creditcard, address, options, shipTo = false)
+        requires!(options, :email)
+
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
           xml.tag! 'firstName',             creditcard.first_name
           xml.tag! 'lastName',              creditcard.last_name 
@@ -363,7 +365,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'company',               address[:company]                 unless address[:company].blank?
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
           xml.tag! 'phoneNumber',           address[:phone_number]            unless address[:phone_number].blank?
-          xml.tag! 'email',                 options[:email]                   unless options[:email].blank?
+          xml.tag! 'email',                 options[:email]
           xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
           xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?
         end 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -65,7 +65,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
 
-    assert response = @gateway.authorize(@amount, response.authorization, @options)
+    assert response = @gateway.authorize(@amount, response.authorization, :order_id => generate_unique_id)
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert response.test?
@@ -146,7 +146,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
 
-    assert response = @gateway.purchase(@amount, response.authorization, @options)
+    assert response = @gateway.purchase(@amount, response.authorization, :order_id => generate_unique_id)
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert response.test?


### PR DESCRIPTION
Moved CyberSource email requirement under add_address, as it is not required when using subscriptions.

Complements Shopify/active_merchant#376

cc @jaredmoody @ntalbott @jduff
