### PR TITLE
Fix Authorize.net CIM extra options formatting.

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -858,7 +858,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def format_extra_options(options)
-        options.map{ |k, v| "#{k}=#{v}" }.join(',') unless options.nil?
+        options.map{ |k, v| "#{k}=#{v}" }.join('&') unless options.nil?
       end
 
       def parse_direct_response(params)


### PR DESCRIPTION
The delimiter here for multiple options should be '&', not ','.

http://www.authorize.net/support/CIM_XML_guide.pdf
