### PR TITLE
Issue #23 is still an issue: Paypal::Notification - #received_at does not correctly parse params["payment_date"]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * NetPay: Fix the signature for void [duff]
 * Cybersource: Add check support [bowmande]
 * Moneris: Use a capture of $0 for void [ntalbott]
+* PayPal Express integration: Fix received_at time zone [ntalbott]
 
 == Version 1.29.3 (December 7, 2012)
 

--- a/test/unit/integrations/notifications/paypal_notification_test.rb
+++ b/test/unit/integrations/notifications/paypal_notification_test.rb
@@ -60,10 +60,10 @@ class PaypalNotificationTest < Test::Unit::TestCase
     assert_equal Money.new(50000, 'CAD'), @paypal.amount
   end
 
-  def test_acknowledgement    
+  def test_acknowledgement
     Paypal::Notification.any_instance.stubs(:ssl_post).returns('VERIFIED')
     assert @paypal.acknowledge
-    
+
     Paypal::Notification.any_instance.stubs(:ssl_post).returns('INVALID')
     assert !@paypal.acknowledge
   end
@@ -74,7 +74,7 @@ class PaypalNotificationTest < Test::Unit::TestCase
       http_raw_data,
       { 'Content-Length' => "#{http_raw_data.size}", 'User-Agent' => "Active Merchant -- http://activemerchant.org" }
     ).returns('VERIFIED')
-    
+
     assert @paypal.acknowledge
   end
 
@@ -82,12 +82,12 @@ class PaypalNotificationTest < Test::Unit::TestCase
     notification = Paypal::Notification.new('payment_status=Completed')
     assert_equal 'Completed', notification.status
   end
-  
+
   def test_payment_pending_status
     notification = Paypal::Notification.new('payment_status=Pending')
     assert_equal 'Pending', notification.status
   end
-  
+
   def test_payment_failure_status
     notification = Paypal::Notification.new('payment_status=Failed')
     assert_equal 'Failed', notification.status
@@ -106,21 +106,24 @@ class PaypalNotificationTest < Test::Unit::TestCase
     notification = Paypal::Notification.new('custom=1')
     assert_equal '1', notification.item_id
   end
-  
+
   def test_nil_notification
     Paypal::Notification.any_instance.stubs(:ssl_post).returns('INVALID')
     assert !@paypal.acknowledge
   end
 
   def test_received_at_time_parsing
-    assert_match %r{15/04/2005 15:23:54 [\-+]\d{4}}, @paypal.received_at.strftime("%d/%m/%Y %H:%M:%S %z")
+    assert_match %r{15/04/2005 08:23:54 UTC}, @paypal.received_at.strftime("%d/%m/%Y %H:%M:%S %Z")
+
+    paypal = Paypal::Notification.new("payment_date=13%3A38%3A14+Jan+22%2C+2013+PST")
+    assert_match %r{22/01/2013 05:38:14 UTC}, paypal.received_at.strftime("%d/%m/%Y %H:%M:%S %Z")
   end
-  
+
   private
 
   def http_raw_data
     "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Completed&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00"
-  end  
+  end
 
   def mass_pay_http_raw_data
     "payer_id=LPV4F4HZHCE&payment_date=06%3A25%3A37+Oct+25%2C+2012+PDT&payment_gross_1=&payment_gross_2=&payment_gross_3=&payment_status=Completed&receiver_email_1=buyer_1348066306_per%40example.com&receiver_email_2=buyer_1351170859_per%40example.com&charset=windows-1252&receiver_email_3=buyer_1351170993_per%40example.com&mc_currency_1=GBP&masspay_txn_id_1=7XW35917TG8293137&mc_currency_2=GBP&masspay_txn_id_2=79512417EL9296629&mc_currency_3=GBP&masspay_txn_id_3=75X24749Y32677910&first_name=Test&unique_id_1=123&notify_version=3.7&unique_id_2=456&unique_id_3=789&payer_status=verified&verify_sign=AwtKW.5QSiJCrI10IE.2gmVei1MEAwsHLftLIB9pXgu82MLXoCS1yeE-&payer_email=massuk_1351170591_biz%40example.com&payer_business_name=Tests%27s+Test+Store&last_name=Test&status_1=Completed&status_2=Completed&status_3=Completed&txn_type=masspay&mc_gross_1=10.00&mc_gross_2=24.50&mc_gross_3=20.00&payment_fee_1=&residence_country=GB&test_ipn=1&payment_fee_2=&payment_fee_3=&mc_fee_1=0.20&mc_fee_2=0.49&mc_fee_3=0.40&ipn_track_id=89f7ff244947f"


### PR DESCRIPTION
(https://github.com/Shopify/active_merchant/issues/23)

This is still an issue. Documentation shows Time.parse params[:payment_date] which is definitely incorrect.

Time.parse "16:56:00 Jan 01, 2013 PDT"ends up being 2013-01-02 16:56:01 -0500

The suggested gist will work. Here is the link to a blog post about it, though.

http://rhnh.net/2008/03/17/paypal-ipn-fails-date-standards
