### PR TITLE
Add Pin.js card token support to Pin Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -93,7 +93,11 @@ module ActiveMerchant #:nodoc:
             :name => "#{creditcard.first_name} #{creditcard.last_name}"
           )
         elsif creditcard.kind_of?(String)
-          post[:customer_token] = creditcard
+          if creditcard =~ /^card_/
+            post[:card_token] = creditcard
+          else
+            post[:customer_token] = creditcard
+          end
         end
       end
 

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -27,7 +27,43 @@ class RemotePinTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_store_and_token_charge
+  # This is a bit manual as we have to create a working card token as
+  # would be returned from Pin.js / the card tokens API which
+  # falls outside of active merchant
+  def test_store_and_charge_with_pinjs_card_token
+    headers = {
+      "Content-Type" => "application/json",
+      "Authorization" => "Basic #{Base64.strict_encode64(@gateway.options[:api_key] + ':').strip}"
+    }
+    # Get a token equivalent to what is returned by Pin.js
+    card_attrs = {
+      :number => @credit_card.number,
+      :expiry_month => @credit_card.month,
+      :expiry_year => @credit_card.year,
+      :cvc => @credit_card.verification_value,
+      :name => "#{@credit_card.first_name} #{@credit_card.last_name}",
+      :address_line1 => "42 Sevenoaks St",
+      :address_city => "Lathlain",
+      :address_postcode => "6454",
+      :address_start => "WA",
+      :address_country => "Australia"
+    }
+    url = @gateway.test_url + "/cards"
+
+    body = JSON.parse(@gateway.ssl_post(url, card_attrs.to_json, headers))
+
+    card_token = body["response"]["token"]
+
+    store = @gateway.store(card_token, @options)
+    assert_success store
+    assert_not_nil store.authorization
+
+    purchase = @gateway.purchase(@amount, card_token, @options)
+    assert_success purchase
+    assert_not_nil purchase.authorization
+  end
+
+  def test_store_and_customer_token_charge
     assert response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_not_nil response.authorization

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -205,10 +205,17 @@ class PinTest < Test::Unit::TestCase
     assert_equal "#{@credit_card.first_name} #{@credit_card.last_name}", post[:card][:name]
   end
 
-  def test_add_creditcard_hash
+  def test_add_creditcard_with_card_token
     post = {}
     @gateway.send(:add_creditcard, post, 'card_nytGw7koRg23EEp9NTmz9w')
-    assert_equal 'card_nytGw7koRg23EEp9NTmz9w', post[:customer_token]
+    assert_equal 'card_nytGw7koRg23EEp9NTmz9w', post[:card_token]
+    assert_false post.has_key?(:card)
+  end
+
+  def test_add_creditcard_with_customer_token
+    post = {}
+    @gateway.send(:add_creditcard, post, 'cus_XZg1ULpWaROQCOT5PdwLkQ')
+    assert_equal 'cus_XZg1ULpWaROQCOT5PdwLkQ', post[:customer_token]
     assert_false post.has_key?(:card)
   end
 


### PR DESCRIPTION
Adds support for passing in a card token to purchase and store with the
Pin gateway.

Information about Pin.js can be found in the documentation at https://pin.net.au/docs/guides/payment-forms
