### PR TITLE
made authorize_with_token method public

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -47,6 +47,14 @@ module ActiveMerchant #:nodoc:
         commit(:post, "refunds/#{transaction_id(authorization)}", post)
       end
 
+      def authorize_with_token(money, card_token, options)
+        post = {}
+
+        add_amount(post, money, options)
+        post[:token] = card_token
+        commit(:post, 'preauthorizations', post)
+      end
+
       private
 
       def add_credit_card(post, credit_card)
@@ -96,14 +104,6 @@ module ActiveMerchant #:nodoc:
         post[:token] = card_token
         post[:description] = options[:description]
         commit(:post, 'transactions', post)
-      end
-
-      def authorize_with_token(money, card_token, options)
-        post = {}
-
-        add_amount(post, money, options)
-        post[:token] = card_token
-        commit(:post, 'preauthorizations', post)
       end
 
       def save_card(credit_card)


### PR DESCRIPTION
The authorize_with_token method is now public. This way sites using the bridge.js from Paymill to generate a token are able to use it when the need to do an authorization.
Fixes #607
