### PR TITLE
Balanced: Adjust BalancedGateway::Error parent

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Balanced'
       self.money_format = :cents
 
-      class Error < StandardError
+      class Error < ActiveMerchant::ActiveMerchantError
         attr_reader :response
 
         def initialize(response, msg=nil)


### PR DESCRIPTION
It's now ActiveMerchant::ActiveMerchantError rather than StandardError.
We want to allow users of ActiveMerchant to generically rescue errors
without having to have special gateway specific handling.
