### PR TITLE
Альфа-Банк gateway support

### DIFF
--- a/lib/active_merchant/billing/gateways/alfabank.rb
+++ b/lib/active_merchant/billing/gateways/alfabank.rb
@@ -1,0 +1,117 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class AlfabankGateway < Gateway
+
+      self.display_name        = 'Alfabank'
+      self.homepage_url        = 'http://www.alfabank.ru'
+      self.live_url            = 'https://engine.paymentgate.ru/payment/rest'
+      self.money_format        = :cents
+      self.ssl_strict          = false
+      self.supported_cardtypes = [:visa, :master]
+      self.supported_countries = ['RU']
+      self.test_url            = 'https://test.paymentgate.ru/testpayment/rest'
+
+      STATUSES_HASH = {
+          '0' => 'Order registered but not paid',
+          '1' => 'Waits when order will be completed',
+          '2' => 'Run the full authorization amount of the order',
+          '3' => 'Authorization revoked',
+          '4' => 'The transaction had an operation return',
+          '5' => 'Initiated ACS authorization through the issuing bank',
+          '6' => 'Authorization rejected'
+      }
+
+      # Creates a new AlfabankGateway
+      #
+      # The gateway requires that valid credentials be passed in the +options+
+      # hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:account</tt> -- The Alfabank API account (REQUIRED)
+      # * <tt>:secret</tt> -- The Alfabank API secret (REQUIRED)
+      def initialize(options = {})
+        requires!(options, :account, :secret)
+        super
+      end
+
+      def make_order(options = {})
+        post = {}
+        add_order_number(post, options)
+        add_return_url(post, options)
+        add_amount(post, options)
+        add_description(post, options)
+
+        commit('register', options[:amount], post)
+      end
+
+      def get_order_status(options = {})
+        post = {}
+        add_order_number(post, options)
+        add_order_id(post, options)
+
+        commit('getOrderStatusExtended', nil, post)
+      end
+
+      private
+
+      def add_order_number(post, options)
+        post[:orderNumber] = options[:order_number]
+      end
+
+      def add_order_id(post, options)
+        post[:orderId] = options[:order_id]
+      end
+
+      def add_return_url(post, options)
+        post[:returnUrl] = options[:return_url]
+      end
+
+      def add_amount(post, options)
+        post[:amount] = amount(options[:amount])
+      end
+
+      def add_description(post, options)
+        post[:description] = options[:description]
+      end
+
+      def commit(action, money, parameters)
+        base_url = (test? ? self.test_url : self.live_url)
+        response = parse(ssl_post("#{base_url}/#{action}.do", post_data(action, parameters)))
+
+        success = !has_error?(response)
+        message = raw_message(response) || parse_status(response) || response['orderId']
+        params  = convert_hash(response)
+
+        Response.new(success, message, params)
+      end
+
+      def post_data(action, parameters = {})
+        parameters.merge!({
+                              :userName => @options[:account],
+                              :password => @options[:secret]
+                          }).to_query
+      end
+
+      def parse(response)
+        ActiveSupport::JSON.decode(response)
+      end
+
+      def has_error?(response)
+        response.blank? || !response['errorCode'].to_i.zero?
+      end
+
+      def raw_message(response)
+        response['errorMessage']
+      end
+
+      def convert_hash(hash)
+        Hash[hash.map { |key, value| [key.underscore, value] }]
+      end
+
+      def parse_status(response)
+        STATUSES_HASH[response['orderStatus'].to_s]
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -11,6 +11,10 @@
 # Paste any required PEM certificates after the pem key.
 #
 
+alfabank:
+  account: account
+  secret: secret
+
 app55:
   api_key: "QDtACYMCFqtuKOQ22QtCkGR1TzD7XM8i"
   api_secret: "yT1FRpuusBIQoEBIfIQ8bPStkl7yzdTz"

--- a/test/remote/gateways/remote_alfabank_test.rb
+++ b/test/remote/gateways/remote_alfabank_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class RemoteAlfabankTest < Test::Unit::TestCase
+
+  def setup
+    @gateway = AlfabankGateway.new(fixtures(:alfabank))
+    @amount = 12
+    @description = 'remote activemerchant test'
+    @return_url = 'http://activemerchant.org'
+  end
+
+  def test_successful_make_order
+    assert response = @gateway.make_order(:order_number => Time.now.to_i,
+                                          :amount => @amount,
+                                          :description => @description,
+                                          :return_url => @return_url)
+    assert_success response
+    order_id = response.params['order_id']
+    assert_not_nil order_id
+    assert response.params['form_url'] =~ /https:\/\/test.paymentgate.ru\/testpayment\/merchants\/[A-Za-z0-9]+\/payment_ru.html\?mdOrder=#{order_id}/
+
+    # Verify by order id
+    assert response = @gateway.get_order_status(:order_id => order_id)
+    assert_valid_response response
+
+    # Verify by order number
+    assert response = @gateway.get_order_status(:order_number => response.params['order_number'])
+    assert_valid_response response
+  end
+
+  def test_unsuccessful_make_same_order_twice
+    order_number = Time.now.to_i
+
+    assert_success @gateway.make_order(:order_number => order_number,
+                                       :amount => @amount,
+                                       :description => @description,
+                                       :return_url => @return_url)
+    assert_failure @gateway.make_order(:order_number => order_number,
+                                       :amount => @amount,
+                                       :description => @description,
+                                       :return_url => @return_url)
+  end
+
+  private
+
+  def assert_valid_response(response)
+    assert_not_nil response.params['order_number']
+    assert_equal @amount, response.params['amount']
+    assert_equal '810', response.params['currency']
+    assert_equal @description, response.params['order_description']
+  end
+end

--- a/test/unit/gateways/alfabank_test.rb
+++ b/test/unit/gateways/alfabank_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class AlfabankTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = AlfabankGateway.new(:account => 'account', :secret => 'secret')
+
+    @amount = 12
+    @description = 'activemerchant test'
+    @return_url = 'http://activemerchant.org'
+  end
+
+  def test_successful_make_order
+    @gateway.expects(:ssl_request).returns(successful_make_order)
+
+    assert response = @gateway.make_order(:amount => 100, :order_number => 87654321, :return_url => 'finish.html')
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_not_nil response.params['form_url']
+  end
+
+  def test_successful_order_status_extended
+    @gateway.expects(:ssl_request).returns(successful_order_status_extended)
+
+    assert response = @gateway.get_order_status(:order_id => '285b2973-4d02-4980-a54e-57c4d0d2xxx9')
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal 100, response.params['amount']
+    assert_equal '810', response.params['currency']
+    assert_equal '1212x31334z15', response.params['order_number']
+  end
+
+  private
+
+  def successful_make_order
+    <<-RESPONSE
+{
+  "orderId": "61351fbd-ac25-484f-b930-4d0ce4101ab7",
+  "formUrl": "https:\/\/test.paymentgate.ru\/testpayment\/merchants\/test\/payment_ru.html?mdOrder=61351fbd-ac25-484f-b930-4d0ce4101ab7"
+}
+    RESPONSE
+  end
+
+  def successful_order_status_extended
+    <<-RESPONSE
+{
+  "attributes": [
+
+  ],
+  "date": 1342007119386,
+  "currency": "810",
+  "amount": 100,
+  "actionCode": 0,
+  "orderNumber": "1212x31334z15",
+  "orderDescription": "test",
+  "orderStatus": 2,
+  "ip": "217.12.97.50",
+  "actionCodeDescription": "\u041f\u043b\u0430\u0442\u0435\u0436 \u0443\u0441\u043f\u0435\u0448\u043d\u043e \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u043d",
+  "merchantOrderParams": [
+
+  ],
+  "cardAuthInfo": {
+    "expiration": "201512",
+    "pan": "411111**1111",
+    "approvalCode": "123456",
+    "cardholderName": "dsd qdqd",
+    "secureAuthInfo": {
+      "eci": 5,
+      "threeDSInfo": {
+        "cavv": "AAABCpEAUBNCAHEgBQAAAAAAAAA=",
+        "xid": "MDAwMDAwMDEzNDIwMDcxMTk3Njc="
+      }
+    }
+  }
+}
+    RESPONSE
+  end
+end


### PR DESCRIPTION
Support for the Альфа-Банк payment gateway (http://alfabank.ru/).

Integration testing was performed with the Kill Bill Альфа-Банк plugin (https://github.com/killbill/killbill-alfabank-plugin).

See original pull request https://github.com/Shopify/active_merchant/pull/1163.
