### PR TITLE
QIWI support

### DIFF
--- a/lib/active_merchant/billing/integrations/qiwi.rb
+++ b/lib/active_merchant/billing/integrations/qiwi.rb
@@ -1,0 +1,25 @@
+require File.dirname(__FILE__) + '/qiwi/helper.rb'
+require File.dirname(__FILE__) + '/qiwi/notification.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Qiwi
+
+        autoload :Helper, File.dirname(__FILE__) + '/qiwi/helper.rb'
+        autoload :Notification, File.dirname(__FILE__) + '/qiwi/notification.rb'
+
+        mattr_accessor :service_url
+        self.service_url = 'https://w.qiwi.ru/payments.action'
+
+        def self.helper(order, account, options = {})
+          Helper.new(order, account, options)
+        end
+
+        def self.notification(query_string, options = {})
+          Notification.new(query_string, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/qiwi/helper.rb
+++ b/lib/active_merchant/billing/integrations/qiwi/helper.rb
@@ -1,0 +1,18 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Qiwi
+        class Helper < ActiveMerchant::Billing::Integrations::Helper
+
+          mapping :account, 'account'
+          mapping :amount, 'amount'
+          mapping :order, 'id'
+
+          def form_method
+            'GET'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/qiwi/notification.rb
+++ b/lib/active_merchant/billing/integrations/qiwi/notification.rb
@@ -1,0 +1,87 @@
+require 'net/http'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Qiwi
+        class Notification < ActiveMerchant::Billing::Integrations::Notification
+          def self.recognizes?(params)
+            params.has_key?('txn_id')
+          end
+
+          def complete?
+            status == 'pay'
+          end
+
+          def check?
+            status == 'check'
+          end
+
+          def amount
+            BigDecimal.new(gross)
+          end
+
+          def item_id
+            params['account']
+          end
+
+          def transaction_id
+            params['txn_id']
+          end
+
+          def currency
+            'RUR'
+          end
+
+          def received_at
+            params['txn_date']
+          end
+
+          def gross
+            params['sum']
+          end
+
+          def status
+            params['command']
+          end
+
+          def acknowledge
+            true
+          end
+
+          def response_content_type
+            'application/xml'
+          end
+
+          @@response_codes = {
+              :fatal_error => 300,
+              :invoice_not_found => 5,
+              :error => 1,
+              :ok => 0
+          }
+
+          def response(response_code, options = {})
+            <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <osmp_txn_id>#{transaction_id}</osmp_txn_id>
+  <prv_txn>#{item_id}</prv_txn>
+  <sum>#{gross}</sum>
+  <result>#{response_code}</result>
+  <comment>#{options[:description]}</comment>
+</response>
+            XML
+          end
+
+          def success_response(options = {})
+            response(@@response_codes[:ok], options)
+          end
+
+          def error_response(error_type, options = {})
+            response(@@response_codes[error_type], options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/integrations/helpers/qiwi_helper_test.rb
+++ b/test/unit/integrations/helpers/qiwi_helper_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class QiwiHelperTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @helper = Qiwi::Helper.new('order-500', 'cody@example.com', :amount => 500, :currency => 'USD')
+  end
+
+  def test_basic_helper_fields
+    assert_field 'account', 'cody@example.com'
+
+    assert_field 'amount', '500'
+    assert_field 'id', 'order-500'
+  end
+
+  def test_unknown_mapping
+    assert_nothing_raised do
+      @helper.company_address :address => '500 Dwemthy Fox Road'
+    end
+  end
+
+  def test_setting_invalid_address_field
+    fields = @helper.fields.dup
+    @helper.billing_address :street => 'My Street'
+    assert_equal fields, @helper.fields
+  end
+end

--- a/test/unit/integrations/notifications/qiwi_notification_test.rb
+++ b/test/unit/integrations/notifications/qiwi_notification_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class QiwiNotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @qiwi = Qiwi::Notification.new(http_raw_data)
+  end
+
+  def test_accessors
+    assert @qiwi.complete?
+    assert_equal "pay", @qiwi.status
+    assert_equal "1234567", @qiwi.transaction_id
+    assert_equal "4957835959", @qiwi.item_id
+    assert_equal "10.45", @qiwi.gross
+    assert_equal "RUR", @qiwi.currency
+    assert_equal "20090815120133", @qiwi.received_at
+  end
+
+  def test_compositions
+    assert_equal 10.45, @qiwi.amount
+  end
+
+  def test_acknowledgement
+    assert @qiwi.acknowledge
+  end
+
+  def test_respond_to_acknowledge
+    assert @qiwi.respond_to?(:acknowledge)
+  end
+
+  private
+
+  def http_raw_data
+    "command=pay&txn_id=1234567&txn_date=20090815120133&account=4957835959&sum=10.45"
+  end
+end

--- a/test/unit/integrations/qiwi_module_test.rb
+++ b/test/unit/integrations/qiwi_module_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class QiwiModuleTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def test_notification_method
+    assert_instance_of Qiwi::Notification, Qiwi.notification('name=cody')
+  end
+end


### PR DESCRIPTION
Support for the QIWI payment gateway (https://qiwi.com/).

Integration testing was performed with the Kill Bill QIWI plugin (https://github.com/killbill/killbill-qiwi-plugin).
