### PR TITLE
Fix status messages for PayU.

### DIFF
--- a/lib/active_merchant/billing/integrations/payu_in/notification.rb
+++ b/lib/active_merchant/billing/integrations/payu_in/notification.rb
@@ -11,24 +11,22 @@ module ActiveMerchant #:nodoc:
           end
 
           def complete?
-            status == "success"
+            status == "Completed"
           end
 
-          # Status of the transaction. List of possible values:
-          # <tt>invalid</tt>:: transaction id is not present
-          # <tt>tampered</tt>:: transaction data has been tampered
-          # <tt>success</tt>:: transaction successful
-          # <tt>pending</tt>:: transaction is pending for some approval
-          # <tt>failure</tt>:: transaction failure
           def status
             @status ||= if checksum_ok?
               if transaction_id.blank?
-                'invalid'
+                'Invalid'
               else
-                transaction_status.downcase
+                case transaction_status.downcase
+                when 'success' then 'Completed'
+                when 'failure' then 'Failed'
+                when 'pending' then 'Pending'
+                end
               end
             else
-              'tampered'
+              'Tampered'
             end
           end
 

--- a/lib/active_merchant/billing/integrations/payu_in/return.rb
+++ b/lib/active_merchant/billing/integrations/payu_in/return.rb
@@ -9,37 +9,20 @@ module ActiveMerchant #:nodoc:
             @notification = Notification.new(query_string, options)
           end
 
-          # PayU Transaction Id
-          #
           def transaction_id
             @notification.transaction_id
           end
 
-          # Returns the status of the transaction as a string
-          # The status can be one of the following
-          #
-          # invalid - transaction id not present
-          # tampered - checksum does not mismatch
-          # mismatch - order id mismatch
-          # success - transaction success
-          # pending - transaction pending
-          # failure - transaction failure
-          #
-          # payu does not put the discount field in the checksum
-          # it can be easily forged by the attacker without detection
-          #
           def status( order_id, order_amount )
             if @notification.invoice_ok?( order_id ) && @notification.amount_ok?( BigDecimal.new(order_amount) )
               @notification.status
             else
-              'mismatch'
+              'Mismatch'
             end
           end
 
-          # check success of the transaction
-          # check order_id and
           def success?
-            status( @params['txnid'], @params['amount'] ) == 'success'
+            status( @params['txnid'], @params['amount'] ) == 'Completed'
           end
 
           def message

--- a/test/unit/integrations/notifications/payu_in_notification_test.rb
+++ b/test/unit/integrations/notifications/payu_in_notification_test.rb
@@ -9,7 +9,7 @@ class PayuInNotificationTest < Test::Unit::TestCase
 
   def test_accessors
     assert @payu.complete?
-    assert_equal "success", @payu.status
+    assert_equal "Completed", @payu.status
     assert_equal "403993715508030204", @payu.transaction_id
     assert_equal "success", @payu.transaction_status
     assert_equal "10.00", @payu.gross

--- a/test/unit/integrations/returns/payu_in_return_test.rb
+++ b/test/unit/integrations/returns/payu_in_return_test.rb
@@ -13,24 +13,24 @@ class PayuInReturnTest < Test::Unit::TestCase
 
   def test_success
     assert @payu.success?
-    assert_equal 'success', @payu.status('4ba4afe87f7e73468f2a','10.00')
+    assert_equal 'Completed', @payu.status('4ba4afe87f7e73468f2a','10.00')
   end
 
   def test_failure_is_successful
     setup_failed_return
-    assert_equal 'failure', @payu.status('8ae1034d1abf47fde1cf', '10.00')
+    assert_equal 'Failed', @payu.status('8ae1034d1abf47fde1cf', '10.00')
   end
 
   def test_treat_initial_failures_as_pending
     setup_failed_return
-    assert_equal 'failure', @payu.notification.status
+    assert_equal 'Failed', @payu.notification.status
   end
 
   def test_return_has_notification
     notification = @payu.notification
 
     assert notification.complete?
-    assert_equal 'success', notification.status
+    assert_equal 'Completed', notification.status
     assert notification.invoice_ok?('4ba4afe87f7e73468f2a')
     assert notification.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
     assert_equal "success", notification.transaction_status


### PR DESCRIPTION
This changes the PayU integration to use standard status messages. (`Completed` instead of `success` and `Failed` instead of `failure`).

This fixes Shopify/shopify#7094

@jduff @odorcicd 
/cc @DavidGeukers @louiskearns 
