### PR TITLE
Stripe: Allow for in-place updating of a credit card

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -125,17 +125,12 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def update(customer_id, creditcard, options = {})
-        options = options.merge(:customer => customer_id, :set_default => true)
-        store(creditcard, options)
+      def update(customer_id, card_id, options = {})
+        commit(:post, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", options, options)
       end
 
       def update_customer(customer_id, options = {})
         commit(:post, "customers/#{CGI.escape(customer_id)}", options, options)
-      end
-
-      def update_credit_card(customer_id, card_id, options = {})
-        commit(:post, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", options, options)
       end
       
       def unstore(customer_id, card_id = nil, options = {})

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -112,17 +112,6 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 2, customer_response.params["cards"]["count"]
   end
 
-  def test_successful_update
-    creation = @gateway.store(@credit_card, {:description => "Active Merchant Update Customer"})
-    assert response = @gateway.update(creation.params['id'], @new_credit_card)
-    assert_success response
-    customer_response = response.responses.last
-    assert_equal "Active Merchant Update Customer", customer_response.params["description"]
-    first_card = customer_response.params["cards"]["data"].first
-    assert_equal customer_response.params["default_card"], first_card["id"]
-    assert_equal @new_credit_card.last_digits, first_card["last4"]
-  end
-
   def test_successful_unstore
     creation = @gateway.store(@credit_card, {:description => "Active Merchant Unstore Customer"})
     customer_id = creation.params['id']
@@ -213,12 +202,12 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'balance_transaction', response.params['balance_transaction']['object']
   end
 
-  def test_successful_update_credit_card
+  def test_successful_update
     creation    = @gateway.store(@credit_card, {:description => "Active Merchant Update Credit Card"})
     customer_id = creation.params['id']
     card_id     = creation.params['cards']['data'].first['id']
 
-    assert response = @gateway.update_credit_card(customer_id, card_id, { :name => "John Doe", :address_line1 => "123 Main Street", :address_city => "Pleasantville", :address_state => "NY", :address_zip => "12345", :exp_year => Time.now.year + 2, :exp_month => 6 })
+    assert response = @gateway.update(customer_id, card_id, { :name => "John Doe", :address_line1 => "123 Main Street", :address_city => "Pleasantville", :address_state => "NY", :address_zip => "12345", :exp_year => Time.now.year + 2, :exp_month => 6 })
     assert_success response
     assert_equal "John Doe",        response.params["name"]
     assert_equal "123 Main Street", response.params["address_line1"]

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -383,9 +383,9 @@ class StripeTest < Test::Unit::TestCase
     @gateway.authorize(@amount, @credit_card, @options)
   end
 
-  def test_new_attributes_are_included_in_update_credit_card
+  def test_new_attributes_are_included_in_update
     stub_comms(@gateway, :ssl_request) do
-      @gateway.send(:update_credit_card, "cus_3sgheFxeBgTQ3M", "card_483etw4er9fg4vF3sQdrt3FG", { :name => "John Smith", :exp_year => 2021, :exp_month => 6 })
+      @gateway.send(:update, "cus_3sgheFxeBgTQ3M", "card_483etw4er9fg4vF3sQdrt3FG", { :name => "John Smith", :exp_year => 2021, :exp_month => 6 })
     end.check_request do |method, endpoint, data, headers|
       assert data == "name=John+Smith&exp_year=2021&exp_month=6" 
       assert endpoint.include? "/customers/cus_3sgheFxeBgTQ3M/cards/card_483etw4er9fg4vF3sQdrt3FG"


### PR DESCRIPTION
Stripe allows for a "partial update", for example changing the address or expiration date on a card without having to pass in the card number (see https://stripe.com/docs/api#update_card). This commit adds a method, `update_credit_card`, which takes a `customer_id`, `card_id`, and `options`, and POSTs to the appropriate endpoint.
