### PR TITLE
Add PayuPaisa gateway

### DIFF
--- a/lib/active_merchant/billing/integrations/payu_in_paisa.rb
+++ b/lib/active_merchant/billing/integrations/payu_in_paisa.rb
@@ -1,0 +1,30 @@
+module ActiveMerchant
+  module Billing
+    module Integrations
+      module PayuInPaisa
+
+        autoload :Return, 'active_merchant/billing/integrations/payu_in_paisa/return.rb'
+        autoload :Helper, 'active_merchant/billing/integrations/payu_in_paisa/helper.rb'
+        autoload :Notification, 'active_merchant/billing/integrations/payu_in_paisa/notification.rb'
+
+        mattr_accessor :test_url
+        mattr_accessor :production_url
+
+        self.test_url = 'https://test.payu.in/_payment.php'
+        self.production_url = 'https://secure.payu.in/_payment.php'
+
+        def self.service_url
+          ActiveMerchant::Billing::Base.integration_mode == :production ? self.production_url : self.test_url
+        end
+
+        def self.notification(post, options = {})
+          Notification.new(post, options)
+        end
+
+        def self.return(post, options = {})
+          Return.new(post, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/payu_in_paisa/helper.rb
+++ b/lib/active_merchant/billing/integrations/payu_in_paisa/helper.rb
@@ -1,0 +1,19 @@
+module ActiveMerchant
+  module Billing
+    module Integrations
+      module PayuInPaisa
+
+        class Helper < PayuIn::Helper
+          mapping :service_provider, 'service_provider'
+
+          def initialize(order, account, options = {})
+            super order, account, options
+            self.service_provider = 'payu_paisa'
+            self.user_defined = { :var2 => order }
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/payu_in_paisa/notification.rb
+++ b/lib/active_merchant/billing/integrations/payu_in_paisa/notification.rb
@@ -1,0 +1,23 @@
+module ActiveMerchant
+  module Billing
+    module Integrations
+      module PayuInPaisa
+        class Notification < PayuIn::Notification
+          def item_id
+            params['udf2']
+          end
+
+          def checksum_ok?
+            fields = user_defined.reverse.push( customer_email, customer_first_name, product_info, gross, invoice, :reverse => true )
+            fields.unshift( transaction_status )
+            unless PayuIn.checksum(@merchant_id, @secret_key, *fields ) == checksum
+              @message = 'Return checksum not matching the data provided'
+              return false
+            end
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/payu_in_paisa/return.rb
+++ b/lib/active_merchant/billing/integrations/payu_in_paisa/return.rb
@@ -1,0 +1,16 @@
+module ActiveMerchant
+  module Billing
+    module Integrations
+      module PayuInPaisa
+
+        class Return < PayuIn::Return
+          def initialize(query_string, options = {})
+            super query_string, options
+            @notification = Notification.new(query_string, options)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/unit/integrations/helpers/payu_in_paisa_helper_test.rb
+++ b/test/unit/integrations/helpers/payu_in_paisa_helper_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class PayuInPaisaHelperTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @helper = PayuInPaisa::Helper.new( 'jh34h53kj4h5hj34kh5', 'C0Dr8m', :amount => '10.00', :credential2 => 'Product Info')
+  end
+
+  def test_basic_helper_fields
+    assert_equal '10.00', @helper.fields['amount']
+    assert_equal 'C0Dr8m', @helper.fields['key']
+    assert_equal 'jh34h53kj4h5hj34kh5', @helper.fields['txnid']
+    assert_equal 'Product Info', @helper.fields['productinfo']
+  end
+
+  def test_customer_fields
+    @helper.customer :first_name => 'Payu-Admin', :last_name => '', :email => 'test@example.com', :phone => '1234567890'
+
+    assert_equal 'Payu-Admin', @helper.fields['firstname']
+    assert_equal 'test@example.com', @helper.fields['email']
+    assert_equal '1234567890', @helper.fields['phone']
+  end
+
+  def test_billing_address_fields
+    @helper.billing_address :city => 'New Delhi', :address1 => '666, Wooo', :address2 => 'EEE Street', :state => 'New Delhi', :zip => '110001', :country => 'india'
+
+    assert_equal 'New Delhi', @helper.fields['city']
+    assert_equal '666, Wooo', @helper.fields['address1']
+    assert_equal 'EEE Street', @helper.fields['address2']
+    assert_equal 'New Delhi', @helper.fields['state']
+    assert_equal '110001', @helper.fields['zip']
+    assert_equal 'india', @helper.fields['country']
+  end
+
+  def test_return_url_fields
+    @helper.return_url 'some_return_url'
+
+    assert_equal 'some_return_url', @helper.fields['surl']
+    assert_equal 'some_return_url', @helper.fields['furl']
+  end
+
+  def test_user_defined_fields
+    @helper.user_defined :var1 => 'var_one', :var2 => 'var_two', :var3 => 'var_three', :var4 => 'var_four', :var5 => 'var_five', :var6 => 'var_six', :var7 => 'var_seven', :var8 => 'var_eight', :var9 => 'var_nine', :var10 => 'var_ten'
+
+    assert_equal 'var_one', @helper.fields['udf1']
+    assert_equal 'var_two', @helper.fields['udf2']
+    assert_equal 'var_three', @helper.fields['udf3']
+    assert_equal 'var_four', @helper.fields['udf4']
+    assert_equal 'var_five', @helper.fields['udf5']
+    assert_equal 'var_six', @helper.fields['udf6']
+    assert_equal 'var_seven', @helper.fields['udf7']
+    assert_equal 'var_eight', @helper.fields['udf8']
+    assert_equal 'var_nine', @helper.fields['udf9']
+    assert_equal 'var_ten', @helper.fields['udf10']
+  end
+
+  def test_add_checksum_method
+    options = { :mode => 'CC' }
+    @helper.customer :first_name => 'Payu-Admin', :email => 'test@example.com'
+    @helper.user_defined :var1 => 'var_one', :var2 => 'var_two', :var3 => 'var_three', :var4 => 'var_four', :var5 => 'var_five', :var6 => 'var_six', :var7 => 'var_seven', :var8 => 'var_eight', :var9 => 'var_nine', :var10 => 'var_ten'
+
+    assert_equal "032606d7fb5cfe357d9e6b358b4bb8db1d34e9dfa30f039cb7dec75ae6d77f7d1f67a58c123ea0ee358bf040554d5e3048066a369ae63888132e27c14e79ee5a", @helper.form_fields["hash"]
+  end
+end

--- a/test/unit/integrations/notifications/payu_in_paisa_notification_test.rb
+++ b/test/unit/integrations/notifications/payu_in_paisa_notification_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class PayuInNotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @payu = PayuInPaisa::Notification.new(http_raw_data, :credential1 => 'C0Dr8m', :credential2 => '3sf0jURk')
+  end
+
+  def test_accessors
+    assert @payu.complete?
+    assert_equal "Completed", @payu.status
+    assert_equal "403993715508030204", @payu.transaction_id
+    assert_equal "success", @payu.transaction_status
+    assert_equal "10.00", @payu.gross
+    assert_equal "Product Info", @payu.product_info
+    assert_equal "INR", @payu.currency
+    assert_equal true, @payu.invoice_ok?('4ba4afe87f7e73468f2a')
+    assert_equal true, @payu.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert_equal "CC", @payu.type
+    assert_equal "4ba4afe87f7e73468f2a", @payu.invoice
+    assert_equal "C0Dr8m", @payu.account
+    assert_equal "0.00", @payu.discount
+    assert_equal "test@example.com", @payu.customer_email
+    assert_equal "1234567890", @payu.customer_phone
+    assert_equal "Payu-Admin", @payu.customer_first_name
+    assert_equal "", @payu.customer_last_name
+    assert_equal "e35f67dc7232d12caa28b16ba31b509f62bdea1e930bb6766a4f71036cc1af34debb8afc0fdd89be50f0604c1e6bca7209dfffe6b3a893c575492edcab3444ee", @payu.checksum
+    assert_equal "E000", @payu.message
+    assert_equal true, @payu.checksum_ok?
+  end
+
+  def test_compositions
+    assert_equal '10.00', @payu.gross
+  end
+
+  def test_acknowledgement
+    assert @payu.acknowledge
+  end
+
+  def test_respond_to_acknowledge
+    assert @payu.respond_to?(:acknowledge)
+  end
+
+  def test_item_id_gives_the_original_item_id
+    assert 'original_item_id', @payu.item_id
+  end
+
+  private
+  def http_raw_data
+   "mihpayid=403993715508030204&mode=CC&status=success&unmappedstatus=captured&key=C0Dr8m&txnid=4ba4afe87f7e73468f2a&amount=10.00&discount=0.00&addedon=2013-05-10 18 32 30&productinfo=Product Info&firstname=Payu-Admin&lastname=&address1=&address2=&city=&state=&country=&zipcode=&email=test@example.com&phone=1234567890&udf1=&udf2=original_item_id&udf3=&udf4=&udf5=&udf6=&udf7=&udf8=&udf9=&udf10=&hash=e35f67dc7232d12caa28b16ba31b509f62bdea1e930bb6766a4f71036cc1af34debb8afc0fdd89be50f0604c1e6bca7209dfffe6b3a893c575492edcab3444ee&field1=313069903923&field2=999999&field3=59117331831301&field4=-1&field5=&field6=&field7=&field8=&PG_TYPE=HDFC&bank_ref_num=59117331831301&bankcode=CC&error=E000&cardnum=512345XXXXXX2346&cardhash=766f0227cc4b4c5f773a04cb31d8d1c5be071dd8d08fe365ecf5e2e5c947546d"
+  end
+end

--- a/test/unit/integrations/payu_in_paisa_module_test.rb
+++ b/test/unit/integrations/payu_in_paisa_module_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class PayuInPaisaModuleTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    ActiveMerchant::Billing::Base.integration_mode = :test
+  end
+
+  def test_service_url_method
+    ActiveMerchant::Billing::Base.integration_mode = :test
+    assert_equal "https://test.payu.in/_payment.php", PayuIn.service_url
+
+    ActiveMerchant::Billing::Base.integration_mode = :production
+    assert_equal "https://secure.payu.in/_payment.php", PayuIn.service_url
+  end
+
+  def test_return_method
+    assert_instance_of PayuIn::Return, PayuIn.return('name=foo', {})
+  end
+
+  def test_notification_method
+    assert_instance_of PayuIn::Notification, PayuIn.notification('name=foo', {})
+  end
+end

--- a/test/unit/integrations/returns/payu_in_paisa_return_test.rb
+++ b/test/unit/integrations/returns/payu_in_paisa_return_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class PayuInReturnTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @payu = PayuInPaisa::Return.new(http_raw_data_success, :credential1 => 'C0Dr8m', :credential2 => '3sf0jURk')
+  end
+
+  def setup_failed_return
+    @payu = PayuInPaisa::Return.new(http_raw_data_failure, :credential1 => 'C0Dr8m', :credential2 => '3sf0jURk')
+  end
+
+  def test_success
+    assert @payu.success?
+    assert_equal 'Completed', @payu.status('4ba4afe87f7e73468f2a','10.00')
+  end
+
+  def test_failure_is_successful
+    setup_failed_return
+    assert_equal 'Failed', @payu.status('8ae1034d1abf47fde1cf', '10.00')
+  end
+
+  def test_treat_initial_failures_as_pending
+    setup_failed_return
+    assert_equal 'Failed', @payu.notification.status
+  end
+
+  def test_return_has_notification
+    notification = @payu.notification
+
+    assert notification.complete?
+    assert_equal 'Completed', notification.status
+    assert notification.invoice_ok?('4ba4afe87f7e73468f2a')
+    assert notification.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert_equal "success", notification.transaction_status
+    assert_equal '403993715508030204', @payu.notification.transaction_id
+    assert_equal 'CC', @payu.notification.type
+    assert_equal 'INR', notification.currency
+    assert_equal '4ba4afe87f7e73468f2a', notification.invoice
+    assert_equal 'C0Dr8m', notification.account
+    assert_equal '10.00', notification.gross
+    assert_equal '0.00', notification.discount
+    assert_equal nil, notification.offer_description
+    assert_equal 'Product Info', notification.product_info
+    assert_equal 'test@example.com', notification.customer_email
+    assert_equal '1234567890', notification.customer_phone
+    assert_equal 'Payu-Admin', notification.customer_first_name
+    assert_equal '', notification.customer_last_name
+    assert_equal ["", "original_item_id", "", "", "", "", "", "", "", ""], notification.user_defined
+    assert_equal "e35f67dc7232d12caa28b16ba31b509f62bdea1e930bb6766a4f71036cc1af34debb8afc0fdd89be50f0604c1e6bca7209dfffe6b3a893c575492edcab3444ee", notification.checksum
+    assert_equal 'E000', notification.message
+    assert notification.checksum_ok?
+  end
+
+  private
+
+  def http_raw_data_success
+   "mihpayid=403993715508030204&mode=CC&status=success&unmappedstatus=captured&key=C0Dr8m&txnid=4ba4afe87f7e73468f2a&amount=10.00&discount=0.00&addedon=2013-05-10 18 32 30&productinfo=Product Info&firstname=Payu-Admin&lastname=&address1=&address2=&city=&state=&country=&zipcode=&email=test@example.com&phone=1234567890&udf1=&udf2=original_item_id&udf3=&udf4=&udf5=&udf6=&udf7=&udf8=&udf9=&udf10=&hash=e35f67dc7232d12caa28b16ba31b509f62bdea1e930bb6766a4f71036cc1af34debb8afc0fdd89be50f0604c1e6bca7209dfffe6b3a893c575492edcab3444ee&field1=313069903923&field2=999999&field3=59117331831301&field4=-1&field5=&field6=&field7=&field8=&PG_TYPE=HDFC&bank_ref_num=59117331831301&bankcode=CC&error=E000&cardnum=512345XXXXXX2346&cardhash=766f0227cc4b4c5f773a04cb31d8d1c5be071dd8d08fe365ecf5e2e5c947546d"
+  end
+
+  def http_raw_data_failure
+    "mihpayid=403993715508030204&mode=CC&status=failure&unmappedstatus=failed&key=C0Dr8m&txnid=8ae1034d1abf47fde1cf&amount=10.00&discount=0.00&addedon=2013-05-13 11:09:20&productinfo=Product Info&firstname=Payu-Admin&lastname=&address1=&address2=&city=&state=&country=&zipcode=&email=test@example.com&phone=1234567890&udf1=&udf2=&udf3=&udf4=&udf5=&udf6=&udf7=&udf8=&udf9=&udf10=&hash=65774f82abe64cec54be31107529b2a3eef8f6a3f97a8cb81e9769f4394b890b0e7171f8988c4df3684e7f9f337035d0fe09a844da4b76e68dd643e8ac5e5c63&field1=&field2=&field3=&field4=&field5=!ERROR!-GV00103-Invalid BrandError Code: GV00103&field6=&field7=&field8=failed in enrollment&PG_TYPE=HDFC&bank_ref_num=&bankcode=CC&error=E201&cardnum=411111XXXXXX1111&cardhash=49c73d6c44f27f7ac71b439de842f91e27fcbc3b9ce9dfbcbf1ce9a8fe790c17"
+  end
+
+end


### PR DESCRIPTION
This adds the PayU.in Paisa offsite gateway, which is based of the standard PayU.in gateway. I make use of inheritance for the most part as there are only a few subtle changes to do with the `item_id` being sent as `udf2`, and the checksum algorithm.

This is tested and working with Shopify

@odorcicd @RichardBlair 
/cc @louiskearns 
