### PR TITLE
Favour Money.parse() over sub() for Valitor parsing

### DIFF
--- a/lib/active_merchant/billing/integrations/valitor/response_fields.rb
+++ b/lib/active_merchant/billing/integrations/valitor/response_fields.rb
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
           end
           
           def gross
-            "%0.2f" % params['Upphaed'].to_s.sub(',', '.')
+            Money.parse(params['Upphaed']).to_s
           end
           
           def card_type


### PR DESCRIPTION
This is a followup of [this comment](https://github.com/Shopify/active_merchant/pull/952#issuecomment-30479360) on #952.

Please review @cjoudrey @melari .
