### PR TITLE
add credit card details to braintree transaction and customer responses

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -277,7 +277,10 @@ module ActiveMerchant #:nodoc:
           {
             "bin" => cc.bin,
             "expiration_date" => cc.expiration_date,
-            "token" => cc.token
+            "token" => cc.token,
+            "last_4" => cc.last_4,
+            "card_type" => cc.card_type,
+            "masked_number" => cc.masked_number
           }
         end
 
@@ -327,10 +330,17 @@ module ActiveMerchant #:nodoc:
           "postal_code"      => transaction.shipping_details.postal_code,
           "country_name"     => transaction.shipping_details.country_name,
         }
+        credit_card_details = {
+          "masked_number"       => transaction.credit_card_details.masked_number,
+          "bin"                 => transaction.credit_card_details.bin,
+          "last_4"              => transaction.credit_card_details.last_4,
+          "card_type"           => transaction.credit_card_details.card_type,
+        }
 
         {
           "order_id"            => transaction.order_id,
           "status"              => transaction.status,
+          "credit_card_details" => credit_card_details,
           "customer_details"    => customer_details,
           "billing_details"     => billing_details,
           "shipping_details"    => shipping_details,

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -16,11 +16,29 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     }
   end
 
+  def test_credit_card_details_on_store
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert_equal '5100', response.params["braintree_customer"]["credit_cards"].first["last_4"]
+    assert_equal('510510******5100', response.params["braintree_customer"]["credit_cards"].first["masked_number"])
+    assert_equal('5100', response.params["braintree_customer"]["credit_cards"].first["last_4"])
+    assert_equal('MasterCard', response.params["braintree_customer"]["credit_cards"].first["card_type"])
+    assert_equal('510510', response.params["braintree_customer"]["credit_cards"].first["bin"])
+  end
+
   def test_successful_authorize
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal 'authorized', response.params["braintree_transaction"]["status"]
+  end
+
+  def test_masked_card_number
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_equal('510510******5100', response.params["braintree_transaction"]["credit_card_details"]["masked_number"])
+    assert_equal('5100', response.params["braintree_transaction"]["credit_card_details"]["last_4"])
+    assert_equal('MasterCard', response.params["braintree_transaction"]["credit_card_details"]["card_type"])
+    assert_equal('510510', response.params["braintree_transaction"]["credit_card_details"]["bin"])
   end
 
   def test_successful_authorize_with_order_id


### PR DESCRIPTION
This change is to enable the use of braintree's client side encryption.  When the cc number is encrypted, you can't figure out what type it is or what the last four digits are.  Braintree's response tells you though.  This change is just adding those parameters on the respective hashes for transaction and customer create calls.

Remote braintree test included.
