### PR TITLE
SagePay, allow configuration of 3d secure per transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -160,6 +160,7 @@ module ActiveMerchant #:nodoc:
 
       def add_optional_data(post, options)
         add_pair(post, :GiftAidPayment, options[:gift_aid_payment]) unless options[:gift_aid_payment].blank?
+        add_pair(post, :Apply3DSecure, options[:apply_3d_secure]) unless options[:apply_3d_secure].blank?
       end
 
       def add_address(post, options)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -132,6 +132,13 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_disable_3d_security_flag_is_submitted
+    stub_comms(:ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({:apply_3d_secure => 1}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/Apply3DSecure=1/, data)
+    end.respond_with(successful_purchase_response)
+  end
 
   private
 


### PR DESCRIPTION
This change will let users decide on a per transaction level whether 3d secure should be enable or disable, even if the account defaults to a different option.
