### PR TITLE
Orbital-specific CVV response codes.

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -1,5 +1,6 @@
 require File.dirname(__FILE__) + '/orbital/orbital_soft_descriptors'
 require File.dirname(__FILE__) + '/orbital/avs_result'
+require File.dirname(__FILE__) + '/orbital/cvv_result'
 require "rexml/document"
 
 module ActiveMerchant #:nodoc:
@@ -439,7 +440,7 @@ module ActiveMerchant #:nodoc:
              :authorization => authorization_string(response[:tx_ref_num], response[:order_id]),
              :test => self.test?,
              :avs_result => OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
-             :cvv_result => response[:cvv2_resp_code]
+             :cvv_result => OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
           }
         )
       end

--- a/lib/active_merchant/billing/gateways/orbital/cvv_result.rb
+++ b/lib/active_merchant/billing/gateways/orbital/cvv_result.rb
@@ -1,0 +1,34 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class OrbitalGateway < Gateway
+      # Unfortunately, Orbital uses their own special codes for CVV responses
+      # that are different than the standard codes defined in
+      # <tt>ActiveMerchant::Billing::CVVResult</tt>.
+      #
+      # This class encapsulates the response codes shown on page 255 of their spec:
+      # http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf
+      #
+      class CVVResult < ActiveMerchant::Billing::CVVResult
+        MESSAGES = {
+          'M' => 'Match',
+          'N' => 'No match',
+          'P' => 'Not processed',
+          'S' => 'Should have been present',
+          'U' => 'Unsupported by issuer/Issuer unable to process request',
+          'I' => 'Invalid',
+          'Y' => 'Invalid',
+          ''  => 'Not applicable'
+        }
+
+        def self.messages
+          MESSAGES
+        end
+
+        def initialize(code)
+          @code = code.blank? ? '' : code.upcase
+          @message = MESSAGES[@code]
+        end
+      end
+    end
+  end
+end

--- a/test/unit/gateways/orbital_cvv_result_test.rb
+++ b/test/unit/gateways/orbital_cvv_result_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class OrbitalCVVResultTest < Test::Unit::TestCase
+  def test_nil_data
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new(nil)
+    assert_equal '', result.code
+    assert_equal ActiveMerchant::Billing::OrbitalGateway::CVVResult.messages[''], result.message
+  end
+
+  def test_blank_data
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new('')
+    assert_equal '', result.code
+    assert_equal ActiveMerchant::Billing::OrbitalGateway::CVVResult.messages[''], result.message
+  end
+
+  def test_successful_match
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new('M')
+    assert_equal 'M', result.code
+    assert_equal ActiveMerchant::Billing::OrbitalGateway::CVVResult.messages['M'], result.message
+  end
+
+  def test_failed_match
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new('N')
+    assert_equal 'N', result.code
+    assert_equal ActiveMerchant::Billing::OrbitalGateway::CVVResult.messages['N'], result.message
+  end
+
+  def test_code_upcasing
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new('m')
+    assert_equal 'M', result.code
+  end
+
+  def test_to_hash
+    result = ActiveMerchant::Billing::OrbitalGateway::CVVResult.new('M').to_hash
+    assert_equal 'M', result['code']
+    assert_equal ActiveMerchant::Billing::OrbitalGateway::CVVResult.messages['M'], result['message']
+  end
+end


### PR DESCRIPTION
The Orbital CVV response codes are similar, but not identical, to the codes used in `ActiveMerchant::Billing::CVVResult`. This PR uses the codes from the [Orbital spec](http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf) (see Appendix A, section A.6, page 255).
