### PR TITLE
Альфа-Банк integration support

### DIFF
--- a/lib/active_merchant/billing/integrations/alfabank.rb
+++ b/lib/active_merchant/billing/integrations/alfabank.rb
@@ -1,0 +1,14 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Alfabank
+        autoload :Notification, File.dirname(__FILE__) + '/alfabank/notification.rb'
+        autoload :Return, File.dirname(__FILE__) + '/alfabank/return.rb'
+
+        def self.return(query_string, options = {})
+          Return.new(query_string, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/alfabank/notification.rb
+++ b/lib/active_merchant/billing/integrations/alfabank/notification.rb
@@ -1,0 +1,16 @@
+require 'net/http'
+require 'digest/sha1'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Alfabank
+        class Notification < ActiveMerchant::Billing::Integrations::Notification
+          def self.recognizes?(params)
+            params.has_key?('orderId')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/integrations/alfabank/return.rb
+++ b/lib/active_merchant/billing/integrations/alfabank/return.rb
@@ -1,0 +1,87 @@
+# -- encoding : utf-8 --
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module Integrations #:nodoc:
+      module Alfabank
+        class Return < ActiveMerchant::Billing::Integrations::Return
+          def initialize(prms, options = {})
+            super(prms)
+            gateway = AlfabankGateway.new options
+            @order  = prms['orderNumber'] ? gateway.get_order_status(:order_number => prms['orderNumber']) : gateway.get_order_status(:order_id => prms['orderId'])
+          end
+
+          def item_id
+            params['order_number']
+          end
+
+          def contains_invoice_info?
+            true
+          end
+
+          def success?
+            @order.success?
+          end
+
+          def paid?
+            status == :paid
+          end
+
+          def authorization?
+            status == :authorization
+          end
+
+          def canceled?
+            status == :canceled
+          end
+
+          def wait?
+            status == :wait
+          end
+
+          def transaction_id
+            params['attributes'].first['value']
+          end
+
+          def params
+            @order.params
+          end
+
+          def currency
+            'RUR'
+          end
+
+          def amount
+            params['amount'].to_i / 100.0
+          end
+
+          def status
+            return nil unless success?
+
+            status = @order.params['order_status']
+            case status.to_i
+              when 0, 1, 5
+                :pending
+              when 2
+                :paid
+              when 3, 4, 6
+                :canceled
+            end
+          end
+
+          def gateway_response
+            @order.try(:params)
+          end
+
+          def status_message
+            if success?
+              AlfabankGateway::STATUSES_HASH(@order.params['order_status'])
+            else
+              "Ошибка при оплате"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support for the Альфа-Банк payment gateway (http://alfabank.ru/).

Integration testing was performed with the Kill Bill Альфа-Банк plugin (https://github.com/killbill/killbill-alfabank-plugin).

See original pull request #1163.
