### PR TITLE
Spreedly: Add ability to retain on success

### DIFF
--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -36,7 +36,9 @@ module ActiveMerchant #:nodoc:
       #
       # money          - The monetary amount of the transaction in cents.
       # payment_method - The CreditCard or the Spreedly payment method token.
-      # options        - A standard ActiveMerchant options hash
+      # options        - A hash of options:
+      #                  :retain_on_success - Retain the payment method if the purchase
+      #                                       succeeds.  Defaults to false.  (optional)
       def purchase(money, payment_method, options = {})
         if payment_method.is_a?(String)
           purchase_with_token(money, payment_method, options)
@@ -52,7 +54,9 @@ module ActiveMerchant #:nodoc:
       #
       # money          - The monetary amount of the transaction in cents.
       # payment_method - The CreditCard or the Spreedly payment method token.
-      # options        - A standard ActiveMerchant options hash
+      # options        - A hash of options:
+      #                  :retain_on_success - Retain the payment method if the authorize
+      #                                       succeeds.  Defaults to false.  (optional)
       def authorize(money, payment_method, options = {})
         if payment_method.is_a?(String)
           authorize_with_token(money, payment_method, options)
@@ -126,6 +130,7 @@ module ActiveMerchant #:nodoc:
         build_xml_request('transaction') do |doc|
           add_invoice(doc, money, options)
           doc.payment_method_token(payment_method_token)
+          doc.retain_on_success(true) if options[:retain_on_success]
         end
       end
 

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -55,6 +55,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded!', response.message
     assert_equal 'Purchase', response.params['transaction_type']
+    assert_equal 'used', response.params['payment_method_storage_state']
   end
 
   def test_successful_purchase_with_card_and_address
@@ -86,6 +87,15 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card)
     assert_failure response
     assert_equal "First name can't be blank", response.message
+  end
+
+  def test_successful_purchase_retain_on_success
+    assert response = @gateway.purchase(@amount, @credit_card, retain_on_success: true)
+    assert_success response
+    assert_equal 'Succeeded!', response.message
+    assert_equal 'Purchase', response.params['transaction_type']
+    assert_equal 'retained', response.params['payment_method_storage_state']
+    assert !response.params['payment_method_token'].blank?
   end
 
   def test_successful_authorize_and_capture_with_credit_card
@@ -130,6 +140,15 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @credit_card)
     assert_failure response
     assert_equal "First name can't be blank", response.message
+  end
+
+  def test_successful_authorize_retain_on_success
+    assert response = @gateway.authorize(@amount, @credit_card, retain_on_success: true)
+    assert_success response
+    assert_equal 'Succeeded!', response.message
+    assert_equal 'Authorization', response.params['transaction_type']
+    assert_equal 'retained', response.params['payment_method_storage_state']
+    assert !response.params['payment_method_token'].blank?
   end
 
   def test_successful_store
@@ -224,6 +243,6 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
 
     assert response = gateway.purchase(@amount, @existing_payment_method)
     assert_failure response
-    assert_equal 'HTTP Basic: Access denied.', response.message
+    assert_match /Unable to authenticate/, response.message
   end
 end

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -52,6 +52,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     assert_equal 'Purchase', response.params['transaction_type']
     assert_equal '5WxC03VQ0LmmkYvIHl7XsPKIpUb', response.params['payment_method_token']
     assert_equal '6644', response.params['payment_method_last_four_digits']
+    assert_equal 'used', response.params['payment_method_storage_state']
   end
 
   def test_failed_purchase_with_invalid_credit_card
@@ -121,6 +122,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     assert_equal 'Authorization', response.params['transaction_type']
     assert_equal '5WxC03VQ0LmmkYvIHl7XsPKIpUb', response.params['payment_method_token']
     assert_equal '6644', response.params['payment_method_last_four_digits']
+    assert_equal 'used', response.params['payment_method_storage_state']
 
     @gateway.expects(:raw_ssl_request).returns(successful_capture_response)
     response = @gateway.capture(@amount, response.authorization)
@@ -283,6 +285,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
           <data>
             <how_many>2</how_many>
           </data>
+          <storage_state>used</storage_state>
           <payment_method_type>credit_card</payment_method_type>
           <verification_value/>
           <number>XXXX-XXXX-XXXX-6644</number>
@@ -411,6 +414,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
           <data>
             <how_many>2</how_many>
           </data>
+          <storage_state>used</storage_state>
           <payment_method_type>credit_card</payment_method_type>
           <verification_value/>
           <number>XXXX-XXXX-XXXX-6644</number>


### PR DESCRIPTION
We now support the ability to pass an optional parameter to the purchase
and authorize calls to notify Spreedly to store (retain) the card if the
purchase/authorize succeeds.
