### PR TITLE
Handle empty responses from Paymill

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -66,7 +66,11 @@ module ActiveMerchant #:nodoc:
         begin
           raw_response = ssl_request(method, "https://api.paymill.com/v2/#{url}", post_data(parameters), headers)
         rescue ResponseError => e
-          parsed = JSON.parse(e.response.body)
+          begin
+            parsed = JSON.parse(e.response.body)
+          rescue JSON::ParserError
+            return Response.new(false, 'Unknown Error')
+          end
           return Response.new(false, response_message(parsed), parsed, {})
         end
 

--- a/test/unit/gateways/paymill_test.rb
+++ b/test/unit/gateways/paymill_test.rb
@@ -46,6 +46,13 @@ class PaymillTest < Test::Unit::TestCase
     assert_equal 'Access Denied', response.message
   end
 
+  def test_empty_server_response
+    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, MockResponse.failed(''))
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_failure response
+    assert_equal 'Unknown Error', response.message
+  end
+
   def test_invalid_login_on_storing_card
     @gateway.stubs(:raw_ssl_request).returns(failed_store_invalid_credentials_response, successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
We've seen cases where HTTP responses from Paymill had an empty body, not a JSON payload that they normally promise.

@girasquid /cc @Shopify/payments.
