### PR TITLE
Cecabank: Handle invalid xml response body

### DIFF
--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -113,30 +113,24 @@ module ActiveMerchant #:nodoc:
         root = REXML::Document.new(body).root
 
         response[:success] = (root.attributes['valor'] == "OK")
-
-        #common params to all responses
         response[:date] = root.attributes['fecha']
         response[:operation_number] = root.attributes['numeroOperacion']
         response[:message] = root.attributes['valor']
 
-        #success
         if root.elements['OPERACION']
           response[:operation_type] = root.elements['OPERACION'].attributes['tipo']
           response[:amount] =  root.elements['OPERACION/importe'].text.strip
         end
 
-        #optional params
         response[:description] = root.elements['OPERACION/descripcion'].text if root.elements['OPERACION/descripcion']
         response[:authorization_number] = root.elements['OPERACION/numeroAutorizacion'].text if root.elements['OPERACION/numeroAutorizacion']
         response[:reference] = root.elements['OPERACION/referencia'].text if root.elements['OPERACION/referencia']
         response[:pan] = root.elements['OPERACION/pan'].text if root.elements['OPERACION/pan']
 
         if root.elements['ERROR']
-          #error
           response[:error_code] = root.elements['ERROR/codigo'].text
           response[:error_message] = root.elements['ERROR/descripcion'].text
         else
-          #authorization
           if("000" == root.elements['OPERACION'].attributes['numeroOperacion'])
             if(root.elements['OPERACION/numeroAutorizacion'])
               response[:authorization] = root.elements['OPERACION/numeroAutorizacion'].text
@@ -146,6 +140,12 @@ module ActiveMerchant #:nodoc:
           end
         end
 
+        return response
+
+      rescue REXML::ParseException => e
+        response[:success] = false
+        response[:message] = "Unable to parse the response."
+        response[:error_message] = e.message
         response
       end
 

--- a/test/unit/gateways/cecabank_test.rb
+++ b/test/unit/gateways/cecabank_test.rb
@@ -30,6 +30,16 @@ class CecabankTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_invalid_xml_response_handling
+    @gateway.expects(:ssl_post).returns(invalid_xml_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+    assert_match(/Unable to parse the response/, response.message)
+    assert_match(/No close tag for/, response.params['error_message'])
+  end
+
   def test_expiration_date_sent_correctly
     response = stub_comms do
       @gateway.purchase(@amount, credit_card("4242424242424242", month: 1, year: 2014), @options)
@@ -89,6 +99,14 @@ class CecabankTest < Test::Unit::TestCase
     <descripcion><![CDATA[ERROR. Formato CVV2/CVC2 no valido.]]></descripcion>
   </ERROR>
 </TRANSACCION>
+    RESPONSE
+  end
+
+  def invalid_xml_purchase_response
+    <<-RESPONSE
+<br>
+<TRANSACCION valor="OK" numeroOperacion="202215722" fecha="22/01/2014 13:15:32">
+Invalid unparsable xml in the response
     RESPONSE
   end
 


### PR DESCRIPTION
We've seen at least one case where the response body returned by
Cecabank was unparsable.  Previously this raised an exception; now we
rescue the exception to include details in a proper
ActiveMerchant::Response.
