### PR TITLE
Update lib/active_merchant/billing/gateways/paymill.rb

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def save_card_url
-        (test? ? 'https://test-token.paymill.de' : 'https://token-v2.paymill.de')
+        (test? ? 'https://test-token.paymill.com' : 'https://token-v2.paymill.com')
       end
 
       def post_data(params)


### PR DESCRIPTION
Change `save_card_url` to `.com` domain rather than `.de`. This prevents the following error, when trying to do a purchase:

```
OpenSSL::SSL::SSLError: hostname was not match with the server certificate
```

Please note that all other urls within `paymilll.rb` end in `.com` too.

This is the script I used to test this:

``` ruby
require 'rubygems'
require 'active_merchant'
require 'json'

# Use the Paymill test servers
ActiveMerchant::Billing::Base.mode = :test

gateway = ActiveMerchant::Billing::PaymillGateway.new(:public_key => 'MyPublicKey', :private_key => 'MyPrivateKey')
gateway.default_currency = 'CHF'

# ActiveMerchant accepts all amounts as Integer values in cents
amount = 1000  # $10.00

# The card verification value is also known as CVV2, CVC2, or CID
credit_card = ActiveMerchant::Billing::CreditCard.new(
                :first_name         => 'Bob',
                :last_name          => 'Bobsen',
                :number             => '5500000000000004',
                :month              => '8',
                :year               => Time.now.year+1,
                :verification_value => '000')

# Validating the card automatically detects the card type
if credit_card.valid?
  # Capture $10 from the credit card
  response = gateway.purchase(amount, credit_card)

  if response.success?
    puts "Successfully charged $#{sprintf("%.2f", amount / 100)} to the credit card #{credit_card.display_number}"
  else
    raise StandardError, response.message
  end
end
```
