### PR TITLE
Update supported cards for the Iridium gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       
       # The card types supported by the payment gateway
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :maestro, :jcb, :solo, :diners_club]
       
       # The homepage URL of the gateway
       self.homepage_url = 'http://www.iridiumcorp.co.uk/'


### PR DESCRIPTION
This adds maestro, jcb, solo, and diners_club to Iridium's list of supported cardtypes

[Iridium Payment Gateway information page](http://www.iridiumcorp.co.uk/InternetPaymentGateway.aspx)
## Review

@Soleone @jduff 
