### PR TITLE
iATS: Fix invalid country code UK -> GB

### DIFF
--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       self.live_na_url = 'https://www.iatspayments.com/NetGate/ProcessLink.asmx'
       self.live_uk_url = 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx'
 
-      self.supported_countries = %w(AU CA CH DE DK ES FI FR GR HK IE IT JP NL NO NZ PT SE SG TR UK US)
+      self.supported_countries = %w(AU CA CH DE DK ES FI FR GR HK IE IT JP NL NO NZ PT SE SG TR GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -122,6 +122,12 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_supported_countries
+    @gateway.supported_countries.each do |country_code|
+      assert ActiveMerchant::Country.find(country_code), "Supported country code #{country_code} is invalid. Please use a value explicitly listed in active_utils' ActiveMerchant::Country class."
+    end
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Fixes erroneous country code. United Kingdom is really `GB`, not `UK`. Tricky!

@ntalbott I'd like to add this supported country code test to the gateway generator to avoid this in the future:

``` ruby
def test_supported_countries
  @gateway.supported_countries.each do |country_code|
  assert ActiveMerchant::Country.find(country_code), "Supported country code #{country_code} is invalid. Please use a value explicitly listed in active_utils' ActiveMerchant::Country class."
  end
end
```

If you think this is sane let me know and I'll add a separate PR.
