### PR TITLE
nil address values should not throw exceptions during truncation.

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -219,14 +219,14 @@ module ActiveMerchant #:nodoc:
           avs_supported = AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s)
 
           if avs_supported
-            xml.tag! :AVSzip, address[:zip].to_s[0..9]
-            xml.tag! :AVSaddress1, address[:address1][0..29]
-            xml.tag! :AVSaddress2, address[:address2][0..29]
-            xml.tag! :AVScity, address[:city][0..19]
+            xml.tag! :AVSzip, address[:zip] ? address[:zip].to_s[0..9] : nil
+            xml.tag! :AVSaddress1, address[:address1] ? address[:address1][0..29] : nil
+            xml.tag! :AVSaddress2, address[:address2] ? address[:address2][0..29] : nil
+            xml.tag! :AVScity, address[:city] ? address[:city][0..19] : nil
             xml.tag! :AVSstate, address[:state]
             xml.tag! :AVSphoneNum, address[:phone] ? address[:phone].scan(/\d/).join.to_s[0..13] : nil
           end
-          xml.tag! :AVSname, creditcard.name[0..29]
+          xml.tag! :AVSname, creditcard.name ? creditcard.name[0..29] : nil
           xml.tag! :AVScountryCode, avs_supported ? address[:country] : ''
         end
       end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -156,6 +156,23 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_nil_address_values_should_not_throw_exceptions
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    address_options = {
+      :address1 => nil,
+      :address2 => nil,
+      :city     => nil,
+      :state    => nil,
+      :zip      => nil,
+      :phone    => nil,
+      :fax      => nil
+    }
+
+    response = @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(address_options))
+    assert_success response
+  end
+
   def test_dont_send_customer_data_by_default
     response = stub_comms do
       @gateway.purchase(50, credit_card, :order_id => 1)


### PR DESCRIPTION
**Changes**
Ensure that each address value is set before truncating it to avoid noMethodErrors being thrown.

@jduff 
