### PR TITLE
Adds XML assertions and a test helper to capture post data

### DIFF
--- a/test/unit/custom_assertions_test.rb
+++ b/test/unit/custom_assertions_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+
+class CustomAssertionsTest < Test::Unit::TestCase
+	def test_capture_post_data
+		gateway = mock()
+		captured_data = capture_post_data(gateway) do |gateway|
+			gateway.ssl_post('url', 'Some post data')
+		end
+		assert_equal 'Some post data', captured_data
+	end
+
+	def test_assert_no_xml_element_basic
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+      </Transaction>
+    XML
+
+		assert_no_xml_element(xml, 'ExpDate')
+	end
+
+	def test_assert_no_xml_element_nested
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+        <Customer>
+        	<Name>John Doe</Name>
+        </Customer>
+        <Details>
+        	<Tax>100</Tax>
+        </Details>
+      </Transaction>
+    XML
+
+		assert_no_xml_element(xml, 'Details/Name')
+		assert_no_xml_element(xml, 'Name')
+		assert_no_xml_element(xml, 'Customer/Tax')
+	end
+
+	def test_assert_no_xml_element_on_root
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+      </Transaction>
+    XML
+
+		assert_no_xml_element(xml, 'Transaction')
+	end
+
+	def test_assert_xml_element_basic
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+      </Transaction>
+    XML
+
+		assert_xml_element(xml, 'Amount')
+	end
+
+	def test_assert_xml_element_nested
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+        <Customer>
+        	<Name>John Doe</Name>
+        </Customer>
+      </Transaction>
+    XML
+
+		assert_xml_element(xml, '//Name')
+		assert_xml_element(xml, '*/Name')
+		assert_xml_element(xml, 'Customer/Name')
+	end
+
+	def test_assert_xml_element_text
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <CardNumber>4111111111111111</CardNumber>
+        <Customer>
+        	<Name>John Doe</Name>
+        </Customer>
+      </Transaction>
+    XML
+
+		assert_xml_element_text(xml, 'Amount', '1000')
+		assert_xml_element_text(xml, '//Name', 'John Doe')
+		assert_xml_element_text(xml, '*/Name', 'John Doe')
+		assert_xml_element_text(xml, 'Customer/Name', 'John Doe')
+	end
+
+	def test_assert_xml_element_text_multiple
+		xml = <<-XML
+      <?xml version="1.0" encoding="utf-8" ?> 
+      <Transaction>
+        <Amount>1000</Amount>
+        <Amount>2000</Amount>
+      </Transaction>
+    XML
+
+		assert_xml_element_text(xml, 'Amount', '1000')
+	end
+
+end


### PR DESCRIPTION
When testing ActiveMerchant code, it is often helpful to be able to inspect the data you are actually sending to the gateway.

For example, if I'm implementing a new option (via the options hash) on a gateway that should send a new XML element with a particular value in the POST data, I would like to know that setting that option results in adding the new XML, without verifying the exact structure of ALL the XML.

One way you might do this is to use an HTTP mocking/expectation library like WebMock and set expectations on the POSTed data.

Since it's probably best not to add another dependency to a mature library, I'm trying a different tact.

This code provides a way to explicitly capture the data being POSTed by any gateway that uses the common +ssl_post+ method. Once captured, you can perform assertions on the data.

```
amount = 1000
xml = capture_post_data(@gateway) do |gateway|
  gateway.purchase(@amount, @visa)
end
assert_xml_element(xml, 'Amount')
assert_xml_element_text(xml, 'Amount', '1000')
```

This code also provides some basic assertions for XML element presence and node text equivalence.
