### PR TITLE
Payflow ach

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -25,15 +25,20 @@ module ActiveMerchant #:nodoc:
         commit(request, options)
       end
 
-      def credit(money, identification_or_credit_card, options = {})
-        if identification_or_credit_card.is_a?(String)
+      def credit(money, funding_source, options = {})
+        case
+        when funding_source.is_a?(String) 
           deprecated CREDIT_DEPRECATION_MESSAGE
           # Perform referenced credit
-          refund(money, identification_or_credit_card, options)
-        else
+          refund(money, funding_source, options)
+        when funding_source.is_a?(CreditCard)
           # Perform non-referenced credit
-          request = build_credit_card_request(:credit, money, identification_or_credit_card, options)
+          request = build_credit_card_request(:credit, money, funding_source, options)
           commit(request, options)
+        when funding_source.is_a?(Check)
+          request = build_check_request(:credit, money, funding_source, options)
+          commit(request, options)
+        else raise ArgumentError, "Unsupported funding source provided"
         end
       end
 

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -46,6 +46,14 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert response.test?
     assert_not_nil response.authorization
   end
+
+  def test_successful_ach_credit
+    assert response = @gateway.credit(50, @check)
+    assert_equal "Approved", response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
+  end
   
   def test_successful_authorization
     assert response = @gateway.authorize(100, @credit_card, @options)

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -85,6 +85,12 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @check)
   end
 
+  def test_ach_credit 
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/<AcctNum>#{@check.account_number}<\//), anything).returns("")
+    @gateway.expects(:parse).returns({})
+    @gateway.credit(@amount, @check)
+  end
+
   def test_using_test_mode
     assert @gateway.test?
   end


### PR DESCRIPTION
These commits add support for Paypal Payflow ACH. Included are unit and remote tests. The remote tests apply purchase and credit ACH transactions against the pilot-payflowpro.paypal.com test endpoint.
