### PR TITLE
Fix that referring to a card token no longer worked

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -183,7 +183,7 @@ module ActiveMerchant #:nodoc:
           if options[:track_data]
             card[:swipe_data] = options[:track_data]
           else
-            card[:number] = creditcard
+            card = creditcard
           end
           post[:card] = card
         end


### PR DESCRIPTION
When using the card token option, you have to submit a string value for the card, like card=tok_XXX, rather than card[number]=tok_XXX, otherwise it takes it as the literal card number, which obviously fails, because tok_XXX is not a valid card number.
