### PR TITLE
Fixes for Klarna

### DIFF
--- a/lib/active_merchant/billing/integrations/klarna.rb
+++ b/lib/active_merchant/billing/integrations/klarna.rb
@@ -24,12 +24,12 @@ module ActiveMerchant #:nodoc:
                     fields['purchase_currency'].to_s + 
                     fields['locale'].to_s
 
-          cart_items.each do |item|
-            payload << item[:type].to_s +
-                       item[:reference].to_s +
-                       item[:quantity].to_s +
-                       item[:unit_price].to_s +
-                       item.fetch(:discount_rate, nil).to_s
+          cart_items.each_with_index do |item, i|
+            payload << fields["cart_item-#{i}_type"].to_s +
+                       fields["cart_item-#{i}_reference"].to_s +
+                       fields["cart_item-#{i}_quantity"].to_s +
+                       fields["cart_item-#{i}_unit_price"].to_s +
+                       fields.fetch("cart_item-#{i}_discount_rate", '').to_s
           end
 
           payload << fields['merchant_id'].to_s +

--- a/lib/active_merchant/billing/integrations/klarna/notification.rb
+++ b/lib/active_merchant/billing/integrations/klarna/notification.rb
@@ -12,11 +12,11 @@ module ActiveMerchant #:nodoc:
           end
 
           def complete?
-            status == 'Complete'
+            status == 'Completed'
           end
 
           def item_id
-            params["reservation"]
+            order
           end
 
           def transaction_id
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
           end
 
           def currency
-            params["purchase_currency"]
+            params["purchase_currency"].upcase
           end
 
           def gross
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
           def status
             case params['status']
             when 'checkout_complete'
-              'Complete'
+              'Completed'
             else
               params['status']
             end
@@ -62,6 +62,10 @@ module ActiveMerchant #:nodoc:
           end
 
           private
+
+          def order
+            Rack::Utils.parse_nested_query(@options[:query_string])["order"]
+          end
 
           def parse(post)
             @raw = post.to_s

--- a/test/unit/integrations/helpers/klarna_helper_test.rb
+++ b/test/unit/integrations/helpers/klarna_helper_test.rb
@@ -61,7 +61,7 @@ class KlarnaHelperTest < Test::Unit::TestCase
   def test_merchant_digest
     @helper = valid_helper
 
-    assert_field 'merchant_digest', "/fUAJJiWEluzrwL1AX8pptGFYP3T1gWIv+tafLnARzY="
+    assert_field 'merchant_digest', "k2BENClM8CRy3h1njQNtUHC+Jd4lVoCCkHMGu5RBAkM="
   end
 
   def test_line_item
@@ -72,20 +72,19 @@ class KlarnaHelperTest < Test::Unit::TestCase
     assert_field 'cart_item-0_reference', item[:reference].to_s
     assert_field 'cart_item-0_name', item[:name].to_s
     assert_field 'cart_item-0_quantity', item[:quantity].to_s
-    assert_field 'cart_item-0_unit_price', item[:unit_price].to_s
+    assert_field 'cart_item-0_unit_price', (item[:unit_price].to_i + item[:tax_amount].to_i).to_s
     assert_field 'cart_item-0_tax_rate', '1111'
   end
 
   def test_merchant_uri_fields
-    @helper.notify_url = 'http://example-notify-url'
-    @helper.return_url = 'http://example-return-url'
+    @helper.notify_url('http://example-notify-url')
+    @helper.return_url('http://example-return-url.com/?something=else')
 
     example_cancel_url = "http://example-cancel-url"
     @helper.cancel_return_url("http://example-cancel-url")
 
-    assert_field 'merchant_push_uri', 'http://example-notify-url'
-    assert_field 'merchant_confirmation_uri', 'http://example-return-url'
-
+    assert_field 'merchant_push_uri', 'http://example-notify-url?order=1'
+    assert_field 'merchant_confirmation_uri', 'http://example-return-url.com/?order=1&something=else'
     assert_field 'merchant_terms_uri', example_cancel_url
     assert_field 'merchant_checkout_uri', example_cancel_url
     assert_field 'merchant_base_uri', example_cancel_url
@@ -99,9 +98,9 @@ class KlarnaHelperTest < Test::Unit::TestCase
       :reference => "##{order_number}",
       :name => 'example item description',
       :quantity => 1.to_s,
-      :unit_price => Money.new(9.00).to_s,
+      :unit_price => Money.new(9.00).cents.to_s,
       :discount_rate => nil,
-      :tax_amount => Money.new(1.00).to_s
+      :tax_amount => Money.new(1.00).cents.to_s
     }
   end
 

--- a/test/unit/integrations/klarna_module_test.rb
+++ b/test/unit/integrations/klarna_module_test.rb
@@ -52,7 +52,7 @@ class KlarnaModuleTest < Test::Unit::TestCase
 
     shared_secret = 'example-shared-secret'
 
-    calculated_digest = "U7HXXlQ6J1Spybv5QA/jZrUP1ud5pWoNxAgYczpQifg="
+    calculated_digest = "AB4kuszp2Y4laIP4pfbHTJTPAsR7gFRxh4ml5LEDZxg="
     assert_equal calculated_digest, Klarna.sign(fields, cart_items, shared_secret)
   end
 

--- a/test/unit/integrations/notifications/klarna_notification_test.rb
+++ b/test/unit/integrations/notifications/klarna_notification_test.rb
@@ -4,17 +4,17 @@ class KlarnaNotificationTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::Integrations
 
   def setup
-    @options = {:authorization_header => authorization_header, :credential2 => 'Example shared secret'}
+    @options = {:authorization_header => authorization_header, :credential2 => 'Example shared secret', :query_string => 'order=123'}
     @klarna = Klarna::Notification.new(request_body, @options)
   end
 
   def test_accessors
     assert @klarna.complete?
-    assert_equal "Complete", @klarna.status
+    assert_equal "Completed", @klarna.status
     assert_equal "14565D2494490B11C39E7220000", @klarna.transaction_id
-    assert_equal "2348456980", @klarna.item_id
+    assert_equal "123", @klarna.item_id
     assert_equal "1110.98", @klarna.gross
-    assert_equal "sek", @klarna.currency
+    assert_equal "SEK", @klarna.currency
     assert_equal "2014-04-15T16:38:04+02:00", @klarna.received_at
     assert_equal "checkout-se@testdrive.klarna.com", @klarna.payer_email
     assert_equal "checkout-se@testdrive.klarna.com", @klarna.receiver_email


### PR DESCRIPTION
- Cart items unit prices always include taxes by adding the passed in unit price + passed in tax amount
- Currency from Notification is always upcased
- Append order id as query param to merchant_push_uri and merchant_confirmation_uri
- Return status 'Completed' and not 'Complete'

Ping @bslobodin 
