### PR TITLE
Wirecard: Capture error code in the response

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -239,22 +239,27 @@ module ActiveMerchant #:nodoc:
       # Parse the <ProcessingStatus> Element which contains all important information
       def parse_response(response, root)
         status = nil
-        # get the root element for this Transaction
+
         root.elements.to_a.each do |node|
           if node.name =~ /FNC_CC_/
             status = REXML::XPath.first(node, "CC_TRANSACTION/PROCESSING_STATUS")
           end
         end
+
         message = ""
         if status
           if info = status.elements['Info']
             message << info.text
           end
-          # Get basic response information
+
           status.elements.to_a.each do |node|
             response[node.name.to_sym] = (node.text || '').strip
           end
+
+          error_code = REXML::XPath.first(status, "ERROR/Number")
+          response['ErrorCode'] = error_code.text if error_code
         end
+
         parse_error(root, message)
         response[:Message] = message
       end

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -128,6 +128,7 @@ class RemoteWirecardTest < Test::Unit::TestCase
     assert response.test?
     assert_failure response
     assert response.message[ /Credit card number not allowed in demo mode/ ], "Got wrong response message"
+    assert_equal "24997", response.params['ErrorCode']
   end
 
   def test_unauthorized_capture

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -62,7 +62,8 @@ class WirecardTest < Test::Unit::TestCase
     assert_failure response
     assert response.test?
     assert_equal TEST_AUTHORIZATION_GUWID, response.authorization
-    assert response.message[/credit card number not allowed in demo mode/i]
+    assert_match /credit card number not allowed in demo mode/i, response.message
+    assert_equal '24997', response.params['ErrorCode']
   end
 
   def test_successful_authorization_and_capture


### PR DESCRIPTION
Allowing customers to see the actual error code can help in two primary
areas:
- Communicating with the gateway's customer support about a given
  transaction.
- Enabling customers to localize error messages if they
  so desire, especially for an international gateway like Wirecard.

Now customers who care can access the error code in the
ActiveMerchant::Response params, which is a gateway specific hash of
response details.
