### PR TITLE
Balanced: Fix exception for invalid email

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -310,6 +310,7 @@ module ActiveMerchant #:nodoc:
             # lookup account from Balanced, account_uri should be in the
             # exception in a dictionary called extras
             account_uri = response['extras']['account_uri']
+            raise Error.new(response) unless account_uri
           end
         end
 

--- a/test/remote/gateways/remote_balanced_test.rb
+++ b/test/remote/gateways/remote_balanced_test.rb
@@ -30,6 +30,12 @@ class RemoteBalancedTest < Test::Unit::TestCase
     assert_match /Customer call bank/, response.message
   end
 
+  def test_invalid_email
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:email => 'invalid_email'))
+    assert_failure response
+    assert_match /Invalid field.*email_address/, response.message
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -98,6 +98,15 @@ class BalancedTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_bad_email
+    @gateway.stubs(:ssl_request).returns(failed_account_response_bad_email).then.returns(successful_card_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert response.test?
+    assert_match /must be a valid email address/, response.message
+  end
+
   def test_unsuccessful_purchase
     @gateway.expects(:ssl_request).times(4).returns(
         successful_account_response
@@ -382,6 +391,23 @@ class BalancedTest < Test::Unit::TestCase
   },
   "request_id": "OHMc3f6135cd1fd11e19f1e026ba7e5e72e",
   "description": "Account with email address 'john.buyer@example.org' already exists. Your request id is OHMc3f6135cd1fd11e19f1e026ba7e5e72e."
+}
+    RESPONSE
+  end
+
+  def failed_account_response_bad_email
+    <<-RESPONSE
+{
+  "status": "Bad Request",
+  "category_code": "request",
+  "additional": null,
+  "status_code": 400,
+  "category_type": "request",
+  "extras": {
+    "email_address": "invalid_email must be a valid email address as specified by RFC-2822"
+  },
+  "request_id": "OHM417b4e7ad9e411e2893c026ba7c1aba6",
+  "description": "Invalid field [email_address] - invalid_email must be a valid email address as specified by RFC-2822 Your request id is OHM417b4e7ad9e411e2893c026ba7c1aba6."
 }
     RESPONSE
   end


### PR DESCRIPTION
On a purchase or authorize call, if an email having an invalid format
was specified, it was causing an exception:

```
can't convert nil into String
lib/active_merchant/billing/gateways/balanced.rb:368:in `+'
lib/active_merchant/billing/gateways/balanced.rb:368:in `http_request'
lib/active_merchant/billing/gateways/balanced.rb:359:in
```

Now we're returning a proper Response with a message from Balanced about
the email being invalid.
