### PR TITLE
Adds custom variable for dynamic return URL with WorldPay offsite

### DIFF
--- a/lib/active_merchant/billing/integrations/world_pay/helper.rb
+++ b/lib/active_merchant/billing/integrations/world_pay/helper.rb
@@ -16,6 +16,7 @@ module ActiveMerchant #:nodoc:
 
           mapping :description, 'desc'
           mapping :notify_url, 'MC_callback'
+          mapping :return_url, 'MC_return'
           
           
           # WorldPay supports two different test modes - :always_succeed and :always_fail

--- a/test/unit/integrations/helpers/world_pay_helper_test.rb
+++ b/test/unit/integrations/helpers/world_pay_helper_test.rb
@@ -87,4 +87,10 @@ class WorldPayHelperTest < Test::Unit::TestCase
     assert_field 'M_custom_2', 'Custom Value 2'
     assert_field 'MC_custom_3', 'Custom Value 3'
   end
+
+  def test_return_url
+    @helper.return_url 'some_return_url'
+
+    assert_equal 'some_return_url', @helper.fields['MC_return']
+  end
 end


### PR DESCRIPTION
This will let merchants using WorldPay offsite redirect customers to their own dynamic thank you page after a successful purchase.  Merchants who want to use 3d secure have to use this older offsite integration.

WorldPay promotes [using a meta refresh to do this now](http://www.worldpay.com/support/kb/bg/paymentresponse/Payment_Response.html#pr5402.html).  I've been talking with their support team.  Now if merchants add the line:

`<meta http-equiv="refresh" content="0;URL=<WPDISPLAY ITEM=MC_return>">`

 to their resultY.html page, that will redirect customers back to the merchant's own 'thank you' page, instead of WorldPay's, after a successful purchase. This will let them use analytics to fully track all aspects of the order.

@melari @jduff 
