### PR TITLE
Litle: truncate order_id

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -370,7 +370,7 @@ module ActiveMerchant #:nodoc:
         hash = {
             'billToAddress'  => bill_to_address,
             'shipToAddress'  => ship_to_address,
-            'orderId'        => (options[:order_id] || @options[:order_id]),
+            'orderId'        => truncated_order_id(options),
             'customerId'     => options[:customer],
             'reportGroup'    => (options[:merchant] || @options[:merchant]),
             'merchantId'     => (options[:merchant_id] || @options[:merchant_id]),
@@ -390,6 +390,12 @@ module ActiveMerchant #:nodoc:
           hash.merge!({ 'amount' => money })
         end
         hash
+      end
+
+      def truncated_order_id(options)
+        order_id = options[:order_id] || @options[:order_id]
+        return unless order_id
+        order_id[0..24]
       end
 
       def fraud_result(authorization_response)

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -3,38 +3,38 @@ require 'test_helper'
 class LitleTest < Test::Unit::TestCase
 
   def setup
-    @gateway = LitleGateway.new({:merchant_id=>'101', :user=>'active', :password=>'merchant', :version=>'8.10', :url=>'https://www.testlitle.com/sandbox/communicator/online'})
+    @gateway = LitleGateway.new({merchant_id: '101', user: 'active', password: 'merchant', version: '8.10', url: 'https://www.testlitle.com/sandbox/communicator/online'})
     @credit_card_options = {
-      :first_name => 'Steve',
-      :last_name  => 'Smith',
-      :month      => '9',
-      :year       => '2010',
-      :brand      => 'visa',
-      :number     => '4242424242424242',
-      :verification_value => '969'
+      first_name: 'Steve',
+      last_name: 'Smith',
+      month: '9',
+      year: '2010',
+      brand: 'visa',
+      number: '4242424242424242',
+      verification_value: '969'
     }
     @billing_address = {
-      :name      => 'Steve Smith',
-      :company   => 'testCompany',
-      :address1  => '900 random st',
-      :address2  => 'floor 10',
-      :city      => 'lowell',
-      :state     => 'ma',
-      :country   => 'usa',
-      :zip       => '12345',
-      :phone     => '1234567890'
+      name: 'Steve Smith',
+      company: 'testCompany',
+      address1: '900 random st',
+      address2: 'floor 10',
+      city: 'lowell',
+      state: 'ma',
+      country: 'usa',
+      zip: '12345',
+      phone: '1234567890'
     }
 
     @shipping_address = {
-      :name      => 'Steve Smith',
-      :company   => '',
-      :address1  => '500 nnnn st',
-      :address2  => '',
-      :city      => 'lowell',
-      :state     => 'ma',
-      :country   => 'usa',
-      :zip       => '12345',
-      :phone     => '1234567890'
+      name: 'Steve Smith',
+      company: '',
+      address1: '500 nnnn st',
+      address2: '',
+      city: 'lowell',
+      state: 'ma',
+      country: 'usa',
+      zip: '12345',
+      phone: '1234567890'
     }
 
     @response_options = {
@@ -46,7 +46,6 @@ class LitleTest < Test::Unit::TestCase
   end
 
   def test_build_purchase_request
-    # define all inputs
     money = 1000
 
     creditcard = CreditCard.new(@credit_card_options)
@@ -61,17 +60,17 @@ class LitleTest < Test::Unit::TestCase
     currency = 'USD'
 
     options = {
-      :order_id=>order_id,
-      :ip=>ip,
-      :customer=>customer,
-      :invoice=>invoice,
-      :merchant=>merchant,
-      :description=>description,
-      :email=>email,
-      :currency=>currency,
-      :billing_address=>@billing_address,
-      :shipping_address=>@shipping_address,
-      :merchant_id=>'101'
+      order_id: order_id,
+      ip: ip,
+      customer: customer,
+      invoice: invoice,
+      merchant: merchant,
+      description: description,
+      email: email,
+      currency: currency,
+      billing_address: @billing_address,
+      shipping_address: @shipping_address,
+      merchant_id: '101'
     }
 
     hash_from_gateway = @gateway.send(:build_purchase_request, money, creditcard, options)
@@ -115,7 +114,6 @@ class LitleTest < Test::Unit::TestCase
   end
 
   def test_build_purchase_request_with_token
-    # define all inputs
     money    = 1000
     token    = '1234567890123456'
     month    = 9
@@ -124,11 +122,11 @@ class LitleTest < Test::Unit::TestCase
     brand    = 'visa'
     cvv      = '123'
     options  = {
-        :token => {
-            :month              => month,
-            :year               => year,
-            :brand              => brand,
-            :verification_value => cvv
+        token: {
+            month: month,
+            year: year,
+            brand: brand,
+            verification_value: cvv
         }
     }
 
@@ -142,16 +140,15 @@ class LitleTest < Test::Unit::TestCase
   end
 
   def test_build_authorize_request_with_token
-    # define all inputs
     money    = 1000
     token    = '1234567890123456'
     month    = 9
     year     = Time.now.year + 1
     exp_date = "#{'%02d' % month.to_i}#{year.to_s[2..3]}"
     options  = {
-        :token => {
-            :month => month,
-            :year  => year
+        token: {
+            month: month,
+            year: year
         }
     }
 
@@ -163,7 +160,6 @@ class LitleTest < Test::Unit::TestCase
   end
 
   def test_create_hash_money_not_nil
-    # define all inputs
     money = 1000
 
     order_id = '1234'
@@ -176,194 +172,180 @@ class LitleTest < Test::Unit::TestCase
     currency = 'USD'
 
     options = {
-      :order_id=>order_id,
-      :ip=>ip,
-      :customer=>customer,
-      :invoice=>invoice,
-      :merchant=>merchant,
-      :description=>description,
-      :email=>email,
-      :currency=>currency,
-      :billing_address=>@billing_address,
-      :shipping_address=>@shipping_address,
-      :merchant_id=>'101'
+      order_id: order_id,
+      ip: ip,
+      customer: customer,
+      invoice: invoice,
+      merchant: merchant,
+      description: description,
+      email: email,
+      currency: currency,
+      billing_address: @billing_address,
+      shipping_address: @shipping_address,
+      merchant_id: '101'
     }
 
-    hashFromGateway = @gateway.send(:create_hash, money, options)
+    hash = @gateway.send(:create_hash, money, options)
 
-    assert_equal 1000, hashFromGateway['amount']
+    assert_equal 1000, hash['amount']
     #billing address
-    assert_equal 'Steve Smith', hashFromGateway['billToAddress']['name']
-    assert_equal 'testCompany', hashFromGateway['billToAddress']['companyName']
-    assert_equal '900 random st', hashFromGateway['billToAddress']['addressLine1']
-    assert_equal 'floor 10', hashFromGateway['billToAddress']['addressLine2']
-    assert_equal 'lowell', hashFromGateway['billToAddress']['city']
-    assert_equal 'ma', hashFromGateway['billToAddress']['state']
-    assert_equal '12345', hashFromGateway['billToAddress']['zip']
-    assert_equal 'usa', hashFromGateway['billToAddress']['country']
-    assert_equal 'abc@xyz.com', hashFromGateway['billToAddress']['email']
-    assert_equal '1234567890', hashFromGateway['billToAddress']['phone']
+    assert_equal 'Steve Smith', hash['billToAddress']['name']
+    assert_equal 'testCompany', hash['billToAddress']['companyName']
+    assert_equal '900 random st', hash['billToAddress']['addressLine1']
+    assert_equal 'floor 10', hash['billToAddress']['addressLine2']
+    assert_equal 'lowell', hash['billToAddress']['city']
+    assert_equal 'ma', hash['billToAddress']['state']
+    assert_equal '12345', hash['billToAddress']['zip']
+    assert_equal 'usa', hash['billToAddress']['country']
+    assert_equal 'abc@xyz.com', hash['billToAddress']['email']
+    assert_equal '1234567890', hash['billToAddress']['phone']
     #shipping address
-    assert_equal 'Steve Smith', hashFromGateway['shipToAddress']['name']
-    assert_nil hashFromGateway['shipToAddress']['company']
-    assert_equal '500 nnnn st', hashFromGateway['shipToAddress']['addressLine1']
-    assert_equal '', hashFromGateway['shipToAddress']['addressLine2']
-    assert_equal 'lowell', hashFromGateway['shipToAddress']['city']
-    assert_equal 'ma', hashFromGateway['shipToAddress']['state']
-    assert_equal '12345', hashFromGateway['shipToAddress']['zip']
-    assert_equal 'usa', hashFromGateway['shipToAddress']['country']
-    assert_equal 'abc@xyz.com', hashFromGateway['shipToAddress']['email']
-    assert_equal '1234567890', hashFromGateway['shipToAddress']['phone']
+    assert_equal 'Steve Smith', hash['shipToAddress']['name']
+    assert_nil hash['shipToAddress']['company']
+    assert_equal '500 nnnn st', hash['shipToAddress']['addressLine1']
+    assert_equal '', hash['shipToAddress']['addressLine2']
+    assert_equal 'lowell', hash['shipToAddress']['city']
+    assert_equal 'ma', hash['shipToAddress']['state']
+    assert_equal '12345', hash['shipToAddress']['zip']
+    assert_equal 'usa', hash['shipToAddress']['country']
+    assert_equal 'abc@xyz.com', hash['shipToAddress']['email']
+    assert_equal '1234567890', hash['shipToAddress']['phone']
 
-    assert_equal '1234', hashFromGateway['orderId']
-    assert_equal '4000', hashFromGateway['customerId']
-    assert_equal 'ABC', hashFromGateway['reportGroup']  #The option :merchant is used for Litle's Report Group
-    assert_equal '101', hashFromGateway['merchantId']
+    assert_equal '1234', hash['orderId']
+    assert_equal '4000', hash['customerId']
+    assert_equal 'ABC', hash['reportGroup']  #The option :merchant is used for Litle's Report Group
+    assert_equal '101', hash['merchantId']
 
-    assert_equal '1000', hashFromGateway['enhancedData']['invoiceReferenceNumber']
-    assert_equal '192.168.0.1', hashFromGateway['fraudCheckType']['customerIpAddress']
-    assert_equal 'cool stuff', hashFromGateway['enhancedData']['customerReference']
+    assert_equal '1000', hash['enhancedData']['invoiceReferenceNumber']
+    assert_equal '192.168.0.1', hash['fraudCheckType']['customerIpAddress']
+    assert_equal 'cool stuff', hash['enhancedData']['customerReference']
   end
 
   def test_create_hash_with_default_order_source
-    # define all inputs
-    money = 1000
-    options = {
-    }
-
-    hashFromGateway = @gateway.send(:create_hash, money, options)
-
-    assert_equal 'ecommerce', hashFromGateway['orderSource']
+    hash = @gateway.send(:create_hash, 1000, {})
+    assert_equal 'ecommerce', hash['orderSource']
   end
 
   def test_create_hash_with_custom_order_source
-    # define all inputs
-    money = 1000
-    options = {
-        :order_source => 'recurring'
-    }
-
-    hashFromGateway = @gateway.send(:create_hash, money, options)
-
-    assert_equal 'recurring', hashFromGateway['orderSource']
+    options = { order_source: 'recurring' }
+    hash = @gateway.send(:create_hash, 1000, options)
+    assert_equal 'recurring', hash['orderSource']
   end
 
   def test_create_hash_money_nil
-    # define all inputs
-    money = nil
+    hash = @gateway.send(:create_hash, nil, {})
+    assert_nil hash['amount']
+  end
 
-    hashFromGateway = @gateway.send(:create_hash, money, {})
-
-    assert_nil hashFromGateway['amount']
+  def test_create_hash_truncates_order_id
+    options = { order_id: 'Litle requires order_id to be less than 26 characters' }
+    hash = @gateway.send(:create_hash, 1000, options)
+    assert_equal 'Litle requires order_id t', hash['orderId']
   end
 
   def test_create_hash_money_empty_string
-    # define all inputs
-    money = ''
-
-    hashFromGateway = @gateway.send(:create_hash, money, {})
-
-    assert_nil hashFromGateway['amount']
+    hash = @gateway.send(:create_hash, '', {})
+    assert_nil hash['amount']
   end
 
   def test_recognize_ax_and_some_empties
-    creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'american_express'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})
-    assert_equal 'AX', hashFromGateway['card']['type']
-    assert_nil hashFromGateway['billToAddress']
-    assert_nil hashFromGateway['shipToAddress']
+    creditcard = CreditCard.new(@credit_card_options.merge(brand: 'american_express'))
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {})
+    assert_equal 'AX', hash['card']['type']
+    assert_nil hash['billToAddress']
+    assert_nil hash['shipToAddress']
   end
 
   def test_recognize_di
-    creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'discover'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})
-    assert_equal 'DI', hashFromGateway['card']['type']
+    creditcard = CreditCard.new(@credit_card_options.merge(brand: 'discover'))
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {})
+    assert_equal 'DI', hash['card']['type']
   end
 
   def test_recognize_mastercard
-    creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'master'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0,creditcard,{})
-    assert_equal 'MC', hashFromGateway['card']['type']
+    creditcard = CreditCard.new(@credit_card_options.merge(brand: 'master'))
+    hash = @gateway.send(:build_purchase_request, 0,creditcard,{})
+    assert_equal 'MC', hash['card']['type']
   end
 
   def test_recognize_jcb
-    creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'jcb'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})
-    assert_equal 'DI', hashFromGateway['card']['type']
+    creditcard = CreditCard.new(@credit_card_options.merge(brand: 'jcb'))
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {})
+    assert_equal 'DI', hash['card']['type']
   end
 
   def test_recognize_diners
-    creditcard = CreditCard.new(@credit_card_options.merge(:brand => 'diners_club'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})
-    assert_equal 'DI', hashFromGateway['card']['type']
+    creditcard = CreditCard.new(@credit_card_options.merge(brand: 'diners_club'))
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {})
+    assert_equal 'DI', hash['card']['type']
   end
 
   def test_two_digit_month
-    creditcard = CreditCard.new(@credit_card_options.merge(:month => '11'))
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {})
-    assert_equal '1110', hashFromGateway['card']['expDate']
+    creditcard = CreditCard.new(@credit_card_options.merge(month: '11'))
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {})
+    assert_equal '1110', hash['card']['expDate']
   end
 
   def test_nils_in_both_addresses
     creditcard = CreditCard.new(@credit_card_options)
 
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard,
-    {:shipping_address=>{},:billing_address=>{}})
+    hash = @gateway.send(:build_purchase_request, 0, creditcard,
+    {shipping_address: {}, billing_address: {}})
 
     %w(name companyName company addressLine1 addressLine2 city state zip country email phone).each do |att|
       #billing address
-      assert_nil hashFromGateway['billToAddress'][att]
+      assert_nil hash['billToAddress'][att]
       #shipping address
-      assert_nil hashFromGateway['shipToAddress'][att]
+      assert_nil hash['shipToAddress'][att]
     end
 
   end
 
   def test_build_credit_request_identification
-    hashFromGateway = @gateway.send(:build_credit_request, 1000, '123456789012345678', {})
-    assert_equal '123456789012345678', hashFromGateway['litleTxnId']
-    assert_equal nil, hashFromGateway['orderSource']
-    assert_equal nil, hashFromGateway['orderId']
+    hash = @gateway.send(:build_credit_request, 1000, '123456789012345678', {})
+    assert_equal '123456789012345678', hash['litleTxnId']
+    assert_equal nil, hash['orderSource']
+    assert_equal nil, hash['orderId']
   end
 
   def test_build_credit_request_token
     token   = '171299999999999'
     options = {
-        :order_id        => '1234',
-        :billing_address => {
-            :zip => '12345'
+        order_id: '1234',
+        billing_address: {
+            zip: '12345'
         },
-        :token           => {
-            :month => 11,
-            :year  => 2014
+        token: {
+            month: 11,
+            year: 2014
         }
     }
 
-    hashFromGateway = @gateway.send(:build_credit_request, 1000, token, options)
-    assert_equal nil, hashFromGateway['litleTxnId']
-    assert_equal 'ecommerce', hashFromGateway['orderSource']
-    assert_equal '1234', hashFromGateway['orderId']
-    assert_equal token, hashFromGateway['token']['litleToken']
-    assert_equal '1114', hashFromGateway['token']['expDate']
-    assert_equal '12345', hashFromGateway['billToAddress']['zip']
+    hash = @gateway.send(:build_credit_request, 1000, token, options)
+    assert_equal nil, hash['litleTxnId']
+    assert_equal 'ecommerce', hash['orderSource']
+    assert_equal '1234', hash['orderId']
+    assert_equal token, hash['token']['litleToken']
+    assert_equal '1114', hash['token']['expDate']
+    assert_equal '12345', hash['billToAddress']['zip']
   end
 
   def test_currency_USD
     creditcard = CreditCard.new(@credit_card_options)
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {:currency=>'USD',:merchant_id=>'101'})
-    assert_equal '101', hashFromGateway['merchantId']
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {currency: 'USD', merchant_id: '101'})
+    assert_equal '101', hash['merchantId']
   end
 
   def test_currency_DEFAULT
     creditcard = CreditCard.new(@credit_card_options)
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {:merchant_id=>'101'})
-    assert_equal '101', hashFromGateway['merchantId']
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {merchant_id: '101'})
+    assert_equal '101', hash['merchantId']
   end
 
   def test_currency_EUR
     creditcard = CreditCard.new(@credit_card_options)
-    hashFromGateway = @gateway.send(:build_purchase_request, 0, creditcard, {:currency=>'EUR',:merchant_id=>'102'})
-    assert_equal '102', hashFromGateway['merchantId']
+    hash = @gateway.send(:build_purchase_request, 0, creditcard, {currency: 'EUR',merchant_id: '102'})
+    assert_equal '102', hash['merchantId']
   end
 
   def test_auth_pass
@@ -475,9 +457,9 @@ class LitleTest < Test::Unit::TestCase
     LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
 
     options = {
-        :token => {
-            :month => '11',
-            :year  => '2014'
+        token: {
+            month: '11',
+            year: '2014'
         }
     }
 
@@ -489,7 +471,7 @@ class LitleTest < Test::Unit::TestCase
   def test_purchase_fail
     purchaseResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','saleResponse'=>purchaseResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
 
     creditcard = CreditCard.new(@credit_card_options)
     responseFrom = @gateway.purchase(0, creditcard)
@@ -499,7 +481,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_purchase_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
 
     creditcard = CreditCard.new(@credit_card_options)
     responseFrom = @gateway.purchase(0, creditcard)
@@ -510,7 +492,7 @@ class LitleTest < Test::Unit::TestCase
   def test_capture_pass
     captureResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','captureResponse'=>captureResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     authorization = "1234"
     responseFrom = @gateway.capture(0, authorization)
     assert_equal true, responseFrom.success?
@@ -520,7 +502,7 @@ class LitleTest < Test::Unit::TestCase
   def test_capture_fail
     captureResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','captureResponse'=>captureResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     authorization = "1234"
     responseFrom = @gateway.capture(0, authorization)
     assert_equal false, responseFrom.success?
@@ -529,7 +511,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_capture_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     authorization = '1234'
     responseFrom = @gateway.capture(0, authorization)
     assert_equal false, responseFrom.success?
@@ -539,7 +521,7 @@ class LitleTest < Test::Unit::TestCase
   def test_void_sale_pass
     voidResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','voidResponse'=>voidResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal true, responseFrom.success?
@@ -549,7 +531,7 @@ class LitleTest < Test::Unit::TestCase
   def test_void_sale_fail
     voidResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','voidResponse'=>voidResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
@@ -558,7 +540,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_void_sale_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;sale"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
@@ -568,7 +550,7 @@ class LitleTest < Test::Unit::TestCase
   def test_void_authorization_pass
     authReversalResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','authReversalResponse'=>authReversalResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;authorization"
     responseFrom = @gateway.void(identification)
     assert_equal true, responseFrom.success?
@@ -578,7 +560,7 @@ class LitleTest < Test::Unit::TestCase
   def test_void_authorization_fail
     authReversalResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','authReversalResponse'=>authReversalResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;authorization"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
@@ -587,7 +569,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_void_authorization_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;authorization"
     responseFrom = @gateway.void(identification)
     assert_equal false, responseFrom.success?
@@ -597,7 +579,7 @@ class LitleTest < Test::Unit::TestCase
   def test_refund_pass
     creditResponseObj = {'response' => '000', 'message' => 'pass', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','creditResponse'=>creditResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;credit"
     responseFrom = @gateway.refund(0, identification)
     assert_equal true, responseFrom.success?
@@ -607,7 +589,7 @@ class LitleTest < Test::Unit::TestCase
   def test_refund_fail
     creditResponseObj = {'response' => '111', 'message' => 'fail', 'litleTxnId'=>'123456789012345678'}
     retObj = {'response'=>'0','creditResponse'=>creditResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = "1234;credit"
     responseFrom = @gateway.refund(0, identification)
     assert_equal false, responseFrom.success?
@@ -616,7 +598,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_refund_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     identification = '1234;credit'
     responseFrom = @gateway.refund(0, identification)
     assert_equal false, responseFrom.success?
@@ -626,7 +608,7 @@ class LitleTest < Test::Unit::TestCase
   def test_store_pass1
     storeResponseObj = {'response' => '801', 'message' => 'successful', 'litleToken'=>'1111222233334444', 'litleTxnId'=>nil}
     retObj = {'response'=>'0','registerTokenResponse'=>storeResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     creditcard = CreditCard.new(@credit_card_options)
 
     responseFrom = @gateway.store(creditcard,{})
@@ -637,7 +619,7 @@ class LitleTest < Test::Unit::TestCase
   def test_store_pass2
     storeResponseObj = {'response' => '802', 'message' => 'already registered', 'litleToken'=>'1111222233334444', 'litleTxnId'=>nil}
     retObj = {'response'=>'0','registerTokenResponse'=>storeResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     creditcard = CreditCard.new(@credit_card_options)
 
     responseFrom = @gateway.store(creditcard,{})
@@ -648,7 +630,7 @@ class LitleTest < Test::Unit::TestCase
   def test_store_fail
     storeResponseObj = {'response' => '803', 'message' => 'fail', 'litleToken'=>'1111222233334444', 'litleTxnId'=>nil}
     retObj = {'response'=>'0','registerTokenResponse'=>storeResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     creditcard = CreditCard.new(@credit_card_options)
 
     responseFrom = @gateway.store(creditcard,{})
@@ -658,7 +640,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_store_fail_schema
     retObj = {'response'=>'1','message'=>'Error validating xml data against the schema'}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     creditcard = CreditCard.new(@credit_card_options)
 
     responseFrom = @gateway.store(creditcard,{})
@@ -669,7 +651,7 @@ class LitleTest < Test::Unit::TestCase
   def test_store_via_paypage
     storeResponseObj = {'response' => '801', 'message' => 'Account number was successfully registered', 'litleToken'=>'1111222233334444', 'litleTxnId'=>nil}
     retObj = {'response'=>'0','registerTokenResponse'=>storeResponseObj}
-    LitleOnline::Communications.expects(:http_post => retObj.to_xml(:root => 'litleOnlineResponse'))
+    LitleOnline::Communications.expects(http_post: retObj.to_xml(root: 'litleOnlineResponse'))
     paypage_registration_id = 'eVY1SUYrSTFndWo0U3p0L2RaWjR1blhMVEh2L0pJTWl5bm1LS3QyUDVWOFRpczRYYS9qbndzLzVEb0M5N3RTcQ=='
 
     responseFrom = @gateway.store(paypage_registration_id,{})
@@ -681,14 +663,14 @@ class LitleTest < Test::Unit::TestCase
     begin
       ActiveMerchant::Billing::Base.mode = :production
       @gateway = LitleGateway.new(
-                   :merchant_id => 'login',
-                   :login => 'login',
-                   :password => 'password',
-                   :test => true
+                   merchant_id: 'login',
+                   login: 'login',
+                   password: 'password',
+                   test: true
                  )
       purchaseResponseObj = {'response' => '000', 'message' => 'successful', 'litleTxnId'=>'123456789012345678'}
       retObj = {'response'=>'0','saleResponse'=>purchaseResponseObj}
-      LitleOnline::Communications.expects(:http_post).with(anything,has_entry('url', 'https://www.testlitle.com/sandbox/communicator/online')).returns(retObj.to_xml(:root => 'litleOnlineResponse'))
+      LitleOnline::Communications.expects(:http_post).with(anything,has_entry('url', 'https://www.testlitle.com/sandbox/communicator/online')).returns(retObj.to_xml(root: 'litleOnlineResponse'))
 
       creditcard = CreditCard.new(@credit_card_options)
       assert response = @gateway.purchase(@amount, credit_card)
@@ -717,7 +699,7 @@ class LitleTest < Test::Unit::TestCase
 
       LitleOnline::Configuration.logger.level = Logger::DEBUG
 
-      LitleGateway.new({:merchant_id=>'101', :user=>'active', :password=>'merchant', :version=>'8.10', :url=>'https://www.testlitle.com/sandbox/communicator/online'})
+      LitleGateway.new({merchant_id: '101', user: 'active', password: 'merchant', version: '8.10', url: 'https://www.testlitle.com/sandbox/communicator/online'})
       assert_equal Logger::WARN, LitleOnline::Configuration.logger.level
     end
   end
@@ -731,7 +713,7 @@ class LitleTest < Test::Unit::TestCase
       assert_not_equal logger, LitleOnline::Configuration.logger
 
       # The initialize call will setup the logger for the gem
-      LitleGateway.new({:merchant_id=>'101', :user=>'active', :password=>'merchant', :version=>'8.10', :url=>'https://www.testlitle.com/sandbox/communicator/online'})
+      LitleGateway.new({merchant_id: '101', user: 'active', password: 'merchant', version: '8.10', url: 'https://www.testlitle.com/sandbox/communicator/online'})
       assert_equal logger, LitleOnline::Configuration.logger
       assert_equal Logger::DEBUG, LitleOnline::Configuration.logger.level
     end
@@ -753,8 +735,8 @@ class LitleTest < Test::Unit::TestCase
         'litleTxnId'  =>'123456789012345678'
       }
     }
-    LitleOnline::Communications.expects(:http_post => return_object.to_xml(:root => 'litleOnlineResponse'))
-    response = @gateway.refund(0, "1234;credit", {:description => 'A lengthy refund description'})
+    LitleOnline::Communications.expects(http_post: return_object.to_xml(root: 'litleOnlineResponse'))
+    response = @gateway.refund(0, "1234;credit", {description: 'A lengthy refund description'})
     assert response.success?
   end
 


### PR DESCRIPTION
Litle requires the order_id to be a maximum of 25 characters.
