### PR TITLE
Validate supported_countries

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -116,6 +116,20 @@ module ActiveMerchant #:nodoc:
         result.to_s.downcase
       end
 
+      class << self
+
+        def supported_countries_with_validation=(country_codes)
+          country_codes.each do |country_code|
+            country = ActiveMerchant::Country.find(country_code)
+            raise ActiveMerchant::InvalidCountryCodeError,
+              "No country could be found for the country #{country_code}" unless country
+          end
+          self.supported_countries_without_validation = country_codes
+        end
+
+        alias_method_chain :supported_countries=, :validation
+      end
+
       def card_brand(source)
         self.class.card_brand(source)
       end

--- a/lib/active_merchant/billing/gateways/app55.rb
+++ b/lib/active_merchant/billing/gateways/app55.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://sandbox.app55.com/v1/'
       self.live_url = 'https://api.app55.com/v1/'
 
-      self.supported_countries = ['AU', 'BR', 'CA', 'CH', 'CL', 'CN', 'CO', 'CZ', 'DK', 'EU', 'GB', 'HK', 'HU', 'ID', 'IS', 'JP', 'KE', 'KR', 'MX', 'MY', 'NO', 'NZ', 'PH', 'PL', 'TH', 'TW', 'US', 'VN', 'ZA']
+      self.supported_countries = ['AU', 'BR', 'CA', 'CH', 'CL', 'CN', 'CO', 'CZ', 'DK', 'GB', 'HK', 'HU', 'ID', 'IS', 'JP', 'KE', 'KR', 'MX', 'MY', 'NO', 'NZ', 'PH', 'PL', 'TH', 'TW', 'US', 'VN', 'ZA']
       self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :maestro, :solo]
       self.default_currency = 'UKP'
       self.money_format = :dollars
@@ -182,4 +182,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = self.live_url = 'https://gateway.cardstream.com/direct/'
       self.money_format = :cents
       self.default_currency = 'GBP'
-      self.supported_countries = ['GB', 'USD', 'EUR', 'CHF', 'SEK', 'SGD', 'NOK', 'JPY', 'ICK', 'HKD', 'DKK', 'CZK', 'CAD', 'AUD']
+      self.supported_countries = ['GB', 'US', 'CH', 'SE', 'SG', 'NO', 'JP', 'IS', 'HK', 'NL', 'CZ', 'CA', 'AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro, :solo, :switch]
       self.homepage_url = 'http://www.cardstream.com/'
       self.display_name = 'CardStream'
@@ -218,4 +218,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/lib/active_merchant/billing/gateways/certo_direct.rb
+++ b/lib/active_merchant/billing/gateways/certo_direct.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.live_url = self.test_url = "https://secure.certodirect.com/gateway/process/v2"
 
       self.supported_countries = [
-        "BE", "BG", "CZ", "DK", "DE", "EE", "IE", "EL", "ES", "FR",
+        "BE", "BG", "CZ", "DK", "DE", "EE", "IE", "ES", "FR",
         "IT", "CY", "LV", "LT", "LU", "HU", "MT", "NL", "AT", "PL",
         "PT", "RO", "SI", "SK", "FI", "SE", "GB"
       ]

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'active_utils/common/country'
 
 class GatewayTest < Test::Unit::TestCase
   def setup
@@ -15,6 +16,22 @@ class GatewayTest < Test::Unit::TestCase
 
     Gateway.supported_cardtypes = []
     assert_false [:visa, :bogus].all? { |invalid_cardtype| Gateway.supports?(invalid_cardtype) }
+  end
+
+  def test_should_validate_supported_countries
+    assert_raise(ActiveMerchant::InvalidCountryCodeError) do
+      Gateway.supported_countries = %w(us uk sg)
+    end
+
+    all_country_codes = ActiveMerchant::Country::COUNTRIES.collect do |country|
+      [country[:alpha2], country[:alpha3]]
+    end.flatten
+
+    assert_nothing_raised do
+      Gateway.supported_countries = all_country_codes
+      assert Gateway.supported_countries == all_country_codes,
+        "List of supported countries not properly set"
+    end
   end
 
   def test_should_gateway_uses_ssl_strict_checking_by_default


### PR DESCRIPTION
Validate that the list of supported country codes sent to
Gateway#supported_countries contains only valid entries (according
to active_utils' ActiveMerchant::Country definition).

This necessitated the modification of some existing gateways'
supported_countries lists. In most cases a mapping to the correct
country code was made. However, in rare cases the invalid country
code was removed and no meaningful new value was substituted.

/cc @ntalbott 
