### PR TITLE
Authorize.net CIM Gateway: Add support for extraOptions to createCustomerProfileTransaction

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -599,8 +599,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_create_customer_profile_transaction_request(xml, options)
+        options[:extra_options] ||= {}
+        options[:extra_options].merge!('x_test_request' => 'TRUE') if @options[:test]
+
         add_transaction(xml, options[:transaction])
-        xml.tag!('extraOptions', "x_test_request=TRUE") if @options[:test]
+        tag_unless_blank(xml, 'extraOptions', format_extra_options(options[:extra_options]))
 
         xml.target!
       end
@@ -652,7 +655,7 @@ module ActiveMerchant #:nodoc:
                 tag_unless_blank(xml,'customerShippingAddressId', transaction[:customer_shipping_address_id])
                 xml.tag!('transId', transaction[:trans_id])
               when :refund
-                #TODO - add lineItems and extraOptions fields
+                #TODO - add lineItems field
                 xml.tag!('amount', transaction[:amount])
                 tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
                 tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
@@ -847,6 +850,10 @@ module ActiveMerchant #:nodoc:
 
       def tag_unless_blank(xml, tag_name, data)
         xml.tag!(tag_name, data) unless data.blank? || data.nil?
+      end
+
+      def format_extra_options(options)
+        options.map{ |k, v| "#{k}=#{v}" }.join(',') unless options.nil?
       end
 
       def parse_direct_response(params)

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -504,6 +504,41 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal "Successful.", response.message
   end
 
+  def test_should_create_duplicate_customer_profile_transactions_with_duplicate_window_alteration
+    assert response = @gateway.create_customer_profile(@options)
+    @customer_profile_id = response.authorization
+
+    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
+
+    key = (Time.now.to_f * 1000000).to_i.to_s
+
+    customer_profile_transaction = {
+      :transaction => {
+        :customer_profile_id => @customer_profile_id,
+        :customer_payment_profile_id => @customer_payment_profile_id,
+        :type => :auth_capture,
+        :order => {
+          :invoice_number => key.to_s,
+          :description => "Test Order Description #{key.to_s}",
+          :purchase_order_number => key.to_s
+        },
+        :amount => @amount
+      },
+      :extra_options => { "x_duplicate_window" => 1 }
+    }
+
+    assert response = @gateway.create_customer_profile_transaction(customer_profile_transaction)
+    assert_success response
+    assert_equal "Successful.", response.message
+
+    sleep(5)
+
+    assert response = @gateway.create_customer_profile_transaction(customer_profile_transaction)
+    assert_success response
+    assert_equal "Successful.", response.message
+  end
+
   def test_should_create_customer_profile_transaction_auth_capture_and_then_void_request
     response = get_and_validate_auth_capture_response
 


### PR DESCRIPTION
This request adds 'extra options' (as defined by the Authorize.net CIM API) to the gateway implementation for creating customer profile transactions.

Their API documentation describes extra options as follows:

Information in name/value pair format that does 
not exist within CIM, such as customer IP address, etc.

The test demonstrates the effects of setting one of these extra options (by default, Authorize.net prevents duplicates within a 2 minute interval - setting 'x_duplicate_window' changes this interval) - not sure how useful that is in the context of this request though.
