### PR TITLE
Bump default protocol version for QuickPay.

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -159,7 +159,7 @@ module ActiveMerchant #:nodoc:
       # Using the API-key, requires that you use version 4+. Specify :version => 4/5/6/7 in options.
       def initialize(options = {})
         requires!(options, :login, :password)
-        @protocol = options.delete(:version) || 3 # default to protocol version 3
+        @protocol = options.delete(:version) || 7 # default to protocol version 7
         super
       end
 


### PR DESCRIPTION
Bump default protocol version to latest version.

Tested via a dev-cardserver, doing authorize/capture/refund, which all works.

For review, @melari 
