### PR TITLE
Wirecard: FunctionID must be no more than 32 characters

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -148,7 +148,7 @@ module ActiveMerchant #:nodoc:
         options[:order_id] ||= generate_unique_id
 
         xml.tag! "FNC_CC_#{options[:action].to_s.upcase}" do
-          xml.tag! 'FunctionID', options[:description]
+          xml.tag! 'FunctionID', options[:description].to_s.slice(0,32)
           xml.tag! 'CC_TRANSACTION' do
             xml.tag! 'TransactionID', options[:order_id]
             case options[:action]

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class WirecardTest < Test::Unit::TestCase
+  include CommStub
+
   TEST_AUTHORIZATION_GUWID = 'C822580121385121429927'
   TEST_PURCHASE_GUWID = 'C865402121385575982910'
   TEST_CAPTURE_GUWID = 'C833707121385268439116'
@@ -98,6 +100,26 @@ class WirecardTest < Test::Unit::TestCase
     assert_nothing_raised do
       @gateway.authorize(@amount, @credit_card, @options)
     end
+  end
+
+  def test_description_trucated_to_32_chars_in_authorize
+    options = {:description => "32chars-------------------------EXTRA"}
+
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FunctionID>32chars-------------------------<\/FunctionID>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_description_trucated_to_32_chars_in_purchase
+    options = {:description => "32chars-------------------------EXTRA"}
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FunctionID>32chars-------------------------<\/FunctionID>/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   private


### PR DESCRIPTION
This XML field is filled from `options[:description]` for authorize and purchase transactions.  The Wirecard documentation and implementation do not allow a value longer than 32 characters.
