### PR TITLE
Add ReferrerID to SagePay Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -293,6 +293,10 @@ module ActiveMerchant #:nodoc:
           :VPSProtocol => "2.23"
         )
 
+        if (application_id.present? && application_id != "ActiveMerchant")
+          parameters.update( :ReferrerID => application_id)
+        end
+
         parameters.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&")
       end
 

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -148,6 +148,17 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_referrer_id_is_added_to_post_data_parameters
+    ActiveMerchant::Billing::SagePayGateway.application_id = '00000000-0000-0000-0000-000000000001'
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert data.include?("ReferrerID=00000000-0000-0000-0000-000000000001")
+    end.respond_with(successful_purchase_response)
+    ensure
+      ActiveMerchant::Billing::SagePayGateway.application_id = nil
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Not sure if it is too heavy handed to use the `post_data section`.  Considered using the `add_optional_data` but worried it might not be sent in all the cases that it should.
