### PR TITLE
SagePay: Truncate description field

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -191,7 +191,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, options)
         add_pair(post, :VendorTxCode, sanitize_order_id(options[:order_id]), :required => true)
-        add_pair(post, :Description, options[:description] || options[:order_id])
+        add_pair(post, :Description, truncate_description(options[:description] || options[:order_id]))
       end
 
       def add_credit_card(post, credit_card)
@@ -211,6 +211,11 @@ module ActiveMerchant #:nodoc:
 
       def sanitize_order_id(order_id)
         order_id.to_s.gsub(/[^-a-zA-Z0-9._]/, '')
+      end
+
+      def truncate_description(description)
+        return nil unless description
+        description[0, 100]
       end
 
       def map_card_type(credit_card)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -2,15 +2,15 @@ require 'test_helper'
 
 # Some of the standard tests have been removed at SagePay test
 # server is pants and accepts anything and says Status=OK. (shift)
-# The tests for American Express will only pass if your account is 
+# The tests for American Express will only pass if your account is
 # American express enabled.
 class RemoteSagePayTest < Test::Unit::TestCase
   # set to true to run the tests in the simulated environment
   SagePayGateway.simulate = false
-  
+
   def setup
     @gateway = SagePayGateway.new(fixtures(:sage_pay))
-    
+
     @amex = CreditCard.new(
       :number => '374200000000004',
       :month => 12,
@@ -66,7 +66,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
       :last_name => 'Suleyman',
       :brand => 'master'
     )
-    
+
     @electron = CreditCard.new(
       :number => '4917300000000008',
       :month => 12,
@@ -86,8 +86,8 @@ class RemoteSagePayTest < Test::Unit::TestCase
       :brand => 'visa'
     )
 
-    @options = { 
-      :billing_address => { 
+    @options = {
+      :billing_address => {
         :name => 'Tekin Suleyman',
         :address1 => 'Flat 10 Lapwing Court',
         :address2 => 'West Didsbury',
@@ -96,7 +96,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
         :country => 'GB',
         :zip => 'M20 2PS'
       },
-      :shipping_address => { 
+      :shipping_address => {
         :name => 'Tekin Suleyman',
         :address1 => '120 Grosvenor St',
         :city => "Manchester",
@@ -110,61 +110,61 @@ class RemoteSagePayTest < Test::Unit::TestCase
       :email => 'tekin@tekin.co.uk',
       :phone => '0161 123 4567'
     }
- 
+
     @amount = 100
   end
 
   def test_successful_mastercard_purchase
     assert response = @gateway.purchase(@amount, @mastercard, @options)
     assert_success response
-    
+
     assert response.test?
     assert !response.authorization.blank?
   end
-  
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    
+
     assert response.test?
   end
-  
+
   def test_successful_authorization_and_capture
     assert auth = @gateway.authorize(@amount, @mastercard, @options)
     assert_success auth
-    
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
   end
-  
+
   def test_successful_authorization_and_void
     assert auth = @gateway.authorize(@amount, @mastercard, @options)
-    assert_success auth    
-     
+    assert_success auth
+
     assert abort = @gateway.void(auth.authorization)
     assert_success abort
   end
-  
+
   def test_successful_purchase_and_void
     assert purchase = @gateway.purchase(@amount, @mastercard, @options)
-    assert_success purchase    
-     
+    assert_success purchase
+
     assert void = @gateway.void(purchase.authorization)
     assert_success void
   end
-  
+
   def test_successful_purchase_and_credit
     assert purchase = @gateway.purchase(@amount, @mastercard, @options)
-    assert_success purchase    
-    
+    assert_success purchase
+
     assert credit = @gateway.credit(@amount, purchase.authorization,
-      :description => 'Crediting trx', 
+      :description => 'Crediting trx',
       :order_id => generate_unique_id
     )
-    
+
     assert_success credit
   end
-  
+
   def test_successful_visa_purchase
     assert response = @gateway.purchase(@amount, @visa, @options)
     assert_success response
@@ -185,24 +185,30 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert response.test?
     assert !response.authorization.blank?
   end
-  
+
   def test_successful_amex_purchase
     assert response = @gateway.purchase(@amount, @amex, @options)
     assert_success response
     assert response.test?
     assert !response.authorization.blank?
   end
-  
+
   def test_successful_electron_purchase
     assert response = @gateway.purchase(@amount, @electron, @options)
     assert_success response
     assert response.test?
     assert !response.authorization.blank?
   end
-  
+
+  def test_successful_purchase_with_long_description
+    description = "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters."
+    assert response = @gateway.purchase(@amount, @visa, @options.merge(description: description))
+    assert_success response
+  end
+
   def test_invalid_login
-    message = SagePayGateway.simulate ? 'VSP Simulator cannot find your vendor name.  Ensure you have have supplied a Vendor field with your VSP Vendor name assigned to it.' : '3034 : The Vendor or VendorName value is required.' 
-    
+    message = SagePayGateway.simulate ? 'VSP Simulator cannot find your vendor name.  Ensure you have have supplied a Vendor field with your VSP Vendor name assigned to it.' : '3034 : The Vendor or VendorName value is required.'
+
     gateway = SagePayGateway.new(
         :login => ''
     )
@@ -210,7 +216,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_equal message, response.message
     assert_failure response
   end
-  
+
   private
 
   def next_year

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -140,6 +140,14 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_description_is_truncated
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(description: "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters."))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/&Description=SagePay\+transactions\+fail\+if\+the\+description\+is\+more\+than\+100\+characters.\+Therefore%2C\+we\+truncate\+it\+&/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
If a description longer than 100 characters is specified, SagePay fails
the transaction with this error message:

3082 : The Description value is too long.

Now we truncate the description to match SagePay's constraint.  This
simplifies the code of those using Active Merchant since they won't need
to conditionally account for SagePay's description contraint.
