### PR TITLE
Use new badge for Code Climate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Active Merchant
 [![Build Status](https://secure.travis-ci.org/Shopify/active_merchant.png)](http://travis-ci.org/Shopify/active_merchant)
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/Shopify/active_merchant)
+[![Code Climate](https://codeclimate.com/github/Shopify/active_merchant.png)](https://codeclimate.com/github/Shopify/active_merchant)
 
 Active Merchant is an extraction from the e-commerce system [Shopify](http://www.shopify.com).
 Shopify's requirements for a simple and unified API to access dozens of different payment


### PR DESCRIPTION
The badge now shows the Code Climate's rating.

![active_merchant-codeclimate-badge](https://f.cloud.github.com/assets/28908/1977571/83c359c6-8399-11e3-9f0e-b7bc269286f6.png)
