### PR TITLE
Add Check Support to Cyber Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pkg
 Gemfile.lock
 Gemfile*.lock
 .rbx/
+
+.bundle/config

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -13,6 +13,7 @@ module ActiveMerchant #:nodoc:
     # names.
     #
     # Important Notes
+    # * For checks you can purchase and store.
     # * AVS and CVV only work against the production server.  You will always
     #   get back X for AVS and no response for CVV against the test server.
     # * Nexus is the list of states or provinces where you have a physical
@@ -131,10 +132,10 @@ module ActiveMerchant #:nodoc:
 
       # Purchase is an auth followed by a capture
       # You must supply an order_id in the options hash
-      def purchase(money, creditcard_or_reference, options = {})
+      def purchase(money, creditcard_or_check_or_reference, options = {})
         requires!(options, :order_id)
         setup_address_hash(options)
-        commit(build_purchase_request(money, creditcard_or_reference, options), options)
+        commit(build_purchase_request(money, creditcard_or_check_or_reference, options), options)
       end
 
       def void(identification, options = {})
@@ -154,10 +155,10 @@ module ActiveMerchant #:nodoc:
       # Stores a customer subscription/profile with type "on-demand".
       # To charge the card while creating a profile, pass
       # options[:setup_fee] => money
-      def store(creditcard, options = {})
+      def store(creditcard_or_check, options = {})
         requires!(options, :order_id)
         setup_address_hash(options)
-        commit(build_create_subscription_request(creditcard, options), options)
+        commit(build_create_subscription_request(creditcard_or_check, options), options)
       end
 
       # Updates a customer subscription/profile
@@ -222,7 +223,7 @@ module ActiveMerchant #:nodoc:
 
       def build_auth_request(money, creditcard_or_reference, options)
         xml = Builder::XmlMarkup.new :indent => 2
-        add_creditcard_or_subscription(xml, money, creditcard_or_reference, options)
+        add_creditcard_or_check_or_subscription(xml, money, creditcard_or_reference, options)
         add_auth_service(xml)
         add_business_rules_data(xml)
         xml.target!
@@ -250,11 +251,16 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def build_purchase_request(money, creditcard_or_reference, options)
+      def build_purchase_request(money, creditcard_or_check_or_reference, options)
+        options[:payment_type] ||= 'Credit Card'
         xml = Builder::XmlMarkup.new :indent => 2
-        add_creditcard_or_subscription(xml, money, creditcard_or_reference, options)
-        add_purchase_service(xml, options)
-        add_business_rules_data(xml)
+        add_creditcard_or_check_or_subscription(xml, money, creditcard_or_check_or_reference, options)
+        if !creditcard_or_check_or_reference.is_a?(Check) && options[:payment_type] == 'Credit Card'
+          add_purchase_service(xml, options)
+          add_business_rules_data(xml)
+        else
+          add_check_service(xml)
+        end
         xml.target!
       end
 
@@ -297,16 +303,22 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def build_create_subscription_request(creditcard, options)
+      def build_create_subscription_request(creditcard_or_check, options)
         options[:subscription] = (options[:subscription] || {}).merge(:frequency => "on-demand", :amount => 0, :automatic_renew => false)
 
         xml = Builder::XmlMarkup.new :indent => 2
-        add_address(xml, creditcard, options[:billing_address], options)
+        add_address(xml, creditcard_or_check, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
-        add_creditcard(xml, creditcard)
-        add_creditcard_payment_method(xml)
+        if creditcard_or_check.is_a? Check
+          add_check(xml, creditcard_or_check)
+          add_check_payment_method(xml)
+          add_check_service(xml, options) if options[:setup_fee]
+        else
+          add_creditcard(xml, creditcard_or_check)
+          add_creditcard_payment_method(xml)    
+          add_purchase_service(xml, options) if options[:setup_fee]
+        end
         add_subscription(xml, options)
-        add_purchase_service(xml, options) if options[:setup_fee]
         add_subscription_create_service(xml, options)
         add_business_rules_data(xml)
         xml.target!
@@ -372,12 +384,12 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_address(xml, creditcard, address, options, shipTo = false)
+      def add_address(xml, creditcard_or_check, address, options, shipTo = false)
         requires!(options, :email)
 
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
-          xml.tag! 'firstName',             creditcard.first_name             if creditcard
-          xml.tag! 'lastName',              creditcard.last_name              if creditcard
+          xml.tag! 'firstName',             creditcard_or_check.first_name             if creditcard_or_check
+          xml.tag! 'lastName',              creditcard_or_check.last_name              if creditcard_or_check
           xml.tag! 'street1',               address[:address1]
           xml.tag! 'street2',               address[:address2]                unless address[:address2].blank?
           xml.tag! 'city',                  address[:city]
@@ -400,6 +412,14 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'expirationYear', format(creditcard.year, :four_digits)
           xml.tag!('cvNumber', creditcard.verification_value) unless (@options[:ignore_cvv] || creditcard.verification_value.blank? )
           xml.tag! 'cardType', @@credit_card_codes[card_brand(creditcard).to_sym]
+        end
+      end
+
+      def add_check(xml, check)
+        xml.tag! 'check' do
+          xml.tag! 'accountNumber', check.account_number
+          xml.tag! 'accountType', check.account_type[0]
+          xml.tag! 'bankTransitNumber', check.routing_number
         end
       end
 
@@ -447,6 +467,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def add_check_service(xml)
+        xml.tag! 'ecDebitService', {'run' => 'true'}
+      end
+
       def add_subscription_create_service(xml, options)
         xml.tag! 'paySubscriptionCreateService', {'run' => 'true'}
       end
@@ -491,14 +515,24 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_creditcard_or_subscription(xml, money, creditcard_or_reference, options)
-        if creditcard_or_reference.is_a?(String)
+      def add_check_payment_method(xml)
+        xml.tag! 'subscription' do
+          xml.tag! 'paymentMethod', "check"
+        end
+      end
+
+      def add_creditcard_or_check_or_subscription(xml, money, creditcard_or_check_or_reference, options)
+        if creditcard_or_check_or_reference.is_a?(String)
           add_purchase_data(xml, money, true, options)
-          add_subscription(xml, options, creditcard_or_reference)
+          add_subscription(xml, options, creditcard_or_check_or_reference)
+        elsif creditcard_or_check_or_reference.is_a?(Check)
+          add_address(xml, creditcard_or_check_or_reference, options[:billing_address], options)
+          add_purchase_data(xml, money, true, options)
+          add_check(xml, creditcard_or_check_or_reference)
         else
-          add_address(xml, creditcard_or_reference, options[:billing_address], options)
+          add_address(xml, creditcard_or_check_or_reference, options[:billing_address], options)
           add_purchase_data(xml, money, true, options)
-          add_creditcard(xml, creditcard_or_reference)
+          add_creditcard(xml, creditcard_or_check_or_reference)
         end
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -12,6 +12,7 @@ class CyberSourceTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111', :brand => 'visa')
     @declined_card = credit_card('801111111111111', :brand => 'visa')
+    @check = check()
 
     @options = { :billing_address => {
                   :address1 => '1234 My Street',
@@ -60,10 +61,20 @@ class CyberSourceTest < Test::Unit::TestCase
     }
   end
 
-  def test_successful_purchase
+  def test_successful_credit_card_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']}", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_check_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @check, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']}", response.authorization
@@ -86,7 +97,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_tax_request
+  def test_successful_credit_card_tax_request
     @gateway.stubs(:ssl_post).returns(successful_tax_response)
     assert response = @gateway.calculate_tax(@credit_card, @options)
     assert_equal Response, response.class
@@ -94,7 +105,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_capture_request
+  def test_successful_credit_card_capture_request
     @gateway.stubs(:ssl_post).returns(successful_authorization_response, successful_capture_response)
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert response.success?
@@ -104,9 +115,16 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response_capture.test?
   end
 
-  def test_successful_purchase_request
+  def test_successful_credit_card_purchase_request
     @gateway.stubs(:ssl_post).returns(successful_capture_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response.success?
+    assert response.test?
+  end
+
+  def test_successful_check_purchase_request
+    @gateway.stubs(:ssl_post).returns(successful_capture_response)
+    assert response = @gateway.purchase(@amount, @check, @options)
     assert response.success?
     assert response.test?
   end
@@ -127,14 +145,14 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_equal 'USD', CyberSourceGateway.default_currency
   end
 
-  def test_successful_store_request
+  def test_successful_credit_card_store_request
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response)
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?
     assert response.test?
   end
 
-  def test_successful_update_request
+  def test_successful_credit_card_update_request
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_update_subscription_response)
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?
@@ -144,7 +162,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_unstore_request
+  def test_successful_credit_card_unstore_request
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_delete_subscription_response)
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?
@@ -154,7 +172,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_retrieve_request
+  def test_successful_credit_card_retrieve_request
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_retrieve_subscription_response)
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?


### PR DESCRIPTION
Cyber Source lacked check support.  This will allow developers to use the ACH features of the Cyber Source Gateway.
