### PR TITLE
Epay: Deprecate credit method

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -283,12 +283,17 @@ module ActiveMerchant #:nodoc:
         void_transaction(options.merge!(:reference_number => identification))
       end
 
-      # Credit a previous transaction.
+      # Refund a previous transaction.
       #
       # Note: See run_transaction for additional options.
       #
-      def credit(money, identification, options={})
+      def refund(money, identification, options={})
         refund_transaction(options.merge!(:amount => money, :reference_number => identification))
+      end
+
+      def credit(money, identification, options={})
+        deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, identification, options)
       end
 
       # Customer ======================================================

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -137,8 +137,17 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
 
   def test_credit
     assert purchase = @gateway.purchase(@amount, @credit_card, @options.dup)
-    
-    assert credit = @gateway.credit(@amount, purchase.authorization, @options)
+
+    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE, @gateway) do
+      assert credit = @gateway.credit(@amount, purchase.authorization, @options)
+      assert_equal 'A', credit.params['refund_transaction_return']['result_code']
+    end
+  end
+
+  def test_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options.dup)
+
+    assert credit = @gateway.refund(@amount, purchase.authorization, @options)
     assert_equal 'A', credit.params['refund_transaction_return']['result_code']
   end
 

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -151,7 +151,19 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
 
   def test_successful_credit
     @gateway.expects(:ssl_post).returns(successful_credit_response)
-    assert response = @gateway.credit(1234, @credit_card, @options)
+    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE, @gateway) do
+      assert response = @gateway.credit(1234, @credit_card, @options)
+      assert_instance_of Response, response
+      assert response.test?
+      assert_success response
+      assert_equal 'Approved', response.message['result']
+      assert_equal '47602599', response.authorization
+    end
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_credit_response)
+    assert response = @gateway.refund(1234, @credit_card, @options)
 
     assert_instance_of Response, response
     assert response.test?


### PR DESCRIPTION
Another gateway that's still missing the credit deprecation message.

@jduff @odorcicd 
