### PR TITLE
Worldpay gateway: Fix test mode

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -57,6 +57,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def test?
+        @options[:test] || super  
+      end
+
       private
 
       def inquire(authorization, options={})


### PR DESCRIPTION
We were actually not properly sending requests to the WorldPay test server unless `Base.gateway_mode` was set to test (which affects all of the gateways). If just this instance of the gateway set the test param, it was ignored before.

A different solution to this issue might have been to change the method body of the `test?` inside the Gateway super class so that the next gateway implementor doesn't run into this issue. But for that change it would've probably been better to remove the definition of `test?` in each of the gateways and use that superclass method instead.

Please review @jduff 
