### PR TITLE
Worldpay: Update billing address mapping

### DIFF
--- a/lib/active_merchant/billing/integrations/world_pay/helper.rb
+++ b/lib/active_merchant/billing/integrations/world_pay/helper.rb
@@ -11,7 +11,11 @@ module ActiveMerchant #:nodoc:
           mapping :customer, :email => 'email',
                              :phone => 'tel'
 
-          mapping :billing_address, :zip => 'postcode',
+          mapping :billing_address, :city     => 'town',
+                                    :address1 => 'address1',
+                                    :address2 => 'address2',
+                                    :state    => 'region',
+                                    :zip      => 'postcode',
                                     :country  => 'country'
 
           mapping :description, 'desc'
@@ -38,16 +42,6 @@ module ActiveMerchant #:nodoc:
             elsif ActiveMerchant::Billing::Base.integration_mode == :always_fail
               add_field('testMode', '101')
             end
-          end
-          
-          # WorldPay only supports a single address field so we 
-          # have to concat together - lines are separated using &#10;
-          def billing_address(params={})
-            add_field(mappings[:billing_address][:zip], params[:zip])
-            add_field(mappings[:billing_address][:country], lookup_country_code(params[:country]))
-            
-            address = [params[:address1], params[:address2], params[:city], params[:state]].compact
-            add_field('address', address.join('&#10;'))
           end
           
           # WorldPay only supports a single name field so we have to concat

--- a/test/unit/integrations/helpers/world_pay_helper_test.rb
+++ b/test/unit/integrations/helpers/world_pay_helper_test.rb
@@ -33,20 +33,12 @@ class WorldPayHelperTest < Test::Unit::TestCase
                             :zip => 'CV1 1AA',
                             :country  => 'GB'
    
-    assert_field 'address', '1 Nowhere Close&#10;Electric Wharf&#10;Coventry&#10;Warwickshire'
+    assert_field 'address1', '1 Nowhere Close'
+    assert_field 'address2', 'Electric Wharf'
+    assert_field 'town', 'Coventry'
+    assert_field 'region', 'Warwickshire'
     assert_field 'postcode', 'CV1 1AA'
     assert_field 'country', 'GB'
-  end
-
-  def test_address_mapping_without_address1_and_state
-    @helper.billing_address :address1 => 'Teststr. 1',
-                            :city => 'Berlin',
-                            :zip => '10000',
-                            :country  => 'DE'
-   
-    assert_field 'address', 'Teststr. 1&#10;Berlin'
-    assert_field 'postcode', '10000'
-    assert_field 'country', 'DE'
   end
   
   def test_unknown_mapping


### PR DESCRIPTION
Worldpay now supports all standard billing address fields. I have updated the mapping and removed custom method.

See: http://www.worldpay.com/support/kb/bg/customisingadvanced/custa9103.html
