### PR TITLE
Ipay88: Use the amount in dollars instead of cents to generate the signature

### DIFF
--- a/lib/active_merchant/billing/integrations/ipay88/helper.rb
+++ b/lib/active_merchant/billing/integrations/ipay88/helper.rb
@@ -46,12 +46,16 @@ module ActiveMerchant #:nodoc:
             add_field mappings[:signature], signature
           end
 
+          def amount_in_dollars
+            sprintf("%.2f", @amount_in_cents.to_f/100)
+          end
+
           def amount=(money)
             @amount_in_cents = money.respond_to?(:cents) ? money.cents : money
             if money.is_a?(String) or @amount_in_cents.to_i < 0
               raise ArgumentError, "money amount must be either a Money object or a positive integer in cents."
             end
-            add_field mappings[:amount], sprintf("%.2f", @amount_in_cents.to_f/100)
+            add_field mappings[:amount], amount_in_dollars
           end
 
           def currency(symbol)
@@ -103,7 +107,7 @@ module ActiveMerchant #:nodoc:
             components  = [merchant_key]
             components << fields[mappings[:account]]
             components << fields[mappings[:order]]
-            components << amount_in_cents.to_s.gsub(/[.,]/, '')
+            components << amount_in_dollars.to_s.gsub(/0+$/, '').gsub(/[.,]/, '')
             components << fields[mappings[:currency]]
             components.join
           end

--- a/test/unit/integrations/helpers/ipay88_helper_test.rb
+++ b/test/unit/integrations/helpers/ipay88_helper_test.rb
@@ -74,7 +74,7 @@ class Ipay88HelperTest < Test::Unit::TestCase
   end
 
   def test_signature
-    assert_field "Signature", "vDwWN/XHvYnlReq3f1llHFCxDTY="
+    assert_field "Signature", "sz25/58PfRuHloIGafsscRjk3H4="
   end
 
   def test_valid_amount
@@ -95,9 +95,19 @@ class Ipay88HelperTest < Test::Unit::TestCase
   end
 
   def test_sig_components_amount_doesnt_include_decimal_points
-    @helper.amount = 0.5
+    @helper.amount = 50
     assert_equal "abcipay88merchcodeorder-50005MYR", @helper.send(:sig_components)
-    @helper.amount = 12.34
+    @helper.amount = 1234
     assert_equal "abcipay88merchcodeorder-5001234MYR", @helper.send(:sig_components)
+    @helper.amount = 1000
+    assert_equal "abcipay88merchcodeorder-50010MYR", @helper.send(:sig_components)
+    @helper.amount = Money.new(90)
+    assert_equal "abcipay88merchcodeorder-50009MYR", @helper.send(:sig_components)
+    @helper.amount = Money.new(1000)
+    assert_equal "abcipay88merchcodeorder-50010MYR", @helper.send(:sig_components)
+  end
+
+  def test_sign_method
+    assert_equal "rq3VxZp9cjkiqiw4mHnZJH49MzQ=", Ipay88::Helper.sign("L3mn6Bpy4HM0605613619416109MYR")
   end
 end


### PR DESCRIPTION
Fixes the signature hashing to correctly use the amount in dollars with decimals removed, instead of the amount in cents. This gives the correct transformation that Ipay88 described with these examples:
$0.90 => 09
$1.50 => 15

Old (incorrect) behavior was:
$0.90 => 90
$1.50 => 150

@RichardBlair @jduff 
/cc @louiskearns 
