### PR TITLE
More user-friendly card brand error.

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -229,7 +229,7 @@ module ActiveMerchant #:nodoc:
         end
 
         unless errors.on(:number) || errors.on(:brand)
-          errors.add :brand, "is not the correct card brand" unless CreditCard.matching_brand?(number, brand)
+          errors.add :brand, "does not match the card number" unless CreditCard.matching_brand?(number, brand)
         end
       end
 


### PR DESCRIPTION
What do you think of this error message tweak?

We don't really know if it's the brand or number that's incorrect - this tells the story better.
