### PR TITLE
ActiveMerchant::Billing::Base.gateway raises when passed an invalid gateway

### DIFF
--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -31,7 +31,8 @@ module ActiveMerchant #:nodoc:
       #
       #   ActiveMerchant::Billing::Base.gateway('moneris').new
       def self.gateway(name)
-        Billing.const_get("#{name.to_s.downcase}_gateway".camelize)
+        raise NameError if (name_str = name.to_s.downcase).blank?
+        Billing.const_get("#{name_str}_gateway".camelize)
       end
 
       # Return the matching integration module

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -18,6 +18,20 @@ class BaseTest < Test::Unit::TestCase
     assert_equal LinkpointGateway,     Base.gateway(:linkpoint)
   end
 
+  def test_should_raise_when_invalid_gateway_is_passed
+    assert_raise NameError do
+      Base.gateway(:nil)
+    end
+
+    assert_raise NameError do
+      Base.gateway('')
+    end
+
+    assert_raise NameError do
+      Base.gateway(:hotdog)
+    end
+  end
+
   def test_should_return_an_integration_by_name
     chronopay = Base.integration(:chronopay)
     


### PR DESCRIPTION
Passing an invalid gateway to `ActiveMerchant::Billing::Base.gateway` raises `NameError`:

``` ruby
irb(main):007:0> ActiveMerchant::Billing::Base.gateway('hotdog')
NameError: uninitialized constant ActiveMerchant::Billing::HotdogGateway
```

However, passing something that casts to an empty string will return `ActiveMerchant::Billing::Gateway`:

``` ruby
irb(main):005:0> ActiveMerchant::Billing::Base.gateway(nil)
=> ActiveMerchant::Billing::Gateway
irb(main):006:0> ActiveMerchant::Billing::Base.gateway('')
=> ActiveMerchant::Billing::Gateway
```

**Note**: Should we look into raising a custom error instead of `NameError`? We could use `const_defined?` to determine. This is a breaking change though since some people probably rescue from `NameError`.
### Review

@jduff @melari
