### PR TITLE
Paysbuy: Added 'Pending' notification status

### DIFF
--- a/lib/active_merchant/billing/integrations/paysbuy/notification.rb
+++ b/lib/active_merchant/billing/integrations/paysbuy/notification.rb
@@ -5,6 +5,7 @@ module ActiveMerchant #:nodoc:
         class Notification < ActiveMerchant::Billing::Integrations::Notification
           SUCCESS = '00'
           FAIL = '99'
+          PENDING = '02'
 
           def complete?
             status == 'Completed'
@@ -15,7 +16,17 @@ module ActiveMerchant #:nodoc:
           end
 
           def status
-            params['result'][0..1] == SUCCESS ? 'Completed' : 'Failed'
+            status_code = params['result'][0..1]
+            case status_code
+            when SUCCESS
+              'Completed'
+            when FAIL
+              'Failed'
+            when PENDING
+              'Pending'
+            else
+              raise "Unknown status code"
+            end
           end
 
           def acknowledge

--- a/test/unit/integrations/notifications/paysbuy_notification_test.rb
+++ b/test/unit/integrations/notifications/paysbuy_notification_test.rb
@@ -3,19 +3,26 @@ require 'test_helper'
 class PaysbuyNotificationTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
-  def setup
-    @paysbuy = Paysbuy::Notification.new(http_raw_data)
-  end
-
-  def test_accessors
-    assert @paysbuy.complete?
-    assert_equal "Completed", @paysbuy.status
+  def test_item_id
+    @paysbuy = Paysbuy::Notification.new("result=00100013")
     assert_equal "100013", @paysbuy.item_id
   end
 
-  private
+  def test_result_completed
+    @paysbuy = Paysbuy::Notification.new("result=00100013")
+    assert @paysbuy.complete?
+    assert_equal "Completed", @paysbuy.status
+  end
 
-  def http_raw_data
-    "result=00100013"
+  def test_result_failed
+    @paysbuy = Paysbuy::Notification.new("result=99100013")
+    assert !@paysbuy.complete?
+    assert_equal "Failed", @paysbuy.status
+  end
+
+  def test_result_pending
+    @paysbuy = Paysbuy::Notification.new("result=02100013")
+    assert !@paysbuy.complete?
+    assert_equal "Pending", @paysbuy.status
   end
 end


### PR DESCRIPTION
Added missed 'Pending' status. Paysbuy uses it for Counter Service.
