### PR TITLE
Balanced gateway: Fix unspecified marketplace.

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -91,8 +91,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>:login</tt> -- The Balanced API Secret (REQUIRED)
       def initialize(options = {})
         requires!(options, :login)
-        initialize_marketplace(options[:marketplace] || load_marketplace)
         super
+        initialize_marketplace(options[:marketplace] || load_marketplace)
       end
 
       # Performs an authorization (Hold in Balanced nonclementure), which

--- a/test/remote/gateways/remote_balanced_test.rb
+++ b/test/remote/gateways/remote_balanced_test.rb
@@ -27,13 +27,13 @@ class RemoteBalancedTest < Test::Unit::TestCase
   def test_invalid_card
     assert response = @gateway.purchase(@amount, @invalid_card, @options)
     assert_failure response
-    assert response.message.index('Processor did not accept this card.') != nil
+    assert_match /Customer call bank/, response.message
   end
 
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert response.message.index('Processor did not accept this card.') != nil
+    assert_match /Account Frozen/, response.message
   end
 
   def test_authorize_and_capture


### PR DESCRIPTION
If the marketplace is unspecifed, the gateway makes an http request
which needs @options to be set.  Fixing the initialize method got
all but 2 of the remote tests working.

Fixed the other 2 remote tests by bringing the expected messages up
to date.
