### PR TITLE
Cybersource: Remove email requirement

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -401,8 +401,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(xml, payment_method, address, options, shipTo = false)
-        requires!(options, :email)
-
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
           xml.tag! 'firstName',             payment_method.first_name             if payment_method
           xml.tag! 'lastName',              payment_method.last_name              if payment_method


### PR DESCRIPTION
No longer raise an ArgumentError when email isn't specified.  Instead
let the gateway itself complain if that's required.

This makes the code for Cybersource more consistent with the other
gateways.
