### PR TITLE
Moneris returns error when trying to void authorization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Eway Managed: Add 'query_customer' API as #retrieve [cdaloisio]
 * NetPay: Fix the signature for void [duff]
 * Cybersource: Add check support [bowmande]
+* Moneris: Use a capture of $0 for void [ntalbott]
 
 == Version 1.29.3 (December 7, 2012)
 

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -70,15 +70,13 @@ module ActiveMerchant #:nodoc:
         commit 'completion', crediting_params(authorization, :comp_amount => amount(money))
       end
 
-      # Voiding requires the original transaction ID and order ID of some open
-      # transaction. Closed transactions must be refunded. Note that the only
-      # methods which may be voided are +capture+ and +purchase+.
+      # Voiding cancels an open authorization.
       #
       # Concatenate your transaction number and order_id by using a semicolon
       # (';'). This is to keep the Moneris interface consistent with other
       # gateways. (See +capture+ for details.)
       def void(authorization, options = {})
-        commit 'purchasecorrection', crediting_params(authorization)
+        capture(0, authorization, options)
       end
 
       # Performs a refund. This method requires that the original transaction

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -7,19 +7,19 @@ class MonerisRemoteTest < Test::Unit::TestCase
     @gateway = MonerisGateway.new(fixtures(:moneris))
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = { 
+    @options = {
       :order_id => generate_unique_id,
       :customer => generate_unique_id
     }
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
-    assert_false response.authorization.blank? 
+    assert_false response.authorization.blank?
   end
-  
+
   def test_successful_authorization
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
@@ -39,38 +39,20 @@ class MonerisRemoteTest < Test::Unit::TestCase
     response = @gateway.capture(@amount, response.authorization)
     assert_success response
   end
-  
+
   def test_successful_authorization_and_void
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert response.authorization
-    
-    # Moneris cannot void a preauthorization
-    # You must capture the auth transaction with an amount of $0.00
-    void = @gateway.capture(0, response.authorization)
-    assert_success void
-  end
-  
-  def test_successful_purchase_and_void
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success purchase
-    
-    void = @gateway.void(purchase.authorization)
-    assert_success void
-  end
-  
-  def test_failed_purchase_and_void
-    purchase = @gateway.purchase(101, @credit_card, @options)
-    assert_failure purchase
 
-    void = @gateway.void(purchase.authorization)
-    assert_failure void
+    void = @gateway.void(response.authorization)
+    assert_success void
   end
-  
+
   def test_successful_purchase_and_credit
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
-    
+
     credit = @gateway.credit(@amount, purchase.authorization)
     assert_success credit
   end

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -22,7 +22,7 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-  
+
     assert response = @gateway.authorize(100, @credit_card, @options)
     assert_success response
     assert_equal '58-0_3;1026.1', response.authorization
@@ -30,11 +30,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-  
+
     assert response = @gateway.authorize(100, @credit_card, @options)
     assert_failure response
   end
-  
+
   def test_deprecated_credit
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns("")
     @gateway.expects(:parse).returns({})
@@ -42,34 +42,34 @@ class MonerisTest < Test::Unit::TestCase
       @gateway.credit(@amount, "123;456", @options)
     end
   end
-  
+
   def test_refund
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns("")
     @gateway.expects(:parse).returns({})
     @gateway.refund(@amount, "123;456", @options)
   end
-  
+
   def test_amount_style
    assert_equal '10.34', @gateway.send(:amount, 1034)
-                                                      
+
    assert_raise(ArgumentError) do
      @gateway.send(:amount, '10.34')
    end
-  end                                                           
-  
+  end
+
   def test_purchase_is_valid_xml
-   params = { 
+   params = {
      :order_id => "order1",
      :amount => "1.01",
      :pan => "4242424242424242",
      :expdate => "0303",
-     :crypt_type => 7,                                                  
+     :crypt_type => 7,
    }
 
    assert data = @gateway.send(:post_data, 'preauth', params)
    assert REXML::Document.new(data)
    assert_equal xml_capture_fixture.size, data.size
-  end  
+  end
 
   def test_purchase_is_valid_xml
    params = {
@@ -86,23 +86,23 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_capture_is_valid_xml
-   params = { 
+   params = {
      :order_id => "order1",
      :amount => "1.01",
      :pan => "4242424242424242",
      :expdate => "0303",
-     :crypt_type => 7,                                                  
+     :crypt_type => 7,
    }
 
    assert data = @gateway.send(:post_data, 'preauth', params)
    assert REXML::Document.new(data)
    assert_equal xml_capture_fixture.size, data.size
-  end  
-  
+  end
+
   def test_supported_countries
     assert_equal ['CA'], MonerisGateway.supported_countries
   end
-  
+
   def test_supported_card_types
     assert_equal [:visa, :master, :american_express, :diners_club, :discover], MonerisGateway.supported_cardtypes
   end
@@ -113,8 +113,7 @@ class MonerisTest < Test::Unit::TestCase
     end
   end
 
-
- def test_successful_store
+  def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
     assert response = @gateway.store(@credit_card)
     assert_success response
@@ -189,10 +188,10 @@ class MonerisTest < Test::Unit::TestCase
     <TimedOut>false</TimedOut>
   </receipt>
 </response>
-    
+
     RESPONSE
   end
-  
+
   def failed_purchase_response
     <<-RESPONSE
 <?xml version="1.0"?>
@@ -214,9 +213,9 @@ class MonerisTest < Test::Unit::TestCase
     <TimedOut>false</TimedOut>
   </receipt>
 </response>
-    
+
     RESPONSE
-  end  
+  end
 
 
   def successful_store_response
@@ -269,5 +268,4 @@ class MonerisTest < Test::Unit::TestCase
   def xml_capture_fixture
    '<request><store_id>store1</store_id><api_token>yesguy</api_token><preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></preauth></request>'
   end
-
 end


### PR DESCRIPTION
This is a follow up to https://github.com/Shopify/active_merchant/pull/317
### Problem

We have merchants complaining that voiding authorizations is not working with Moneris.

When we try we get the error:

`Invalid follow_up_amount number`
### TODO

Should we maybe change the implementation of the `void` method to do the $0 capture?
