### PR TITLE
Add an ISO currency code accessor to integration notifications.

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('json', '~> 1.7')
-  s.add_dependency('active_utils', '~> 2.0', '>= 2.0.1')
+  s.add_dependency('active_utils', '~> 2.1')
   s.add_dependency('nokogiri', "~> 1.4")
 
   s.add_development_dependency('rake')

--- a/lib/active_merchant/billing/integrations/notification.rb
+++ b/lib/active_merchant/billing/integrations/notification.rb
@@ -55,6 +55,10 @@ module ActiveMerchant #:nodoc:
           false
         end
 
+        def iso_currency
+          ActiveMerchant::CurrencyCode.standardize(currency)
+        end
+
         private
 
         # Take the posted data and move the relevant data into a hash

--- a/test/unit/integrations/notifications/notification_test.rb
+++ b/test/unit/integrations/notifications/notification_test.rb
@@ -15,7 +15,7 @@ class NotificationTest < Test::Unit::TestCase
     assert_equal "500.00", @notification.params['mc_gross']
     assert_equal "confirmed", @notification.params['address_status']
     assert_equal "EVMXCLDZJV77Q", @notification.params['payer_id']
-    assert_equal "Completed", @notification.params['payment_status']    
+    assert_equal "Completed", @notification.params['payment_status']
     assert_equal "ru", @notification.params['yamoney-lang']
     assert_equal '', @notification.params['empty_params']
     assert_equal CGI.unescape("15%3A23%3A54+Apr+15%2C+2005+PDT"), @notification.params['payment_date']
@@ -26,7 +26,7 @@ class NotificationTest < Test::Unit::TestCase
     assert_raise(NotImplementedError){ @notification.gross }
     assert_raise(NotImplementedError){ @notification.gross_cents }
   end
-  
+
   def test_notification_data_with_period
     notification = Notification.new(http_raw_data_with_period)
     assert_equal 'clicked', notification.params['checkout.x']
@@ -44,13 +44,31 @@ class NotificationTest < Test::Unit::TestCase
     assert @notification.valid_sender?('localhost')
     ActiveMerchant::Billing::Base.integration_mode = :test
   end
-  
+
+  def test_iso_currency
+    assert_equal 'USD', CurrencyNotificationStub.new('currency=usd').iso_currency
+    assert_equal 'CAD', CurrencyNotificationStub.new('currency=CAD').iso_currency
+
+    assert_equal 'TWD', CurrencyNotificationStub.new('currency=NTD').iso_currency
+    assert_equal 'CNY', CurrencyNotificationStub.new('currency=rmb').iso_currency
+
+    assert_raise ActiveMerchant::InvalidCurrencyCodeError do
+      CurrencyNotificationStub.new('currency=not_real').iso_currency
+    end
+  end
+
   private
   def http_raw_data
     "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Completed&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00&yamoney-lang=ru&empty_params="
   end
-  
+
   def http_raw_data_with_period
     "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Completed&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00&checkout.x=clicked&yamoney-lang=ru&empty_params="
+  end
+end
+
+class CurrencyNotificationStub < ActiveMerchant::Billing::Integrations::Notification
+  def currency
+    params['currency']
   end
 end


### PR DESCRIPTION
Cannot be merged until after https://github.com/Shopify/active_utils/pull/30 is merged and the new gem released; the tests won't pass until then.

Just adds an `iso_currency` accessor that we can make use of that will do the ISO currency mapping if needed.

@jeromecornet 
@Smcchoi 
