### PR TITLE
NAB Transact Gateway: Fix merchant descriptor with capture/refund requests

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -127,6 +127,8 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'purchaseOrderNo', order_id
         xml.tag! 'preauthID', preauth_id
 
+        add_metadata(xml, options)
+
         xml.target!
       end
 


### PR DESCRIPTION
Fixes a problem where merchant descriptor wasn't being added 
to the request for capture and authorization requests.
