### PR TITLE
Better rake task for gem release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg
 Gemfile.lock
 Gemfile*.lock
 .rbx/
+*.gem


### PR DESCRIPTION
I recently did the same thing for liquid https://github.com/Shopify/liquid/commit/0644da02bbae2123109b59685f401cb9e9e8511c .

What this does is provide a `rake release` which will build and tag.

[@odorcicd @melari @jduff].any_for_review
