### PR TITLE
Update Beanstreams supported_cardtypes as per their site

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
         base.supported_countries = ['CA']
 
         # The card types supported by the payment gateway
-        base.supported_cardtypes = [:visa, :master, :american_express]
+        base.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
 
         # The homepage URL of the gateway
         base.homepage_url = 'http://www.beanstream.com/'


### PR DESCRIPTION
## Changes

This updates the list of supported card types for Beanstream as listed on their site [here](https://www.beanstream.com/site/ca/credit-card-payment-processing-and-merchant-accounts.html).

No tests affected.
## Review

@Soleone @csaunders 
