### PR TITLE
Wirecard partial captures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * PayPal Express integration: Fix received_at time zone [ntalbott]
 * NAB Transact: Add refund capability [nagash]
 * Stripe: Add support for application_fee [duff]
+* Wirecard: Pass amount on capture [ntalbott]
 
 == Version 1.29.3 (December 7, 2012)
 

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -158,6 +158,7 @@ module ActiveMerchant #:nodoc:
               add_address(xml, options[:billing_address])
             when :capture_authorization
               xml.tag! 'GuWID', options[:authorization]
+              add_amount(xml, money, options) if money
             end
           end
         end
@@ -165,12 +166,16 @@ module ActiveMerchant #:nodoc:
 
       # Includes the payment (amount, currency, country) to the transaction-xml
       def add_invoice(xml, money, options)
-        xml.tag! 'Amount', amount(money)
-        xml.tag! 'Currency', options[:currency] || currency(money)
+        add_amount(xml, money, options)
         xml.tag! 'CountryCode', options[:billing_address][:country]
         xml.tag! 'RECURRING_TRANSACTION' do
           xml.tag! 'Type', options[:recurring] || 'Single'
         end
+      end
+
+      def add_amount(xml, money, options)
+        xml.tag! 'Amount', amount(money)
+        xml.tag! 'Currency', options[:currency] || currency(money)
       end
 
       # Includes the credit-card data to the transaction-xml

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -77,6 +77,17 @@ class WirecardTest < Test::Unit::TestCase
     assert response.message[/this is a demo/i]
   end
 
+  def test_capture_with_amount
+    capture = stub_comms do
+      @gateway.capture((@amount - 1), "auth")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<Amount>#{@amount - 1}</Amount>}i, data)
+      assert_match(%r{<Currency>EUR</Currency>}i, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
   def test_unauthorized_capture
     @gateway.expects(:ssl_post).returns(unauthorized_capture_response)
     assert response = @gateway.capture(@amount, "1234567890123456789012", @options)


### PR DESCRIPTION
#### Problem

According to Wirecard's [documentation](https://www.dropbox.com/s/2p7sscxpiz1o1qt/WD_card_processing_4-1-1_en.pdf) (p.13-14) they support partial captures by supplying an amount to capture in the capture request. Currently there is no amount specified in capture requests made with active merchant, so the entire amount is always captured. 
#### TODO

Add the money amount to be captured to the capture request
