### PR TITLE
Stripe: Send application_fee with capture requests.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 * PayPal Express gateway: Add unstore support [duff]
+* Stripe: Send application_fee with capture requests [melari]
 
 == Version 1.33.0 (May 30, 2013)
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -58,7 +58,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
-        commit(:post, "charges/#{CGI.escape(authorization)}/capture", {:amount => amount(money)})
+        post = {}
+        post[:amount] = amount(money)
+        add_application_fee(post, options)
+
+        commit(:post, "charges/#{CGI.escape(authorization)}/capture", post)
       end
 
       def void(identification, options = {})
@@ -109,14 +113,18 @@ module ActiveMerchant #:nodoc:
         add_customer(post, options)
         add_customer_data(post,options)
         post[:description] = options[:description] || options[:email]
-        post[:application_fee] = options[:application_fee] if options[:application_fee]
         add_flags(post, options)
+        add_application_fee(post, options)
         post
       end
 
       def add_amount(post, money, options)
         post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money)).downcase
+      end
+
+      def add_application_fee(post, options)
+        post[:application_fee] = options[:application_fee] if options[:application_fee]
       end
 
       def add_customer_data(post, options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -30,7 +30,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_request).returns(successful_capture_response)
 
-    assert response = @gateway.capture(@amount, "ch_test_charge");
+    assert response = @gateway.capture(@amount, "ch_test_charge")
     assert_success response
     assert response.test?
   end
@@ -110,12 +110,20 @@ class StripeTest < Test::Unit::TestCase
     assert !post[:customer]
   end
 
-  def test_application_fee_is_submitted
+  def test_application_fee_is_submitted_for_purchase
     stub_comms(:ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:application_fee => 144}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_application_fee_is_submitted_for_capture
+    stub_comms(:ssl_request) do
+      @gateway.capture(@amount, "ch_test_charge", @options.merge({:application_fee => 144}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/application_fee=144/, data)
+    end.respond_with(successful_capture_response)
   end
 
   def test_client_data_submitted_with_purchase


### PR DESCRIPTION
Adds the optional `application_fee` for capture requests for stripe.
Also got rid of a stray semicolon :-1: 

@RichardBlair @odorcicd 
