### PR TITLE
Merchant Warrior: Scrub names

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
 
       def store(creditcard, options = {})
         post = {
-          'cardName' => creditcard.name,
+          'cardName' => scrub_name(creditcard.name),
           'cardNumber' => creditcard.number,
           'cardExpiryMonth' => format(creditcard.month, :two_digits),
           'cardExpiryYear'  => format(creditcard.year, :two_digits)
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
       def add_address(post, options)
         return unless(address = (options[:billing_address] || options[:address]))
 
-        post['customerName'] = address[:name]
+        post['customerName'] = scrub_name(address[:name])
         post['customerCountry'] = address[:country]
         post['customerState'] = address[:state]
         post['customerCity'] = address[:city]
@@ -103,9 +103,13 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard(post, creditcard)
         post['paymentCardNumber'] = creditcard.number
-        post['paymentCardName'] = creditcard.name
+        post['paymentCardName'] = scrub_name(creditcard.name)
         post['paymentCardExpiry'] = creditcard.expiry_date.expiration.strftime("%m%y")
         post['paymentCardCSC'] = creditcard.verification_value if creditcard.verification_value?
+      end
+
+      def scrub_name(name)
+        name.gsub(/[^a-zA-Z\. -]/, '')
       end
 
       def add_amount(post, money, options)

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -103,4 +103,14 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@success_amount, auth.authorization)
     assert_success capture
   end
+
+  def test_successful_purchase_with_funky_names
+    @credit_card.first_name = "Phillips & Sons"
+    @credit_card.last_name = "Other-Things; MW. doesn't like"
+    @options[:billing_address][:name] = "Merchant Warrior wants % alphanumerics"
+
+    assert purchase = @gateway.purchase(@success_amount, @credit_card, @options)
+    assert_equal 'Transaction approved', purchase.message
+    assert_success purchase
+  end
 end


### PR DESCRIPTION
Merchant Warrior is somewhat particular about what characters are
acceptable for the name on a card.  Their docs state:

"Only alphanumeric characters, hyphens, spaces and full stops are
allowed."

http://dox.merchantwarrior.com/files/MWE%20API.pdf

We now strip out the characters that Merchant Warrior doesn't like
because we don't want payments failing because the gateway isn't fond of
an & character.
