### PR TITLE
Update country list for Authorize.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 
 * [App55](https://www.app55.com/) - AU, BR, CA, CH, CL, CN, CO, CZ, DK, EU, GB, HK, HU, ID, IS, JP, KE, KR, MX, MY, NO, NZ, PH, PL, TH, TW, US, VN, ZA
 * [Authorize.Net CIM](http://www.authorize.net/) - US
-* [Authorize.Net](http://www.authorize.net/) - US, CA, GB
+* [Authorize.Net](http://www.authorize.net/) - US, CA, GB, AU, AD, GR, PT, AT, HU, RO, BE, IE, SM, BG, IT, SK, CY, LI, SI, CZ, LU, ES, DK, MT, SE, FI, MC, CH, FR, NL, TR, DE, NO, GB, GI, PL, VA
 * [Balanced](https://www.balancedpayments.com/) - US
 * [Banwire](http://www.banwire.com/) - MX
 * [Barclays ePDQ Extra Plus](http://www.barclaycard.co.uk/business/accepting-payments/epdq-ecomm/) - GB

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'USD'
 
-      self.supported_countries = ['US', 'CA', 'GB']
+      self.supported_countries = %w(US CA GB AU AD GR PT AT HU RO BE IE SM BG IT SK CY LI SI CZ LU ES DK MT SE FI MC CH FR NL TR DE NO GB GI PL VA)
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
       self.homepage_url = 'http://www.authorize.net/'
       self.display_name = 'Authorize.Net'

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -255,7 +255,9 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['US', 'CA', 'GB'], AuthorizeNetGateway.supported_countries
+    ['US', 'CA', 'AU', 'VA'].each do |country|
+      assert AuthorizeNetGateway.supported_countries.include?(country)
+    end
   end
 
   def test_supported_card_types


### PR DESCRIPTION
Official List
http://www.authorize.net/international/

Press Release
http://blog.pilotgroup.net/2013/10/11/authorize-net-adds-new-supported-countries/
