### PR TITLE
bluepay gateway add_address was overwriting the name fields

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -422,8 +422,6 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         if address = (options[:shipping_address] || options[:billing_address] || options[:address])
-          post[:NAME1]        = address[:first_name]
-          post[:NAME2]        = address[:last_name]
           post[:ADDR1]        = address[:address1]
           post[:ADDR2]        = address[:address2]
           post[:COMPANY_NAME] = address[:company]

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -54,7 +54,7 @@ class BluePayTest < Test::Unit::TestCase
     result = {}
 
     @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'DE', :state => ''} )
-    assert_equal ["ADDR1", "ADDR2", "CITY", "COMPANY_NAME", "COUNTRY", "NAME1", "NAME2", "PHONE", "STATE", "ZIP"], result.stringify_keys.keys.sort
+    assert_equal ["ADDR1", "ADDR2", "CITY", "COMPANY_NAME", "COUNTRY", "PHONE", "STATE", "ZIP"], result.stringify_keys.keys.sort
     assert_equal 'n/a', result[:STATE]
     assert_equal '123 Test St.', result[:ADDR1]
     assert_equal 'DE', result[:COUNTRY]
@@ -65,11 +65,21 @@ class BluePayTest < Test::Unit::TestCase
 
     @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'US', :state => 'AK'} )
 
-    assert_equal ["ADDR1", "ADDR2", "CITY", "COMPANY_NAME", "COUNTRY", "NAME1", "NAME2", "PHONE", "STATE", "ZIP"], result.stringify_keys.keys.sort
+    assert_equal ["ADDR1", "ADDR2", "CITY", "COMPANY_NAME", "COUNTRY", "PHONE", "STATE", "ZIP"], result.stringify_keys.keys.sort
     assert_equal 'AK', result[:STATE]
     assert_equal '123 Test St.', result[:ADDR1]
     assert_equal 'US', result[:COUNTRY]
 
+  end
+
+  def test_name_comes_from_payment_method
+    result = {}
+
+    @gateway.send(:add_creditcard, result, @credit_card)
+    @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'US', :state => 'AK'} )
+
+    assert_equal @credit_card.first_name, result[:NAME1]
+    assert_equal @credit_card.last_name, result[:NAME2]
   end
 
   def test_add_invoice


### PR DESCRIPTION
The add_address method in the bluepay gateway currently overwrites the name parameters.  These parameters are originally set by the payment method (or options in case of refund). This change corrects the problem.
