### PR TITLE
Add support for Samurai's reverse method

### DIFF
--- a/lib/active_merchant/billing/gateways/samurai.rb
+++ b/lib/active_merchant/billing/gateways/samurai.rb
@@ -60,6 +60,11 @@ module ActiveMerchant #:nodoc:
         handle_result(transaction.void)
       end
 
+      def reverse(transaction_id, options = {})
+        transaction = Samurai::Transaction.find(transaction_id)
+        handle_result(transaction.reverse)
+      end
+
       def store(creditcard, options = {})
         address = options[:billing_address] || options[:address] || {}
 

--- a/test/unit/gateways/samurai_test.rb
+++ b/test/unit/gateways/samurai_test.rb
@@ -112,6 +112,19 @@ class SamuraiTest < Test::Unit::TestCase
     assert_equal "reference_id", response.authorization
   end
 
+  def test_successful_reverse
+    Samurai::Transaction.expects(:find).
+                         with(@successful_authorization_id).
+                         returns(transaction = successful_authorize_response)
+
+    transaction.expects(:reverse).returns(successful_reverse_response)
+
+    response = @gateway.reverse(@successful_authorization_id)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal "reference_id", response.authorization
+  end
+
   def test_successful_store
     card_to_store = {
       :card_number  => "4242424242424242",
@@ -229,6 +242,10 @@ class SamuraiTest < Test::Unit::TestCase
 
   def successful_void_response
     successful_response("Void")
+  end
+
+  def successful_reverse_response
+    successful_response("Reverse")
   end
 
   def successful_store_result


### PR DESCRIPTION
Often times, when we're dealing with allowing our users to give a customer their money back, we don't care how it happens, it just needs to work.  Samurai has a nice API abstraction which deals with that case and does not distinguish between whether or not the card funds have been captured or not.

This pull request adds support for that abstraction.

Tests were added and we're also submitting a separate pull request for the Authorize.net implementation.
