### PR TITLE
Moneris: Use the name on the card

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -45,10 +45,9 @@ module ActiveMerchant #:nodoc:
       def authorize(money, creditcard_or_datakey, options = {})
         requires!(options, :order_id)
         post = {}
-        add_payment_source(post, creditcard_or_datakey)
+        add_payment_source(post, creditcard_or_datakey, options)
         post[:amount]     = amount(money)
         post[:order_id]   = options[:order_id]
-        post[:cust_id]    = options[:customer]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         action = (post[:data_key].blank?) ? 'preauth' : 'res_preauth_cc'
         commit(action, post)
@@ -61,10 +60,9 @@ module ActiveMerchant #:nodoc:
       def purchase(money, creditcard_or_datakey, options = {})
         requires!(options, :order_id)
         post = {}
-        add_payment_source(post, creditcard_or_datakey)
+        add_payment_source(post, creditcard_or_datakey, options)
         post[:amount]     = amount(money)
         post[:order_id]   = options[:order_id]
-        post[:cust_id]    = options[:customer]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         action = (post[:data_key].blank?) ? 'purchase' : 'res_purchase_cc'
         commit(action, post)
@@ -148,13 +146,15 @@ module ActiveMerchant #:nodoc:
         sprintf("%.4i", creditcard.year)[-2..-1] + sprintf("%.2i", creditcard.month)
       end
 
-      def add_payment_source(post, source)
+      def add_payment_source(post, source, options)
         if source.is_a?(String)
           post[:data_key]   = source
+          post[:cust_id]    = options[:customer]
         else
           post[:pan]        = source.number
           post[:expdate]    = expdate(source)
           post[:cvd_value]  = source.verification_value if source.verification_value?
+          post[:cust_id]    = options[:customer] || source.name
         end
       end
 

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -211,6 +211,22 @@ class MonerisTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_customer_can_be_specified
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_id: "3", customer: "Joe Jones")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{cust_id>Joe Jones}, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_customer_not_specified_card_name_used
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_id: "3")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{cust_id>Longbob Longsen}, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Now if options[:customer] is not specified, we use the name on the
credit card so it'll show up in the Moneris UI.
