### PR TITLE
making sure that active_merchant will work without loading rails

### DIFF
--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -27,6 +27,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/enumerable.rb'
 
 if(!defined?(ActiveSupport::VERSION) || (ActiveSupport::VERSION::STRING < "4.1"))
   require 'active_support/core_ext/class/attribute_accessors'


### PR DESCRIPTION
This fixes issue:
`activemerchant-1.42.4/lib/active_merchant/billing/gateways/authorize_net.rb:298:in `success?': undefined method `exclude?' for ["310", "311"]:Array (NoMethodError)
(...)
from payment.rb:20:in `<main>'`

when used without using rails / manually requiring 'active_support/core_ext/enumerable.rb'  first.
