### PR TITLE
#checksum_ok? does not crash if tampered

### DIFF
--- a/lib/active_merchant/billing/integrations/citrus/notification.rb
+++ b/lib/active_merchant/billing/integrations/citrus/notification.rb
@@ -118,7 +118,7 @@ module ActiveMerchant
           end
 
           def checksum_ok?
-            fields = invoice + transaction_status + amount.to_s + transaction_id + issuerrefno + authidcode + customer_first_name + customer_last_name + pgrespcode + customer_address[:zip]
+            fields = [invoice, transaction_status, amount.to_s, transaction_id, issuerrefno, authidcode, customer_first_name, customer_last_name, pgrespcode, customer_address[:zip]].join
 
             unless Citrus.checksum(@secret_key, fields ) == checksum
               @message = 'checksum mismatch...'

--- a/test/unit/integrations/notifications/citrus_notification_test.rb
+++ b/test/unit/integrations/notifications/citrus_notification_test.rb
@@ -31,6 +31,11 @@ class CitrusNotificationTest < Test::Unit::TestCase
     assert @citrus.acknowledge
   end
 
+  def test_acknowledgement_does_not_crash_if_tampered
+    @citrus.stubs(:transaction_status).returns(nil)
+    assert_nothing_raised { @citrus.acknowledge }
+  end
+
   def test_respond_to_acknowledge
     assert @citrus.respond_to?(:acknowledge)
   end


### PR DESCRIPTION
Fixes [Shopify#9594](https://github.com/Shopify/shopify/issues/9594)

During a security challenge, someone forged a request with no invoice, no transaction_status, etc. This ended up in a `NoMethodError`. This patch will prevent that kind of bug to bubble up to Shopify.
