### PR TITLE
Add AuthorizeNetGateway#reverse method to hide details of void-or-refund

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -177,6 +177,30 @@ module ActiveMerchant #:nodoc:
         refund(money, identification, options)
       end
 
+      # Reverse a transaction.
+      #
+      # Attempt to void the transaction.  If that fails, because the transaction has been settled, refund it.
+      #
+      # ==== Parameters
+      #
+      # * <tt>money</tt> -- The amount to be credited to the customer as an Integer value in cents.
+      # * <tt>identification</tt> -- The ID of the original transaction against which the reversal is being issued.
+      # * <tt>options</tt> -- A hash of parameters.
+      #
+      # ==== Options
+      #
+      # * <tt>:card_number</tt> -- The credit card number the refund is being issued to. (REQUIRED)
+      # * <tt>:first_name</tt> -- The first name of the account being refunded.
+      # * <tt>:last_name</tt> -- The last name of the account being refunded.
+      # * <tt>:zip</tt> -- The postal code of the account being refunded.
+      def reverse(money, identification, options = {})
+        void_response = void(identification, options)
+
+        return void_response if void_response.success?
+
+        refund(money, identification, options)
+      end
+
       # Create a recurring payment.
       #
       # This transaction creates a new Automated Recurring Billing (ARB) subscription. Your account must have ARB enabled.

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -41,6 +41,25 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal '508141794', response.authorization
   end
 
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    assert response = @gateway.void('508141795')
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '508141796', response.authorization
+  end
+
+  def test_successful_reverse
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    assert response = @gateway.reverse(@amount, '508141795', :card_number => @credit_card.number)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '508141797', response.authorization
+  end
+
   def test_add_address_outsite_north_america
     result = {}
 
@@ -309,6 +328,18 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def failed_authorization_response
     '$2$,$1$,$1$,$This transaction was declined.$,$advE7f$,$Y$,$508141794$,$5b3fe66005f3da0ebe51$,$$,$1.00$,$CC$,$auth_only$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$2860A297E0FE804BCB9EF8738599645C$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  end
+
+  def successful_void_response
+    '$1$,$1$,$1$,$This transaction has been approved.$,$xxx$,$P$,$508141796$,$$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$9F92C24C21E956E195A61B8F74CC8F62$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$XXXX1111$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  end
+
+  def failed_void_response
+    '$3$,$2$,$16$,$The transaction cannot be found.$,$$,$P$,$0$,$$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$F78CEDA63CEF500FB122F402BB603498$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  end
+
+  def successful_refund_response
+    '$1$,$1$,$1$,$This transaction has been approved.$,$$,$P$,$508141797$,$$,$$,$0.01$,$CC$,$credit$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$BFC43CB4A170D55D279619C740FA28D1$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$XXXX1111$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
   end
 
   def fraud_review_response


### PR DESCRIPTION
Often times, when we're dealing with allowing our users to give a customer their money back, we don't care how it happens, it just needs to work.  Unfortunately Authorize.net isn't as nice as Samurai in that it distinguishes needing to do a `void` if a capture has not already taken place and needing to do a `refund` if it has.

Adding `AuthorizeNetGateway#reverse` allows us to abstract away the details of that.

Tests were added and we're also submitting a separate pull request for the Samurai implementation.
