### PR TITLE
added missing authorization_code param to response

### DIFF
--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -106,6 +106,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     assert_equal Response, response.class
     assert_equal ["action",
+                  "authorization_code",
                   "avs_result_code",
                   "card_code",
                   "response_code",
@@ -128,6 +129,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     assert_equal Response, response.class
     assert_equal ["action",
+                  "authorization_code",
                   "avs_result_code",
                   "card_code",
                   "response_code",


### PR DESCRIPTION
I ran remote test with my credentials and I realized that the response had changed. I have updated the response expected in the test.
