### PR TITLE
Pass the AccessCode from previous response instead of trying to split on = in Location header

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
         }
         add_credit_card(post, payment_method)
 
-        commit_form(endpoint, build_form_request(post))
+        commit_form(endpoint, build_form_request(post), :identification => identification)
       end
 
       def add_metadata(doc, options)
@@ -228,14 +228,13 @@ module ActiveMerchant #:nodoc:
         return EwayRapidResponse.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
       end
 
-      def commit_form(url, request)
+      def commit_form(url, request, parameters)
         http_response = raw_ssl_request(:post, url, request)
 
         success = (http_response.code.to_s == "302")
         message = (success ? "Succeeded" : http_response.body)
-        if success
-          authorization = CGI.unescape(http_response["Location"].split("=").last)
-        end
+        authorization = parameters[:identification] if success
+
         Response.new(success, message, {:location => http_response["Location"]}, :authorization => authorization, :test => test?)
       end
 

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -79,7 +79,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
 
     assert response = @gateway.send(:run_purchase, "bogus", @credit_card, setup_response.params["formactionurl"])
     assert_failure response
-    assert_match(%r{Not Found}, response.message)
+    assert_match(%r{Access Code Invalid}, response.message)
   end
 
   def test_failed_status
@@ -106,7 +106,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
     @options[:billing_address].merge!(:country => nil)
     assert response = @gateway.store(@credit_card, @options)
     assert_failure response
-    assert_equal "V6045,V6044", response.message
+    assert_equal "V6044", response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
@ntalbott @melari 

eWAY Rapid AccessCode can be padded with = (equals) and I suspect contain them too. This causes issues as it passes an incorrect AccessCode to `run_purchase` for a select few merchants.

Instead of trying to parse the AccessCode from the Location header, is there anything wrong with simply passing it from the previous request?
