### PR TITLE
Remove fractional amounts from TWD currency

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       include Utils
 
       DEBIT_CARDS = [ :switch, :solo ]
-      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY', 'HUF' ]
+      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY', 'HUF', 'TWD' ]
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
 
       cattr_reader :implementations

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -281,6 +281,12 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert response.success?
   end
 
+  def test_removes_fractional_amounts_with_twd_currency
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, {:currency => 'TWD'}))
+
+    assert_equal '1', REXML::XPath.first(xml, '//n2:OrderTotal').text
+  end
+
   def test_does_not_add_allow_note_if_not_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { }))
 


### PR DESCRIPTION
#### Problem

PayPal does not support fractional amounts for TWD currency: https://github.com/Shopify/active_merchant/issues/561
#### Changes

Added TWD to CURRENCIES_WITHOUT_FRACTIONS
#### Review

@Soleone @jduff 
