### PR TITLE
Adding additional 2Checkout fields for a better customer experience.

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout/helper.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout/helper.rb
@@ -37,7 +37,8 @@ module ActiveMerchant #:nodoc:
                   :zip      => 'zip',
                   :country  => 'country'
 
-          mapping :shipping_address, :city     => 'ship_city',
+          mapping :shipping_address, :name => 'ship_name',
+                  :city     => 'ship_city',
                   :address1 => 'ship_street_address',
                   :state    => 'ship_state',
                   :zip      => 'ship_zip',
@@ -48,6 +49,12 @@ module ActiveMerchant #:nodoc:
 
           # notifications are sent via static URLs in the Instant Notification Settings of 2Checkout admin
           mapping :notify_url, 'notify_url'
+
+          # Allow seller to indicate the purchase plete on the checkout page
+          mapping :purchase_step, 'purchase_step'
+
+          # Allow referral partners to indicate their shopping cart
+          mapping :cart_type, '2co_cart_type'
 
           def customer(params = {})
             add_field(mappings[:customer][:email], params[:email])

--- a/test/unit/integrations/helpers/two_checkout_helper_test.rb
+++ b/test/unit/integrations/helpers/two_checkout_helper_test.rb
@@ -22,11 +22,15 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     @helper.invoice '123'
     @helper.return_url 'https://return.url/'
     @helper.notify_url 'https://notify.url/'
+    @helper.cart_type 'shopify'
+    @helper.purchase_step 'payment-method'
 
     assert_field 'currency_code', 'ZAR'
     assert_field 'cart_order_id', '123'
     assert_field 'notify_url', 'https://notify.url/'
     assert_field 'x_receipt_link_url', 'https://return.url/'
+    assert_field '2co_cart_type', 'shopify'
+    assert_field 'purchase_step', 'payment-method'
   end
 
   def test_customer_fields
@@ -75,13 +79,15 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
   end
 
   def test_shipping_address
-    @helper.shipping_address :address1 => '1 My Street',
+    @helper.shipping_address :name => 'Testing Tester',
+                             :address1 => '1 My Street',
                              :address2 => 'Apt. 1',
                              :city => 'London',
                              :state => 'Whales',
                              :zip => 'LS2 7E1',
                              :country  => 'GB'
 
+    assert_field 'ship_name', 'Testing Tester'
     assert_field 'ship_city', 'London'
     assert_field 'ship_street_address', '1 My Street'
     assert_field 'ship_state', 'Whales'


### PR DESCRIPTION
The `ship_name` field is currently missing so the buyer must enter it on 2Checkout's hosted page.

If all billing information (and shipping information if applicable) is passed the `purchase_step` parameter can be passed with the name of the checkout step to display to the buyer when they arrive on 2Checkout's hosted page.
Possible values are ‘review-cart’, ‘shipping-information’, ‘shipping-method’, ‘billing-information’ and ‘payment-method’.
https://www.2checkout.com/documentation/checkout/parameter-sets/pass-through-products

2Checkout referral partners can optionally pass the `2co_cart_type` parameter to identify themselves or their cart software.
