### PR TITLE
Fix format() with string input error

### DIFF
--- a/lib/active_merchant/billing/credit_card_formatting.rb
+++ b/lib/active_merchant/billing/credit_card_formatting.rb
@@ -1,21 +1,21 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module CreditCardFormatting
-      
-      # This method is used to format numerical information pertaining to credit cards. 
-      # 
+
+      # This method is used to format numerical information pertaining to credit cards.
+      #
       #   format(2005, :two_digits)  # => "05"
       #   format(05,   :four_digits) # => "0005"
       def format(number, option)
         return '' if number.blank?
-        
+
         case option
-          when :two_digits  ; sprintf("%.2i", number)[-2..-1]
-          when :four_digits ; sprintf("%.4i", number)[-4..-1]
+          when :two_digits  ; sprintf("%.2i", number.to_i)[-2..-1]
+          when :four_digits ; sprintf("%.4i", number.to_i)[-4..-1]
           else number
         end
       end
-      
+
     end
   end
 end

--- a/test/unit/credit_card_formatting_test.rb
+++ b/test/unit/credit_card_formatting_test.rb
@@ -2,17 +2,20 @@ require 'test_helper'
 
 class CreditCardFormattingTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::CreditCardFormatting
-  
+
   def test_should_format_number_by_rule
     assert_equal 2005, format(2005, :steven_colbert)
-    
+
     assert_equal '0005', format(05, :four_digits)
     assert_equal '2005', format(2005, :four_digits)
-    
+
     assert_equal '05', format(2005, :two_digits)
     assert_equal '05', format(05, :two_digits)
     assert_equal '08', format(8, :two_digits)
-    
+
+    assert_equal '08', format('8', :two_digits)
+    assert_equal '08', format('08', :two_digits)
+
     assert format(nil, :two_digits).blank?
     assert format('', :two_digits).blank?
   end


### PR DESCRIPTION
The documentation on http://activemerchant.org uses strings when instantiating `ActiveMerchant::Billing::CreditCard`. However, if '08' or '09' is used, it can cause an error as sprintf assumes it is doing an octal conversion.

Failing test case:

```
test_should_format_number_by_rule(CreditCardFormattingTest):
ArgumentError: invalid value for Integer(): "08"
    /Users/gabebug/github/active_merchant/lib/active_merchant/billing/credit_card_formatting.rb:13:in `sprintf'
    /Users/gabebug/github/active_merchant/lib/active_merchant/billing/credit_card_formatting.rb:13:in `format'
    /Users/gabebug/github/active_merchant/test/unit/credit_card_formatting_test.rb:17:in `test_should_format_number_by_rule'
    /Users/gabebug/.rvm/gems/ruby-1.9.3-p286/gems/mocha-0.11.4/lib/mocha/integration/mini_test/version_230_to_262.rb:28:in `run'
```
