### PR TITLE
adding the capture method (environment) to data cash

### DIFF
--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -286,6 +286,7 @@ module ActiveMerchant
             xml.tag! :TxnDetails do
               xml.tag! :merchantreference, format_reference_number(options[:order_id])
               xml.tag! :amount, amount(money), :currency => options[:currency] || currency(money)
+              xml.tag! :capturemethod, 'ecomm'
             end
           end
         end

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -116,9 +116,10 @@ class DataCashTest < Test::Unit::TestCase
     assert_equal 'ACCEPTED', response.message
   end
 
-  def test_capturemethod_is_set_to_ecomm
-    xml = REXML::Document.new(@gateway.send(:build_void_or_capture_request, 'fulfill', 100, 'authorization', {}))
-    assert_equal 'ecomm', REXML::XPath.first(xml, '//TxnDetails/capturemethod').text
+  def test_capture_method_is_ecomm
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/<capturemethod>ecomm<\/capturemethod>/)).returns(successful_purchase_response)
+    response = @gateway.purchase(100, @credit_card, @options)
+    assert_success response
   end
   
   private


### PR DESCRIPTION
Customer getting a 401 error with Data Cash.  Seems to be caused by them using that account for multiple things, and us not explicitly stating that we are an eCommerce environment.

Here's their documentation: https://datacash.custhelp.com/app/answers/detail/a_id/318/~/return-code-190---no-capture-method-specified

@melari 
@odorcicd 
