### PR TITLE
Improve credit card validation

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -204,8 +204,8 @@ module ActiveMerchant #:nodoc:
         # Bogus card is pretty much for testing purposes. Lets just skip these extra tests if its used
         return if brand == 'bogus'
 
-        validate_card_brand
         validate_card_number
+        validate_card_brand
         validate_verification_value
         validate_switch_or_solo_attributes
       end
@@ -226,21 +226,21 @@ module ActiveMerchant #:nodoc:
         self.brand = self.class.brand?(number) if brand.blank?
       end
 
-      def validate_card_number #:nodoc:
+      def validate_card_number
         if number.blank?
           errors.add :number, "is required"
         elsif !CreditCard.valid_number?(number)
           errors.add :number, "is not a valid credit card number"
         end
+      end
+
+      def validate_card_brand
+        errors.add :brand, "is required" if brand.blank? && !errors.on(:number)
+        errors.add :brand, "is invalid"  unless brand.blank? || CreditCard.card_companies.keys.include?(brand)
 
         unless errors.on(:number) || errors.on(:brand)
           errors.add :brand, "does not match the card number" unless CreditCard.matching_brand?(number, brand)
         end
-      end
-
-      def validate_card_brand #:nodoc:
-        errors.add :brand, "is required" if brand.blank? && number.present?
-        errors.add :brand, "is invalid"  unless brand.blank? || CreditCard.card_companies.keys.include?(brand)
       end
 
       alias_method :validate_card_type, :validate_card_brand

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -90,18 +90,32 @@ class CreditCardTest < Test::Unit::TestCase
     @visa.brand = 'master'
 
     assert_not_valid @visa
-    assert_not_equal @visa.errors.on(:number), @visa.errors.on(:brand)
+    assert_false @visa.errors.on(:number)
+    assert @visa.errors.on(:brand)
+    assert_equal "does not match the card number", @visa.errors.on(:brand)
   end
 
   def test_should_be_invalid_when_brand_cannot_be_detected
-    @visa.number = nil
     @visa.brand = nil
 
+    @visa.number = nil
     assert_not_valid @visa
-    assert !@visa.errors.on(:brand)
-    assert !@visa.errors.on(:type)
+    assert_false @visa.errors.on(:brand)
+    assert_false @visa.errors.on(:type)
     assert @visa.errors.on(:number)
     assert_equal 'is required', @visa.errors.on(:number)
+
+    @visa.number = "11112222333344ff"
+    assert_not_valid @visa
+    assert_false @visa.errors.on(:type)
+    assert_false @visa.errors.on(:brand)
+    assert       @visa.errors.on(:number)
+
+    @visa.number = "11112222333344444"
+    assert_not_valid @visa
+    assert_false @visa.errors.on(:brand)
+    assert_false @visa.errors.on(:type)
+    assert @visa.errors.on(:number)
   end
 
   def test_should_be_a_valid_card_number


### PR DESCRIPTION
Previously, if you specified an invalid card number and you specified a
nil brand, you'd get two validation messages:
- card type can't be blank
- number is invalid

When your form doesn't allow you to specify a brand, that first error
message is confusing to users.

So now, we only validate the brand if the number is legitimate.
