### PR TITLE
Update AuthorizeNetGateway#commit to always store the action being performed in the params hash of the Response

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -269,7 +269,8 @@ module ActiveMerchant #:nodoc:
         url = test? ? self.test_url : self.live_url
         data = ssl_post url, post_data(action, parameters)
 
-        response = parse(data)
+        response          = parse(data)
+        response[:action] = action
 
         message = message_from(response)
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -112,6 +112,13 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end
   end
 
+  def test_action_included_in_params
+   @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+   response = @gateway.capture(50, '123456789')
+   assert_equal('PRIOR_AUTH_CAPTURE', response.params['action'] )
+  end
+
   def test_capture_passing_extra_info
     response = stub_comms do
       @gateway.capture(50, '123456789', :description => "Yo", :order_id => "Sweetness")


### PR DESCRIPTION
This makes it easier when storing the raw Response object to be able to query it for what action triggered the response.
