### PR TITLE
BridgePay: Switch method of success detection.

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         raw = parse(ssl_post(url, data))
 
         Response.new(
-          success_from(raw[:message]),
+          success_from(raw[:respmsg]),
           message_from(raw),
           raw,
           authorization: authorization_from(raw),
@@ -143,7 +143,7 @@ module ActiveMerchant #:nodoc:
 
       def success_from(result)
         case result
-        when "APPROVAL"
+        when "Approved"
           true
         else
           false


### PR DESCRIPTION
In test the 'Message' field returned APPROVAL for success but in production it was
'AUTH/TKT  02992G'. It appears that checking the RespMSG field will be a
better choice.
