### PR TITLE
Leave one blank line below 'private'

### DIFF
--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -107,6 +107,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+      
       def save_card(retain, credit_card, options)
         request = build_xml_request('payment_method') do |doc|
           add_credit_card(doc, credit_card, options)


### PR DESCRIPTION
More readable and eye appealing ;)

According to: ruby-style-guide ( https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#classes--modules )

`Leave one blank line above the visibility modifier and one blank line below in order to emphasize that it applies to all methods below it.`
