### PR TITLE
required_login_params to verify required options prior to instantiating ...

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -133,6 +133,10 @@ module ActiveMerchant #:nodoc:
         (@options.has_key?(:test) ? @options[:test] : Base.test?)
       end
 
+      def self.required_login_params
+        @@required_login_params ||= [:login, :password]
+      end
+
       private # :nodoc: all
 
       def name

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server.
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
       #   Will hold the same value as :test by default.
       # * <tt>:delimiter</tt> -- The delimiter used in the direct response.  Default is ',' (comma).
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
         @options[:test_requests] = test? if @options[:test_requests].nil?
       end

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>:login</tt> -- The Balanced API Secret (REQUIRED)
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
         initialize_marketplace(options[:marketplace] || load_marketplace)
       end
@@ -284,6 +284,10 @@ module ActiveMerchant #:nodoc:
         Response.new(true, "Card stored", {}, :test => is_test, :authorization => [card_uri, account_uri].compact.join(';'))
       rescue Error => ex
         failed_response(ex.response)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Banwire'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -24,6 +24,10 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
 
         commit(money, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/barclays_epdq.rb
+++ b/lib/active_merchant/billing/gateways/barclays_epdq.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Barclays ePDQ MPI'
 
       def initialize(options = {})
-        requires!(options, :login, :password, :client_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -82,6 +82,10 @@ module ActiveMerchant #:nodoc:
         end
 
         commit(document)
+      end
+
+      def self.required_login_params
+        @@login_params ||= super + [:client_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/be2bill.rb
+++ b/lib/active_merchant/billing/gateways/be2bill.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
       #             :email       => user.email }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -159,6 +159,10 @@ module ActiveMerchant #:nodoc:
         commit(post, true)
       end
 
+      def self.required_login_params
+        @@login_params ||= [super.first]
+      end
+
       private
       def build_response(*args)
         Response.new(*args)

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
       # and password to your account under administration -> account settings ->
       # order settings -> Use username/password validation
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/beanstream_interac.rb
+++ b/lib/active_merchant/billing/gateways/beanstream_interac.rb
@@ -7,21 +7,21 @@ module ActiveMerchant #:nodoc:
         params['pageContents']
       end
     end
-    
+
     class BeanstreamInteracGateway < Gateway
       include BeanstreamCore
 
       # Confirm a transaction posted back from the bank to Beanstream.
       # Confirming a transaction does not require any credentials,
       # and in an application with many merchants sharing a funded
-      # URL the application may not yet know which merchant the 
+      # URL the application may not yet know which merchant the
       # post back is for until the response of the confirmation is
       # received, which contains the order number.
       def self.confirm(transaction)
         gateway = new(:login => '')
         gateway.confirm(transaction)
       end
-      
+
       def purchase(money, options = {})
         post = {}
         add_amount(post, money)
@@ -31,20 +31,24 @@ module ActiveMerchant #:nodoc:
         add_transaction_type(post, :purchase)
         commit(post)
       end
-      
+
       # Confirm a transaction posted back from the bank to Beanstream.
       def confirm(transaction)
         post(transaction)
       end
-      
+
+      def self.required_login_params
+        @@login_params ||= [super.first]
+      end
+
       private
-      
+
       def add_interac_details(post, options)
         address = options[:billing_address] || options[:address] || {}
         post[:trnCardOwner] = address[:name]
         post[:paymentMethod] = 'IO'
       end
-      
+
       def build_response(*args)
         BeanstreamInteracResponse.new(*args)
       end

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:secret_key</tt> -- The BluePay gateway Secret Key (REQUIRED)
       # * <tt>:test</tt> -- set to true for TEST mode or false for LIVE mode
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -357,7 +357,7 @@ module ActiveMerchant #:nodoc:
           else
             message = message.chomp('.')
           end
-        elsif message == "Missing ACCOUNT_ID" 
+        elsif message == "Missing ACCOUNT_ID"
           message = "The merchant login ID or password is invalid"
         elsif message =~ /Approved/
           message = "This transaction has been approved"

--- a/lib/active_merchant/billing/gateways/braintree.rb
+++ b/lib/active_merchant/billing/gateways/braintree.rb
@@ -4,15 +4,19 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BraintreeGateway < Gateway
       include BraintreeCommon
-      
+
       self.abstract_class = true
 
       def self.new(options={})
-        if options.has_key?(:login)
+        if options.has_key? required_login_params.first
           BraintreeOrangeGateway.new(options)
         else
           BraintreeBlueGateway.new(options)
         end
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Braintree (Blue Platform)'
 
       def initialize(options = {})
-        requires!(options, :merchant_id, :public_key, :private_key)
+        requires!(options, *self.class.required_login_params)
         @merchant_account_id = options[:merchant_account_id]
 
         super
@@ -168,6 +168,10 @@ module ActiveMerchant #:nodoc:
         end
       end
       alias_method :delete, :unstore
+
+      def self.required_login_params
+        @@required_params ||= [:merchant_id, :public_key, :private_key]
+      end
 
       private
 

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :shared_secret)
+        requires!(options, *self.class.required_login_params)
         if (options[:threeDSRequired])
           @threeDSRequired = options[:threeDSRequired]
         else
@@ -107,6 +107,10 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_pair(post, :xref, authorization)
         commit('REFUND', post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:login, :shared_secret]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
+  module Billing #:nodoc
     # CC5 API is used by many banks in Turkey. Extend this base class to provide
     # concrete implementations.
     class CC5Gateway < Gateway
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password, :client_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -31,6 +31,10 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         commit(build_capture_request(money, authorization, options))
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:client_id]
       end
 
       protected

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server.
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
-        requires!(options, :merchant_id, :acquirer_bin, :terminal_id, :key)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -92,6 +92,10 @@ module ActiveMerchant #:nodoc:
                 'TipoMoneda' => CECA_CURRENCIES_DICTIONARY[options[:currency] || currency(money)]}
 
         commit(CECA_ACTION_REFUND, post)
+      end
+
+      def self.required_login_params
+        @required_params ||= [:merchant_id, :acquirer_bin, :terminal_id, :key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/certo_direct.rb
+++ b/lib/active_merchant/billing/gateways/certo_direct.rb
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server.
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'MXN'
 
       def initialize(options = {})
-        requires!(options, :key)
+        requires!(options, *self.class.required_login_params)
         options[:version] ||= '0.2.0'
         super
       end
@@ -72,6 +72,10 @@ module ActiveMerchant #:nodoc:
 
       def unstore(customer_id, options = {})
         commit(:delete, "customers/#{CGI.escape(customer_id)}", nil)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       # :ignore_cvv => true   don't want to use CVV so continue processing even
       #                       if CVV would have failed
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -48,7 +48,7 @@ module ActiveMerchant
       # * <tt>:test => +true+ or +false+</tt> -- Use the test or live Datacash url.
       #
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       # login is your Store ID
       # password is your Store Key
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:user</tt> -- Specify a subuser of the account (optional)
       # * <tt>:test => +true+ or +false+</tt> -- Force test transactions
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
       # login: merchant number
       # password: referrer url (for authorize authentication)
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -108,6 +108,10 @@ module ActiveMerchant #:nodoc:
       def credit(money, identification, options = {})
         deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, identification, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -87,7 +87,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:username</tt>
       # * <tt>:password</tt>
       def initialize(options = {})
-        requires!(options, :username, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -195,6 +195,10 @@ module ActiveMerchant #:nodoc:
         post = {:transactionid => identification}
         add_order(post, options)
         commit('update', nil, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:username, super.last]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -19,7 +19,7 @@ module ActiveMerchant #:nodoc:
       #           :password  - Your XML Refund Password that you
       #                        specified on the Eway site. (optional)
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -50,6 +50,10 @@ module ActiveMerchant #:nodoc:
         post[:CardExpiryYear] = nil
 
         commit(refund_url, money, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -22,7 +22,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'eWay Managed Payments'
 
       def initialize(options = {})
-        requires!(options, :login, :username, :password)
+        requires!(options, *self.class.required_login_params)
 
         # eWay returns 500 code for faults, which AM snaffles.
         # So, we tell it to allow them.
@@ -99,6 +99,10 @@ module ActiveMerchant #:nodoc:
         post[:managedCustomerID] = billing_id.to_s
 
         commit("QueryCustomer", post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:username]
       end
 
       # TODO: eWay API also provides QueryPayment

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = "AUD"
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -41,8 +41,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'E-xact'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
-
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       # You can find your username and token at https://dashboard.fatzebra.com.au
       # Under the Your Account section
       def initialize(options = {})
-        requires!(options, :username, :token)
+        requires!(options, *self.class.required_login_params)
         @username = options[:username]
         @token    = options[:token]
         super
@@ -67,6 +67,10 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, creditcard)
 
         commit(:post, "credit_cards", post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:username, :token]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Federated Canada'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'FirstGiving'
 
       def initialize(options = {})
-        requires!(options, :application_key, :security_token, :charity_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -32,6 +32,10 @@ module ActiveMerchant #:nodoc:
         get[:transactionId] = identifier
         get[:tranType]     = 'REFUNDREQUEST'
         commit("/transaction/refundrequest?" + encode(get))
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:application_key, :security_token, :charity_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
       #                         (Found in your administration terminal settings)
       # * <tt>:password</tt> -- The terminal password (not your account password)
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         @options = options
 
         super

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
 
 
       def initialize(options = {})
-        requires!(options, :login, :password, :terminal_id, :merchant_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -48,6 +48,10 @@ module ActiveMerchant #:nodoc:
       def capture(money, ref_id, options = {})
         options = options.merge(:gvp_order_type => "postauth")
         commit(money, build_capture_request(money, ref_id, options))
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:terminal_id, :merchant_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = [:visa, :master, :discover, :diners_club]
 
       def initialize(options={})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
+++ b/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       API_VERSION = '1.1.0'
 
       def initialize(options = {})
-        requires!(options, :login, :password, :pem)
+        requires!(options, *self.class.required_login_params)
 
         options[:pem_password] = options[:password]
         super
@@ -43,6 +43,10 @@ module ActiveMerchant #:nodoc:
       # Get list of issuers from response.issuer_list
       def issuers
         commit(build_directory_request)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:pem]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:password</tt> -- The Inspire Passowrd.
       # See the Inspire Integration Guide for details. (default: +false+)
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options,*self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/instapay.rb
+++ b/lib/active_merchant/billing/gateways/instapay.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       SUCCESS_MESSAGE = "The transaction has been approved"
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -52,6 +52,10 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money)
         add_reference(post, authorization)
         commit('ns_quicksale_cc', post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test_mode</tt> - <tt>true</tt> or <tt>false</tt>. Run *all* transactions with the 'TestMode' element set to 'TRUE'.
       #
       def initialize(options = {})
-        requires!(options, :login, :password, :gateway_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -262,6 +262,10 @@ module ActiveMerchant #:nodoc:
         end.doc
 
         commit(payload)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:gateway_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -97,6 +97,10 @@ module ActiveMerchant #:nodoc:
         transaction_id = reference.split(";").first
         credit_card = options[:credit_card]
         commit(money, build_credit_request('CREDIT', money, transaction_id, credit_card))
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
 

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'LinkPoint'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
 
         @options = {
           :result => 'LIVE',
@@ -241,6 +241,10 @@ module ActiveMerchant #:nodoc:
       def credit(money, identification, options = {})
         deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, identification, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
         options[:merchant] ||= 'Default Report Group'
         options[:user]     ||= options[:login]
 
-        requires!(options, :merchant_id, :user, :password, :merchant, :version)
+        requires!(options, *self.class.required_login_params)
 
         super
       end
@@ -125,6 +125,10 @@ module ActiveMerchant #:nodoc:
       def store(creditcard_or_paypage_registration_id, options = {})
         to_pass = create_token_hash(creditcard_or_paypage_registration_id, options)
         build_response(:registerToken, @litle.register_token_request(to_pass), %w(000 801 802))
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:merchant_id, :user, :password, :merchant, :version]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/maxipago.rb
+++ b/lib/active_merchant/billing/gateways/maxipago.rb
@@ -16,7 +16,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'maxiPago!'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Merchant e-Solutions'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
 
       def initialize(options = {})
-        requires!(options, :username, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -54,6 +54,10 @@ module ActiveMerchant #:nodoc:
 
       def new_connection(endpoint)
         MerchantOneSslConnection.new(endpoint)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:username, super.last]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:password</tt> - The MerchantWARE Key.
       # * <tt>:name</tt> - The MerchantWARE Name.
       def initialize(options = {})
-        requires!(options, :login, :password, :name)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -114,6 +114,10 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, reference, options = {})
         perform_reference_credit(money, reference, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:name]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:password</tt> - The MerchantWARE Key.
       # * <tt>:name</tt> - The MerchantWARE Name.
       def initialize(options = {})
-        requires!(options, :login, :password, :name)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -106,6 +106,10 @@ module ActiveMerchant #:nodoc:
         end
 
         commit(:refund, request)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:name]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'AUD'
 
       def initialize(options = {})
-        requires!(options, :merchant_uuid, :api_key, :api_passphrase)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -66,6 +66,10 @@ module ActiveMerchant #:nodoc:
           'cardExpiryYear'  => format(creditcard.year, :two_digits)
         }
         commit('addCard', post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:merchant_uuid, :api_key, :api_passphrase]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'USD'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         @use_tokenization = (!options.has_key?(:tokenization) || options[:tokenization])
         super
       end

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server.
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:advanced_login</tt> -- The MiGS AMA User
       # * <tt>:advanced_password</tt> -- The MiGS AMA User's password
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/modern_payments.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.abstract_class = true
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -22,7 +22,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
       #                            Only particular account types at Moneris will allow this.
       #                            Defaults to false.  (optional)
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         @cvv_enabled = options[:cvv_enabled]
         options = { :crypt_type => 7 }.merge(options)
         super

--- a/lib/active_merchant/billing/gateways/moneris_us.rb
+++ b/lib/active_merchant/billing/gateways/moneris_us.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       # login is your Store ID
       # password is your API Token
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         options = { :crypt_type => 7 }.merge(options)
         super
       end

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.ssl_version = :SSLv3
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         @options = options
         super
       end

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
 
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -48,7 +48,7 @@ module ActiveMerchant
       #
       # Options :login and :password must be given.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'NOK'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -81,6 +81,10 @@ module ActiveMerchant #:nodoc:
 
       def test?
         (@options[:login] == TEST_LOGIN || super)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/netpay.rb
+++ b/lib/active_merchant/billing/gateways/netpay.rb
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
       RESPONSE_KEYS = ['ResponseMsg', 'ResponseText', 'ResponseCode', 'TimeIn', 'TimeOut', 'AuthCode', 'OrderId', 'CardTypeName', 'MerchantId', 'IssuerAuthDate']
 
       def initialize(options = {})
-        requires!(options, :store_id, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -112,6 +112,10 @@ module ActiveMerchant #:nodoc:
 
         #commit('Refund', post, options)
         commit('Credit', post, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:store_id] + super
       end
 
       private

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
       self.ssl_version = :TLSv1
 
       def initialize(options = {})
-        requires!(options, :login, :user, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -211,6 +211,10 @@ module ActiveMerchant #:nodoc:
         response = authorize(@options[:store_amount] || 1, payment_source, options)
         void(response.authorization) if response.success?
         response
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:user] + super
       end
 
       private

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
       # 2. Sign up
       # 3. Activate your account clicking on the email confirmation
       def initialize(options = {})
-        requires!(options, :key, :merchant_id)
+        requires!(options, *self.class.required_login_params)
         @api_key = options[:key]
         @merchant_id = options[:merchant_id]
         super
@@ -81,6 +81,10 @@ module ActiveMerchant #:nodoc:
         else
           commit(:delete, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", nil, options)
         end
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:key, :merchant_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Optimal Payments'
 
       def initialize(options = {})
-        #requires!(options, :login, :password)
+        #requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -180,8 +180,11 @@ module ActiveMerchant #:nodoc:
       SENSITIVE_FIELDS = [:account_num]
 
       def initialize(options = {})
-        requires!(options, :merchant_id)
-        requires!(options, :login, :password) unless options[:ip_authentication]
+        if options[:ip_authentication]
+          requires!(options, self.class.required_login_params.last)
+        else
+          requires!(options, *self.class.required_login_params)
+        end
         super
       end
 
@@ -284,6 +287,10 @@ module ActiveMerchant #:nodoc:
         options = {:customer_profile_action => DELETE, :customer_ref_num => customer_ref_num}
         order = build_customer_request_xml(nil, options)
         commit(order, :delete_customer_profile)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:merchant_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Raven PacNet'
 
       def initialize(options = {})
-        requires!(options, :user, :secret, :prn)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -60,6 +60,10 @@ module ActiveMerchant #:nodoc:
         add_currency_code(post, money, options)
 
         commit('cc_refund', money, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:user, :secret, :prn]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'PayJunction'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Paybox Direct'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :account, :encryption_key)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -166,6 +166,10 @@ module ActiveMerchant #:nodoc:
       # Returns an ActiveMerchant::Billing::Response object
       def unstore(authorization, options = {})
         send_delete_agreement(authorization)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:account, :encryption_key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *Gateway.required_login_params)
 
         options[:partner] = partner if options[:partner].blank?
         super

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
       # then the token will be sent as the DPS specified "DpsBillingId".  This is per the documentation at
       # http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#Tokenbilling
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'EUR'
 
       def initialize(options = {})
-        requires!(options, :public_key, :private_key)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -47,6 +47,10 @@ module ActiveMerchant #:nodoc:
 
       def store(credit_card, options={})
         save_card(credit_card)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:public_key, :private_key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       #                       globally and then you won't need to
       #                       include this option
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *Gateway.required_login_params)
 
         headers = {'X-PP-AUTHORIZATION' => options.delete(:auth_signature), 'X-PAYPAL-MESSAGE-PROTOCOL' => 'SOAP11'} if options[:auth_signature]
         options = {

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.ssl_version = 'SSLv3'
 
       def initialize(options = {})
-        requires!(options, :username, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -56,6 +56,10 @@ module ActiveMerchant #:nodoc:
         post[:transactionid] = authorization
 
         commit('void', nil, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:username, super.last]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       self.money_format        = :cents
 
       def initialize(options = {})
-        requires!(options, :paystation_id, :gateway_id)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -76,6 +76,10 @@ module ActiveMerchant #:nodoc:
         store_credit_card(post, options)
 
         commit(post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:paystation_id, :gateway_id]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -87,7 +87,7 @@ module ActiveMerchant
         @options = options
 
         @options[:merchant] ||= 'TEST' if test?
-        requires!(options, :username, :password, :merchant, :pem)
+        requires!(options, *self.class.required_login_params)
 
         @options[:eci] ||= 'SSL'
       end
@@ -141,6 +141,10 @@ module ActiveMerchant
         requires!(options, :order_id)
 
         commit(:status, 'customer.orderNumber' => options[:order_id])
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:username, super.last, :merchant, :pem]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Pin'
 
       def initialize(options = {})
-        requires!(options, :api_key)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -48,6 +48,10 @@ module ActiveMerchant #:nodoc:
       # kept for compatibility reasons
       def refund(money, token, options = {})
         commit("charges/#{CGI.escape(token)}/refunds", { :amount => amount(money) }, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:api_key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -98,7 +98,7 @@ module ActiveMerchant
       self.display_name = "Plug'n Pay"
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
       FAILURE_MESSAGE = 'The transaction was declined'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -88,7 +88,7 @@ module ActiveMerchant
       #   -options:
       #     :login -    the PslCard account login (required)
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
 
         super
       end
@@ -163,6 +163,10 @@ module ActiveMerchant
         add_purchase_details(post)
 
         commit(post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       #   Otherwise, perform transactions against the production server.
       #
       def initialize(options = {})
-        requires!(options, :login, :ticket)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -111,6 +111,10 @@ module ActiveMerchant #:nodoc:
       # Query the merchant account status
       def query
         commit(:query, nil, {})
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first, :ticket]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
       # :ignore_cvv => true   don't want to use CVV so continue processing even if CVV would have failed
       #
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -120,7 +120,7 @@ module ActiveMerchant #:nodoc:
 
           :chstatus  => %w(protocol msgtype merchant apikey)
         },
-        
+
         7 => {
           :authorize => %w(protocol msgtype merchant ordernumber amount
                            currency autocapture cardnumber expirationdate cvd
@@ -148,7 +148,7 @@ module ActiveMerchant #:nodoc:
           :status    => %w(protocol msgtype merchant transaction apikey),
 
           :chstatus  => %w(protocol msgtype merchant apikey)
-        }        
+        }
       }
 
       APPROVED = '000'
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
       # To use the API-key from the Quickpay manager, specify :api-key
       # Using the API-key, requires that you use version 4+. Specify :version => 4/5/6/7 in options.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         @protocol = options.delete(:version) || 7 # default to protocol version 7
         super
       end

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -43,7 +43,7 @@ module ActiveMerchant
       ERROR = CLIENT_DEACTIVATED = "Gateway Error"
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         options[:refund_hash] = Digest::SHA1.hexdigest(options[:rebate_secret]) if options.has_key?(:rebate_secret)
         super
       end

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -179,7 +179,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:terminal</tt> -- The Redsys Terminal. Defaults to 1. (OPTIONAL)
       # * <tt>:test</tt> -- +true+ or +false+. Defaults to +false+. (OPTIONAL)
       def initialize(options = {})
-        requires!(options, :login, :secret_key)
+        requires!(options, *self.class.required_login_params)
         options[:terminal] ||= 1
         super
       end
@@ -236,6 +236,10 @@ module ActiveMerchant #:nodoc:
         add_order(data, order_id)
 
         commit data
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first, :secret_key]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -19,7 +19,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:login</tt> - The Sage Payment Solutions Merchant ID Number.
       # * <tt>:password</tt> - The Sage Payment Solutions Merchant Key Number.
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/sage/sage_core.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_core.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *Gateway.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'SagePay'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -120,6 +120,10 @@ module ActiveMerchant #:nodoc:
       def credit(money, identification, options = {})
         deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, identification, options)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/sallie_mae.rb
+++ b/lib/active_merchant/billing/gateways/sallie_mae.rb
@@ -16,7 +16,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Sallie Mae'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -48,6 +48,10 @@ module ActiveMerchant #:nodoc:
         post = PostData.new
         post[:postonly] = authorization
         commit(:capture, money, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/samurai.rb
+++ b/lib/active_merchant/billing/gateways/samurai.rb
@@ -16,7 +16,7 @@ module ActiveMerchant #:nodoc:
           raise "Could not load the samurai gem (>= 0.2.25).  Use `gem install samurai` to install it."
         end
 
-        requires!(options, :login, :password, :processor_token)
+        requires!(options, *self.class.required_login_params)
         Samurai.options = {
           :merchant_key       => options[:login],
           :merchant_password  => options[:password],
@@ -90,6 +90,10 @@ module ActiveMerchant #:nodoc:
                      { :payment_method_token => result.is_sensitive_data_valid && result.payment_method_token })
       rescue ActiveResource::ServerError => e
         Response.new(false, e.message, {}, test: test?)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:processor_token]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
       AVS_ERRORS = %w( A E N R W Z )
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
       SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'SecurePayTech'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:advanced => +true+ or +false+</tt> -- Set to true if you're using an advanced processor
       # See the SkipJack Integration Guide for details. (default: +false+)
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.abstract_class = true
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'SoEasyPay'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
       #           :gateway_token - The token of the gateway you've created in
       #                            Spreedly.
       def initialize(options = {})
-        requires!(options, :login, :password, :gateway_token)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -104,6 +104,10 @@ module ActiveMerchant #:nodoc:
       # options        - A standard ActiveMerchant options hash
       def unstore(authorization, options={})
         commit("payment_methods/#{authorization}/redact.xml", '', :put)
+      end
+
+      def self.required_login_params
+        @@required_params ||= super + [:gateway_token]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Stripe'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         @api_key = options[:login]
         @fee_refund_api_key = options[:fee_refund_login]
         @version = options[:version]
@@ -140,6 +140,10 @@ module ActiveMerchant #:nodoc:
         else
           commit(:delete, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", nil, options)
         end
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
       # and swipehq.ca respectively). Merchants must use the region that they
       # signed up in for authentication with their merchant ID and API key to succeed.
       def initialize(options = {})
-        requires!(options, :login, :api_key, :region)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -44,6 +44,10 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
 
         commit('sale', money, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first, :api_key, :region]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
       DECLINED = 'The transaction was declined'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/transnational.rb
+++ b/lib/active_merchant/billing/gateways/transnational.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'USD'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:login</tt> -- TestMerchant
       # * <tt>:password</tt> -- password
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
 
         super
       end

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:soap_response</tt> -- set to +true+ to add :soap_response to the params hash containing the entire soap xml message
       #
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
 
         if options[:software_id]
           self.live_url = "#{LIVE_URL_BASE}#{options[:software_id].to_s}"

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -19,7 +19,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -66,6 +66,10 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         post = { :refNum => authorization }
         commit(:void, post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [super.first]
       end
 
     private

--- a/lib/active_merchant/billing/gateways/verifi.rb
+++ b/lib/active_merchant/billing/gateways/verifi.rb
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Verifi'
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:user</tt> -- Specify a subuser of the account (optional)
       # * <tt>:test => +true+ or +false+</tt> -- Force test transactions
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/vindicia.rb
+++ b/lib/active_merchant/billing/gateways/vindicia.rb
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:cvn_success</tt> -- Array of valid CVN Check return values - defaults to [M, P] (OPTIONAL)
       # * <tt>:avs_success</tt> -- Array of valid AVS Check return values - defaults to [X, Y, A, W, Z] (OPTIONAL)
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
 
         config = lambda do |config|

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'WePay'
 
       def initialize(options = {})
-        requires!(options, :client_id, :account_id, :access_token)
+        requires!(options, *self.class.required_login_params)
         super(options)
       end
 
@@ -94,6 +94,10 @@ module ActiveMerchant #:nodoc:
           end
         end
         commit('/credit_card/create', post)
+      end
+
+      def self.required_login_params
+        @@required_params ||= [:client_id, :account_id, :access_token]
       end
 
       private

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
       #           :password      - The password
       #           :signature     - The BusinessCaseSignature
       def initialize(options = {})
-        requires!(options, :login, :password, :signature)
+        requires!(options, *self.class.required_login_params)
         super
       end
 
@@ -69,6 +69,9 @@ module ActiveMerchant #:nodoc:
         commit(:bookback, money, options)
       end
 
+      def self.required_login_params
+        @@required_params ||= super + [:signature]
+      end
 
       private
       def clean_description(description)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, *self.class.required_login_params)
         super
       end
 


### PR DESCRIPTION
...a gateway

Gateway class is inherited by all gateways. A static class method is introduced to the Gateway class: required_login_params that returns an array of default required params (most commonly found amongst all gateways). For custom required params each gateway can override the self.required_login_params method. This method should always return an array. Also in case a user is accessing each gateway in some crazy batch and ends up creating a new instance every time (very inefficient but people do stuff like this), the required_login_params array is static to help prevent inefficient calls to the method. 
