### PR TITLE
QBMS gateway: Allow partial addresses.

### DIFF
--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -126,6 +126,7 @@ module ActiveMerchant #:nodoc:
         parameters[:trans_request_id] ||= SecureRandom.hex(10)
 
         req = build_request(type, money, parameters)
+
         data = ssl_post(url, req, "Content-Type" => "application/x-qbmsxml")
         response = parse(type, data)
         message = (response[:status_message] || '').strip
@@ -260,8 +261,8 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, parameters)
         if address = parameters[:billing_address] || parameters[:address]
-          xml.tag!("CreditCardAddress", address[:address1][0...30])
-          xml.tag!("CreditCardPostalCode", address[:zip][0...9])
+          xml.tag!("CreditCardAddress", address[:address1].try(:[], 0...30))
+          xml.tag!("CreditCardPostalCode", address[:zip].try(:[], 0...9))
         end
       end
 


### PR DESCRIPTION
We now handle the case of someone specifying a partial address such as a
zip code without a street address.

Added a test for the address truncation.
