### PR TITLE
Updated Paypal Digital Goods gateway to allow for mobile

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -11,9 +11,10 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AU CA CN FI GB ID IN IT MY NO NZ PH PL SE SG TH VN)
       self.homepage_url = 'https://www.x.com/community/ppx/xspaces/digital_goods'
       self.display_name = 'PayPal Express Checkout for Digital Goods'
-      
+
       def redirect_url_for(token, options = {})
-        "#{redirect_url}?token=#{token}&useraction=commit"
+        options[:review] ||= false
+        super
       end
 
       # GATEWAY.setup_purchase(100,

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -1,31 +1,35 @@
 require 'test_helper'
 
 class PaypalDigitalGoodsTest < Test::Unit::TestCase
-  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/incontext?token=1234567890&useraction=commit'
-  LIVE_REDIRECT_URL        = 'https://www.paypal.com/incontext?token=1234567890&useraction=commit'
-  
+  TEST_REDIRECT_URL         = 'https://www.sandbox.paypal.com/incontext?cmd=_express-checkout&token=1234567890&useraction=commit'
+  MOBILE_TEST_REDIRECT_URL  = 'https://www.sandbox.paypal.com/incontext?cmd=_express-checkout-mobile&token=1234567890&useraction=commit'
+  LIVE_REDIRECT_URL         = 'https://www.paypal.com/incontext?cmd=_express-checkout&token=1234567890&useraction=commit'
+  MOBILE_LIVE_REDIRECT_URL  = 'https://www.paypal.com/incontext?cmd=_express-checkout-mobile&token=1234567890&useraction=commit'
+
   def setup
     @gateway = PaypalDigitalGoodsGateway.new(
-      :login => 'cody', 
+      :login => 'cody',
       :password => 'test',
       :pem => 'PEM'
     )
 
     Base.gateway_mode = :test
-  end 
-  
+  end
+
   def teardown
     Base.gateway_mode = :test
-  end 
+  end
 
   def test_live_redirect_url
     Base.gateway_mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+    assert_equal MOBILE_LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_test_redirect_url
     assert_equal :test, Base.gateway_mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+    assert_equal MOBILE_TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_setup_request_invalid_requests
@@ -34,7 +38,7 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
       :ip                => "127.0.0.1",
       :description       => "Test Title",
       :return_url        => "http://return.url",
-      :cancel_return_url => "http://cancel.url")                                      
+      :cancel_return_url => "http://cancel.url")
    end
 
    assert_raise ArgumentError do
@@ -73,7 +77,7 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
 
   def test_build_setup_request_valid
     @gateway.expects(:ssl_post).returns(successful_setup_response)
-    
+
     @gateway.setup_purchase(100,
       :ip                => "127.0.0.1",
       :description       => "Test Title",
@@ -117,6 +121,6 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
 		</SOAP-ENV:Body>
 	</SOAP-ENV:Envelope>"
   end
-  
+
 end
 


### PR DESCRIPTION
The current implementation cuts out any options you'd want to add. I updated it to allow for options (most important of which is mobile).

I added tests for the mobile test cases.

Let me know if there's anything else you'd want me to update before pulling this in. Thank you!
