### PR TITLE
3D Secure transaction support for WorldPay gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -331,7 +331,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_session(xml, ip, session_id)
-        xml.tag! 'session', shopperIPAddress: ip, id: session_id
+        xml.tag! 'session', 'shopperIPAddress' => ip, 'id' => session_id
       end
 
       def parse(action, xml)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -116,12 +116,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @credit_card.first_name = nil
     @credit_card.last_name = '3D'
     @options.merge!({
-      browser: {
-        accept_header: 'text/html',
-        user_agent: 'Mozilla/5.0',
+      :browser => {
+        :accept_header => 'text/html',
+        :user_agent => 'Mozilla/5.0',
       },
-      ip: '10.0.0.1',
-      session_id: '123412341234',
+      :ip => '10.0.0.1',
+      :session_id => '123412341234',
     })
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
@@ -131,10 +131,10 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert cookie = response.params['cookie']
 
     @options.merge!({
-      echo_data: echo_data,
-      cookie: cookie,
-      payer_authentication: {
-        pa_response: 'IDENTIFIED'
+      :echo_data => echo_data,
+      :cookie => cookie,
+      :payer_authentication => {
+        :pa_response => 'IDENTIFIED'
       }
     })
     assert response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -11,9 +11,9 @@ class WorldpayTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = {:order_id => 1} 
+    @options = {:order_id => 1}
   end
-  
+
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -33,11 +33,11 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_3d_secure_authentication_challenge
     @options.merge!({
-      ip: '10.0.0.123',
-      session_id: '1234123412341234',
-      browser: {
-        accept_header: 'text/html',
-        user_agent: 'Mozilla/5.0'
+      :ip =>  '10.0.0.123',
+      :session_id => '1234123412341234',
+      :browser => {
+        :accept_header => 'text/html',
+        :user_agent => 'Mozilla/5.0'
       }
     })
     response = stub_comms do
@@ -57,9 +57,9 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_3d_secure_authentication_response
     @options.merge!({
-      echo_data: '4a4a4a4a4a4a4a4a4a',
-      payer_authentication: {
-        pa_response: '5b5b5b5b5b5b5b5b5b'
+      :echo_data => '4a4a4a4a4a4a4a4a4a',
+      :payer_authentication => {
+        :pa_response => '5b5b5b5b5b5b5b5b5b'
       }
     })
     response = stub_comms do


### PR DESCRIPTION
To support the 3D Secure payer authentication protocol a number of new
options have been implemented for the worldpay gateway plugin:
- Add basic cookie handling support as the Worldpay gateway sends a
  session cookie in the first order message response and expects that
  cookie to be returned in the second order message (after completing 3D
  Secure authentication).
- Add support for passing session information (client IP and session ID)
  in the authorize method. Mandatory for 3D Secure transactions.
- Add support for passing information about the shopper's browser
  (accept header and user agent) into the autorize method so that the
  gateway can determine the correct issuer redirect URL.
- Add support for passing the Payment Authentication response from the
  3D Secure authentication as well as the "echo data" from the Worldpay
  gateway in the second authorize method call.

The initial gateway response will have the `request3_d_secure` flag set to true
in the response's `params` hash if 3D Secure payer authentication is reuqired.
Additionally the hash will contain the `echo_data` and optionally a session
cookie which must be passed back to the gateway in subsequent request for the
same transaction. `params` also contains the `issuer_url` to which the shopper
must be redirected to complete 3D Secure authentication and the `pa_request`
data which needs to be passed to the issuer site.

Added unit and remote tests to cover 3D Secure authentication. (As well
as a missing unit test for localized_currency support.)

References:
- Worldpay documentation: http://www.worldpay.com/support/bg/xml/kb/3dsecure/dxml.html
