### PR TITLE
Litle: Allow easier access to the response code

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -171,11 +171,11 @@ module ActiveMerchant #:nodoc:
           Response.new(
               valid_responses.include?(detail['response']),
               detail['message'],
-              { :litleOnlineResponse => response },
-              :authorization => authorization_from(detail, kind),
-              :avs_result    => { :code => fraud['avs'] },
-              :cvv_result    => fraud['cvv'],
-              :test          => test?
+              { litleOnlineResponse: response, response_code: detail['response'] },
+              authorization: authorization_from(detail, kind),
+              avs_result: { :code => fraud['avs'] },
+              cvv_result: fraud['cvv'],
+              test: test?
           )
         else
           Response.new(false, response['message'], :litleOnlineResponse => response, :test => test?)

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -377,6 +377,7 @@ class LitleTest < Test::Unit::TestCase
     assert_equal 'successful', responseFrom.message
     assert_equal '1234;authorization', responseFrom.authorization
     assert_equal '1111222233334444', responseFrom.params['litleOnlineResponse']['authorizationResponse']['litleToken']
+    assert_equal '000', responseFrom.params['response_code']
   end
 
   def test_avs


### PR DESCRIPTION
Prior to this commit, the response code could show up within a number of
different response param keys, depending on whether it was an authorize,
a purchase, etc.

Now, we have the 'response_code' key in the Response params allowing
clients to get the code in the same way regardless of the operation.
In addition, Active Merchant uses the response_code key for a number of
other gateways.
