### PR TITLE
Add support for First Data offsite payment gateway

### DIFF
--- a/lib/active_merchant/billing/integrations/first_data.rb
+++ b/lib/active_merchant/billing/integrations/first_data.rb
@@ -1,0 +1,38 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module FirstData 
+        autoload :Helper, 'active_merchant/billing/integrations/first_data/helper.rb'
+        autoload :Notification, 'active_merchant/billing/integrations/first_data/notification.rb'
+
+        # Overwrite this if you want to change the ANS test url
+        mattr_accessor :test_url
+        self.test_url = 'https://demo.globalgatewaye4.firstdata.com/payment'
+        
+        # Overwrite this if you want to change the ANS production url
+        mattr_accessor :production_url 
+        self.production_url = 'https://checkout.globalgatewaye4.firstdata.com/payment'
+        
+        def self.service_url
+          mode = ActiveMerchant::Billing::Base.integration_mode
+          case mode
+          when :production
+            self.production_url    
+          when :test
+            self.test_url
+          else
+            raise StandardError, "Integration mode set to an invalid value: #{mode}"
+          end
+        end
+            
+        def self.notification(post)
+          Notification.new(post)
+        end
+        
+        def self.return(query_string)
+          Return.new(query_string)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/first_data/helper.rb
+++ b/lib/active_merchant/billing/integrations/first_data/helper.rb
@@ -1,0 +1,67 @@
+require 'active_support/core_ext/float/rounding.rb' # Float#round(precision)
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module FirstData
+        # First Data payment pages emulates the Authorize.Net SIM API. See
+        # ActiveMerchant::Billing::Integrations::AuthorizeNetSim::Helper for
+        # more details.
+        #
+        # An example. Note the username as a parameter and transaction key you
+        # will want to use later.
+        # 
+        #  payment_service_for('order_id', 'first_data_payment_page_id', :service => :first_data,  :amount => 157.0) do |service|
+        # 
+        #    # You must call setup_hash and invoice
+        #    
+        #    service.setup_hash :transaction_key => '8CP6zJ7uD875J6tY',
+        #        :order_timestamp => 1206836763
+        #    service.customer_id 8
+        #    service.customer :first_name => 'g',
+        #                       :last_name => 'g',
+        #                       :email => 'g@g.com',
+        #                       :phone => '3'
+        #   service.billing_address :zip => 'g',
+        #                   :country => 'United States of America',
+        #                   :address => 'g'
+        # 
+        #   service.ship_to_address :first_name => 'g',
+        #                            :last_name => 'g',
+        #                            :city => '',
+        #                            :address => 'g',
+        #                            :address2 => '',
+        #                            :state => address.state,
+        #                            :country => 'United States of America',
+        #                            :zip => 'g'
+        # 
+        #   service.invoice "516428355" # your invoice number
+        #   # The end-user is presented with the HTML produced by the notify_url
+        #   # (using the First Data Receipt Link feature).
+        #   service.return_url "http://mysite/first_data_receipt_generator_page"
+        #   service.payment_header 'My store name'
+        #   service.add_line_item :name => 'item name', :quantity => 1, :unit_price => 0
+        #   service.test_request 'true' # only if it's just a test
+        #   service.shipping '25.0'
+        #   # Tell it to display a "0" line item for shipping, with the price in
+        #   # the name, otherwise it isn't shown at all, leaving the end user to
+        #   # wonder why the total is different than the sum of the line items.
+        #   service.add_shipping_as_line_item
+        #   server.add_tax_as_line_item # same with tax
+        #   # See the helper.rb file for various custom fields
+        # end
+        
+        class Helper < ActiveMerchant::Billing::Integrations::AuthorizeNetSim::Helper
+          
+          # Configure notify_url to use the "Relay Response" feature
+          mapping :notify_url, 'x_relay_url'
+
+          # Configure return_url to use the "Receipt Link" feature
+          mapping :return_url, 'x_receipt_link_url'
+          
+        end
+
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/first_data/notification.rb
+++ b/lib/active_merchant/billing/integrations/first_data/notification.rb
@@ -1,0 +1,59 @@
+require 'net/http'
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+
+      # First Data payment pages emulates the Authorize.Net SIM API. See
+      # ActiveMerchant::Billing::Integrations::FirstData::Notification for
+      # more details.
+      #
+      # # Example:
+      # parser = FirstData::Notification.new(request.raw_post)
+      # passed = parser.complete?
+      # 
+      # order = Order.find_by_order_number(parser.invoice_num)
+      # 
+      # unless order
+      #   @message = 'Error--unable to find your transaction! Please contact us directly.'
+      #   return render :partial => 'first_data_payment_response'
+      # end
+      #       
+      # if order.total != parser.gross.to_f
+      #   logger.error "First Data said they paid for #{parser.gross} and it should have been #{order.total}!"
+      #   passed = false
+      # end
+      # 
+      # # Theoretically, First Data will *never* pass us the same transaction
+      # # ID twice, but we can double check that... by using
+      # # parser.transaction_id, and checking against previous orders' transaction
+      # # id's (which you can save when the order is completed)....      
+      # unless parser.acknowledge FIRST_DATA_TRANSACTION_KEY, FIRST_DATA_RESPONSE_KEY
+      #  passed = false
+      #  logger.error "ALERT POSSIBLE FRAUD ATTEMPT"
+      # end
+      # 
+      # unless parser.cavv_matches? and parser.avs_code_matches?
+      #   logger.error 'Warning--non matching CC!' + params.inspect
+      #   # Could fail them here, as well (recommended)...
+      # end
+      # 
+      # if passed
+      #  # Set up your session, and render something that will redirect them to
+      #  # your site, most likely.
+      # else
+      #  # Render failure or redirect them to your site where you will render failure
+      # end
+        
+      module FirstData
+        class Notification < ActiveMerchant::Billing::Integrations::AuthorizeNetSim::Notification
+
+          def acknowledge(response_key, payment_page_id)
+            Digest::MD5.hexdigest(response_key + payment_page_id + params['x_trans_id'] + sprintf('%.2f', gross)) == params['x_MD5_Hash'].downcase
+          end
+        
+        end
+      end
+      
+    end
+  end
+end

--- a/test/unit/integrations/first_data_module_test.rb
+++ b/test/unit/integrations/first_data_module_test.rb
@@ -1,0 +1,244 @@
+require 'test_helper'
+
+class FirstDataModuleTest < Test::Unit::TestCase
+  include ActionViewHelperTestHelper
+  include ActiveMerchant::Billing::Integrations
+
+  def test_notification_method
+    assert_instance_of FirstData::Notification, FirstData.notification('name=cody')
+  end
+
+  def test_address2
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+	    service.billing_address :address1 => 'address1', :address2 => 'line 2'
+    }
+    all= ['<input id="x_address" name="x_address" type="hidden" value="address1 line 2" />']
+    check_inclusion all
+  end
+
+  def test_lots_of_line_items_same_name
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      35.times {service.add_line_item :name => 'beauty2 - ayoyo', :quantity => 1, :unit_price => 0}
+    }
+    assert @output_buffer =~ / more unshown items after this one/
+    # It should display them all in, despite each having the same name.
+    assert @output_buffer.scan(/beauty2 - ayoyo/).length > 5
+  end
+
+  def test_lots_of_line_items_different_names
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      35.times {|n| service.add_line_item :name => 'beauty2 - ayoyo' + n.to_s, :quantity => 1, :unit_price => 0}
+    }
+    assert @output_buffer =~ / ayoyo3/
+    assert @output_buffer =~ / ayoyo4/
+  end
+
+  def test_should_round_numbers
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => "157.003"){}
+    assert @output_buffer !~ /x_amount.*157.003"/
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => "157.005"){}
+    assert @output_buffer =~ /x_amount.*157.01"/
+  end
+
+  def test_all_fields
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+
+       service.setup_hash :transaction_key => '8CP6zJ7uD875J6tY',
+           :order_timestamp => 1206836763
+       service.customer_id 8
+       service.customer :first_name => 'g',
+                          :last_name => 'g',
+                          :email => 'g@g.com',
+                          :phone => '3'
+
+      service.billing_address :zip => 'g',
+                      :country => 'United States of America',
+                      :address1 => 'g'
+
+      service.ship_to_address :first_name => 'g',
+                               :last_name => 'g',
+                               :city => '',
+                               :address1 => 'g',
+                               :address2 => '',
+                               :state => 'ut',
+                               :country => 'United States of America',
+                               :zip => 'g'
+
+      service.invoice "516428355"
+      service.notify_url "http://t/first_data/payment_received_notification_sub_step"
+      service.payment_header 'MyFavoritePal'
+      service.add_line_item :name => 'beauty2 - ayoyo', :quantity => 1, :unit_price => 0.0
+      service.test_request 'true'
+      service.shipping '25.0'
+      service.add_shipping_as_line_item
+    }
+
+    all = '<INPUT TYPE=HIDDEN name="x_cust_id" value="8">
+      <INPUT TYPE=HIDDEN name="x_ship_to_last_name" value="g">
+      <INPUT TYPE=HIDDEN name="x_fp_timestamp" value="1206836763">
+      <INPUT TYPE=HIDDEN name="x_ship_to_first_name" value="g">
+      <INPUT TYPE=HIDDEN name="x_last_name" value="g">
+      <INPUT TYPE=HIDDEN name="x_amount" value="157.0">
+      <INPUT TYPE=HIDDEN name="x_ship_to_country" value="United States of America">
+      <INPUT TYPE=HIDDEN name="x_ship_to_zip" value="g">
+      <INPUT TYPE=HIDDEN name="x_zip" value="g">
+      <INPUT TYPE=HIDDEN name="x_country" value="United States of America">
+      <INPUT TYPE=HIDDEN name="x_duplicate_window" value="28800">
+      <INPUT TYPE=HIDDEN name="x_relay_response" value="TRUE">
+      <INPUT TYPE=HIDDEN name="x_ship_to_address" value="g">
+      <INPUT TYPE=HIDDEN name="x_first_name" value="g">
+      <INPUT TYPE=HIDDEN name="x_version" value="3.1">
+      <INPUT TYPE=HIDDEN name="x_invoice_num" value="516428355">
+      <INPUT TYPE=HIDDEN name="x_address" value="g">
+      <INPUT TYPE=HIDDEN name="x_login" value="8wd65QS">
+      <INPUT TYPE=HIDDEN name="x_phone" value="3">
+      <INPUT TYPE=HIDDEN name="x_relay_url" value="http://t/first_data/payment_received_notification_sub_step">
+      <INPUT TYPE=HIDDEN name="x_fp_sequence" value="44">
+      <INPUT TYPE=HIDDEN name="x_show_form" value="PAYMENT_FORM">
+      <INPUT TYPE=HIDDEN name="x_header_html_payment_form" value="MyFavoritePal">
+      <INPUT TYPE=HIDDEN name="x_email" value="g@g.com">
+      <INPUT TYPE=HIDDEN name="x_fp_hash" value="31d572da4e9910b36e999d73925eb01c">
+      <INPUT TYPE=HIDDEN name="x_line_item" value="Item 1<|>beauty2 - ayoyo<|>beauty2 - ayoyo<|>1<|>0.0<|>N">
+      <INPUT TYPE=HIDDEN name="x_test_request" value="true">
+      <INPUT TYPE=HIDDEN name="x_freight" value="25.0"/>
+      <INPUT TYPE=HIDDEN name="x_line_item" value="Shipping<|>Shipping and Handling Cost<|>Shipping and Handling Cost<|>1<|>25.0<|>N">'
+
+    # clean it up a bit for parsing
+    @output_buffer.gsub!("type=\"hidden\" ", "")
+    for line in all.split("\n") do
+      line.strip!
+      if line =~ /(name=".*".*value=".*")/i
+        line = $1
+        assert @output_buffer.include?(line), 'didnt find' + line + 'in ' + @output_buffer
+      end
+    end
+  end
+
+  def check_inclusion(these_lines)
+    for line in these_lines do
+      assert @output_buffer.include?(line), ['unable to find ', line, ' ', 'in \n', @output_buffer].join(' ')
+    end
+  end
+
+  def test_custom
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      service.add_custom_field 'abc', 'def'
+    }
+    all = ["<input id=\"abc\" name=\"abc\" type=\"hidden\" value=\"def\" />"]
+    check_inclusion all
+  end
+
+
+  def test_shipping_and_tax_line_item
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      service.shipping 44.0
+      service.tax 44.0
+      service.add_shipping_as_line_item
+      service.add_tax_as_line_item
+    }
+    all = ['<input id="x_line_item" name="x_line_item" type="hidden" value="Tax<|>Total Tax<|>Total Tax<|>1<|>44.0<|>N',
+    'input id="x_line_item" name="x_line_item" type="hidden" value="Shipping<|>Shipping and Handling Cost<|>Shipping and Handling Cost<|>1<|>44.0<|>N" />'
+    ]
+    check_inclusion all
+  end
+
+  def test_shipping_large
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+
+    service.ship_to_address :first_name => 'first', :last_name => 'last', :company => 'company1',
+      :city => 'city2', :state => 'TX', :zip => 84601, :country => 'US'
+    }
+     expected = "<input id=\"x_ship_to_city\" name=\"x_ship_to_city\" type=\"hidden\" value=\"city2\" />\n<input id=\"x_ship_to_last_name\" name=\"x_ship_to_last_name\" type=\"hidden\" value=\"last\" />\n<input id=\"x_ship_to_first_name\" name=\"x_ship_to_first_name\" type=\"hidden\" value=\"first\" />
+     <input id=\"x_ship_to_country\" name=\"x_ship_to_country\" type=\"hidden\" value=\"US\" />\n<input id=\"x_ship_to_zip\" name=\"x_ship_to_zip\" type=\"hidden\" value=\"84601\" />\n<input id=\"x_ship_to_company\" name=\"x_ship_to_company\" type=\"hidden\" value=\"company1\" />\n
+     <input id=\"x_ship_to_state\" name=\"x_ship_to_state\" type=\"hidden\" value=\"TX\" />\n"
+    for line in expected.split("\n") do
+      assert @output_buffer.include?(line.strip), 'expected but not found' + line
+    end
+  end
+
+  def test_line_item
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      service.add_line_item :name => 'name1', :quantity => 1, :unit_price => 1, :tax => 'true'
+      service.add_line_item :name => 'name2', :quantity => '2', :unit_price => '2'
+      assert_raise(RuntimeError) do
+        service.add_line_item :name => 'name3', :quantity => '3',  :unit_price => '-3'
+      end
+      service.tax 4
+      service.shipping 5
+      service.add_tax_as_line_item
+      service.add_shipping_as_line_item
+    }
+    all = ["<input id=\"x_line_item\" name=\"x_line_item\" type=\"hidden\" value=\"Item 1<|>name1<|>name1<|>1<|>1.0<|>N\" />"]
+    check_inclusion all
+  end
+
+  def test_line_item_weird_prices
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+      service.add_line_item :name => 'name1', :quantity => 1, :unit_price => "1.001", :tax => 'true'
+      service.add_line_item :name => 'name2', :quantity => '2', :unit_price => '1.006'
+    }
+    # should round the prices
+    assert @output_buffer !~ /1.001/
+    assert @output_buffer =~ /1.01/
+  end
+
+  def test_ship_to
+      payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+        service.tax 4
+        service.ship_to_address :first_name => 'firsty'
+      }
+      assert @output_buffer.include? "<input id=\"x_ship_to_first_name\" name=\"x_ship_to_first_name\" type=\"hidden\" value=\"firsty\" />"
+  end
+
+  def test_normal_fields
+    payment_service_for('44','8wd65QS', :service => :first_data,  :amount => 157.0){|service|
+
+      service.setup_hash :transaction_key => '8CP6zJ7uD875J6tY',
+          :order_timestamp => 1206836763
+      service.customer_id 8
+      service.customer :first_name => 'Cody',
+                         :last_name => 'Fauser',
+                         :phone => '(555)555-5555',
+                         :email => 'g@g.com'
+
+      service.billing_address :city => 'city1',
+                                :address1 => 'g',
+                                :address2 => '',
+                                :state => 'UT',
+                                :country => 'United States of America',
+                                :zip => '90210'
+       service.invoice '#1000'
+       service.shipping '30.00'
+       service.tax '31.00'
+       service.test_request 'true'
+
+    }
+
+    expected = "<input id=\"x_cust_id\" name=\"x_cust_id\" type=\"hidden\" value=\"8\" />
+
+    <input id=\"x_city\" name=\"x_city\" type=\"hidden\" value=\"city1\" />
+      <input id=\"x_fp_timestamp\" name=\"x_fp_timestamp\" type=\"hidden\" value=\"1206836763\" />
+    <input id=\"x_last_name\" name=\"x_last_name\" type=\"hidden\" value=\"Fauser\" />\n<input id=\"x_amount\" name=\"x_amount\" type=\"hidden\" value=\"157.0\" />
+    <input id=\"x_country\" name=\"x_country\" type=\"hidden\" value=\"United States of America\" />\n<input id=\"x_zip\" name=\"x_zip\" type=\"hidden\" value=\"90210\" />\n<input id=\"x_duplicate_window\" name=\"x_duplicate_window\" type=\"hidden\" value=\"28800\" />
+    \n<input id=\"x_relay_response\" name=\"x_relay_response\" type=\"hidden\" value=\"TRUE\" />\n<input id=\"x_first_name\" name=\"x_first_name\" type=\"hidden\" value=\"Cody\" />\n<input id=\"x_type\" name=\"x_type\" type=\"hidden\" value=\"AUTH_CAPTURE\" />\n<input id=\"x_version\" name=\"x_version\" type=\"hidden\" value=\"3.1\" />\n<input id=\"x_login\" name=\"x_login\" type=\"hidden\" value=\"8wd65QS\" />\n<input id=\"x_invoice_num\" name=\"x_invoice_num\" type=\"hidden\" value=\"#1000\" />\n<input id=\"x_phone\" name=\"x_phone\" type=\"hidden\" value=\"(555)555-5555\" />\n<input id=\"x_fp_sequence\" name=\"x_fp_sequence\" type=\"hidden\" value=\"44\" />\n<input id=\"x_show_form\" name=\"x_show_form\" type=\"hidden\" value=\"PAYMENT_FORM\" />
+    <input id=\"x_state\" name=\"x_state\" type=\"hidden\" value=\"UT\" />\n<input id=\"x_email\" name=\"x_email\" type=\"hidden\" value=\"g@g.com\" />\n<input id=\"x_fp_hash\" name=\"x_fp_hash\" type=\"hidden\" value=\"31d572da4e9910b36e999d73925eb01c\" />
+    <input id=\"x_tax\" name=\"x_tax\" type=\"hidden\" value=\"31.00\" />
+    <input id=\"x_freight\" name=\"x_freight\" type=\"hidden\" value=\"30.00\" />".split("\n")
+
+    for line in expected
+      assert @output_buffer.include?(line.strip), 'missing field' + line + ' in' + "\n"
+    end
+
+  end
+
+  def test_test_mode
+    ActiveMerchant::Billing::Base.integration_mode = :test
+    assert_equal 'https://demo.globalgatewaye4.firstdata.com/payment', FirstData.service_url
+  end
+
+  def test_production_mode
+    ActiveMerchant::Billing::Base.integration_mode = :production
+    assert_equal 'https://checkout.globalgatewaye4.firstdata.com/payment', FirstData.service_url
+  end
+
+end

--- a/test/unit/integrations/helpers/first_data_helper_test.rb
+++ b/test/unit/integrations/helpers/first_data_helper_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class FirstDataHelperTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+  
+  def setup
+    # currency is currently ignored...
+    @helper = FirstData::Helper.new('order-500','cody@example.com', :amount => 500, :currency => 'USD')
+  end
+ 
+  def test_basic_helper_fields
+    assert_field 'x_login', 'cody@example.com'
+    assert_field 'x_amount', '500.0'
+    assert_field 'x_fp_sequence', 'order-500'
+  end
+  
+  def test_customer_fields
+    @helper.customer :first_name => 'Cody', :last_name => 'Fauser', :email => 'cody@example.com'
+    assert_field 'x_first_name', 'Cody'
+    assert_field 'x_last_name', 'Fauser'
+    assert_field 'x_email', 'cody@example.com'
+  end
+
+  def test_address_mapping
+    @helper.billing_address :address1 => '1 My Street',
+                            :address2 => '',
+                            :city => 'Leeds',
+                            :state => 'Yorkshire',
+                            :zip => 'LS2 7EE',
+                            :country  => 'CA'
+    assert_field 'x_address', '1 My Street'
+    assert_field 'x_city', 'Leeds'
+    assert_field 'x_state', 'Yorkshire'
+    assert_field 'x_zip', 'LS2 7EE'
+  end
+  
+  def test_unknown_address_mapping
+    @helper.billing_address :farm => 'CA'
+    assert_equal 8, @helper.fields.size
+  end
+
+  def test_unknown_mapping
+    assert_nothing_raised do
+      @helper.company_address :address => '500 Dwemthy Fox Road'
+    end
+  end
+  
+  def test_setting_invalid_address_field
+    fields = @helper.fields.dup
+    @helper.billing_address :street => 'My Street'
+    assert_equal fields, @helper.fields
+  end
+end

--- a/test/unit/integrations/notifications/first_data_notification_test.rb
+++ b/test/unit/integrations/notifications/first_data_notification_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class FirstDataNotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @first_data = FirstData::Notification.new(http_raw_data)
+  end
+
+  def test_accessors_when_not_set
+    @first_data = FirstData::Notification.new("")
+    assert !@first_data.complete?
+    assert_equal [], @first_data.billing_address.values.compact
+    assert_equal [], @first_data.ship_to_address.values.compact
+    assert_equal({}, @first_data.all_custom_values_passed_in_and_now_passed_back_to_us)
+    assert !@first_data.avs_code_matches?
+    assert !@first_data.cavv_matches?
+    
+    assert !@first_data.test? # default is false
+    # should fail...assert !@first_data.acknowledge('', '')
+    [:customer_id, :auth_code, :po_num,
+    :tax, :transaction_type, :method, :method_available, :invoice_num,
+    :duty, :freight, :shipping, :description, :response_code_as_ruby_symbol, :response_reason_text, :response_reason_code,
+    :response_subcode, :tax_exempt, :avs_code, :cvv2_resp_code, :cavv_response, 
+    :item_id, :transaction_id, :payer_email, :security_key, :gross].each{|m| 
+      assert_equal nil, @first_data.send(m)
+    }
+  end
+
+  def test_compositions
+    assert_equal Money.new(12100, 'USD'), @first_data.amount
+  end
+  
+  def test_accessors_when_set
+    {:gross => "121.00", :auth_code => "000000", :payer_email => "test@test.com", :item_id => "441543269", :complete? => true,
+     :duty => "0.0000", :customer_id => "10", :avs_code => "P", :cvv2_resp_code_matches? => false, :cvv2_resp_code => "", :tax_exempt => "FALSE",
+     :billing_address => {:country=>"United States of America", :fax=>"", :email=>"test@test.com", :address=>"test", :first_name=>"test", :company=>"", :city=>"test", :state=>"UT", :zip=>"84601", :last_name=>"test"},
+     :ship_to_address => {:country=>"United States of America", :address=>"test", :first_name=>"test", :city=>"test", :zip=>"84601", :last_name=>"test"},
+     :test? => true,:response_reason_code => "1", :status => true, :security_key => "9B934370EE2378E844B0A6A6C6FC42E4", :response_code_as_ruby_symbol => :approved,
+     :cavv_matches? => true, :po_num => "", :all_custom_values_passed_in_and_now_passed_back_to_us => {"commit"=>"Pay securely with First Data"},
+     :receiver_email => nil, :invoice_num => "441543269"}.each{|m, v|
+      assert_equal(v, @first_data.send(m))
+    }
+  end
+      
+  def test_acknowledgement    
+    assert !@first_data.acknowledge('abc', 'def')
+    assert @first_data.acknowledge('', '8wd65QSj')
+  end
+
+  def test_respond_to_acknowledge
+    assert @first_data.respond_to?(:acknowledge)
+  end
+
+  private
+  
+  def http_raw_data
+    "x_response_code=1&x_response_subcode=1&x_response_reason_code=1&x_response_reason_text=%28TESTMODE%29+This+transaction+has+been+approved%2E&x_auth_code=000000&x_avs_code=P&x_trans_id=0&x_invoice_num=441543269&x_description=&x_amount=121%2E00&x_method=CC&x_type=auth%5Fcapture&x_cust_id=10&x_first_name=test&x_last_name=test&x_company=&x_address=test&x_city=test&x_state=UT&x_zip=84601&x_country=United+States+of+America&x_phone=8013776152&x_fax=&x_email=test%40test%2Ecom&x_ship_to_first_name=test&x_ship_to_last_name=test&x_ship_to_company=&x_ship_to_address=test&x_ship_to_city=test&x_ship_to_state=UT&x_ship_to_zip=84601&x_ship_to_country=United+States+of+America&x_tax=0%2E0000&x_duty=0%2E0000&x_freight=25%2E0000&x_tax_exempt=FALSE&x_po_num=&x_MD5_Hash=9B934370EE2378E844B0A6A6C6FC42E4&x_cvv2_resp_code=&x_cavv_response=&x_test_request=true&commit=Pay+securely+with+First+Data&x_method_available=true"
+  end
+  
+end


### PR DESCRIPTION
Add support for the First Data payment pages API as described in the following URL.

https://firstdata.zendesk.com/entries/407522-first-data-global-gateway-e4sm-payment-pages-integration-manual

First Data basically emulates Authorize.Net SIM, so the new FirstData classes (notification, helper, etc) inherit from the existing AuthorizeNetSim classes.
