### PR TITLE
Litle: Fix case of missing address parts

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -191,14 +191,14 @@ module ActiveMerchant #:nodoc:
       def add_address(doc, address)
         return unless address
 
-        doc.companyName(address[:company])
-        doc.addressLine1(address[:address1])
-        doc.addressLine2(address[:address2])
-        doc.city(address[:city])
-        doc.state(address[:state])
-        doc.zip(address[:zip])
-        doc.country(address[:country])
-        doc.phone(address[:phone])
+        doc.companyName(address[:company]) unless address[:company].blank?
+        doc.addressLine1(address[:address1]) unless address[:address1].blank?
+        doc.addressLine2(address[:address2]) unless address[:address2].blank?
+        doc.city(address[:city]) unless address[:city].blank?
+        doc.state(address[:state]) unless address[:state].blank?
+        doc.zip(address[:zip]) unless address[:zip].blank?
+        doc.country(address[:country]) unless address[:country].blank?
+        doc.phone(address[:phone]) unless address[:phone].blank?
       end
 
       def exp_date(payment_method)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -75,6 +75,17 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_some_empty_address_parts
+    assert response = @gateway.purchase(10010, @credit_card1, {
+      order_id: '1',
+      email: 'wow@example.com',
+      billing_address: {
+      }
+    })
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(60060, @credit_card2, {
         :order_id=>'6',


### PR DESCRIPTION
Litle doesn't like it if you specify an empty country for example.
