### PR TITLE
paypal: fix dereference error in paypal_express_response

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
       end
       
       def address
-        address = (@params['PaymentDetails']||{})['ShipToAddress']
+        address = (@params['PaymentDetails']||{'ShipToAddress' => {}})['ShipToAddress']
         {  'name'       => address['Name'],
            'company'    => info['PayerBusiness'],
            'address1'   => address['Street1'],


### PR DESCRIPTION
Calling PaypalExpressResponse#address when the response didn't contain
any address information was causing a dereference error:

  NoMethodError: undefined method `[]' for nil:NilClass

Testing done: verified the dereference error doesn't happen
by issuing a SetExpressCheckout API Operation with an invalid
security header.

Signed-off-by: Pierre-Alexandre Meyer pierre@ning.com
