### PR TITLE
NetPay: Improve support for void

### DIFF
--- a/lib/active_merchant/billing/gateways/netpay.rb
+++ b/lib/active_merchant/billing/gateways/netpay.rb
@@ -76,17 +76,19 @@ module ActiveMerchant #:nodoc:
       # Capture an authorization
       def capture(money, authorization, options = {})
         post = {}
-        add_order_id(post, authorization)
+        add_order_id(post, order_id_from(authorization))
         add_amount(post, money, options)
 
         commit('PostAuth', post, options)
       end
 
       # Cancel an auth/purchase within first 24 hours
-      def void(money, authorization, options = {})
+      def void(authorization, options = {})
         post = {}
-        add_order_id(post, authorization)
-        add_amount(post, money, options)
+        order_id, amount, currency = split_authorization(authorization)
+        add_order_id(post, order_id)
+        post['Total'] = amount
+        post['CurrencyCode'] = currency
 
         commit('Refund', post, options)
       end
@@ -105,7 +107,7 @@ module ActiveMerchant #:nodoc:
       # Perform a Credit transaction.
       def refund(money, authorization, options = {})
         post = {}
-        add_order_id(post, authorization)
+        add_order_id(post, order_id_from(authorization))
         add_amount(post, money, options)
 
         #commit('Refund', post, options)
@@ -150,6 +152,19 @@ module ActiveMerchant #:nodoc:
         post['CVV2']         = creditcard.verification_value unless creditcard.verification_value.nil?
       end
 
+      def build_authorization(request_params, response_params)
+        [response_params['OrderId'], request_params['Total'], request_params['CurrencyCode']].join('|')
+      end
+
+      def split_authorization(authorization)
+        order_id, amount, currency = authorization.split("|")
+        [order_id, amount, currency]
+      end
+
+      def order_id_from(authorization)
+        split_authorization(authorization).first
+      end
+
       def expdate(credit_card)
         year  = sprintf("%.4i", credit_card.year)
         month = sprintf("%.2i", credit_card.month)
@@ -161,14 +176,15 @@ module ActiveMerchant #:nodoc:
         test? ? test_url : live_url
       end
 
-      def parse(response)
-        params = params_from_response(response)
+      def parse(response, request_params)
+        response_params = params_from_response(response)
 
-        success = (params['ResponseCode'] == '00')
-        message = params['ResponseText'] || params['ResponseMsg']
-        options = @options.merge(:test => test?, :authorization => params['OrderId'])
+        success = (response_params['ResponseCode'] == '00')
+        message = response_params['ResponseText'] || response_params['ResponseMsg']
+        options = @options.merge(:test => test?,
+                                 :authorization => build_authorization(request_params, response_params))
 
-        Response.new(success, message, params, options)
+        Response.new(success, message, response_params, options)
       end
 
       def commit(action, parameters, options)
@@ -176,7 +192,7 @@ module ActiveMerchant #:nodoc:
         add_action(parameters, action, options)
 
         post = parameters.collect{|key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&")
-        parse ssl_post(url, post)
+        parse(ssl_post(url, post), parameters)
       end
 
       # Override the regular handle response so we can access the headers

--- a/test/remote/gateways/remote_netpay_test.rb
+++ b/test/remote/gateways/remote_netpay_test.rb
@@ -31,7 +31,7 @@ class RemoteNetpayTest < Test::Unit::TestCase
   def test_successful_purchase_and_void
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
-    assert void = @gateway.void(@amount, purchase.authorization)
+    assert void = @gateway.void(purchase.authorization)
     assert_success void
     assert_equal 'Aprobada', void.message
   end

--- a/test/unit/gateways/netpay_test.rb
+++ b/test/unit/gateways/netpay_test.rb
@@ -52,8 +52,7 @@ class NetpayTest < Test::Unit::TestCase
     assert_instance_of ActiveMerchant::Billing::Response, response
     assert_success response
 
-    # Replace with authorization number from the successful response
-    assert_equal @order_id, response.authorization
+    assert_equal "#{@order_id}|10.00|484", response.authorization
     assert response.test?
   end
 
@@ -99,7 +98,7 @@ class NetpayTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_instance_of ActiveMerchant::Billing::Response, response
     assert_success response
-    assert_equal @order_id, response.authorization
+    assert_equal "#{@order_id}|10.00|484", response.authorization
     assert response.test?
   end
 
@@ -108,11 +107,11 @@ class NetpayTest < Test::Unit::TestCase
       anything,
       all_of(
         includes('ResourceName=PostAuth'),
-        includes("Total=10.00"),
-        includes("OrderId=#{@order_id}")
+        includes("Total=10.00&"),
+        includes("OrderId=#{@order_id}&")
       )
     ).returns(successful_response)
-    assert response = @gateway.capture(@amount, @order_id)
+    assert response = @gateway.capture(@amount, "#{@order_id}|10.00|484")
     assert_success response
   end
 
@@ -122,11 +121,12 @@ class NetpayTest < Test::Unit::TestCase
       anything,
       all_of(
         includes('ResourceName=Refund'),
-        includes("Total=10.00"),
-        includes("OrderId=#{@order_id}")
+        includes("Total=10.00&"),
+        includes("OrderId=#{@order_id}&"),
+        includes("CurrencyCode=484&")
       )
     ).returns(successful_response)
-    assert response = @gateway.void(@amount, @order_id)
+    assert response = @gateway.void("#{@order_id}|10.00|484")
     assert_success response
   end
 
@@ -139,7 +139,7 @@ class NetpayTest < Test::Unit::TestCase
         includes("OrderId=#{@order_id}")
       )
     ).returns(successful_response)
-    assert response = @gateway.refund(@amount, @order_id)
+    assert response = @gateway.refund(@amount, "#{@order_id}|10.00|484")
     assert_success response
   end
 


### PR DESCRIPTION
This makes the interface to #void consistent with the other gateways.
It does this by building the authorization and then splitting it later
to get the parts that we need.

This is similar to how we're handling void in the Redsys gateway which
also seems to need an amount on their call to void.
