### PR TITLE
Adds stripe key to allowed options in generate_options

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -240,7 +240,7 @@ module ActiveMerchant #:nodoc:
 
       def generate_options(raw_options)
         options = generate_meta(raw_options)
-        options.merge!(raw_options.slice(:version))
+        options.merge!(raw_options.slice(:version, :key))
       end
 
       def generate_meta(options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -326,6 +326,10 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def generate_options_should_allow_key
+    assert_equal({:key => '12345'}, generate_options({:key => '12345'}))
+  end
+
   private
 
   # Create new customer and set default credit card


### PR DESCRIPTION
Adds :key to slice in generate_options for stripe gateway to allow access token key to be used from stripe connect authorizations to make requests on behalf of user, https://stripe.com/docs/connect/collecting-fees. The rest of the logic existed for this, it just wasn't allowing the key to make it through to the headers call to set the correct auth header.

@odorcicd review please :)
