### PR TITLE
Change CyberSource address retrieval from :phone_number to :phone

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -414,7 +414,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'country',               address[:country]
           xml.tag! 'company',               address[:company]                 unless address[:company].blank?
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
-          xml.tag! 'phoneNumber',           address[:phone_number]            unless address[:phone_number].blank?
+          xml.tag! 'phoneNumber',           address[:phone]                   unless address[:phone].blank?
           xml.tag! 'email',                 options[:email]
           xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
           xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?


### PR DESCRIPTION
The documentation for using the CyberSource gateway states to pay special
attention to the options hash from the specs, but the actual gateway code did
not use the same hash structure as the specs. `:phone` is used in the specs,
but the retrieval key in the gateway code is `:phone_number`. This causes the
gateway to throw an error.

I chose to update the application code rather than the specs because the
usage of the :phone key seems much more standardized (based on the
contribution guideline docs as well as the `#address` helper method that gets
used in `test_helper.rb`) than the :phone_number key. The specs could
certainly be updated instead without affecting existing code.
