### PR TITLE
Format the credit card month and year as said in the Merchnat Warrior do...

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -62,8 +62,8 @@ module ActiveMerchant #:nodoc:
         post = {
           'cardName' => creditcard.name,
           'cardNumber' => creditcard.number,
-          'cardExpiryMonth' => sprintf('%02d', creditcard.month),
-          'cardExpiryYear' => sprintf('%02d', creditcard.year)
+          'cardExpiryMonth' => formatted_month_for(creditcard),
+          'cardExpiryYear'  => formatted_year_for(creditcard)
         }
         commit('addCard', post)
       end
@@ -184,6 +184,21 @@ module ActiveMerchant #:nodoc:
 
       def post_data(post)
         post.collect{|k,v| "#{k}=#{CGI.escape(v.to_s)}" }.join("&")
+      end
+
+      def formatted_year_for(creditcard)
+        date(creditcard).strftime("%y")
+      end
+
+      def formatted_month_for(creditcard)
+        date(creditcard).strftime("%m")
+      end
+
+      def date(creditcard)
+        time  = ->{ Time.now }
+        year  = creditcard.year  or time.().year
+        month = creditcard.month or time.().month
+        Date.new(year, month)
       end
     end
   end


### PR DESCRIPTION
Format the credit card month and year as said in the Merchnat Warrior documentation.
### API Method - addCard

[Link](http://dox.merchantwarrior.com/files/MWE%20API.pdf)

**cardExpiryMonth**
Example: 05
Notes: This must be in MM format. The month must be zero-padded if it’s less than 10. 
Valid Length: 2 digits.

**cardExpiryYear**
Example: 13
Notes: This must be in YY format.
Valid Length: 2 digits
