### PR TITLE
Add an auth_reversal method for Litle which is the preferred way to reve...

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -82,18 +82,26 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
-        to_pass = create_capture_hash(money, authorization, options)
+        transaction_id, kind = authorization.split(';')
+        to_pass = create_capture_hash(money, transaction_id, options)
         build_response(:capture, @litle.capture(to_pass))
       end
 
+      # Note: Litle requires that authorization requests be voided via auth_reversal
+      # and other requests via void. To maintain the same interface as the other
+      # gateways the transaction_id and the kind of transaction are concatenated
+      # together with a ; separator (e.g. 1234;authorization)
+      #
+      # A partial auth_reversal can be accomplished by passing :amount as an option
       def void(identification, options = {})
-        to_pass = create_void_hash(identification, options)
-        build_response(:void, @litle.void(to_pass))
-      end
-
-      def auth_reversal(identification, money = nil, options = {})
-        to_pass = create_auth_reversal_hash(identification, money, options)
-        build_response(:authReversal, @litle.auth_reversal(to_pass))
+        transaction_id, kind = identification.split(';')
+        if kind == 'authorization'
+          to_pass = create_auth_reversal_hash(transaction_id, options[:amount], options)
+          build_response(:authReversal, @litle.auth_reversal(to_pass))
+        else
+          to_pass = create_void_hash(transaction_id, options)
+          build_response(:void, @litle.void(to_pass))
+        end
       end
 
       def credit(money, identification_or_token, options = {})
@@ -147,17 +155,11 @@ module ActiveMerchant #:nodoc:
         if response['response'] == "0"
           detail        = response["#{kind}Response"]
           fraud         = fraud_result(detail)
-          authorization = case kind
-                          when :registerToken
-                            response['registerTokenResponse']['litleToken']
-                          else
-                            detail['litleTxnId']
-                          end
           Response.new(
               valid_responses.include?(detail['response']),
               detail['message'],
               { :litleOnlineResponse => response },
-              :authorization => authorization,
+              :authorization => authorization_from(detail, kind),
               :avs_result    => { :code => fraud['avs'] },
               :cvv_result    => fraud['cvv'],
               :test          => test?
@@ -165,6 +167,13 @@ module ActiveMerchant #:nodoc:
         else
           Response.new(false, response['message'], :litleOnlineResponse => response, :test => test?)
         end
+      end
+
+      # Generates an authorization string of the appropriate id and the kind of transaction
+      # See #void for how the kind is used
+      def authorization_from(litle_response, kind)
+        authorization = kind == :registerToken ? litle_response['litleToken'] : litle_response['litleTxnId']
+        "#{authorization};#{kind}"
       end
 
       def build_authorize_request(money, creditcard_or_token, options)
@@ -229,7 +238,8 @@ module ActiveMerchant #:nodoc:
         if identification_or_cardtoken.is_a?(LitleCardToken)
           add_cardtoken_hash(hash, identification_or_cardtoken)
         else
-          hash['litleTxnId'] = identification_or_cardtoken
+          transaction_id, kind = identification_or_cardtoken.split(';')
+          hash['litleTxnId'] = transaction_id
         end
       end
 

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -290,7 +290,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
                                  :year => '2014', :brand => 'visa')
     assert auth_response2 = @gateway.authorize(18699, credit_card, :order_id => '29')
 
-    assert reversal_response = @gateway.auth_reversal(auth_response2.authorization)
+    assert reversal_response = @gateway.void(auth_response2.authorization)
     assert_success reversal_response
   end
 
@@ -306,7 +306,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert auth_response = @gateway.authorize(20500, credit_card, options)
     assert_success auth_response
 
-    assert reversal_response = @gateway.auth_reversal(auth_response.authorization, 10000)
+    assert reversal_response = @gateway.void(auth_response.authorization, amount: 10000)
     assert !reversal_response.success?
     assert_equal '336', reversal_response.params['litleOnlineResponse']['authReversalResponse']['response']
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -375,7 +375,7 @@ class LitleTest < Test::Unit::TestCase
     responseFrom = @gateway.authorize(0, creditcard)
     assert_equal true, responseFrom.success?
     assert_equal 'successful', responseFrom.message
-    assert_equal '1234', responseFrom.authorization
+    assert_equal '1234;authorization', responseFrom.authorization
     assert_equal '1111222233334444', responseFrom.params['litleOnlineResponse']['authorizationResponse']['litleToken']
   end
 
@@ -443,7 +443,7 @@ class LitleTest < Test::Unit::TestCase
     creditcard = CreditCard.new(@credit_card_options)
     responseFrom = @gateway.authorize(0, creditcard)
     assert_equal false, responseFrom.success?
-    assert_equal '1234', responseFrom.authorization
+    assert_equal '1234;authorization', responseFrom.authorization
     assert_equal '1111222233334444', responseFrom.params['litleOnlineResponse']['authorizationResponse']['litleToken']
   end
 
@@ -465,7 +465,7 @@ class LitleTest < Test::Unit::TestCase
     creditcard = CreditCard.new(@credit_card_options)
     responseFrom = @gateway.purchase(0, creditcard)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;sale', responseFrom.authorization
   end
 
   def test_purchase_pass_with_token
@@ -482,7 +482,7 @@ class LitleTest < Test::Unit::TestCase
 
     responseFrom = @gateway.purchase(0, '171299999999999', options)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;sale', responseFrom.authorization
   end
 
   def test_purchase_fail
@@ -493,7 +493,7 @@ class LitleTest < Test::Unit::TestCase
     creditcard = CreditCard.new(@credit_card_options)
     responseFrom = @gateway.purchase(0, creditcard)
     assert_equal false, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;sale', responseFrom.authorization
   end
 
   def test_purchase_fail_schema
@@ -513,7 +513,7 @@ class LitleTest < Test::Unit::TestCase
     authorization = "1234"
     responseFrom = @gateway.capture(0, authorization)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;capture', responseFrom.authorization
   end
 
   def test_capture_fail
@@ -523,7 +523,7 @@ class LitleTest < Test::Unit::TestCase
     authorization = "1234"
     responseFrom = @gateway.capture(0, authorization)
     assert_equal false, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;capture', responseFrom.authorization
   end
 
   def test_capture_fail_schema
@@ -535,60 +535,60 @@ class LitleTest < Test::Unit::TestCase
     assert_equal 'Error validating xml data against the schema', responseFrom.message
   end
 
-  def test_void_pass
+  def test_void_sale_pass
     voidResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','voidResponse'=>voidResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
+    identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;void', responseFrom.authorization
   end
 
-  def test_void_fail
+  def test_void_sale_fail
     voidResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','voidResponse'=>voidResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
+    identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;void', responseFrom.authorization
   end
 
-  def test_void_fail_schema
+  def test_void_sale_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
+    identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
     assert_equal 'Error validating xml data against the schema', responseFrom.message
   end
 
-  def test_auth_reversal_pass
+  def test_void_authorization_pass
     authReversalResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','authReversalResponse'=>authReversalResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
-    responseFrom = @gateway.auth_reversal(identification)
+    identification = "1234;authorization"
+    responseFrom = @gateway.void(identification)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;authReversal', responseFrom.authorization
   end
 
-  def test_auth_reversal_fail
+  def test_void_authorization_fail
     authReversalResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','authReversalResponse'=>authReversalResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
-    responseFrom = @gateway.auth_reversal(identification)
+    identification = "1234;authorization"
+    responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;authReversal', responseFrom.authorization
   end
 
-  def test_auth_reversal_fail_schema
+  def test_void_authorization_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
-    responseFrom = @gateway.auth_reversal(identification)
+    identification = "1234;authorization"
+    responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
     assert_equal 'Error validating xml data against the schema', responseFrom.message
   end
@@ -597,26 +597,26 @@ class LitleTest < Test::Unit::TestCase
     creditResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','creditResponse'=>creditResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
+    identification = "1234;credit"
     responseFrom = @gateway.credit(0, identification)
     assert_equal true, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;credit', responseFrom.authorization
   end
 
   def test_credit_fail
     creditResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','creditResponse'=>creditResponseObj}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = "1234"
+    identification = "1234;credit"
     responseFrom = @gateway.credit(0, identification)
     assert_equal false, responseFrom.success?
-    assert_equal '123456789012345678', responseFrom.authorization
+    assert_equal '123456789012345678;credit', responseFrom.authorization
   end
 
   def test_credit_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
-    identification = '1234'
+    identification = '1234;credit'
     responseFrom = @gateway.credit(0, identification)
     assert_equal false, responseFrom.success?
     assert_equal 'Error validating xml data against the schema', responseFrom.message


### PR DESCRIPTION
...rse an authorization.
- Added certification and unit tests for auth_reversal.
- Fixed certification tests to always use a random string of length 24 which is required by the XML schema
