### PR TITLE
Add debug mode for webmoney helper

### DIFF
--- a/lib/active_merchant/billing/integrations/webmoney/helper.rb
+++ b/lib/active_merchant/billing/integrations/webmoney/helper.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
           mapping :fail_url, 'LMI_FAIL_URL'
           mapping :success_url, 'LMI_SUCCESS_URL'
           mapping :result_url, 'LMI_RESULT_URL'
+          mapping :debug, 'LMI_SIM_MODE'
         end
       end
     end


### PR DESCRIPTION
Add mapping `debug` to `LMI_SIM_MODE`. See description on
http://wiki.wmtransfer.com/projects/webmoney/wiki/Web_Merchant_Interface#request
