### PR TITLE
Use just name instead of firstname & lastname.

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -122,8 +122,7 @@ module ActiveMerchant #:nodoc:
       def add_address(xml, tag, address, options)
         return if address.nil?
         xml.tag! tag do
-          xml.tag! 'FirstName', address[:first_name] unless address[:first_name].blank?
-          xml.tag! 'LastName', address[:last_name] unless address[:last_name].blank?
+          xml.tag! 'Name', address[:name] unless address[:name].blank?
           xml.tag! 'EMail', options[:email] unless options[:email].blank?
           xml.tag! 'Phone', address[:phone] unless address[:phone].blank?
           xml.tag! 'CustCode', options[:customer] if !options[:customer].blank? && tag == 'BillTo'

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -288,9 +288,9 @@ class PayflowTest < Test::Unit::TestCase
     assert_match /Timeout="#{timeout}"/, xml
   end
 
-  def test_first_and_last_name_fields_are_included
+  def test_name_field_are_included_instead_of_first_and_last
     @gateway.expects(:ssl_post).returns(successful_authorization_response).with do |url, data|
-      data =~ /FirstName/ && data =~ /LastName/
+      data !~ /FirstName/ && data !~ /LastName/ && data =~ /<Name>/
     end
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
**Problem**
We have been getting reports of payflow pro users not receiving customer information in their merchant account.

**Solution**
I believe this was being caused by a change I made to this area a while back (https://github.com/Shopify/active_merchant/pull/599/files). Payflow Link had deprecated their `name` field and was now requiring both a `firstname` and `lastname` separately. When looking at the documentation for payflow pro (https://cms.paypal.com/cms_content/en_US/files/developer/PP_PayflowPro_Guide.pdf), it appears to have the same requirement of separate first and last names, so the same change was made for payflow pro as well.

However, because we actually use their XML api, there is a slightly different documentation (https://cms.paypal.com/cms_content/MX/es_XC/files/developer/PP_PayflowPro_XMLPay_Guide.pdf) which states that both `firstname` and `lastname` should continue to be mapped into a single `name` field for payflow pro.

Review
@odorcicd @jduff 
/cc @BlakeMesdag @louiskearns 
