### PR TITLE
Add support for passing line item information to offsite integrations.

### DIFF
--- a/generators/integration/templates/helper.rb
+++ b/generators/integration/templates/helper.rb
@@ -27,6 +27,14 @@ module ActiveMerchant #:nodoc:
           mapping :description, ''
           mapping :tax, ''
           mapping :shipping, ''
+
+          mapping :line_items, ''
+          mapping :line_item, :reference      => '',
+                              :name           => '',
+                              :unit_price     => '',
+                              :quantity       => '',
+                              :tax_rate       => '',
+                              :url            => ''
         end
       end
     end

--- a/lib/active_merchant/billing/integrations/action_view_helper.rb
+++ b/lib/active_merchant/billing/integrations/action_view_helper.rb
@@ -11,11 +11,11 @@ module ActiveMerchant #:nodoc:
         #
         # The helper creates a scope around a payment service helper
         # which provides the specific mapping for that service.
-        # 
+        #
         #  <% payment_service_for 1000, 'paypalemail@mystore.com',
-        #                               :amount => 50.00, 
-        #                               :currency => 'CAD', 
-        #                               :service => :paypal, 
+        #                               :amount => 50.00,
+        #                               :currency => 'CAD',
+        #                               :service => :paypal,
         #                               :html => { :id => 'payment-form' } do |service| %>
         #
         #    <% service.customer :first_name => 'Cody',
@@ -29,6 +29,20 @@ module ActiveMerchant #:nodoc:
         #                              :state => 'ON',
         #                              :country => 'CA',
         #                              :zip => 'K1J1E5' %>
+        #
+        #    <% service.line_item :reference => '1234',
+        #                         :name => 'T-shirt',
+        #                         :unit_price => 10.00,
+        #                         :quantity => 2,
+        #                         :tax_rate => 0.13,
+        #                         :url => 'http://myshop.com/products/1234' %>
+        #
+        #    <% service.line_item :reference => '1235',
+        #                         :name => 'Pants',
+        #                         :unit_price => 30.00,
+        #                         :quantity => 1,
+        #                         :tax_rate => 0.13,
+        #                         :url => 'http://myshop.com/products/1235' %>
         #
         #    <% service.invoice '#1000' %>
         #    <% service.shipping '0.00' %>
@@ -57,14 +71,14 @@ module ActiveMerchant #:nodoc:
           service.form_fields.each do |field, value|
             result << hidden_field_tag(field, value)
           end
-          
+
           service.raw_html_fields.each do |field, value|
             result << "<input id=\"#{field}\" name=\"#{field}\" type=\"hidden\" value=\"#{value}\" />\n"
           end
-          
+
           result << '</form>'
           result= result.join("\n")
-          
+
           concat(result.respond_to?(:html_safe) ? result.html_safe : result)
           nil
         end

--- a/lib/active_merchant/billing/integrations/helper.rb
+++ b/lib/active_merchant/billing/integrations/helper.rb
@@ -44,6 +44,15 @@ module ActiveMerchant #:nodoc:
           end
         end
 
+        def add_array_field(top_level_key, subkey, index, params)
+          return unless top_level = mappings[top_level_key]
+
+          params.each do |k, v|
+            field = mappings[subkey][k]
+            add_field("#{top_level}[#{index}][#{field}]", v) unless field.blank?
+          end
+        end
+
         # Add a field that has characters that CGI::escape would mangle. Allows
         # for multiple fields with the same name (e.g., to support line items).
         def add_raw_html_field(name, value)
@@ -62,7 +71,19 @@ module ActiveMerchant #:nodoc:
         def shipping_address(params = {})
           add_address(:shipping_address, params)
         end
-        
+
+        def line_item(params = {})
+          add_array_field(:line_items, :line_item, next_line_item_number, params)
+        end
+
+        def next_line_item_number
+          if @line_item_number
+            @line_item_number += 1
+          else
+            @line_item_number = 0
+          end
+        end
+
         def form_fields
           @fields
         end


### PR DESCRIPTION
This defines a standard way to pass line item information to integrations. Individual integrations can then override the `line_item` method to suit their needs.

There are already a few integrations which support passing in line items such as auth.net sims. These should be refactored to this common interface as some point.

@odorcicd @RichardBlair
