### PR TITLE
Worldpay: Fix error messages for some failures

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund_request(money, authorization, options)
-        commit('inquiry', build_refund_request(money, authorization, options), :ok)
+        commit('refund', build_refund_request(money, authorization, options), :ok)
       end
 
       def build_request
@@ -227,19 +227,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, request, success_criteria)
-        xmr = ssl_post((test? ? self.test_url : self.live_url),
-          request,
-          'Content-Type' => 'text/xml',
-          'Authorization' => encoded_credentials)
-
+        xmr = ssl_post(url, request, 'Content-Type' => 'text/xml', 'Authorization' => encoded_credentials)
         raw = parse(action, xmr)
+        success, message = success_and_message_from(raw, success_criteria)
 
         Response.new(
-          success_from(raw, success_criteria),
-          message_from(raw),
+          success,
+          message,
           raw,
           :authorization => authorization_from(raw),
           :test => test?)
+
       rescue ActiveMerchant::ResponseError => e
         if e.response.code.to_s == "401"
           return Response.new(false, "Invalid credentials", {}, :test => test?)
@@ -248,15 +246,25 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def success_from(raw, success_criteria)
-        (raw[:last_event] == success_criteria ||
-          raw[:ok].present?)
+      def url
+        test? ? self.test_url : self.live_url
       end
 
-      def message_from(raw)
-        (raw[:iso8583_return_code_description] ||
-          raw[:error] ||
-          "SUCCESS")
+      def success_and_message_from(raw, success_criteria)
+        success = (raw[:last_event] == success_criteria || raw[:ok].present?)
+        if success
+          message = "SUCCESS"
+        else
+          message = raw[:iso8583_return_code_description] || raw[:error] || required_status_message(raw, success_criteria)
+        end
+
+        [ success, message ]
+      end
+
+      def required_status_message(raw, success_criteria)
+        if raw[:last_event] != success_criteria
+          "A transaction status of '#{success_criteria}' is required."
+        end
       end
 
       def authorization_from(raw)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -1,18 +1,17 @@
 require 'test_helper'
 
 class RemoteWorldpayTest < Test::Unit::TestCase
-  
 
   def setup
     @gateway = WorldpayGateway.new(fixtures(:world_pay_gateway))
-    
+
     @amount = 100
     @credit_card = credit_card('4111111111111111')
     @declined_card = credit_card('4111111111111111', :first_name => nil, :last_name => 'REFUSED')
-    
+
     @options = {:order_id => generate_unique_id}
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -45,28 +44,16 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_void
-    assert_success(auth = @gateway.authorize(@amount, @credit_card, @options))
-    assert_success @gateway.void(auth.authorization)
-
-    assert_failure @gateway.void('bogus')
+    assert_success(response = @gateway.authorize(@amount, @credit_card, @options))
+    assert_success (void = @gateway.void(response.authorization))
+    assert_equal "SUCCESS", void.message
+    assert void.params["cancel_received_order_code"]
   end
 
-  # Worldpay has a delay between asking for a transaction to be captured and actually marking it as captured
-  # These tests work if you take the auth code, wait some time and then request the refund
-  #def test_refund
-  #  assert_success(auth = @gateway.authorize(@amount, @credit_card, @options))
-  #  assert_success auth
-  #  assert_equal 'SUCCESS', auth.message
-  #  assert auth.authorization
-  #  puts auth.authorization
-  #  assert capture = @gateway.capture(@amount, auth.authorization)
-  #  assert_success @gateway.refund(@amount, auth.authorization)
-  #end
-  #
-  #def test_refund_existing_transaction
-  #  assert_success resp = @gateway.refund(@amount, "7c85e685c35115689ff9c429be9f65e7")
-  #  puts resp.inspect
-  #end
+  def test_void_nonexistent_transaction
+    assert_failure response = @gateway.void('non_existent_authorization')
+    assert_equal "Could not find payment for order", response.message
+  end
 
   def test_currency
     assert_success(result = @gateway.authorize(@amount, @credit_card, @options.merge(:currency => 'USD')))
@@ -109,4 +96,37 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Invalid credentials', response.message
   end
+
+  def test_refund_fails_unless_status_is_captured
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success(response)
+
+    assert refund = @gateway.refund(30, response.authorization)
+    assert_failure refund
+    assert_equal "A transaction status of 'CAPTURED' is required.", refund.message
+  end
+
+  def test_refund_nonexistent_transaction
+    assert_failure response = @gateway.refund(@amount, "non_existent_authorization")
+    assert_equal "Could not find payment for order", response.message
+  end
+
+
+  # Worldpay has a delay between asking for a transaction to be captured and actually marking it as captured
+  # These 2 tests work if you take the auth code, wait some time and then perform the next operation.
+
+  # def test_refund
+  #   assert_success(response = @gateway.purchase(@amount, @credit_card, @options))
+  #   assert response.authorization
+  #   refund = @gateway.refund(@amount, capture.authorization)
+  #   assert_success refund
+  #   assert_equal "SUCCESS", refund.message
+  # end
+
+  # def test_void_fails_unless_status_is_authorised
+  #   response = @gateway.void("33d6dfa9726198d44a743488cf611d3b") # existing transaction in CAPTURED state
+  #   assert_failure response
+  #   assert_equal "A transaction status of 'AUTHORISED' is required.", response.message
+  # end
+
 end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -11,9 +11,9 @@ class WorldpayTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = {:order_id => 1} 
+    @options = {:order_id => 1}
   end
-  
+
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -70,11 +70,37 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal %w(authorize capture), response.responses.collect{|e| e.params["action"]}
   end
 
+  def test_successful_void
+    response = stub_comms do
+      @gateway.void(@options[:order_id], @options)
+    end.respond_with(successful_void_inquiry_response, successful_void_response)
+    assert_success response
+    assert_equal "SUCCESS", response.message
+    assert_equal "924e810350efc21a989e0ac7727ce43b", response.params["cancel_received_order_code"]
+  end
+
+  def test_void_fails_unless_status_is_authorized
+    response = stub_comms do
+      @gateway.void(@options[:order_id], @options)
+    end.respond_with(failed_void_inquiry_response, successful_void_response)
+    assert_failure response
+    assert_equal "A transaction status of 'AUTHORISED' is required.", response.message
+  end
+
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, @options[:order_id], @options)
     end.respond_with(successful_refund_inquiry_response, successful_refund_response)
     assert_success response
+    assert_equal "05d9f8c622553b1df1fe3a145ce91ccf", response.params['refund_received_order_code']
+  end
+
+  def test_refund_fails_unless_status_is_captured
+    response = stub_comms do
+      @gateway.refund(@amount, @options[:order_id], @options)
+    end.respond_with(failed_refund_inquiry_response, successful_refund_response)
+    assert_failure response
+    assert_equal "A transaction status of 'CAPTURED' is required.", response.message
   end
 
   def test_capture
@@ -244,181 +270,280 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   private
-  
+
   def successful_authorize_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
-                                "http://dtd.bibit.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="XXXXXXXXXXXXXXX">
-  <reply>
-    <orderStatus orderCode="R50704213207145707">
-      <payment>
-        <paymentMethod>VISA-SSL</paymentMethod>
-        <amount value="15000" currencyCode="HKD" exponent="2" debitCreditIndicator="credit"/>
-        <lastEvent>AUTHORISED</lastEvent>
-        <CVCResultCode description="UNKNOWN"/>
-        <AVSResultCode description="UNKNOWN"/>
-        <balance accountType="IN_PROCESS_AUTHORISED">
-          <amount value="15000" currencyCode="HKD" exponent="2" debitCreditIndicator="credit"/>
-        </balance>
-        <cardNumber>4111********1111</cardNumber>
-        <riskScore value="1"/>
-      </payment>
-    </orderStatus>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
+                                      "http://dtd.bibit.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="XXXXXXXXXXXXXXX">
+        <reply>
+          <orderStatus orderCode="R50704213207145707">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="15000" currencyCode="HKD" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>AUTHORISED</lastEvent>
+              <CVCResultCode description="UNKNOWN"/>
+              <AVSResultCode description="UNKNOWN"/>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="15000" currencyCode="HKD" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4111********1111</cardNumber>
+              <riskScore value="1"/>
+            </payment>
+          </orderStatus>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def failed_authorize_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
-                                "http://dtd.bibit.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="XXXXXXXXXXXXXXX">
-  <reply>
-    <orderStatus orderCode="R12538568107150952">
-      <error code="7">
-        <![CDATA[Invalid payment details : Card number : 4111********1111]]>
-      </error>
-    </orderStatus>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
+                                      "http://dtd.bibit.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="XXXXXXXXXXXXXXX">
+        <reply>
+          <orderStatus orderCode="R12538568107150952">
+            <error code="7">
+              <![CDATA[Invalid payment details : Card number : 4111********1111]]>
+            </error>
+          </orderStatus>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def successful_capture_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
-                                "http://dtd.bibit.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="SPREEDLY">
-  <reply>
-    <ok>
-      <captureReceived orderCode="33955f6bb4524813b51836de76228983">
-        <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-      </captureReceived>
-    </ok>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
+                                      "http://dtd.bibit.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLY">
+        <reply>
+          <ok>
+            <captureReceived orderCode="33955f6bb4524813b51836de76228983">
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+            </captureReceived>
+          </ok>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def successful_inquiry_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
-                                "http://dtd.bibit.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="SPREEDLY">
-  <reply>
-    <orderStatus orderCode="d192c159d5730d339c03fa1a8dc796eb">
-      <payment>
-        <paymentMethod>VISA-SSL</paymentMethod>
-        <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-        <lastEvent>AUTHORISED</lastEvent>
-        <CVCResultCode description="UNKNOWN"/>
-        <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
-        <balance accountType="IN_PROCESS_AUTHORISED">
-          <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-        </balance>
-        <cardNumber>4111********1111</cardNumber>
-        <riskScore value="1"/>
-      </payment>
-      <date dayOfMonth="20" month="04" year="2011" hour="22" minute="24" second="0"/>
-    </orderStatus>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
+                                      "http://dtd.bibit.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLY">
+        <reply>
+          <orderStatus orderCode="d192c159d5730d339c03fa1a8dc796eb">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>AUTHORISED</lastEvent>
+              <CVCResultCode description="UNKNOWN"/>
+              <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4111********1111</cardNumber>
+              <riskScore value="1"/>
+            </payment>
+            <date dayOfMonth="20" month="04" year="2011" hour="22" minute="24" second="0"/>
+          </orderStatus>
+        </reply>
+      </paymentService>
+    RESPONSE
+  end
+
+  def successful_void_inquiry_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="CHARGEBEEM1">
+        <reply>
+          <orderStatus orderCode="1266bc1b6ab96c026741300418453d43">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>AUTHORISED</lastEvent>
+              <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+              <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <cardHolderName><![CDATA[Longbob Longsen]]></cardHolderName>
+              <issuerCountryCode>N/A</issuerCountryCode>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4111********1111</cardNumber>
+              <riskScore value="1"/>
+            </payment>
+            <date dayOfMonth="05" month="03" year="2013" hour="22" minute="52" second="0"/>
+          </orderStatus></reply></paymentService>
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="CHARGEBEEM1">
+        <reply>
+          <ok>
+            <cancelReceived orderCode="924e810350efc21a989e0ac7727ce43b"/>
+          </ok>
+        </reply>
+      </paymentService>
+    RESPONSE
+  end
+
+  def failed_void_inquiry_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="CHARGEBEEM1">
+        <reply>
+          <orderStatus orderCode="33d6dfa9726198d44a743488cf611d3b">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>SENT_FOR_REFUND</lastEvent>
+              <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+              <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <cardHolderName><![CDATA[Longbob Longsen]]></cardHolderName>
+              <issuerCountryCode>N/A</issuerCountryCode>
+              <balance accountType="IN_PROCESS_CAPTURED">
+                <amount value="30" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <riskScore value="1"/>
+            </payment>
+            <date dayOfMonth="05" month="03" year="2013" hour="23" minute="6" second="0"/>
+          </orderStatus>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def successful_refund_inquiry_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
-                                "http://dtd.bibit.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="SPREEDLY">
-  <reply>
-    <orderStatus orderCode="d192c159d5730d339c03fa1a8dc796eb">
-      <payment>
-        <paymentMethod>VISA-SSL</paymentMethod>
-        <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-        <lastEvent>CAPTURED</lastEvent>
-        <CVCResultCode description="UNKNOWN"/>
-        <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
-        <balance accountType="IN_PROCESS_AUTHORISED">
-          <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-        </balance>
-        <cardNumber>4111********1111</cardNumber>
-        <riskScore value="1"/>
-      </payment>
-      <date dayOfMonth="20" month="04" year="2011" hour="22" minute="24" second="0"/>
-    </orderStatus>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"
+                                      "http://dtd.bibit.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLY">
+        <reply>
+          <orderStatus orderCode="d192c159d5730d339c03fa1a8dc796eb">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>CAPTURED</lastEvent>
+              <CVCResultCode description="UNKNOWN"/>
+              <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4111********1111</cardNumber>
+              <riskScore value="1"/>
+            </payment>
+            <date dayOfMonth="20" month="04" year="2011" hour="22" minute="24" second="0"/>
+          </orderStatus>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def successful_refund_response
     <<-RESPONSE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN" 
-                                "http://dtd.worldpay.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="SPREEDLY">
-  <reply>
-    <ok>
-      <refundReceived orderCode="1">
-        <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
-      </refundReceived>
-    </ok>
-  </reply>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="CHARGEBEEM1">
+        <reply>
+          <ok>
+            <refundReceived orderCode="05d9f8c622553b1df1fe3a145ce91ccf">
+              <amount value="35" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+            </refundReceived>
+          </ok>
+        </reply>
+      </paymentService>
+    RESPONSE
+  end
+
+  def failed_refund_inquiry_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="CHARGEBEEM1">
+        <reply>
+          <orderStatus orderCode="417ceff8079ea6a0d8e803f6c0bb2b76">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>AUTHORISED</lastEvent>
+              <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+              <AVSResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <cardHolderName><![CDATA[Longbob Longsen]]></cardHolderName>
+              <issuerCountryCode>N/A</issuerCountryCode>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4111********1111</cardNumber>
+              <riskScore value="1"/>
+            </payment>
+            <date dayOfMonth="05" month="03" year="2013" hour="23" minute="19" second="0"/>
+          </orderStatus>
+        </reply>
+      </paymentService>
     RESPONSE
   end
 
   def sample_authorization_request
     <<-REQUEST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE paymentService PUBLIC "-//RBS WorldPay//DTD RBS WorldPay PaymentService v1//EN" "http://dtd.wp3.rbsworldpay.com/paymentService_v1.dtd">
-<paymentService merchantCode="XXXXXXXXXXXXXXX" version="1.4">
-<submit>
-  <order installationId="0000000000" orderCode="R85213364408111039">
-    <description>Products Products Products</description>
-    <amount value="100" exponent="2" currencyCode="HKD"/>
-    <orderContent>Products Products Products</orderContent>
-    <paymentDetails>
-      <VISA-SSL>
-        <cardNumber>4242424242424242</cardNumber>
-        <expiryDate>
-          <date month="09" year="2011"/>
-        </expiryDate>
-        <cardHolderName>Jim Smith</cardHolderName>
-        <cvc>123</cvc>
-        <cardAddress>
-          <address>
-            <firstName>Jim</firstName>
-            <lastName>Smith</lastName>
-            <street>1234 My Street</street>
-            <houseName>Apt 1</houseName>
-            <postalCode>K1C2N6</postalCode>
-            <city>Ottawa</city>
-            <state>ON</state>
-            <countryCode>CA</countryCode>
-            <telephoneNumber>(555)555-5555</telephoneNumber>
-          </address>
-        </cardAddress>
-      </VISA-SSL>
-      <session id="asfasfasfasdgvsdzvxzcvsd" shopperIPAddress="127.0.0.1"/>
-    </paymentDetails>
-    <shopper>
-      <browser>
-        <acceptHeader>application/json, text/javascript, */*</acceptHeader>
-        <userAgentHeader>Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.19</userAgentHeader>
-      </browser>
-    </shopper>
-  </order>
-</submit>
-</paymentService>
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//RBS WorldPay//DTD RBS WorldPay PaymentService v1//EN" "http://dtd.wp3.rbsworldpay.com/paymentService_v1.dtd">
+      <paymentService merchantCode="XXXXXXXXXXXXXXX" version="1.4">
+      <submit>
+        <order installationId="0000000000" orderCode="R85213364408111039">
+          <description>Products Products Products</description>
+          <amount value="100" exponent="2" currencyCode="HKD"/>
+          <orderContent>Products Products Products</orderContent>
+          <paymentDetails>
+            <VISA-SSL>
+              <cardNumber>4242424242424242</cardNumber>
+              <expiryDate>
+                <date month="09" year="2011"/>
+              </expiryDate>
+              <cardHolderName>Jim Smith</cardHolderName>
+              <cvc>123</cvc>
+              <cardAddress>
+                <address>
+                  <firstName>Jim</firstName>
+                  <lastName>Smith</lastName>
+                  <street>1234 My Street</street>
+                  <houseName>Apt 1</houseName>
+                  <postalCode>K1C2N6</postalCode>
+                  <city>Ottawa</city>
+                  <state>ON</state>
+                  <countryCode>CA</countryCode>
+                  <telephoneNumber>(555)555-5555</telephoneNumber>
+                </address>
+              </cardAddress>
+            </VISA-SSL>
+            <session id="asfasfasfasdgvsdzvxzcvsd" shopperIPAddress="127.0.0.1"/>
+          </paymentDetails>
+          <shopper>
+            <browser>
+              <acceptHeader>application/json, text/javascript, */*</acceptHeader>
+              <userAgentHeader>Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.19</userAgentHeader>
+            </browser>
+          </shopper>
+        </order>
+      </submit>
+      </paymentService>
     REQUEST
   end
 end


### PR DESCRIPTION
In particular, their docs state:

"A payment can only be cancelled after it has reached the status
AUTHORISED and can no longer be cancelled after it has reached the
status of CAPTURED."

and:

"Refunds can be processed after a payment has reached the CAPTURED
status. If a payment still has the AUTHORISED status, it can be
cancelled but not refunded."

Previously, if a transaction was in the wrong state, the error message
we were giving back was "SUCCESS", which was confusing to everyone.  Now
we explain why the operation failed.

We also now have some unit tests for the void operation.
