### PR TITLE
Update MiGS test with new credit card expiries

### DIFF
--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -8,10 +8,10 @@ class RemoteMigsTest < Test::Unit::TestCase
 
     @amount = 100
     @declined_amount = 105
-    @visa   = credit_card('4005550000000001', :month => 5, :year => 2013, :brand => 'visa')
-    @master = credit_card('5123456789012346', :month => 5, :year => 2013, :brand => 'master')
-    @amex   = credit_card('371449635311004',  :month => 5, :year => 2013, :brand => 'american_express')
-    @diners = credit_card('30123456789019',   :month => 5, :year => 2013, :brand => 'diners_club')
+    @visa   = credit_card('4005550000000001', :month => 5, :year => 2017, :brand => 'visa')
+    @master = credit_card('5123456789012346', :month => 5, :year => 2017, :brand => 'master')
+    @amex   = credit_card('371449635311004',  :month => 5, :year => 2017, :brand => 'american_express')
+    @diners = credit_card('30123456789019',   :month => 5, :year => 2017, :brand => 'diners_club')
     @credit_card = @visa
 
     @options = {


### PR DESCRIPTION
MiGS test credit cards (used in the remote tests) expire at the end of May 2013 (this month).

This commit simply updates to the new expiry year of 2017.

I have run the tests and 1 remote test fails (but that test did fail before the change).

I will try to address that failure (given I originally wrote the test) in a separate pull request.
