### PR TITLE
Rename Conekta's :login back to :key

### DIFF
--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'MXN'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, :key)
         options[:version] ||= '0.2.0'
         super
       end
@@ -185,7 +185,7 @@ module ActiveMerchant #:nodoc:
 
         {
           "Accept" => "application/vnd.conekta-v#{options[:version]}+json",
-          "Authorization" => "Basic " + Base64.encode64("#{options[:login]}:"),
+          "Authorization" => "Basic " + Base64.encode64("#{options[:key]}:"),
           "RaiseHtmlError" => "false",
           "User-Agent" => "Conekta ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           "X-Conekta-Client-User-Agent" => @@ua,

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -98,7 +98,7 @@ cyber_source:
   password: Y
 
 conekta:
-  login: 1tv5yJp3xnVZ7eK67m4h
+  key: 1tv5yJp3xnVZ7eK67m4h
 
 data_cash:
   login: X

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -55,13 +55,13 @@ class RemoteConektaTest < Test::Unit::TestCase
     assert_success response
     assert_equal nil, response.message
 
-    assert response = @gateway.refund(response.authorization, @amount, @options)
+    assert response = @gateway.refund(@amount, response.authorization, @options)
     assert_success response
     assert_equal nil, response.message
   end
 
   def test_unsuccessful_refund
-    assert response = @gateway.refund("1", @amount, @options)
+    assert response = @gateway.refund(@amount, "1", @options)
     assert_failure response
     assert_equal "The charge does not exist or it is not suitable for this operation", response.message
   end
@@ -110,8 +110,8 @@ class RemoteConektaTest < Test::Unit::TestCase
     assert_equal "The charge does not exist or it is not suitable for this operation", response.message
   end
 
-  def test_invalid_login
-    gateway = ConektaGateway.new(login: 'invalid_token')
+  def test_invalid_key
+    gateway = ConektaGateway.new(key: 'invalid_token')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal "Unrecognized authentication key", response.message

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ConektaTest < Test::Unit::TestCase
   def setup
-    @gateway = ConektaGateway.new(:login => "1tv5yJp3xnVZ7eK67m4h")
+    @gateway = ConektaGateway.new(:key => "1tv5yJp3xnVZ7eK67m4h")
 
     @amount = 300
 
@@ -94,8 +94,8 @@ class ConektaTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_invalid_login
-    gateway = ConektaGateway.new(:login => 'invalid_token')
+  def test_invalid_key
+    gateway = ConektaGateway.new(:key => 'invalid_token')
     gateway.expects(:ssl_request).returns(failed_login_response)
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response


### PR DESCRIPTION
I now believe #1031 was slightly misguided and we should keep using `:key` for Conekta gateways. This PR reverts that change and fixes 2 failing remote tests.

@odorcicd and @ntalbott to review, cc @Shopify/payments.
