### PR TITLE
First Data E4: Add credential instructions

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -27,6 +27,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = "http://www.firstdata.com"
       self.display_name = "FirstData Global Gateway e4"
 
+      # Public: Create a new FirstdataE4Gateway.
+      #
+      # options - A hash of options:
+      #           :login    - The EXACT ID.  Also known as the Gateway ID. (Found in your
+      #                       administration terminal settings)
+      #           :password - The terminal password (not your account password)
       def initialize(options = {})
         requires!(options, :login, :password)
         @options = options


### PR DESCRIPTION
Added a comment so users of the API know what credentials they need to
use and where to find those credentials.

Figuring out the right credentials can be painful with E4 since they cut
you off for 15 minutes if you get it wrong a few times.  Hopefully these
instructions will save folks some time.
