### PR TITLE
PaymillGateway correction

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -164,7 +164,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_amount(post, money, options)
-        post[:amount] = money.to_i
+        post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money))
       end
 


### PR DESCRIPTION
- I removed the amount(money) by money.to_i for avoiding the float value (It causes a problem when I use purchase method)
- Now if the customer option is setted with the paymill client id, the transaction will be added to the paymill client. (only with purchase method)
