### PR TITLE
Swap out REXML for Nokogiri in payflow common parser.

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -1,3 +1,4 @@
+require 'nokogiri'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module PayflowCommonAPI
@@ -140,17 +141,18 @@ module ActiveMerchant #:nodoc:
 
       def parse(data)
         response = {}
-        xml = REXML::Document.new(data)
-        root = REXML::XPath.first(xml, "//ResponseData")
+        xml = Nokogiri::XML(data)
+        xml.remove_namespaces!
+        root = xml.xpath("//ResponseData")
 
         # REXML::XPath in Ruby 1.8.6 is now unable to match nodes based on their attributes
-        tx_result = REXML::XPath.first(root, "//TransactionResult")
+        tx_result = root.xpath(".//TransactionResult").first
 
-        if tx_result && tx_result.attributes['Duplicate'] == "true"
+        if tx_result && tx_result.attributes['Duplicate'].to_s == "true"
           response[:duplicate] = true
         end
 
-        root.elements.to_a.each do |node|
+        root.xpath(".//*").each do |node|
           parse_element(response, node)
         end
 
@@ -166,14 +168,14 @@ module ActiveMerchant #:nodoc:
           # in an RPPaymentResults element so we'll come here multiple times
           response[node_name] ||= []
           response[node_name] << ( payment_result_response = {} )
-          node.elements.each{ |e| parse_element(payment_result_response, e) }
-        when node.has_elements?
-          node.elements.each{|e| parse_element(response, e) }
+          node.xpath(".//*").each{ |e| parse_element(payment_result_response, e) }
+        when node.xpath(".//*").to_a.any?
+          node.xpath(".//*").each{|e| parse_element(response, e) }
         when node_name.to_s =~ /amt$/
           # *Amt elements don't put the value in the #text - instead they use a Currency attribute
-          response[node_name] = node.attributes['Currency']
+          response[node_name] = node.attributes['Currency'].to_s
         when node_name == :ext_data
-          response[node.attributes['Name'].underscore.to_sym] = node.attributes['Value']
+          response[node.attributes['Name'].to_s.underscore.to_sym] = node.attributes['Value'].to_s
         else
           response[node_name] = node.text
         end

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -116,7 +116,18 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert_equal 'US', address['country']
     assert_nil address['phone']
   end
-  
+
+  def test_get_express_details_with_invalid_xml
+    @gateway.expects(:ssl_post).returns(successful_get_express_details_response(:street => "Main & Magic"))
+    response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
+    assert_instance_of PayflowExpressResponse, response
+    assert_success response
+    assert response.test?
+
+    assert address = response.address
+    assert_equal 'Main  Magic', address['address1']
+  end
+
   def test_button_source
     xml = Builder::XmlMarkup.new
     @gateway.send(:add_paypal_details, xml, {})
@@ -126,7 +137,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   
   private
   
-  def successful_get_express_details_response
+  def successful_get_express_details_response(options={:street => "111 Main St."})
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
   <ResponseData>
@@ -145,7 +156,7 @@ class PayflowExpressTest < Test::Unit::TestCase
           <Name>Joe</Name>
           <ShipTo>
             <Address>
-              <Street>111 Main St.</Street>
+              <Street>#{options[:street]}</Street>
               <City>San Jose</City>
               <State>CA</State>
               <Zip>95100</Zip>


### PR DESCRIPTION
REXML is very strict with its xml parsing so fails hard on invalid
characters, Nokogiri strips them and continues on. This is a much better
experience for ActiveMerchant users.

I've only replaced the parser in Payflow common, but we should work on
moving everything to Nokogiri since it is a much better XML parser.

@hornairs @Soleone for review.
