### PR TITLE
Add authorization to response of purchase transaction in BogusGateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(credit_card_or_reference)
         when /1$/, AUTHORIZATION
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
         else


### PR DESCRIPTION
Most (if not all) gateways add 'authorization' to response of purchase transaction. It allows developer to use returned 'authorization' as a payment source for subsequent transactions in some gateways (PayJunction for example).

To test this behavior properly it makes sense to have BogusGateway to return 'authorization' in purchase response too.
