### PR TITLE
PlugNPay: Fix some remote tests

### DIFF
--- a/test/remote/gateways/remote_plugnpay_test.rb
+++ b/test/remote/gateways/remote_plugnpay_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class PlugnpayTest < Test::Unit::TestCase
   def setup
     @gateway = PlugnpayGateway.new(fixtures(:plugnpay))
-    @good_credit_card = credit_card('4242424242424242')
-    @bad_credit_card = credit_card('1234123412341234')
+    @good_card = credit_card("4111111111111111", first_name: 'cardtest')
+    @bad_card = credit_card('1234123412341234')
     @options = {
       :billing_address => address,
       :description => 'Store purchaes'
@@ -12,31 +12,37 @@ class PlugnpayTest < Test::Unit::TestCase
     @amount = 100
   end
 
-  def test_bad_credit_card
-    assert response = @gateway.authorize(@amount, @bad_credit_card, @options)
+  def test_successful_authorize
+    assert response = @gateway.authorize(@amount, @good_card, @options)
+    assert_success response
+    assert !response.authorization.blank?
+    assert_equal 'Success', response.message
+  end
+
+  def test_failed_authorize
+    assert response = @gateway.authorize(@amount, @bad_card, @options)
     assert_failure response
     assert_equal 'Invalid Credit Card No.', response.message
   end
 
-  def test_good_credit_card
-    assert response = @gateway.authorize(@amount, @good_credit_card, @options)
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @good_card, @options)
     assert_success response
     assert !response.authorization.blank?
     assert_equal 'Success', response.message
   end
 
-  def test_purchase_transaction
-    assert response = @gateway.purchase(@amount, @good_credit_card, @options)
-    assert_success response
-    assert !response.authorization.blank?
-    assert_equal 'Success', response.message
+  def test_failed_purchase
+    assert response = @gateway.purchase(@amount, @bad_card, @options)
+    assert_failure response
+    assert_equal 'Invalid Credit Card No.', response.message
   end
 
   # Capture, and Void require that you Whitelist your IP address.
   # In the gateway admin tool, you must add your IP address to the allowed addresses and uncheck "Remote client" under the
   # "Auth Transactions" section of the "Security Requirements" area in the test account Security Administration Area.
   def test_authorization_and_capture
-    assert authorization = @gateway.authorize(@amount, @good_credit_card, @options)
+    assert authorization = @gateway.authorize(@amount, @good_card, @options)
     assert_success authorization
 
     assert capture = @gateway.capture(@amount, authorization.authorization)
@@ -46,7 +52,7 @@ class PlugnpayTest < Test::Unit::TestCase
   end
 
   def test_authorization_and_partial_capture
-    assert authorization = @gateway.authorize(@amount, @good_credit_card, @options)
+    assert authorization = @gateway.authorize(@amount, @good_card, @options)
     assert_success authorization
 
     assert capture = @gateway.capture(@amount - 1, authorization.authorization)
@@ -56,7 +62,7 @@ class PlugnpayTest < Test::Unit::TestCase
   end
 
   def test_authorization_and_void
-    assert authorization = @gateway.authorize(@amount, @good_credit_card, @options)
+    assert authorization = @gateway.authorize(@amount, @good_card, @options)
     assert_success authorization
 
     assert void = @gateway.void(authorization.authorization)
@@ -64,19 +70,19 @@ class PlugnpayTest < Test::Unit::TestCase
     assert_equal 'Success', void.message
   end
 
-  def test_purchase_and_credit
-    assert purchase = @gateway.purchase(@amount, @good_credit_card, @options)
+  def test_purchase_and_refund
+    assert purchase = @gateway.purchase(@amount, @good_card, @options)
     assert_success purchase
 
-    assert credit = @gateway.credit(@amount, purchase.authorization)
-    assert_success credit
-    assert_equal 'Success', credit.message
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'Success', refund.message
   end
 
-  def test_credit_with_no_previous_transaction
-    assert credit = @gateway.credit(@amount, @good_credit_card, @options)
+  def test_refund_with_no_previous_transaction
+    assert refund = @gateway.refund(@amount, @good_card, @options)
 
-    assert_success credit
-    assert_equal 'Success', credit.message
+    assert_success refund
+    assert_equal 'Success', refund.message
   end
 end


### PR DESCRIPTION
The PlugNPay test gateway now requires the name to have 'cardtest' for
the transaction to work.  This commit gets some of the remote tests to
work again.

I'm still having difficulty with the remote tests for capture, void, and
refund.  Tech support for PlugNPay says that those operations are not
supported on their test gateway.  And they confirmed this fact on the
phone.

I'm hesitant to remove the remote tests for capture, void, and refund
though since they've been added in the past and they were clearly
working for someone at some point.  I don't know if PlugNPay adjusted
their test gateway to no longer support them.  Or if their tech
support is simply wrong and that there's actually some gateway setting
needed to enable those operations.  I'll leave those tests for now.
