### PR TITLE
OgoneGateway: New :store_amount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [Litle](http://www.litle.com/) - US
 * [Merchant e-Solutions](http://merchante-solutions.com/) - US
 * [MerchantWare](http://merchantwarehouse.com/merchantware) - US
-* [Merchant Warrior] (http://merchantwarrior.com) - AU
+* [Merchant Warrior](http://merchantwarrior.com) - AU
 * [Mercury](http://www.mercurypay.com) - US
 * [MasterCard Internet Gateway Service (MiGS)](http://mastercard.com/mastercardsps) - AU, AE, BD, BN, EG, HK, ID, IN, JO, KW, LB, LK, MU, MV, MY, NZ, OM, PH, QA, SA, SG, TT, VN
 * [Modern Payments](http://www.modpay.com) - US

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -32,13 +32,13 @@ module ActiveMerchant #:nodoc:
     # == Usage
     #
     #   gateway = ActiveMerchant::Billing::OgoneGateway.new(
-    #               :login                     => "my_ogone_psp_id",
-    #               :user                      => "my_ogone_user_id",
-    #               :password                  => "my_ogone_pswd",
-    #               :signature                 => "my_ogone_sha_signature", # Only if you configured your Ogone environment so.
-    #               :signature_encryptor       => "sha512", # Can be "none" (default), "sha1", "sha256" or "sha512".
+    #     :login               => "my_ogone_psp_id",
+    #     :user                => "my_ogone_user_id",
+    #     :password            => "my_ogone_pswd",
+    #     :signature           => "my_ogone_sha_signature", # Only if you configured your Ogone environment so.
+    #     :signature_encryptor => "sha512"                  # Can be "none" (default), "sha1", "sha256" or "sha512".
     #                                                       # Must be the same as the one configured in your Ogone account.
-    #            )
+    #   )
     #
     #   # set up credit card object as in main ActiveMerchant example
     #   creditcard = ActiveMerchant::Billing::CreditCard.new(
@@ -75,7 +75,19 @@ module ActiveMerchant #:nodoc:
     #
     #   # When using store, you can also let Ogone generate the alias for you
     #   response = gateway.store(creditcard)
-    #   puts response.billing_id  # Retrieve the generated alias
+    #   puts response.billing_id # Retrieve the generated alias
+    #
+    #   # By default, Ogone tries to authorize 0.01 EUR but you can change this
+    #   # amount using the :store_amount option when creating the gateway object:
+    #   gateway = ActiveMerchant::Billing::OgoneGateway.new(
+    #     :login               => "my_ogone_psp_id",
+    #     :user                => "my_ogone_user_id",
+    #     :password            => "my_ogone_pswd",
+    #     :signature           => "my_ogone_sha_signature",
+    #     :signature_encryptor => "sha512",
+    #     :store_amount        => 100 # The store method will try to authorize 1 EUR instead of 0.01 EUR
+    #   )
+    #   response = gateway.store(creditcard) # authorize 1 EUR and void the authorization right away
     #
     # == 3-D Secure feature
     #
@@ -201,7 +213,7 @@ module ActiveMerchant #:nodoc:
       # Store a credit card by creating an Ogone Alias
       def store(payment_source, options = {})
         options.merge!(:alias_operation => 'BYPSP') unless(options.has_key?(:billing_id) || options.has_key?(:store))
-        response = authorize(1, payment_source, options)
+        response = authorize(@options[:store_amount] || 1, payment_source, options)
         void(response.authorization) if response.success?
         response
       end

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -163,17 +163,18 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_store_with_store_amount_at_the_gateway_level
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(:store_amount => 100))
+    assert response = gateway.store(@credit_card, :billing_id => 'test_alias')
+    assert_success response
+    assert purchase = gateway.purchase(@amount, 'test_alias')
+    assert_success purchase
+  end
+
   def test_successful_store_generated_alias
     assert response = @gateway.store(@credit_card)
     assert_success response
     assert purchase = @gateway.purchase(@amount, response.billing_id)
-    assert_success purchase
-  end
-
-  def test_successful_store
-    assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
-    assert_success response
-    assert purchase = @gateway.purchase(@amount, 'test_alias')
     assert_success purchase
   end
 

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -171,14 +171,22 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    @gateway.expects(:add_pair).at_least(1)
-    @gateway.expects(:add_pair).with(anything, 'ECI', '7')
-    @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
+    @gateway.expects(:authorize).with(1, @credit_card, :billing_id => @billing_id).returns(OgoneResponse.new(true, '', @gateway.send(:parse, successful_purchase_response), :authorization => '3014726;RES'))
+    @gateway.expects(:void).with('3014726;RES')
     assert response = @gateway.store(@credit_card, :billing_id => @billing_id)
     assert_success response
     assert_equal '3014726;RES', response.authorization
-    assert_equal '2', response.billing_id
-    assert response.test?
+    assert_equal @billing_id, response.billing_id
+  end
+
+  def test_store_amount_at_gateway_level
+    gateway = OgoneGateway.new(@credentials.merge(:store_amount => 100))
+    gateway.expects(:authorize).with(100, @credit_card, :billing_id => @billing_id).returns(OgoneResponse.new(true, '', gateway.send(:parse, successful_purchase_response_100), :authorization => '3014726;RES'))
+    gateway.expects(:void).with('3014726;RES')
+    assert response = gateway.store(@credit_card, :billing_id => @billing_id)
+    assert_success response
+    assert_equal '3014726;RES', response.authorization
+    assert_equal @billing_id, response.billing_id
   end
 
   def test_deprecated_store_option
@@ -258,7 +266,7 @@ class OgoneTest < Test::Unit::TestCase
   def test_billing_id
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
-    assert_equal '2', response.billing_id
+    assert_equal @billing_id, response.billing_id
   end
 
   def test_order_id
@@ -456,7 +464,32 @@ class OgoneTest < Test::Unit::TestCase
         currency="EUR"
         PM="CreditCard"
         BRAND="VISA"
-        ALIAS="2">
+        ALIAS="#{@billing_id}">
+      </ncresponse>
+    END
+  end
+
+  def successful_purchase_response_100
+    <<-END
+      <?xml version="1.0"?><ncresponse
+        orderID="1233680882919266242708828"
+        PAYID="3014726"
+        NCSTATUS="0"
+        NCERROR="0"
+        NCERRORPLUS="!"
+        ACCEPTANCE="test123"
+        STATUS="5"
+        IPCTY="99"
+        CCCTY="99"
+        ECI="7"
+        CVCCheck="NO"
+        AAVCheck="NO"
+        VC="NO"
+        amount="100"
+        currency="EUR"
+        PM="CreditCard"
+        BRAND="VISA"
+        ALIAS="#{@billing_id}">
       </ncresponse>
     END
   end


### PR DESCRIPTION
Hi,

Some banks don't authorize too small amounts. The new `:store_amount`
gateway option allows to specify a different amount for the authorization
part of the `#store` method. Let me know what you think! :)

Unfortunately I was not able to run the remote test. By any chance,
@ZenCocoon would you be able to run the remote tests?

Thanks!
