### PR TITLE
Balanced: Add support for customer name in purchase.

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -161,6 +161,12 @@ module ActiveMerchant #:nodoc:
       #   purchase.
       # * <tt>account_uri</tt> -- `account_uri` is the URI of an existing
       #   Balanced account.
+      #
+      # If you are passing a new card URI from balanced.js, you should pass
+      # the customer's name
+      #
+      # * <tt>name</tt> -- the customer's name, to appear on the Account
+      #   on Balanced.
       def purchase(money, credit_card, options = {})
         if credit_card.respond_to?('number')
           requires!(options, :email) unless options[:account_uri]
@@ -310,6 +316,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if account_uri == nil
+          post[:name] = options[:name] if options[:name]
           post[:email_address] = options[:email]
 
           # create an account

--- a/test/remote/gateways/remote_balanced_test.rb
+++ b/test/remote/gateways/remote_balanced_test.rb
@@ -50,6 +50,15 @@ class RemoteBalancedTest < Test::Unit::TestCase
     assert_equal "Homer Electric", response.params['appears_on_statement_as']
   end
 
+  def test_passing_customer_name
+    options = @options.merge(name: 'Test User')
+    options[:email] = 'john.buyer+withname@example.org'
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal options[:name], response.params['account']['name']
+  end
+
   def test_authorize_and_capture
     amount = @amount
     assert auth = @gateway.authorize(amount, @credit_card, @options)


### PR DESCRIPTION
Since card tokens that are generated with balanced.js do not need to be stored, allow `purchase` to accept a `name` option that will be set to the user's account when doing a purchase with their newly tokenized card. This saves the developer from doing an extra POST with the `store` action.
