### PR TITLE
Removes rubies that have been end of life'd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
-  - 1.8.7
-  - ree
-  - rbx-18mode
 
 gemfile:
   - Gemfile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Active Merchant
+[![Build Status](https://secure.travis-ci.org/Shopify/active_merchant.png)](http://travis-ci.org/Shopify/active_merchant)
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/Shopify/active_merchant)
 
 Active Merchant is an extraction from the e-commerce system [Shopify](http://www.shopify.com).
 Shopify's requirements for a simple and unified API to access dozens of different payment
@@ -216,7 +218,3 @@ information on adding a new gateway to ActiveMerchant.
 
 Please don't touch the CHANGELOG in your pull requests, we'll add the appropriate CHANGELOG entries
 at release time.
-
-[![Build Status](https://secure.travis-ci.org/Shopify/active_merchant.png)](http://travis-ci.org/Shopify/active_merchant)
-
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/Shopify/active_merchant)


### PR DESCRIPTION
Ruby 1.8.7 - http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
REE - http://blog.phusion.nl/2012/02/21/ruby-enterprise-edition-1-8-7-2012-02-released-end-of-life-imminent/

Rubinius doesn't say anything, but whatever, let's remove all 1.8
support.

Also moves the CI and Code Climate details to the top of the readme

Please review @ntalbott @jordanwheeler 
