### PR TITLE
Truncate enhancedData customerReference to 17 characters due to limitations by Litle library

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -335,7 +335,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if options[:description]
-          enhanced_data['customerReference'] = options[:description]
+          enhanced_data['customerReference'] = options[:description][0..16]
         end
 
         if options[:billing_address]

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -744,6 +744,20 @@ class LitleTest < Test::Unit::TestCase
     end
   end
 
+  def test_refund_should_not_error_on_customer_reference_length
+    return_object = {
+      'response' => '0',
+      'creditResponse' => {
+        'response'    => '000',
+        'message'     => 'pass',
+        'litleTxnId'  =>'123456789012345678'
+      }
+    }
+    LitleOnline::Communications.expects(:http_post => return_object.to_xml(:root => 'litleOnlineResponse'))
+    response = @gateway.refund(0, "1234;credit", {:description => 'A lengthy refund description'})
+    assert response.success?
+  end
+
   private
 
   def with_litle_configuration_restoration(&block)


### PR DESCRIPTION
@silverstreaked @melari 

Problem: The Litle implementation limits `customerReference` to 17 characters, and going above throws an error:
`If enhancedData customerReference is specified, it must be between 1 and 17 characters long`
