### PR TITLE
Wirecard: Handle a utf-8 description

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -71,6 +71,10 @@ module ActiveMerchant #:nodoc:
 
 
       private
+      def clean_description(description)
+        description.to_s.slice(0,32).encode("US-ASCII", invalid: :replace, undef: :replace, replace: '?')
+      end
+
       def prepare_options_hash(options)
         result = @options.merge(options)
         setup_address_hash!(result)
@@ -139,7 +143,7 @@ module ActiveMerchant #:nodoc:
         options[:order_id] ||= generate_unique_id
 
         xml.tag! "FNC_CC_#{options[:action].to_s.upcase}" do
-          xml.tag! 'FunctionID', options[:description].to_s.slice(0,32)
+          xml.tag! 'FunctionID', clean_description(options[:description])
           xml.tag! 'CC_TRANSACTION' do
             xml.tag! 'TransactionID', options[:order_id]
             case options[:action]

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test_helper'
 
 class RemoteWirecardTest < Test::Unit::TestCase
@@ -82,6 +83,12 @@ class RemoteWirecardTest < Test::Unit::TestCase
 
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_match /THIS IS A DEMO/, response.message
+  end
+
+  def test_utf8_description_does_not_blow_up
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(description: "Habitación"))
     assert_success response
     assert_match /THIS IS A DEMO/, response.message
   end

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test_helper'
 
 class WirecardTest < Test::Unit::TestCase
@@ -156,7 +157,7 @@ class WirecardTest < Test::Unit::TestCase
   end
 
   def test_description_trucated_to_32_chars_in_authorize
-    options = {:description => "32chars-------------------------EXTRA"}
+    options = { description: "32chars-------------------------EXTRA" }
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
@@ -166,12 +167,22 @@ class WirecardTest < Test::Unit::TestCase
   end
 
   def test_description_trucated_to_32_chars_in_purchase
-    options = {:description => "32chars-------------------------EXTRA"}
+    options = { description: "32chars-------------------------EXTRA" }
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
       assert_match(/<FunctionID>32chars-------------------------<\/FunctionID>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_description_is_ascii_encoded_since_wirecard_does_not_like_utf_8
+    options = { description: "¿Dónde está la estación?" }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FunctionID>\?D\?nde est\? la estaci\?n\?<\/FunctionID>/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
If you specify a description that includes utf-8 characters, Wirecard
returns the following error:

Content of FunctionID is not according to the given content
restrictions. (1. Content of FunctionID must be alphanumerical with a
size of 0 to 32 characters.)

We now take a somewhat heavy handed approach with that description
field.  If Wirecard wants ascii, we'll give them ascii.  And we'll
replace non-ascii chacters with a question mark.
