### PR TITLE
Respect authorization in Balanced gateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -219,7 +219,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>authorization</tt> -- The uri of the authorization returned from
       #   an `authorize` request.
       def void(authorization, options = {})
-        authorization = authorization.split("|")[0] if authorization.include?("|")
+        authorization = authorization.split("|")[2] if authorization.include?("|")
         create_transaction(:delete, authorization, nil)
       rescue Error => ex
         failed_response(ex.response)
@@ -409,7 +409,11 @@ module ActiveMerchant #:nodoc:
           url = url.gsub("{debits.id}", response["debits"][0]["id"])
         end
 
-        authorization = [capture_url, refund_url].map(&:to_s).join("|")
+        void_url = if response.has_key?("card_holds")
+          url =  response["card_holds"][0]["href"]
+        end
+
+        authorization = [capture_url, refund_url, void_url].map(&:to_s).join("|")
 
         Response.new(
           success,

--- a/test/remote/gateways/remote_balanced_test.rb
+++ b/test/remote/gateways/remote_balanced_test.rb
@@ -102,6 +102,16 @@ class RemoteBalancedTest < Test::Unit::TestCase
     assert void.params["card_holds"][0]['voided_at']
   end
 
+  def test_void_authorization_via_authorization
+    amount = @amount
+    assert auth = @gateway.authorize(amount, @credit_card, @options)
+    assert_success auth
+    assert auth.authorization
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert void.params["card_holds"][0]['voided_at']
+  end
+
   def test_authorize_authorization
     amount = @amount
     assert auth = @gateway.authorize(amount, @credit_card, @options)


### PR DESCRIPTION
Builds on top of #1022, in response to https://github.com/Shopify/active_merchant/pull/1022#issuecomment-35106282

/cc @duff

I didn't realize that this particular option on Response needs to be set, so now it is.
