### PR TITLE
Updating the test url for direcpay integrations.

### DIFF
--- a/lib/active_merchant/billing/integrations/direc_pay.rb
+++ b/lib/active_merchant/billing/integrations/direc_pay.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
         mattr_accessor :production_url, :test_url
         
         self.production_url = "https://www.timesofmoney.com/direcpay/secure/dpMerchantTransaction.jsp"
-        self.test_url       = "https://test.timesofmoney.com/direcpay/secure/dpMerchantTransaction.jsp"
+        self.test_url       = "https://test.direcpay.com/direcpay/secure/dpMerchantTransaction.jsp"
 
         def self.service_url
           mode = ActiveMerchant::Billing::Base.integration_mode

--- a/lib/active_merchant/billing/integrations/direc_pay/status.rb
+++ b/lib/active_merchant/billing/integrations/direc_pay/status.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
         class Status
           include PostsData
                     
-          STATUS_TEST_URL = 'https://test.timesofmoney.com/direcpay/secure/dpPullMerchAtrnDtls.jsp'
+          STATUS_TEST_URL = 'https://test.direcpay.com/direcpay/secure/dpMerchantTransaction.jsp'
           STATUS_LIVE_URL = 'https://www.timesofmoney.com/direcpay/secure/dpPullMerchAtrnDtls.jsp'
           
           attr_reader :account, :options

--- a/test/unit/integrations/helpers/direc_pay_helper_test.rb
+++ b/test/unit/integrations/helpers/direc_pay_helper_test.rb
@@ -238,7 +238,7 @@ class DirecPayHelperTest < Test::Unit::TestCase
 
   def test_status_update_in_test_mode
     params = "dummy-authorization|1234|http://localhost/notify"
-    DirecPay::Status.any_instance.expects(:ssl_get).with("https://test.timesofmoney.com/direcpay/secure/dpPullMerchAtrnDtls.jsp?requestparams=#{CGI.escape(params)}")
+    DirecPay::Status.any_instance.expects(:ssl_get).with("https://test.direcpay.com/direcpay/secure/dpMerchantTransaction.jsp?requestparams=#{CGI.escape(params)}")
 
     DirecPay::Status.new(1234, :test => true).update("dummy-authorization", "http://localhost/notify")
   end


### PR DESCRIPTION
Direcpay have changed their test url from https://test.timesofmoney.com/direcpay/secure/dpMerchantTransaction.jsp to "https://test.direcpay.com/direcpay/secure/dpMerchantTransaction.jsp"
