### PR TITLE
Paypal Express: Allow an amount of 0

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
               end
               xml.tag! 'n2:CallbackURL', options[:callback_url] unless options[:callback_url].blank?
 
-              add_payment_details(xml, with_money_default(money), currency_code, options)
+              add_payment_details(xml, money, currency_code, options)
               if options[:shipping_options]
                 options[:shipping_options].each do |shipping_option|
                   xml.tag! 'n2:FlatRateShippingOptions' do
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'n2:ReferenceID', options[:reference_id]
               xml.tag! 'n2:PaymentAction', action
               xml.tag! 'n2:PaymentType', options[:payment_type] || 'Any'
-              add_payment_details(xml, with_money_default(money), currency_code, options)
+              add_payment_details(xml, money, currency_code, options)
               xml.tag! 'n2:IPAddress', options[:ip]
             end
           end
@@ -212,10 +212,6 @@ module ActiveMerchant #:nodoc:
 
       def build_response(success, message, response, options = {})
         PaypalExpressResponse.new(success, message, response, options)
-      end
-
-      def with_money_default(money)
-        amount(money).to_f.zero? ? 100 : money
       end
 
       def locale_code(country_code)

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -273,12 +273,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '0.50', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:OrderTotal').text
   end
 
-  def test_handles_zero_amount
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {}))
-
-    assert_equal '1.00', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:OrderTotal').text
-  end
-
   def test_amount_format_for_jpy_currency
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_authorization_response)
     response = @gateway.authorize(100, :token => 'EC-6WS104951Y388951L', :payer_id => 'FWRVKNRRZ3WUC', :currency => 'JPY')
@@ -472,16 +466,6 @@ class PaypalExpressTest < Test::Unit::TestCase
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
-  end
-
-  def test_build_setup_request_money_defaults_money_to_100
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', nil, {}))
-    assert_equal '1.00', REXML::XPath.first(xml, '//n2:OrderTotal').text
-  end
-
-  def test_build_reference_transaction_request_defaults_money_to_100
-    xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', nil, {}))
-    assert_equal '1.00', REXML::XPath.first(xml, '//n2:OrderTotal').text
   end
 
   def test_not_adds_brand_name_if_not_specified


### PR DESCRIPTION
No longer default the amount to a dollar.  There are times when an
amount of 0 is perfectly fine for a Paypal Express transaction.

In fact, an amount of 0 is required if you'd like to do an authorization
without an immediate charge.

https://www.x.com/developers/paypal/documentation-tools/express-checkout/integration-guide/ECReferenceTxns
