### PR TITLE
update hitrust test & live urls

### DIFF
--- a/lib/active_merchant/billing/integrations/hi_trust.rb
+++ b/lib/active_merchant/billing/integrations/hi_trust.rb
@@ -7,8 +7,8 @@ module ActiveMerchant #:nodoc:
         autoload :Return, File.dirname(__FILE__) + '/hi_trust/return.rb'
         autoload :Notification, File.dirname(__FILE__) + '/hi_trust/notification.rb'
 
-        TEST_URL = 'https://testtrustlink.hitrust.com.tw/TrustLink/TrxReq'
-        LIVE_URL = 'https://trustlink.hitrust.com.tw/TrustLink/TrxReq'
+        TEST_URL = 'https://testtrustlink.hitrust.com.tw/TrustLink/TrxReqForJava'
+        LIVE_URL = 'https://trustlink.hitrust.com.tw/TrustLink/TrxReqForJava'
         
         def self.service_url
           ActiveMerchant::Billing::Base.integration_mode == :test ? TEST_URL : LIVE_URL


### PR DESCRIPTION
When we noticed that successful transactions were no longer being processed through HiTrust, I reached out to their support team to see whether they had made any changes to their gateway URLs. Sure enough, they provided the updated URLs included here. 

Correspondence Below

---

From: HiTRUSTpay Tech. ServiceCenter cybercity@hitrust.com.tw

Thank you for using our service.
Our payment urls now are as following:

TEST_URL = 'https://testtrustlink.hitrust.com.tw/TrustLink/TrxReqForJava'

LIVE_URL = 'https://trustlink.hitrust.com.tw/TrustLink/TrxReqForJava '

Thanks.

If you got any questions, DO NOT hesitate to contact us.
Best Regards,
# 

HiTRUST e-Payment Service Center
7F, NO. 200, Kang-Chien Rd, Taipei, 114, Taiwan, R.O.C.
Telephone: 886-2-2658-6000, Ext 500
# Facsimile  : 886-2-2658-6063

@melari for review
