### PR TITLE
Fixed Robokassa signature for empty amount

### DIFF
--- a/lib/active_merchant/billing/integrations/robokassa/common.rb
+++ b/lib/active_merchant/billing/integrations/robokassa/common.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
           def generate_signature_string
             custom_param_keys = params.keys.select {|key| key =~ /^shp/}.sort
             custom_params = custom_param_keys.map {|key| "#{key}=#{params[key]}"}
-            [main_params, secret, custom_params].flatten.compact.join(':')
+            [main_params, secret, custom_params.compact].flatten.join(':')
           end
 
           def generate_signature

--- a/test/unit/integrations/helpers/robokassa_helper_test.rb
+++ b/test/unit/integrations/helpers/robokassa_helper_test.rb
@@ -5,6 +5,7 @@ class RobokassaHelperTest < Test::Unit::TestCase
 
   def setup
     @helper = Robokassa::Helper.new(123,'test_account', :amount => 500, :currency => 'USD', :secret => 'secret')
+    @helper_empty_amount = Robokassa::Helper.new(123,'test_account', :currency => 'USD', :secret => 'secret')
   end
 
   def test_basic_helper_fields
@@ -16,6 +17,10 @@ class RobokassaHelperTest < Test::Unit::TestCase
 
   def test_signature_string
     assert_equal 'test_account:500:123:secret', @helper.generate_signature_string
+  end
+
+  def test_signature_string_with_empty_amount
+    assert_equal 'test_account::123:secret', @helper_empty_amount.generate_signature_string
   end
 
   def test_custom_fields


### PR DESCRIPTION
Robokassa has allowed empty amount in parameters (buyer enter amount before payment). But gem generate bad signature for this case. 
I fix signature generation and make test.
