### PR TITLE
Updates to orbital gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -302,13 +302,13 @@ module ActiveMerchant #:nodoc:
         if address[:dest_zip]
           xml.tag! :AVSDestzip,      address[:dest_zip] ? address[:dest_zip].to_s[0..9] : nil
           xml.tag! :AVSDestaddress1, address[:dest_address1] ? address[:dest_address1][0..29] : nil
-          xml.tag! :AVSaddress2,     address[:dest_address2] ? address[:dest_address2][0..29] : nil
+          xml.tag! :AVSDestaddress2, address[:dest_address2] ? address[:dest_address2][0..29] : nil
           xml.tag! :AVSDestcity,     address[:dest_city] ? address[:dest_city][0..19] : nil
           xml.tag! :AVSDeststate,    address[:dest_state]
           xml.tag! :AVSDestphoneNum, address[:dest_phone] ? address[:dest_phone].scan(/\d/).join.to_s[0..13] : nil
 
           xml.tag! :AVSDestname,        address[:dest_name] ? address[:dest_name][0..29] : nil
-          xml.tag! :AVSDesccountryCode, address[:dest_country]
+          xml.tag! :AVSDestcountryCode, address[:dest_country]
         end
       end
 
@@ -366,6 +366,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! :MBRecurringStartDate,          mb[:start_date].scan(/\d/).join.to_s if mb[:start_date]
           # MMDDYYYY
           xml.tag! :MBRecurringEndDate,            mb[:end_date].scan(/\d/).join.to_s if mb[:end_date]
+          # By default listen to any value set in MBRecurringEndDate.
           xml.tag! :MBRecurringNoEndDateFlag,      mb[:no_end_date_flag] || 'N' # 'Y' || 'N' (Yes or No).
           xml.tag! :MBRecurringMaxBillings,        mb[:max_billings]       if mb[:max_billings]
           xml.tag! :MBRecurringFrequency,          mb[:frequency]          if mb[:frequency]
@@ -375,7 +376,6 @@ module ActiveMerchant #:nodoc:
           xml.tag! :MBMicroPaymentMaxTransactions, mb[:max_transactions]   if mb[:max_transactions]
         end
       end
-
 
       def parse(body)
         response = {}

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -165,11 +165,63 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       :city     => nil,
       :state    => nil,
       :zip      => nil,
+      :email    => nil,
       :phone    => nil,
       :fax      => nil
     }
 
     response = @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(address_options))
+    assert_success response
+  end
+
+  def test_dest_address
+    response = stub_comms do
+      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:dest_zip => '90001', 
+                :dest_address1 => '123 Main St.', 
+                :dest_city => 'Somewhere', 
+                :dest_state => 'CA',
+                :dest_name => 'Joan Smith',
+                :dest_phone => '(123) 456-7890',
+                :dest_country => 'USA'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<AVSDestzip>90001/, data)
+      assert_match(/<AVSDestaddress1>123 Main St./, data)
+      assert_match(/<AVSDestaddress2/, data)
+      assert_match(/<AVSDestcity>Somewhere/, data)
+      assert_match(/<AVSDeststate>CA/, data)
+      assert_match(/<AVSDestname>Joan Smith/, data)
+      assert_match(/<AVSDestphoneNum>1234567890/, data)
+      assert_match(/<AVSDestcountryCode>USA/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_default_managed_billing
+    response = stub_comms do
+      @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014" })
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MBType>R/, data)
+      assert_match(/<MBOrderIdGenerationMethod>IO/, data)
+      assert_match(/<MBRecurringStartDate>10102014/, data)
+      assert_match(/<MBRecurringNoEndDateFlag>N/, data)
+    end.respond_with(successful_profile_response)
+    assert_success response
+  end
+
+  def test_managed_billing
+    response = stub_comms do
+      @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014",
+              :end_date => "10-10-2015",
+              :max_dollar_value => 1500,
+              :max_transactions => 12})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MBType>R/, data)
+      assert_match(/<MBOrderIdGenerationMethod>IO/, data)
+      assert_match(/<MBRecurringStartDate>10102014/, data)
+      assert_match(/<MBRecurringEndDate>10102015/, data)
+      assert_match(/<MBMicroPaymentMaxDollarValue>1500/, data)
+      assert_match(/<MBMicroPaymentMaxTransactions>12/, data)
+    end.respond_with(successful_profile_response)
     assert_success response
   end
 
@@ -283,6 +335,16 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_add_customer_profile_with_email
+    response = stub_comms do
+      @gateway.add_customer_profile(credit_card, { :billing_address => { :email => 'xiaobozzz@example.com' } })
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<CustomerProfileAction>C/, data)
+      assert_match(/<CustomerEmail>xiaobozzz@example.com/, data)
+    end.respond_with(successful_profile_response)
+    assert_success response
+  end
+
   def test_update_customer_profile
     response = stub_comms do
       @gateway.update_customer_profile(credit_card)
@@ -320,6 +382,29 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).with(OrbitalGateway.secondary_test_url, anything, anything).returns(successful_purchase_response)
 
     response = @gateway.purchase(50, credit_card, :order_id => '1')
+    assert_success response
+  end
+
+  # retry_logic true and some value for trace_number.
+  def test_headers_when_retry_logic_is_enabled
+    @gateway.options[:retry_logic] = true
+    response = stub_comms do
+      @gateway.purchase(50, credit_card, :order_id => 1, :trace_number => 1)
+    end.check_request do |endpoint, data, headers|
+      assert_equal('1', headers['Trace-number'])
+      assert_equal('merchant_id', headers['Merchant-Id'])
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_retry_logic_not_enabled
+    @gateway.options[:retry_logic] = false
+    response = stub_comms do
+      @gateway.purchase(50, credit_card, :order_id => 1, :trace_number => 1)
+    end.check_request do |endpoint, data, headers|
+      assert_equal(false, headers.has_key?('Trace-number'))
+      assert_equal(false, headers.has_key?('Merchant-Id'))
+    end.respond_with(successful_purchase_response)
     assert_success response
   end
 


### PR DESCRIPTION
Updates to Chase Paymentech Orbital Gateway.  Fixed a bug with phone number, added CustomerEmail, added Retry Logic, added Managed Billing and added Destination Address (partial building blocks for Level 2 and Level 3 Data, Bill Me Later & Safetech).
