### PR TITLE
fix path of gateway remote test in generator

### DIFF
--- a/generators/gateway/gateway_generator.rb
+++ b/generators/gateway/gateway_generator.rb
@@ -20,6 +20,6 @@ class GatewayGenerator < ActiveMerchantGenerator
   end
 
   def remote_gateway_test_file
-    "lib/active_merchant/billing/gateways/remote_#{identifier}_test.rb"
+    "test/remote/gateways/remote_#{identifier}_test.rb"
   end
 end


### PR DESCRIPTION
Looks like a small typo in aa9d15e617.

Generator was creating "lib/active_merchant/billing/gateways/remote_#{identifier}_test.rb"
 instead of "test/remote/gateways/remote_#{identifier}_test.rb"
