### PR TITLE
Push delimiter as x_delim_char for Authorize CIM Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -610,9 +610,12 @@ module ActiveMerchant #:nodoc:
       def build_create_customer_profile_transaction_request(xml, options)
         options[:extra_options] ||= {}
         options[:extra_options].merge!('x_test_request' => 'TRUE') if @options[:test_requests]
+        options[:extra_options].merge!('x_delim_char' => @options[:delimiter]) if @options[:delimiter]
 
         add_transaction(xml, options[:transaction])
-        tag_unless_blank(xml, 'extraOptions', format_extra_options(options[:extra_options]))
+        xml.tag!('extraOptions') do
+          xml.cdata!(format_extra_options(options[:extra_options]))
+        end unless options[:extra_options].blank?
 
         xml.target!
       end


### PR DESCRIPTION
While you can specify a `delimiter` when initializing a `AuthorizeNetCimGateway`, ActiveMerchant doesn't send this information to Authorize (it relies on you changing it globally using the web admin). Since `delimiter` is used to parse each response, we should also send it with each request. The CIM gateway allows this by sending `x_delim_char` via `extraOptions`.

`extraOptions` should also be submitted as CDATA instead of plain tag content - this only became a visible problem when appending multiple parameters. You can see an example on page 33 of https://www.authorize.net/support/CIM_XML_guide.pdf
