### PR TITLE
Refactor IPay88 to follow correct integration using Notification

### DIFF
--- a/lib/active_merchant/billing/integrations/ipay88/notification.rb
+++ b/lib/active_merchant/billing/integrations/ipay88/notification.rb
@@ -1,0 +1,103 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Ipay88
+        class Notification < ActiveMerchant::Billing::Integrations::Notification
+          include ActiveMerchant::PostsData
+
+          def status
+            params["Status"] == '1' ? 'Completed' : 'Failed'
+          end
+
+          def complete?
+            status == 'Completed'
+          end
+
+          def item_id
+            params["RefNo"]
+          end
+
+          def gross
+            params["Amount"]
+          end
+
+          def currency
+            params["Currency"]
+          end
+
+          def account
+            params["MerchantCode"]
+          end
+
+          def payment
+            params["PaymentId"].to_i
+          end
+
+          def remark
+            params["Remark"]
+          end
+
+          def transaction_id
+            params["TransId"]
+          end
+
+          def auth_code
+            params["AuthCode"]
+          end
+
+          def error
+            params["ErrDesc"]
+          end
+
+          def signature
+            params["Signature"]
+          end
+
+          def secure?
+            generated_signature == signature
+          end
+
+          def success?
+            status == 'Completed'
+          end
+
+          def acknowledge
+            secure? && success? && requery == "00"
+          end
+
+          protected
+
+          def generated_signature
+            Helper.sign(sig_components)
+          end
+
+          def sig_components
+            components = [@options[:credential2]]
+            [:account, :payment, :item_id, :amount_in_cents, :currency].each do |i|
+              components << send(i)
+            end
+            components << params["Status"]
+            components.join
+          end
+
+          def requery
+            data   = { "MerchantCode" => account, "RefNo" => item_id, "Amount" => gross }
+            params = parameterize(data)
+            ssl_post Ipay88.requery_url, params, { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
+          end
+
+          private
+
+          def parameterize(params)
+            params.reject { |k, v| v.blank? }.keys.sort.collect { |key| "#{key}=#{CGI.escape(params[key].to_s)}" }.join("&")
+          end
+
+          def amount_in_cents
+            @amount_in_cents ||= (gross || "").gsub(/[.,]/, "")
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/active_merchant/billing/integrations/ipay88/return.rb
+++ b/lib/active_merchant/billing/integrations/ipay88/return.rb
@@ -5,96 +5,22 @@ module ActiveMerchant #:nodoc:
     module Integrations #:nodoc:
       module Ipay88
         class Return < ActiveMerchant::Billing::Integrations::Return
-          include ActiveMerchant::PostsData
 
-          def account
-            params["MerchantCode"]
-          end
-
-          def payment
-            params["PaymentId"].to_i
-          end
-
-          def order
-            params["RefNo"]
-          end
-
-          def amount
-            params["Amount"]
-          end
-
-          def currency
-            params["Currency"]
-          end
-
-          def remark
-            params["Remark"]
-          end
-
-          def transaction
-            params["TransId"]
-          end
-
-          def auth_code
-            params["AuthCode"]
-          end
-
-          def status
-            params["Status"]
-          end
-
-          def error
-            params["ErrDesc"]
-          end
-
-          def signature
-            params["Signature"]
-          end
-
-          def secure?
-            self.generated_signature == self.signature
+          def initialize(query_string, options = {})
+            super
+            @notification = Notification.new(query_string, options)
           end
 
           def success?
-            self.secure? && self.requery == "00" && self.status == "1"
+            params["Status"] == "1"
           end
 
           def cancelled?
-            error == 'Customer Cancel Transaction'
+            params["ErrDesc"] == 'Customer Cancel Transaction'
           end
 
           def message
             params["ErrDesc"]
-          end
-
-          protected
-
-          def generated_signature
-            Helper.sign(self.sig_components)
-          end
-
-          def sig_components
-            components = [@options[:credential2]]
-            [:account, :payment, :order, :amount_in_cents, :currency, :status].each do |i|
-              components << self.send(i)
-            end
-            components.join
-          end
-
-          def requery
-            data   = { "MerchantCode" => self.account, "RefNo" => self.order, "Amount" => self.amount }
-            params = parameterize(data)
-            ssl_post Ipay88.requery_url, params, { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
-          end
-
-          private
-
-          def parameterize(params)
-            params.reject { |k, v| v.blank? }.keys.sort.collect { |key| "#{key}=#{CGI.escape(params[key].to_s)}" }.join("&")
-          end
-
-          def amount_in_cents
-            @amount_in_cents ||= (self.amount || "").gsub(/[.,]/, "")
           end
         end
       end

--- a/test/unit/integrations/notifications/ipay88_notification_test.rb
+++ b/test/unit/integrations/notifications/ipay88_notification_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+
+class Ipay88NotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @ipay88 = build_notification(http_raw_data)
+  end
+
+  def test_accessors
+    assert_equal "ipay88merchcode",              @ipay88.account
+    assert_equal 6,                              @ipay88.payment
+    assert_equal "order-500",                    @ipay88.item_id
+    assert_equal "5.00",                         @ipay88.gross
+    assert_equal "MYR",                          @ipay88.currency
+    assert_equal "Remarkable",                   @ipay88.remark
+    assert_equal "12345",                        @ipay88.transaction_id
+    assert_equal "auth123",                      @ipay88.auth_code
+    assert_equal "Completed",                    @ipay88.status
+    assert_equal "Invalid merchant",             @ipay88.error
+    assert_equal "bPlMszCBwxlfGX9ZkgmSfT+OeLQ=", @ipay88.signature
+  end
+
+  def test_secure_request
+    assert @ipay88.secure?
+  end
+
+  def test_success
+    assert @ipay88.success?
+  end
+
+  def test_insecure_request
+    assert !build_notification(http_raw_data(:invalid_sig)).secure?
+  end
+
+  def test_acknowledge
+    params = parameterize(payload)
+    @ipay88.expects(:ssl_post).with(Ipay88.requery_url, params,
+      { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
+    ).returns("00")
+
+    assert @ipay88.acknowledge
+  end
+
+  def test_unsuccessful_acknowledge_due_to_signature
+    ipay = build_notification(http_raw_data(:invalid_sig))
+    assert !ipay.acknowledge
+  end
+
+  def test_unsuccessful_acknowledge_due_to_requery
+    params = parameterize(payload)
+    @ipay88.expects(:ssl_post).with(Ipay88.requery_url, params,
+      { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
+    ).returns("Invalid parameters")
+    assert !@ipay88.acknowledge
+  end
+
+  def test_unsuccessful_acknowledge_due_to_payment_failed
+    params = parameterize(payload)
+    ipay = build_notification(http_raw_data(:payment_failed))
+    assert !ipay.acknowledge
+  end
+
+  def test_unsuccessful_acknowledge_due_to_missing_amount
+    ipay = build_notification(http_raw_data(:missing_amount))
+    assert !ipay.acknowledge
+  end
+
+  private
+  def http_raw_data(mode=:success)
+    base = { "MerchantCode" => "ipay88merchcode",
+             "PaymentId"    =>  6,
+             "RefNo"        =>  "order-500",
+             "Amount"       =>  "5.00",
+             "Currency"     =>  "MYR",
+             "Remark"       =>  "Remarkable",
+             "TransId"      =>  "12345",
+             "AuthCode"     =>  "auth123",
+             "Status"       =>  1,
+             "ErrDesc"      =>  "Invalid merchant" }
+
+    case mode
+    when :success
+      parameterize(base.merge("Signature" => "bPlMszCBwxlfGX9ZkgmSfT+OeLQ="))
+    when :invalid_sig
+      parameterize(base.merge("Signature" => "hacked"))
+    when :payment_failed
+      parameterize(base.merge("Status" => 0, "Signature" => "p8nXYcl/wytpNMzsf31O/iu/2EU="))
+    when :missing_amount
+      parameterize(base.except("Amount"))
+    else
+      ""
+    end
+  end
+
+  def payload
+    { "MerchantCode" => "ipay88merchcode", "RefNo" => "order-500", "Amount" => "5.00" }
+  end
+
+  def parameterize(params)
+    params.reject{|k, v| v.blank?}.keys.sort.collect { |key| "#{key}=#{CGI.escape(params[key].to_s)}" }.join("&")
+  end
+
+  def build_notification(data)
+    Ipay88::Notification.new(data, :credential2 => "apple")
+  end
+end

--- a/test/unit/integrations/returns/ipay88_return_test.rb
+++ b/test/unit/integrations/returns/ipay88_return_test.rb
@@ -4,113 +4,23 @@ class Ipay88ReturnTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
   def setup
-    @ipay88 = build_return(http_raw_data)
+    @ipay = Ipay88::Return.new(http_raw_data, :credential2 => 'secret')
   end
 
-  def test_accessors
-    assert_equal "ipay88merchcode",              @ipay88.account
-    assert_equal 6,                              @ipay88.payment
-    assert_equal "order-500",                    @ipay88.order
-    assert_equal "5.00",                         @ipay88.amount
-    assert_equal "MYR",                          @ipay88.currency
-    assert_equal "Remarkable",                   @ipay88.remark
-    assert_equal "12345",                        @ipay88.transaction
-    assert_equal "auth123",                      @ipay88.auth_code
-    assert_equal "1",                            @ipay88.status
-    assert_equal "Invalid merchant",             @ipay88.error
-    assert_equal "bPlMszCBwxlfGX9ZkgmSfT+OeLQ=", @ipay88.signature
-  end
-
-  def test_secure_request
-    assert @ipay88.secure?
-  end
-
-  def test_insecure_request
-    assert !build_return(http_raw_data(:invalid_sig)).secure?
-  end
-
-  def test_successful_return
-    params = parameterize(payload)
-    Ipay88::Return.any_instance.expects(:ssl_post).with(Ipay88.requery_url, params,
-      { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
-    ).returns("00")
-
-    assert @ipay88.success?
-  end
-
-  def test_unsuccessful_return_due_to_signature
-    ipay = build_return(http_raw_data(:invalid_sig))
-    assert !ipay.success?
-  end
-
-  def test_unsuccessful_return_due_to_requery
-    params = parameterize(payload)
-    Ipay88::Return.any_instance.expects(:ssl_post).with(Ipay88.requery_url, params,
-      { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
-    ).returns("Invalid parameters")
-    assert !@ipay88.success?
-  end
-
-  def test_unsuccessful_return_due_to_payment_failed
-    params = parameterize(payload)
-    Ipay88::Return.any_instance.expects(:ssl_post).with(Ipay88.requery_url, params,
-      { "Content-Length" => params.size.to_s, "User-Agent" => "Active Merchant -- http://activemerchant.org" }
-    ).returns("00")
-    ipay = build_return(http_raw_data(:payment_failed))
-    assert !ipay.success?
-  end
-
-  def test_unsuccessful_return_due_to_missing_amount
-    ipay = build_return(http_raw_data(:missing_amount))
-    assert !ipay.success?
+  def test_success?
+    assert @ipay.success?
   end
 
   def test_message_returns_error_description
-    ipay = build_return(parameterize({"ErrDesc" => "Invalid merchant"}))
-    assert_equal 'Invalid merchant', ipay.message
+    assert_equal 'Customer Cancel Transaction', @ipay.message
   end
 
   def test_cancelled
-    ipay = build_return(parameterize({"ErrDesc" => "Customer Cancel Transaction"}))
-    assert ipay.cancelled?
+    assert @ipay.cancelled?
   end
 
   private
-  def http_raw_data(mode=:success)
-    base = { "MerchantCode" => "ipay88merchcode",
-             "PaymentId"    =>  6,
-             "RefNo"        =>  "order-500",
-             "Amount"       =>  "5.00",
-             "Currency"     =>  "MYR",
-             "Remark"       =>  "Remarkable",
-             "TransId"      =>  "12345",
-             "AuthCode"     =>  "auth123",
-             "Status"       =>  1,
-             "ErrDesc"      =>  "Invalid merchant" }
-
-    case mode
-    when :success
-      parameterize(base.merge("Signature" => "bPlMszCBwxlfGX9ZkgmSfT+OeLQ="))
-    when :invalid_sig
-      parameterize(base.merge("Signature" => "hacked"))
-    when :payment_failed
-      parameterize(base.merge("Status" => 0, "Signature" => "p8nXYcl/wytpNMzsf31O/iu/2EU="))
-    when :missing_amount
-      parameterize(base.except("Amount"))
-    else
-      ""
-    end
-  end
-
-  def payload
-    { "MerchantCode" => "ipay88merchcode", "RefNo" => "order-500", "Amount" => "5.00" }
-  end
-
-  def parameterize(params)
-    params.reject{|k, v| v.blank?}.keys.sort.collect { |key| "#{key}=#{CGI.escape(params[key].to_s)}" }.join("&")
-  end
-
-  def build_return(data)
-    Ipay88::Return.new(data, :credential2 => "apple")
+  def http_raw_data
+    "Amount=0.10&AuthCode=12345678&Currency=USD&ErrDesc=Customer Cancel Transaction&MerchantCode=M00001&PaymentId=1&RefNo=10000001&Remark=&Signature=RWAehzFtiNCKQWpXheazrCF33J4%3D&Status=1&TransId=T123456789"
   end
 end


### PR DESCRIPTION
@melari @bizla 

A Return doesn't work with the flow we have at Shopify. I've changed IPay88 to include a Notification class which the Return class references, like many of the other integration implementations.
