### PR TITLE
Orbital: Never send country code for orders outside of US, CA and GB

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -152,7 +152,6 @@ module ActiveMerchant #:nodoc:
         if address = options[:billing_address] || options[:address]
           add_avs_details(xml, address)
           xml.tag! :AVSname, creditcard.name
-          xml.tag! :AVScountryCode, address[:country]
         end
       end
 
@@ -175,14 +174,18 @@ module ActiveMerchant #:nodoc:
       end
       
       def add_avs_details(xml, address)
-        return unless AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s)
-
-        xml.tag! :AVSzip, address[:zip]
-        xml.tag! :AVSaddress1, address[:address1]
-        xml.tag! :AVSaddress2, address[:address2]
-        xml.tag! :AVScity, address[:city]
-        xml.tag! :AVSstate, address[:state]
-        xml.tag! :AVSphoneNum, address[:phone] ? address[:phone].scan(/\d/).join.to_s : nil
+        if AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s)
+          xml.tag! :AVSzip, address[:zip]
+          xml.tag! :AVSaddress1, address[:address1]
+          xml.tag! :AVSaddress2, address[:address2]
+          xml.tag! :AVScity, address[:city]
+          xml.tag! :AVSstate, address[:state]
+          xml.tag! :AVSphoneNum, address[:phone] ? address[:phone].scan(/\d/).join.to_s : nil
+          country_code = address[:country]
+        else
+          country_code = ''
+        end
+        xml.tag! :AVScountryCode, country_code
       end
 
 

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -101,7 +101,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_no_match(/<AVSstate>ON/, data)
       assert_no_match(/<AVSphoneNum>5555555555/, data)
       assert_match(/<AVSname>Longbob Longsen/, data)
-      assert_match(/<AVScountryCode>DE/, data)
+      assert_match(/<AVScountryCode><\/AVScountryCode>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response    
   end


### PR DESCRIPTION
Follow up to e589e57

When talking to Orbital support I was under the impression that a country code can be sent, but it turns out that this is not correct and requests for transactions outside of US, CA and GB with `AVSCountry` provided cause the transaction to fail.

Quote from Orbital Support:

> Per the specification, the only valid country code for credit card transactions are US, CA, GB, UK, for all other countries this tag should be blank.
> 
> AVScountryCode
> 
> Valid values:
> 
> US United States
> 
> CA Canada
> 
> GB Great Britain
> 
> UK United Kingdom
> 
> " " Blank for all other countries

Please review @jduff 
