### PR TITLE
AVS response needs to have the keys for the object in the hash returned, even if nil

### DIFF
--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -24,19 +24,17 @@ module ActiveMerchant #:nodoc:
         @authorization = options[:authorization]
         @fraud_review = options[:fraud_review]
 
-        avs_result_builder = if options[:avs_result].kind_of?(Hash)
-          AVSResult.new(options[:avs_result])
+        @avs_result = if options[:avs_result].kind_of?(AVSResult)
+          options[:avs_result].to_hash
         else
-          options[:avs_result] || {}
+          AVSResult.new(options[:avs_result]).to_hash
         end
-        @avs_result = avs_result_builder.to_hash
 
-        cvv_result_builder = if options[:cvv_result].kind_of?(String)
-          CVVResult.new(options[:cvv_result])
+        @cvv_result = if options[:cvv_result].kind_of?(CVVResult)
+          options[:cvv_result].to_hash
         else
-          options[:cvv_result] || {}
+          CVVResult.new(options[:cvv_result]).to_hash
         end
-        @cvv_result = cvv_result_builder.to_hash
       end
     end
 

--- a/test/unit/gateways/orbital_avs_result_test.rb
+++ b/test/unit/gateways/orbital_avs_result_test.rb
@@ -25,6 +25,18 @@ class OrbitalAVSResultTest < Test::Unit::TestCase
     assert_nil result.message
   end
 
+  def test_response_with_orbital_avs
+    response = Response.new(true, 'message', {}, :avs_result => OrbitalGateway::AVSResult.new('A'))
+
+    assert_equal 'A', response.avs_result['code']
+  end
+
+  def test_response_with_orbital_avs_nil
+    response = Response.new(true, 'message', {}, :avs_result => OrbitalGateway::AVSResult.new(nil))
+
+    assert response.avs_result.has_key?('code')
+  end
+
   # Helper functions
 
   def check_match_results(code, street_match, postal_match)

--- a/test/unit/multi_response_test.rb
+++ b/test/unit/multi_response_test.rb
@@ -38,7 +38,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :test => true,
       :authorization => "auth1",
       :avs_result => {:code => "AVS1"},
-      :cvv_result => {"code" => "CVV1"},
+      :cvv_result => "CVV1",
       :fraud_review => true
     )
     m.process{r1}
@@ -58,7 +58,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :test => false,
       :authorization => "auth2",
       :avs_result => {:code => "AVS2"},
-      :cvv_result => {"code" => "CVV2"},
+      :cvv_result => "CVV2",
       :fraud_review => false
     )
     m.process{r2}

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -6,6 +6,16 @@ class ResponseTest < Test::Unit::TestCase
     assert !Response.new(false, 'message', :param => 'value').success?
   end
 
+  def test_response_without_avs
+    response = Response.new(true, 'message', :param => 'value')
+    assert response.avs_result.has_key?('code')
+  end
+
+  def test_response_without_cvv
+    response = Response.new(true, 'message', :param => 'value')
+    assert response.cvv_result.has_key?('code')
+  end
+
   def test_get_params
     response = Response.new(true, 'message', :param => 'value')
 


### PR DESCRIPTION
8cf277a broke this expectation, now there are tests to cover the case.

A MultiResponse test needed to be fixed because of this change as well,
it shouldn't affect the interface or how AVSResult/CVVResult are
returned.

@Soleone, @samuelkadolph for review
