### PR TITLE
Correctly calculates PP Express discounts for non-fractional currencies

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -161,7 +161,11 @@ module ActiveMerchant #:nodoc:
 
       def localized_amount(money, currency)
         amount = amount(money)
-        CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s) ? amount.split('.').first : amount
+        non_fractional_currency?(currency) ? amount.split('.').first : amount
+      end
+
+      def non_fractional_currency?(currency)
+        CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s)
       end
 
       def currency(money)

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -542,7 +542,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'n2:Number', item[:number]
             xml.tag! 'n2:Quantity', item[:quantity]
             if item[:amount]
-              xml.tag! 'n2:Amount', localized_amount(item[:amount], currency_code), 'currencyID' => currency_code
+              xml.tag! 'n2:Amount', item_amount(item[:amount], currency_code), 'currencyID' => currency_code
             end
             xml.tag! 'n2:Description', item[:description]
             xml.tag! 'n2:ItemURL', item[:url]
@@ -656,6 +656,14 @@ module ActiveMerchant #:nodoc:
 
       def date_to_iso(date)
         (date.is_a?(Date) ? date.to_time : date).utc.iso8601
+      end
+
+      def item_amount(amount, currency_code)
+        if amount.to_i < 0 && non_fractional_currency?(currency_code)
+          amount(amount).to_f.floor
+        else
+          localized_amount(amount, currency_code)
+        end
       end
     end
   end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -285,6 +285,45 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '1', REXML::XPath.first(xml, '//n2:OrderTotal').text
   end
 
+  def test_fractional_discounts_are_correctly_calculated_with_jpy_currency
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250, { :items =>
+                            [{:name => 'item one', :description => 'description', :amount => 15000, :number => 1, :quantity => 1},
+                             {:name => 'Discount', :description => 'Discount', :amount => -750, :number => 2, :quantity => 1}],
+                             :subtotal => 14250, :currency => 'JPY', :shipping => 0, :handling => 0, :tax => 0 }))
+
+    assert_equal '142', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '142', REXML::XPath.first(xml, '//n2:ItemTotal').text
+    amounts = REXML::XPath.match(xml, '//n2:Amount')
+    assert_equal '150', amounts[0].text
+    assert_equal '-8', amounts[1].text
+  end
+
+  def test_non_fractional_discounts_are_correctly_calculated_with_jpy_currency
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14300, { :items =>
+                            [{:name => 'item one', :description => 'description', :amount => 15000, :number => 1, :quantity => 1},
+                             {:name => 'Discount', :description => 'Discount', :amount => -700, :number => 2, :quantity => 1}],
+                             :subtotal => 14300, :currency => 'JPY', :shipping => 0, :handling => 0, :tax => 0 }))
+
+    assert_equal '143', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '143', REXML::XPath.first(xml, '//n2:ItemTotal').text
+    amounts = REXML::XPath.match(xml, '//n2:Amount')
+    assert_equal '150', amounts[0].text
+    assert_equal '-7', amounts[1].text
+  end
+
+  def test_fractional_discounts_are_correctly_calculated_with_usd_currency
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250, { :items =>
+                            [{:name => 'item one', :description => 'description', :amount => 15000, :number => 1, :quantity => 1},
+                             {:name => 'Discount', :description => 'Discount', :amount => -750, :number => 2, :quantity => 1}],
+                             :subtotal => 14250, :currency => 'USD', :shipping => 0, :handling => 0, :tax => 0 }))
+
+    assert_equal '142.50', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '142.50', REXML::XPath.first(xml, '//n2:ItemTotal').text
+    amounts = REXML::XPath.match(xml, '//n2:Amount')
+    assert_equal '150.00', amounts[0].text
+    assert_equal '-7.50', amounts[1].text
+  end
+
   def test_does_not_add_allow_note_if_not_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { }))
 


### PR DESCRIPTION
My solution to fix https://github.com/Shopify/active_merchant/issues/759

PayPal Express does have a shipping discount field, but if you want to have a discount on the order itself you just have to add an extra item with a negative amount.  As discussed in the issue, that causes problems when you've got non-fractional currencies and percentage-based discount codes.

To fix this, we just need to round up the subtotal and the order total in these cases.  If the order is placed in a non fractional currency, and it has a discount code that does not end in an exact dollar amount, then we round the totals.  Eg. a $5 item with a $1.01 discount.  The subtotal is $3.99, the discount code gets split at the decimal and ends up as -$1.  We used to send the subtotal as $3 (also split at the decimal), but this PR will round that up to $4.  $5 - $1 = $4, we're good.  Same thing as a $5 item with a $1.99 discount.  The subtotal is $3.01, this will round it up to $4, and now $5 - $1 adds up.  When the discount is an even $1, the subtotal is already $4 and nothing happens.

The discount code is always the last item sent in an order, so this method rounds the totals if the last item has a negative amount that does not end in .00 (only discount codes can have negative amounts.)  I had to pass the entire options hash into the calculate_total method because it needs to check that options[:items].present?

I also slightly modified the add_payment_details_adds_items_details test because it threw a 'can't convert Symbol into Integer' error when it just sent :items => [1] and didn't specify that 1 was the amount.

Review
@jduff @BlakeMesdag 
