### PR TITLE
WorldPay Direct: Allow transactions with a status of SETTLED_BY_MERCHANT to be refunded.

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options = {})
         MultiResponse.run do |r|
-          r.process{inquire_request(authorization, options, "CAPTURED", "SETTLED")}
+          r.process{inquire_request(authorization, options, "CAPTURED", "SETTLED", "SETTLED_BY_MERCHANT")}
           r.process{refund_request(money, authorization, options)}
         end
       end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -103,7 +103,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(30, response.authorization)
     assert_failure refund
-    assert_equal "A transaction status of 'CAPTURED' or 'SETTLED' is required.", refund.message
+    assert_equal "A transaction status of 'CAPTURED' or 'SETTLED' or 'SETTLED_BY_MERCHANT' is required.", refund.message
   end
 
   def test_refund_nonexistent_transaction

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -107,7 +107,7 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.refund(@amount, @options[:order_id], @options)
     end.respond_with(failed_refund_inquiry_response, successful_refund_response)
     assert_failure response
-    assert_equal "A transaction status of 'CAPTURED' or 'SETTLED' is required.", response.message
+    assert_equal "A transaction status of 'CAPTURED' or 'SETTLED' or 'SETTLED_BY_MERCHANT' is required.", response.message
   end
 
   def test_capture


### PR DESCRIPTION
Fixes #812

Looks like worldpay added a "SETTLED_BY_MERCHANT" status that a transaction can have. This fixes a remote test that started failing because of it, and fixes the refund method to work with transactions that have this new status.

@jduff @silverstreaked 
