### PR TITLE
itransact 'void' has a non-standard interface.

### DIFF
--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -196,7 +196,6 @@ module ActiveMerchant #:nodoc:
       # This will reverse a previously run transaction which *has* *not* settled.
       #
       # ==== Parameters
-      # * <tt>money</tt> - This parameter is ignored -- the PaymentClearing gateway does not allow partial voids.
       # * <tt>authorization</tt> - The authorization returned from the previous capture or purchase request
       # * <tt>options</tt> - A Hash of options, all are optional
       #
@@ -209,7 +208,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test_mode</tt> - <tt>true</tt> or <tt>false</tt>. Runs the transaction with the 'TestMode' element set to 'TRUE' or 'FALSE'.
       #
       # ==== Examples
-      #  response = gateway.void(nil, '9999999999',
+      #  response = gateway.void('9999999999',
       #    :vendor_data => [{'repId' => '1234567'}, {'customerId' => '9886'}],
       #    :send_customer_email => true,
       #    :send_merchant_email => true,
@@ -217,11 +216,7 @@ module ActiveMerchant #:nodoc:
       #    :test_mode => true
       #  )
       #
-      def void(*args)
-        raise ArgumentException("Void accepts 1-3 arguments.  #{args.size} provided") if args.size < 1 or args.size > 3
-        options = {}
-        options = args.pop if args.last.respond_to?(:has_key?) # last arg is options if it's hash-like
-        authorization = args.pop # always have this.
+      def void(authorization, options = {})
         payload = Nokogiri::XML::Builder.new do |xml|
           xml.VoidTransaction {
             xml.OperationXID(authorization)

--- a/test/remote/gateways/remote_itransact_test.rb
+++ b/test/remote/gateways/remote_itransact_test.rb
@@ -56,17 +56,12 @@ class RemoteItransactTest < Test::Unit::TestCase
     assert_success response
     assert_nil response.message
     assert response.authorization
-    assert capture = @gateway.void(nil, response.authorization)
+    assert capture = @gateway.void(response.authorization)
     assert_success capture
   end
 
   def test_void
-    assert void = @gateway.void(nil, '9999999999')
-    assert_success void
-  end
-
-  def test_void_partial
-    assert void = @gateway.void(5.55, '9999999999')
+    assert void = @gateway.void('9999999999')
     assert_success void
   end
 


### PR DESCRIPTION
the 'void' operation had a funny interface; just about all the other gateways have a 2-argument 'void' interface ( authorization, optional options).  This one had a 3-argument one, with a required 'money' amount that was just ignored.  So I made it so you can now pass 1, 2 or 3 args to it (so it should continue to work with old code) and it should auto-sense which is being done.

Also tweaked the tests slightly.
