### PR TITLE
Balanced: Fix #void interface

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -210,7 +210,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>authorization</tt> -- The uri of the authorization returned from
       #   an `authorize` request.
-      def void(authorization)
+      def void(authorization, options = {})
         post = {}
         post[:is_void] = true
 


### PR DESCRIPTION
The other gateways take an optional options hash as a second parameter.
Now Balanced does as well, allowing us to call the #void method in the
same way regardless of which gateway we're talking to.
