### PR TITLE
PxPay: Trim MerchantReferences longer than 50 characters.

### DIFF
--- a/lib/active_merchant/billing/integrations/pxpay/helper.rb
+++ b/lib/active_merchant/billing/integrations/pxpay/helper.rb
@@ -80,6 +80,7 @@ module ActiveMerchant #:nodoc:
             root = xml.add_element('GenerateRequest')
 
             @fields.each do | k, v |
+              v = v.slice(0, 50) if k == "MerchantReference"
               root.add_element(k).text = v
             end
 

--- a/test/remote/integrations/remote_pxpay_integration_test.rb
+++ b/test/remote/integrations/remote_pxpay_integration_test.rb
@@ -12,6 +12,12 @@ class RemotePxpayIntegrationTest < Test::Unit::TestCase
     @helper = Pxpay::Helper.new('500', @options[:login], :amount => "120.99", :currency => 'USD', :credential2 => @options[:password])
   end
 
+  def test_merchant_references_longer_than_50_characters_should_be_trimmed
+    @helper.description = "more than 50 chars--------------------40--------50---55"
+    request = @helper.send(:generate_request)
+    assert_match /<MerchantReference>more than 50 chars--------------------40--------50<\/MerchantReference>/, request
+  end
+
   def test_valid_credentials_returns_secure_token
     @helper.return_url "http://t/pxpay/return_url"
     @helper.cancel_return_url "http://t/pxpay/cancel_url"


### PR DESCRIPTION
**Problem**
This is actually the same issue as #583, just for their offsite gateway PxPay.

**Changes**
Trim down any MerchantReference longer than 50 characters.

**Review**
@jduff 
cc @silverstreaked 
