### PR TITLE
Balanced: Associate card URI when given an email address.

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -361,6 +361,7 @@ module ActiveMerchant #:nodoc:
 
           post[:card_uri] = card_uri
         elsif credit_card.kind_of?(String)
+          associate_card_to_account(post[:account_uri], credit_card) unless options[:account_uri]
           post[:card_uri] = credit_card
         end
 


### PR DESCRIPTION
When using balanced.js, you get a card_uri without needing to use `store`. This means that if you perform an operation with a card URI and an email address, you get a "Funding instrument is not associated with account" message, along with an error from Balanced.

By always associating the card to the (created) account if you're not given an `account_uri`, you can avoid this issue and are able to use balanced.js with the BalancedGateway.
