### PR TITLE
Added support for passing optional fields in Litle token based transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
       self.live_url = 'https://payments.litle.com/vap/communicator/online'
 
-      LITLE_SCHEMA_VERSION = '8.10'
+      LITLE_SCHEMA_VERSION     = '8.13'
 
       # The countries the gateway supports merchants from as 2 digit ISO country codes
       self.supported_countries = ['US']
@@ -46,10 +46,10 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
 
       # The homepage URL of the gateway
-      self.homepage_url = 'http://www.litle.com/'
+      self.homepage_url        = 'http://www.litle.com/'
 
       # The name of the gateway
-      self.display_name = 'Litle & Co.'
+      self.display_name        = 'Litle & Co.'
 
       self.default_currency = 'USD'
 
@@ -91,8 +91,8 @@ module ActiveMerchant #:nodoc:
         build_response(:void, @litle.void(to_pass))
       end
 
-      def credit(money, identification, options = {})
-        to_pass = create_credit_hash(money, identification, options)
+      def credit(money, identification_or_token, options = {})
+        to_pass = build_credit_request(money, identification_or_token, options)
         build_response(:credit, @litle.credit(to_pass))
       end
 
@@ -104,30 +104,30 @@ module ActiveMerchant #:nodoc:
       private
 
       CARD_TYPE = {
-        'visa' => 'VI',
-        'master' => 'MC',
-        'american_express' => 'AX',
-        'discover' => 'DI',
-        'jcb' => 'DI',
-        'diners_club' => 'DI'
+          'visa'             => 'VI',
+          'master'           => 'MC',
+          'american_express' => 'AX',
+          'discover'         => 'DI',
+          'jcb'              => 'DI',
+          'diners_club'      => 'DI'
       }
 
       AVS_RESPONSE_CODE = {
-        '00' => 'Y',
-        '01' => 'X',
-        '02' => 'D',
-        '10' => 'Z',
-        '11' => 'W',
-        '12' => 'A',
-        '13' => 'A',
-        '14' => 'P',
-        '20' => 'N',
-        '30' => 'S',
-        '31' => 'R',
-        '32' => 'U',
-        '33' => 'R',
-        '34' => 'I',
-        '40' => 'E'
+          '00' => 'Y',
+          '01' => 'X',
+          '02' => 'D',
+          '10' => 'Z',
+          '11' => 'W',
+          '12' => 'A',
+          '13' => 'A',
+          '14' => 'P',
+          '20' => 'N',
+          '30' => 'S',
+          '31' => 'R',
+          '32' => 'U',
+          '33' => 'R',
+          '34' => 'I',
+          '40' => 'E'
       }
 
       def url
@@ -140,22 +140,22 @@ module ActiveMerchant #:nodoc:
         response = Hash.from_xml(litle_response.raw_xml.to_s)['litleOnlineResponse']
 
         if response['response'] == "0"
-          detail = response["#{kind}Response"]
-          fraud = fraud_result(detail)
+          detail        = response["#{kind}Response"]
+          fraud         = fraud_result(detail)
           authorization = case kind
-          when :registerToken
-            response['registerTokenResponse']['litleToken']
-          else
-            detail['litleTxnId']
-          end
+                          when :registerToken
+                            response['registerTokenResponse']['litleToken']
+                          else
+                            detail['litleTxnId']
+                          end
           Response.new(
-            valid_responses.include?(detail['response']),
-            detail['message'],
-            {:litleOnlineResponse => response},
-            :authorization => authorization,
-            :avs_result => {:code => fraud['avs']},
-            :cvv_result => fraud['cvv'],
-            :test => test?
+              valid_responses.include?(detail['response']),
+              detail['message'],
+              { :litleOnlineResponse => response },
+              :authorization => authorization,
+              :avs_result    => { :code => fraud['avs'] },
+              :cvv_result    => fraud['cvv'],
+              :test          => test?
           )
         else
           Response.new(false, response['message'], :litleOnlineResponse => response, :test => test?)
@@ -163,39 +163,83 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_authorize_request(money, creditcard_or_token, options)
+        payment_method = build_payment_method(creditcard_or_token, options)
+
         hash = create_hash(money, options)
 
-        add_credit_card_or_token_hash(hash, creditcard_or_token)
+        add_creditcard_or_cardtoken_hash(hash, payment_method)
 
         hash
       end
 
       def build_purchase_request(money, creditcard_or_token, options)
+        payment_method = build_payment_method(creditcard_or_token, options)
+
         hash = create_hash(money, options)
 
-        add_credit_card_or_token_hash(hash, creditcard_or_token)
+        add_creditcard_or_cardtoken_hash(hash, payment_method)
 
         hash
       end
 
-      def add_credit_card_or_token_hash(hash, creditcard_or_token)
-        if creditcard_or_token.is_a?(String)
-          add_token_hash(hash, creditcard_or_token)
+      def build_credit_request(money, identification_or_token, options)
+        payment_method = build_payment_method(identification_or_token, options)
+
+        hash = create_hash(money, options)
+
+        add_identification_or_cardtoken_hash(hash, payment_method)
+
+        unless payment_method.is_a?(LitleCardToken)
+          hash['orderSource'] = nil
+          hash['orderId']     = nil
+        end
+
+        hash
+      end
+
+      def build_payment_method(payment_method, options)
+        result = payment_method
+
+        # Build instance of the LitleCardToken class for internal use if this is a token request.
+        if payment_method.is_a?(String) && options.has_key?(:token)
+          result                    = LitleCardToken.new(:token => payment_method)
+          result.month              = options[:token][:month]
+          result.year               = options[:token][:year]
+          result.verification_value = options[:token][:verification_value]
+          result.brand              = options[:token][:brand]
+        end
+
+        result
+      end
+
+      def add_creditcard_or_cardtoken_hash(hash, creditcard_or_cardtoken)
+        if creditcard_or_cardtoken.is_a?(LitleCardToken)
+          add_cardtoken_hash(hash, creditcard_or_cardtoken)
         else
-          add_credit_card_hash(hash, creditcard_or_token)
+          add_creditcard_hash(hash, creditcard_or_cardtoken)
         end
       end
 
-      def add_token_hash(hash, creditcard_or_token)
-        token_info = {
-            'litleToken' => creditcard_or_token
-        }
+      def add_identification_or_cardtoken_hash(hash, identification_or_cardtoken)
+        if identification_or_cardtoken.is_a?(LitleCardToken)
+          add_cardtoken_hash(hash, identification_or_cardtoken)
+        else
+          hash['litleTxnId'] = identification_or_cardtoken
+        end
+      end
+
+      def add_cardtoken_hash(hash, cardtoken)
+        token_info               = {}
+        token_info['litleToken'] = cardtoken.token
+        token_info['expDate'] = cardtoken.exp_date if cardtoken.exp_date?
+        token_info['cardValidationNum'] = cardtoken.verification_value unless cardtoken.verification_value.blank?
+        token_info['type'] = cardtoken.type unless cardtoken.type.blank?
 
         hash['token'] = token_info
         hash
       end
 
-      def add_credit_card_hash(hash, creditcard)
+      def add_creditcard_hash(hash, creditcard)
         cc_type     = CARD_TYPE[creditcard.brand]
         exp_date_yr = creditcard.year.to_s[2..3]
         exp_date_mo = '%02d' % creditcard.month.to_i
@@ -213,27 +257,19 @@ module ActiveMerchant #:nodoc:
       end
 
       def create_capture_hash(money, authorization, options)
-        hash = create_hash(money, options)
+        hash               = create_hash(money, options)
         hash['litleTxnId'] = authorization
         hash
       end
 
-      def create_credit_hash(money, identification, options)
-        hash = create_hash(money, options)
-        hash['litleTxnId'] = identification
-        hash['orderSource'] = nil
-        hash['orderId'] = nil
-        hash
-      end
-
       def create_token_hash(creditcard, options)
-        hash = create_hash(0, options)
+        hash                  = create_hash(0, options)
         hash['accountNumber'] = creditcard.number
         hash
       end
 
       def create_void_hash(identification, options)
-        hash = create_hash(nil, options)
+        hash               = create_hash(nil, options)
         hash['litleTxnId'] = identification
         hash
       end
@@ -255,54 +291,54 @@ module ActiveMerchant #:nodoc:
 
         if options[:billing_address]
           bill_to_address = {
-            'name' => options[:billing_address][:name],
-            'companyName' => options[:billing_address][:company],
-            'addressLine1' => options[:billing_address][:address1],
-            'addressLine2' => options[:billing_address][:address2],
-            'city' => options[:billing_address][:city],
-            'state' => options[:billing_address][:state],
-            'zip' => options[:billing_address][:zip],
-            'country' => options[:billing_address][:country],
-            'email' => options[:email],
-            'phone' => options[:billing_address][:phone]
+              'name'         => options[:billing_address][:name],
+              'companyName'  => options[:billing_address][:company],
+              'addressLine1' => options[:billing_address][:address1],
+              'addressLine2' => options[:billing_address][:address2],
+              'city'         => options[:billing_address][:city],
+              'state'        => options[:billing_address][:state],
+              'zip'          => options[:billing_address][:zip],
+              'country'      => options[:billing_address][:country],
+              'email'        => options[:email],
+              'phone'        => options[:billing_address][:phone]
           }
         end
         if options[:shipping_address]
           ship_to_address = {
-            'name' => options[:shipping_address][:name],
-            'companyName' => options[:shipping_address][:company],
-            'addressLine1' => options[:shipping_address][:address1],
-            'addressLine2' => options[:shipping_address][:address2],
-            'city' => options[:shipping_address][:city],
-            'state' => options[:shipping_address][:state],
-            'zip' => options[:shipping_address][:zip],
-            'country' => options[:shipping_address][:country],
-            'email' => options[:email],
-            'phone' => options[:shipping_address][:phone]
+              'name'         => options[:shipping_address][:name],
+              'companyName'  => options[:shipping_address][:company],
+              'addressLine1' => options[:shipping_address][:address1],
+              'addressLine2' => options[:shipping_address][:address2],
+              'city'         => options[:shipping_address][:city],
+              'state'        => options[:shipping_address][:state],
+              'zip'          => options[:shipping_address][:zip],
+              'country'      => options[:shipping_address][:country],
+              'email'        => options[:email],
+              'phone'        => options[:shipping_address][:phone]
           }
         end
 
         hash = {
-          'billToAddress' => bill_to_address,
-          'shipToAddress' => ship_to_address,
-          'orderId' => (options[:order_id] || @options[:order_id]),
-          'customerId' => options[:customer],
-          'reportGroup' => (options[:merchant] || @options[:merchant]),
-          'merchantId' => (options[:merchant_id] || @options[:merchant_id]),
-          'orderSource' => (options[:order_source] || 'ecommerce'),
-          'enhancedData' => enhanced_data,
-          'fraudCheckType' => fraud_check_type,
-          'user' => (options[:user] || @options[:user]),
-          'password' => (options[:password] || @options[:password]),
-          'version' => (options[:version] || @options[:version]),
-          'url' => (options[:url] || url),
-          'proxy_addr' => (options[:proxy_addr] || @options[:proxy_addr]),
-          'proxy_port' => (options[:proxy_port] || @options[:proxy_port]),
-          'id' => (options[:id] || options[:order_id] || @options[:order_id])
+            'billToAddress'  => bill_to_address,
+            'shipToAddress'  => ship_to_address,
+            'orderId'        => (options[:order_id] || @options[:order_id]),
+            'customerId'     => options[:customer],
+            'reportGroup'    => (options[:merchant] || @options[:merchant]),
+            'merchantId'     => (options[:merchant_id] || @options[:merchant_id]),
+            'orderSource'    => (options[:order_source] || 'ecommerce'),
+            'enhancedData'   => enhanced_data,
+            'fraudCheckType' => fraud_check_type,
+            'user'           => (options[:user] || @options[:user]),
+            'password'       => (options[:password] || @options[:password]),
+            'version'        => (options[:version] || @options[:version]),
+            'url'            => (options[:url] || url),
+            'proxy_addr'     => (options[:proxy_addr] || @options[:proxy_addr]),
+            'proxy_port'     => (options[:proxy_port] || @options[:proxy_port]),
+            'id'             => (options[:id] || options[:order_id] || @options[:order_id])
         }
 
-        if( !money.nil? && money.to_s.length > 0 )
-          hash.merge!({'amount' => money})
+        if (!money.nil? && money.to_s.length > 0)
+          hash.merge!({ 'amount' => money })
         end
         hash
       end
@@ -315,7 +351,159 @@ module ActiveMerchant #:nodoc:
 
           avs_to_pass = AVS_RESPONSE_CODE[result['avsResult']] unless result['avsResult'].blank?
         end
-        {'cvv'=>cvv_to_pass, 'avs'=>avs_to_pass}
+        { 'cvv' => cvv_to_pass, 'avs' => avs_to_pass }
+      end
+
+      # A +LitleCardToken+ object represents a tokenized credit card, and is capable of validating the various
+      # data associated with these.
+      #
+      # == Example Usage
+      #   token = LitleCardToken.new(
+      #     :token              => '1234567890123456',
+      #     :month              => '9',
+      #     :year               => '2010',
+      #     :brand              => 'visa',
+      #     :verification_value => '123'
+      #   )
+      #
+      #   token.valid? # => true
+      #   cc.exp_date # => 0910
+      #
+      class LitleCardToken
+        include Validateable
+
+        # Returns or sets the token. (required)
+        #
+        # @return [String]
+        attr_accessor :token
+
+        # Returns or sets the expiry month for the card associated with token. (optional)
+        #
+        # @return [Integer]
+        attr_accessor :month
+
+        # Returns or sets the expiry year for the card associated with token. (optional)
+        #
+        # @return [Integer]
+        attr_accessor :year
+
+        # Returns or sets the card verification value. (optional)
+        #
+        # @return [String] the verification value
+        attr_accessor :verification_value
+
+        # Returns or sets the credit card brand. (optional)
+        #
+        # Valid card types are
+        #
+        # * +'visa'+
+        # * +'master'+
+        # * +'discover'+
+        # * +'american_express'+
+        # * +'diners_club'+
+        # * +'jcb'+
+        # * +'switch'+
+        # * +'solo'+
+        # * +'dankort'+
+        # * +'maestro'+
+        # * +'forbrugsforeningen'+
+        # * +'laser'+
+        #
+        # @return (String) the credit card brand
+        attr_accessor :brand
+
+        # Returns the Litle credit card type identifier.
+        #
+        # @return (String) the credit card type identifier
+        def type
+          CARD_TYPE[brand] unless brand.blank?
+        end
+
+        # Returns true if the expiration date is set.
+        #
+        # @return (Boolean)
+        def exp_date?
+          !month.to_i.zero? && !year.to_i.zero?
+        end
+
+        # Returns the card token expiration date in MMYY format.
+        #
+        # @return (String) the expiration date in MMYY format
+        def exp_date
+          result = ''
+          if exp_date?
+            exp_date_yr = year.to_s[2..3]
+            exp_date_mo = '%02d' % month.to_i
+
+            result = exp_date_mo + exp_date_yr
+          end
+          result
+        end
+
+        # Validates the card token details.
+        #
+        # Any validation errors are added to the {#errors} attribute.
+        def validate
+          validate_card_token
+          validate_expiration_date
+          validate_card_brand
+        end
+
+        def check?
+          false
+        end
+
+        private
+
+        CARD_TYPE = {
+            'visa'             => 'VI',
+            'master'           => 'MC',
+            'american_express' => 'AX',
+            'discover'         => 'DI',
+            'jcb'              => 'DI',
+            'diners_club'      => 'DI'
+        }
+
+        def before_validate #:nodoc:
+          self.month = month.to_i
+          self.year  = year.to_i
+        end
+
+        # Litle XML Reference Guide 1.8.2
+        #
+        # The length of the original card number is reflected in the token, so a
+        # submitted 16-digit number results in a 16-digit token. Also, all tokens
+        # use only numeric characters, so you do not have to change your
+        # systems to accept alpha-numeric characters.
+        #
+        # The credit card token numbers themselves have two parts.
+        # The last four digits match the last four digits of the card number.
+        # The remaining digits (length can vary based upon original card number
+        # length) are a randomly generated.
+        def validate_card_token #:nodoc:
+          if token.to_s.length < 12 || token.to_s.match(/\A\d+\Z/).nil?
+            errors.add :token, "is not a valid card token"
+          end
+        end
+
+        def validate_expiration_date #:nodoc:
+          if !month.to_i.zero? || !year.to_i.zero?
+            errors.add :month, "is not a valid month" unless valid_month?(month)
+            errors.add :year, "is not a valid year" unless valid_expiry_year?(year)
+          end
+        end
+
+        def validate_card_brand #:nodoc:
+          errors.add :brand, "is invalid" unless brand.blank? || CreditCard.card_companies.keys.include?(brand)
+        end
+
+        def valid_month?(month)
+          (1..12).include?(month.to_i)
+        end
+
+        def valid_expiry_year?(year)
+          year.to_s =~ /\A\d{4}\Z/ && year.to_i > 1987
+        end
       end
     end
   end

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'securerandom'
 
 class RemoteLitleCertification < Test::Unit::TestCase
   def setup
@@ -10,7 +11,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     credit_card = CreditCard.new(
       :number => '4457010000000009',
       :month => '01',
-      :year => '2012',
+      :year => '2014',
       :verification_value => '349',
       :brand => 'visa'
     )
@@ -37,7 +38,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test2
     credit_card = CreditCard.new(:number => '5112010000000003', :month => '02',
-                                 :year => '2012', :brand => 'master',
+                                 :year => '2014', :brand => 'master',
                                  :verification_value => '261')
 
     options = {
@@ -64,7 +65,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     credit_card = CreditCard.new(
       :number => '6011010000000003',
       :month => '03',
-      :year => '2012',
+      :year => '2014',
       :verification_value => '758',
       :brand => 'discover'
     )
@@ -92,7 +93,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     credit_card = CreditCard.new(
       :number => '375001000000005',
       :month => '04',
-      :year => '2012',
+      :year => '2014',
       :brand => 'american_express'
     )
 
@@ -118,7 +119,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test6
     credit_card = CreditCard.new(:number => '4457010100000008', :month => '06',
-                                 :year => '2012', :brand => 'visa',
+                                 :year => '2014', :brand => 'visa',
                                  :verification_value => '992')
 
     options = {
@@ -136,6 +137,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 6: authorize
     assert response = @gateway.authorize(60060, credit_card, options)
     assert !response.success?
+    assert_equal '110', response.params['litleOnlineResponse']['authorizationResponse']['response']
     assert_equal 'Insufficient Funds', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
@@ -143,18 +145,20 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 6. sale
     assert response = @gateway.purchase(60060, credit_card, options)
     assert !response.success?
+    assert_equal '110', response.params['litleOnlineResponse']['saleResponse']['response']
     assert_equal 'Insufficient Funds', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
 
     # 6A. void
-    assert response = @gateway.void(response.authorization)
+    assert response = @gateway.void(response.authorization, {:order_id => '6A'})
+    assert_equal '360', response.params['litleOnlineResponse']['voidResponse']['response']
     assert_equal 'No transaction found with specified litleTxnId', response.message
   end
 
   def test7
     credit_card = CreditCard.new(:number => '5112010100000002', :month => '07',
-                                 :year => '2012', :brand => 'master',
+                                 :year => '2014', :brand => 'master',
                                  :verification_value => '251')
 
     options = {
@@ -172,6 +176,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 7: authorize
     assert response = @gateway.authorize(70070, credit_card, options)
     assert !response.success?
+    assert_equal '301', response.params['litleOnlineResponse']['authorizationResponse']['response']
     assert_equal 'Invalid Account Number', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "N", response.cvv_result["code"]
@@ -180,8 +185,9 @@ class RemoteLitleCertification < Test::Unit::TestCase
     authorize_avs_assertions(credit_card, options, :avs => "I", :cvv => "N", :message => "Invalid Account Number", :success => false)
 
     # 7. sale
-    assert response = @gateway.purchase(60060, credit_card, options)
+    assert response = @gateway.purchase(70070, credit_card, options)
     assert !response.success?
+    assert_equal '301', response.params['litleOnlineResponse']['saleResponse']['response']
     assert_equal 'Invalid Account Number', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "N", response.cvv_result["code"]
@@ -189,7 +195,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test8
     credit_card = CreditCard.new(:number => '6011010100000002', :month => '08',
-                                 :year => '2012', :brand => 'discover',
+                                 :year => '2014', :brand => 'discover',
                                  :verification_value => '184')
 
     options = {
@@ -207,6 +213,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 8: authorize
     assert response = @gateway.authorize(80080, credit_card, options)
     assert !response.success?
+    assert_equal '123', response.params['litleOnlineResponse']['authorizationResponse']['response']
     assert_equal 'Call Discover', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
@@ -217,6 +224,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 8: sale
     assert response = @gateway.purchase(80080, credit_card, options)
     assert !response.success?
+    assert_equal '123', response.params['litleOnlineResponse']['saleResponse']['response']
     assert_equal 'Call Discover', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
@@ -224,11 +232,11 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test9
     credit_card = CreditCard.new(:number => '375001010000003', :month => '09',
-                                 :year => '2012', :brand => 'american_express',
+                                 :year => '2014', :brand => 'american_express',
                                  :verification_value => '0421')
 
     options = {
-      :order_id => '8',
+      :order_id => '9',
       :billing_address => {
         :name => 'James Miller',
         :address1 => '9 Main St.',
@@ -241,7 +249,9 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     # 9: authorize
     assert response = @gateway.authorize(90090, credit_card, options)
+
     assert !response.success?
+    assert_equal '303', response.params['litleOnlineResponse']['authorizationResponse']['response']
     assert_equal 'Pick Up Card', response.message
     assert_equal "I", response.avs_result["code"]
 
@@ -251,8 +261,59 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 9: sale
     assert response = @gateway.purchase(90090, credit_card, options)
     assert !response.success?
+    assert_equal '303', response.params['litleOnlineResponse']['saleResponse']['response']
     assert_equal 'Pick Up Card', response.message
     assert_equal "I", response.avs_result["code"]
+  end
+
+  # Explicit Token Registration Tests
+  def test50
+    credit_card = CreditCard.new(:number => '4457119922390123')
+    options     = {
+        :order_id => '50'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_success store_response
+    assert_equal 'Account number was successfully registered', store_response.message
+    assert_equal '445711', store_response.params['litleOnlineResponse']['registerTokenResponse']['bin']
+    assert_equal 'VI', store_response.params['litleOnlineResponse']['registerTokenResponse']['type'] #type is on Object in 1.8.7 - later versions can use .registerTokenResponse.type
+    assert_equal '801', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
+    assert_equal '0123', store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken'][-4,4]
+  end
+
+  def test51
+    credit_card = CreditCard.new(:number => '4457119999999999')
+    options     = {
+        :order_id => '51'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_failure store_response
+    assert_equal 'Credit card number was invalid', store_response.message
+    assert_equal '820', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
+    assert_equal nil, store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken']
+  end
+
+  def test52
+    credit_card = CreditCard.new(:number => '4457119922390123')
+    options     = {
+        :order_id => '52'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_success store_response
+    assert_equal 'Account number was previously registered', store_response.message
+    assert_equal '445711', store_response.params['litleOnlineResponse']['registerTokenResponse']['bin']
+    assert_equal 'VI', store_response.params['litleOnlineResponse']['registerTokenResponse']['type'] #type is on Object in 1.8.7 - later versions can use .registerTokenResponse.type
+    assert_equal '802', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
+    assert_equal '0123', store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken'][-4,4]
   end
 
   # Implicit Token Registration Tests
@@ -298,7 +359,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal '301', response.params['litleOnlineResponse']['authorizationResponse']['response']
   end
 
-  def test57
+  def test57_58
     credit_card = CreditCard.new(:number             => '5435101234510196',
                                  :month              => '11',
                                  :year               => '2014',
@@ -308,7 +369,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
         :order_id => '57'
     }
 
-    # authorize
+    # authorize card
     assert response = @gateway.authorize(15000, credit_card, options)
 
     assert_success response
@@ -317,27 +378,50 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert %w(801 802).include? response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['tokenResponseCode']
     assert_equal 'MC', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['type']
     assert_equal '543510', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['bin']
+
+    # authorize token
+    token   = response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['litleToken']
+    options = {
+        :order_id => '58',
+        :token    => {
+            :month => credit_card.month,
+            :year  => credit_card.year
+        }
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, token, options)
+
+    assert_success response
+    assert_equal 'Approved', response.message
   end
 
   def test59
-      token = '1712990000040196'
+    token   = '1712990000040196'
+    options = {
+        :order_id => '59',
+        :token    => {
+            :month => '11',
+            :year  => '2014'
+        }
+    }
 
-      options = {
-          :order_id => '59'
-      }
-
-      # authorize
-      assert response = @gateway.authorize(15000, token, options)
+    # authorize
+    assert response = @gateway.authorize(15000, token, options)
 
     assert_failure response
     assert_equal '822', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal 'Token was not found', response.message
   end
 
   def test60
-    token = '171299999999999'
-
+    token   = '171299999999999'
     options = {
-        :order_id => '59'
+        :order_id => '60',
+        :token    => {
+            :month => '11',
+            :year  => '2014'
+        }
     }
 
     # authorize
@@ -345,9 +429,22 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     assert_failure response
     assert_equal '823', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal 'Token was invalid', response.message
   end
 
-  def test_authorize_and_purchase_with_token
+  def test_authorize_and_purchase_and_credit_with_token
+    options = {
+        :order_id => transaction_id,
+        :billing_address => {
+            :name => 'John Smith',
+            :address1 => '1 Main St.',
+            :city => 'Burlington',
+            :state => 'MA',
+            :zip => '01803-3747',
+            :country => 'US'
+        }
+    }
+
     credit_card = CreditCard.new(:number             => '5435101234510196',
                                  :month              => '11',
                                  :year               => '2014',
@@ -355,7 +452,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
                                  :verification_value => '987')
 
     # authorize
-    assert auth_response = @gateway.authorize(0, credit_card, :order_id => '12345678')
+    assert auth_response = @gateway.authorize(0, credit_card, options)
 
     assert_success auth_response
     assert_equal 'Approved', auth_response.message
@@ -364,9 +461,32 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert %w(801 802).include? auth_response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['tokenResponseCode']
 
     # purchase
-    assert purchase_response = @gateway.authorize(0, token, :order_id => '12345679')
+    purchase_options = options.merge({
+                                         :order_id => transaction_id,
+                                         :token    => {
+                                             :month => credit_card.month,
+                                             :year  => credit_card.year
+                                         }
+                                     })
+
+    assert purchase_response = @gateway.purchase(100, token, purchase_options)
     assert_success purchase_response
     assert_equal 'Approved', purchase_response.message
+    assert_equal purchase_options[:order_id], purchase_response.params['litleOnlineResponse']['saleResponse']['id']
+
+    # credit
+    credit_options = options.merge({
+                                       :order_id => transaction_id,
+                                       :token    => {
+                                           :month => credit_card.month,
+                                           :year  => credit_card.year
+                                       }
+                                   })
+
+    assert credit_response = @gateway.credit(500, token, credit_options)
+    assert_success credit_response
+    assert_equal 'Approved', credit_response.message
+    assert_equal credit_options[:order_id], credit_response.params['litleOnlineResponse']['creditResponse']['id']
   end
 
   private
@@ -378,18 +498,25 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal 'Approved', response.message
     assert_equal assertions[:avs], response.avs_result["code"]
     assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
+    assert_equal options[:order_id], response.params['litleOnlineResponse']['authorizationResponse']['id']
 
     # 1A: capture
-    assert response = @gateway.capture(amount, response.authorization)
+    id = transaction_id
+    assert response = @gateway.capture(amount, response.authorization, {:id => id})
     assert_equal 'Approved', response.message
+    assert_equal id, response.params['litleOnlineResponse']['captureResponse']['id']
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization)
+    id = transaction_id
+    assert response = @gateway.credit(amount, response.authorization, {:id => id})
     assert_equal 'Approved', response.message
+    assert_equal id, response.params['litleOnlineResponse']['creditResponse']['id']
 
     # 1C: void
-    assert response = @gateway.void(response.authorization)
+    id = transaction_id
+    assert response = @gateway.void(response.authorization, {:id => id})
     assert_equal 'Approved', response.message
+    assert_equal id, response.params['litleOnlineResponse']['voidResponse']['id']
   end
 
   def authorize_avs_assertions(credit_card, options, assertions={})
@@ -398,6 +525,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal assertions[:message] || 'Approved', response.message
     assert_equal assertions[:avs], response.avs_result["code"], caller.inspect
     assert_equal assertions[:cvv], response.cvv_result["code"], caller.inspect if assertions[:cvv]
+    assert_equal options[:order_id], response.params['litleOnlineResponse']['authorizationResponse']['id']
   end
 
   def sale_assertions(amount, card, options, assertions)
@@ -407,14 +535,29 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal 'Approved', response.message
     assert_equal assertions[:avs], response.avs_result["code"]
     assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
+    assert_equal options[:order_id], response.params['litleOnlineResponse']['saleResponse']['id']
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization)
+    id = transaction_id
+    assert response = @gateway.credit(amount, response.authorization, {:id => id})
     assert_equal 'Approved', response.message
+    assert_equal id, response.params['litleOnlineResponse']['creditResponse']['id']
 
     # 1C: void
-    assert response = @gateway.void(response.authorization)
+    id = transaction_id
+    assert response = @gateway.void(response.authorization, {:id => id})
     assert_equal 'Approved', response.message
+    assert_equal id, response.params['litleOnlineResponse']['voidResponse']['id']
+  end
+
+  def transaction_id
+    # A unique identifier assigned by the presenter and mirrored back in the response.
+    # This attribute is also used for Duplicate Transaction Detection.
+    # For Online transactions, omitting this attribute, or setting it to a
+    # null value (id=""), disables Duplicate Detection for the transaction.
+    #
+    # minLength = N/A   maxLength = 25
+    SecureRandom.hex(8)
   end
 
 end

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -161,7 +161,15 @@ class RemoteLitleTest < Test::Unit::TestCase
     token = store_response.authorization
     assert_equal store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken'], token
 
-    assert response = @gateway.purchase(10010, token, :order_id => '12345')
+    options = {
+        :order_id => '12345',
+        :token    => {
+            :month => credit_card.month,
+            :year  => credit_card.year
+        }
+    }
+
+    assert response = @gateway.purchase(10010, token, options)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle/litle_card_token_test.rb
+++ b/test/unit/gateways/litle/litle_card_token_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+require 'active_merchant/billing/gateways/litle'
+
+class CardTokenTest < Test::Unit::TestCase
+  def setup
+    @card_token = LitleGateway::LitleCardToken.new(:token              => '1234567890123456',
+                                                   :month              => 9,
+                                                   :year               => Time.now.year + 1,
+                                                   :brand              => 'visa',
+                                                   :verification_value => '123')
+  end
+
+  def teardown
+  end
+
+  def test_constructor_should_properly_assign_values
+    assert_equal '1234567890123456', @card_token.token
+    assert_equal 9, @card_token.month
+    assert_equal Time.now.year + 1, @card_token.year
+    assert_equal 'visa', @card_token.brand
+    assert_equal 'VI', @card_token.type
+    assert_equal '123', @card_token.verification_value
+    assert_valid @card_token
+  end
+
+  def test_new_card_token_should_not_be_valid
+    c = LitleGateway::LitleCardToken.new
+
+    assert_not_valid c
+    assert_false c.errors.empty?
+  end
+
+  def test_should_be_able_to_access_errors_indifferently
+    @card_token.token = ''
+
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:token)
+    assert @card_token.errors.on('token')
+  end
+
+  def test_should_be_able_to_identify_invalid_tokens
+    @card_token.token = nil
+    assert_not_valid @card_token
+
+    @card_token.token = '11112222333344ff'
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:token)
+
+    @card_token.token = '123456'
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:token)
+
+    @card_token.token = 'Q11ab222333344444'
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:token)
+  end
+
+  def test_should_have_errors_with_invalid_card_brand_for_otherwise_correct_number
+    @card_token.brand = 'larry'
+
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:brand)
+    assert !@card_token.errors.on(:token)
+  end
+
+  def test_should_have_blank_type_for_invalid_brand
+    @card_token.brand = 'larry'
+
+    assert_not_valid @card_token
+    assert @card_token.errors.on(:brand)
+    assert @card_token.type.blank?
+  end
+
+  def test_should_have_blank_type_with_blank_card_brand
+    @card_token.brand = ''
+
+    assert_valid @card_token
+    assert @card_token.type.blank?
+  end
+
+  def test_should_require_a_valid_card_month
+    @card_token.month = Time.now.utc.month
+    @card_token.year  = Time.now.utc.year
+
+    assert_valid @card_token
+  end
+
+  def test_should_not_be_valid_with_empty_month_and_valid_year
+    @card_token.month = ''
+
+    assert_not_valid @card_token
+    assert_equal 'is not a valid month', @card_token.errors.on('month')
+  end
+
+  def test_should_not_be_valid_for_edge_month_cases
+    @card_token.month = 13
+    @card_token.year  = Time.now.year
+    assert_not_valid @card_token
+    assert @card_token.errors.on('month')
+
+    @card_token.month = 0
+    @card_token.year  = Time.now.year
+    assert_not_valid @card_token
+    assert @card_token.errors.on('month')
+  end
+
+  def test_should_be_invalid_with_valid_month_and_empty_year
+    @card_token.year = ''
+    assert_not_valid @card_token
+    assert_equal 'is not a valid year', @card_token.errors.on('year')
+  end
+
+  def test_should_not_be_valid_for_edge_year_cases
+    @card_token.year = 1987
+    assert_not_valid @card_token
+    assert @card_token.errors.on('year')
+
+    @card_token.year = 1977
+    assert_not_valid @card_token
+    assert @card_token.errors.on('year')
+  end
+
+  def test_should_be_a_valid_future_year
+    @card_token.year = Time.now.year + 1
+    assert_valid @card_token
+  end
+
+  # The following is a regression for a bug that raised an exception when
+  # a new credit card was validated
+  def test_validate_new_card
+    card_token = LitleGateway::LitleCardToken.new
+
+    assert_nothing_raised do
+      card_token.validate
+    end
+  end
+end


### PR DESCRIPTION
- Updated existing token based tests to passed optional fields in the options hash.
- Added missing certification tests for explicit token registration.
- Updated existing certification tests to use the latest documented data.
- Added support for processing a credit transaction with a token as well as a previous transaction id (identification).
- Updated certification specs based on direct feedback from Litle. (some required data was missing).
