### PR TITLE
Allows one to update a CyberSource subscription billing address only (without the need to pass a credit card again)

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -354,8 +354,8 @@ module ActiveMerchant #:nodoc:
         requires!(options, :email)
 
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
-          xml.tag! 'firstName',             creditcard.first_name
-          xml.tag! 'lastName',              creditcard.last_name 
+          xml.tag! 'firstName',             creditcard.first_name             if creditcard
+          xml.tag! 'lastName',              creditcard.last_name              if creditcard
           xml.tag! 'street1',               address[:address1]
           xml.tag! 'street2',               address[:address2]                unless address[:address2].blank?
           xml.tag! 'city',                  address[:city]

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -218,13 +218,26 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_update_subscription
+  def test_successful_update_subscription_creditcard
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert response.test?
 
     assert response = @gateway.update(response.authorization, @credit_card, {:order_id => generate_unique_id, :setup_fee => 100})
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+  end
+
+  def test_successful_update_subscription_billing_address
+    assert response = @gateway.store(@credit_card, @subscription_options)
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+
+    assert response = @gateway.update(response.authorization, nil, 
+      {:order_id => generate_unique_id, :setup_fee => 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert response.test?


### PR DESCRIPTION
Fixes an issue while trying to update a CyberSource subscription passing the billing address only.
