### PR TITLE
WorldPay: Fix currencies without fractions like JPY and HUF

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       include Utils
 
       DEBIT_CARDS = [ :switch, :solo ]
-      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY' ]
+      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY', 'HUF' ]
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
 
       cattr_reader :implementations

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -73,6 +73,31 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal "USD", result.params['amount_currency_code']
   end
 
+  def test_authorize_currency_without_fractional_units
+    assert_success(result = @gateway.authorize(1200, @credit_card, @options.merge(:currency => 'HUF')))
+    assert_equal "HUF", result.params['amount_currency_code']
+    assert_equal "12", result.params['amount_value']
+  end
+
+  def test_authorize_currency_without_fractional_units_and_fractions_in_amount
+    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'HUF')))
+    assert_equal "HUF", result.params['amount_currency_code']
+    assert_equal "12", result.params['amount_value']
+  end
+
+  def test_authorize_and_capture_currency_without_fractional_units_and_fractions_in_amount
+    assert_success(auth = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'HUF')))
+    assert_equal "12", auth.params['amount_value']
+
+    assert_success(result = @gateway.capture(1234, auth.authorization))
+    assert_equal "12", result.params['amount_value']
+  end
+
+  def test_purchase_currency_without_fractional_units_and_fractions_in_amount
+    assert_success(result = @gateway.purchase(1234, @credit_card, @options.merge(:currency => 'HUF')))
+    assert_equal "12", result.params['amount_value']
+  end
+
   def test_reference_transaction
     assert_success(original = @gateway.authorize(100, @credit_card, @options))
     assert_success(@gateway.authorize(200, original.authorization, :order_id => generate_unique_id))


### PR DESCRIPTION
### Problem

When trying to send fractional amounts like `49.41` to WorldPay for currencies without fractions they return the following error: `Fractional number of minor currency units`. We were sending the amount in a cents value e.g. `4941`.
### Solution

Always round down the amount and send e.g. `4900` instead. This is how currencies without fractions are currently displayed in Shopify, the digits after the decimal are just stripped off (floor).
### Background

The following was sent to WorldPay Technical Support:

> Here are two examples of how we are sending amounts to their servers in the XML:
> 
> Failing for 49.41 HUF (this amount was calculated from a percentage based discount):
> 
> `<amount currencyCode="HUF" exponent="2">4941</amount>`
> 
> Working for $100.00:
> 
> `<amount currencyCode="USD" exponent="2">10000</amount>`
> 1. Should we remove the “exponent” attribute for currencies that do not use any decimals like HUF?
> 2. Or should we be rounding e.g. 49.41 Ft to 50 Ft before sending it to WorldPay?

Their reply was:

> > 1) Should we remove the “exponent” attribute for currencies that do not use any decimals like HUF?
> 
> RESPONSE: Add "00" to the value, Eg. HUF 1234
> 
> `<amount currencyCode="HUF" exponent="2">123400</amount>`
> 
> > 2) Or should we be rounding e.g. 49.41 Ft to 50 Ft before sending it to WorldPay?
> 
> RESPONSE: As mention, currencies are always in whole number. Depending on your business processing, rounding should be decided by you.

Please review @jduff, cc @ntalbott 
