### PR TITLE
Moneybookers - Do not raise if credential2 hasn't been passed in

### DIFF
--- a/lib/active_merchant/billing/integrations/moneybookers/notification.rb
+++ b/lib/active_merchant/billing/integrations/moneybookers/notification.rb
@@ -7,13 +7,7 @@ module ActiveMerchant #:nodoc:
       module Moneybookers
         class Notification < ActiveMerchant::Billing::Integrations::Notification
 
-          def initialize(data, options)
-            if options[:credential2].nil?
-              raise ArgumentError, "You need to provide the md5 secret as the option :credential2 to verify that the notification originated from Moneybookers"
-            end
-            super
-          end
-          
+
           def complete?
             status == 'Completed'
           end
@@ -119,7 +113,7 @@ module ActiveMerchant #:nodoc:
           #       ... log possible hacking attempt ...
           #     end
           def acknowledge(authcode = nil)
-            fields = [merchant_id, item_id, Digest::MD5.hexdigest(secret).upcase, merchant_amount, merchant_currency, status_code].join
+            fields = [merchant_id, item_id, Digest::MD5.hexdigest(secret.to_s).upcase, merchant_amount, merchant_currency, status_code].join
             md5sig == Digest::MD5.hexdigest(fields).upcase
           end
         end

--- a/test/unit/integrations/notifications/moneybookers_notification_test.rb
+++ b/test/unit/integrations/notifications/moneybookers_notification_test.rb
@@ -26,15 +26,6 @@ class MoneybookersNotificationTest < Test::Unit::TestCase
   def test_respond_to_acknowledge
     assert @moneybookers.respond_to?(:acknowledge)
   end
-
-  def test_credential2_required
-    assert_raises ArgumentError do
-      Moneybookers::Notification.new(http_raw_data, {})
-    end
-    assert_nothing_raised do
-      Moneybookers::Notification.new(http_raw_data, :credential2 => 'secret')
-    end
-  end
   
   def test_status_failed
     notification = Moneybookers::Notification.new(http_raw_data.sub(/status=2/, 'status=-2'), :credential2 => 'secret')


### PR DESCRIPTION
@Soleone @bslobodin 

We don't normally raise in initialization, instead the `acknowledge` method will fail if the credential was not passed in.
