### PR TITLE
Specify rails 4 so it does not include rails 4.1 in Gemfile_rails40.

### DIFF
--- a/Gemfile_rails40
+++ b/Gemfile_rails40
@@ -4,6 +4,6 @@ gemspec
 gem 'builder', '~> 3.0'
 gem 'activesupport', '~> 4.0'
 gem 'activeresource', '~> 4.0'
-gem 'rails', '~> 4.0'
+gem 'rails', '~> 4.0.0'
 
 eval File.read(File.expand_path("../Gemfile_common", __FILE__))


### PR DESCRIPTION
Rails 4.1 was getting loaded by bundler during the tests. Rails 4.1 includes minitest 5 which is incompatible with our tests and was breaking them since its release.
