### PR TITLE
move card code to where it works with the XSD

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -673,9 +673,11 @@ module ActiveMerchant #:nodoc:
                 xml.tag!('customerProfileId', transaction[:customer_profile_id])
                 xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
                 xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
-                tag_unless_blank(xml, 'cardCode', transaction[:card_code])
             end
             add_order(xml, transaction[:order]) if transaction[:order].present?
+            unless [:void,:refund,:prior_auth_capture].include?(transaction[:type])
+              tag_unless_blank(xml, 'cardCode', transaction[:card_code])
+            end
           end
         end
       end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -146,6 +146,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           :description => 'Test Order Description',
           :purchase_order_number => '4321'
         },
+        :card_code => '900', # authorize.net says this is a matching CVV
         :amount => @amount
       }
     )


### PR DESCRIPTION
The Authorize.net XSD requires that order come before cardCode.  The current
implementation has it going the other way, and since the remote tests don't set
the card_code in the transaction AND the unit tests don't validate against
their schema, we can't see the bug.

I cannot run the remote tests for whatever reason, but I believe if you
run them using the modified test, you should see a failure
that is fixed by applying the change to authorize_net_cim.rb.

I can recreate this easily in my environment, and this fixes it - I just
don't know how to run the remote tests here.  Happy to do so if someone
can show me how.
