### PR TITLE
Fixing Elavon, to match 3 digit country codes

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -50,6 +50,19 @@ module ActiveMerchant #:nodoc:
         :void => 'CCVOID'
       }
 
+      NON_STANDARD_LOCALE_CODES = {
+        'US' => 'USA'
+        'CA' => 'CAN'
+        'PR' => 'PRI'
+        'DE' => 'DEU'
+        'IE' => 'IRL'
+        'NO' => 'NOR'
+        'PL' => 'POL'
+        'LU' => 'LUX'
+        'BE' => 'BEL'
+        'NL' => 'NLD'
+      }
+
       # Initialize the Gateway
       #
       # The gateway requires that a valid login and password be passed
@@ -228,7 +241,7 @@ module ActiveMerchant #:nodoc:
           form[:state]          = billing_address[:state].to_s.slice(0, 10)
           form[:company]        = billing_address[:company].to_s.slice(0, 50)
           form[:phone]          = billing_address[:phone].to_s.slice(0, 20)
-          form[:country]        = billing_address[:country].to_s.slice(0, 50)
+          form[:country]        = locale_code(options[:country]).to_s.slice(0, 50) unless options[:country].blank?
         end
 
         if shipping_address = options[:shipping_address]
@@ -240,7 +253,7 @@ module ActiveMerchant #:nodoc:
           form[:ship_to_city]           = shipping_address[:city].to_s.slice(0, 30)
           form[:ship_to_state]          = shipping_address[:state].to_s.slice(0, 10)
           form[:ship_to_company]        = shipping_address[:company].to_s.slice(0, 50)
-          form[:ship_to_country]        = shipping_address[:country].to_s.slice(0, 50)
+          form[:ship_to_country]        = locale_code(options[:country]).to_s.slice(0, 50) unless options[:country].blank?
           form[:ship_to_zip]            = shipping_address[:zip].to_s.slice(0, 10)
         end
       end
@@ -304,6 +317,10 @@ module ActiveMerchant #:nodoc:
             resp[key.strip.gsub(/^ssl_/, '')] = value.to_s.strip
           }
         resp
+      end
+
+      def locale_code(country_code)
+        NON_STANDARD_LOCALE_CODES[country_code] || country_code
       end
 
     end


### PR DESCRIPTION
This originated from a support ticket in July 2013, apparently our country codes did not match the Elavon supported 3 letter codes: https://www.myvirtualmerchant.com/VirtualMerchant/download/developerGuide.pdf - search for "fraud prevention"

This is just based on the advice left by @jordanwheeler 

you can see in active merchant where the country code gets added in for elavon. here:https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/gateways/elavon.rb#L231

and here for shipping address: https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/gateways/elavon.rb#L244

so what you'll want to do is something like what we already have in paypal. like this:https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/gateways/paypal_express.rb#L13-27
at the top of elavon.rb, you'll add pretty much the exact same thing. on the left hand side you'll have the shopify country code, then on the right hand side you'll have the elavon country code. like 'US' => 'USA', for example. you'd do that for all the countries that have a different country code in elavon than in shopify.

then, you'll add your own method at the bottom of elavon.rb. exactly like this: https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/gateways/paypal_express.rb#L234-236

except in our case, just the country+
so, in elavon.rb, you'll replace the lines like = billing_address[:country].to_s.slice(0, 50) with a call to your method. say, '"

@odorcicd @bslobodin not sure if anything else is required. Advice?
