### PR TITLE
Add Check as payment method for Authorize.net gateway

### DIFF
--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
     # not backed by any database.
     #
     # You may use Check in place of CreditCard with any gateway that supports it. Currently, only
-    # +BraintreeGateway+ supports the Check object.
+    # +BraintreeGateway+ and +Authorize.net+ support the Check object.
     class Check
       include Validateable
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -7,6 +7,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @gateway = AuthorizeNetGateway.new(fixtures(:authorize_net))
     @amount = 100
     @credit_card = credit_card('4242424242424242')
+    @check = check
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,
@@ -37,6 +38,15 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+
+  def test_successful_echeck_purchase
+    assert response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
   def test_expired_credit_card
     @credit_card.year = 2004
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -56,6 +66,13 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_authorization
     assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
+  def test_successfule_echeck_authorization
+    assert response = @gateway.authorize(@amount, @check, @options)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
     assert response.authorization

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -12,6 +12,34 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card = credit_card
     @subscription_id = '100748'
     @subscription_status = 'active'
+    @check = check
+  end
+
+  def test_successful_echeck_authorization
+    @gateway.expects(:ssl_post).returns(successful_authorization_response)
+
+    assert response = @gateway.authorize(@amount, @check)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '508141794', response.authorization
+  end
+
+  def test_successful_echeck_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @check)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '508141795', response.authorization
+  end
+
+  def test_failed_echeck_authorization
+    @gateway.expects(:ssl_post).returns(failed_authorization_response)
+
+    assert response = @gateway.authorize(@amount, @check)
+    assert_instance_of Response, response
+    assert_failure response
+    assert_equal '508141794', response.authorization
   end
 
   def test_successful_authorization


### PR DESCRIPTION
I have added the functionality for using a Check object as a payment method to the Authorize.net gateway.

Unit and remote tests are included. Please let me know if there are other things I need to add or change as this is my first pull request! Thanks! 
