### PR TITLE
Add ECI method for Braintree orange to accept 'recurring' for its billing method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * SagePay: Add support for ReferrerID [markabe]
 * Cecabank: Fix expiration date formatting [duff]
 * Add WePay gateway [faizalzakaria]
+* SmartPs: Add ECI option to SmartPs
 
 == Version 1.42.6 (February 24, 2014)
 

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -43,6 +43,7 @@ module ActiveMerchant #:nodoc:
         add_currency(post, money, options)
         add_taxes(post, options)
         add_processor(post, options)
+        add_eci(post, options)
         commit('sale', money, post)
       end
 
@@ -205,6 +206,10 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction(post, auth)
         post[:transactionid] = auth
+      end
+
+      def add_eci(post, options)
+        post[:billing_method] = options[:eci] if options[:eci]
       end
 
       def parse(body)

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -115,6 +115,14 @@ class BraintreeOrangeTest < Test::Unit::TestCase
     assert_equal 'N', response.cvv_result['code']
   end
 
+  def test_add_eci
+    @gateway.expects(:commit).with { |_, _, parameters| !parameters.has_key?(:billing_method) }
+    @gateway.purchase(@amount, @credit_card, {})
+
+    @gateway.expects(:commit).with { |_, _, parameters| parameters[:billing_method] == 'recurring' }
+    @gateway.purchase(@amount, @credit_card, {:eci => 'recurring'})
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
@emilienoel @bslobodin 

This adds the option to allow setting `billing_method` for Braintree Orange (using SmartPs).
The `billing_method` can be set to `recurring` on subsequent billing attempts to help with success rate.
