### PR TITLE
Setting shipping address using the linkpoint gateway fails if the credit card object is nil.

### DIFF
--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -392,7 +392,7 @@ module ActiveMerchant #:nodoc:
         if shipping_address = options[:shipping_address] 
 
           params[:shipping] = {}
-          params[:shipping][:name]      = shipping_address[:name] || creditcard ? creditcard.name : nil
+          params[:shipping][:name]      = shipping_address[:name] || (creditcard ? creditcard.name : nil)
           params[:shipping][:address1]  = shipping_address[:address1] unless shipping_address[:address1].blank?
           params[:shipping][:address2]  = shipping_address[:address2] unless shipping_address[:address2].blank?
           params[:shipping][:city]      = shipping_address[:city]     unless shipping_address[:city].blank?


### PR DESCRIPTION
When setting up parameters for the LinkpointGateway, if no creditcard object is supplied while trying to set the shipping address, you will receive a nil object reference for creditcard. This happens when attempting to access name property of the creditcard object.

I have added a fix, in the same fashion to the code for handling the billing address (which works)
