### PR TITLE
Paypal Express: Lessen parameter requirements

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def reference_transaction(money, options = {})
-        requires!(options, :reference_id, :payment_type, :invoice_id, :description, :ip)
+        requires!(options, :reference_id)
 
         commit 'DoReferenceTransaction', build_reference_transaction_request('Sale', money, options)
       end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -409,12 +409,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_reference_transaction
     @gateway.expects(:ssl_post).returns(successful_reference_transaction_response)
 
-    response = @gateway.reference_transaction(2000,  {
-      :reference_id => "ref_id",
-      :payment_type => 'Any',
-      :invoice_id   => 'invoice_id',
-      :description  => 'Description',
-      :ip           => '127.0.0.1' })
+    response = @gateway.reference_transaction(2000,  { :reference_id => "ref_id" })
 
     assert_equal "Success", response.params['ack']
     assert_equal "Success", response.message
@@ -422,19 +417,8 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_reference_transaction_requires_fields
-    valid_options = {
-      :reference_id => "ref_id",
-      :payment_type => 'Any',
-      :invoice_id   => 'invoice_id',
-      :description  => 'Description',
-      :ip           => '127.0.0.1' }
-
-    [:reference_id, :payment_type, :invoice_id, :description, :ip].each do |field|
-      options = valid_options.dup
-      options.delete(field)
-      assert_raise ArgumentError do
-        @gateway.reference_transaction(2000, options)
-      end
+    assert_raise ArgumentError do
+      @gateway.reference_transaction(2000, {})
     end
   end
 


### PR DESCRIPTION
For reference transactions, Paypal Express does not require a payment
type, an invoice_id, a description, or an IP.  We shouldn't require them
either.

They can certainly be specified and we pass them to Paypal
appropriately, but they're not required.
