### PR TITLE
Refund full application fee if 'refund_application_fee' is set.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -72,6 +72,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         post[:amount] = amount(money) if money
+        post[:refund_application_fee] = true if options[:refund_application_fee]
 
         commit(:post, "charges/#{CGI.escape(identification)}/refund", post, meta)
       end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -12,7 +12,8 @@ class RemoteStripeTest < Test::Unit::TestCase
 
     @options = {
       :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      :email => 'wow@example.com',
+      :currency => 'CAD'
     }
   end
 
@@ -24,13 +25,13 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_purchase_description
-    assert response = @gateway.purchase(@amount, @credit_card, { :description => "TheDescription", :email => "email@example.com" })
+    assert response = @gateway.purchase(@amount, @credit_card, { :currency => "CAD", :description => "TheDescription", :email => "email@example.com" })
     assert_equal "TheDescription", response.params["description"], "Use the description if it's specified."
 
-    assert response = @gateway.purchase(@amount, @credit_card, { :email => "email@example.com" })
+    assert response = @gateway.purchase(@amount, @credit_card, { :currency => "CAD", :email => "email@example.com" })
     assert_equal "email@example.com", response.params["description"], "Use the email if no description is specified."
 
-    assert response = @gateway.purchase(@amount, @credit_card, { })
+    assert response = @gateway.purchase(@amount, @credit_card, { :currency => "CAD" })
     assert_nil response.params["description"], "No description or email specified."
   end
 
@@ -87,7 +88,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert response = @gateway.store(@credit_card, {:currency => 'CAD', :description => "Active Merchant Test Customer", :email => "email@example.com"})
     assert_success response
     assert_equal "customer", response.params["object"]
     assert_equal "Active Merchant Test Customer", response.params["description"]
@@ -118,7 +119,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_application_fee_for_stripe_connect
-    assert response = @gateway.purchase(@amount, @credit_card, { :application_fee => 12 })
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12 ))
     assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
     assert response.params['fee_details'].any? do |fee|
       (fee['type'] == 'application_fee') && (fee['amount'] == 12)
@@ -141,6 +142,14 @@ class RemoteStripeTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, authorization.authorization)
     assert_success capture
+  end
+
+  def test_successful_refund_with_application_fee
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
+    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
+    assert refund = @gateway.refund(@amount, response.authorization, :refund_application_fee => true)
+    assert_success refund
+    assert_equal 12, refund.params["fee_details"].first["amount_refunded"]
   end
 
 end


### PR DESCRIPTION
This is a temporary fix until stripe fixes their refund endpoint so that we don't have to do #768.
We use the existing flag on the refund endpoint to refund the full application fee whenever `refund_application_fee` is set.

Again, I had to make the same currency changes since my test account only supports CAD

@RichardBlair @odorcicd 
