### PR TITLE
ElavonGateway ssl_salestax param

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -209,7 +209,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_salestax(form, options)
-        form[:salestax] = options[:tax].presence || 0
+        form[:salestax] = options[:tax]
       end
 
       def expdate(creditcard)

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.28.0"
+  VERSION = "1.28.1"
 end


### PR DESCRIPTION
Update ElavonGateway to use consistent :tax parameter to be passed to ssl_salestax param, this param is required and will cause payments to fail when missing
