### PR TITLE
Orbital: Ensure param passed to AVSResult#initialize is a hash.

### DIFF
--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -69,7 +69,6 @@ module ActiveMerchant
       
       def initialize(attrs)
         attrs ||= {}
-        attrs = attrs.to_hash
         
         @code = attrs[:code].upcase unless attrs[:code].blank?
         @message = self.class.messages[code]

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -438,7 +438,7 @@ module ActiveMerchant #:nodoc:
           {
              :authorization => authorization_string(response[:tx_ref_num], response[:order_id]),
              :test => self.test?,
-             :avs_result => OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
+             :avs_result => OrbitalGateway::AVSResult.new(response[:avs_resp_code]).to_hash,
              :cvv_result => response[:cvv2_resp_code]
           }
         )


### PR DESCRIPTION
When creating customer profiles with Orbital, AVSResult#initialize is receiving an Orbital::AVSResult object, which results in a 'undefined method []' error when it gets treated as a Hash.
