### PR TITLE
Fix Conekta to work with Shopify

### DIFF
--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, "charges", post)
       end
 
-      def capture(identifier, money, options = {})
+      def capture(money, identifier, options = {})
         post = {}
 
         post[:order_id] = identifier
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_order(post, money, options)
-        post[:description] = options[:description]
+        post[:description] = options[:description] || "Active Merchant Purchase"
         post[:reference_id] = options[:order_id]
         post[:currency] = (options[:currency] || currency(money)).downcase
         post[:amount] = amount(money)

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -83,7 +83,7 @@ class RemoteConektaTest < Test::Unit::TestCase
     assert_success response
     assert_equal nil, response.message
 
-    assert response = @gateway.capture(response.authorization, @amount, @options)
+    assert response = @gateway.capture(@amount, response.authorization, @options)
     assert_success response
     assert_equal nil, response.message
   end
@@ -104,8 +104,7 @@ class RemoteConektaTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_capture
-    @options[:order_id] = "1"
-    assert response = @gateway.capture(@amount, @options)
+    assert response = @gateway.capture(@amount, "1", @options)
     assert_failure response
     assert_equal "The charge does not exist or it is not suitable for this operation", response.message
   end

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -89,7 +89,7 @@ class ConektaTest < Test::Unit::TestCase
 
   def test_unsuccessful_capture
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
-    assert response = @gateway.capture("1", @amount, @options)
+    assert response = @gateway.capture(@amount, "1", @options)
     assert_failure response
     assert response.test?
   end


### PR DESCRIPTION
1. Added default for `:description`
2. Fixed `capture` parameter order, `money` needs to go 1st

@odorcicd and @ntalbott to review, cc @Shopify/payments.
