### PR TITLE
Deprecate recurring functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Beanstream: Add support for Legato single use tokens [tylerrooney]
 * PayPal Digital Goods: Allow mobile [tomprats]
 * Maxipago: Add installment support [alexandremcosta]
+* Deprecate recurring API support [ntalbott]
 
 == Version 1.43.1 (May 1, 2014)
 

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -16,10 +16,6 @@ module ActiveMerchant #:nodoc:
     # * <tt>void(identification, options = {})</tt>
     # * <tt>credit(money, identification, options = {})</tt>
     #
-    # Some gateways include features for recurring billing
-    #
-    # * <tt>recurring(money, creditcard, options = {})</tt>
-    #
     # Some gateways also support features for storing credit cards:
     #
     # * <tt>store(creditcard, options = {})</tt>
@@ -64,6 +60,7 @@ module ActiveMerchant #:nodoc:
       DEBIT_CARDS = [ :switch, :solo ]
       CURRENCIES_WITHOUT_FRACTIONS = [ 'BIF', 'BYR', 'CLP', 'CVE', 'DJF', 'GNF', 'HUF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'TWD', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' ]
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
+      RECURRING_DEPRECATION_MESSAGE = "Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it."
 
       cattr_reader :implementations
       @@implementations = []

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -100,6 +100,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def recurring(money, source, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         add_amount(post, money)
         add_invoice(post, options)
@@ -111,6 +113,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def update_recurring(amount, source, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         add_recurring_amount(post, amount)
         add_recurring_invoice(post, options)
@@ -122,6 +126,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def cancel_recurring(options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         add_recurring_operation_type(post, :cancel)
         add_recurring_service(post, options)

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -224,6 +224,8 @@ module ActiveMerchant #:nodoc:
       #   :rebill_amount     => '39.95'
       #   A money object of 1995 cents would be passed into the 'money' parameter.
       def recurring(money, payment_object, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         requires!(options, :rebill_start_date, :rebill_expression)
         options[:rebill] = true
         if money
@@ -241,6 +243,8 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>rebill_id</tt> -- A string containing the rebill_id of the recurring billing that is already active (REQUIRED)
       def status_recurring(rebill_id)
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         requires!(rebill_id)
         post[:REBILL_ID] = rebill_id
@@ -262,6 +266,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>:rebill_next_amount</tt> -- A string containing the next rebilling amount to charge the customer. This ONLY affects the next scheduled charge; all other rebillings will continue at the regular (rebill_amount) amount.
       #   Take a look above at the recurring_payment method for similar examples on how to use.
       def update_recurring(options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         requires!(options, :rebill_id)
         post[:REBILL_ID]          = options[:rebill_id]
@@ -282,6 +288,8 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>rebill_id</tt> -- A string containing the rebill_id of the recurring billing that you wish to cancel/stop (REQUIRED)
       def cancel_recurring(rebill_id)
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         post = {}
         requires!(rebill_id)
         post[:REBILL_ID]         = rebill_id
@@ -357,7 +365,7 @@ module ActiveMerchant #:nodoc:
           else
             message = message.chomp('.')
           end
-        elsif message == "Missing ACCOUNT_ID" 
+        elsif message == "Missing ACCOUNT_ID"
           message = "The merchant login ID or password is invalid"
         elsif message =~ /Approved/
           message = "This transaction has been approved"

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -42,18 +42,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def recurring(money, paysource, options = {})
-        money = amount(money)
-        case normalize(paysource)
-        when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-        when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
-        else
-          raise Error, error_message(paysource)
-        end
-      end
-
       def credit(money, paysource, options = {})
         if paysource.is_a?(String)
           deprecated CREDIT_DEPRECATION_MESSAGE

--- a/lib/active_merchant/billing/gateways/certo_direct.rb
+++ b/lib/active_merchant/billing/gateways/certo_direct.rb
@@ -101,9 +101,10 @@ module ActiveMerchant #:nodoc:
       # ==== Options
       #
       def recurring(identification, options={})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         commit(build_recurring_request(identification, options))
       end
-
 
       private
 

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -166,6 +166,8 @@ module ActiveMerchant #:nodoc:
       # :comments               Uh... comments
       #
       def recurring(money, creditcard, options={})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         requires!(options, [:periodicity, :bimonthly, :monthly, :biweekly, :weekly, :yearly, :daily], :installments, :order_id )
 
         options.update(

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -403,6 +403,8 @@ module ActiveMerchant #:nodoc:
 
       def add_managed_billing(xml, options)
         if mb = options[:managed_billing]
+          deprecated RECURRING_DEPRECATION_MESSAGE
+
           # default to recurring (R).  Other option is deferred (D).
           xml.tag! :MBType, mb[:type] || RECURRING
           # default to Customer Reference Number

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -239,6 +239,8 @@ module ActiveMerchant #:nodoc:
       # YYYYMMDD format and can be used to specify when the first charge will be made.
       # If omitted the first charge will be immediate.
       def recurring(money, payment_source, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         requires!(options, [:periodicity, :monthly, :weekly, :daily], :payments)
 
         periodic_type = case options[:periodicity]

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -57,6 +57,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>payments</tt> - The term, or number of payments that will be made
       # * <tt>comment</tt> - A comment associated with the profile
       def recurring(money, credit_card, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         options[:name] = credit_card.name if options[:name].blank? && credit_card
         request = build_recurring_request(options[:profile_id] ? :modify : :add, money, options) do |xml|
           add_credit_card(xml, credit_card) if credit_card
@@ -65,11 +67,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def cancel_recurring(profile_id)
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         request = build_recurring_request(:cancel, 0, :profile_id => profile_id)
         commit(request, options.merge(:request_type => :recurring))
       end
 
       def recurring_inquiry(profile_id, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         request = build_recurring_request(:inquiry, nil, options.update( :profile_id => profile_id ))
         commit(request, options.merge(:request_type => :recurring))
       end

--- a/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
@@ -23,8 +23,10 @@ module ActiveMerchant #:nodoc:
       # * <tt>:cycles</tt> -- Limit to certain # of cycles (OPTIONAL)
       # * <tt>:start_date</tt> -- When does the charging starts (REQUIRED)
       # * <tt>:description</tt> -- The description to appear in the profile (REQUIRED)
-      
+
       def recurring(amount, credit_card, options = {})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         options[:credit_card] = credit_card
         options[:amount] = amount
         requires!(options, :description, :start_date, :period, :frequency, :amount)
@@ -34,7 +36,7 @@ module ActiveMerchant #:nodoc:
       # Update a recurring payment's details.
       #
       # This transaction updates an existing Recurring Billing Profile
-      # and the subscription must have already been created previously 
+      # and the subscription must have already been created previously
       # by calling +recurring()+. The ability to change certain
       # details about a recurring payment is dependent on transaction history
       # and the type of plan you're subscribed with paypal. Web Payment Pro
@@ -49,6 +51,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>:profile_id</tt> -- A string containing the <tt>:profile_id</tt>
       # of the recurring payment already in place for a given credit card. (REQUIRED)
       def update_recurring(options={})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         requires!(options, :profile_id)
         opts = options.dup
         commit 'UpdateRecurringPaymentsProfile', build_change_profile_request(opts.delete(:profile_id), opts)
@@ -65,6 +69,8 @@ module ActiveMerchant #:nodoc:
       # recurring payment already in place for a given credit card. (REQUIRED)
       # * <tt>options</tt> -- A hash with extra info ('note' for ex.)
       def cancel_recurring(profile_id, options = {})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         raise_error_if_blank('profile_id', profile_id)
         commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Cancel', options)
       end
@@ -76,6 +82,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
       # recurring payment already in place for a given credit card. (REQUIRED)
       def status_recurring(profile_id)
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         raise_error_if_blank('profile_id', profile_id)
         commit 'GetRecurringPaymentsProfileDetails', build_get_profile_details_request(profile_id)
       end
@@ -87,6 +95,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
       # recurring payment already in place for a given credit card. (REQUIRED)
       def suspend_recurring(profile_id, options = {})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         raise_error_if_blank('profile_id', profile_id)
         commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Suspend', options)
       end
@@ -98,6 +108,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
       # recurring payment already in place for a given credit card. (REQUIRED)
       def reactivate_recurring(profile_id, options = {})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         raise_error_if_blank('profile_id', profile_id)
 commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(profile_id, 'Reactivate', options)
       end
@@ -109,6 +121,8 @@ commit 'ManageRecurringPaymentsProfileStatus', build_manage_profile_request(prof
       # * <tt>profile_id</tt> -- A string containing the +profile_id+ of the
       # recurring payment already in place for a given credit card. (REQUIRED)
       def bill_outstanding_amount(profile_id, options = {})
+        deprecated Gateway::RECURRING_DEPRECATION_MESSAGE
+
         raise_error_if_blank('profile_id', profile_id)
         commit 'BillOutstandingAmount', build_bill_outstanding_amount(profile_id, options)
       end

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -235,6 +235,8 @@ module ActiveMerchant #:nodoc:
       #
       # You can optionally specify how long you want payments to continue using 'payments'
       def recurring(money, creditcard, options = {})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         requires!(options, [:periodicity, :bimonthly, :monthly, :biweekly, :weekly, :yearly, :daily] )
 
         cycle = case options[:periodicity]

--- a/lib/active_merchant/billing/gateways/vindicia.rb
+++ b/lib/active_merchant/billing/gateways/vindicia.rb
@@ -167,6 +167,8 @@ module ActiveMerchant #:nodoc:
       # * <tt>:product_sku</tt> -- The subscription product's sku
       # * <tt>:autobill_prefix</tt> -- Prefix to order id for subscriptions - defaults to 'A' (OPTIONAL)
       def recurring(money, creditcard, options={})
+        deprecated RECURRING_DEPRECATION_MESSAGE
+
         options[:recurring] = true
         @autobill_prefix = options[:autobill_prefix] || "A"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -126,7 +126,7 @@ module ActiveMerchant
       end
     end
 
-    def assert_deprecation_warning(message, target)
+    def assert_deprecation_warning(message, target=@gateway)
       target.expects(:deprecated).with(message)
       yield
     end

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -140,7 +140,9 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
-    assert response = @gateway.recurring(@amount, @credit_card, @recurring_options)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, @recurring_options)
+    end
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -148,13 +150,17 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_update_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
-    assert response = @gateway.recurring(@amount, @credit_card, @recurring_options)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, @recurring_options)
+    end
     assert_success response
     assert_equal 'Approved', response.message
 
     @gateway.expects(:ssl_post).returns(successful_update_recurring_response)
 
-    assert response = @gateway.update_recurring(@amount, @credit_card, @recurring_options.merge(:account_id => response.params["rbAccountId"]))
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.update_recurring(@amount, @credit_card, @recurring_options.merge(:account_id => response.params["rbAccountId"]))
+    end
     assert_success response
     assert_equal "Request successful", response.message
   end
@@ -162,13 +168,17 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_cancel_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
-    assert response = @gateway.recurring(@amount, @credit_card, @recurring_options)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, @recurring_options)
+    end
     assert_success response
     assert_equal 'Approved', response.message
 
     @gateway.expects(:ssl_post).returns(successful_cancel_recurring_response)
 
-    assert response = @gateway.cancel_recurring(:account_id => response.params["rbAccountId"])
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.cancel_recurring(:account_id => response.params["rbAccountId"])
+    end
     assert_success response
     assert_equal "Request successful", response.message
   end

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -8,7 +8,6 @@ RSP = {
   :approved_purchase => "AUTH_CODE=GYRUY&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=SALE&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203767&CVV2=_&MESSAGE=Approved%20Sale"
 }
 
-
 class BluePayTest < Test::Unit::TestCase
   include CommStub
 
@@ -191,13 +190,15 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
-    response = @gateway.recurring(@amount, @credit_card,
-      :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
-      :rebill_start_date => '1 MONTH',
-      :rebill_expression => '14 DAYS',
-      :rebill_cycles     => '24',
-      :rebill_amount     => @amount * 4
-   )
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card,
+        :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
+        :rebill_start_date => '1 MONTH',
+        :rebill_expression => '14 DAYS',
+        :rebill_cycles     => '24',
+        :rebill_amount     => @amount * 4
+     )
+    end
 
     assert_instance_of Response, response
     assert response.success?
@@ -208,7 +209,9 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_update_recurring
     @gateway.expects(:ssl_post).returns(successful_update_recurring_response)
 
-    response = @gateway.update_recurring(:rebill_id => @rebill_id, :rebill_amount => @amount * 2)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.update_recurring(:rebill_id => @rebill_id, :rebill_amount => @amount * 2)
+    end
 
     assert_instance_of Response, response
     assert response.success?
@@ -219,7 +222,9 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_cancel_recurring
     @gateway.expects(:ssl_post).returns(successful_cancel_recurring_response)
 
-    response = @gateway.cancel_recurring(@rebill_id)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.cancel_recurring(@rebill_id)
+    end
 
     assert_instance_of Response, response
     assert response.success?
@@ -230,7 +235,9 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_status_recurring
     @gateway.expects(:ssl_post).returns(successful_status_recurring_response)
 
-    response = @gateway.status_recurring(@rebill_id)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.status_recurring(@rebill_id)
+    end
     assert_instance_of Response, response
     assert response.success?
     assert response.test?

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -35,15 +35,6 @@ class BogusTest < Test::Unit::TestCase
     assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
   end
 
-  def test_recurring
-    assert  @gateway.recurring(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    assert !@gateway.recurring(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
-    e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.recurring(1000, credit_card('123'))
-    end
-    assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
-  end
-
   def test_capture
     assert  @gateway.capture(1000, '1337').success?
     assert  @gateway.capture(1000, @response.params["transid"]).success?
@@ -132,15 +123,6 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.purchase(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => CHECK_SUCCESS_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.purchase(1000, check(:account_number => '123', :number => nil))
-    end
-    assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
-  end
-
-  def test_recurring_with_check
-    assert  @gateway.recurring(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
-    assert !@gateway.recurring(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
-    e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.recurring(1000, check(:account_number => '123', :number => nil))
     end
     assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
   end

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class LinkpointTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
-    
+
     @gateway = LinkpointGateway.new(
       :login => 123123,
       :pem => 'PEM'
@@ -12,58 +12,60 @@ class LinkpointTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
     @options = { :order_id => 1000, :billing_address => address }
   end
-  
+
   def test_credit_card_formatting
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, 2004)
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, '2004')
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, 4)
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, '04')
   end
-  
+
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_success response
     assert_equal '1000', response.authorization
   end
-  
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    
+
     assert response = @gateway.capture(@email, '1000', @options)
     assert_instance_of Response, response
     assert_success response
     assert_equal '1000', response.authorization
   end
-    
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_success response
     assert_equal '1000', response.authorization
   end
-  
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end
-  
+
   def test_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
-    
-    assert response = @gateway.recurring(2400, @credit_card, :order_id => 1003, :installments => 12, :startdate => "immediate", :periodicity => :monthly)
+
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(2400, @credit_card, :order_id => 1003, :installments => 12, :startdate => "immediate", :periodicity => :monthly)
+    end
     assert_success response
   end
-  
+
   def test_amount_style
     assert_equal '10.34', @gateway.send(:amount, 1034)
-                                                      
+
     assert_raise(ArgumentError) do
       @gateway.send(:amount, '10.34')
     end
@@ -115,7 +117,7 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_declined_purchase_is_valid_xml
     @gateway = LinkpointGateway.new(:login => 123123, :pem => 'PEM')
-    
+
     parameters = @gateway.send(:parameters, 1000, @credit_card, :ordertype => "SALE", :order_id => 1005,
       :billing_address => {
         :address1 => '1313 lucky lane',
@@ -124,73 +126,73 @@ class LinkpointTest < Test::Unit::TestCase
         :zip => '90210'
       }
     )
-  
+
     assert data = @gateway.send(:post_data, @amount, @credit_card, @options)
     assert REXML::Document.new(data)
   end
-  
+
   def test_overriding_test_mode
     Base.gateway_mode = :production
-    
+
     gateway = LinkpointGateway.new(
       :login => 'LOGIN',
       :pem => 'PEM',
       :test => true
     )
-    
+
     assert gateway.test?
   end
-  
+
   def test_using_production_mode
     Base.gateway_mode = :production
-    
+
     gateway = LinkpointGateway.new(
       :login => 'LOGIN',
       :pem => 'PEM'
     )
-    
+
     assert !gateway.test?
   end
-  
+
   def test_supported_countries
     assert_equal ['US'], LinkpointGateway.supported_countries
   end
-  
+
   def test_supported_card_types
     assert_equal [:visa, :master, :american_express, :discover, :jcb, :diners_club], LinkpointGateway.supported_cardtypes
   end
-  
+
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'N', response.avs_result['code']
   end
-  
+
   def test_cvv_result
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'M', response.cvv_result['code']
   end
-  
+
   private
   def successful_authorization_response
     '<r_csp>CSI</r_csp><r_time>Sun Jan 6 21:41:31 2008</r_time><r_ref>0004486182</r_ref><r_error/><r_ordernum>1000</r_ordernum><r_message>APPROVED</r_message><r_code>1234560004486182:NNNM:100018312899:</r_code><r_tdate>1199680890</r_tdate><r_score/><r_authresponse/><r_approved>APPROVED</r_approved><r_avs>NNNM</r_avs>'
   end
-  
+
   def successful_capture_response
     '<r_csp>CSI</r_csp><r_time>Wed Dec 2 13:57:19 2009</r_time><r_ref>0009554566</r_ref><r_error></r_error><r_ordernum>1000</r_ordernum><r_message>ACCEPTED</r_message><r_code>0000000009554566: :9554566:</r_code><r_tdate>1259780240</r_tdate><r_score></r_score><r_authresponse></r_authresponse><r_approved>APPROVED</r_approved><r_avs>    </r_avs>'
   end
-  
+
   def successful_purchase_response
-    '<r_csp>CSI</r_csp><r_time>Sun Jan 6 21:45:22 2008</r_time><r_ref>0004486195</r_ref><r_error></r_error><r_ordernum>1000</r_ordernum><r_message>APPROVED</r_message><r_code>1234560004486195:NNNM:100018312912:</r_code><r_tdate>1199681121</r_tdate><r_score></r_score><r_authresponse></r_authresponse><r_approved>APPROVED</r_approved><r_avs>NNNM</r_avs>'    
+    '<r_csp>CSI</r_csp><r_time>Sun Jan 6 21:45:22 2008</r_time><r_ref>0004486195</r_ref><r_error></r_error><r_ordernum>1000</r_ordernum><r_message>APPROVED</r_message><r_code>1234560004486195:NNNM:100018312912:</r_code><r_tdate>1199681121</r_tdate><r_score></r_score><r_authresponse></r_authresponse><r_approved>APPROVED</r_approved><r_avs>NNNM</r_avs>'
   end
-  
+
   def failed_purchase_response
     '<r_csp></r_csp><r_time>Sun Jan 6 21:50:51 2008</r_time><r_ref></r_ref><r_error>SGS-002300: Invalid credit card type.</r_error><r_ordernum>2aec6babe076111deb2c94c21181d9fe</r_ordernum><r_message></r_message><r_code></r_code><r_tdate></r_tdate><r_score></r_score><r_authresponse></r_authresponse><r_approved>DECLINED</r_approved><r_avs></r_avs>'
   end
-  
+
   def successful_recurring_response
     '<r_csp>CSI</r_csp><r_time>Sun Jan 6 21:49:00 2008</r_time><r_ref>0004486198</r_ref><r_error></r_error><r_ordernum>2206b7c9a31de5fb077913134011059d</r_ordernum><r_message>APPROVED</r_message><r_code>1234560004486198:NNNM:100018312915:</r_code><r_tdate>1199681339</r_tdate><r_score></r_score><r_authresponse></r_authresponse><r_approved>APPROVED</r_approved><r_avs>NNN</r_avs>'
   end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -218,7 +218,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_default_managed_billing
     response = stub_comms do
-      @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014" })
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014" })
+      end
     end.check_request do |endpoint, data, headers|
       assert_match(/<MBType>R/, data)
       assert_match(/<MBOrderIdGenerationMethod>IO/, data)
@@ -230,10 +232,12 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_managed_billing
     response = stub_comms do
-      @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014",
-              :end_date => "10-10-2015",
-              :max_dollar_value => 1500,
-              :max_transactions => 12})
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => "10-10-2014",
+                :end_date => "10-10-2015",
+                :max_dollar_value => 1500,
+                :max_transactions => 12})
+      end
     end.check_request do |endpoint, data, headers|
       assert_match(/<MBType>R/, data)
       assert_match(/<MBOrderIdGenerationMethod>IO/, data)

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -162,38 +162,48 @@ class PayflowTest < Test::Unit::TestCase
 
   def test_initial_recurring_transaction_missing_parameters
     assert_raises ArgumentError do
-      response = @gateway.recurring(@amount, @credit_card,
-        :periodicity => :monthly,
-        :initial_transaction => { }
-      )
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card,
+          :periodicity => :monthly,
+          :initial_transaction => { }
+        )
+      end
     end
   end
 
   def test_initial_purchase_missing_amount
     assert_raises ArgumentError do
-      response = @gateway.recurring(@amount, @credit_card,
-        :periodicity => :monthly,
-        :initial_transaction => { :amount => :purchase }
-      )
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card,
+          :periodicity => :monthly,
+          :initial_transaction => { :amount => :purchase }
+        )
+      end
     end
   end
 
   def test_recurring_add_action_missing_parameters
     assert_raises ArgumentError do
-      response = @gateway.recurring(@amount, @credit_card)
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card)
+      end
     end
   end
 
   def test_recurring_modify_action_missing_parameters
     assert_raises ArgumentError do
-      response = @gateway.recurring(@amount, nil)
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, nil)
+      end
     end
   end
 
   def test_successful_recurring_action
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
-    response = @gateway.recurring(@amount, @credit_card, :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, :periodicity => :monthly)
+    end
 
     assert_instance_of PayflowResponse, response
     assert_success response
@@ -205,7 +215,9 @@ class PayflowTest < Test::Unit::TestCase
   def test_successful_recurring_modify_action
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
-    response = @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :periodicity => :monthly)
+    end
 
     assert_instance_of PayflowResponse, response
     assert_success response
@@ -217,7 +229,9 @@ class PayflowTest < Test::Unit::TestCase
   def test_successful_recurring_modify_action_with_retry_num_days
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
-    response = @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :retry_num_days => 3, :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :retry_num_days => 3, :periodicity => :monthly)
+    end
 
     assert_instance_of PayflowResponse, response
     assert_success response
@@ -229,7 +243,9 @@ class PayflowTest < Test::Unit::TestCase
   def test_falied_recurring_modify_action_with_starting_at_in_the_past
     @gateway.stubs(:ssl_post).returns(start_date_error_recurring_response)
 
-    response = @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :starting_at => Date.yesterday, :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :starting_at => Date.yesterday, :periodicity => :monthly)
+    end
 
     assert_instance_of PayflowResponse, response
     assert_success response
@@ -242,7 +258,9 @@ class PayflowTest < Test::Unit::TestCase
   def test_falied_recurring_modify_action_with_starting_at_missing_and_changed_periodicity
     @gateway.stubs(:ssl_post).returns(start_date_missing_recurring_response)
 
-    response = @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :periodicity => :yearly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, nil, :profile_id => "RT0000000009", :periodicity => :yearly)
+    end
 
     assert_instance_of PayflowResponse, response
     assert_success response
@@ -255,7 +273,9 @@ class PayflowTest < Test::Unit::TestCase
   def test_recurring_profile_payment_history_inquiry
     @gateway.stubs(:ssl_post).returns(successful_payment_history_recurring_response)
 
-    response = @gateway.recurring_inquiry('RT0000000009', :history => true)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring_inquiry('RT0000000009', :history => true)
+    end
     assert_equal 1, response.payment_history.size
     assert_equal '1', response.payment_history.first['payment_num']
     assert_equal '7.25', response.payment_history.first['amt']

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -20,47 +20,85 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_no_ip_address
-    assert_raise(ArgumentError){ @gateway.purchase(@amount, @credit_card, :billing_address => address)}
+    assert_raise(ArgumentError) do
+      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+    end
   end
 
   def test_recurring_requires_description
     @recurring_required_fields.delete(:description)
-    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields))
+      end
+    end
   end
 
   def test_recurring_requires_start_date
     @recurring_required_fields.delete(:start_date)
-    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields))
+      end
+    end
   end
 
   def test_recurring_requires_frequency
     @recurring_required_fields.delete(:frequency)
-    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields))
+      end
+    end
   end
 
   def test_recurring_requires_period
     @recurring_required_fields.delete(:period)
-    assert_raise(ArgumentError){ @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields)) }
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.recurring(@amount, @credit_card, @options.merge(@recurring_required_fields))
+      end
+    end
   end
 
   def test_update_recurring_requires_profile_id
-    assert_raise(ArgumentError){ @gateway.update_recurring(:amount => 100)}
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.update_recurring(:amount => 100)
+      end
+    end
   end
 
   def test_cancel_recurring_requires_profile_id
-    assert_raise(ArgumentError){ @gateway.cancel_recurring(nil, :note => 'Note')}
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.cancel_recurring(nil, :note => 'Note')
+      end
+    end
   end
 
   def test_status_recurring_requires_profile_id
-    assert_raise(ArgumentError){ @gateway.status_recurring(nil, :note => 'Note')}
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.status_recurring(nil)
+      end
+    end
   end
 
   def test_suspend_recurring_requires_profile_id
-    assert_raise(ArgumentError){ @gateway.suspend_recurring(nil, :note => 'Note')}
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.suspend_recurring(nil, :note => 'Note')
+      end
+    end
   end
 
   def test_reactivate_recurring_requires_profile_id
-    assert_raise(ArgumentError){ @gateway.reactivate_recurring(nil, :note => 'Note')}
+    assert_raise(ArgumentError) do
+      assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+        @gateway.reactivate_recurring(nil, :note => 'Note')
+      end
+    end
   end
 
   def test_successful_purchase_with_auth_signature
@@ -306,7 +344,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_successful_create_profile
     @gateway.expects(:ssl_post).returns(successful_create_profile_paypal_response)
-    response = @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    end
     assert_instance_of Response, response
     assert response.success?
     assert response.test?
@@ -316,7 +356,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_failed_create_profile
     @gateway.expects(:ssl_post).returns(failed_create_profile_paypal_response)
-    response = @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, :description => "some description", :start_date => Time.now, :frequency => 12, :period => 'Month')
+    end
     assert_instance_of Response, response
     assert !response.success?
     assert response.test?
@@ -327,42 +369,56 @@ class PaypalTest < Test::Unit::TestCase
   def test_update_recurring_delegation
     @gateway.expects(:build_change_profile_request).with('I-G7A2FF8V75JY', :amount => 200)
     @gateway.stubs(:commit)
-    @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+    end
   end
 
   def test_update_recurring_response
     @gateway.expects(:ssl_post).returns(successful_update_recurring_payment_profile_response)
-    response = @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+    end
     assert response.success?
   end
 
   def test_cancel_recurring_delegation
     @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Cancel', :note => 'A Note').returns(:cancel_request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :cancel_request)
-    @gateway.cancel_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.cancel_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    end
   end
 
   def test_suspend_recurring_delegation
     @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Suspend', :note => 'A Note').returns(:request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
-    @gateway.suspend_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.suspend_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    end
   end
 
   def test_reactivate_recurring_delegation
     @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Reactivate', :note => 'A Note').returns(:request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
-    @gateway.reactivate_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.reactivate_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+    end
   end
 
   def test_status_recurring_delegation
     @gateway.expects(:build_get_profile_details_request).with('I-G7A2FF8V75JY').returns(:request)
     @gateway.expects(:commit).with('GetRecurringPaymentsProfileDetails', :request)
-    @gateway.status_recurring('I-G7A2FF8V75JY')
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.status_recurring('I-G7A2FF8V75JY')
+    end
   end
 
   def test_status_recurring_response
     @gateway.expects(:ssl_post).returns(succesful_get_recurring_payments_profile_response)
-    response = @gateway.status_recurring('I-M1L3RX91DPDD')
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.status_recurring('I-M1L3RX91DPDD')
+    end
     assert response.success?
     assert_equal 'I-M1L3RX91DPDD', response.params['profile_id']
   end
@@ -370,12 +426,16 @@ class PaypalTest < Test::Unit::TestCase
   def test_bill_outstanding_amoung_delegation
     @gateway.expects(:build_bill_outstanding_amount).with('I-G7A2FF8V75JY', :amount => 400).returns(:request)
     @gateway.expects(:commit).with('BillOutstandingAmount', :request)
-    @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+    assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+    end
   end
 
   def test_bill_outstanding_amoung_response
     @gateway.expects(:ssl_post).returns(successful_bill_outstanding_amount)
-    response = @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+    end
     assert response.success?
   end
 

--- a/test/unit/gateways/vindicia_test.rb
+++ b/test/unit/gateways/vindicia_test.rb
@@ -87,7 +87,9 @@ class VindiciaTest < Test::Unit::TestCase
                                                  successful_capture_response,
                                                  successful_update_response)
 
-    assert response = @gateway.recurring(@amount, @credit_card, @options.merge(:product_sku => "TEST_SKU"))
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, @options.merge(:product_sku => "TEST_SKU"))
+    end
     assert_instance_of Response, response
     assert_success response
 
@@ -101,7 +103,9 @@ class VindiciaTest < Test::Unit::TestCase
                                                  unsuccessful_update_response,
                                                  successful_void_response)
 
-    assert response = @gateway.recurring(@amount, @credit_card, @options.merge(:product_sku => "TEST_SKU"))
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(@amount, @credit_card, @options.merge(:product_sku => "TEST_SKU"))
+    end
     assert_failure response
     assert response.test?
   end


### PR DESCRIPTION
There is too much variance between the recurring functionality provided by gateways for ActiveMerchant to do a good job of abstracting it. Thus this deprecates all such functionality with the intention of stripping it out completely at some future point.

Note that this does _not_ refer to tokenization support, but rather the ability to set up and manage the ability some gateways support to automatically charge a card on a recurring basis.

@bslobodin @odorcicd @jduff do you concur?
