### PR TITLE
Add back Stripe's refund_application_fee parameter to the refund method

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -69,6 +69,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, identification, options = {})
         post = {:amount => amount(money)}
+        post[:refund_application_fee] = true if options[:refund_application_fee]
 
         MultiResponse.run(:first) do |r|
           r.process { commit(:post, "charges/#{CGI.escape(identification)}/refund", post, options) }

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -170,7 +170,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
     assert refund = @gateway.refund(@amount, response.authorization, :refund_application_fee => true)
     assert_success refund
-    assert_equal 12, refund.params["fee_details"].first["amount_refunded"]
+    assert_equal 0, refund.params["fee"]
   end
 
   def test_refund_partial_application_fee

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -125,6 +125,15 @@ class StripeTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_refund_with_refund_application_fee
+    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+      assert post.include?("refund_application_fee=true")
+    end.returns(successful_partially_refunded_response)
+
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_application_fee => true)
+    assert_success response
+  end
+
   def test_successful_refund_with_refund_fee_amount
     s = sequence("request")
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)


### PR DESCRIPTION
@bizla @girasquid 

Stripe now supports refunding (partial) application fees using the `refund_application_fee` parameter, but this shouldn't have been removed in the first place anyways. Adding it back.
