### PR TITLE
Add MassPay payment to recipients by UserID

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -349,10 +349,12 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'MassPayRequest', 'xmlns:n2' => EBAY_NAMESPACE do
             xml.tag! 'n2:Version', API_VERSION
             xml.tag! 'EmailSubject', default_options[:subject] if default_options[:subject]
+            xml.tag! 'ReceiverType', default_options[:receiver_type] if default_options[:receiver_type]
             recipients.each do |money, recipient, options|
               options ||= default_options
               xml.tag! 'MassPayItem' do
-                xml.tag! 'ReceiverEmail', recipient
+                xml.tag! 'ReceiverEmail', recipient unless default_options[:receiver_type] && default_options[:receiver_type] != 'EmailAddress'
+                xml.tag! 'ReceiverID', recipient if default_options[:receiver_type] && default_options[:receiver_type] == 'UserID'
                 xml.tag! 'Amount', amount(money), 'currencyID' => options[:currency] || currency(money)
                 xml.tag! 'Note', options[:note] if options[:note]
                 xml.tag! 'UniqueId', options[:unique_id] if options[:unique_id]

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -190,6 +190,30 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.transfer(*recipients)
     assert_failure response
   end
+
+  def test_successful_email_transfer
+    response = @gateway.purchase(@amount, @creditcard, @params)
+    assert_success response
+
+    response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'EmailAddress', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    assert_success response
+  end
+
+  def test_successful_userid_transfer
+    response = @gateway.purchase(@amount, @creditcard, @params)
+    assert_success response
+
+    response = @gateway.transfer([@amount, '4ET96X3PQEN8H'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    assert_success response
+  end
+
+  def test_failed_userid_transfer
+    response = @gateway.purchase(@amount, @creditcard, @params)
+    assert_success response
+
+    response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    assert_failure response
+  end
   
   # Makes a purchase then makes another purchase adding $1.00 using just a reference id (transaction id)
   def test_successful_referenced_id_purchase


### PR DESCRIPTION
MassPay allows payment to recipients by EmailAddress, UserID or PhoneNumber.
All MassPay items in a single request must use the same field to identify recipients.
https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/MassPay_API_Operation_SOAP/
