### PR TITLE
Paymill: Add 3 more countries

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -1,9 +1,9 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PaymillGateway < Gateway
-      self.supported_countries = %w(AD AT BE CH CY CZ DE DK EE ES FI FO FR GB GR
-                                    HU IE IL IS IT LI LT LU LV MT NL NO PL PT SE
-                                    SI SK TR VA)
+      self.supported_countries = %w(AD AT BE BG CH CY CZ DE DK EE ES FI FO FR GB
+                                    GI GR HU IE IL IS IT LI LT LU LV MT NL NO PL
+                                    PT RO SE SI SK TR VA)
 
       self.supported_cardtypes = [:visa, :master]
       self.homepage_url = 'https://paymill.com'


### PR DESCRIPTION
Paymill recently added Bulgaria, Gibraltar, and Romania to their list of
supported countries.
