### PR TITLE
Refactor gateway selector error handling

### DIFF
--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -31,8 +31,15 @@ module ActiveMerchant #:nodoc:
       #
       #   ActiveMerchant::Billing::Base.gateway('moneris').new
       def self.gateway(name)
-        raise NameError if (name_str = name.to_s.downcase).blank?
-        Billing.const_get("#{name_str}_gateway".camelize)
+        name_str = name.to_s.strip.downcase
+
+        raise(ArgumentError, 'A gateway provider must be specified') if name_str.blank?
+
+        begin
+          Billing.const_get("#{name_str}_gateway".camelize)
+        rescue
+          raise ArgumentError, "The specified gateway is not valid (#{name_str})"
+        end
       end
 
       # Return the matching integration module

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -18,18 +18,32 @@ class BaseTest < Test::Unit::TestCase
     assert_equal LinkpointGateway,     Base.gateway(:linkpoint)
   end
 
-  def test_should_raise_when_invalid_gateway_is_passed
-    assert_raise NameError do
-      Base.gateway(:nil)
+  def test_should_raise_when_nil_gateway_is_passed
+    e = assert_raise ArgumentError do
+      Base.gateway(nil)
     end
+    assert_equal 'A gateway provider must be specified', e.message
+  end
 
-    assert_raise NameError do
+  def test_should_raise_when_empty_gateway_is_passed
+    e = assert_raise ArgumentError do
       Base.gateway('')
     end
+    assert_equal 'A gateway provider must be specified', e.message
+  end
 
-    assert_raise NameError do
+  def test_should_raise_when_invalid_gateway_symbol_is_passed
+    e = assert_raise ArgumentError do
       Base.gateway(:hotdog)
     end
+    assert_equal 'The specified gateway is not valid (hotdog)', e.message
+  end
+
+  def test_should_raise_when_invalid_gateway_string_is_passed
+    e = assert_raise ArgumentError do
+      Base.gateway('hotdog')
+    end
+    assert_equal 'The specified gateway is not valid (hotdog)', e.message
   end
 
   def test_should_return_an_integration_by_name


### PR DESCRIPTION
Simple change to expose better errors to external app using the gem.

First PR over this project, don't be shy to propose alternatives if they are better fit for the project standards.

Notes:
1. Would have liked to replace `.downcase` by a method that actually do an `.underscore`(or simply remove that `downcase`) as information could be lost when processing the string.
1. Is there a reason we do not whitelist what gateway are available? I fear it could lead to potential security breach if the user is in control of the gateway name as we evaluate it.
