### PR TITLE
spreedly-core should supply country with other cc information

### DIFF
--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -147,6 +147,7 @@ module ActiveMerchant #:nodoc:
           doc.city(options[:billing_address].try(:[], :city))
           doc.state(options[:billing_address].try(:[], :state))
           doc.zip(options[:billing_address].try(:[], :zip))
+          doc.country(options[:billing_address].try(:[], :country))
         end
       end
 


### PR DESCRIPTION
Adds country to cc information in spreedly-core
