### PR TITLE
SecureNet: Allow some optional fields

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -182,8 +182,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(xml, options)
-        xml.tag! 'INVOICEDESC', options[:description]
-        xml.tag! 'INVOICENUM', 'inv-8'
+        xml.tag! 'NOTE', options[:description] if options[:description]
+        xml.tag! 'INVOICEDESC', options[:invoice_description] if options[:invoice_description]
+        xml.tag! 'INVOICENUM', options[:invoice_number] if options[:invoice_number]
       end
 
       def add_merchant_key(xml, options)


### PR DESCRIPTION
Now :invoice_description and :invoice_number can be specified in the
options for a purchase or an authorization and we map :description to
the much larger NOTES field.

http://cl.ly/image/2e360n1g1T21/content.png
