### PR TITLE
Stripe: Separate email from description

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -143,7 +143,8 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, creditcard, options)
         add_customer(post, creditcard, options)
         add_customer_data(post,options)
-        post[:description] = options[:description] || options[:email]
+        post[:description] = options[:description]
+        post[:metadata] = { email: options[:email] } if options[:email]
         add_flags(post, options)
         add_application_fee(post, options)
         post

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -24,17 +24,8 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert_equal "charge", response.params["object"]
     assert response.params["paid"]
-  end
-
-  def test_purchase_description
-    assert response = @gateway.purchase(@amount, @credit_card, { :currency => @currency, :description => "TheDescription", :email => "email@example.com" })
-    assert_equal "TheDescription", response.params["description"], "Use the description if it's specified."
-
-    assert response = @gateway.purchase(@amount, @credit_card, { :currency => @currency, :email => "email@example.com" })
-    assert_equal "email@example.com", response.params["description"], "Use the email if no description is specified."
-
-    assert response = @gateway.purchase(@amount, @credit_card, { :currency => @currency })
-    assert_nil response.params["description"], "No description or email specified."
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
   end
 
   def test_unsuccessful_purchase
@@ -47,6 +38,8 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
     assert !authorization.params["captured"]
+    assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
+    assert_equal "wow@example.com", authorization.params["metadata"]["email"]
 
     assert capture = @gateway.capture(@amount, authorization.authorization)
     assert_success capture

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -261,6 +261,7 @@ class StripeTest < Test::Unit::TestCase
       assert_match(/external_id=42/, data)
       assert_match(/referrer=http\%3A\%2F\%2Fwww\.shopify\.com/, data)
       assert_match(/payment_user_agent=Stripe\%2Fv1\+ActiveMerchantBindings\%2F\d+\.\d+\.\d+/, data)
+      assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Before:
Specify the description for the purchase or authorization using the
options[:description] || options[:email].

After:
Use options[:description] for description.  Use metadata for the email.
Keep the 2 options separate as the Stripe docs suggest:

https://stripe.com/docs/api#metadata
