### PR TITLE
Worldpay: Fixed a bug where supported card types had no card-code associated with ...

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -16,6 +16,9 @@ module ActiveMerchant #:nodoc:
         'master'           => 'ECMC-SSL',
         'discover'         => 'DISCOVER-SSL',
         'american_express' => 'AMEX-SSL',
+        'jcb'              => 'JCB-SSL',
+        'maestro'          => 'MAESTRO-SSL',
+        'laser'            => 'LASER-SSL'
       }
 
       def initialize(options = {})


### PR DESCRIPTION
...them.
- Prevents NoMethodError to_sym for nil.
- Added JCB card code.
- Added Maestro card code.
- Added Laser card code.

Sorry, just noticed my commit message isn't prefixed with Worldpay.
