### PR TITLE
Adds support to Paypal CreateBillingAgreement

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -59,6 +59,10 @@ module ActiveMerchant #:nodoc:
         commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Sale', money, options)
       end
 
+      def store(token, options = {})
+        commit 'CreateBillingAgreement', build_create_billing_agreement_request(token, options)
+      end
+
       def reference_transaction(money, options = {})
         requires!(options, :reference_id, :payment_type, :invoice_id, :description, :ip)
 
@@ -160,6 +164,18 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'n2:BuyerEmailOptInEnable', (options[:allow_buyer_optin] ? '1' : '0')
               end
             end
+          end
+        end
+
+        xml.target!
+      end
+
+      def build_create_billing_agreement_request(token, options = {})
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'CreateBillingAgreementReq', 'xmlns' => PAYPAL_NAMESPACE do
+          xml.tag! 'CreateBillingAgreementRequest', 'xmlns:n2' => EBAY_NAMESPACE do
+            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'Token', token
           end
         end
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -350,6 +350,23 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '4', REXML::XPath.match(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Quantity')[1].text
   end
 
+  def test_build_create_billing_agreement
+    PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
+    xml = REXML::Document.new(@gateway.send(:build_create_billing_agreement_request, "ref_id"))
+
+    assert_equal 'ref_id', REXML::XPath.first(xml, '//CreateBillingAgreementReq/CreateBillingAgreementRequest/Token').text
+  end
+
+  def test_store
+    @gateway.expects(:ssl_post).returns(successful_create_billing_agreement_response)
+
+    response = @gateway.store("ref_id")
+
+    assert_equal "Success", response.params['ack']
+    assert_equal "Success", response.message
+    assert_equal "B-3R788221G4476823M", response.params["billing_agreement_id"]
+  end
+
   def test_build_reference_transaction_test
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
     xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000, {
@@ -531,6 +548,38 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   private
+
+  def successful_create_billing_agreement_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType">
+  </Security>
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string"></Username>
+        <Password xsi:type="xs:string"></Password>
+        <Signature xsi:type="xs:string">OMGOMGOMG</Signature>
+        <Subject xsi:type="xs:string"></Subject>
+    </Credentials>
+  </RequesterCredentials>
+</SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <CreateBillingAgreementResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2013-02-28T16:34:47Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">8007ac99c51af</CorrelationID>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">5331358</Build>
+      <BillingAgreementID xsi:type="xs:string">B-3R788221G4476823M</BillingAgreementID>
+    </CreateBillingAgreementResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+
+    RESPONSE
+  end
+
   def successful_reference_transaction_response
     <<-RESPONSE
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
According to the [docs](https://cms.paypal.com/uk/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_ECReferenceTxns), one can get a billing agreement either by calling DoExpressCheckoutPayment, if that involves charging right away, or by calling CreateBillingAgreement.

This pull request implements CreateBillingAgreement.
