### PR TITLE
Worldpay: XML encoding is required to be ISO-8859-1 for proper parsing o...

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
 
       def build_request
         xml = Builder::XmlMarkup.new :indent => 2
-        xml.instruct!
+        xml.instruct! :xml, :encoding => 'ISO-8859-1'
         xml.declare! :DOCTYPE, :paymentService, :PUBLIC, "-//WorldPay//DTD WorldPay PaymentService v1//EN", "http://dtd.wp3.rbsworldpay.com/paymentService_v1.dtd"
         xml.tag! 'paymentService', 'version' => "1.4", 'merchantCode' => @options[:login] do
           yield xml


### PR DESCRIPTION
Worldpay: XML encoding is required to be ISO-8859-1 for proper parsing of non-Latin characters.
- Confirmed in practice and by Worldpay Engineers on their support line.
