### PR TITLE
Remove usage of `uname -a`

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -234,8 +234,7 @@ module ActiveMerchant #:nodoc:
           :lang => 'ruby',
           :lang_version => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
           :platform => RUBY_PLATFORM,
-          :publisher => 'active_merchant',
-          :uname => (RUBY_PLATFORM =~ /linux|darwin/i ? `uname -a 2>/dev/null`.strip : nil)
+          :publisher => 'active_merchant'
         })
 
         key = options[:key] || @api_key

--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -68,8 +68,7 @@ module ActiveMerchant #:nodoc:
           :lang => 'ruby',
           :lang_version => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
           :platform => RUBY_PLATFORM,
-          :publisher => 'active_merchant',
-          :uname => (RUBY_PLATFORM =~ /linux|darwin/i ? `uname -a 2>/dev/null`.strip : nil)
+          :publisher => 'active_merchant'
         })
 
         {


### PR DESCRIPTION
I discovered that this was leaking internal host names, and could potentially
leak other information depending on how a given distro implements uname. It
also just seems less than prudent to shell out from within a gateway.

I've also done a quick review of the code for any other uses of command
execution (`` or %x) and found none.

@jduff @melari please review. @boucher please let us know if you see any
issue with this.
