### PR TITLE
PaypalExpress: Remember the response authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -630,7 +630,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
-        response[:transaction_id] || response[:authorization_id] || response[:refund_transaction_id] # middle one is from reauthorization
+        response[:transaction_id] || response[:authorization_id] || response[:refund_transaction_id] || response[:billing_agreement_id]
       end
 
       def successful?(response)


### PR DESCRIPTION
The Paypal Express #store method uses Paypal's CreateBillingAgreement
API call.  The response to this call gives us the billing_agreement_id
which can then be used for future charges via the DoReferenceTransaction
API call.

This commit allows us to consistently ask the response for its
authorization.

https://www.x.com/developers/paypal/documentation-tools/api/createbillingagreement-api-operation-nvp
