### PR TITLE
Adds support for subscription refund on Cybersource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -147,8 +147,12 @@ module ActiveMerchant #:nodoc:
         commit(build_void_request(identification, options), options)
       end
 
-      def refund(money, identification, options = {})
-        commit(build_credit_request(money, identification, options), options)
+      # Refunds referencing an existing purchase or a subscription (stand alone credit).
+      # For a stand alone credit, identification_or_reference has to be the subscription
+      # reference and you also need to pass in options[:stand_alone] = true, as well
+      # as an options[:order_id].
+      def refund(money, identification_or_reference, options = {})
+        commit(build_credit_request(money, identification_or_reference, options), options)
       end
 
       def credit(money, identification, options = {})
@@ -281,13 +285,19 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def build_credit_request(money, identification, options)
-        order_id, request_id, request_token = identification.split(";")
-        options[:order_id] = order_id
-
+      def build_credit_request(money, identification_or_reference, options)
         xml = Builder::XmlMarkup.new :indent => 2
+
         add_purchase_data(xml, money, true, options)
-        add_credit_service(xml, request_id, request_token)
+
+        if options[:stand_alone]
+          requires!(options, :order_id)
+          add_subscription(xml, options, identification_or_reference)
+          add_credit_service(xml)
+        else
+          options[:order_id], request_id, request_token = identification_or_reference.split(";")
+          add_credit_service(xml, request_id, request_token)
+        end
 
         xml.target!
       end
@@ -435,10 +445,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_credit_service(xml, request_id, request_token)
+      def add_credit_service(xml, request_id = nil, request_token = nil)
         xml.tag! 'ccCreditService', {'run' => 'true'} do
-          xml.tag! 'captureRequestID', request_id
-          xml.tag! 'captureRequestToken', request_token
+          xml.tag! 'captureRequestID', request_id if request_id
+          xml.tag! 'captureRequestToken', request_token if request_token
         end
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -204,6 +204,19 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_subscription_refund
+    assert response = @gateway.store(@credit_card, @subscription_options)
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+
+    assert response = @gateway.refund(@amount, response.authorization, :stand_alone => true, :order_id => generate_unique_id)
+
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+  end
+
   def test_successful_create_subscription
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_equal 'Successful transaction', response.message


### PR DESCRIPTION
This pull request allows one to refund a Cybersource subscription (stand alone credit http://support.cybersource.com/cybskb/index?page=content&id=C138&actp=LIST).

cc/ @jmazzi @tfwright @itspriddle
