### PR TITLE
Allow transaction search for PayPal by filtering of ProfileID

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -397,7 +397,7 @@ module ActiveMerchant #:nodoc:
         transaction_search_optional_fields = %w{ Payer ReceiptID Receiver
                                                  TransactionID InvoiceID CardNumber
                                                  AuctionItemNumber TransactionClass
-                                                 CurrencyCode Status }
+                                                 CurrencyCode Status ProfileID }
         build_request_wrapper('TransactionSearch') do |xml|
           xml.tag! 'StartDate', date_to_iso(options[:start_date])
           xml.tag! 'EndDate', date_to_iso(options[:end_date]) unless options[:end_date].blank?


### PR DESCRIPTION
According to PayPal's documentation:

https://www.x.com/developers/paypal/documentation-tools/api/transactionsearch-api-operation-soap

The ProfileID field was not included as an option for `PaypalCommonAPI#transaction_search`.

This commit adds this option in.
