### PR TITLE
Allow passing in the Stripe API version as an initialiation option

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -33,6 +33,8 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login)
         @api_key = options[:login]
         @fee_refund_api_key = options[:fee_refund_login]
+        @version = options[:version]
+
         super
       end
 
@@ -258,7 +260,8 @@ module ActiveMerchant #:nodoc:
           :publisher => 'active_merchant'
         })
 
-        key = options[:key] || @api_key
+        key     = options[:key] || @api_key
+        version = options[:version] || @version
 
         headers = {
           "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
@@ -266,7 +269,7 @@ module ActiveMerchant #:nodoc:
           "X-Stripe-Client-User-Agent" => @@ua,
           "X-Stripe-Client-User-Metadata" => {:ip => options[:ip]}.to_json
         }
-        headers.merge!("Stripe-Version" => options[:version]) if options[:version]
+        headers.merge!("Stripe-Version" => version) if version
         headers
       end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -316,6 +316,15 @@ class StripeTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, @options.merge(:version => '2013-10-29'))
   end
 
+  def test_initialize_gateway_with_version
+    @gateway = StripeGateway.new(:login => 'login', :version => '2013-12-03')
+    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+      headers && headers['Stripe-Version'] == '2013-12-03'
+    }.returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
   def test_track_data_and_traditional_should_be_mutually_exclusive
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
@bizla  @karlhungus 

Currently, the API version can only be passed to the individual methods when making API calls.
With this, you can set it when initializing the gateway so it will be used across all calls as the default.
