### PR TITLE
Only consider the last number in the CC or reference in BogusGateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -3,57 +3,57 @@ module ActiveMerchant #:nodoc:
     # Bogus Gateway
     class BogusGateway < Gateway
       AUTHORIZATION = '53433'
-      
+
       SUCCESS_MESSAGE = "Bogus Gateway: Forced success"
       FAILURE_MESSAGE = "Bogus Gateway: Forced failure"
-      ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number 1 for success, 2 for exception and anything else for error"
-      CREDIT_ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number 1 for success, 2 for exception and anything else for error"
-      UNSTORE_ERROR_MESSAGE = "Bogus Gateway: Use trans_id 1 for success, 2 for exception and anything else for error"
-      CAPTURE_ERROR_MESSAGE = "Bogus Gateway: Use authorization number 1 for exception, 2 for error and anything else for success"
-      VOID_ERROR_MESSAGE = "Bogus Gateway: Use authorization number 1 for exception, 2 for error and anything else for success"
-      REFUND_ERROR_MESSAGE = "Bogus Gateway: Use trans_id number 1 for exception, 2 for error and anything else for success"
-      
+      ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error"
+      CREDIT_ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error"
+      UNSTORE_ERROR_MESSAGE = "Bogus Gateway: Use trans_id ending in 1 for success, 2 for exception and anything else for error"
+      CAPTURE_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error and anything else for success"
+      VOID_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error and anything else for success"
+      REFUND_ERROR_MESSAGE = "Bogus Gateway: Use trans_id number ending in 1 for exception, 2 for error and anything else for success"
+
       self.supported_countries = ['US']
       self.supported_cardtypes = [:bogus]
       self.homepage_url = 'http://example.com'
       self.display_name = 'Bogus'
-      
+
       def authorize(money, credit_card_or_reference, options = {})
         money = amount(money)
         case normalize(credit_card_or_reference)
-        when '1'
+        when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
           raise Error, ERROR_MESSAGE
-        end      
+        end
       end
-  
+
       def purchase(money, credit_card_or_reference, options = {})
         money = amount(money)
         case normalize(credit_card_or_reference)
-        when '1', AUTHORIZATION
+        when /1$/, AUTHORIZATION
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
         else
           raise Error, ERROR_MESSAGE
         end
       end
- 
+
       def recurring(money, credit_card_or_reference, options = {})
         money = amount(money)
         case normalize(credit_card_or_reference)
-        when '1'
+        when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
         else
           raise Error, ERROR_MESSAGE
         end
       end
- 
+
       def credit(money, credit_card_or_reference, options = {})
         if credit_card_or_reference.is_a?(String)
           deprecated CREDIT_DEPRECATION_MESSAGE
@@ -62,9 +62,9 @@ module ActiveMerchant #:nodoc:
 
         money = amount(money)
         case normalize(credit_card_or_reference)
-        when '1'
+        when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true )
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
           raise Error, CREDIT_ERROR_MESSAGE
@@ -74,21 +74,21 @@ module ActiveMerchant #:nodoc:
       def refund(money, reference, options = {})
         money = amount(money)
         case reference
-        when '1'
+        when /1$/
           raise Error, REFUND_ERROR_MESSAGE
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         end
       end
- 
+
       def capture(money, reference, options = {})
         money = amount(money)
         case reference
-        when '1'
+        when /1$/
           raise Error, CAPTURE_ERROR_MESSAGE
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
@@ -97,31 +97,31 @@ module ActiveMerchant #:nodoc:
 
       def void(reference, options = {})
         case reference
-        when '1'
+        when /1$/
           raise Error, VOID_ERROR_MESSAGE
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true)
         else
           Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
         end
       end
-      
+
       def store(credit_card_or_reference, options = {})
         case normalize(credit_card_or_reference)
-        when '1'
+        when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true)
         else
           raise Error, ERROR_MESSAGE
-        end              
+        end
       end
-      
+
       def unstore(reference, options = {})
         case reference
-        when '1'
+        when /1$/
           Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
-        when '2'
+        when /2$/
           Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE },:test => true)
         else
           raise Error, UNSTORE_ERROR_MESSAGE

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -1,36 +1,39 @@
 require 'test_helper'
 
 class BogusTest < Test::Unit::TestCase
+  SUCCESS_PLACEHOLDER = '4444333322221111'
+  FAILURE_PLACEHOLDER = '4444333311112222'
+
   def setup
     @gateway = BogusGateway.new(
       :login => 'bogus',
       :password => 'bogus'
     )
-    
-    @creditcard = credit_card('1')
+
+    @creditcard = credit_card(SUCCESS_PLACEHOLDER)
 
     @response = ActiveMerchant::Billing::Response.new(true, "Transaction successful", :transid => BogusGateway::AUTHORIZATION)
   end
 
   def test_authorize
-    assert  @gateway.authorize(1000, credit_card('1')).success?
-    assert !@gateway.authorize(1000, credit_card('2')).success?
+    assert  @gateway.authorize(1000, credit_card(SUCCESS_PLACEHOLDER)).success?
+    assert !@gateway.authorize(1000, credit_card(FAILURE_PLACEHOLDER)).success?
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.authorize(1000, credit_card('123'))
     end
   end
 
   def test_purchase
-    assert  @gateway.purchase(1000, credit_card('1')).success?
-    assert !@gateway.purchase(1000, credit_card('2')).success?
+    assert  @gateway.purchase(1000, credit_card(SUCCESS_PLACEHOLDER)).success?
+    assert !@gateway.purchase(1000, credit_card(FAILURE_PLACEHOLDER)).success?
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.purchase(1000, credit_card('123'))
     end
   end
 
   def test_recurring
-    assert  @gateway.recurring(1000, credit_card('1')).success?
-    assert !@gateway.recurring(1000, credit_card('2')).success?
+    assert  @gateway.recurring(1000, credit_card(SUCCESS_PLACEHOLDER)).success?
+    assert !@gateway.recurring(1000, credit_card(FAILURE_PLACEHOLDER)).success?
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.recurring(1000, credit_card('123'))
     end
@@ -39,15 +42,15 @@ class BogusTest < Test::Unit::TestCase
   def test_capture
     assert  @gateway.capture(1000, '1337').success?
     assert  @gateway.capture(1000, @response.params["transid"]).success?
-    assert !@gateway.capture(1000, '2').success?
+    assert !@gateway.capture(1000, FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.capture(1000, '1')
+      @gateway.capture(1000, SUCCESS_PLACEHOLDER)
     end
   end
 
   def test_credit
-    assert  @gateway.credit(1000, credit_card('1')).success?
-    assert !@gateway.credit(1000, credit_card('2')).success?
+    assert  @gateway.credit(1000, credit_card(SUCCESS_PLACEHOLDER)).success?
+    assert !@gateway.credit(1000, credit_card(FAILURE_PLACEHOLDER)).success?
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.credit(1000, credit_card('123'))
     end
@@ -56,9 +59,9 @@ class BogusTest < Test::Unit::TestCase
   def test_refund
     assert  @gateway.refund(1000, '1337').success?
     assert  @gateway.refund(1000, @response.params["transid"]).success?
-    assert !@gateway.refund(1000, '2').success?
+    assert !@gateway.refund(1000, FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.refund(1000, '1')
+      @gateway.refund(1000, SUCCESS_PLACEHOLDER)
     end
   end
 
@@ -73,29 +76,29 @@ class BogusTest < Test::Unit::TestCase
   def test_void
     assert  @gateway.void('1337').success?
     assert  @gateway.void(@response.params["transid"]).success?
-    assert !@gateway.void('2').success?
+    assert !@gateway.void(FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.void('1')
+      @gateway.void(SUCCESS_PLACEHOLDER)
     end
   end
 
   def test_store
     @gateway.store(@creditcard)
   end
-  
+
   def test_unstore
-    @gateway.unstore('1')
+    @gateway.unstore(SUCCESS_PLACEHOLDER)
   end
 
   def test_store_then_purchase
     reference = @gateway.store(@creditcard)
     assert @gateway.purchase(1000, reference.authorization).success?
   end
-  
+
   def test_supported_countries
     assert_equal ['US'], BogusGateway.supported_countries
   end
-  
+
   def test_supported_card_types
     assert_equal [:bogus], BogusGateway.supported_cardtypes
   end


### PR DESCRIPTION
BogusGateway only allowing CC numbers like '1' and '2' makes mixing BogusGateway & CC form validation routines very difficult.

To work around this I've modified BogusGateway to use the last digit of the CC (or reference) to determine whether the transaction has failed.
