### PR TITLE
SecureNet: Fix order of xml params

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -93,9 +93,8 @@ module ActiveMerchant #:nodoc:
 
         xml.tag! 'AMOUNT', amount(money)
         add_credit_card(xml, creditcard)
-        add_required_params(xml, action, options)
+        add_params_in_required_order(xml, action, options)
         add_address(xml, creditcard, options)
-        add_invoice(xml, options)
         add_more_required_params(xml, options)
 
         xml.target!
@@ -111,7 +110,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'CARDNUMBER', last_four
         end
 
-        add_required_params(xml, action, options)
+        add_params_in_required_order(xml, action, options)
         xml.tag! 'REF_TRANSID', transaction_id
         add_more_required_params(xml, options)
 
@@ -181,12 +180,6 @@ module ActiveMerchant #:nodoc:
 
       end
 
-      def add_invoice(xml, options)
-        xml.tag! 'NOTE', options[:description] if options[:description]
-        xml.tag! 'INVOICEDESC', options[:invoice_description] if options[:invoice_description]
-        xml.tag! 'INVOICENUM', options[:invoice_number] if options[:invoice_number]
-      end
-
       def add_merchant_key(xml, options)
         xml.tag!("MERCHANT_KEY") do
           xml.tag! 'GROUPID', 0
@@ -195,13 +188,17 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_required_params(xml, action, options)
+      # SecureNet requires some of the xml params to be in a certain order.  http://cl.ly/image/3K260E0p0a0n/content.png
+      def add_params_in_required_order(xml, action, options)
         xml.tag! 'CODE', TRANSACTIONS[action]
         add_customer_data(xml, options)
         xml.tag! 'DCI', 0 # No duplicate checking will be done, except for ORDERID
         xml.tag! 'INSTALLMENT_SEQUENCENUM', 1
+        xml.tag! 'INVOICEDESC', options[:invoice_description] if options[:invoice_description]
+        xml.tag! 'INVOICENUM', options[:invoice_number] if options[:invoice_number]
         add_merchant_key(xml, options)
         xml.tag! 'METHOD', 'CC'
+        xml.tag! 'NOTE', options[:description] if options[:description]
         xml.tag! 'ORDERID', options[:order_id]
         xml.tag! 'OVERRIDE_FROM', 0 # Docs say not required, but doesn't work without it
       end

--- a/test/remote/gateways/remote_secure_net_test.rb
+++ b/test/remote/gateways/remote_secure_net_test.rb
@@ -12,15 +12,15 @@ class SecureNetTest < Test::Unit::TestCase
 
     n = Time.now
     order_id = n.to_i.to_s + n.usec.to_s
-    @options = { 
-      :order_id => order_id,
-      :billing_address => address,
-      :description => 'Store Purchase'
+    @options = {
+      order_id: order_id,
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
   def test_expired_credit_card
-    @credit_card.year = 2004 
+    @credit_card.year = 2004
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert response.test?
@@ -109,6 +109,20 @@ class SecureNetTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_failure refund
     assert_equal 'CREDIT CANNOT BE COMPLETED ON AN UNSETTLED TRANSACTION', refund.message
+  end
+
+  def test_invoice_description_and_number
+    options = @options.merge({
+      invoice_description: "TheInvoiceDescriptions",
+      invoice_number: "TheInvoiceNumber"
+    })
+
+    assert auth = @gateway.authorize(@amount, @credit_card, options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, options)
+    assert_success capture
+    assert_equal 'Approved', capture.message
   end
 
 end


### PR DESCRIPTION
SecureNet doesn't seem to pick up the invoice description and invoice
number if they show up after the merchant key.  And they seem to want
the note field after the method field.  Perhaps someday they'll fix this
to not be order dependent.  For now, we'll jump through some hoops.
