### PR TITLE
QuickPay API documentation specifies amount and currency as required

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -136,11 +136,12 @@ module ActiveMerchant #:nodoc:
 
           :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
-          :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                           expirationdate cvd acquirer cardtypelock description testmode
-                           fraud_remote_addr fraud_http_accept fraud_http_accept_language
-                           fraud_http_accept_encoding fraud_http_accept_charset
-                           fraud_http_referer fraud_http_user_agent apikey),
+          :subscribe => %w(protocol msgtype merchant ordernumber amount currency
+                           cardnumber expirationdate cvd acquirer cardtypelock
+                           description testmode fraud_remote_addr fraud_http_accept
+                           fraud_http_accept_language fraud_http_accept_encoding
+                           fraud_http_accept_charset fraud_http_referer
+                           fraud_http_user_agent apikey),
 
           :recurring => %w(protocol msgtype merchant ordernumber amount currency
                            autocapture transaction apikey),
@@ -226,6 +227,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_creditcard(post, creditcard, options)
+        add_amount(post, 100, {:currency => 'DKK'})
         add_invoice(post, options)
         add_description(post, options)
         add_fraud_parameters(post, options)


### PR DESCRIPTION
As indicated in the subject, the fields amount and currency are required when storing cards. The fields have no technical importance and it is acceptable to hardcode them in the request.

This will make store() work.
