### PR TITLE
Authorize.net CIM response message can be hash

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -833,7 +833,11 @@ module ActiveMerchant #:nodoc:
 
         response_params = parse(action, xml)
 
-        message = response_params['messages']['message']['text']
+        message = if response_params['messages']['message'].is_a?(Hash)
+          response_params['messages']['message']['text']
+        elsif response_params['messages']['message'].is_a?(Array)
+          response_params['messages']['message'].map{|hash| hash['text']}.join(', ')
+        end
         test_mode = test? || message =~ /Test Mode/
         success = response_params['messages']['result_code'] == 'Ok'
         response_params['direct_response'] = parse_direct_response(response_params['direct_response']) if response_params['direct_response']


### PR DESCRIPTION
If more then one error then Authorize.net return array of hashes as:
{"messages"=>{"result_code"=>"Error", "message"=>[{"code"=>"E00015",
"text"=>"The field length is invalid for ABA Routing Number."},
{"code"=>"E00015", "text"=>"The field length is invalid for Bank
Account Number."}]}}
