### PR TITLE
Firstdata E4: Include missing address information for AVS and CVV results

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
         if credit_card_or_store_authorization.is_a? String
           add_credit_card_token(xml, credit_card_or_store_authorization)
         else
-          add_credit_card(xml, credit_card_or_store_authorization)
+          add_credit_card(xml, credit_card_or_store_authorization, options)
         end
 
         add_customer_data(xml, options)
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
       def build_store_request(credit_card, options)
         xml = Builder::XmlMarkup.new
 
-        add_credit_card(xml, credit_card)
+        add_credit_card(xml, credit_card, options)
         add_customer_data(xml, options)
 
         xml.target!
@@ -164,11 +164,22 @@ module ActiveMerchant #:nodoc:
         xml.tag! "DollarAmount", amount(money)
       end
 
-      def add_credit_card(xml, credit_card)
+      def add_credit_card(xml, credit_card, options)
         xml.tag! "Card_Number", credit_card.number
         xml.tag! "Expiry_Date", expdate(credit_card)
         xml.tag! "CardHoldersName", credit_card.name
         xml.tag! "CardType", credit_card.brand
+
+        add_credit_card_verification_strings(xml, credit_card, options)
+      end
+
+      def add_credit_card_verification_strings(xml, credit_card, options)
+        address = options[:billing_address] || options[:address]
+        if address
+          address_values = []
+          [:address1, :zip, :city, :state, :country].each { |part| address_values << address[part].to_s }
+          xml.tag! "VerificationStr1", address_values.join("|")
+        end
 
         if credit_card.verification_value?
           xml.tag! "CVD_Presence_Ind", "1"

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -78,4 +78,12 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_match /Unauthorized Request/, response.message
     assert_failure response
   end
+
+  def test_response_contains_cvv_and_avs_results
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'M', response.cvv_result["code"]
+    assert_equal '1', response.avs_result["code"]
+  end
+
 end

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'yaml'
 
 class FirstdataE4Test < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = FirstdataE4Gateway.new(
       :login    => "A00427-01",
@@ -105,6 +107,14 @@ class FirstdataE4Test < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card)
     assert_equal 'M', response.cvv_result['code']
+  end
+
+  def test_requests_include_verification_string
+    stub_comms(:ssl_post) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<VerificationStr1>1234 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>", data
+    end.respond_with(successful_purchase_response)
   end
 
   private


### PR DESCRIPTION
This adds in a missing field "VerificationStr1" to firstdata e4 requests. We were already sending "VerificationStr2", but both are required to get AVS and CVV results back.

@jduff @odorcicd 
