### PR TITLE
Authorize.NET Gateway Is Not Sending Customer Emails

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -262,7 +262,9 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         if options.has_key? :email
           post[:email] = options[:email]
-          post[:email_customer] = false
+          if options.has_key? :email_customer
+            post[:email_customer] = options[:email_customer]
+          end
         end
 
         if options.has_key? :customer


### PR DESCRIPTION
The email_customer attribute in the post was getting hard-coded to false.  We added an option to allow control of the email_customer variable.
