### PR TITLE
Dont force old nokogiri versions... again

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('active_utils', '~> 2.0')
-  s.add_dependency('nokogiri', "~> 1.4")
+  s.add_dependency('nokogiri', ">= 1.4.7")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 0.13.0')


### PR DESCRIPTION
As per the reasons in #813 and #765 we shouldn't force nokogiri 1.4. This was already fixed by #813 but then bungled by #815.
