### PR TITLE
Fix ActiveMerchant::Billing::Gateways::UsaEpayAdvanced#build_check_data

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -1334,7 +1334,7 @@ module ActiveMerchant #:nodoc:
 
       def build_check_data(soap, options)
         soap.CheckData 'xsi:type' => "ns1:CheckData" do |soap|
-          build_tag soap, :string, 'Account', options[:payment_method].number
+          build_tag soap, :string, 'Account', options[:payment_method].account_number
           build_tag soap, :string, 'Routing', options[:payment_method].routing_number
           build_tag soap, :string, 'AccountType', options[:payment_method].account_type.capitalize
           CHECK_DATA_OPTIONS.each do |k,v|


### PR DESCRIPTION
According to [the USAePAY](http://wiki.usaepay.com/developer/soap-1.4/objects/checkdata) wiki, `CheckData.Account` in the request is the bank account number.

This was setting it to `ActiveMerchant::Billing::Check#number` instead of `ActiveMerchant::Billing::Check#account_number`.
