### PR TITLE
Add override for PostCodes for Ireland if not included in requests

### DIFF
--- a/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
+++ b/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
@@ -64,6 +64,9 @@ module ActiveMerchant #:nodoc:
 
             fields['FailureURL'] ||= fields['SuccessURL']
 
+            fields['BillingPostCode'] ||= "0000" if fields['BillingCountry'] == "IE"
+            fields['DeliveryPostCode'] ||= "0000" if fields['DeliveryCountry'] == "IE"
+
             crypt_skip = ['Vendor', 'EncryptKey', 'SendEmail']
             crypt_skip << 'BillingState'  unless fields['BillingCountry']  == 'US'
             crypt_skip << 'DeliveryState' unless fields['DeliveryCountry'] == 'US'

--- a/test/unit/integrations/helpers/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/helpers/sage_pay_form_helper_test.rb
@@ -213,6 +213,34 @@ class SagePayFormHelperTest < Test::Unit::TestCase
     assert_equal 5, crypts.uniq.count
   end
 
+  def test_ireland_addresses_use_default_0000_post_code
+    @helper.billing_address(
+      :address1 => '1 My Street',
+      :address2 => '',
+      :city => 'Dublin',
+      :country  => 'IE'
+    )
+    @helper.shipping_address(
+      :address1 => '1 Shipping Street',
+      :address2 => '',
+      :city => 'Dublin Shipping',
+      :country  => 'IE'
+    )
+
+    @helper.form_fields
+    assert_equal 16, @helper.fields.size
+
+    assert_field 'BillingAddress1', '1 My Street'
+    assert_field 'BillingCity', 'Dublin'
+    assert_field 'BillingPostCode', '0000'
+    assert_field 'BillingCountry', 'IE'
+
+    assert_field 'DeliveryAddress1', '1 Shipping Street'
+    assert_field 'DeliveryCity', 'Dublin Shipping'
+    assert_field 'DeliveryPostCode', '0000'
+    assert_field 'DeliveryCountry', 'IE'
+  end
+
   private
 
   def with_crypt_plaintext


### PR DESCRIPTION
## Issue

Ireland doesn't have Postal Codes but Sage Pay Form requires a post code for all orders being passed.
## Changes

This adds default values to the sage pay form helpers fields method to pass a default post code of 0000 if one hasn't been provided.
## Reviewers

@jduff @Soleone 
