### PR TITLE
Add referrerId to sage pay form.

### DIFF
--- a/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
+++ b/lib/active_merchant/billing/integrations/sage_pay_form/helper.rb
@@ -41,6 +41,8 @@ module ActiveMerchant #:nodoc:
           mapping :return_url, 'SuccessURL'
           mapping :description, 'Description'
 
+          class_attribute :referrer_id
+
           def shipping_address(params = {})
             @shipping_address_set = true unless params.empty?
 
@@ -74,12 +76,14 @@ module ActiveMerchant #:nodoc:
             key = fields['EncryptKey']
             @crypt ||= create_crypt_field(fields.except(*crypt_skip), key)
 
-            {
+            result = {
               'VPSProtocol' => '2.23',
               'TxType' => 'PAYMENT',
               'Vendor' => @fields['Vendor'],
               'Crypt'  => @crypt
             }
+            result['ReferrerID'] = referrer_id if referrer_id
+            result
           end
 
           private


### PR DESCRIPTION
**Changes**
Allows a Referral ID to be included in requests to sage pay form.

Not 100% sure this is everything that needs to be changed, but when I tried it out it seemed to be working.

**Review**
@jduff 
