### PR TITLE
Stripe: Ignore tthe customer option when paying with a creditcard.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -127,7 +127,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_amount(post, money, options)
         add_creditcard(post, creditcard, options)
-        add_customer(post, options)
+        add_customer(post, creditcard, options)
         add_customer_data(post,options)
         post[:description] = options[:description] || options[:email]
         add_flags(post, options)
@@ -189,8 +189,8 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_customer(post, options)
-        post[:customer] = options[:customer] if options[:customer]
+      def add_customer(post, creditcard, options)
+        post[:customer] = options[:customer] if options[:customer] && !creditcard.respond_to?(:number)
       end
 
       def add_flags(post, options)

--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -48,8 +48,8 @@ module ActiveMerchant #:nodoc:
         post[:amount] = localized_amount(money, post[:currency].upcase)
       end
 
-      def add_customer(post, options)
-        post[:customer] = options[:customer] if options[:customer] && post[:card].blank?
+      def add_customer(post, creditcard, options)
+        post[:customer] = options[:customer] if options[:customer] && !creditcard.respond_to?(:number)
       end
 
       def json_error(raw_response)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -173,4 +173,11 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount - 20, response.authorization, { :refund_fee_amount => 10 })
     assert_success refund
   end
+
+  def test_creditcard_purchase_with_customer
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:customer => '1234'))
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+  end
 end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -182,7 +182,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_add_customer
     post = {}
-    @gateway.send(:add_customer, post, {:customer => "test_customer"})
+    @gateway.send(:add_customer, post, @creditcard, {:customer => "test_customer"})
     assert_equal "test_customer", post[:customer]
   end
 

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -88,13 +88,13 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_add_customer
     post = {}
-    @gateway.send(:add_customer, post, {:customer => "test_customer"})
+    @gateway.send(:add_customer, post, 'card_token', {:customer => "test_customer"})
     assert_equal "test_customer", post[:customer]
   end
 
   def test_doesnt_add_customer_if_card
-    post = { :card => 'foo' }
-    @gateway.send(:add_customer, post, {:customer => "test_customer"})
+    post = {}
+    @gateway.send(:add_customer, post, @credit_card, {:customer => "test_customer"})
     assert !post[:customer]
   end
 


### PR DESCRIPTION
This fixes an issue where purchase & auth transactions would fail if specifying both a creditcard number as well as a customer. This change will make the integration ignore any specified customer if there is a creditcard given.

@jduff @odorcicd 
