### PR TITLE
Make #unstore method interface more consistent

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -172,7 +172,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def unstore(customer_vault_id)
+      def unstore(customer_vault_id, options = {})
         commit do
           Braintree::Customer.delete(customer_vault_id)
           Response.new(true, "OK")

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -55,7 +55,7 @@ module ActiveMerchant #:nodoc:
         commit('T', nil, post)
       end
 
-      def unstore(card_id)
+      def unstore(card_id, options = {})
         post = {}
         post[:client_reference_number] = options[:customer] if options.has_key?(:customer)
         post[:card_id] = card_id

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -101,7 +101,7 @@ module ActiveMerchant #:nodoc:
         commit('res_add_cc', post)
       end
 
-      def unstore(data_key)
+      def unstore(data_key, options = {})
         post = {}
         post[:data_key] = data_key
         commit('res_delete', post)

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         commit 'CreateBillingAgreement', build_create_billing_agreement_request(token, options)
       end
 
-      def unstore(token)
+      def unstore(token, options = {})
         commit 'BAUpdate', build_cancel_billing_agreement_request(token)
       end
 


### PR DESCRIPTION
While it's true that a number of gateways don't use the options
parameter in their #unstore method, having that parameter there with a
default value allows consumers of the API to call the method
consistently regardless of the gateway.
