### PR TITLE
Refactor of my last PR to remove warnings for ruby >= 1.9

### DIFF
--- a/test/remote/gateways/remote_finansbank_test.rb
+++ b/test/remote/gateways/remote_finansbank_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class RemoteFinansbankTest < Test::Unit::TestCase
   def setup
-    @original_kcode = $KCODE
     if RUBY_VERSION < '1.9' && $KCODE == "NONE"
+      @original_kcode = $KCODE
       $KCODE = 'u'
     end
 
@@ -23,7 +23,7 @@ class RemoteFinansbankTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode
+    $KCODE = @original_kcode if @original_kcode
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_garanti_test.rb
+++ b/test/remote/gateways/remote_garanti_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 class RemoteGarantiTest < Test::Unit::TestCase
 
   def setup
-    @original_kcode = $KCODE
     if RUBY_VERSION < '1.9' && $KCODE == "NONE"
+      @original_kcode = $KCODE
       $KCODE = 'u'
     end
 
@@ -23,7 +23,7 @@ class RemoteGarantiTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode
+    $KCODE = @original_kcode if @original_kcode
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/finansbank_test.rb
+++ b/test/unit/gateways/finansbank_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class FinansbankTest < Test::Unit::TestCase
   def setup
-    @original_kcode = $KCODE
     if RUBY_VERSION < '1.9' && $KCODE == "NONE"
+      @original_kcode = $KCODE
       $KCODE = 'u'
     end
 
@@ -24,7 +24,7 @@ class FinansbankTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode
+    $KCODE = @original_kcode if @original_kcode
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/garanti_test.rb
+++ b/test/unit/gateways/garanti_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 
 class GarantiTest < Test::Unit::TestCase
   def setup
-    @original_kcode = $KCODE
     if RUBY_VERSION < '1.9' && $KCODE == "NONE"
+      @original_kcode = $KCODE
       $KCODE = 'u'
     end
 
@@ -23,7 +23,7 @@ class GarantiTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode
+    $KCODE = @original_kcode if @original_kcode
   end
 
   def test_successful_purchase


### PR DESCRIPTION
My last PR was throwing a bunch of warnings in ruby >= 1.9 when running the tests since it was accessing `$KCODE`.

This refactors that code so that `$KCODE` is not touched whatsoever unless ruby is < 1.9. This removes the warnings.

@jduff 
