### PR TITLE
Fixes for Mercury tokenization

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -99,10 +99,10 @@ module ActiveMerchant #:nodoc:
         xml.tag! "TStream" do
           xml.tag! "Transaction" do
             xml.tag! 'TranType', 'Credit'
-            xml.tag! 'TranCode', (@use_tokenization ? (action + "ByRecordNo") : action)
             if action == 'PreAuthCapture'
               xml.tag! "PartialAuth", "Allow"
             end
+            xml.tag! 'TranCode', (@use_tokenization ? (action + "ByRecordNo") : action)
             add_invoice(xml, invoice_no, ref_no, options)
             add_reference(xml, record_no) if @use_tokenization
             add_customer_data(xml, options)


### PR DESCRIPTION
On tokenized requests, the RecordNo and Frequency parameters were being sent twice, and the PartialAuth check wasn't accounting for the PartialAuthByRecordNo action.
