### PR TITLE
Add Ogone action option

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -154,23 +154,25 @@ module ActiveMerchant #:nodoc:
 
       # Verify and transfer the specified amount.
       def purchase(money, payment_source, options = {})
-        post = {}
+        post   = {}
+        action = options[:action] || 'SAL'
         add_invoice(post, options)
         add_payment_source(post, payment_source, options)
         add_address(post, payment_source, options)
         add_customer_data(post, options)
         add_money(post, money, options)
-        commit('SAL', post)
+        commit(action, post)
       end
 
       # Complete a previously authorized transaction.
       def capture(money, authorization, options = {})
-        post = {}
+        post   = {}
+        action = options[:action] || 'SAL'
         add_authorization(post, reference_from(authorization))
         add_invoice(post, options)
         add_customer_data(post, options)
         add_money(post, money, options)
-        commit('SAL', post)
+        commit(action, post)
       end
 
       # Cancels a previously authorized transaction.

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -50,6 +50,17 @@ class OgoneTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_action_param
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'ECI', '7')
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:action => 'SAS'))
+    assert_success response
+    assert_equal '3014726;SAS', response.authorization
+    assert response.params['HTML_ANSWER'].nil?
+    assert response.test?
+  end
+
   def test_successful_purchase_without_order_id
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     @options.delete(:order_id)
@@ -114,6 +125,14 @@ class OgoneTest < Test::Unit::TestCase
     assert response = @gateway.capture(@amount, "3048326")
     assert_success response
     assert_equal '3048326;SAL', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_capture_with_action_option
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    assert response = @gateway.capture(@amount, "3048326", :action => 'SAS')
+    assert_success response
+    assert_equal '3048326;SAS', response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
Added possibility to change Ogone  action option to capture and purchase methods
Default action `SAL` was hardcoded but now it's possible to pass it as an option to be able to use `SAS`.
