### PR TITLE
Allow Valitor gateway to accept other currencies

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       include Utils
 
       DEBIT_CARDS = [ :switch, :solo ]
-      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY', 'HUF', 'TWD' ]
+      CURRENCIES_WITHOUT_FRACTIONS = [ 'JPY', 'HUF', 'TWD', 'ISK' ]
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
 
       cattr_reader :implementations

--- a/lib/active_merchant/billing/integrations/valitor/helper.rb
+++ b/lib/active_merchant/billing/integrations/valitor/helper.rb
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
             requires!(options, :amount, :description)
             options.assert_valid_keys([:description, :quantity, :amount, :discount])
 
-            add_field("Vara_#{id}_Verd", format_amount(options[:amount]))
+            add_field("Vara_#{id}_Verd", format_amount(options[:amount], @fields[mappings[:currency]]))
             add_field("Vara_#{id}_Fjoldi", options[:quantity] || "1")
             
             add_field("Vara_#{id}_Lysing", options[:description]) if options[:description]
@@ -76,8 +76,8 @@ module ActiveMerchant #:nodoc:
             @fields.merge('RafraenUndirskrift' => signature)
           end
           
-          def format_amount(amount)
-            amount.to_f.round
+          def format_amount(amount, currency)
+            Gateway::CURRENCIES_WITHOUT_FRACTIONS.include?(currency) ? amount.to_f.round : sprintf("%.2f", amount)
           end
         end
       end

--- a/test/unit/integrations/helpers/valitor_helper_test.rb
+++ b/test/unit/integrations/helpers/valitor_helper_test.rb
@@ -20,7 +20,7 @@ class ValitorHelperTest < Test::Unit::TestCase
     assert_field 'Tilvisunarnumer', 'order-500'
     assert_field 'Gjaldmidill', 'USD'
     
-    assert_equal Digest::MD5.hexdigest(['123', '0', '1', '1000', '0', 'cody@example.com', 'order-500', 'USD'].join('')),
+    assert_equal Digest::MD5.hexdigest(['123', '0', '1', '1000.00', '0', 'cody@example.com', 'order-500', 'USD'].join('')),
                  @helper.form_fields['RafraenUndirskrift']
   end
   
@@ -30,18 +30,18 @@ class ValitorHelperTest < Test::Unit::TestCase
     
     assert_field 'Vara_1_Lysing', 'one'
     assert_field 'Vara_1_Fjoldi', '2'
-    assert_field 'Vara_1_Verd', '100'
+    assert_field 'Vara_1_Verd', '100.00'
     assert_field 'Vara_1_Afslattur', '50'
     
     assert_field 'Vara_2_Lysing', 'two'
     assert_field 'Vara_2_Fjoldi', '1'
-    assert_field 'Vara_2_Verd', '200'
+    assert_field 'Vara_2_Verd', '200.00'
     assert_field 'Vara_2_Afslattur', '0'
 
     assert_equal Digest::MD5.hexdigest(
       ['123', '0',
-        '2', '100', '50',
-        '1', '200', '0',
+        '2', '100.00', '50',
+        '1', '200.00', '0',
         'cody@example.com', 'order-500', 'USD'].join('')),
       @helper.form_fields['RafraenUndirskrift']
   end
@@ -100,7 +100,7 @@ class ValitorHelperTest < Test::Unit::TestCase
 
     assert_equal Digest::MD5.hexdigest(
       ['123', '0',
-         '1', '1000', '0',
+         '1', '1000.00', '0',
         'cody@example.com', 'order-500', 'http://example.com/return', 'http://example.com/notify', 'USD'].join('')),
       @helper.form_fields['RafraenUndirskrift']
   end
@@ -127,9 +127,15 @@ class ValitorHelperTest < Test::Unit::TestCase
     assert_field 'Lang', 'en'
   end
   
-  def test_amount_gets_sent_without_decimals
+  def test_amount_gets_sent_without_decimals_for_non_decimal_currencies
     @helper = Valitor::Helper.new('order-500', 'cody@example.com', :currency => 'ISK', :credential2 => '123', :amount => 115.10)
     @helper.form_fields
     assert_field "Vara_1_Verd", '115'
+  end
+
+  def test_amount_gets_sent_with_decimals_for_decimal_currencies
+    @helper = Valitor::Helper.new('order-500', 'cody@example.com', :currency => 'USD', :credential2 => '123', :amount => 115.10)
+    @helper.form_fields
+    assert_field "Vara_1_Verd", '115.10'
   end
 end


### PR DESCRIPTION
This Valitor gateway used to only accept the ISK currency, which is a non-decimal currency.  So we used to always round the amount before sending it on to the gateway.

Now, this gateway accepts other currencies, like USD.  So at this point in time if you purchase through Valitor in USD, your order is always rounded to the nearest dollar.  Like this:

https://www.monosnap.com/image/Hml7dSfv8rims7j01wXmupCmU
https://www.monosnap.com/image/bgFY6N8D892R0J2UOLHxG8CDv

This PR will keep the correct behaviour for the ISK currency, and correctly format the cents if you're paying with a non-decimal currency.  I've also added ISK to the `CURRENCIES_WITHOUT_FRACTIONS` in `Gateway.rb`.

Review
@melari @Soleone 

cc/
@benjlcox 
