### PR TITLE
Яндекс support

### DIFF
--- a/lib/active_merchant/billing/integrations/yandex.rb
+++ b/lib/active_merchant/billing/integrations/yandex.rb
@@ -1,0 +1,33 @@
+require File.dirname(__FILE__) + '/yandex/helper.rb'
+require File.dirname(__FILE__) + '/yandex/notification.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Yandex
+
+        mattr_accessor :service_url
+        self.service_url = 'https://money.yandex.ru/eshop.xml'
+
+        autoload :Helper, File.dirname(__FILE__) + '/yandex/helper.rb'
+        autoload :Notification, File.dirname(__FILE__) + '/yandex/notification.rb'
+        autoload :Return, File.dirname(__FILE__) + '/yandex/return.rb'
+
+        mattr_accessor :signature_parameter_name
+        self.signature_parameter_name = 'md5'
+
+        def self.helper(order, account, options = {})
+          Helper.new(order, account, options)
+        end
+
+        def self.notification(query_string, options = {})
+          Notification.new(query_string, options)
+        end
+
+        def self.return(query_string)
+          Return.new(query_string)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/yandex/helper.rb
+++ b/lib/active_merchant/billing/integrations/yandex/helper.rb
@@ -1,0 +1,20 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Yandex
+        class Helper < ActiveMerchant::Billing::Integrations::Helper
+          def initialize(order, account, options = {})
+            @secret = options.delete(:secret)
+            super
+          end
+
+          mapping :account, 'ShopID'
+          mapping :amount, 'Sum'
+          mapping :order, 'orderNumber'
+          mapping :customer, 'customerNumber'
+          mapping :scid, 'scid'
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/yandex/notification.rb
+++ b/lib/active_merchant/billing/integrations/yandex/notification.rb
@@ -1,0 +1,95 @@
+require 'net/http'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Yandex
+        class Notification < ActiveMerchant::Billing::Integrations::Notification
+          def self.recognizes?(params)
+            params.has_key?('shopId')
+          end
+
+          def complete?
+            params['request_type'] == 'payment_success' && params['orderIsPaid'] == '1'
+          end
+
+          def check?
+            @check ||= if params['request_type'] == 'check'
+                         true
+                       else
+                         false
+                       end
+          end
+
+          def amount
+            BigDecimal.new(gross)
+          end
+
+          def item_id
+            params['orderNumber']
+          end
+
+          def transaction_id
+            params['invoiceId']
+          end
+
+          def security_key
+            params[ActiveMerchant::Billing::Integrations::Yandex.signature_parameter_name].to_s.downcase
+          end
+
+          def currency
+            'RUR'
+          end
+
+          def gross
+            params['orderSumAmount']
+          end
+
+          def status
+            'success'
+          end
+
+          def generate_signature_string
+            %w(orderIsPaid orderSumAmount orderSumCurrencyPaycash orderSumBankPaycash shopId invoiceId customerNumber).map { |param| params[param] }.join(';') + ';' + @options[:secret]
+          end
+
+          def generate_signature
+            Digest::MD5.hexdigest(generate_signature_string)
+          end
+
+          def acknowledge
+            security_key == generate_signature
+          end
+
+          def success_response(*args)
+            xml('0', Time.now)
+          end
+
+          def error_response(error_type, options = {})
+            if error_type.to_s == 'duplicate_payment'
+              success_response
+            else
+              xml('1000', Time.now, error_type.to_s)
+            end
+          end
+
+          def xml(code, datetime, msg = nil)
+            datetime_str = datetime.strftime("%Y-%m-%dT%H:%M:%S+0#{datetime.gmt_offset / 3600}:00")
+
+            action = case params['request_type']
+                       when 'check' then
+                         'Check'
+                       when 'payment_success' then
+                         'PaymentSuccess'
+                     end
+
+            %Q{<?xml version="1.0" encoding="windows-1251"?>
+<response performedDatetime="#{datetime_str}">
+  <result code="#{code}" action="#{action}" shopId="#{@options[:account]}" invoiceId="#{params['invoiceId']}" #{"techMessage=\"#{msg}\"" if msg} />
+</response>}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/yandex/return.rb
+++ b/lib/active_merchant/billing/integrations/yandex/return.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Yandex
+        class Return < ActiveMerchant::Billing::Integrations::Return
+          def item_id
+            params['orderNumber']
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/integrations/helpers/yandex_helper_test.rb
+++ b/test/unit/integrations/helpers/yandex_helper_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class YandexHelperTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @helper = Yandex::Helper.new('order-500', 'cody@example.com', :amount => 500, :currency => 'USD')
+  end
+
+  def test_basic_helper_fields
+    assert_field 'ShopID', 'cody@example.com'
+
+    assert_field 'Sum', '500'
+    assert_field 'orderNumber', 'order-500'
+  end
+
+  def test_unknown_address_mapping
+    @helper.billing_address :farm => 'CA'
+    assert_equal 3, @helper.fields.size
+  end
+
+  def test_unknown_mapping
+    assert_nothing_raised do
+      @helper.company_address :address => '500 Dwemthy Fox Road'
+    end
+  end
+
+  def test_setting_invalid_address_field
+    fields = @helper.fields.dup
+    @helper.billing_address :street => 'My Street'
+    assert_equal fields, @helper.fields
+  end
+end

--- a/test/unit/integrations/notifications/yandex_notification_test.rb
+++ b/test/unit/integrations/notifications/yandex_notification_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class YandexNotificationTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def setup
+    @yandex = Yandex::Notification.new(http_raw_data, :secret => 'secret')
+  end
+
+  def test_accessors
+    assert @yandex.complete?
+    assert !@yandex.check?
+    assert_equal "success", @yandex.status
+    assert_equal "0909", @yandex.transaction_id
+    assert_equal "09834", @yandex.item_id
+    assert_equal "400", @yandex.gross
+    assert_equal "RUR", @yandex.currency
+    assert !@yandex.test?
+  end
+
+  def test_compositions
+    assert_equal 400, @yandex.amount
+  end
+
+  def test_acknowledgement
+    puts ActiveMerchant::Billing::Integrations::Yandex.signature_parameter_name
+    puts @yandex.security_key
+    assert @yandex.acknowledge
+  end
+
+  def test_wrong_signature
+    yandex = Yandex::Notification.new(http_raw_data_with_wrong_signature, :secret => 'secret')
+    assert !yandex.acknowledge
+  end
+
+  def test_respond_to_acknowledge
+    assert @yandex.respond_to?(:acknowledge)
+  end
+
+  private
+
+  def http_raw_data
+    "shopId=9384&orderNumber=09834&request_type=payment_success&orderIsPaid=1&invoiceId=0909&orderSumAmount=400&md5=e49ac35a5a93284597bc5adb5f348cf1"
+  end
+
+  def http_raw_data_with_wrong_signature
+    "InvId=123&OutSum=500&SignatureValue=wrong&shpMySuperParam=456&shpa=123&md5=1"
+  end
+end

--- a/test/unit/integrations/yandex_module_test.rb
+++ b/test/unit/integrations/yandex_module_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class YandexModuleTest < Test::Unit::TestCase
+  include ActiveMerchant::Billing::Integrations
+
+  def test_notification_method
+    assert_instance_of Yandex::Notification, Yandex.notification('name=cody')
+  end
+end


### PR DESCRIPTION
Support for the Яндекс payment gateway (https://money.yandex.ru/).

Integration testing was performed with the Kill Bill Яндекс plugin (https://github.com/killbill/killbill-yandex-plugin).
