### PR TITLE
fixes #770 purchase with card token or card id

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -183,14 +183,14 @@ module ActiveMerchant #:nodoc:
           if options[:track_data]
             card[:swipe_data] = options[:track_data]
           else
-            card[:number] = creditcard
+            card = creditcard
           end
           post[:card] = card
         end
       end
 
       def add_customer(post, options)
-        post[:customer] = options[:customer] if options[:customer] && !post[:card]
+        post[:customer] = options[:customer] if options[:customer]
       end
 
       def add_flags(post, options)


### PR DESCRIPTION
Stripe supports charging a card token or a customer's card.
A card number only be passed with an associated customer.

Both methods are documented:

"If you also pass a customer ID, the card must be the ID of a card
belonging to the customer. Otherwise, if you do not pass a customer
ID, the card you provide must either be a token, like the ones returned
by Stripe.js, or a dictionary containing a user's credit card details"
    - https://stripe.com/docs/api#create_charge

Resolved this issue by allowing the api user to pass in flags in the
options hash.

a) options[:is_token] :
    charging a card token
b) options[:is_customer_card_id] :
    charging a customer's card.
    options[:customer] should also be included.

Request parameters.
a) Charging a card token:
curl https://api.stripe.com/v1/charges \
   -u sk_test_NMgf6M5lzRW3Vp345LJvR6Ua: \
   -d amount=208973 \
   -d currency=usd \
   -d card=tok_2DWWZ7t5sJQZPt \
   -d "description=Charge for test@example.com"

b) Charging a charging a card id.
{
    amount: "90707"
    currency: "usd"
    customer: cus_2IJycssqIpDju6
    card: cc_2IJy79OB3PjOCh
    description: "Spree Order ID: R252432727-AEWE8QED"
    payment_user_agent: "Stripe/v1 ActiveMerchantBindings/1.36.0"
}
