### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/active_merchant/billing/integrations/authorize_net_sim/helper.rb
+++ b/lib/active_merchant/billing/integrations/authorize_net_sim/helper.rb
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
             raise unless options[:order_timestamp]
             amount = @fields['x_amount']
             data = "#{@fields['x_login']}^#{@fields['x_fp_sequence']}^#{options[:order_timestamp].to_i}^#{amount}^#{@fields['x_currency_code']}"
-            hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('md5'), options[:transaction_key], data)
+            hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('md5'), options[:transaction_key], data)
             add_field 'x_fp_hash', hmac
             add_field 'x_fp_timestamp', options[:order_timestamp].to_i
           end

--- a/lib/active_merchant/billing/integrations/citrus.rb
+++ b/lib/active_merchant/billing/integrations/citrus.rb
@@ -42,7 +42,7 @@ module ActiveMerchant
         end
 
         def self.checksum(secret_key, payload_items )
-          digest = OpenSSL::Digest::Digest.new('sha1')
+          digest = OpenSSL::Digest.new('sha1')
 		      OpenSSL::HMAC.hexdigest(digest, secret_key, payload_items)
         end
       end


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to use from very ancient era such as Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and finally was deprecated recently. ruby/ruby#446
