### PR TITLE
Payment Express: Hong Kong is a supported country

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -16,7 +16,7 @@ module ActiveMerchant #:nodoc:
       # However, regular accounts with DPS only support VISA and Mastercard
       self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb ]
 
-      self.supported_countries = %w[ AU MY NZ SG ZA GB US ]
+      self.supported_countries = %w[ AU MY NZ SG ZA GB US HK ]
 
       self.homepage_url = 'http://www.paymentexpress.com/'
       self.display_name = 'PaymentExpress'


### PR DESCRIPTION
http://www.paymentexpress.co.uk/Knowledge_Base/Bank_Guides/Hong_Kong.aspx
