### PR TITLE
iATS Payments gateway support

### DIFF
--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -1,34 +1,219 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
-    class IatsPaymentsGateway < AuthorizeNetGateway
-      self.live_url = self.test_url = 'https://www.iatspayments.com/netgate/AEGateway.aspx'
+    class IatsPaymentsGateway < Gateway
 
-      self.homepage_url = 'http://www.iatspayments.com/'
-      self.display_name = 'IATSPayments'
+      class_attribute :live_na_url, :live_uk_url
 
-      def authorize(money, paysource, options = {})
-        raise NotImplementedError
+      self.live_na_url = 'https://www.iatspayments.com/NetGate/ProcessLink.asmx'
+      self.live_uk_url = 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx'
+
+      self.supported_countries = %w(US UK AU CA FI DK FR DE IT HK GR IE TR CH SE ES SG PT NO NL JP NZ)
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://home.iatspayments.com/'
+      self.display_name = 'iATS Payments'
+
+      def initialize(options={})
+
+        if(options[:login])
+          deprecated("The 'login' option is deprecated in favor of 'agent_code' and will be removed in a future version.")
+          options[:agent_code] = options[:login]
+        end
+
+        options[:region] = 'na' unless options[:region]
+
+        requires!(options, :agent_code, :password, :region)
+        super
       end
 
-      def capture(money, authorization, options = {})
-        raise NotImplementedError
+      def purchase(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, options)
+        add_customer_data(post, options)
+
+        commit('ProcessCreditCardV1', post)
       end
 
-      def void(authorization, options = {})
-        raise NotImplementedError
+      def authorize(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, options)
+        add_customer_data(post, options)
+
+        commit('authonly', post)
       end
 
-      def refund(money, identification, options = {})
-        raise NotImplementedError
+      def capture(money, authorization, options={})
+        commit('capture', post)
       end
 
-      def credit(money, identification, options = {})
-        raise NotImplementedError
+      def refund(money, authorization, options={})
+        post = {}
+        post[:transaction_id] = authorization
+        add_customer_data(post, options)
+        add_invoice(post, -money, options)
+
+        commit('ProcessCreditCardRefundWithTransactionIdV1', post)
+      end
+
+      def void(authorization, options={})
+        commit('void', post)
       end
 
       private
-      def split(response)
-        response.split(',')
+
+      def add_customer_data(post, options)
+        post[:customer_ip_address] = options[:ip] if options.has_key?(:ip)
+      end
+
+      def add_address(post, options)
+        billing_address = options[:billing_address] || options[:address]
+        if(billing_address)
+          post[:address] = billing_address[:address1]
+          post[:city] = billing_address[:city]
+          post[:state] = billing_address[:state]
+          post[:zip_code] = billing_address[:zip]
+        end
+      end
+
+      def add_invoice(post, money, options)
+        post[:invoice_num] = options[:order_id] if options[:order_id]
+        post[:total] = amount(money)
+        post[:comment] = options[:description] if options[:description]
+      end
+
+      def add_payment(post, payment)
+        post[:first_name] = payment.first_name
+        post[:last_name] = payment.last_name
+        post[:credit_card_num] = payment.number
+        post[:credit_card_expiry] = expdate(payment)
+        post[:cvv2] = payment.verification_value if payment.verification_value?
+        post[:mop] = creditcard_brand(payment.brand)
+      end
+
+      def expdate(creditcard)
+        year  = sprintf("%.4i", creditcard.year)
+        month = sprintf("%.2i", creditcard.month)
+
+        "#{month}/#{year[-2..-1]}"
+      end
+
+      def creditcard_brand(brand)
+        case brand
+        when "visa" then "VISA"
+        when "master" then "MC"
+        when "discover" then "DSC"
+        when "american_express" then "AMX"
+        when "maestro" then "MAESTR"
+        else
+          raise "Unhandled credit card brand #{brand}"
+        end
+      end
+
+      def commit(action, parameters)
+        response = parse(ssl_post(url(action), post_data(action, parameters),
+         { 'Content-Type' => 'application/soap+xml; charset=utf-8'}))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?
+        )
+      end
+
+      def url(action)
+        base_url = @options[:region] == 'uk' ? live_uk_url : live_na_url
+        "#{base_url}?op=#{action}"
+      end
+
+      def parse(body)
+        response = {}
+        hashify_xml!(body, response)
+        response
+      end
+
+      def dexmlize_param_name(name)
+        names = {
+          'AUTHORIZATIONRESULT' => :authorization_result,
+          'SETTLEMENTBATCHDATE' => :settlement_batch_date,
+          'SETTLEMENTDATE' => :settlement_date,
+          'TRANSACTIONID' => :transaction_id
+        }
+        names[name] || name.to_s.downcase.intern
+      end
+
+      def hashify_xml!(xml, response)
+        xml = REXML::Document.new(xml)
+
+        # Purchase, refund
+        xml.elements.each("//IATSRESPONSE/*") do |node|
+          recursively_parse_element(node, response)
+        end
+      end
+
+      # Flatten nested XML structures
+      def recursively_parse_element(node, response)
+        if(node.has_elements?)
+          node.elements.each { |n| recursively_parse_element(n, response) }
+        else
+          response[dexmlize_param_name(node.name)] = (node.text ? node.text.strip : nil)
+        end
+      end
+
+      def successful_result_message?(response)
+        response[:authorization_result].start_with?('OK')
+      end
+
+      def success_from(response)
+        response[:status] == "Success" && successful_result_message?(response)
+      end
+
+      def message_from(response)
+        if(!successful_result_message?(response))
+          return response[:authorization_result].strip
+        elsif(response[:status] == 'Failure')
+          return response[:errors]
+        else
+          response[:status]
+        end
+      end
+
+      def authorization_from(response)
+        response[:transaction_id]
+      end
+
+      ENVELOPE_NAMESPACES = {
+        "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
+        "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema",
+        "xmlns:soap12" => "http://www.w3.org/2003/05/soap-envelope"
+      }
+
+      def post_data(action, parameters = {})
+        xml = Builder::XmlMarkup.new
+        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        xml.tag! 'soap12:Envelope', ENVELOPE_NAMESPACES do
+          xml.tag! 'soap12:Body' do
+            xml.tag! action, { "xmlns" => "https://www.iatspayments.com/NetGate/" } do
+              xml.tag!('agentCode', @options[:agent_code])
+              xml.tag!('password', @options[:password])
+              parameters.each do |name, value|
+                xml.tag!(xmlize_param_name(name), value)
+              end
+            end
+          end
+        end
+        xml.target!
+      end
+
+      def xmlize_param_name(name)
+        names = { customer_ip_address: 'customerIPAddress' }
+        names[name] || name.to_s.camelcase(:lower)
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -715,8 +715,9 @@ world_pay_gateway:
   password: PASSWORD
 
 iats_payments:
-  login: TEST88
+  agent_code: TEST88
   password: TEST88
+  region: na
 
 bit_pay:
   api_key: 'rKrahSl7WRrYeKRUhGzbvW3nBzo0jG4FPaL8uPYaoPk'

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -5,24 +5,222 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
   def setup
     @gateway = IatsPaymentsGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      :agent_code => 'login',
+      :password => 'password',
+      :region => 'uk'
     )
     @amount = 100
     @credit_card = credit_card
+    @options = {
+      :ip => '71.65.249.145',
+      :order_id => generate_unique_id,
+      :billing_address => address,
+      :description => 'Store purchase'
+    }
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<agentCode>login<\/agentCode>/, data)
+      assert_match(/<password>password<\/password>/, data)
+      assert_match(/<customerIPAddress>#{@options[:ip]}<\/customerIPAddress>/, data)
+      assert_match(/<invoiceNum>#{@options[:order_id]}<\/invoiceNum>/, data)
+      assert_match(/<creditCardNum>#{@credit_card.number}<\/creditCardNum>/, data)
+      assert_match(/<creditCardExpiry>0#{@credit_card.month}\/#{@credit_card.year.to_s[-2..-1]}<\/creditCardExpiry>/, data)
+      assert_match(/<cvv2>#{@credit_card.verification_value}<\/cvv2>/, data)
+      assert_match(/<mop>VISA<\/mop>/, data)
+      assert_match(/<firstName>#{@credit_card.first_name}<\/firstName>/, data)
+      assert_match(/<lastName>#{@credit_card.last_name}<\/lastName>/, data)
+      assert_match(/<address>#{@options[:billing_address][:address1]}<\/address>/, data)
+      assert_match(/<city>#{@options[:billing_address][:city]}<\/city>/, data)
+      assert_match(/<state>#{@options[:billing_address][:state]}<\/state>/, data)
+      assert_match(/<zipCode>#{@options[:billing_address][:zip]}<\/zipCode>/, data)
+      assert_match(/<total>1.00<\/total>/, data)
+      assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
+      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+      assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'
+    end.respond_with(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card)
+    assert response
     assert_instance_of Response, response
     assert_success response
-    assert_equal '508141795', response.authorization
+    assert_equal 'A6DE6F24', response.authorization
+    assert_equal 'Success', response.message
+  end
+
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(failed_purchase_response)
+
+    assert response
+    assert_failure response
+    assert_equal 'A6DE6F24', response.authorization
+    assert response.message.include?('REJECT')
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.refund(@amount, '1234', @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<transactionId>1234<\/transactionId>/, data)
+      assert_match(/<total>-1.00<\/total>/, data)
+    end.respond_with(successful_refund_response)
+
+    assert response
+    assert_success response
+    assert_equal 'A6DEA654', response.authorization
+  end
+
+  def test_failed_refund
+    response = stub_comms do
+      @gateway.refund(@amount, '1234', @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<transactionId>1234<\/transactionId>/, data)
+      assert_match(/<total>-1.00<\/total>/, data)
+    end.respond_with(failed_refund_response)
+
+    assert response
+    assert_failure response
+    assert_equal 'A6DEA654', response.authorization
+  end
+
+  def test_deprecated_options
+
+    IatsPaymentsGateway.any_instance.expects(:deprecated).with("The 'login' option is deprecated in favor of 'agent_code' and will be removed in a future version.")
+    @gateway = IatsPaymentsGateway.new(
+      :login => 'login',
+      :password => 'password'
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<agentCode>login<\/agentCode>/, data)
+      assert_match(/<password>password<\/password>/, data)
+      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_region_urls
+    @gateway = IatsPaymentsGateway.new(
+      :agent_code => 'code',
+      :password => 'password',
+      :region => 'na' #North america
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 
   private
+
   def successful_purchase_response
-    '1,1,1,This transaction has been approved.,d1GENk,Y,508141795,32968c18334f16525227,Store purchase,1.00,CC,auth_capture,,Longbob,Longsen,,,,,,,,,,,,,,,,,,,,,,,269862C030129C1173727CC10B1935ED,P,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,'
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+  <soap12:Body>
+    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardV1Result>
+        <IATSRESPONSE>
+          <STATUS>Success</STATUS>
+          <ERRORS />
+          <PROCESSRESULT>
+            <AUTHORIZATIONRESULT> OK</AUTHORIZATIONRESULT>
+            <CUSTOMERCODE />
+            <SETTLEMENTBATCHDATE> 04/22/2014</SETTLEMENTBATCHDATE>
+            <SETTLEMENTDATE> 04/23/2014</SETTLEMENTDATE>
+            <TRANSACTIONID>A6DE6F24</TRANSACTIONID>
+          </PROCESSRESULT>
+        </IATSRESPONSE>
+      </ProcessCreditCardV1Result>
+    </ProcessCreditCardV1Response>
+  </soap12:Body>
+</soap12:Envelope>
+    XML
+  end
+
+  def failed_purchase_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardV1Result>
+        <IATSRESPONSE xmlns="">
+          <STATUS>Success</STATUS>
+          <ERRORS />
+          <PROCESSRESULT>
+            <AUTHORIZATIONRESULT> REJECT: 15</AUTHORIZATIONRESULT>
+            <CUSTOMERCODE />
+            <SETTLEMENTBATCHDATE> 04/22/2014</SETTLEMENTBATCHDATE>
+            <SETTLEMENTDATE> 04/23/2014</SETTLEMENTDATE>
+            <TRANSACTIONID>A6DE6F24</TRANSACTIONID>
+          </PROCESSRESULT>
+        </IATSRESPONSE>
+      </ProcessCreditCardV1Result>
+    </ProcessCreditCardV1Response>
+  </soap:Body>
+</soap:Envelope>
+    XML
+  end
+
+  def successful_refund_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardV1Result>
+        <IATSRESPONSE xmlns="">
+          <STATUS>Success</STATUS>
+          <ERRORS />
+          <PROCESSRESULT>
+            <AUTHORIZATIONRESULT> OK: 678594: </AUTHORIZATIONRESULT>
+            <CUSTOMERCODE />
+            <SETTLEMENTBATCHDATE> 04/22/2014 </SETTLEMENTBATCHDATE>
+            <SETTLEMENTDATE> 04/23/2014 </SETTLEMENTDATE>
+            <TRANSACTIONID>A6DEA654</TRANSACTIONID>
+          </PROCESSRESULT>
+        </IATSRESPONSE>
+      </ProcessCreditCardV1Result>
+    </ProcessCreditCardV1Response>
+  </soap:Body>
+</soap:Envelope>
+    XML
+  end
+
+  def failed_refund_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardV1Result>
+        <IATSRESPONSE xmlns="">
+          <STATUS>Success</STATUS>
+          <ERRORS />
+          <PROCESSRESULT>
+            <AUTHORIZATIONRESULT> REJECT: 15 </AUTHORIZATIONRESULT>
+            <CUSTOMERCODE />
+            <SETTLEMENTBATCHDATE> 04/22/2014 </SETTLEMENTBATCHDATE>
+            <SETTLEMENTDATE> 04/23/2014 </SETTLEMENTDATE>
+            <TRANSACTIONID>A6DEA654</TRANSACTIONID>
+          </PROCESSRESULT>
+        </IATSRESPONSE>
+      </ProcessCreditCardV1Result>
+    </ProcessCreditCardV1Response>
+  </soap:Body>
+</soap:Envelope>
+    XML
   end
 end


### PR DESCRIPTION
This commit adds support for the `purchase` and `refund` operations on the iATS Payments gateway. This replaces the existing iATS implementation (http://cl.ly/V8DE) and supersedes another, existing, pull request (http://cl.ly/V88q).

There is a backwards-incompatible change which I'd like advice on how to handle: The original implementation used credentials named `login` and `password` whereas this implementation sticks with gateway-specific naming of `agent_code` and `password`, and requires an additional `region` option. I don't believe the current implementation is being used, but do want to know how such changes should be handled.
