### PR TITLE
Stripe: Add support for application_fee.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -50,6 +50,7 @@ module ActiveMerchant #:nodoc:
         add_customer(post, options)
         add_customer_data(post,options)
         post[:description] = options[:description] || options[:email]
+        post[:application_fee] = options[:application_fee] if options[:application_fee]
         add_flags(post, options)
 
         meta = generate_meta(options)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -37,7 +37,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Your card number is invalid', response.message
+    assert_match /card number.* invalid/, response.message
   end
 
   def test_successful_void
@@ -97,6 +97,14 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal "Invalid API Key provided: active_merchant_test", response.message
+  end
+
+  def test_application_fee_for_stripe_connect
+    assert response = @gateway.purchase(@amount, @credit_card, { :application_fee => 12 })
+    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
+    assert response.params['fee_details'].any? do |fee|
+      (fee['type'] == 'application_fee') && (fee['amount'] == 12)
+    end
   end
 
 end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -91,6 +91,14 @@ class StripeTest < Test::Unit::TestCase
     assert !post[:customer]
   end
 
+  def test_application_fee_is_submitted
+    stub_comms(:ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({:application_fee => 144}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/application_fee=144/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_client_data_submitted_with_purchase
     stub_comms(:ssl_request) do
       updated_options = @options.merge({:description => "a test customer",:browser_ip => "127.127.127.127", :user_agent => "some browser", :order_id => "42", :email => "foo@wonderfullyfakedomain.com", :referrer =>"http://www.shopify.com"})


### PR DESCRIPTION
When using Stripe Connect, Stripe allows you to pass an
application_fee parameter such that you can specify a fee on top of
Stripe's fees.

https://stripe.com/docs/connect/collecting-fees

Also made a remote test a bit more forgiving.
