### PR TITLE
Wepay: Fix for a full refund

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -18,11 +18,11 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_method, options = {})
         post = {}
         if payment_method.is_a?(String)
-          purchase_with_token(post, money, payment_method, options)
+          purchase_with_token(post, money, id_auth(payment_method), options)
         else
           MultiResponse.run do |r|
             r.process { store(payment_method, options) }
-            r.process { purchase_with_token(post, money, r.authorization, options) }
+            r.process { purchase_with_token(post, money, id_auth(r.authorization), options) }
           end
         end
       end
@@ -30,32 +30,34 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment_method, options = {})
         post = {auto_capture: 0}
         if payment_method.is_a?(String)
-          purchase_with_token(post, money, payment_method, options)
+          purchase_with_token(post, money, id_auth(payment_method), options)
         else
           MultiResponse.run do |r|
             r.process { store(payment_method, options) }
-            r.process { purchase_with_token(post, money, r.authorization, options) }
+            r.process { purchase_with_token(post, money, id_auth(r.authorization), options) }
           end
         end
       end
 
       def capture(identifier, options = {})
         post = {}
-        post[:checkout_id] = identifier
+        post[:checkout_id] = id_auth(identifier)
         commit('/checkout/capture', post)
       end
 
       def void(identifier, options = {})
         post = {}
-        post[:checkout_id] = identifier
+        post[:checkout_id] = id_auth(identifier)
         post[:cancel_reason] = (options[:description] || "Void")
         commit('/checkout/cancel', post)
       end
 
       def refund(money, identifier, options = {})
+        auth, original_amount = split_authorization(identifier)
+
         post = {}
-        post[:checkout_id] = identifier
-        post[:amount] = amount(money) if money
+        post[:checkout_id] = auth
+        post[:amount] = amount(money) if money && (original_amount != amount(money))
         post[:refund_reason] = (options[:description] || "Refund")
         post[:app_fee] = options[:application_fee] if options[:application_fee]
         post[:payer_email_message] = options[:payer_email_message] if options[:payer_email_message]
@@ -89,7 +91,7 @@ module ActiveMerchant #:nodoc:
             post[:address]["postcode"] = billing_address[:zip]
           end
         end
-        commit('/credit_card/create', post, authorization_field: "credit_card_id")
+        commit('/credit_card/create', post)
       end
 
       private
@@ -148,7 +150,7 @@ module ActiveMerchant #:nodoc:
           success_from(response),
           message_from(response),
           response,
-          authorization: authorization_from(response, options),
+          authorization: authorization_from(response, params),
           test: test?
         )
       end
@@ -161,8 +163,18 @@ module ActiveMerchant #:nodoc:
         (response["error"] ? response["error_description"] : "Success")
       end
 
-      def authorization_from(response, options)
-        response[options[:authorization_field] || "checkout_id"].to_s
+      def authorization_from(response, params)
+        auth = response["credit_card_id"] || response["checkout_id"]
+        [ auth, params[:amount] ].join('|')
+      end
+
+      def split_authorization(authorization)
+        auth, original_amount = authorization.split("|")
+        [ auth, original_amount ]
+      end
+
+      def id_auth(authorization)
+        split_authorization(authorization).first
       end
 
       def headers

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -57,8 +57,17 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_full_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    sleep 30 # Wait for purchase to clear. Doesn't always work.
+    response = @gateway.refund(@amount, purchase.authorization)
+    assert_success response
+  end
+
   def test_failed_capture
-    response = @gateway.capture(@amount, '123')
+    response = @gateway.capture('123')
     assert_failure response
   end
 


### PR DESCRIPTION
From the Wepay docs:
"This amount must be less than the 'net' of the transaction.
To perform a full refund, do not pass the amount parameter."

If you pass the full amount on a refund, Wepay don't like that. So now
we only pass an amount if it's not equal to the original amount of the
purchase or capture.

Relevant Wepay docs:
https://www.wepay.com/developer/reference/checkout#refund
