### PR TITLE
Deprecate credit method in net registry gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -41,7 +41,7 @@ module ActiveMerchant
         :purchase => 'purchase',
         :capture => 'completion',
         :status => 'status',
-        :credit => 'refund'
+        :refund => 'refund'
       }
 
       # Create a new NetRegistry gateway.
@@ -94,13 +94,18 @@ module ActiveMerchant
         commit(:purchase, params)
       end
 
-      def credit(money, identification, options = {})
+      def refund(money, identification, options = {})
         params = {
           'AMOUNT'  => amount(money),
           'TXNREF'  => identification
         }
         add_request_details(params, options)
-        commit(:credit, params)
+        commit(:refund, params)
+      end
+
+      def credit(money, identification, options = {})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, identification, options)
       end
 
       # Specific to NetRegistry.

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -27,7 +27,20 @@ class NetRegistryTest < Test::Unit::TestCase
     assert_success response
     assert_match(/\A\d{16}\z/, response.authorization)
 
-    response = @gateway.credit(@amount, response.authorization)
+    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE, @gateway) do
+      response = @gateway.credit(@amount, response.authorization)
+      assert_equal 'approved', response.params['status']
+      assert_success response
+    end
+  end
+
+  def test_successful_purchase_and_refund
+    response = @gateway.purchase(@amount, @valid_creditcard)
+    assert_equal 'approved', response.params['status']
+    assert_success response
+    assert_match(/\A\d{16}\z/, response.authorization)
+
+    response = @gateway.refund(@amount, response.authorization)
     assert_equal 'approved', response.params['status']
     assert_success response
   end

--- a/test/unit/gateways/net_registry_test.rb
+++ b/test/unit/gateways/net_registry_test.rb
@@ -34,7 +34,15 @@ class NetRegistryTest < Test::Unit::TestCase
 
   def test_successful_credit
     @gateway.stubs(:ssl_post).returns(successful_credit_response)
-    response = @gateway.credit(@amount, '0707161858000000', @options)
+    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE, @gateway) do
+      response = @gateway.credit(@amount, '0707161858000000', @options)
+      assert_success response
+    end
+  end
+
+  def test_successful_refund
+    @gateway.stubs(:ssl_post).returns(successful_credit_response)
+    response = @gateway.refund(@amount, '0707161858000000', @options)
     assert_success response
   end
   


### PR DESCRIPTION
@melari @Soleone for review

Looks like this was missed during the great credit deprecation of '11
