### PR TITLE
Format the credit card cardExpiryMonth and cardExpiryYear as described in the Merchnat Warrior documentation.

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -62,8 +62,8 @@ module ActiveMerchant #:nodoc:
         post = {
           'cardName' => creditcard.name,
           'cardNumber' => creditcard.number,
-          'cardExpiryMonth' => sprintf('%02d', creditcard.month),
-          'cardExpiryYear' => sprintf('%02d', creditcard.year)
+          'cardExpiryMonth' => formatted_month_for(creditcard),
+          'cardExpiryYear'  => formatted_year_for(creditcard)
         }
         commit('addCard', post)
       end
@@ -184,6 +184,21 @@ module ActiveMerchant #:nodoc:
 
       def post_data(post)
         post.collect{|k,v| "#{k}=#{CGI.escape(v.to_s)}" }.join("&")
+      end
+
+      def formatted_year_for(creditcard)
+        date_formatter(creditcard, "%y")
+      end
+
+      def formatted_month_for(creditcard)
+        date_formatter(creditcard, "%m")
+      end
+
+      def date_formatter(creditcard, pattern)
+        time  = proc { Time.now }
+        year  = (creditcard.year  or time.call.year)
+        month = (creditcard.month or time.call.month)
+        Date.new(year,month).strftime(pattern)
       end
     end
   end

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -69,6 +69,8 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
+    @gateway.expects(:formatted_year_for).with(@credit_card)
+    @gateway.expects(:formatted_month_for).with(@credit_card)
 
     assert store = @gateway.store(@credit_card, @options)
     assert_success store


### PR DESCRIPTION
According the [MerchantWarrior API documentation](http://dox.merchantwarrior.com/files/MWE%20API.pdf), Is expected that cardExpiryYear and cardExpiryMonth follow the conditions bellow:

**cardExpiryMonth**
Example: 05
Notes: This must be in MM format. The month must be zero-padded if it’s less than 10. 
Valid Length: 2 digits.

**cardExpiryYear**
Example: 13
Notes: This must be in YY format. 
Valid Length: 2 digits.
