### PR TITLE
Add Citrus integration

### DIFF
--- a/lib/active_merchant/billing/integrations/action_view_helper.rb
+++ b/lib/active_merchant/billing/integrations/action_view_helper.rb
@@ -49,7 +49,8 @@ module ActiveMerchant #:nodoc:
           service = service_class.new(order, account, options)
           form_options[:method] = service.form_method
           result = []
-          result << form_tag(integration_module.service_url, form_options)
+          service_url = integration_module.respond_to?(:credential_based_url) ? integration_module.credential_based_url(options) : integration_module.service_url
+          result << form_tag(service_url, form_options)
 
           result << capture(service, &proc)
 

--- a/lib/active_merchant/billing/integrations/citrus.rb
+++ b/lib/active_merchant/billing/integrations/citrus.rb
@@ -1,54 +1,50 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    module Integrations #:nodoc:
+module ActiveMerchant
+  module Billing
+    module Integrations
       module Citrus
-		autoload :Helper, File.dirname(__FILE__) + '/citrus/helper.rb'
+        autoload :Helper, File.dirname(__FILE__) + '/citrus/helper.rb'
         autoload :Notification, File.dirname(__FILE__) + '/citrus/notification.rb'
         autoload :Return, File.dirname(__FILE__) + '/citrus/return.rb'
-        
+
         mattr_accessor :sandbox_url
         mattr_accessor :staging_url
         mattr_accessor :production_url
-        mattr_accessor :pmt_url
-		
-		
+
         self.sandbox_url = 'https://sandbox.citruspay.com/'
         self.staging_url = 'https://stg.citruspay.com/'
         self.production_url = 'https://www.citruspay.com/'
-        
-		
-        def self.service_url
-          mode = ActiveMerchant::Billing::Base.integration_mode
-          case mode
+
+        def self.credential_based_url(options)
+          pmt_url = options[:credential3]
+
+          case ActiveMerchant::Billing::Base.integration_mode
           when :production
-            self.production_url + self.pmt_url   
+            self.production_url + pmt_url
           when :test
-            self.sandbox_url + self.pmt_url
+            self.sandbox_url    + pmt_url
           when :staging
-          	self.staging_url + self.pmt_url
+          	self.staging_url    + pmt_url
           else
             raise StandardError, "Integration mode set to an invalid value: #{mode}"
           end
         end
 
-		def self.helper(order, account, options = {})
+        def self.helper(order, account, options = {})
           Helper.new(order, account, options)
         end
-		
+
         def self.notification(post, options = {})
-          Notification.new(post)
+          Notification.new(post, options)
         end
-        
+
         def self.return(query_string, options = {})
-          Return.new(query_string)
+          Return.new(query_string, options)
         end
-        
+
         def self.checksum(secret_key, payload_items )
-         digest = OpenSSL::Digest::Digest.new('sha1')
-		 sig=OpenSSL::HMAC.hexdigest(digest, secret_key, payload_items)
-		 return sig
+          digest = OpenSSL::Digest::Digest.new('sha1')
+		      OpenSSL::HMAC.hexdigest(digest, secret_key, payload_items)
         end
-        
       end
     end
   end

--- a/lib/active_merchant/billing/integrations/citrus/helper.rb
+++ b/lib/active_merchant/billing/integrations/citrus/helper.rb
@@ -1,41 +1,39 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    module Integrations #:nodoc:
+module ActiveMerchant
+  module Billing
+    module Integrations
       module Citrus
         class Helper < ActiveMerchant::Billing::Integrations::Helper
-          
-		  mapping :order, 'merchantTxnId'
-		  mapping :amount, 'orderAmount'
+
+          mapping :order, 'merchantTxnId'
+          mapping :amount, 'orderAmount'
           mapping :account, 'merchantAccessKey'
-		  mapping :credential2, 'secret_key'
-		  mapping :credential3, 'pmt_url'
+          mapping :credential2, 'secret_key'
+          mapping :credential3, 'pmt_url'
           mapping :currency, 'currency'
-		  
+
           mapping :customer, :first_name => 'firstName',:last_name => 'lastName', :email => 'email', :phone => 'mobileNo'
 
           mapping :billing_address, :city => 'addressCity', :address1 => 'addressStreet1', :address2 => 'addressStreet2',:state => 'addressState',:zip => 'addressZip', :country => 'addressCountry'
 
-		  mapping :checksum, 'secSignature'
+          mapping :checksum, 'secSignature'
           mapping :return_url, 'returnUrl'
-		  
-		  
-		  def initialize(order, account, options = {})
+
+
+          def initialize(order, account, options = {})
             super
-			add_field 'paymentMode', 'NET_BANKING'
-			add_field 'reqtime', (Time.now.to_i * 1000).to_s
-          end
-		
-          def form_fields
-		  	@fields.merge(mappings[:checksum] => generate_checksum)
+            add_field 'paymentMode', 'NET_BANKING'
+            add_field 'reqtime', (Time.now.to_i * 1000).to_s
           end
 
-          def generate_checksum()
-            checksum_fields = @fields["pmt_url"] + @fields["orderAmount"].to_s + @fields["merchantTxnId"] + @fields["currency"] 
+          def form_fields
+            @fields.merge(mappings[:checksum] => generate_checksum)
+          end
+
+          def generate_checksum
+            checksum_fields = @fields["pmt_url"] + @fields["orderAmount"].to_s + @fields["merchantTxnId"] + @fields["currency"]
             Citrus.checksum(@fields["secret_key"],  checksum_fields )
           end
-
         end
-
       end
     end
   end

--- a/lib/active_merchant/billing/integrations/citrus/notification.rb
+++ b/lib/active_merchant/billing/integrations/citrus/notification.rb
@@ -1,32 +1,30 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    module Integrations #:nodoc:
+module ActiveMerchant
+  module Billing
+    module Integrations
       module Citrus
         class Notification < ActiveMerchant::Billing::Integrations::Notification
-      	  
+
       	  def initialize(post, options = {})
             super(post, options)
             @secret_key = options[:credential2]
           end
 
           def complete?
-            status == "success" || status == 'canceled'
+            status == "Completed" || status == 'Canceled'
           end
 
-          # Status of the transaction. List of possible values:
-          # <tt>invalid</tt>:: transaction id is not present
-          # <tt>tampered</tt>:: transaction data has been tampered
-          # <tt>success</tt>:: transaction successful
-          # <tt>canceled</tt>:: transaction is pending for some approval
           def status
             @status ||= if checksum_ok?
               if transaction_id.blank?
-                'invalid'
+                'Invalid'
               else
-                transaction_status.downcase
+                case transaction_status.downcase
+                when 'success' then 'Completed'
+                when 'canceled' then 'Canceled'
+                end
               end
             else
-              'tampered'
+              'Tampered'
             end
           end
 
@@ -34,16 +32,16 @@ module ActiveMerchant #:nodoc:
             order_id.to_s == invoice.to_s
           end
 
-          # Order amount should be equal to gross - discount
           def amount_ok?( order_amount )
-            BigDecimal.new( amount ) == order_amount 
+            BigDecimal.new( amount ) == order_amount
           end
-		  
-		  # capture Citrus response parameters
-		  
-		  # This is the invoice which you passed to Citrus
-          def invoice
+
+          def item_id
             params['TxId']
+          end
+
+          def invoice
+            item_id
           end
 
           # Status of transaction return from the Citrus. List of possible values:
@@ -52,86 +50,76 @@ module ActiveMerchant #:nodoc:
           def transaction_status
             params['TxStatus']
           end
-		  
-          # amount paid by customer
-          def amount
+
+          def gross
             params['amount']
           end
-		  		
-          # ID of this transaction returned by Citrus
+
+          def amount
+            gross
+          end
+
           def transaction_id
             params['pgTxnNo']
           end
-		  
-		  # for future use	
-          def issuerrefno
-		  	params['issuerRefNo']
-		  end
 
-		  # authorization code by Citrus
-		  def authidcode
-		  	params['authIdCode']
-		  end
-		  
-		  # gateway resp code by Citrus
-		  def pgrespcode
-		  	params['pgRespCode']
-		  end
-		  
-		  # by Citrus
-		  def checksum
+          def issuerrefno
+            params['issuerRefNo']
+          end
+
+          def authidcode
+            params['authIdCode']
+          end
+
+          def pgrespcode
+            params['pgRespCode']
+          end
+
+          def checksum
             params['signature']
           end
-		  
-		  def paymentmode
-		  	params['paymentMode']
-		  end
-		  
-          # payment currency
+
+          def paymentmode
+            params['paymentMode']
+          end
+
           def currency
             params['currency']
           end
 
-		  
-          # Email of the customer
           def customer_email
             params['email']
           end
 
-          # Phone of the customer
           def customer_phone
             params['mobileNo']
           end
 
-          # Firstname of the customer
           def customer_first_name
             params['firstName']
           end
 
-          # Lastname of the customer
           def customer_last_name
             params['lastName']
           end
 
-          # Full address of the customer
           def customer_address
             { :address1 => params['addressStreet1'], :address2 => params['addressStreet2'],
               :city => params['addressCity'], :state => params['addressState'],
               :country => params['addressCountry'], :zip => params['addressZip'] }
           end
 
-
           def message
             @message || params['TxMsg']
           end
-          
+
           def acknowledge
             checksum_ok?
           end
 
           def checksum_ok?
             fields = invoice + transaction_status + amount.to_s + transaction_id + issuerrefno + authidcode + customer_first_name + customer_last_name + pgrespcode + customer_address[:zip]
-            
+
             unless Citrus.checksum(@secret_key, fields ) == checksum
               @message = 'checksum mismatch...'
               return false

--- a/lib/active_merchant/billing/integrations/citrus/return.rb
+++ b/lib/active_merchant/billing/integrations/citrus/return.rb
@@ -1,6 +1,6 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    module Integrations #:nodoc:
+module ActiveMerchant
+  module Billing
+    module Integrations
       module Citrus
         class Return < ActiveMerchant::Billing::Integrations::Return
 
@@ -9,8 +9,6 @@ module ActiveMerchant #:nodoc:
             @notification = Notification.new(query_string, options)
           end
 
-          # Citrus Transaction Id
-          #
           def transaction_id
             @notification.transaction_id
           end
@@ -19,18 +17,20 @@ module ActiveMerchant #:nodoc:
             if @notification.invoice_ok?( order_id ) && @notification.amount_ok?( BigDecimal.new(order_amount) )
               @notification.status
             else
-              'mismatch'
+              'Mismatch'
             end
           end
 
-          # check success of the transaction
-          # check order_id and
           def success?
-            status( @params['TxId'], @params['amount'] ) == 'success'
+            status( @params['TxId'], @params['amount'] ) == 'Completed'
           end
 
           def message
             @notification.message
+          end
+
+          def cancelled?
+            @notification.status == 'Cancelled'
           end
 
         end

--- a/test/unit/integrations/citrus_module_test.rb
+++ b/test/unit/integrations/citrus_module_test.rb
@@ -8,24 +8,25 @@ class CitrusModuleTest < Test::Unit::TestCase
     @access_key = 'G0JW45KCS3630NX335YX'
     @secret_key = '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9'
     @pmt_url = 'gqwnliur74'
+
+    @options = {
+      :credential2 => @secret_key,
+      :credential3 => @pmt_url
+    }
   end
 
-  def test_service_url_method
-  	Citrus.pmt_url=@pmt_url
-	ActiveMerchant::Billing::Base.integration_mode = :test
-    assert_equal 'https://sandbox.citruspay.com/gqwnliur74', Citrus.service_url
-	p Citrus.service_url
+  def test_credential_based_url_method
+	  ActiveMerchant::Billing::Base.integration_mode = :test
+    assert_equal 'https://sandbox.citruspay.com/gqwnliur74', Citrus.credential_based_url(@options)
   end
-  
+
   def test_production_service_url_method
-  	Citrus.pmt_url=@pmt_url
-	ActiveMerchant::Billing::Base.integration_mode = :production
-    assert_equal 'https://www.citruspay.com/gqwnliur74', Citrus.service_url
-    p Citrus.service_url
+	  ActiveMerchant::Billing::Base.integration_mode = :production
+    assert_equal 'https://www.citruspay.com/gqwnliur74', Citrus.credential_based_url(@options)
   end
 
   def test_helper_method
-    assert_instance_of Citrus::Helper, Citrus.helper('ORD01','G0JW45KCS3630NX335YX', :amount => 10.0, :currency => 'USD', :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9', :credential3 => 'gqwnliur74')
+    assert_instance_of Citrus::Helper, Citrus.helper('ORD01','G0JW45KCS3630NX335YX', @options.merge(:amount => 10.0, :currency => 'USD'))
   end
 
   def test_return_method
@@ -35,10 +36,9 @@ class CitrusModuleTest < Test::Unit::TestCase
   def test_notification_method
     assert_instance_of Citrus::Notification, Citrus.notification('name=cody')
   end
-  
+
   def test_checksum_method
-    payu_load = @pmt_url+"10"+"ORD123"+"USD"
-    assert_equal "ecf7eaafec270b9b91b898e7f8e794c30245eb7f", Citrus.checksum(@secret_key, payu_load)
+    citrus_load = @pmt_url+"10"+"ORD123"+"USD"
+    assert_equal "ecf7eaafec270b9b91b898e7f8e794c30245eb7f", Citrus.checksum(@secret_key, citrus_load)
   end
-  
 end

--- a/test/unit/integrations/helpers/citrus_helper_test.rb
+++ b/test/unit/integrations/helpers/citrus_helper_test.rb
@@ -2,30 +2,26 @@ require 'test_helper'
 
 class CitrusHelperTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
-  
+
   def setup
     @helper = Citrus::Helper.new('ORD123','G0JW45KCS3630NX335YX', :amount => 10, :currency => 'USD', :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9', :credential3 => 'gqwnliur74')
   end
-  
- 
+
   def test_basic_helper_fields
- 
     assert_equal '10', @helper.fields['orderAmount']
     assert_equal 'ORD123', @helper.fields['merchantTxnId']
     assert_equal 'G0JW45KCS3630NX335YX', @helper.fields['merchantAccessKey']
     assert_equal '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9', @helper.fields['secret_key']
-	assert_equal 'USD', @helper.fields['currency']
-	assert_equal 'gqwnliur74', @helper.fields['pmt_url']
-	assert_equal 'NET_BANKING', @helper.fields['paymentMode']
-	
+    assert_equal 'USD', @helper.fields['currency']
+    assert_equal 'gqwnliur74', @helper.fields['pmt_url']
+    assert_equal 'NET_BANKING', @helper.fields['paymentMode']
   end
-  
+
   def test_customer_fields
     @helper.customer :first_name => 'Amit', :last_name => 'Pandey', :email => 'support@viatechs.in', :phone => '9832120202'
     assert_field 'firstName', 'Amit'
     assert_field 'lastName', 'Pandey'
     assert_field 'email', 'support@viatechs.in'
-	assert_field 'mobileNo', '9832120202'
   end
 
   def test_address_mapping
@@ -35,16 +31,15 @@ class CitrusHelperTest < Test::Unit::TestCase
                             :state => 'New York',
                             :zip => 'NY 12207',
                             :country  => 'US'
-   
+
     assert_field 'addressStreet1', '22 Avenue'
     assert_field 'addressStreet2', 'South'
     assert_field 'addressCity', 'Albany'
     assert_field 'addressState', 'New York'
-	assert_field 'addressZip', 'NY 12207'
-	assert_field 'addressCountry', 'US'
-	
+    assert_field 'addressZip', 'NY 12207'
+    assert_field 'addressCountry', 'US'
   end
-  
+
   def test_unknown_address_mapping
     @helper.billing_address :farm => 'CA'
     assert_equal 8, @helper.fields.size
@@ -52,21 +47,21 @@ class CitrusHelperTest < Test::Unit::TestCase
 
   def test_form_fields
    	assert_equal 'ecf7eaafec270b9b91b898e7f8e794c30245eb7f', @helper.form_fields["secSignature"]
-	rt = (Time.now.to_i * 1000).to_s
+    rt = (Time.now.to_i * 1000).to_s
   	assert_equal rt, @helper.fields['reqtime']
   end
 
   def test_return_url_fields
     @helper.return_url 'some_return_url'
-	assert_equal 'some_return_url', @helper.fields['returnUrl']
+    assert_equal 'some_return_url', @helper.fields['returnUrl']
   end
-  
+
   def test_unknown_mapping
     assert_nothing_raised do
       @helper.company_address :address => '500 Dwemthy Fox Road'
     end
   end
-  
+
   def test_setting_invalid_address_field
     fields = @helper.fields.dup
     @helper.billing_address :street => 'My Street'

--- a/test/unit/integrations/notifications/citrus_notification_test.rb
+++ b/test/unit/integrations/notifications/citrus_notification_test.rb
@@ -3,16 +3,13 @@ require 'test_helper'
 class CitrusNotificationTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
- 
   def setup
     @citrus = Citrus::Notification.new(http_raw_data_success, :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9')
-	#@citrus = Citrus::Notification.new(http_raw_data_canceled, :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9')
-	#@citrus = Citrus::Notification.new(http_raw_data_tampered, :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9')
   end
 
   def test_accessors
     assert @citrus.complete?
-    assert_equal "success", @citrus.status
+    assert_equal "Completed", @citrus.status
     assert_equal "CTX1309180549472058821", @citrus.transaction_id
     assert_equal "SUCCESS", @citrus.transaction_status
     assert_equal "10.00", @citrus.amount

--- a/test/unit/integrations/returns/citrus_return_test.rb
+++ b/test/unit/integrations/returns/citrus_return_test.rb
@@ -10,37 +10,37 @@ class CitrusReturnTest < Test::Unit::TestCase
   def setup_failed_return
     @citrus = Citrus::Return.new(http_raw_data_canceled, :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9')
   end
-  
+
   def setup_tampered_return
     @citrus = Citrus::Return.new(http_raw_data_tampered, :credential2 => '2c71a4ea7d2b88e151e60d9da38b2d4552568ba9')
   end
 
   def test_success
     assert @citrus.success?
-    assert_equal 'success', @citrus.status('ORD427','10.00')
+    assert_equal 'Completed', @citrus.status('ORD427','10.00')
   end
 
   def test_failure_is_successful
     setup_failed_return
-    assert_equal 'canceled', @citrus.status('ORD483', '10.00')
+    assert_equal 'Canceled', @citrus.status('ORD483', '10.00')
   end
 
   def test_tampered_is_successful
     setup_tampered_return
-    assert_equal 'tampered', @citrus.status('ORD427', '100.00')
+    assert_equal 'Tampered', @citrus.status('ORD427', '100.00')
   end
 
   def test_treat_initial_failures_as_pending
     setup_failed_return
-    assert_equal 'canceled', @citrus.notification.status
+    assert_equal 'Canceled', @citrus.notification.status
   end
 
   def test_return_has_notification
     notification = @citrus.notification
 
     assert notification.complete?
-    
-    assert_equal "success", notification.status
+
+    assert_equal "Completed", notification.status
     assert_equal "CTX1309180549472058821", notification.transaction_id
     assert_equal "SUCCESS", notification.transaction_status
     assert_equal "10.00", notification.amount
@@ -56,16 +56,16 @@ class CitrusReturnTest < Test::Unit::TestCase
 
   private
 
- def http_raw_data_success
+  def http_raw_data_success
 	  "TxGateway=&TxId=ORD427&TxMsg=Cash+on+delivery+requested&TxRefNo=CTX1309180549472058821&TxStatus=SUCCESS&action=callback&addressCity=Kolkata&addressCountry=India&addressState=West+Bengal&addressStreet1=122+sksdlk+sdjf&addressStreet2=&addressZip=9292929292&amount=10.00&authIdCode=&controller=test&currency=INR&email=sujoy.goswami%40gmail.com&firstName=Amit&isCOD=true&issuerRefNo=&lastName=Pandey&mobileNo=929292929&paymentMode=CASH_ON_DELIVERY&pgRespCode=0&pgTxnNo=CTX1309180549472058821&signature=807bb30a30a02b904f1434539f2eb07942ecb6f1&transactionId=40689"
   end
-	
+
   def http_raw_data_canceled
   	"TxGateway=&TxId=ORD483&TxMsg=Canceled+by+user&TxRefNo=CTX1309180556554473079&TxStatus=CANCELED&action=callback&addressCity=Kolkata&addressCountry=India&addressState=West+Bengal&addressStreet1=22+sks+ksks&addressStreet2=&addressZip=782828282&amount=10.00&authIdCode=&controller=test&currency=INR&email=sujoy.goswami%40gmail.com&firstName=Amit&isCOD=&issuerRefNo=&lastName=Pandey&mobileNo=928282828&paymentMode=&pgRespCode=3&pgTxnNo=CTX1309180556554473079&signature=ea298e6cd6a92fba4b6f62f754fb98905ae7a3a3&transactionId=40693"
   end
-  
+
   def http_raw_data_tampered
- "TxGateway=&TxId=ORD427&TxMsg=Cash+on+delivery+requested&TxRefNo=CTX1309180549472058821&TxStatus=SUCCESS&action=callback&addressCity=Kolkata&addressCountry=India&addressState=West+Bengal&addressStreet1=122+sksdlk+sdjf&addressStreet2=&addressZip=9292929292&amount=100.00&authIdCode=&controller=test&currency=USD&email=sujoy.goswami%40gmail.com&firstName=Amit&isCOD=true&issuerRefNo=&lastName=Pandey&mobileNo=929292929&paymentMode=CASH_ON_DELIVERY&pgRespCode=0&pgTxnNo=CTX1309180549472058821&signature=807bb30a30a02b904f1434539f2eb07942ecb6f1&transactionId=40689"
+   "TxGateway=&TxId=ORD427&TxMsg=Cash+on+delivery+requested&TxRefNo=CTX1309180549472058821&TxStatus=SUCCESS&action=callback&addressCity=Kolkata&addressCountry=India&addressState=West+Bengal&addressStreet1=122+sksdlk+sdjf&addressStreet2=&addressZip=9292929292&amount=100.00&authIdCode=&controller=test&currency=USD&email=sujoy.goswami%40gmail.com&firstName=Amit&isCOD=true&issuerRefNo=&lastName=Pandey&mobileNo=929292929&paymentMode=CASH_ON_DELIVERY&pgRespCode=0&pgTxnNo=CTX1309180549472058821&signature=807bb30a30a02b904f1434539f2eb07942ecb6f1&transactionId=40689"
   end
 
 end


### PR DESCRIPTION
This is a cleaned up and working version of #796 which adds an integration for the Citrus gateway. Tested and working with Shopify.

I had to make a small change to the action_view_helper to allow for integrations to specify a `credential_based_url` method as alternative to the standard `service_url`. This was needed because the citrus url depends on the merchant's credentials.

@odorcicd @jduff 
/cc @louiskearns 
