### PR TITLE
PaymentExpress: Limit MerchantReference/description to 64 chars

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -212,7 +212,7 @@ module ActiveMerchant #:nodoc:
       
       def add_invoice(xml, options)
         xml.add_element("TxnId").text = options[:order_id].to_s.slice(0, 16) unless options[:order_id].blank?
-        xml.add_element("MerchantReference").text = options[:description] unless options[:description].blank?
+        xml.add_element("MerchantReference").text = options[:description].to_s.slice(0, 64) unless options[:description].blank?
       end
       
       def add_address_verification_data(xml, options)


### PR DESCRIPTION
PaymentExpress enforces a max length on the MerchantReference field of 64 characters.  This field is derived from the description field which is passed in the options hash.

Before, MerchantReference was unbounded.  If more than 64 characters were passed in this field, PaymentExpress would return an error when running the transaction.

Documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#MerchantReference

Note: This commit also includes a test verifying that TxnId is limited to 16 characters.  This restriction was already implemented, but untested.

Documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#TxnId
