### PR TITLE
Balanced: Pass on appears_on_statement_as

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -131,6 +131,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:amount] = money
         post[:description] = options[:description]
+        post[:appears_on_statement_as] = options[:appears_on_statement_as] if options[:appears_on_statement_as]
 
         create_or_find_account(post, options)
         add_credit_card(post, credit_card, options)
@@ -168,6 +169,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:amount] = money
         post[:description] = options[:description]
+        post[:appears_on_statement_as] = options[:appears_on_statement_as] if options[:appears_on_statement_as]
 
         create_or_find_account(post, options)
         add_credit_card(post, credit_card, options)
@@ -197,6 +199,7 @@ module ActiveMerchant #:nodoc:
         post[:hold_uri] = authorization
         post[:amount] = money if money
         post[:description] = options[:description] if options[:description]
+        post[:appears_on_statement_as] = options[:appears_on_statement_as] if options[:appears_on_statement_as]
         post[:on_behalf_of_uri] = options[:on_behalf_of_uri] if options[:on_behalf_of_uri]
 
         create_transaction(:post, @debits_uri, post)
@@ -213,6 +216,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         post = {}
         post[:is_void] = true
+        post[:appears_on_statement_as] = options[:appears_on_statement_as] if options[:appears_on_statement_as]
 
         create_transaction(:put, authorization, post)
       rescue Error => ex
@@ -246,6 +250,7 @@ module ActiveMerchant #:nodoc:
         post[:debit_uri] = debit_uri
         post[:amount] = amount
         post[:description] = options[:description]
+        post[:appears_on_statement_as] = options[:appears_on_statement_as] if options[:appears_on_statement_as]
         create_transaction(:post, @refunds_uri, post)
       rescue Error => ex
         failed_response(ex.response)
@@ -265,12 +270,12 @@ module ActiveMerchant #:nodoc:
         else
           card_uri = associate_card_to_account(account_uri, credit_card)
         end
-        
+
         is_test = false
         if @marketplace_uri
           is_test = (@marketplace_uri.index("TEST") ? true : false)
         end
-        
+
         Response.new(true, "Card stored", {}, :test => is_test, :authorization => [card_uri, account_uri].compact.join(';'))
       rescue Error => ex
         failed_response(ex.response)

--- a/test/remote/gateways/remote_balanced_test.rb
+++ b/test/remote/gateways/remote_balanced_test.rb
@@ -42,6 +42,14 @@ class RemoteBalancedTest < Test::Unit::TestCase
     assert_match /Account Frozen/, response.message
   end
 
+  def test_passing_appears_on_statement
+    options = @options.merge(appears_on_statement_as: "Homer Electric")
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal "Homer Electric", response.params['appears_on_statement_as']
+  end
+
   def test_authorize_and_capture
     amount = @amount
     assert auth = @gateway.authorize(amount, @credit_card, @options)


### PR DESCRIPTION
If it's specified, pass it to Balanced so that the descriptor on the
customer's statement can be customized.
