### PR TITLE
Litle Partial Capture Transaction Gateway Feature

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -295,6 +295,7 @@ module ActiveMerchant #:nodoc:
 
       def create_capture_hash(money, authorization, options)
         hash               = create_hash(money, options)
+        hash['partial']    = options[:partial] if options.has_key?(:partial)
         hash['litleTxnId'] = authorization
         hash
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -266,6 +266,16 @@ class LitleTest < Test::Unit::TestCase
     assert_nil hashFromGateway['amount']
   end
 
+  def test_create_catpure_hash_partial_nil
+    hashFromGateway = @gateway.send(:create_capture_hash, 0, '1234', {:partial => nil})
+    assert_nil hashFromGateway['partial']
+  end
+
+  def test_create_capture_hash_partial_true
+    hashFromGateway = @gateway.send(:create_capture_hash, 0, '1234', {:partial => true})
+    assert hashFromGateway['partial']
+  end
+
   def test_recognize_ax_and_some_empties
     creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'american_express'))
     hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})


### PR DESCRIPTION
Added support for partial capture of an authorization for a Litle Capture Transaction. According to the Litle documentation:

> **1.12.3 Capture Transaction**
> 
> You can submit a Capture transaction for the full amount of the Authorization, or for a lesser amount by setting the `partial` attribute to true.
