### PR TITLE
Handle missing secureHash in PayDollar notifications

### DIFF
--- a/lib/active_merchant/billing/integrations/paydollar/notification.rb
+++ b/lib/active_merchant/billing/integrations/paydollar/notification.rb
@@ -36,8 +36,11 @@ module ActiveMerchant #:nodoc:
 
           def acknowledge(authcode = nil)
             # paydollar supports multiple signature keys, therefore we need to check if any
-            # of their signatures matches ours
-            return false unless hash = @params['secureHash']
+            # of their signatures match ours
+            hash = @params['secureHash']
+            if !hash
+              return false
+            end
             hash.split(',').include? generate_secure_hash
           end
 

--- a/test/unit/integrations/notifications/paydollar_notification_test.rb
+++ b/test/unit/integrations/notifications/paydollar_notification_test.rb
@@ -26,7 +26,7 @@ class PaydollarNotificationTest < Test::Unit::TestCase
   end
 
   def test_unsigned_acknowledgement
-    @notification = Paydollar::Notification.new(http_raw_data_unsigned, {:credential2 => @secret})
+    @notification = Paydollar::Notification.new(unsigned_http_raw_data, {:credential2 => @secret})
     assert !@notification.acknowledge
   end
 
@@ -35,7 +35,7 @@ class PaydollarNotificationTest < Test::Unit::TestCase
     'prc=0&src=0&Ord=12345678&Ref=9&PayRef=1384996&successcode=0&Amt=139.62&Cur=344&Holder=Test Card&AuthId=384996&AlertCode=R14&remark=Shop One store purchase. Order #9&eci=07&payerAuth=U&sourceIp=216.191.231.218&ipCountry=CA&payMethod=VISA&TxTime=2014-02-14 23:53:27.0&panFirst4=4918&panLast4=5005&cardIssuingCountry=HK&channelType=SPC&MerchantId=18100230&secureHash=0b9b2664b48eebfd40a6d9ad027ed1ee673ad574,36177307e270a7d7de59fe84d013d40911b3fc71'
   end
 
-  def http_raw_data_unsigned
+  def unsigned_http_raw_data
     'prc=0&src=0&Ord=12345678&Ref=9&PayRef=1384996&successcode=0&Amt=139.62&Cur=344&Holder=Test Card&AuthId=384996&AlertCode=R14&remark=Shop One store purchase. Order #9&eci=07&payerAuth=U&sourceIp=216.191.231.218&ipCountry=CA&payMethod=VISA&TxTime=2014-02-14 23:53:27.0&panFirst4=4918&panLast4=5005&cardIssuingCountry=HK&channelType=SPC&MerchantId=18100230'
   end
 end


### PR DESCRIPTION
It looks like at least some notifications from PayDollar do not contain `secureHash`. This fix fails `acknowledge` for those, but I'm still waiting for a response as to what those notifications are.

@edward to review.
