### PR TITLE
[Mollie iDEAL] Use description option in helper to set the order's description

### DIFF
--- a/lib/active_merchant/billing/integrations/helper.rb
+++ b/lib/active_merchant/billing/integrations/helper.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
         end
 
         def initialize(order, account, options = {})
-          options.assert_valid_keys([:amount, :currency, :test, :credential2, :credential3, :credential4, :country, :account_name, :transaction_type, :authcode, :notify_url, :return_url, :redirect_param, :forward_url])
+          options.assert_valid_keys([:amount, :currency, :test, :credential2, :credential3, :credential4, :country, :account_name, :description, :transaction_type, :authcode, :notify_url, :return_url, :redirect_param, :forward_url])
           @fields             = {}
           @raw_html_fields    = []
           @test               = options[:test]

--- a/lib/active_merchant/billing/integrations/mollie_ideal/helper.rb
+++ b/lib/active_merchant/billing/integrations/mollie_ideal/helper.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
             @token = account
             @redirect_paramaters = {
               :amount => options[:amount],
-              :description => options[:account_name],
+              :description => options[:description],
               :issuer => options[:redirect_param],
               :redirectUrl => options[:return_url],
               :method => 'ideal',
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
 
             raise ArgumentError, "The redirect_param option needs to be set to the bank_id the customer selected." if options[:redirect_param].blank?
             raise ArgumentError, "The return_url option needs to be set." if options[:return_url].blank?
-            raise ArgumentError, "The account_name option needs to be set." if options[:account_name].blank?
+            raise ArgumentError, "The description option needs to be set." if options[:description].blank?
           end
 
           def credential_based_url

--- a/test/unit/integrations/helpers/mollie_ideal_helper_test.rb
+++ b/test/unit/integrations/helpers/mollie_ideal_helper_test.rb
@@ -6,6 +6,7 @@ class MollieIdealHelperTest < Test::Unit::TestCase
   def setup
     @required_options = {
       :account_name => "My shop",
+      :description => 'Order #111',
       :amount => 500,
       :currency => 'EUR',
       :redirect_param => 'ideal_TESTNL99',
@@ -19,7 +20,7 @@ class MollieIdealHelperTest < Test::Unit::TestCase
 
   def test_credential_based_url
     @mock_api.expects(:post_request)
-      .with('payments', :amount => 500, :description => 'My shop', :method => 'ideal', :issuer => 'ideal_TESTNL99', :redirectUrl => 'https://return.com', :metadata => {:order => 'order-500'})
+      .with('payments', :amount => 500, :description => 'Order #111', :method => 'ideal', :issuer => 'ideal_TESTNL99', :redirectUrl => 'https://return.com', :metadata => {:order => 'order-500'})
       .returns(CREATE_PAYMENT_RESPONSE_JSON)
 
     assert_equal Hash.new, @helper.fields
@@ -34,7 +35,7 @@ class MollieIdealHelperTest < Test::Unit::TestCase
   def test_raises_without_required_options
     assert_raises(ArgumentError) { MollieIdeal::Helper.new('order-500','1234567', @required_options.merge(:redirect_param => nil)) }
     assert_raises(ArgumentError) { MollieIdeal::Helper.new('order-500','1234567', @required_options.merge(:return_url => nil)) }
-    assert_raises(ArgumentError) { MollieIdeal::Helper.new('order-500','1234567', @required_options.merge(:account_name => nil)) }
+    assert_raises(ArgumentError) { MollieIdeal::Helper.new('order-500','1234567', @required_options.merge(:description => nil)) }
   end
 
   CREATE_PAYMENT_RESPONSE_JSON = JSON.parse(<<-JSON)


### PR DESCRIPTION
This is what shows up as description on the customer's bank statement. Previously we were using the account name for this, which is suboptimal.

@maartenvg @cjoudrey @odorcicd /cc @RickWong
