### PR TITLE
Mercury: reworked refund and void to support Reversals and partial refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -59,11 +59,24 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         requires!(options, :credit_card) unless @use_tokenization
 
-        request = build_authorized_request('VoidSale', money, authorization, options[:credit_card], options)
-        commit(options[:void], request)
+        request = build_authorized_request('Return', money, authorization, options[:credit_card], options)
+        commit('Return', request)
       end
 
       def void(authorization, options={})
+        requires!(options, :credit_card) unless @use_tokenization
+
+        if options[:try_reversal]
+          request = build_authorized_request('VoidSale', nil, authorization, options[:credit_card], options.merge(:void => true, :reversal => true))
+          response = commit('VoidSale', request)
+
+          return response if response.success?
+        end
+
+        request = build_authorized_request('VoidSale', nil, authorization, options[:credit_card], options.merge(:void => true))
+        commit('VoidSale', request)
+
+
         refund(nil, authorization, options.merge(:void => true))
       end
 
@@ -111,8 +124,8 @@ module ActiveMerchant #:nodoc:
             add_address(xml, options)
             xml.tag! 'TranInfo' do
               xml.tag! "AuthCode", auth_code
-              xml.tag! "AcqRefData", acq_ref_data
-              xml.tag! "ProcessData", process_data
+              xml.tag! "AcqRefData", acq_ref_data if options[:reversal]
+              xml.tag! "ProcessData", process_data if options[:reversal]
             end
           end
         end

--- a/test/remote/gateways/remote_mercury_certification_test.rb
+++ b/test/remote/gateways/remote_mercury_certification_test.rb
@@ -13,7 +13,7 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     assert_success sale
     assert_equal "AP", sale.params["text_response"]
 
-    reversal = tokenization_gateway.refund(101, sale.authorization, options)
+    reversal = tokenization_gateway.void(sale.authorization, options.merge(:try_reversal => true))
     assert_success reversal
     assert_equal "REVERSED", reversal.params["text_response"]
   end
@@ -27,7 +27,47 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
 
     void = tokenization_gateway.void(sale.authorization, options)
     assert_success void
-    assert_equal "REVERSED", void.params["text_response"]
+    assert_equal "AP", void.params["text_response"]
+  end
+
+  def test_preauth_capture_and_reversal
+    close_batch(tokenization_gateway)
+
+    preauth = tokenization_gateway.authorize(106, visa_5, options("1"))
+    assert_success preauth
+    assert_equal "AP", preauth.params["text_response"]
+
+    capture = tokenization_gateway.capture(106, preauth.authorization, options)
+    assert_success capture
+    assert_equal "AP", capture.params["text_response"]
+
+    reversal = tokenization_gateway.void(capture.authorization, options.merge(:try_reversal => true))
+    assert_success reversal
+    assert_equal "REVERSED", reversal.params["text_response"]
+  end
+
+  def test_return_and_void
+    close_batch(tokenization_gateway)
+
+    credit = tokenization_gateway.credit(109, visa, options("1"))
+    assert_success credit
+    assert_equal "AP", credit.params["text_response"]
+
+    void = tokenization_gateway.void(credit.authorization, options)
+    assert_success void
+    assert_equal "AP*", void.params["text_response"]
+  end
+
+  def test_preauth_and_reversal
+    close_batch(tokenization_gateway)
+
+    preauth = tokenization_gateway.authorize(113, disc, options("1"))
+    assert_success preauth
+    assert_equal "AP", preauth.params["text_response"]
+
+    reversal = tokenization_gateway.void(preauth.authorization, options.merge(:try_reversal => true))
+    assert_success reversal
+    assert_equal "REVERSED", reversal.params["text_response"]
   end
 
   def test_preauth_capture_and_reversal
@@ -37,25 +77,13 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     assert_success preauth
     assert_equal "AP", preauth.params["text_response"]
 
-    capture = tokenization_gateway.capture(106, preauth.authorization, options)
+    capture = tokenization_gateway.capture(206, preauth.authorization, options)
     assert_success capture
     assert_equal "AP", capture.params["text_response"]
 
-    reversal = tokenization_gateway.refund(106, capture.authorization, options)
-    assert_success reversal
-    assert_equal "REVERSED", reversal.params["text_response"]
-  end
-
-  def test_preauth_and_reversal
-    close_batch(tokenization_gateway)
-
-    preauth = tokenization_gateway.authorize(113, visa, options("1"))
-    assert_success preauth
-    assert_equal "AP", preauth.params["text_response"]
-
-    reversal = tokenization_gateway.void(preauth.authorization, options)
-    assert_success reversal
-    assert_equal "REVERSED", reversal.params["text_response"]
+    void = tokenization_gateway.void(capture.authorization, options)
+    assert_success void
+    assert_equal "AP", void.params["text_response"]
   end
 
   private
@@ -71,6 +99,36 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     @visa ||= credit_card(
       "4003000123456781",
       :brand => "visa",
+      :month => "12",
+      :year => "15",
+      :verification_value => "123"
+    )
+  end
+
+  def disc
+    @disc ||= credit_card(
+      "6011000997235373",
+      :brand => "discover",
+      :month => "12",
+      :year => "15",
+      :verification_value => "362"
+    )
+  end
+
+  def visa_5
+    @visa_5 ||= credit_card(
+      "4005550000000480",
+      :brand => "visa",
+      :month => "12",
+      :year => "15",
+      :verification_value => "123"
+    )
+  end
+
+  def mc
+    @mc ||= credit_card(
+      "5439750001500248",
+      :brand => "master",
       :month => "12",
       :year => "15",
       :verification_value => "123"

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -134,7 +134,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
     refund = @gateway.refund(200, capture.authorization)
     assert_success refund
     assert_equal '2.00', refund.params['purchase']
-    assert_equal 'VoidSale', refund.params['tran_code']
+    assert_equal 'Return', refund.params['tran_code']
   end
 
   def test_amex_authorize_and_capture_with_refund


### PR DESCRIPTION
Background for this is in another pull request, https://github.com/Shopify/active_merchant/pull/775
