### PR TITLE
[pin] Use CreditCard#name

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
             :expiry_month => creditcard.month,
             :expiry_year => creditcard.year,
             :cvc => creditcard.verification_value,
-            :name => "#{creditcard.first_name} #{creditcard.last_name}"
+            :name => creditcard.name
           )
         elsif creditcard.kind_of?(String)
           if creditcard =~ /^card_/

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -202,7 +202,7 @@ class PinTest < Test::Unit::TestCase
     assert_equal @credit_card.month, post[:card][:expiry_month]
     assert_equal @credit_card.year, post[:card][:expiry_year]
     assert_equal @credit_card.verification_value, post[:card][:cvc]
-    assert_equal "#{@credit_card.first_name} #{@credit_card.last_name}", post[:card][:name]
+    assert_equal @credit_card.name, post[:card][:name]
   end
 
   def test_add_creditcard_with_card_token


### PR DESCRIPTION
Within Spree, we have a field called "Name on Card", which gets assigned to our CreditCard object as `name`. Many gateways within ActiveMerchant already use the `name` method to represent this, but Pin did it differently using `first_name` and `last_name`. Spree does not have a `first_name` and `last_name` field, and so Pin chokes because we're giving it `name`, rather than `first_name` and `last_name`.

This patch aims to standardise Pin into using the same method that many other gateways within ActiveMerchant use.
