### PR TITLE
Remove extraneous Klarna test

### DIFF
--- a/test/unit/integrations/klarna_module_test.rb
+++ b/test/unit/integrations/klarna_module_test.rb
@@ -8,31 +8,6 @@ class KlarnaModuleTest < Test::Unit::TestCase
     Klarna.notification('post_body', authorization_header: 'auth header')
   end
 
-  def test_sign
-    fields = {
-      'purchase_country' => 'SE',
-      'purchase_currency' => 'SEK',
-      'locale' => 'sv-se',
-      'merchant_id' => '1860',
-
-      'merchant_terms_uri' => 'http://some-webstore.se?URI=tc',
-      'merchant_checkout_uri' => 'http://some-webstore.se?URI=checkout',
-      'merchant_base_uri' => 'http://some-webstore.se?URI=home',
-      'merchant_confirmation_uri' => 'http://some-webstore.se?URI=confirmation'
-    }
-
-    cart_items = [{:type => 'physical',
-                   :reference => '12345',
-                   :quantity => '1',
-                   :unit_price => '10000',
-                   :discount_rate => '1000'}]
-
-    shared_secret = 'example-shared-secret'
-
-    calculated_digest = "eEvBSNj7drZoBk6JX83ioAkpLSsYmHSDZWH2jkHvY+g="
-    assert_equal calculated_digest, Klarna.sign(fields, cart_items, shared_secret)
-  end
-
   def test_sign_without_discount_rate
     fields = {
       'purchase_country' => 'SE',


### PR DESCRIPTION
@ntalbott @bslobodin I did a bad and left this extra test in there.

They’re essentially equivalent, so I don’t think we need to worry about code being in production going untested, but it’d be good to remove the double-test sooner than later.
