### PR TITLE
Pin: Add a default description if none is specified in the options.

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -78,7 +78,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, options)
-        post[:description] = options[:description]
+        post[:description] = options[:description] || "Active Merchant Purchase"
       end
 
       def add_creditcard(post, creditcard)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -22,6 +22,12 @@ class RemotePinTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_without_description
+    @options.delete(:description)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
**Problem**
Purchase requests to Pin fail if no description is included.

**Changes**
Adds a default description to purchase request if none is specified in the options hash.

**Review**
@jduff 
