### PR TITLE
Add refund method to Viaklix gateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
       def credit(money, credit_card, options = {})
         deprecated CREDIT_DEPRECATION_MESSAGE
         raise ArgumentError, "Reference credits are not supported. Please supply the original credit card" if credit_card.is_a?(String)
-        refund(money, "", credit_card: credit_card)
+        refund(money, "", :credit_card => credit_card)
       end
 
       private

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -68,7 +68,7 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_success purchase
     assert purchase.authorization
 
-    assert refund = @gateway.refund(@amount, purchase.authorization, credit_card: @credit_card)
+    assert refund = @gateway.refund(@amount, purchase.authorization, :credit_card => @credit_card)
     assert_success refund
   end
 


### PR DESCRIPTION
This brings Viaklix and Elavon in line with the other gateways in that
the #credit method is deprecated and the refund method is the
recommended path.

Viaklix and Elavon are a bit unconventional in that they don't seem to
support credit via reference.  Instead, they require the full card
details again to do a credit.  In fact, they seem to require the card to
do a capture as well.

All in all, it's sub-optimal, but at least things are now a little more
consistent with the other direct gateways.
