### PR TITLE
Fix Payway registration bug

### DIFF
--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -132,11 +132,11 @@ module ActiveMerchant
       end
 
       def store(credit_card, options={})
-        requires!(options, :customer_reference_number)
+        requires!(options, :billing_id)
 
         post = {}
         add_payment_method(post, credit_card)
-        add_payment_method(post, options[:customer_reference_number])
+        add_payment_method(post, options[:billing_id])
         commit(:store, post)
       end
 

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -210,7 +210,7 @@ class PaywayTest < Test::Unit::TestCase
   def test_store
     @gateway.stubs(:ssl_post).returns(successful_response_store)
 
-    response = @gateway.store(@credit_card, :customer_reference_number => 84517)
+    response = @gateway.store(@credit_card, :billing_id => 84517)
 
     assert_instance_of Response, response
     assert_success response


### PR DESCRIPTION
According the document, customer reference number is required to register a credit card. The bill_id is not required and is not used at all.
