### PR TITLE
Update Ogone gateway : allow d3d for payment with alias

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -244,6 +244,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_source(post, payment_source, options)
+        add_d3d(post, options) if options[:d3d]
+
         if payment_source.is_a?(String)
           add_alias(post, payment_source, options[:alias_operation])
           add_eci(post, options[:eci] || '9')
@@ -254,7 +256,6 @@ module ActiveMerchant #:nodoc:
           end
           add_alias(post, options[:billing_id], options[:alias_operation])
           add_eci(post, options[:eci] || '7')
-          add_d3d(post, options) if options[:d3d]
           add_creditcard(post, payment_source)
         end
       end


### PR DESCRIPTION
This allow d3d usage for payment with alias
