### PR TITLE
Improve empty error handling for Paymill

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
           begin
             parsed = JSON.parse(e.response.body)
           rescue JSON::ParserError
-            return Response.new(false, 'Unknown Error')
+            return Response.new(false, "Unable to parse error response: '#{e.response.body}'")
           end
           return Response.new(false, response_message(parsed), parsed, {})
         end

--- a/test/unit/gateways/paymill_test.rb
+++ b/test/unit/gateways/paymill_test.rb
@@ -50,7 +50,14 @@ class PaymillTest < Test::Unit::TestCase
     @gateway.stubs(:raw_ssl_request).returns(successful_store_response, MockResponse.failed(''))
     response = @gateway.purchase(@amount, @credit_card)
     assert_failure response
-    assert_equal 'Unknown Error', response.message
+    assert_equal "Unable to parse error response: ''", response.message
+  end
+
+  def test_invalid_server_response
+    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, MockResponse.failed('not-json'))
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_failure response
+    assert_equal "Unable to parse error response: 'not-json'", response.message
   end
 
   def test_invalid_login_on_storing_card


### PR DESCRIPTION
@ntalbott and @girasquid as suggested in https://github.com/Shopify/active_merchant/pull/1136.
