### PR TITLE
Add refund capability to NAB Transact gateway

### DIFF
--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -82,7 +82,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     authorization = response.authorization
-    assert response = @gateway.refund(@amount, authorization, :order_id => @options[:order_id])
+    assert response = @gateway.refund(@amount, authorization)
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -91,7 +91,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     authorization = response.authorization
-    assert response = @gateway.refund(@amount+1, authorization, :order_id => @options[:order_id])
+    assert response = @gateway.refund(@amount+1, authorization)
     assert_failure response
     assert_equal 'Only $2.0 available for refund', response.message
   end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -24,7 +24,7 @@ class NabTransactTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal '009887', response.authorization
+    assert_equal '009887*test**200', response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
Adds refunds to nab transact.

The gateway requires both the authorization and the order_id which was used to make the purchase request. I've noticed that some other gateways get around this by delimiting the purchase authorization returned by AM, and then automatically splitting them into the necessary bits when performing refunds, however, this means being unable to perform refunds with AM (for purchases made outside of AM) without knowing what the joining/splitting algorithm used is.

So, not sure if there is an official stance one way or another on handling multiple required parameters for refunds, but happy to change whatever is required.
