### PR TITLE
Sage gateway: Deprecate #credit call

### DIFF
--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -119,17 +119,22 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      # Performs a credit transaction. (Sage +Credit+ transaction).
+      def credit(money, source, options = {})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, source, options)
+      end
+
+      # Performs a refund transaction.
       #
       # ==== Parameters
       #
       # * <tt>money</tt> - The amount to be authorized as an integer value in cents.
-      # * <tt>source</tt> - The CreditCard or Check object to be used as the target for the credit.
-      def credit(money, source, options = {})
+      # * <tt>source</tt> - The CreditCard or Check object to be used as the target for the refund.
+      def refund(money, source, options = {})
         if card_brand(source) == "check"
-          virtual_check.credit(money, source, options)
+          virtual_check.refund(money, source, options)
         else
-          bankcard.credit(money, source, options)
+          bankcard.refund(money, source, options)
         end
       end
 

--- a/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       include SageCore
       self.live_url = 'https://www.sagepayments.net/cgi-bin/eftBankcard.dll?transaction'
       self.source = 'bankcard'
-          
+
       # Credit cards supported by Sage
       # * VISA
       # * MasterCard
@@ -17,42 +17,47 @@ module ActiveMerchant #:nodoc:
       # * JCB
       # * Sears
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
-      
+
       def authorize(money, credit_card, options = {})
         post = {}
         add_credit_card(post, credit_card)
         add_transaction_data(post, money, options)
         commit(:authorization, post)
       end
-      
+
       def purchase(money, credit_card, options = {})
         post = {}
         add_credit_card(post, credit_card)
         add_transaction_data(post, money, options)
         commit(:purchase, post)
-      end                       
-    
-      # The +money+ amount is not used. The entire amount of the 
+      end
+
+      # The +money+ amount is not used. The entire amount of the
       # initial authorization will be captured.
       def capture(money, reference, options = {})
         post = {}
         add_reference(post, reference)
         commit(:capture, post)
       end
-      
+
       def void(reference, options = {})
         post = {}
         add_reference(post, reference)
         commit(:void, post)
       end
-      
+
       def credit(money, credit_card, options = {})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, credit_card, options)
+      end
+
+      def refund(money, credit_card, options = {})
         post = {}
         add_credit_card(post, credit_card)
         add_transaction_data(post, money, options)
         commit(:credit, post)
       end
-          
+
       private
       def exp_date(credit_card)
         year  = sprintf("%.4i", credit_card.year)
@@ -67,7 +72,7 @@ module ActiveMerchant #:nodoc:
         post[:C_exp]        = exp_date(credit_card)
         post[:C_cvv]        = credit_card.verification_value if credit_card.verification_value?
       end
-      
+
       def parse(data)
         response = {}
         response[:success]          = data[1,1]
@@ -78,7 +83,7 @@ module ActiveMerchant #:nodoc:
         response[:avs_result]       = data[43, 1].strip
         response[:risk]             = data[44, 2]
         response[:reference]        = data[46, 10]
-        
+
         response[:order_number], response[:recurring] = data[57...-1].split("\034")
         response
       end

--- a/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       include SageCore
       self.live_url = 'https://www.sagepayments.net/cgi-bin/eftVirtualCheck.dll?transaction'
       self.source = 'virtual_check'
-      
+
       def purchase(money, credit_card, options = {})
         post = {}
         add_check(post, credit_card)
@@ -14,21 +14,26 @@ module ActiveMerchant #:nodoc:
         add_transaction_data(post, money, options)
         commit(:purchase, post)
       end
-      
+
       def void(reference, options = {})
         post = {}
         add_reference(post, reference)
         commit(:void, post)
       end
-      
+
       def credit(money, credit_card, options = {})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, source, options)
+      end
+
+      def refund(money, credit_card, options = {})
         post = {}
         add_check(post, credit_card)
         add_check_customer_data(post, options)
         add_transaction_data(post, money, options)
         commit(:credit, post)
       end
-      
+
       private
       def add_check(post, check)
         post[:C_first_name]   = check.first_name
@@ -38,37 +43,37 @@ module ActiveMerchant #:nodoc:
         post[:C_check_number] = check.number
         post[:C_acct_type]    = account_type(check)
       end
-      
+
       def add_check_customer_data(post, options)
         # Required  Customer Type – (NACHA Transaction Class)
-        # CCD for Commercial, Merchant Initiated 
+        # CCD for Commercial, Merchant Initiated
         # PPD for Personal, Merchant Initiated
-        # WEB for Internet, Consumer Initiated 
-        # RCK for Returned Checks 
-        # ARC for Account Receivable Entry 
+        # WEB for Internet, Consumer Initiated
+        # RCK for Returned Checks
+        # ARC for Account Receivable Entry
         # TEL for TelephoneInitiated
         post[:C_customer_type] = "WEB"
 
-        # Optional  10  Digit Originator  ID – Assigned  By for  each transaction  class  or  business  purpose. If  not provided, the default Originator ID for the specific  Customer Type will be applied.  
+        # Optional  10  Digit Originator  ID – Assigned  By for  each transaction  class  or  business  purpose. If  not provided, the default Originator ID for the specific  Customer Type will be applied. 
         post[:C_originator_id] = options[:originator_id]
 
         # Optional  Transaction Addenda
         post[:T_addenda] = options[:addenda]
 
-        # Required  Check  Writer  Social  Security  Number  (  Numbers Only, No Dashes )  
+        # Required  Check  Writer  Social  Security  Number  (  Numbers Only, No Dashes ) 
         post[:C_ssn] = options[:ssn].to_s.gsub(/[^\d]/, '')
 
         post[:C_dl_state_code] = options[:drivers_license_state]
         post[:C_dl_number]     = options[:drivers_license_number]
         post[:C_dob]           = format_birth_date(options[:date_of_birth])
       end
-      
+
       def format_birth_date(date)
         date.respond_to?(:strftime) ? date.strftime("%m/%d/%Y") : date
       end
 
-      # DDA for Checking 
-      # SAV for Savings  
+      # DDA for Checking
+      # SAV for Savings 
       def account_type(check)
         case check.account_type
         when 'checking' then 'DDA'
@@ -76,7 +81,7 @@ module ActiveMerchant #:nodoc:
         else raise ArgumentError, "Unknown account type #{check.account_type}"
         end
       end
-      
+
       def parse(data)
         response = {}
         response[:success]          = data[1,1]
@@ -84,7 +89,7 @@ module ActiveMerchant #:nodoc:
         response[:message]          = data[8,32].strip
         response[:risk]             = data[40, 2]
         response[:reference]        = data[42, 10]
-        
+
         extra_data = data[53...-1].split("\034")
         response[:order_number] = extra_data[0]
         response[:authentication_indicator] = extra_data[1]

--- a/test/remote/gateways/remote_sage_bankcard_test.rb
+++ b/test/remote/gateways/remote_sage_bankcard_test.rb
@@ -91,8 +91,8 @@ class RemoteSageBankcardTest < Test::Unit::TestCase
     assert_equal 'INVALID T_REFERENCE', response.message
   end
   
-  def test_successful_credit
-    assert response = @gateway.credit(@amount, @visa, @options)
+  def test_successful_refund
+    assert response = @gateway.refund(@amount, @visa, @options)
     assert_success response
     assert response.test?
   end

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -63,14 +63,14 @@ class RemoteSageTest < Test::Unit::TestCase
     assert_success void
   end
 
-  def test_visa_credit
-    assert response = @gateway.credit(@amount, @visa, @options)
+  def test_visa_refund
+    assert response = @gateway.refund(@amount, @visa, @options)
     assert_success response
     assert response.test?
   end
   
-  def test_check_credit
-    assert response = @gateway.credit(@amount, @check, @options)
+  def test_check_refund
+    assert response = @gateway.refund(@amount, @check, @options)
     assert_success response
     assert response.test?
   end


### PR DESCRIPTION
Use #refund instead.
