### PR TITLE
Added PaypalRecurringApi to PaypalExpressGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -1,5 +1,6 @@
 require File.dirname(__FILE__) + '/paypal/paypal_common_api'
 require File.dirname(__FILE__) + '/paypal/paypal_express_response'
+require File.dirname(__FILE__) + '/paypal/paypal_recurring_api'
 require File.dirname(__FILE__) + '/paypal_express_common'
 
 module ActiveMerchant #:nodoc:
@@ -7,6 +8,7 @@ module ActiveMerchant #:nodoc:
     class PaypalExpressGateway < Gateway
       include PaypalCommonAPI
       include PaypalExpressCommon
+      include PaypalRecurringApi
 
       NON_STANDARD_LOCALE_CODES = {
         'DK' => 'da_DK',


### PR DESCRIPTION
This includes PaypalRecurringApi in PaypalExpressGateway so that you can do recurring payments with Express checkout also.
