### PR TITLE
SagePay: Add support for GiftAidPayment

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -65,6 +65,7 @@ module ActiveMerchant #:nodoc:
         add_credit_card(post, credit_card)
         add_address(post, options)
         add_customer_data(post, options)
+        add_optional_data(post, options)
 
         commit(:purchase, post)
       end
@@ -79,6 +80,7 @@ module ActiveMerchant #:nodoc:
         add_credit_card(post, credit_card)
         add_address(post, options)
         add_customer_data(post, options)
+        add_optional_data(post, options)
 
         commit(:authorization, post)
       end
@@ -154,6 +156,10 @@ module ActiveMerchant #:nodoc:
         add_pair(post, :CustomerEMail, options[:email][0,255]) unless options[:email].blank?
         add_pair(post, :BillingPhone, options[:phone].gsub(/[^0-9+]/, '')[0,20]) unless options[:phone].blank?
         add_pair(post, :ClientIPAddress, options[:ip])
+      end
+
+      def add_optional_data(post, options)
+        add_pair(post, :GiftAidPayment, options[:gift_aid_payment]) unless options[:gift_aid_payment].blank?
       end
 
       def add_address(post, options)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -1,14 +1,16 @@
 require 'test_helper'
 
 class SagePayTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = SagePayGateway.new(
       :login => 'X'
     )
 
     @credit_card = credit_card('4242424242424242', :brand => 'visa')
-    @options = { 
-      :billing_address => { 
+    @options = {
+      :billing_address => {
         :name => 'Tekin Suleyman',
         :address1 => 'Flat 10 Lapwing Court',
         :address2 => 'West Didsbury',
@@ -28,7 +30,7 @@ class SagePayTest < Test::Unit::TestCase
 
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_equal "1;B8AE1CF6-9DEF-C876-1BB4-9B382E6CE520;4193753;OHMETD7DFK;purchase", response.authorization
@@ -37,59 +39,59 @@ class SagePayTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase
     @gateway.expects(:ssl_post).returns(unsuccessful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
   end
-  
+
   def test_purchase_url
     assert_equal 'https://test.sagepay.com/gateway/service/vspdirect-register.vsp', @gateway.send(:url_for, :purchase)
   end
-  
+
   def test_capture_url
     assert_equal 'https://test.sagepay.com/gateway/service/release.vsp', @gateway.send(:url_for, :capture)
   end
-  
+
   def test_electron_cards
     # Visa range
     assert_no_match SagePayGateway::ELECTRON, '4245180000000000'
-    
+
     # First electron range
     assert_match SagePayGateway::ELECTRON, '4245190000000000'
-                                                                
-    # Second range                                              
+
+    # Second range
     assert_match SagePayGateway::ELECTRON, '4249620000000000'
     assert_match SagePayGateway::ELECTRON, '4249630000000000'
-                                                                
-    # Third                                                     
+
+    # Third
     assert_match SagePayGateway::ELECTRON, '4508750000000000'
-                                                                
-    # Fourth                                                    
+
+    # Fourth
     assert_match SagePayGateway::ELECTRON, '4844060000000000'
     assert_match SagePayGateway::ELECTRON, '4844080000000000'
-                                                                
-    # Fifth                                                     
+
+    # Fifth
     assert_match SagePayGateway::ELECTRON, '4844110000000000'
     assert_match SagePayGateway::ELECTRON, '4844550000000000'
-                                                                
-    # Sixth                                                     
+
+    # Sixth
     assert_match SagePayGateway::ELECTRON, '4917300000000000'
     assert_match SagePayGateway::ELECTRON, '4917590000000000'
-                                                                
-    # Seventh                                                   
+
+    # Seventh
     assert_match SagePayGateway::ELECTRON, '4918800000000000'
-    
+
     # Visa
     assert_no_match SagePayGateway::ELECTRON, '4918810000000000'
-    
+
     # 19 PAN length
     assert_match SagePayGateway::ELECTRON, '4249620000000000000'
-    
+
     # 20 PAN length
     assert_no_match SagePayGateway::ELECTRON, '42496200000000000'
   end
-  
+
   def test_avs_result
      @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
@@ -121,7 +123,16 @@ class SagePayTest < Test::Unit::TestCase
 
     @gateway.send(:add_amount, {}, @amount, @options)
   end
-   
+
+  def test_gift_aid_payment_is_submitted
+    stub_comms(:ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({:gift_aid_payment => 1}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/GiftAidPayment=1/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+
   private
 
   def successful_purchase_response
@@ -139,7 +150,7 @@ CV2Result=NOTMATCHED
 3DSecureStatus=NOTCHECKED
     RESP
   end
-  
+
   def unsuccessful_purchase_response
     <<-RESP
 VPSProtocol=2.23


### PR DESCRIPTION
This is an optional flag to indicate that the payment is a Gift Aid
charitable donation and the customer has agreed to donate the tax.

From the SagePay docs:

![Screenshot_1_31_13_2_53_PM](https://f.cloud.github.com/assets/2437/115948/7ba69f74-6be3-11e2-9ff9-cd76a011de65.jpg)
