### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,5 @@ Please don't touch the CHANGELOG in your pull requests, we'll add the appropriat
 at release time.
 
 [![Build Status](https://secure.travis-ci.org/Shopify/active_merchant.png)](http://travis-ci.org/Shopify/active_merchant)
+
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/Shopify/active_merchant)


### PR DESCRIPTION
Hey,

Just wanted to let you know that Active Mechant was added to Code Climate about a month ago. Code Climate is a service I built that provides quality metrics for Ruby code, and like GitHub is free for OSS.

You can view the data for Active Merchant here:

https://codeclimate.com/github/Shopify/active_merchant

This PR adds a Code Climate badge to the Contributing section of the README (similar to TravisCI) in case you want this information to be available to people working on the gem. Some other projects like RSpec do this currently:

https://github.com/rspec/rspec-rails#readme

Let me know if you have any questions/feedback at all!

(BTW, it was good meeting some of the Shopify people in Denver at RubyConf!)

Thanks,
-Bryan
