### PR TITLE
Add support for Authorize.net in CA and UK

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -41,7 +41,9 @@ module ActiveMerchant #:nodoc:
       RESPONSE_CODE, RESPONSE_REASON_CODE, RESPONSE_REASON_TEXT = 0, 2, 3
       AVS_RESULT_CODE, TRANSACTION_ID, CARD_CODE_RESPONSE_CODE  = 5, 6, 38
 
-      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+
+      self.supported_countries = ['US', 'CA', 'UK']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
       self.homepage_url = 'http://www.authorize.net/'
       self.display_name = 'Authorize.Net'
@@ -85,6 +87,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>options</tt> -- A hash of optional parameters.
       def authorize(money, creditcard, options = {})
         post = {}
+        add_currency_code(post, money, options)
         add_invoice(post, options)
         add_creditcard(post, creditcard)
         add_address(post, options)
@@ -103,6 +106,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>options</tt> -- A hash of optional parameters.
       def purchase(money, creditcard, options = {})
         post = {}
+        add_currency_code(post, money, options)
         add_invoice(post, options)
         add_creditcard(post, creditcard)
         add_address(post, options)
@@ -326,6 +330,10 @@ module ActiveMerchant #:nodoc:
 
         request = post.merge(parameters).collect { |key, value| "x_#{key}=#{CGI.escape(value.to_s)}" }.join("&")
         request
+      end
+
+      def add_currency_code(post, money, options)
+        post[:currency_code] = options[:currency] || currency(money)
       end
 
       def add_invoice(post, options)

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -158,4 +158,18 @@ class AuthorizeNetTest < Test::Unit::TestCase
   ensure
     ActiveMerchant::Billing::AuthorizeNetGateway.application_id = nil
   end
+
+  def test_bad_currency
+    @options[:currency] = "XYZ"
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'The supplied currency code is either invalid, not supported, not allowed for this merchant or doesn\'t have an exchange rate', response.message
+  end
+
+  def test_usd_currency
+    @options[:currency] = "USD"
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization
+  end
 end


### PR DESCRIPTION
##### Changes

Sends the buyer's currency to Authorize.net during authorize and purchase requests. Also adds 'CA' and 'UK' to the supported_countries list.

**Note:** I originally had a remote test included which would send test requests using both the CAN and GBP currencies. However this would always fail with the message: 
_"The supplied currency code is either invalid, not supported, not allowed for this merchant or doesn't have an exchange rate."_
Looking through their documentation, it states the the merchant account must have certain payment processors enabled to handle these different currencies. However after getting in contact with Auth.net, they have said that their test environment only works with USD since it does not have the required payment processors available. It seems we will not be able to properly test this until it is using live servers...

The changes are straight foreword and all existing tests which use USD are still passing as expected so it seems safe enough - but I'm not completely sure what we want to do with this one.
##### Reviewers

@jduff 
@Soleone 
