### PR TITLE
Removing fraud_review flag from blue_pay module responses.

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -14,8 +14,6 @@ module ActiveMerchant #:nodoc:
       AVS_ERRORS = %w( A E N R W Z )
       AVS_REASON_CODES = %w(27 45)
 
-      FRAUD_REVIEW_STATUSES = %w( E 0 )
-
       FIELD_MAP = {
         'TRANS_ID' => :transaction_id,
         'STATUS' => :response_code,
@@ -344,7 +342,6 @@ module ActiveMerchant #:nodoc:
         Response.new(success, message, parsed,
           :test          => test?,
           :authorization => (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
-          :fraud_review  => FRAUD_REVIEW_STATUSES.include?(parsed[:response_code]),
           :avs_result    => { :code => parsed[:avs_result_code] },
           :cvv_result    => parsed[:card_code]
         )

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -163,27 +163,18 @@ class BluePayTest < Test::Unit::TestCase
     end
   end
 
-  def test_response_under_review_by_fraud_service
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
-
-    response = @gateway.purchase(@amount, @credit_card)
-    assert_failure response
-    assert response.fraud_review?
-    assert_equal "Thank you! For security reasons your order is currently being reviewed", response.message
-  end
-
   def test_avs_result
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
+    @gateway.expects(:ssl_post).returns(successful_authorization_response)
 
     response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'X', response.avs_result['code']
+    assert_equal '_', response.avs_result['code']
   end
 
   def test_cvv_result
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
+    @gateway.expects(:ssl_post).returns(successful_authorization_response)
 
     response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'M', response.cvv_result['code']
+    assert_equal '_', response.cvv_result['code']
   end
 
   def test_message_from
@@ -278,10 +269,6 @@ class BluePayTest < Test::Unit::TestCase
 
   def failed_authorization_response
     "AUTH_CODE=&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=AUTH&REBID=&STATUS=0&AVS=_&TRANS_ID=100134229728&CVV2=_&MESSAGE=Declined%20Auth"
-  end
-
-  def fraud_review_response
-    "AUTH_CODE=&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=AUTH&REBID=&STATUS=0&AVS=X&TRANS_ID=100134229728&CVV2=M&MESSAGE=Thank%20you!%20For%20security%20reasons%20your%20order%20is%20currently%20being%20reviewed"
   end
 
   def successful_recurring_response


### PR DESCRIPTION
BluePay20Post does not support fraud review response status and the Response :fraud_review param causes the success param to be ignored (by design) in Shoppify.  

API doc if you'd like to veify: https://secure.assurebuy.com/BluePay/BluePay_bp20post/Bluepay20post.txt
