### PR TITLE
Merchant Warrior: Use billing_address

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -75,7 +75,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless(address = options[:address])
+        return unless(address = (options[:billing_address] || options[:address]))
 
         post['customerName'] = address[:name]
         post['customerCountry'] = address[:country]

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -16,7 +16,7 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     )
 
     @options = {
-      :address => {
+      :billing_address => {
         :name => 'Longbob Longsen',
         :country => 'AU',
         :state => 'Queensland',


### PR DESCRIPTION
This allows folks to use either billing_address or address just like
many other gateways do.  Previously our Merchant Warrior support ignored
billing_address.
