### PR TITLE
BridgePay: Use Return as TransType for refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -22,6 +22,8 @@ module ActiveMerchant #:nodoc:
       def purchase(amount, creditcard, options={})
         post = post_required_fields("Sale")
 
+        # Allow the same amount in multiple transactions.
+        post[:ExtData] = "<Force>T</Force>"
         add_invoice(post, amount, options)
         add_creditcard(post, creditcard)
         add_customer_data(post, options)
@@ -50,8 +52,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(amount, authorization, options={})
-        post = post_required_fields("Reversal")
+        post = post_required_fields("Return")
 
+        add_invoice(post, amount, options)
         add_reference(post, authorization)
 
         commit(post)
@@ -81,8 +84,7 @@ module ActiveMerchant #:nodoc:
         post[:Street] = ""
         post[:CVNum] = ""
         post[:MagData] = ""
-        # Allow the same amount in multiple transactions.
-        post[:ExtData] = "<Force>T</Force>"
+        post[:ExtData] = ""
         post
       end
 


### PR DESCRIPTION
Advice from BridgePay is to use Return rather than Reversal for refunds.
Also not sending Force=true when not a Sale to avoid possible side
effects.
