### PR TITLE
Use the standard method for determining if the payment method is a check

### DIFF
--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -45,10 +45,6 @@ module ActiveMerchant #:nodoc:
         'check'
       end
 
-      def check?
-        true
-      end
-
       # Routing numbers may be validated by calculating a checksum and dividing it by 10. The
       # formula is:
       #   (3(d1 + d4 + d7) + 7(d2 + d5 + d8) + 1(d3 + d6 + d9))mod 10 = 0

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -209,10 +209,6 @@ module ActiveMerchant #:nodoc:
         require_verification_value
       end
 
-      def check?
-        false
-      end
-
       private
 
       def before_validate #:nodoc:

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
       def build_purchase_request(money, payment_method_or_reference, options)
         xml = Builder::XmlMarkup.new :indent => 2
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
-        if(payment_method_or_reference.respond_to?(:check?) && payment_method_or_reference.check?)
+        if card_brand(payment_method_or_reference) == 'check'
           add_check_service(xml)
         else
           add_purchase_service(xml, options)
@@ -308,7 +308,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
-        if payment_method.check?
+        if card_brand(payment_method) == 'check'
           add_check(xml, payment_method)
           add_check_payment_method(xml)
           add_check_service(xml, options) if options[:setup_fee]
@@ -524,7 +524,7 @@ module ActiveMerchant #:nodoc:
         if payment_method_or_reference.is_a?(String)
           add_purchase_data(xml, money, true, options)
           add_subscription(xml, options, payment_method_or_reference)
-        elsif payment_method_or_reference.check?
+        elsif card_brand(payment_method_or_reference) == 'check'
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_purchase_data(xml, money, true, options)
           add_check(xml, payment_method_or_reference)

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -245,7 +245,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_paymentmethod(post, payment)
-        if payment.check?
+        if card_brand(payment)=='check'
           post[:payment]              = 'check'
           post[:checkname]            = payment.name
           post[:checkaba]             = payment.routing_number


### PR DESCRIPTION
@ntalbott @samuelkadolph @melari please take a look. Pretty sure this is the standard way to see if the payment method is a check, the added method was unnecessary.
