### PR TITLE
NmiGateway: Add optional :recurring flag 

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -342,7 +342,7 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description]
       end
 
-      def add_creditcard(post, creditcard)
+      def add_creditcard(post, creditcard, options={})
         post[:card_num]   = creditcard.number
         post[:card_code]  = creditcard.verification_value if creditcard.verification_value?
         post[:exp_date]   = expdate(creditcard)
@@ -354,7 +354,7 @@ module ActiveMerchant #:nodoc:
         if card_brand(source) == "check"
           add_check(params, source, options)
         else
-          add_creditcard(params, source)
+          add_creditcard(params, source, options)
         end
       end
 

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -7,7 +7,14 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'NMI'
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      private
+      def add_creditcard(post, creditcard, options={})
+        super
+        post[:recurring_billing] = "TRUE" if options[:recurring]
+      end
     end
+
   end
 end
 

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -53,11 +53,11 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', void.message
   end
 
-  def test_credit
+  def test_refund
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    assert response = @gateway.credit(@amount, response.authorization, :card_number => @credit_card.number)
+    assert response = @gateway.refund(@amount, response.authorization, :card_number => @credit_card.number)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
   end

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -55,7 +55,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal '508141795', response.authorization
   end
 
-  def test_passing_recurring_flag
+  def test_echeck_passing_recurring_flag
     response = stub_comms do
       @gateway.purchase(@amount, @check, :recurring => true)
     end.check_request do |endpoint, data, headers|

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -4,9 +4,26 @@ require 'unit/gateways/authorize_net_test'
 class NmiTest < AuthorizeNetTest
   def setup
     super
-    @gateway = NmiGateway.new(
-      :login => 'X',
-      :password => 'Y'
-    )
+    @gateway = NmiGateway.new(:login => 'X', :password => 'Y')
+  end
+
+  def test_credit_card_purchase_no_recurring_flag
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_no_match(/x_recurring_billing/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_credit_card_purchase_with_recurring_flag
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, :recurring => true)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/x_recurring_billing=TRUE/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 end


### PR DESCRIPTION
Nmi customer support confirmed that this optional flag can be passed to
purchase and authorize to turn off the CVV requirement.

And our customer has confirmed that it's working as expected.
