### PR TITLE
Braintree Blue implementation should instantiate Braintree::Gateway instead of using global vars and convenience methods

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -23,33 +23,18 @@ module ActiveMerchant #:nodoc:
     # Setting an ActiveMerchant +wiredump_device+ will automatically
     # configure the Braintree logger (via the Braintree gem's
     # configuration) when the BraintreeBlueGateway is instantiated.
-    # Additionally, the log level will be set to +DEBUG+.  Therefore,
-    # all you have to do is set the +wiredump_device+ and you'll
-    # get your debug output from your HTTP interactions with the
-    # remote gateway. (Don't enable this in production.)
+    # Additionally, the log level will be set to +DEBUG+. Therefore,
+    # all you have to do is set the +wiredump_device+ and you'll get
+    # your debug output from your HTTP interactions with the remote
+    # gateway. (Don't enable this in production.) The ActiveMerchant
+    # implementation doesn't mess with the Braintree::Configuration
+    # globals at all, so there won't be any side effects outside
+    # Active Merchant.
     #
-    # For example:
+    # If no +wiredump_device+ is set, the logger in
+    # +Braintree::Configuration.logger+ will be cloned and the log
+    # level set to +WARN+.
     #
-    #     ActiveMerchant::Billing::BraintreeBlueGateway.wiredump_device = Logger.new(STDOUT)
-    #     # => #<Logger:0x107d385f8 ...>
-    #
-    #     Braintree::Configuration.logger
-    #     # => (some other logger, created by default by the gem)
-    #
-    #     Braintree::Configuration.logger.level
-    #     # => 1 (INFO)
-    #
-    #     ActiveMerchant::Billing::BraintreeBlueGateway.new(:merchant_id => 'x', :public_key => 'x', :private_key => 'x')
-    #
-    #     Braintree::Configuration.logger
-    #     # => #<Logger:0x107d385f8 ...>
-    #
-    #     Braintree::Configuration.logger.level
-    #     # => 0 (DEBUG)
-    #
-    #  Alternatively, you can avoid setting the +wiredump_device+
-    #  and set +Braintree::Configuration.logger+ and/or
-    #  +Braintree::Configuration.logger.level+ directly.
     class BraintreeBlueGateway < Gateway
       include BraintreeCommon
 
@@ -61,18 +46,24 @@ module ActiveMerchant #:nodoc:
 
         super
 
-        Braintree::Configuration.merchant_id = options[:merchant_id]
-        Braintree::Configuration.public_key = options[:public_key]
-        Braintree::Configuration.private_key = options[:private_key]
-        Braintree::Configuration.environment = (options[:environment] || (test? ? :sandbox : :production)).to_sym
-        Braintree::Configuration.custom_user_agent = "ActiveMerchant #{ActiveMerchant::VERSION}"
-
         if wiredump_device
-          Braintree::Configuration.logger = ((Logger === wiredump_device) ? wiredump_device : Logger.new(wiredump_device))
-          Braintree::Configuration.logger.level = Logger::DEBUG
+          logger = ((Logger === wiredump_device) ? wiredump_device : Logger.new(wiredump_device))
+          logger.level = Logger::DEBUG
         else
-          Braintree::Configuration.logger.level = Logger::WARN
+          logger = Braintree::Configuration.logger.clone
+          logger.level = Logger::WARN
         end
+
+        @configuration = Braintree::Configuration.new(
+          :merchant_id       => options[:merchant_id],
+          :public_key        => options[:public_key],
+          :private_key       => options[:private_key],
+          :environment       => (options[:environment] || (test? ? :sandbox : :production)).to_sym,
+          :custom_user_agent => "ActiveMerchant #{ActiveMerchant::VERSION}",
+          :logger            => logger,
+        )
+
+        @braintree_gateway = Braintree::Gateway.new( @configuration )
       end
 
       def authorize(money, credit_card_or_vault_id, options = {})
@@ -81,7 +72,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         commit do
-          result = Braintree::Transaction.submit_for_settlement(authorization, amount(money).to_s)
+          result = @braintree_gateway.transaction.submit_for_settlement(authorization, amount(money).to_s)
           Response.new(result.success?, message_from_result(result))
         end
       end
@@ -101,7 +92,7 @@ module ActiveMerchant #:nodoc:
         money = amount(money).to_s if money
 
         commit do
-          result = Braintree::Transaction.refund(transaction_id, money)
+          result = @braintree_gateway.transaction.refund(transaction_id, money)
           Response.new(result.success?, message_from_result(result),
             {:braintree_transaction => (transaction_hash(result.transaction) if result.success?)},
             {:authorization => (result.transaction.id if result.success?)}
@@ -111,7 +102,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         commit do
-          result = Braintree::Transaction.void(authorization)
+          result = @braintree_gateway.transaction.void(authorization)
           Response.new(result.success?, message_from_result(result),
             {:braintree_transaction => (transaction_hash(result.transaction) if result.success?)},
             {:authorization => (result.transaction.id if result.success?)}
@@ -132,7 +123,7 @@ module ActiveMerchant #:nodoc:
               :expiration_year => creditcard.year.to_s
             }
           }
-          result = Braintree::Customer.create(merge_credit_card_options(parameters, options))
+          result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           Response.new(result.success?, message_from_result(result),
             {
               :braintree_customer => (customer_hash(result.customer) if result.success?),
@@ -146,7 +137,7 @@ module ActiveMerchant #:nodoc:
       def update(vault_id, creditcard, options = {})
         braintree_credit_card = nil
         commit do
-          braintree_credit_card = Braintree::Customer.find(vault_id).credit_cards.detect { |cc| cc.default? }
+          braintree_credit_card = @braintree_gateway.customer.find(vault_id).credit_cards.detect { |cc| cc.default? }
           return Response.new(false, 'Braintree::NotFoundError') if braintree_credit_card.nil?
 
           options.merge!(:update_existing_token => braintree_credit_card.token)
@@ -159,14 +150,14 @@ module ActiveMerchant #:nodoc:
             }
           }, options)[:credit_card]
 
-          result = Braintree::Customer.update(vault_id,
+          result = @braintree_gateway.customer.update(vault_id,
             :first_name => creditcard.first_name,
             :last_name => creditcard.last_name,
             :email => options[:email],
             :credit_card => credit_card_params
           )
           Response.new(result.success?, message_from_result(result),
-            :braintree_customer => (customer_hash(Braintree::Customer.find(vault_id)) if result.success?),
+            :braintree_customer => (customer_hash(@braintree_gateway.customer.find(vault_id)) if result.success?),
             :customer_vault_id => (result.customer.id if result.success?)
           )
         end
@@ -174,7 +165,7 @@ module ActiveMerchant #:nodoc:
 
       def unstore(customer_vault_id, options = {})
         commit do
-          Braintree::Customer.delete(customer_vault_id)
+          @braintree_gateway.customer.delete(customer_vault_id)
           Response.new(true, "OK")
         end
       end
@@ -236,7 +227,7 @@ module ActiveMerchant #:nodoc:
         transaction_params = create_transaction_parameters(money, credit_card_or_vault_id, options)
 
         commit do
-          result = Braintree::Transaction.send(transaction_type, transaction_params)
+          result = @braintree_gateway.transaction.send(transaction_type, transaction_params)
           response_params, response_options, avs_result, cvv_result = {}, {}, {}, {}
           if result.success?
             response_params[:braintree_transaction] = transaction_hash(result.transaction)
@@ -398,4 +389,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -7,10 +7,12 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :public_key => 'test',
       :private_key => 'test'
     )
+
+    @internal_gateway = @gateway.instance_variable_get( :@braintree_gateway )
   end
 
   def test_refund_legacy_method_signature
-    Braintree::Transaction.expects(:refund).
+    Braintree::TransactionGateway.any_instance.expects(:refund).
       with('transaction_id', nil).
       returns(braintree_result(:id => "refund_transaction_id"))
     response = @gateway.refund('transaction_id', :test => true)
@@ -18,7 +20,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_refund_method_signature
-    Braintree::Transaction.expects(:refund).
+    Braintree::TransactionGateway.any_instance.expects(:refund).
       with('transaction_id', '10.00').
       returns(braintree_result(:id => "refund_transaction_id"))
     response = @gateway.refund(1000, 'transaction_id', :test => true)
@@ -26,7 +28,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_void_transaction
-    Braintree::Transaction.expects(:void).
+    Braintree::TransactionGateway.any_instance.expects(:void).
       with('transaction_id').
       returns(braintree_result(:id => "void_transaction_id"))
 
@@ -35,7 +37,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_user_agent_includes_activemerchant_version
-    assert Braintree::Configuration.instantiate.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
+    assert @internal_gateway.config.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
   end
 
   def test_merchant_account_id_present_when_provided_on_gateway_initialization
@@ -46,7 +48,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :private_key => 'test'
     )
 
-    Braintree::Transaction.expects(:sale).
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(has_entries(:merchant_account_id => "present")).
       returns(braintree_result)
 
@@ -61,7 +63,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :private_key => 'test'
     )
 
-    Braintree::Transaction.expects(:sale).
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(has_entries(:merchant_account_id => "account_on_transaction")).
       returns(braintree_result)
 
@@ -69,7 +71,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_merchant_account_id_present_when_provided
-    Braintree::Transaction.expects(:sale).
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(has_entries(:merchant_account_id => "present")).
       returns(braintree_result)
 
@@ -77,7 +79,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_merchant_account_id_absent_if_not_provided
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       not params.has_key?(:merchant_account_id)
     end.returns(braintree_result)
 
@@ -93,7 +95,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     )
     customer.stubs(:id).returns('123')
     result = Braintree::SuccessfulResult.new(:customer => customer)
-    Braintree::Customer.expects(:create).with do |params|
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options].has_key?(:verify_card)
       assert_equal true, params[:credit_card][:options][:verify_card]
       params
@@ -113,7 +115,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     )
     customer.stubs(:id).returns('123')
     result = Braintree::SuccessfulResult.new(:customer => customer)
-    Braintree::Customer.expects(:create).with do |params|
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options].has_key?(:verify_card)
       assert_equal false, params[:credit_card][:options][:verify_card]
       params
@@ -142,7 +144,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     customer = mock(customer_attributes)
     customer.stubs(:id).returns('123')
     result = Braintree::SuccessfulResult.new(:customer => customer)
-    Braintree::Customer.expects(:create).with do |params|
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_not_nil params[:credit_card][:billing_address]
       [:street_address, :extended_address, :locality, :region, :postal_code, :country_name].each do |billing_attribute|
         params[:credit_card][:billing_address].has_key?(billing_attribute) if params[:billing_address]
@@ -156,11 +158,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_update_with_cvv
     stored_credit_card = mock(:token => "token", :default? => true)
     customer = mock(:credit_cards => [stored_credit_card], :id => '123')
-    Braintree::Customer.stubs(:find).with('vault_id').returns(customer)
+    Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
     BraintreeBlueGateway.any_instance.stubs(:customer_hash)
 
     result = Braintree::SuccessfulResult.new(:customer => customer)
-    Braintree::Customer.expects(:update).with do |vault, params|
+    Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
       assert_equal "567", params[:credit_card][:cvv]
       [vault, params]
     end.returns(result)
@@ -171,11 +173,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_update_with_verify_card_true
     stored_credit_card = mock(:token => "token", :default? => true)
     customer = mock(:credit_cards => [stored_credit_card], :id => '123')
-    Braintree::Customer.stubs(:find).with('vault_id').returns(customer)
+    Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
     BraintreeBlueGateway.any_instance.stubs(:customer_hash)
 
     result = Braintree::SuccessfulResult.new(:customer => customer)
-    Braintree::Customer.expects(:update).with do |vault, params|
+    Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
       assert_equal true, params[:credit_card][:options][:verify_card]
       [vault, params]
     end.returns(result)
@@ -240,27 +242,27 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_address_country_handling
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == "US")
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country => "US"})
 
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == "US")
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_alpha2 => "US"})
 
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_name] == "United States of America")
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_name => "United States of America"})
 
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha3] == "USA")
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_alpha3 => "USA"})
 
-    Braintree::Transaction.expects(:sale).with do |params|
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_numeric] == 840)
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_numeric => 840})
@@ -274,13 +276,13 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :private_key => 'test'
     )
 
-    Braintree::Transaction.expects(:sale).
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(has_entries(:recurring => true)).
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card("41111111111111111111"), :recurring => true)
 
-    Braintree::Transaction.expects(:sale).
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(Not(has_entries(:recurring => true))).
       returns(braintree_result)
 
@@ -291,26 +293,28 @@ class BraintreeBlueTest < Test::Unit::TestCase
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not
     # configure a logger
-    assert Braintree::Configuration.logger.is_a?(Logger)
+    assert @internal_gateway.config.logger.is_a?(Logger)
   end
 
   def test_configured_logger_has_a_default_log_level_defined_by_active_merchant
-    assert_equal Logger::WARN, Braintree::Configuration.logger.level
+    assert_equal Logger::WARN, @internal_gateway.config.logger.level
   end
 
-  def test_configured_logger_respects_any_custom_log_level_set_without_overwriting_it
+  def test_default_logger_sets_warn_level_without_overwriting_global
     with_braintree_configuration_restoration do
       assert Braintree::Configuration.logger.level != Logger::DEBUG
       Braintree::Configuration.logger.level = Logger::DEBUG
 
-      # Re-instatiate a gateway to show it doesn't affect the log level
-      BraintreeBlueGateway.new(
+      # Re-instatiate a gateway to show it doesn't touch the global
+      gateway = BraintreeBlueGateway.new(
         :merchant_id => 'test',
         :public_key => 'test',
         :private_key => 'test'
       )
+      internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
 
-      assert_equal Logger::WARN, Braintree::Configuration.logger.level
+      assert_equal Logger::WARN, internal_gateway.config.logger.level
+      assert_equal Logger::DEBUG, Braintree::Configuration.logger.level
     end
   end
 
@@ -321,14 +325,15 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
       assert_not_equal logger, Braintree::Configuration.logger
 
-      BraintreeBlueGateway.new(
+      gateway = BraintreeBlueGateway.new(
         :merchant_id => 'test',
         :public_key => 'test',
         :private_key => 'test'
       )
+      internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
 
-      assert_equal logger, Braintree::Configuration.logger
-      assert_equal Logger::DEBUG, Braintree::Configuration.logger.level
+      assert_equal logger, internal_gateway.config.logger
+      assert_equal Logger::DEBUG, internal_gateway.config.logger.level
     end
   end
 


### PR DESCRIPTION
The Braintree Blue gateway implementation in AM uses the Braintree::Configuration global and performs all operations through class methods. Here are a couple of obvious things that breaks:
- You can't have two instances of BraintreeBlueGateway with different settings
- You can't use BraintreeBlueGateway in conjunction with other code that uses the Braintree gem

This isn't a shortcoming of the Braintree gem, which provides a way to create an instance bound to a particular configuration with appropriate instance methods for performing operations.

This commit moves from using the global vars and shortcut methods to instantiating a Braintree::Gateway object and using the appropriate instance methods instead.
