### PR TITLE
Add #success_response to Integrations::Webmoney::Notification

### DIFF
--- a/lib/active_merchant/billing/integrations/webmoney/notification.rb
+++ b/lib/active_merchant/billing/integrations/webmoney/notification.rb
@@ -36,6 +36,10 @@ module ActiveMerchant #:nodoc:
           def acknowledge
             (security_key == generate_signature)
           end
+
+          def success_response(*args)
+            {:nothing => true}
+          end
         end
       end
     end


### PR DESCRIPTION
It simplifies code if we have to render something back to payment service. We can write in our controllers code like this `render @notification.success_response`.
