### PR TITLE
Pin: Really pass special headers

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, creditcard)
         add_address(post, creditcard, options)
 
-        commit('charges', post)
+        commit('charges', post, options)
       end
 
       # Create a customer and associated credit card. The token that is returned
@@ -40,14 +40,14 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, creditcard)
         add_customer_data(post, options)
         add_address(post, creditcard, options)
-        commit('customers', post)
+        commit('customers', post, options)
       end
 
       # Refund a transaction, note that the money attribute is ignored at the
       # moment as the API does not support partial refunds. The parameter is
       # kept for compatibility reasons
       def refund(money, token, options = {})
-        commit("charges/#{CGI.escape(token)}/refunds", :amount => amount(money))
+        commit("charges/#{CGI.escape(token)}/refunds", { :amount => amount(money) }, options)
       end
 
       private
@@ -112,11 +112,11 @@ module ActiveMerchant #:nodoc:
         result
       end
 
-      def commit(action, params)
+      def commit(action, params, options)
         url = "#{test? ? test_url : live_url}/#{action}"
 
         begin
-          body = parse(ssl_post(url, post_data(params), headers(params)))
+          body = parse(ssl_post(url, post_data(params), headers(options)))
         rescue ResponseError => e
           body = parse(e.response.body)
         end

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -226,16 +226,21 @@ class PinTest < Test::Unit::TestCase
   end
 
   def test_headers
-    headers = @gateway.send(:headers)
-    assert_equal "application/json", headers['Content-Type']
-    assert_equal "Basic #{Base64.strict_encode64('I_THISISNOTAREALAPIKEY:').strip}", headers['Authorization']
-    assert !headers.has_key?('X-Partner-Key')
-    assert !headers.has_key?('X-Safe-Card')
+    expected_headers = {
+      "Content-Type" => "application/json",
+      "Authorization" => "Basic #{Base64.strict_encode64('I_THISISNOTAREALAPIKEY:').strip}"
+    }
 
-    headers = @gateway.send(:headers, :partner_key => "MyPartnerKey", :safe_card => '1')
-    assert_equal 'MyPartnerKey', headers['X-Partner-Key']
-    assert_equal '1', headers['X-Safe-Card']
+    @gateway.expects(:ssl_post).with(anything, anything, expected_headers).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, {})
+
+    expected_headers['X-Partner-Key'] = 'MyPartnerKey'
+    expected_headers['X-Safe-Card'] = '1'
+
+    @gateway.expects(:ssl_post).with(anything, anything, expected_headers).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, :partner_key => 'MyPartnerKey', :safe_card => '1')
   end
+
 
   private
 


### PR DESCRIPTION
My previous commit around this functionality was actually not passing
the special headers like it was supposed to.
(5dc3bd5c78470068eda1af098e14d6d255f6fa82)

This commit fixes the previous careless attempt and adjusts things such
that we're now actually testing that the right headers get passed rather
than just testing that the right headers are created.
