### PR TITLE
Add BridgePay gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -1,0 +1,179 @@
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BridgePayGateway < Gateway
+      self.display_name = 'BridgePay'
+      self.homepage_url = 'http://www.bridgepaynetwork.com/'
+
+      self.test_url = 'https://gatewaystage.itstgate.com/SmartPayments/transact.asmx/ProcessCreditCard'
+      self.live_url = 'https://gateway.itstgate.com/SmartPayments/transact.asmx/ProcessCreditCard'
+
+      self.supported_countries = ['US','CA']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
+
+
+      def initialize(options={})
+        requires!(options, :user_name, :password)
+        super
+      end
+
+      def purchase(amount, creditcard, options={})
+        post = post_required_fields
+        post[:TransType] = 'Sale'
+        add_invoice(post, amount, options)
+        add_creditcard(post, creditcard)
+        add_customer_data(post, options)
+
+        commit('purchase', post)
+      end
+
+      def authorize(amount, creditcard, options={})
+        post = post_required_fields
+        post[:TransType] = 'Auth'
+        add_invoice(post, amount, options)
+        add_creditcard(post, creditcard)
+        add_customer_data(post, options)
+
+        resp = commit('authorize', post)
+      end
+
+      def capture(amount, authorization, options={})
+        post = post_required_fields
+        post[:TransType] = 'Force'
+        add_invoice(post, amount, options)
+        add_reference(post, authorization)
+        add_customer_data(post, options)
+
+        commit('capture', post)
+      end
+
+      def refund(amount, authorization, options={})
+        post = post_required_fields
+        post[:TransType] = 'Reversal'
+        add_reference(post, authorization)
+
+        commit('refund', post)
+      end
+
+      def void(authorization, options={})
+        post = post_required_fields
+        post[:TransType] = 'Void'
+        add_reference(post, authorization)
+
+        commit('void', post)
+      end
+
+      private
+
+      def post_required_fields
+        post = {}
+        post[:Amount] = ''
+        post[:PNRef] = ''
+        post[:InvNum] = ''
+        post[:CardNum] = ''
+        post[:ExpDate] = ''
+        post[:MagData] = ''
+        post[:NameOnCard] = ''
+        post[:Zip] = ''
+        post[:Street] = ''
+        post[:CVNum] = ''
+        post[:MagData] = ''
+        # Allow the same amount in multiple transactions.
+        post[:ExtData] = '<Force>T</Force>'
+        post
+      end
+
+      def add_customer_data(post, options)
+        if(billing_address = (options[:billing_address] || options[:address]))
+          post[:Street]        = billing_address[:address1]
+          post[:Zip]           = billing_address[:zip]
+        end
+      end
+
+      def add_invoice(post, amount, options)
+        post[:Amount] = amount(amount)
+        post[:InvNum] = options[:order_id]
+      end
+
+      def add_creditcard(post, creditcard)
+        post[:NameOnCard]             = creditcard.name if creditcard.name
+        post[:ExpDate]                = expdate(creditcard)
+        post[:CardNum]                = creditcard.number
+        post[:CVNum]                  = creditcard.verification_value
+      end
+
+      def expdate(creditcard)
+        "#{format(creditcard.month, :two_digits)}#{format(creditcard.year, :two_digits)}"
+      end
+
+      def parse(xml)
+        response = {}
+
+        doc = Nokogiri::XML(xml)
+        doc.root.xpath("*").each do |node|
+          if (node.elements.size == 0)
+            response[node.name.downcase.to_sym] = node.text
+          else
+            node.elements.each do |childnode|
+              name = "#{node.name.downcase}_#{childnode.name.downcase}"
+              response[name.to_sym] = childnode.text
+            end
+          end
+        end unless doc.root.nil?
+
+        response
+      end
+
+      def commit(action, parameters)
+        url = (test? ? test_url : live_url)
+        data = post_data(action, parameters)
+        raw = parse(ssl_post(url, data))
+
+        Response.new(
+          success_from(raw[:message]),
+          message_from(raw),
+          raw,
+          authorization: authorization_from(raw),
+          test: test?
+        )
+      end
+
+      def success_from(result)
+        case result
+        when "APPROVAL"
+          true
+        else
+          false
+        end
+      end
+
+      def message_from(response)
+        response[:respmsg]
+      end
+
+      def authorization_from(response)
+        [response[:authcode], response[:pnref]].join("|")
+      end
+
+      def split_authorization(authorization)
+        authcode, pnref = authorization.split("|")
+        [authcode, pnref]
+      end
+
+      def add_reference(post, authorization)
+        authcode, pnref = split_authorization(authorization)
+        post[:AuthCode] = authcode
+        post[:PNRef] = pnref
+      end
+
+      def post_data(action, parameters = {})
+        post = post_required_fields
+        post[:UserName] = @options[:user_name]
+        post[:Password] = @options[:password]
+        post.merge(parameters).collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&")
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -71,6 +71,11 @@ braintree_blue_with_processing_rules:
   public_key: Y
   private_key: Z
 
+# Working credentials, no need to replace
+bridge_pay:
+  user_name: Spre3676
+  password: H3392nc5
+
 #Username/Password given in sign up email. Not MMS credentials
 card_save:
   login: merchant_id

--- a/test/remote/gateways/remote_bridge_pay_test.rb
+++ b/test/remote/gateways/remote_bridge_pay_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+class RemoteBridgePayTest < Test::Unit::TestCase
+  def setup
+    @gateway = BridgePayGateway.new(fixtures(:bridge_pay))
+
+    @amount = 100
+    @credit_card = credit_card('4005550000000019')
+    @declined_card = credit_card('4000300011100000')
+
+    @options = {
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Invalid Account Number', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(nil, '')
+    assert_failure response
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(nil, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(nil, '')
+    assert_failure response
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+  end
+
+  def test_invalid_login
+    gateway = BridgePayGateway.new(
+      user_name: '',
+      password: ''
+    )
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+end

--- a/test/unit/gateways/bridge_pay_test.rb
+++ b/test/unit/gateways/bridge_pay_test.rb
@@ -1,0 +1,252 @@
+require 'test_helper'
+
+class BridgePayTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    Base.mode = :test
+
+    @gateway = BridgePayGateway.new(
+      user_name: 'login',
+      password: 'password'
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_success response
+
+    assert_equal 'OK9757|837495', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_failure response
+    assert_equal 'Duplicate Transaction', response.message
+  end
+
+  def test_authorize_and_capture
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal "OK2657|838662", response.authorization
+
+    capture = stub_comms do
+      @gateway.capture(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/OK2657/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
+  def test_refund
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "OK9757|837495", response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/OK9757/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_void
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "OK9757|837495", response.authorization
+
+    refund = stub_comms do
+      @gateway.void(response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/OK9757/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_passing_cvv
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/#{@credit_card.verification_value}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_billing_address
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/Street=1234\+My\+Street/, data)
+      assert_match(/Zip=K1C2N6/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  private
+
+  def successful_purchase_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>OK9757</AuthCode>
+        <PNRef>837495</PNRef>
+        <HostCode>837495</HostCode>
+        <GetAVSResult>Z</GetAVSResult>
+        <GetAVSResultTXT>5 Zip Match No Address Match</GetAVSResultTXT>
+        <GetStreetMatchTXT>No Match</GetStreetMatchTXT>
+        <GetZipMatchTXT>Match</GetZipMatchTXT>
+        <GetCVResult>P</GetCVResult>
+        <GetCVResultTXT>Service Not Available</GetCVResultTXT>
+        <GetCommercialCard>False</GetCommercialCard>
+        <ExtData>InvNum=1,CardType=VISA</ExtData>
+      </Response>
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>110</Result>
+        <RespMSG>Duplicate Transaction</RespMSG>
+        <Message>Duplicate transaction</Message>
+        <PNRef>837614</PNRef>
+        <HostCode>837613</HostCode>
+        <GetGetOrigResult>OK2538</GetGetOrigResult>
+        <GetCommercialCard>False</GetCommercialCard>
+        <ExtData>InvNum=1,CardType=VISA</ExtData>
+      </Response>
+    )
+  end
+
+  def successful_authorize_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>OK2657</AuthCode>
+        <PNRef>838662</PNRef>
+        <HostCode>838662</HostCode>
+        <GetAVSResult>Z</GetAVSResult>
+        <GetAVSResultTXT>5 Zip Match No Address Match</GetAVSResultTXT>
+        <GetStreetMatchTXT>No Match</GetStreetMatchTXT>
+        <GetZipMatchTXT>Match</GetZipMatchTXT>
+        <GetCVResult>P</GetCVResult>
+        <GetCVResultTXT>Service Not Available</GetCVResultTXT>
+        <GetCommercialCard>False</GetCommercialCard>
+        <ExtData>InvNum=ebd7cd3348d4789e2cabf31e5914ef24,CardType=VISA</ExtData>
+      </Response>
+    )
+  end
+
+  def failed_authorize_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>OK9877</AuthCode>
+        <PNRef>837499</PNRef>
+        <HostCode>837499</HostCode>
+        <GetAVSResult>Z</GetAVSResult>
+        <GetAVSResultTXT>5 Zip Match No Address Match</GetAVSResultTXT>
+        <GetStreetMatchTXT>No Match</GetStreetMatchTXT>
+        <GetZipMatchTXT>Match</GetZipMatchTXT>
+        <GetCVResult>P</GetCVResult>
+        <GetCVResultTXT>Service Not Available</GetCVResultTXT>
+        <GetCommercialCard>False</GetCommercialCard>
+        <ExtData>InvNum=1,CardType=VISA</ExtData>
+      </Response>
+    )
+  end
+
+  def successful_capture_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>OK2667</AuthCode>
+        <PNRef>838665</PNRef>
+        <GetCommercialCard>False</GetCommercialCard>
+      </Response>
+    )
+  end
+
+  def failed_capture_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>1000</Result>
+        <RespMSG>Error - Unknown Card Type : </RespMSG>
+      </Response>
+    )
+  end
+
+  def successful_refund_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>868686</AuthCode>
+        <PNRef>838669</PNRef>
+        <HostCode>838669</HostCode>
+        <GetCommercialCard>False</GetCommercialCard>
+      </Response>
+    )
+  end
+
+  def failed_refund_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>19</Result>
+        <RespMSG>Original Transaction ID Not Found</RespMSG>
+        <Message>Original PNRef is required.</Message>
+      </Response>
+    )
+  end
+
+  def successful_void_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>0</Result>
+        <RespMSG>Approved</RespMSG>
+        <Message>APPROVAL</Message>
+        <AuthCode>OK2707</AuthCode>
+        <PNRef>838671</PNRef>
+        <GetCommercialCard>False</GetCommercialCard>
+      </Response>
+    )
+  end
+
+  def failed_void_response
+    %(
+      <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://TPISoft.com/SmartPayments/">
+        <Result>19</Result>
+        <RespMSG>Original Transaction ID Not Found</RespMSG>
+        <Message>Original PNRef is required.</Message>
+      </Response>
+    )
+  end
+end


### PR DESCRIPTION
BridgePay says that to be able to update a transation the 'Capture'
TransType should not be used since that locks the record. There may need
to be a nightly process enable on the backend to process the batch of
transactions for the day.
