### PR TITLE
Support all of the Orbital response codes which have “Approved” status.

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -40,7 +40,27 @@ module ActiveMerchant #:nodoc:
         "Interface-Version" => "Ruby|ActiveMerchant|Proprietary Gateway"
       }
 
-      SUCCESS, APPROVED = '0', '00'
+      SUCCESS = '0'
+
+      APPROVED = [
+        '00', # Approved
+        '08', # Approved authorization, honor with ID
+        '11', # Approved authorization, VIP approval
+        '24', # Validated
+        '26', # Pre-noted
+        '27', # No reason to decline
+        '28', # Received and stored
+        '29', # Provided authorization
+        '31', # Request received
+        '32', # BIN alert
+        '34', # Approved for partial
+        '91', # Approved low fraud
+        '92', # Approved medium fraud
+        '93', # Approved high fraud
+        '94', # Approved fraud service unavailable
+        'E7', # Stored
+        'PA'  # Partial approval
+      ]
 
       class_attribute :secondary_test_url, :secondary_live_url
 
@@ -459,7 +479,7 @@ module ActiveMerchant #:nodoc:
           response[:profile_proc_status] == SUCCESS
         else
           response[:proc_status] == SUCCESS &&
-          response[:resp_code] == APPROVED
+          APPROVED.include?(response[:resp_code])
         end
       end
 

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -452,10 +452,20 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  ActiveMerchant::Billing::OrbitalGateway::APPROVED.each do |resp_code|
+    define_method "test_approval_response_code_#{resp_code}" do
+      @gateway.expects(:ssl_post).returns(successful_purchase_response(resp_code))
+
+      assert response = @gateway.purchase(50, credit_card, :order_id => '1')
+      assert_instance_of Response, response
+      assert_success response
+    end
+  end
+
   private
 
-  def successful_purchase_response
-    %q{<?xml version="1.0" encoding="UTF-8"?><Response><NewOrderResp><IndustryType></IndustryType><MessageType>AC</MessageType><MerchantID>700000000000</MerchantID><TerminalID>001</TerminalID><CardBrand>VI</CardBrand><AccountNum>4111111111111111</AccountNum><OrderID>1</OrderID><TxRefNum>4A5398CF9B87744GG84A1D30F2F2321C66249416</TxRefNum><TxRefIdx>1</TxRefIdx><ProcStatus>0</ProcStatus><ApprovalStatus>1</ApprovalStatus><RespCode>00</RespCode><AVSRespCode>H </AVSRespCode><CVV2RespCode>N</CVV2RespCode><AuthCode>091922</AuthCode><RecurringAdviceCd></RecurringAdviceCd><CAVVRespCode></CAVVRespCode><StatusMsg>Approved</StatusMsg><RespMsg></RespMsg><HostRespCode>00</HostRespCode><HostAVSRespCode>Y</HostAVSRespCode><HostCVV2RespCode>N</HostCVV2RespCode><CustomerRefNum></CustomerRefNum><CustomerName></CustomerName><ProfileProcStatus></ProfileProcStatus><CustomerProfileMessage></CustomerProfileMessage><RespTime>144951</RespTime></NewOrderResp></Response>}
+  def successful_purchase_response(resp_code = '00')
+    %Q{<?xml version="1.0" encoding="UTF-8"?><Response><NewOrderResp><IndustryType></IndustryType><MessageType>AC</MessageType><MerchantID>700000000000</MerchantID><TerminalID>001</TerminalID><CardBrand>VI</CardBrand><AccountNum>4111111111111111</AccountNum><OrderID>1</OrderID><TxRefNum>4A5398CF9B87744GG84A1D30F2F2321C66249416</TxRefNum><TxRefIdx>1</TxRefIdx><ProcStatus>0</ProcStatus><ApprovalStatus>1</ApprovalStatus><RespCode>#{resp_code}</RespCode><AVSRespCode>H </AVSRespCode><CVV2RespCode>N</CVV2RespCode><AuthCode>091922</AuthCode><RecurringAdviceCd></RecurringAdviceCd><CAVVRespCode></CAVVRespCode><StatusMsg>Approved</StatusMsg><RespMsg></RespMsg><HostRespCode>00</HostRespCode><HostAVSRespCode>Y</HostAVSRespCode><HostCVV2RespCode>N</HostCVV2RespCode><CustomerRefNum></CustomerRefNum><CustomerName></CustomerName><ProfileProcStatus></ProfileProcStatus><CustomerProfileMessage></CustomerProfileMessage><RespTime>144951</RespTime></NewOrderResp></Response>}
   end
 
   def failed_purchase_response


### PR DESCRIPTION
The [Orbital specs](http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf) (see appendix A, section A.2) consider several response codes as "approved". This PR allows all of them to return as successful.
