### PR TITLE
Mercury: Add support for requesting a token

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
         commit('VoidSale', request)
       end
 
-      def request_token(credit_card, options={})
+      def store(credit_card, options={})
         request = build_card_lookup_request(credit_card, options)
         commit('CardLookup', request)
       end

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -71,8 +71,8 @@ class RemoteMercuryTest < Test::Unit::TestCase
     assert_equal "0.50", response.params["purchase"]
   end
 
-  def test_request_token
-    response = @gateway.request_token(@credit_card, @options)
+  def test_store
+    response = @gateway.store(@credit_card, @options)
 
     assert_success response
     assert response.params.has_key?("record_no")


### PR DESCRIPTION
There is already tokenization support for generating token after an authorization. This pull request adds support for generating a token without an authorization. This method is useful because Mercury documentation explicitly disallows using a zero-auth for generating a token.
