### PR TITLE
Send `ip` parameter to Stripe instead of `browser_ip`

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -145,10 +145,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        metadata_options = [:description,:user_agent,:referrer]
+        metadata_options = [:description, :ip, :user_agent, :referrer]
         post.update(options.slice(*metadata_options))
 
-        post[:ip] = options[:browser_ip]
         post[:external_id] = options[:order_id]
         post[:payment_user_agent] = "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
       end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -174,7 +174,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:description => "a test customer",:browser_ip => "127.127.127.127", :user_agent => "some browser", :order_id => "42", :email => "foo@wonderfullyfakedomain.com", :referrer =>"http://www.shopify.com"})
+      updated_options = @options.merge({:description => "a test customer",:ip => "127.127.127.127", :user_agent => "some browser", :order_id => "42", :email => "foo@wonderfullyfakedomain.com", :referrer =>"http://www.shopify.com"})
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/description=a\+test\+customer/, data)


### PR DESCRIPTION
When you made the change in https://github.com/Shopify/active_merchant/commit/930175f5d9e3748b0bf883a2614ca7ec5518d0af it caused the issue where Stripe's API responded with the following error message:

```
Received unknown parameter: browser_ip
```

Stripe API expects a parameter `ip` and not `browser_ip`. If you send a parameter Stripe doesn't expect, the call fails.

Attached is code that'll take the option `browser_ip` but then assign it to the `ip` parameter that the Stripe API expects.
