### PR TITLE
Return CC token in transaction hash for Braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -340,6 +340,7 @@ module ActiveMerchant #:nodoc:
           "bin"                 => transaction.credit_card_details.bin,
           "last_4"              => transaction.credit_card_details.last_4,
           "card_type"           => transaction.credit_card_details.card_type,
+          "token"               => transaction.credit_card_details.token
         }
 
         {


### PR DESCRIPTION
Credit card vault tokens are returned in the the transaction hash if the store_in_vault option is true.
