### PR TITLE
Bitpay: Raise in helper on failed invoice creation

### DIFF
--- a/lib/active_merchant/billing/integrations/bit_pay/helper.rb
+++ b/lib/active_merchant/billing/integrations/bit_pay/helper.rb
@@ -38,6 +38,8 @@ module ActiveMerchant #:nodoc:
           def form_fields
             invoice = create_invoice
 
+            raise StandardError, "Invalid response while retrieving BitPay Invoice ID. Please try again." unless invoice
+
             {"id" => invoice['id']}
           end
 

--- a/test/unit/integrations/helpers/bit_pay_helper_test.rb
+++ b/test/unit/integrations/helpers/bit_pay_helper_test.rb
@@ -50,4 +50,10 @@ class BitPayHelperTest < Test::Unit::TestCase
 
     assert_equal '98kui1gJ7FocK41gUaBZxG', @helper.form_fields['id']
   end
+
+  def test_raises_when_invalid_json_returned
+    Net::HTTP.any_instance.expects(:request).returns(stub(:body => 'Invalid JSON'))
+
+    assert_raises(StandardError) { @helper.form_fields['id'] }
+  end
 end


### PR DESCRIPTION
@bizla 
Raises something a little more useful for when Bitpay invoice creation fails
