### PR TITLE
Add eWay Rapid 3.0 gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Elavon MyVirtualMerchant](http://www.elavon.com) - US, CA
 * [ePay](http://www.epay.dk/) - DK, SE, NO
 * [eWAY](http://www.eway.com.au/) - AU
+* [eWay Rapid 3.0](http://www.eway.com.au/) - AU
 * [E-xact](http://www.e-xact.com) - CA, US
 * [Fat Zebra](https://www.fatzebra.com.au) - AU
 * [Federated Canada](http://www.federatedcanada.com/) - CA

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -1,0 +1,301 @@
+require "nokogiri"
+require "cgi"
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class EwayRapidGateway < Gateway
+      self.test_url = "https://api.sandbox.ewaypayments.com/"
+      self.live_url = "https://api.ewaypayments.com/"
+
+      self.money_format = :cents
+      self.supported_countries = ["AU"]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+      self.homepage_url = "http://www.eway.com.au/"
+      self.display_name = "eWAY Rapid 3.0"
+      self.default_currency = "AUD"
+
+      def initialize(options = {})
+        requires!(options, :login, :password)
+        super
+      end
+
+      # Public: Run a purchase transaction. Treats the Rapid 3.0 transparent
+      # redirect as an API endpoint in order to conform to the standard
+      # ActiveMerchant #purchase API.
+      #
+      # amount  - The monetary amount of the transaction in cents.
+      # options - A standard ActiveMerchant options hash:
+      #           :order_id         - A merchant-supplied identifier for the
+      #                               transaction (optional).
+      #           :description      - A merchant-supplied description of the
+      #                               transaction (optional).
+      #           :currency         - Three letter currency code for the
+      #                               transaction (default: "AUD")
+      #           :billing_address  - Standard ActiveMerchant address hash
+      #                               (optional).
+      #           :shipping_address - Standard ActiveMerchant address hash
+      #                               (optional).
+      #           :ip               - The ip of the consumer initiating the
+      #                               transaction (optional).
+      #           :application_id   - A string identifying the application
+      #                               submitting the transaction
+      #                               (default: "https://github.com/Shopify/active_merchant")
+      #
+      # Returns an ActiveMerchant::Billing::Response object
+      def purchase(amount, payment_method, options={})
+        MultiResponse.new.tap do |r|
+          # Rather than follow the redirect, we detect the 302 and capture the
+          # token out of the Location header in the run_purchase step. But we
+          # still need a placeholder url to pass to eWay, and that is what
+          # example.com is used for here.
+          r.process{setup_purchase(amount, options.merge(:redirect_url => "http://example.com/"))}
+          r.process{run_purchase(r.authorization, payment_method, r.params["formactionurl"])}
+          r.process{status(r.authorization)}
+        end
+      end
+
+      # Public: Acquire the token necessary to run a transparent redirect.
+      #
+      # amount  - The monetary amount of the transaction in cents.
+      # options - A supplemented ActiveMerchant options hash:
+      #           :redirect_url     - The url to return the customer to after
+      #                               the transparent redirect is completed
+      #                               (required).
+      #           :order_id         - A merchant-supplied identifier for the
+      #                               transaction (optional).
+      #           :description      - A merchant-supplied description of the
+      #                               transaction (optional).
+      #           :currency         - Three letter currency code for the
+      #                               transaction (default: "AUD")
+      #           :billing_address  - Standard ActiveMerchant address hash
+      #                               (optional).
+      #           :shipping_address - Standard ActiveMerchant address hash
+      #                               (optional).
+      #           :ip               - The ip of the consumer initiating the
+      #                               transaction (optional).
+      #           :application_id   - A string identifying the application
+      #                               submitting the transaction
+      #                               (default: "https://github.com/Shopify/active_merchant")
+      #
+      # Returns an EwayRapidResponse object, which conforms to the
+      # ActiveMerchant::Billing::Response API, but also exposes #form_url.
+      def setup_purchase(amount, options={})
+        requires!(options, :redirect_url)
+        request = build_xml_request("CreateAccessCodeRequest") do |doc|
+          add_metadata(doc, options)
+          add_invoice(doc, amount, options)
+          add_customer_data(doc, options)
+        end
+
+        commit(url_for("CreateAccessCode"), request)
+      end
+
+      # Public: Retrieve the status of a transaction.
+      #
+      # identification - The Eway Rapid 3.0 access code for the transaction
+      #                  (returned as the response.authorization by
+      #                  #setup_purchase).
+      #
+      # Returns an EwayRapidResponse object.
+      def status(identification)
+        request = build_xml_request("GetAccessCodeResultRequest") do |doc|
+          doc.AccessCode identification
+        end
+        commit(url_for("GetAccessCodeResult"), request)
+      end
+
+      private
+
+      def run_purchase(identification, payment_method, endpoint)
+        post = {
+          "accesscode" => identification
+        }
+        add_credit_card(post, payment_method)
+
+        commit_form(endpoint, build_form_request(post))
+      end
+
+      def add_metadata(doc, options)
+        doc.RedirectUrl(options[:redirect_url])
+        doc.CustomerIP options[:ip] if options[:ip]
+        doc.Method "ProcessPayment"
+        doc.DeviceID(options[:application_id] || application_id)
+      end
+
+      def add_invoice(doc, money, options)
+        doc.Payment do
+          doc.TotalAmount amount(money)
+          doc.InvoiceReference options[:order_id]
+          doc.InvoiceDescription options[:description]
+          currency_code = (options[:currency] || currency(money) || default_currency)
+          doc.CurrencyCode currency_code
+        end
+      end
+
+      def add_customer_data(doc, options)
+        doc.Customer do
+          add_address(doc, (options[:billing_address] || options[:address]), {:email => options[:email]})
+        end
+        doc.ShippingAddress do
+          add_address(doc, options[:shipping_address], {:skip_company => true})
+        end
+      end
+
+      def add_address(doc, address, options={})
+        return unless address
+        if name = address[:name]
+          parts = name.split(/\s+/)
+          doc.FirstName parts.shift if parts.size > 1
+          doc.LastName parts.join(" ")
+        end
+        doc.CompanyName address[:company] unless options[:skip_company]
+        doc.Street1 address[:address1]
+        doc.Street2 address[:address2]
+        doc.City address[:city]
+        doc.State address[:state]
+        doc.PostalCode address[:zip]
+        doc.Country address[:country]
+        doc.Phone address[:phone]
+        doc.Fax address[:fax]
+        doc.Email options[:email]
+      end
+
+      def add_credit_card(post, credit_card)
+        post["cardname"] = credit_card.name
+        post["cardnumber"] = credit_card.number
+        post["cardexpirymonth"] = credit_card.month
+        post["cardexpiryyear"] = credit_card.year
+        post["cardcvn"] = credit_card.verification_value
+      end
+
+      def build_xml_request(root)
+        builder = Nokogiri::XML::Builder.new
+        builder.__send__(root) do |doc|
+          yield(doc)
+        end
+        builder.to_xml
+      end
+
+      def build_form_request(post)
+        request = []
+        post.each do |key, value|
+          request << "EWAY_#{key.upcase}=#{CGI.escape(value.to_s)}"
+        end
+        request.join("&")
+      end
+
+      def url_for(action)
+        (test? ? test_url : live_url) + action + ".xml"
+      end
+
+      def commit(url, request, form_post=false)
+        headers = {
+          "Authorization" => ("Basic " + Base64.strict_encode64(@options[:login].to_s + ":" + @options[:password].to_s).chomp),
+          "Content-Type" => "text/xml"
+        }
+
+        raw = parse(ssl_post(url, request, headers))
+
+        succeeded = success?(raw)
+        EwayRapidResponse.new(
+          succeeded,
+          message_from(succeeded, raw),
+          raw,
+          :authorization => authorization_from(raw),
+          :test => test?,
+          :avs_result => avs_result_from(raw),
+          :cvv_result => cvv_result_from(raw)
+        )
+      rescue ActiveMerchant::ResponseError => e
+        return EwayRapidResponse.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
+      end
+
+      def commit_form(url, request)
+        http_response = raw_ssl_request(:post, url, request)
+
+        success = (http_response.code.to_s == "302")
+        message = (success ? "Succeeded" : http_response.body)
+        if success
+          authorization = CGI.unescape(http_response["Location"].split("=").last)
+        end
+        Response.new(success, message, {:location => http_response["Location"]}, :authorization => authorization, :test => test?)
+      end
+
+      def parse(xml)
+        response = {}
+
+        doc = Nokogiri::XML(xml)
+        doc.root.xpath("*").each do |node|
+          if (node.elements.size == 0)
+            response[node.name.downcase.to_sym] = node.text
+          else
+            node.elements.each do |childnode|
+              name = "#{node.name.downcase}_#{childnode.name.downcase}"
+              response[name.to_sym] = childnode.text
+            end
+          end
+        end unless doc.root.nil?
+
+        response
+      end
+
+      def success?(response)
+        if response[:errors]
+          false
+        elsif response[:transactionstatus]
+          (response[:transactionstatus] == "true")
+        else
+          true
+        end
+      end
+
+      def message_from(succeeded, response)
+        if response[:errors]
+          response[:errors]
+        elsif response[:responsecode]
+          ActiveMerchant::Billing::EwayGateway::MESSAGES[response[:responsecode]]
+        elsif response[:responsemessage]
+          response[:responsemessage]
+        elsif succeeded
+          "Succeeded"
+        else
+          "Failed"
+        end
+      end
+
+      def authorization_from(response)
+        response[:accesscode]
+      end
+
+      def avs_result_from(response)
+        code = case response[:verification_address]
+        when "Valid"
+          "M"
+        when "Invalid"
+          "N"
+        else
+          "I"
+        end
+        {:code => code}
+      end
+
+      def cvv_result_from(response)
+        case response[:verification_cvn]
+        when "Valid"
+          "M"
+        when "Invalid"
+          "N"
+        else
+          "P"
+        end
+      end
+
+      class EwayRapidResponse < ActiveMerchant::Billing::Response
+        def form_url
+          params["formactionurl"]
+        end
+      end
+    end
+  end
+end
+

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -104,6 +104,11 @@ eway_managed:
   password: 'test123'
 
 # Working credentials, no need to replace
+eway_rapid:
+  login: "F9802CIVgUgNaD8y/H52MBMnL5OvMoy4cYimpi1L/dCXeNNR6or3vLPoC9GjeLVdA7ymi+"
+  password: "sandbox1"
+
+# Working credentials, no need to replace
 exact:
   login: "A00427-01"
   password: testus

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -1,0 +1,105 @@
+require 'test_helper'
+
+class RemoteEwayRapidTest < Test::Unit::TestCase
+  def setup
+    @gateway = EwayRapidGateway.new(fixtures(:eway_rapid))
+
+    @amount = 100
+    @failed_amount = 105
+    @credit_card = credit_card("4444333322221111")
+
+    @options = {
+      :order_id => "1",
+      :billing_address => address,
+      :description => "Store Purchase",
+      :redirect_url => "http://bogus.com"
+    }
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "Transaction Approved", response.message
+  end
+
+  def test_fully_loaded_purchase
+    assert response = @gateway.purchase(@amount, @credit_card,
+      :redirect_url => "http://awesomesauce.com",
+      :ip => "0.0.0.0",
+      :application_id => "Woohoo",
+      :description => "Description",
+      :order_id => "orderid1",
+      :currency => "AUD",
+      :email => "jim@example.com",
+      :billing_address => {
+        :name => "Jim Awesome Smith",
+        :company => "Awesome Co",
+        :address1 => "1234 My Street",
+        :address2 => "Apt 1",
+        :city     => "Ottawa",
+        :state    => "ON",
+        :zip      => "K1C2N6",
+        :country  => "CA",
+        :phone    => "(555)555-5555",
+        :fax      => "(555)555-6666"
+      },
+      :shipping_address => {
+        :name => "Baker",
+        :company => "Elsewhere Inc.",
+        :address1 => "4321 Their St.",
+        :address2 => "Apt 2",
+        :city     => "Chicago",
+        :state    => "IL",
+        :zip      => "60625",
+        :country  => "US",
+        :phone    => "1115555555",
+        :fax      => "1115556666"
+      }
+    )
+    assert_success response
+  end
+
+  def test_failed_purchase
+    assert response = @gateway.purchase(@failed_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Do Not Honour", response.message
+  end
+
+  def test_failed_setup_purchase
+    assert response = @gateway.setup_purchase(@amount, :redirect_url => "")
+    assert_failure response
+    assert_equal "V6047", response.message
+  end
+
+  def test_failed_run_purchase
+    setup_response = @gateway.setup_purchase(@amount, @options)
+    assert_success setup_response
+
+    assert response = @gateway.send(:run_purchase, "bogus", @credit_card, setup_response.params["formactionurl"])
+    assert_failure response
+    assert_match(%r{Not Found}, response.message)
+  end
+
+  def test_failed_status
+    setup_response = @gateway.setup_purchase(@failed_amount, @options)
+    assert_success setup_response
+
+    assert run_response = @gateway.send(:run_purchase, setup_response.authorization, @credit_card, setup_response.params["formactionurl"])
+    assert_success run_response
+
+    response = @gateway.status(run_response.authorization)
+    assert_failure response
+    assert_equal "Do Not Honour", response.message
+    assert_equal run_response.authorization, response.authorization
+  end
+
+  def test_invalid_login
+    gateway = EwayRapidGateway.new(
+                :login => "bogus",
+                :password => "bogus"
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Unauthorized", response.message
+  end
+end

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -1,0 +1,377 @@
+require "test_helper"
+
+class EwayRapidTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = EwayRapidGateway.new(
+      :login => "login",
+      :password => "password"
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+  end
+
+  def test_purchase_calls_sub_methods
+    request = sequence("request")
+    @gateway.expects(:setup_purchase).with(@amount, {:order_id => 1, :redirect_url => "http://example.com/"}).returns(Response.new(true, "Success", {"formactionurl" => "url"}, :authorization => "auth1")).in_sequence(request)
+    @gateway.expects(:run_purchase).with("auth1", @credit_card, "url").returns(Response.new(true, "Success", {}, :authorization => "auth2")).in_sequence(request)
+    @gateway.expects(:status).with("auth2").returns(Response.new(true, "Success", {})).in_sequence(request)
+
+    response = @gateway.purchase(@amount, @credit_card, :order_id => 1)
+    assert_success response
+  end
+
+  def test_successful_setup_purchase
+    response = stub_comms do
+      @gateway.setup_purchase(@amount, :redirect_url => "http://bogus")
+    end.respond_with(successful_setup_purchase_response)
+
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert_equal(
+      "60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT",
+      response.authorization
+    )
+    assert_equal "https://secure-au.sandbox.ewaypayments.com/Process", response.form_url
+    assert response.test?
+  end
+
+  def test_failed_setup_purchase
+    response = stub_comms do
+      @gateway.setup_purchase(@amount, :redirect_url => "http://bogus")
+    end.respond_with(failed_setup_purchase_response)
+
+    assert_failure response
+    assert_equal "V6047", response.message
+    assert_nil response.authorization
+    assert response.test?
+  end
+
+  def test_setup_purchase_with_all_options
+    response = stub_comms do
+      @gateway.setup_purchase(200,
+        :redirect_url => "http://awesomesauce.com",
+        :ip => "0.0.0.0",
+        :application_id => "Woohoo",
+        :description => "Description",
+        :order_id => "orderid1",
+        :currency => "INR",
+        :email => "jim@example.com",
+        :billing_address => {
+          :name => "Jim Awesome Smith",
+          :company => "Awesome Co",
+          :address1 => "1234 My Street",
+          :address2 => "Apt 1",
+          :city     => "Ottawa",
+          :state    => "ON",
+          :zip      => "K1C2N6",
+          :country  => "CA",
+          :phone    => "(555)555-5555",
+          :fax      => "(555)555-6666"
+        },
+        :shipping_address => {
+          :name => "Baker",
+          :company => "Elsewhere Inc.",
+          :address1 => "4321 Their St.",
+          :address2 => "Apt 2",
+          :city     => "Chicago",
+          :state    => "IL",
+          :zip      => "60625",
+          :country  => "US",
+          :phone    => "1115555555",
+          :fax      => "1115556666"
+        }
+      )
+    end.check_request do |endpoint, data, headers|
+      assert_no_match(%r{#{@credit_card.number}}, data)
+
+      assert_match(%r{RedirectUrl>http://awesomesauce.com<}, data)
+      assert_match(%r{CustomerIP>0.0.0.0<}, data)
+      assert_match(%r{DeviceID>Woohoo<}, data)
+
+      assert_match(%r{TotalAmount>200<}, data)
+      assert_match(%r{InvoiceDescription>Description<}, data)
+      assert_match(%r{InvoiceReference>orderid1<}, data)
+      assert_match(%r{CurrencyCode>INR<}, data)
+
+      assert_match(%r{FirstName>Jim<}, data)
+      assert_match(%r{LastName>Awesome Smith<}, data)
+      assert_match(%r{CompanyName>Awesome Co<}, data)
+      assert_match(%r{Street1>1234 My Street<}, data)
+      assert_match(%r{Street2>Apt 1<}, data)
+      assert_match(%r{City>Ottawa<}, data)
+      assert_match(%r{State>ON<}, data)
+      assert_match(%r{PostalCode>K1C2N6<}, data)
+      assert_match(%r{Country>CA<}, data)
+      assert_match(%r{Phone>\(555\)555-5555<}, data)
+      assert_match(%r{Fax>\(555\)555-6666<}, data)
+      assert_match(%r{Email>jim@example\.com<}, data)
+
+      assert_match(%r{LastName>Baker<}, data)
+      assert_no_match(%r{Elsewhere Inc.}, data)
+      assert_match(%r{Street1>4321 Their St.<}, data)
+      assert_match(%r{Street2>Apt 2<}, data)
+      assert_match(%r{City>Chicago<}, data)
+      assert_match(%r{State>IL<}, data)
+      assert_match(%r{PostalCode>60625<}, data)
+      assert_match(%r{Country>US<}, data)
+      assert_match(%r{Phone>1115555555<}, data)
+      assert_match(%r{Fax>1115556666<}, data)
+      assert_match(%r{Email><}, data)
+    end.respond_with(successful_setup_purchase_response)
+
+    assert_success response
+    assert_equal(
+      "60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT",
+      response.authorization
+    )
+    assert response.test?
+  end
+
+  def test_successful_run_purchase
+    request_sequence = sequence("request")
+    @gateway.expects(:ssl_request).returns(successful_setup_purchase_response).in_sequence(request_sequence)
+    @gateway.expects(:raw_ssl_request).with(
+      :post,
+      "https://secure-au.sandbox.ewaypayments.com/Process",
+      all_of(
+        regexp_matches(%r{EWAY_ACCESSCODE=60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT}),
+        regexp_matches(%r{EWAY_CARDNAME=Longbob\+Longsen}),
+        regexp_matches(%r{EWAY_CARDNUMBER=#{@credit_card.number}}),
+        regexp_matches(%r{EWAY_CARDEXPIRYMONTH=#{@credit_card.month}}),
+        regexp_matches(%r{EWAY_CARDEXPIRYYEAR=#{@credit_card.year}}),
+        regexp_matches(%r{EWAY_CARDCVN=#{@credit_card.verification_value}})
+      ),
+      anything
+    ).returns(successful_run_purchase_response).in_sequence(request_sequence)
+    @gateway.expects(:ssl_request).returns(successful_status_response).in_sequence(request_sequence)
+
+    response = @gateway.purchase(@amount, @credit_card, :order_id => 1)
+    assert_success response
+    assert_equal "Transaction Approved", response.message
+    assert_equal(
+      "60CF3sfH7-yvAsUAHrdIiGppPrQW7v7DMAXxKkaKwyrIUoqvUvK44XbK9G9HNbngIz_iwQpfmPT_duMgh2G0pXCX8i4z1RAmMHpUQwa6VrghV3Bx9rh_tojjym7LC_fE-eR97",
+      response.authorization
+    )
+    assert response.test?
+  end
+
+  def test_failed_run_purchase
+    request_sequence = sequence("request")
+    @gateway.expects(:ssl_request).returns(successful_setup_purchase_response).in_sequence(request_sequence)
+    @gateway.expects(:raw_ssl_request).returns(failed_run_purchase_response).in_sequence(request_sequence)
+
+    response = @gateway.purchase(@amount, @credit_card, :order_id => 1)
+    assert_failure response
+    assert_match %r{Not Found}, response.message
+    assert_nil response.authorization
+    assert response.test?
+  end
+
+  def test_successful_status
+    response = stub_comms do
+      @gateway.status("thetransauth")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{thetransauth}, data)
+    end.respond_with(successful_status_response)
+
+    assert_success response
+    assert_equal(
+      "60CF3sfH7-yvAsUAHrdIiGppPrQW7v7DMAXxKkaKwyrIUoqvUvK44XbK9G9HNbngIz_iwQpfmPT_duMgh2G0pXCX8i4z1RAmMHpUQwa6VrghV3Bx9rh_tojjym7LC_fE-eR97",
+      response.authorization
+    )
+    assert response.test?
+    assert_equal "Transaction Approved", response.message
+    assert_equal "orderid1", response.params["invoicereference"]
+  end
+
+  def test_failed_status
+    response = stub_comms do
+      @gateway.status("thetransauth")
+    end.respond_with(failed_status_response)
+
+    assert_failure response
+    assert_equal(
+      "A1001WfAHR_QP8daLnG6fQLcadzuCBJbpIp-zsUL6FkQgUyY2MXwVA0etYvflPe_rDBiuOMV-BfTSGDKt7uU3E2bLUhsD1rrXwGT9BTPcOOH_Vh9jHDSn2inqk8udwQIRcxuc",
+      response.authorization
+    )
+    assert response.test?
+    assert_equal "Do Not Honour", response.message
+    assert_equal "1", response.params["invoicereference"]
+  end
+
+  def test_verification_results
+    response = stub_comms do
+      @gateway.status("thetransauth")
+    end.respond_with(successful_status_response(:verification_status => "Valid"))
+
+    assert_success response
+    assert_equal "M", response.cvv_result["code"]
+    assert_equal "M", response.avs_result["code"]
+
+    response = stub_comms do
+      @gateway.status("thetransauth")
+    end.respond_with(successful_status_response(:verification_status => "Invalid"))
+
+    assert_success response
+    assert_equal "N", response.cvv_result["code"]
+    assert_equal "N", response.avs_result["code"]
+
+    response = stub_comms do
+      @gateway.status("thetransauth")
+    end.respond_with(successful_status_response(:verification_status => "Unchecked"))
+
+    assert_success response
+    assert_equal "P", response.cvv_result["code"]
+    assert_equal "I", response.avs_result["code"]
+  end
+
+  private
+
+  def successful_setup_purchase_response
+    %(
+      <CreateAccessCodeResponse>
+        <AccessCode>60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT</AccessCode>
+        <Customer>
+          <TokenCustomerID p3:nil=\"true\" xmlns:p3=\"http://www.w3.org/2001/XMLSchema-instance\" />
+          <Reference />
+          <Title />
+          <FirstName />
+          <LastName />
+          <CompanyName />
+          <JobDescription />
+          <Street1 />
+          <Street2 />
+          <City />
+          <State />
+          <PostalCode />
+          <Country />
+          <Email />
+          <Phone />
+          <Mobile />
+          <Comments />
+          <Fax />
+          <Url />
+          <CardNumber />
+          <CardStartMonth />
+          <CardStartYear />
+          <CardIssueNumber />
+          <CardName />
+          <CardExpiryMonth />
+          <CardExpiryYear />
+          <IsActive>false</IsActive>
+        </Customer>
+        <Payment>
+          <TotalAmount>100</TotalAmount>
+          <InvoiceDescription>Store Purchase</InvoiceDescription>
+          <InvoiceReference>1</InvoiceReference>
+          <CurrencyCode>AUD</CurrencyCode>
+        </Payment>
+        <FormActionURL>https://secure-au.sandbox.ewaypayments.com/Process</FormActionURL>
+      </CreateAccessCodeResponse>
+    )
+  end
+
+  def failed_setup_purchase_response
+    %(
+      <CreateAccessCodeResponse>
+        <Errors>V6047</Errors>
+        <Customer>
+          <TokenCustomerID p3:nil="true" xmlns:p3="http://www.w3.org/2001/XMLSchema-instance" />
+          <IsActive>false</IsActive>
+        </Customer>
+        <Payment>
+          <TotalAmount>100</TotalAmount>
+          <CurrencyCode>AUD</CurrencyCode>
+        </Payment>
+      </CreateAccessCodeResponse>
+    )
+  end
+
+  def successful_status_response(options={})
+    verification_status = (options[:verification_status] || "Unchecked")
+    %(
+      <GetAccessCodeResultResponse>
+        <AccessCode>60CF3sfH7-yvAsUAHrdIiGppPrQW7v7DMAXxKkaKwyrIUoqvUvK44XbK9G9HNbngIz_iwQpfmPT_duMgh2G0pXCX8i4z1RAmMHpUQwa6VrghV3Bx9rh_tojjym7LC_fE-eR97</AccessCode>
+        <AuthorisationCode>957199</AuthorisationCode>
+        <ResponseCode>00</ResponseCode>
+        <ResponseMessage>A2000</ResponseMessage>
+        <InvoiceNumber />
+        <InvoiceReference>orderid1</InvoiceReference>
+        <TotalAmount>100</TotalAmount>
+        <TransactionID>9942726</TransactionID>
+        <TransactionStatus>true</TransactionStatus>
+        <TokenCustomerID p2:nil=\"true\" xmlns:p2=\"http://www.w3.org/2001/XMLSchema-instance\" />
+        <BeagleScore>0</BeagleScore>
+        <Options />
+        <Verification>
+          <CVN>#{verification_status}</CVN>
+          <Address>#{verification_status}</Address>
+          <Email>#{verification_status}</Email>
+          <Mobile>#{verification_status}</Mobile>
+          <Phone>#{verification_status}</Phone>
+        </Verification>
+      </GetAccessCodeResultResponse>
+    )
+  end
+
+  def failed_status_response
+    %(
+      <GetAccessCodeResultResponse>
+        <AccessCode>A1001WfAHR_QP8daLnG6fQLcadzuCBJbpIp-zsUL6FkQgUyY2MXwVA0etYvflPe_rDBiuOMV-BfTSGDKt7uU3E2bLUhsD1rrXwGT9BTPcOOH_Vh9jHDSn2inqk8udwQIRcxuc</AccessCode>
+        <AuthorisationCode />
+        <ResponseCode>05</ResponseCode>
+        <ResponseMessage>D4405</ResponseMessage>
+        <InvoiceNumber />
+        <InvoiceReference>1</InvoiceReference>
+        <TotalAmount>105</TotalAmount>
+        <TransactionID>9942743</TransactionID>
+        <TransactionStatus>false</TransactionStatus>
+        <TokenCustomerID p2:nil=\"true\" xmlns:p2=\"http://www.w3.org/2001/XMLSchema-instance\" />
+        <BeagleScore>0</BeagleScore>
+        <Options />
+        <Verification>
+          <CVN>Unchecked</CVN>
+          <Address>Unchecked</Address>
+          <Email>Unchecked</Email>
+          <Mobile>Unchecked</Mobile>
+          <Phone>Unchecked</Phone>
+        </Verification>
+      </GetAccessCodeResultResponse>
+    )
+  end
+
+  class MockResponse
+    attr_reader :code, :body
+    def initialize(code, body, headers={})
+      @code, @body, @headers = code, body, headers
+    end
+
+    def [](header)
+      @headers[header]
+    end
+  end
+
+  def successful_run_purchase_response
+    MockResponse.new(
+      302,
+      %(
+        <html><head><title>Object moved</title></head><body>
+        <h2>Object moved to <a href="http://example.com/?AccessCode=60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT">here</a>.</h2>
+        </body></html>
+      ),
+      "Location" => "http://example.com/?AccessCode=60CF3xWrFUQeDCEsJcA8zNHaspAT3CKpe-0DiqWjTYA3RZw1xhw2LU-BFCNYbr7eJt8KFaxCxmzYh9WDAYX8yIuYexTq0tC8i2kOt0dm0EV-mjxYEQ2YeHP2dazkSc7j58OiT"
+    )
+  end
+
+  def failed_run_purchase_response
+    MockResponse.new(
+      200,
+      %(
+        {"Message":"Not Found","Errors":null}
+      )
+    )
+  end
+end


### PR DESCRIPTION
This adds support for eWay's Rapid 3.0 API to ActiveMerchant. Rapid 3.0 is a transparent redirect API by design, so this gateway provides both:
- A standard ActiveMerchant `#purchase` API for PCI compliant environments.
- A non-standard `#setup_purchase` + `#status` API that eases using the transparent redirect for merchants that want to avoid PCI compliance concerns.

Includes documentation, unit tests and remote tests.
