### PR TITLE
Inspire Commerce: Can now purchase with vault_id

### DIFF
--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -123,14 +123,14 @@ module ActiveMerchant #:nodoc:
       
       def add_payment_source(params, source, options={})
         case determine_funding_source(source)
-        when :vault       then add_customer_vault_id(params, source)
+        when :vault       then add_customer_vault_id(params, options)
         when :credit_card then add_creditcard(params, source, options)
         when :check       then add_check(params, source)
         end
       end
       
-      def add_customer_vault_id(params,vault_id)
-        params[:customer_vault_id] = vault_id
+      def add_customer_vault_id(params, options)
+        params[:customer_vault_id] = options[:customer_vault_id]
       end
       
       def add_creditcard(post, creditcard,options)


### PR DESCRIPTION
I couldn't get purchase() to work on Inspire Commerce using a vault_id, previously stored using authorize(). It seemed like AM was trying to use the second parameter as a card if it's not a string. So, when using 'vault' as payment source, you had no way to specify the vault_id to use. Couldn't figure out the "correct" way to do this from the source or tests, so I don't know if I'm just missing something.

You can now make a purchase by using the following syntax:

``` ruby
gateway = ActiveMerchant::Billing::InspireGateway.new(
    :login  => 'LOGIN',
    :password => 'PASSWORD')
result = gateway.purchase(1234, 'vault', {:customer_vault_id => current_user.inspire_vault_id})
```
