### PR TITLE
[Fixes #719] Cybersource recurring payments 

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -313,21 +313,31 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_create_subscription_request(payment_method, options)
-        options[:subscription] = (options[:subscription] || {}).merge(:frequency => "on-demand", :amount => 0, :automatic_renew => false)
+        # Set default subscription parameters
+        default_subscription_params = {:frequency => "on-demand", :amount => 0, :automatic_renew => false}
+        options[:subscription] = (options[:subscription] || {})
+
+        # Override subscription parameters and give priority to parameters passed in
+        options[:subscription] = default_subscription_params.update(options[:subscription])
 
         xml = Builder::XmlMarkup.new :indent => 2
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
+
+        # Fix for #719, cybersource recurring payments expects the xml elements to have a specific order 
         if card_brand(payment_method) == 'check'
           add_check(xml, payment_method)
           add_check_payment_method(xml)
           add_check_service(xml, options) if options[:setup_fee]
+          add_subscription(xml, options)
         else
+          # The order in which the tags are generated matters
           add_creditcard(xml, payment_method)
           add_creditcard_payment_method(xml)
-          add_purchase_service(xml, options) if options[:setup_fee]
+          add_subscription(xml, options)
+          add_purchase_service(xml, options) if options[:setup_fee]          
         end
-        add_subscription(xml, options)
+        
         add_subscription_create_service(xml, options)
         add_business_rules_data(xml)
         xml.target!
@@ -358,7 +368,7 @@ module ActiveMerchant #:nodoc:
         add_subscription_retrieve_service(xml, options)
         xml.target!
       end
-
+      
       def build_validate_pinless_debit_request(creditcard,options)
         xml = Builder::XmlMarkup.new :indent => 2
         add_creditcard(xml, creditcard)
@@ -461,8 +471,8 @@ module ActiveMerchant #:nodoc:
         if options[:pinless_debit_card]
           xml.tag! 'pinlessDebitService', {'run' => 'true'}
         else
-          xml.tag! 'ccAuthService', {'run' => 'true'}
-          xml.tag! 'ccCaptureService', {'run' => 'true'}
+       	 xml.tag! 'ccAuthService', {'run' => 'true'}
+         xml.tag! 'ccCaptureService', {'run' => 'true'}
         end
       end
 
@@ -555,7 +565,7 @@ module ActiveMerchant #:nodoc:
           add_creditcard(xml, payment_method_or_reference)
         end
       end
-
+      
       def add_validate_pinless_debit_service(xml)
         xml.tag!'pinlessDebitValidateService', {'run' => 'true'}
       end


### PR DESCRIPTION
Cybersource recurring payments would give a 500 Internal Server Error, cybersource expects xml elements in the request to be ordered in a particular way, this patch generates xml elements in the correct order, also subscription params are not overriden in the method.
