### PR TITLE
Add option to change the outstanding balance of a PayPal recurring billing profile 

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -509,10 +509,10 @@ module ActiveMerchant #:nodoc:
       def add_credentials(xml)
         xml.tag! 'RequesterCredentials', CREDENTIALS_NAMESPACES do
           xml.tag! 'n1:Credentials' do
-            xml.tag! 'Username', @options[:login]
-            xml.tag! 'Password', @options[:password]
-            xml.tag! 'Subject', @options[:subject]
-            xml.tag! 'Signature', @options[:signature] unless @options[:signature].blank?
+            xml.tag! 'n1:Username', @options[:login]
+            xml.tag! 'n1:Password', @options[:password]
+            xml.tag! 'n1:Subject', @options[:subject]
+            xml.tag! 'n1:Signature', @options[:signature] unless @options[:signature].blank?
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
@@ -202,6 +202,9 @@ commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(prof
               if options.has_key?(:start_date)
                 xml.tag! 'n2:BillingStartDate', (options[:start_date].is_a?(Date) ? options[:start_date].to_time : options[:start_date]).utc.iso8601
               end
+              if options.has_key?(:outstanding_balance)
+                xml.tag! 'n2:OutstandingBalance', amount(options[:outstanding_balance]), 'currencyID' => options[:currency] || 'USD'
+              end
             end
           end
         end


### PR DESCRIPTION
Adds support for OutstandingBalance in the UpdateRecurringPaymentsProfileReq request.

I have also added "n1" prefixes to the Username, Password, Subject, and Signature fields in the add_credentials() functions.  This is due to a bug with PayPal that seems to only be triggered when changing the outstanding balance.
