### PR TITLE
Fix an issue with thousand separators in SagePay

### DIFF
--- a/lib/active_merchant/billing/integrations/sage_pay_form/notification.rb
+++ b/lib/active_merchant/billing/integrations/sage_pay_form/notification.rb
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
 
           # Total amount (no fees).
           def gross
-            params['Amount']
+            params['Amount'].gsub(/,(?=\d{3}\b)/, '')
           end
           
           # AVS and CV2 check results.  Possible values:

--- a/test/unit/integrations/notifications/sage_pay_form_notification_test.rb
+++ b/test/unit/integrations/notifications/sage_pay_form_notification_test.rb
@@ -18,7 +18,7 @@ class SagePayFormNotificationTest < Test::Unit::TestCase
     assert_equal '28', n.item_id
     assert_equal '{2D370B0B-692D-4D07-B616-91B86CCDF85A}', n.transaction_id
     assert_equal '7349', n.auth_id
-    assert_equal '31.47', n.gross
+    assert_equal '1231.47', n.gross
     assert_equal 'ALL MATCH', n.avs_cv2_result
     assert_equal 'MATCHED', n.address_result
     assert_equal 'MATCHED', n.post_code_result
@@ -96,7 +96,7 @@ class SagePayFormNotificationTest < Test::Unit::TestCase
 
   def test_compositions
     n = SagePayForm::Notification.new(successful_purchase, @options)
-    assert_equal Money.new(3147, nil), n.amount
+    assert_equal Money.new(123147, nil), n.amount
   end
 
   def test_bogus_crypt
@@ -120,7 +120,7 @@ class SagePayFormNotificationTest < Test::Unit::TestCase
   private
 
   def successful_purchase
-    'utm_nooverride=1&crypt=FhoCBgwDSSYkSBgRGEVHQAELFxMQHEk6Gg0oAApCVEYpAhpSOAUAAQAcIhYcVRJnNw8NARgTAAAAAG0zHF9WXDc6GzEWFBFUXVZtMyliZksMCl4JSzRHXl8seydUBwsBAUNXNklHWStZX31IQABwC3MtIDY/SEEoEkgfHThERlsLAV5FSkRNTy4DJBAXRQ8AdEBXRV8xIjosOHlYOH1+EwgvNzExVjUNCxwuFgpjV0AwAhdPNDEgKicrD0MpXkFHBgEHFysVBxwDGnYoOGVxewAqRTEvQiYMHBsnEUR8c2cGJiY2XzcdDxsvIgFEARQAAT0GEQwCETobDz8QCgx9eGMtIiQvTTknKFYRJDN1eGEQJTRLSTczMDUgHy1fclNBIToaAhxNIiA8L20pGEJGBwEHBBsNA0lRXFt9'
+    'utm_nooverride=1&crypt=FhoCBgwDSSYkSBgRGEVHQAELFxMQHEk6Gg0oAApCVEYpAhpSOAUAAQAcIhYcVRJnNw8NARgTAAAAAG0zHF9WXDc6GzEWFBFUXVZtMyliZksMCl4JSzRHXl8seydUBwsBAUNXNklHWStZX31IQABwC3MtIDY/SEEoEkgfHThERlsLAV5FSkRNTy4DJBAXRQ8CaVxQQ1dEQ08uOBgmLwMPcgkiQz84JDchSS8vAQtUQUAXCxAHFQRJJC46CC08dRRjKh0XMRYUETsKHT4JDQx/chEtKzc9Vjc/XTwuFgxdRg4ILzcxMTUwTygHLRE4WFYOdUhQNioVFxwdCxgRGEVHQHghKFQ6MSI/UiMFIkFrc3kBJDEnMidNWSgpEj83ZXoVBg8RFi0JBAxSOAI2OBd+UjYaVzYQFx0dHFNzVkwH'
   end
 
   def failed_purchase


### PR DESCRIPTION
## Problem

SagePay returns the amount with thousand comma separators. This is not aligned with expectations from AM. AM expects `gross` to be "the money amount we received in X.2 decimal."
## Solution

Remove commas that are followed by 3 digits in the amount.

@bslobodin @bizla 
