### PR TITLE
gemspec: Dont force nokogiri lesser than 1.6.0

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('json', '>= 1.5.1')
   s.add_dependency('active_utils', '>= 1.0.2')
-  s.add_dependency('nokogiri', "< 1.6.0")
+  s.add_dependency('nokogiri', ">= 1.5.10")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 0.13.0')


### PR DESCRIPTION
Nokogiri drop support for Ruby 1.8 with nokogiri 1.6.0.
It fix a lot of bugs with libxml2 and others.
- https://github.com/sparklemotion/nokogiri/commit/7c5f3f6c444b73192abbcc19ef9e3c987cdf7ab0

And force a user to downgrade his nokogiri version is not very friendly to
a project that want to be up-to-date.

ref #765
