### PR TITLE
WebPay: modify webpay.rb to support authorize and capture methods.

### DIFF
--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -13,12 +13,10 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://webpay.jp/'
       self.display_name = 'WebPay'
 
-      def authorize(money, credit_card, options = {})
-        raise NotImplementedError.new
-      end
-
-      def capture(money, credit_card, options = {})
-        raise NotImplementedError.new
+      def capture(money, authorization, options = {})
+        post = {:amount => localized_amount(money)}
+        add_application_fee(post, options)
+        commit(:post, "charges/#{CGI.escape(authorization)}/capture", post)
       end
 
       def refund(money, identification, options = {})
@@ -50,6 +48,26 @@ module ActiveMerchant #:nodoc:
 
       def add_customer(post, creditcard, options)
         post[:customer] = options[:customer] if options[:customer] && !creditcard.respond_to?(:number)
+      end
+
+      def store(creditcard, options = {})
+        post = {}
+        add_creditcard(post, creditcard, options)
+        post[:description] = options[:description]
+        post[:email] = options[:email]
+
+        commit_options = generate_options(options)
+        if options[:customer]
+          MultiResponse.run(:first) do |r|
+            r.process { commit(:post, "customers/#{CGI.escape(options[:customer])}/", post, commit_options) }
+
+            return r unless options[:set_default] and r.success? and !r.params["id"].blank?
+
+            r.process { update_customer(options[:customer], :default_card => r.params["id"]) }
+          end
+        else
+          commit(:post, 'customers', post, commit_options)
+        end
       end
 
       def json_error(raw_response)

--- a/test/remote/gateways/remote_webpay_test.rb
+++ b/test/remote/gateways/remote_webpay_test.rb
@@ -48,6 +48,24 @@ class RemoteWebpayTest < Test::Unit::TestCase
     assert_equal 'Your card number is incorrect', response.message
   end
 
+  def test_authorization_and_capture
+    assert authorization = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorization
+    assert !authorization.params["captured"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+  end
+
+  def test_authorization_and_void
+    assert authorization = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorization
+    assert !authorization.params["captured"]
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
   def test_successful_void
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
WebPay now supports authorize and capture methods. I implement the two methods.
