### PR TITLE
Use capture test credentials as regular no longer has extPaySelect permi...

### DIFF
--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -37,7 +37,7 @@ class RemoteMigsTest < Test::Unit::TestCase
     }
 
     responses.each_pair do |card_type, response_text|
-      url = @gateway.purchase_offsite_url(@amount, options.merge(:card_type => card_type))
+      url = @capture_gateway.purchase_offsite_url(@amount, options.merge(:card_type => card_type))
       assert_response_contains response_text, url
     end
   end


### PR DESCRIPTION
Commit message says it all. The test credentials no longer work for the specified test so I've switched to the other credential which has the appropriate permissions.
