### PR TITLE
PaymentExpress: Limit MerchantReference/description to 64 chars

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -209,7 +209,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(xml, options)
         xml.add_element("TxnId").text = options[:order_id].to_s.slice(0, 16) unless options[:order_id].blank?
-        xml.add_element("MerchantReference").text = options[:description] unless options[:description].blank?
+        xml.add_element("MerchantReference").text = options[:description].to_s.slice(0, 64) unless options[:description].blank?
       end
 
       def add_address_verification_data(xml, options)

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class PaymentExpressTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
         
     @gateway = PaymentExpressGateway.new(
@@ -148,6 +150,70 @@ class PaymentExpressTest < Test::Unit::TestCase
     assert_nil response.cvv_result['code']
   end
   
+  def test_purchase_truncates_order_id_to_16_chars
+    stub_comms do
+      @gateway.purchase(@amount, @visa, {:order_id => "16chars---------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_authorize_truncates_order_id_to_16_chars
+    stub_comms do
+      @gateway.authorize(@amount, @visa, {:order_id => "16chars---------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_capture_truncates_order_id_to_16_chars
+    stub_comms do
+      @gateway.capture(@amount, 'identification', {:order_id => "16chars---------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_refund_truncates_order_id_to_16_chars
+    stub_comms do
+      @gateway.refund(@amount, 'identification', {:description => 'refund', :order_id => "16chars---------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_purchase_truncates_description_to_64_chars
+    stub_comms do
+      @gateway.purchase(@amount, @visa, {:description => "64chars---------------------------------------------------------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MerchantReference>64chars---------------------------------------------------------<\/MerchantReference>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_authorize_truncates_description_to_64_chars
+    stub_comms do
+      @gateway.authorize(@amount, @visa, {:description => "64chars---------------------------------------------------------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MerchantReference>64chars---------------------------------------------------------<\/MerchantReference>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_capture_truncates_description_to_64_chars
+    stub_comms do
+      @gateway.capture(@amount, 'identification', {:description => "64chars---------------------------------------------------------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MerchantReference>64chars---------------------------------------------------------<\/MerchantReference>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_refund_truncates_description_to_64_chars
+    stub_comms do
+      @gateway.refund(@amount, 'identification', {:description => "64chars---------------------------------------------------------EXTRA"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MerchantReference>64chars---------------------------------------------------------<\/MerchantReference>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   private
 
   def billing_id_token_purchase(options = {})


### PR DESCRIPTION
PaymentExpress enforces a max length on the `MerchantReference` field of 64 characters.  This field is derived from the `:description` field which is passed in the `options` hash.

Documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#MerchantReference

Note: This commit also includes a test verifying that `TxnId` is limited to 16 characters.  This restriction was already implemented, but untested.

Documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#TxnId
