### PR TITLE
Raise ActionViewHelperError when an exception is raised during form building

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Cecabank: Fix expiration date formatting [duff]
 * Add WePay gateway [faizalzakaria]
 * SmartPs: Add ECI option to SmartPs [odorcicd]
+* Rescue and re-raise ActionViewHelperError when offsite helpers raise an error [odorcicd]
 
 == Version 1.42.6 (February 24, 2014)
 

--- a/lib/active_merchant/billing/integrations/action_view_helper.rb
+++ b/lib/active_merchant/billing/integrations/action_view_helper.rb
@@ -3,6 +3,8 @@ require 'action_pack'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module Integrations #:nodoc:
+      ActionViewHelperError = Class.new(StandardError)
+
       module ActionViewHelper
         # This helper allows the usage of different payment integrations
         # through a single form helper.  Payment integrations are the
@@ -67,6 +69,8 @@ module ActiveMerchant #:nodoc:
           
           concat(result.respond_to?(:html_safe) ? result.html_safe : result)
           nil
+        rescue => e
+          raise ActionViewHelperError.new(e)
         end
       end
     end

--- a/test/unit/integrations/action_view_helper_test.rb
+++ b/test/unit/integrations/action_view_helper_test.rb
@@ -15,6 +15,14 @@ class ActionViewHelperTest < Test::Unit::TestCase
     assert_raise(ArgumentError){ payment_service_for }
   end
 
+  def test_payment_service_rendering_error
+    ActiveMerchant::Billing::Integrations::Bogus::Helper.any_instance.stubs(:form_fields).raises(StandardError.new('Standard Error'))
+
+    assert_raise(ActiveMerchant::Billing::Integrations::ActionViewHelperError) do
+      payment_service_for('order-1', 'test', :service => :bogus){}
+    end
+  end
+
   protected
   def protect_against_forgery?
     false


### PR DESCRIPTION
@jduff @bslobodin 

Currently, a number of offsite gateways make external calls when building their form fields. Often enough, an exception is raised which bubbles all the way up through apps. This raises a more specific exception so that it can be rescued and dealt with accordingly (display exception message to user using offsite gateway).
Thoughts?
