### PR TITLE
MerchantWarrior: Pass description

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_product(post, options)
-        post['transactionProduct'] = options[:transaction_product]
+        post['transactionProduct'] = options[:description]
       end
 
       def add_payment_method(post, payment_method)

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -24,7 +24,7 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
         :address1 => '123 test st',
         :zip => '4000'
       },
-      :transaction_product => 'TestProduct'
+      :description => 'TestProduct'
     }
   end
 


### PR DESCRIPTION
Merchant Warrior docs say the transactionProduct attribute is the
description:
http://cl.ly/image/0D0E3u3k1417/content.png

http://dox.merchantwarrior.com/files/MWE%20API.pdf

Use options[:description] like many other gateways to abstract this away
so we're not passing in custom options for each gateway.
