### PR TITLE
Remove billing fields from Universal Offsite

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Balanced: Voiding a capture is not allowed [duff]
 * Add HPS gateway (Heartland Payment Systems) [SecureSubmit]
 * Balanced: Fix handling of 500 errors [ntalbott]
+* Universal: Remove all billing address fields [bslobodin]
 
 == Version 1.43.1 (May 1, 2014)
 

--- a/lib/active_merchant/billing/integrations/universal/helper.rb
+++ b/lib/active_merchant/billing/integrations/universal/helper.rb
@@ -46,15 +46,6 @@ module ActiveMerchant #:nodoc:
                              :email      => 'x_customer_email',
                              :phone      => 'x_customer_phone'
 
-          mapping :billing_address, :city =>     'x_customer_billing_city',
-                                    :company =>  'x_customer_billing_company',
-                                    :address1 => 'x_customer_billing_address1',
-                                    :address2 => 'x_customer_billing_address2',
-                                    :state =>    'x_customer_billing_state',
-                                    :zip =>      'x_customer_billing_zip',
-                                    :country =>  'x_customer_billing_country',
-                                    :phone =>    'x_customer_billing_phone'
-
           mapping :shipping_address, :first_name => 'x_customer_shipping_first_name',
                                      :last_name =>  'x_customer_shipping_last_name',
                                      :city =>       'x_customer_shipping_city',

--- a/test/unit/integrations/helpers/universal_helper_test.rb
+++ b/test/unit/integrations/helpers/universal_helper_test.rb
@@ -61,26 +61,6 @@ class UniversalHelperTest < Test::Unit::TestCase
     assert_field 'x_customer_phone',      '(613) 456-7890'
   end
 
-  def test_billing_address_fields
-    @helper.billing_address :city =>     'Ottawa',
-                            :company =>  'Shopify Ottawa',
-                            :address1 => '126 York St',
-                            :address2 => '2nd floor',
-                            :state =>    'ON',
-                            :zip =>      'K1N 5T5',
-                            :country =>  'CA',
-                            :phone =>    '(613) 987-6543'
-
-    assert_field 'x_customer_billing_city',     'Ottawa'
-    assert_field 'x_customer_billing_company',  'Shopify Ottawa'
-    assert_field 'x_customer_billing_address1', '126 York St'
-    assert_field 'x_customer_billing_address2', '2nd floor'
-    assert_field 'x_customer_billing_state',    'ON'
-    assert_field 'x_customer_billing_zip',      'K1N 5T5'
-    assert_field 'x_customer_billing_country',  'CA'
-    assert_field 'x_customer_billing_phone',    '(613) 987-6543'
-  end
-
   def test_shipping_address_fields
     @helper.shipping_address :first_name => 'John',
                              :last_name  => 'Doe',


### PR DESCRIPTION
@edward we are no longer planning on collecting billing details in the first place, so no need to encourage integrators to expect them /cc @Shopify/payments.
