### PR TITLE
fix ordering of order/trans_id for auth.net cim.

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -672,20 +672,23 @@ module ActiveMerchant #:nodoc:
                 tag_unless_blank(xml, 'creditCardNumberMasked', transaction[:credit_card_number_masked])
                 tag_unless_blank(xml, 'bankRoutingNumberMasked', transaction[:bank_routing_number_masked])
                 tag_unless_blank(xml, 'bankAccountNumberMasked', transaction[:bank_account_number_masked])
+                add_order(xml, transaction[:order]) if transaction[:order].present?
                 xml.tag!('transId', transaction[:trans_id])
                 add_tax(xml, transaction[:tax]) if transaction[:tax]
                 add_duty(xml, transaction[:duty]) if transaction[:duty]
                 add_shipping(xml, transaction[:shipping]) if transaction[:shipping]
               when :prior_auth_capture
                 xml.tag!('amount', transaction[:amount])
+                add_order(xml, transaction[:order]) if transaction[:order].present?
                 xml.tag!('transId', transaction[:trans_id])
               else
                 xml.tag!('amount', transaction[:amount])
                 xml.tag!('customerProfileId', transaction[:customer_profile_id])
                 xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
                 xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
+                add_order(xml, transaction[:order]) if transaction[:order].present?
+                
             end
-            add_order(xml, transaction[:order]) if transaction[:order].present?
             unless [:void,:refund,:prior_auth_capture].include?(transaction[:type])
               tag_unless_blank(xml, 'cardCode', transaction[:card_code])
             end


### PR DESCRIPTION
When processing a refund in Auth.net CIM the order fields need to come before the transId field in order to include the invoice number on the credit transaction.  Without this commit including :order => {:invoice_num => 'xxxx'} on a refund transaction fails.

I was working on some remote tests to verify this change but it is very difficult to automate the test. The connection needs to be in live mode to the test server because otherwise you don't get a valid transId.  Also you can't refund transactions until they have been settled which usually happens overnight.
