### PR TITLE
Immediately convert date fields to integers

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -2,7 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # Convenience methods that can be included into a custom Credit Card object, such as an ActiveRecord based Credit Card object.
     module CreditCardMethods
-      CARD_COMPANIES = { 
+      CARD_COMPANIES = {
         'visa'               => /^4\d{12}(\d{3})?$/,
         'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
         'discover'           => /^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/,
@@ -16,69 +16,69 @@ module ActiveMerchant #:nodoc:
         'forbrugsforeningen' => /^600722\d{10}$/,
         'laser'              => /^(6304|6706|6709|6771(?!89))\d{8}(\d{4}|\d{6,7})?$/
       }
-    
+
       def self.included(base)
         base.extend(ClassMethods)
       end
-      
+
       def valid_month?(month)
         (1..12).include?(month.to_i)
       end
-      
+
       def valid_expiry_year?(year)
         (Time.now.year..Time.now.year + 20).include?(year.to_i)
       end
-      
+
       def valid_start_year?(year)
-        year.to_s =~ /^\d{4}$/ && year.to_i > 1987
+        ((year.to_s =~ /^\d{4}$/) && (year.to_i > 1987))
       end
-      
+
       def valid_issue_number?(number)
-        number.to_s =~ /^\d{1,2}$/
+        (number.to_s =~ /^\d{1,2}$/)
       end
-      
+
       module ClassMethods
-        # Returns true if it validates. Optionally, you can pass a card brand as an argument and 
+        # Returns true if it validates. Optionally, you can pass a card brand as an argument and
         # make sure it is of the correct brand.
         #
         # References:
         # - http://perl.about.com/compute/perl/library/nosearch/P073000.htm
         # - http://www.beachnet.com/~hstiles/cardtype.html
         def valid_number?(number)
-          valid_test_mode_card_number?(number) || 
-            valid_card_number_length?(number) && 
+          valid_test_mode_card_number?(number) ||
+            valid_card_number_length?(number) &&
             valid_checksum?(number)
         end
-        
+
         # Regular expressions for the known card companies.
-        # 
-        # References: 
-        # - http://en.wikipedia.org/wiki/Credit_card_number 
-        # - http://www.barclaycardbusiness.co.uk/information_zone/processing/bin_rules.html 
+        #
+        # References:
+        # - http://en.wikipedia.org/wiki/Credit_card_number
+        # - http://www.barclaycardbusiness.co.uk/information_zone/processing/bin_rules.html
         def card_companies
           CARD_COMPANIES
         end
-        
+
         # Returns a string containing the brand of card from the list of known information below.
         # Need to check the cards in a particular order, as there is some overlap of the allowable ranges
         #--
-        # TODO Refactor this method. We basically need to tighten up the Maestro Regexp. 
-        # 
-        # Right now the Maestro regexp overlaps with the MasterCard regexp (IIRC). If we can tighten 
-        # things up, we can boil this whole thing down to something like... 
-        # 
+        # TODO Refactor this method. We basically need to tighten up the Maestro Regexp.
+        #
+        # Right now the Maestro regexp overlaps with the MasterCard regexp (IIRC). If we can tighten
+        # things up, we can boil this whole thing down to something like...
+        #
         #   def brand?(number)
         #     return 'visa' if valid_test_mode_card_number?(number)
         #     card_companies.find([nil]) { |brand, regexp| number =~ regexp }.first.dup
         #   end
-        # 
+        #
         def brand?(number)
           return 'bogus' if valid_test_mode_card_number?(number)
 
           card_companies.reject { |c,p| c == 'maestro' }.each do |company, pattern|
-            return company.dup if number =~ pattern 
+            return company.dup if number =~ pattern
           end
-          
+
           return 'maestro' if number =~ card_companies['maestro']
 
           return nil
@@ -88,19 +88,19 @@ module ActiveMerchant #:nodoc:
           deprecated "CreditCard#type? is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand? instead."
           brand?(number)
         end
-        
+
         def first_digits(number)
-          number.to_s.slice(0,6) 
+          number.to_s.slice(0,6)
         end
-        
-        def last_digits(number)     
-          number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1) 
+
+        def last_digits(number)
+          number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
         end
-        
+
         def mask(number)
           "XXXX-XXXX-XXXX-#{last_digits(number)}"
         end
-        
+
         # Checks to see if the calculated brand matches the specified brand
         def matching_brand?(number, brand)
           brand?(number) == brand
@@ -114,18 +114,18 @@ module ActiveMerchant #:nodoc:
         def deprecated(message)
           warn(Kernel.caller[1] + message)
         end
-        
+
         private
-        
+
         def valid_card_number_length?(number) #:nodoc:
           number.to_s.length >= 12
         end
-        
+
         def valid_test_mode_card_number?(number) #:nodoc:
-          ActiveMerchant::Billing::Base.test? && 
+          ActiveMerchant::Billing::Base.test? &&
             %w[1 2 3 success failure error].include?(number.to_s)
         end
-        
+
         # Checks the validity of a card number by use of the Luhn Algorithm.
         # Please see http://en.wikipedia.org/wiki/Luhn_algorithm for details.
         def valid_checksum?(number) #:nodoc:
@@ -134,7 +134,7 @@ module ActiveMerchant #:nodoc:
             weight = number[-1 * (i + 2), 1].to_i * (2 - (i % 2))
             sum += (weight < 10) ? weight : weight - 9
           end
-          
+
           (number[-1,1].to_i == (10 - sum % 10) % 10)
         end
       end

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -235,8 +235,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def expdate(creditcard)
-        year  = sprintf("%.04i", creditcard.year.to_i)
-        month = sprintf("%.02i", creditcard.month.to_i)
+        year  = sprintf("%.04i", creditcard.year)
+        month = sprintf("%.02i", creditcard.month)
 
         "#{month}#{year[-2..-1]}"
       end

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class CreditCardMethodsTest < Test::Unit::TestCase
   include ActiveMerchant::Billing::CreditCardMethods
-  
+
   class CreditCard
-    include ActiveMerchant::Billing::CreditCardMethods 
+    include ActiveMerchant::Billing::CreditCardMethods
   end
-  
+
   def maestro_card_numbers
     %w[
       5000000000000000 5099999999999999 5600000000000000
@@ -14,27 +14,27 @@ class CreditCardMethodsTest < Test::Unit::TestCase
       6761999999999999 6763000000000000 5038999999999999
     ]
   end
-  
+
   def non_maestro_card_numbers
     %w[
-      4999999999999999 5100000000000000 5599999999999999 
+      4999999999999999 5100000000000000 5599999999999999
       5900000000000000 5999999999999999 7000000000000000
     ]
   end
-  
+
   def test_should_be_able_to_identify_valid_expiry_months
     assert_false valid_month?(-1)
     assert_false valid_month?(13)
     assert_false valid_month?(nil)
     assert_false valid_month?('')
-    
+
     1.upto(12) { |m| assert valid_month?(m) }
   end
 
   def test_should_be_able_to_identify_valid_expiry_years
     assert_false valid_expiry_year?(-1)
     assert_false valid_expiry_year?(Time.now.year + 21)
-    
+
     0.upto(20) { |n| assert valid_expiry_year?(Time.now.year + n) }
   end
 
@@ -42,29 +42,29 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert valid_start_year?(1988)
     assert valid_start_year?(2007)
     assert valid_start_year?(3000)
-    
+
     assert_false valid_start_year?(1987)
   end
-  
+
   def test_valid_start_year_can_handle_strings
     assert valid_start_year?("2009")
   end
-  
+
   def test_valid_month_can_handle_strings
     assert valid_month?("1")
   end
-  
+
   def test_valid_expiry_year_can_handle_strings
     year = Time.now.year + 1
     assert valid_expiry_year?(year.to_s)
   end
-  
+
   def test_should_be_able_to_identify_valid_issue_numbers
     assert valid_issue_number?(1)
     assert valid_issue_number?(10)
     assert valid_issue_number?('12')
     assert valid_issue_number?(0)
-    
+
     assert_false valid_issue_number?(-1)
     assert_false valid_issue_number?(123)
     assert_false valid_issue_number?('CAT')
@@ -73,120 +73,120 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_should_ensure_brand_from_credit_card_class_is_not_frozen
     assert_false CreditCard.brand?('4242424242424242').frozen?
   end
-  
+
   def test_should_be_dankort_card_brand
     assert_equal 'dankort', CreditCard.brand?('5019717010103742')
   end
-  
+
   def test_should_detect_visa_dankort_as_visa
     assert_equal 'visa', CreditCard.brand?('4571100000000000')
   end
-  
+
   def test_should_detect_electron_dk_as_visa
     assert_equal 'visa', CreditCard.brand?('4175001000000000')
   end
-  
+
   def test_should_detect_diners_club
     assert_equal 'diners_club', CreditCard.brand?('36148010000000')
   end
-  
+
   def test_should_detect_diners_club_dk
     assert_equal 'diners_club', CreditCard.brand?('30401000000000')
   end
-  
+
   def test_should_detect_maestro_dk_as_maestro
     assert_equal 'maestro', CreditCard.brand?('6769271000000000')
   end
-  
+
   def test_should_detect_maestro_cards
     assert_equal 'maestro', CreditCard.brand?('5020100000000000')
-    
+
     maestro_card_numbers.each { |number| assert_equal 'maestro', CreditCard.brand?(number) }
     non_maestro_card_numbers.each { |number| assert_not_equal 'maestro', CreditCard.brand?(number) }
   end
-  
+
   def test_should_detect_mastercard
     assert_equal 'master', CreditCard.brand?('6771890000000000')
     assert_equal 'master', CreditCard.brand?('5413031000000000')
   end
-  
+
   def test_should_detect_forbrugsforeningen
     assert_equal 'forbrugsforeningen', CreditCard.brand?('6007221000000000')
   end
-  
+
   def test_should_detect_laser_card
     # 16 digits
     assert_equal 'laser', CreditCard.brand?('6304985028090561')
-    
+
     # 18 digits
     assert_equal 'laser', CreditCard.brand?('630498502809056151')
-    
+
     # 19 digits
     assert_equal 'laser', CreditCard.brand?('6304985028090561515')
-    
+
     # 17 digits
     assert_not_equal 'laser', CreditCard.brand?('63049850280905615')
-    
+
     # 15 digits
     assert_not_equal 'laser', CreditCard.brand?('630498502809056')
-    
+
     # Alternate format
     assert_equal 'laser', CreditCard.brand?('6706950000000000000')
-    
+
     # Alternate format (16 digits)
     assert_equal 'laser', CreditCard.brand?('6706123456789012')
 
     # New format (16 digits)
     assert_equal 'laser', CreditCard.brand?('6709123456789012')
-    
+
     # Ulster bank (Ireland) with 12 digits
     assert_equal 'laser', CreditCard.brand?('677117111234')
   end
-  
+
   def test_should_detect_when_an_argument_brand_does_not_match_calculated_brand
     assert CreditCard.matching_brand?('4175001000000000', 'visa')
     assert_false CreditCard.matching_brand?('4175001000000000', 'master')
   end
-  
+
   def test_detecting_full_range_of_maestro_card_numbers
     maestro = '50000000000'
-    
+
     assert_equal 11, maestro.length
     assert_not_equal 'maestro', CreditCard.brand?(maestro)
-    
+
     while maestro.length < 19
       maestro << '0'
       assert_equal 'maestro', CreditCard.brand?(maestro)
     end
-    
+
     assert_equal 19, maestro.length
-    
+
     maestro << '0'
     assert_not_equal 'maestro', CreditCard.brand?(maestro)
   end
-  
+
   def test_matching_discover_card
     assert_equal 'discover', CreditCard.brand?('6011000000000000')
     assert_equal 'discover', CreditCard.brand?('6500000000000000')
     assert_equal 'discover', CreditCard.brand?('6221260000000000')
     assert_equal 'discover', CreditCard.brand?('6450000000000000')
-    
+
     assert_not_equal 'discover', CreditCard.brand?('6010000000000000')
     assert_not_equal 'discover', CreditCard.brand?('6600000000000000')
   end
-  
+
   def test_16_digit_maestro_uk
     number = '6759000000000000'
     assert_equal 16, number.length
     assert_equal 'switch', CreditCard.brand?(number)
   end
-  
+
   def test_18_digit_maestro_uk
     number = '675900000000000000'
     assert_equal 18, number.length
     assert_equal 'switch', CreditCard.brand?(number)
   end
-  
+
   def test_19_digit_maestro_uk
     number = '6759000000000000000'
     assert_equal 19, number.length

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -268,12 +268,12 @@ class CreditCardTest < Test::Unit::TestCase
     ccn = CreditCard.new(:number => "1")
     assert_equal "1", ccn.last_digits
   end
-  
+
   def test_should_return_first_four_digits_of_card_number
     ccn = CreditCard.new(:number => "4779139500118580")
     assert_equal "477913", ccn.first_digits
   end
-  
+
   def test_should_return_first_bogus_digit_of_card_number
     ccn = CreditCard.new(:number => "1")
     assert_equal "1", ccn.first_digits
@@ -384,7 +384,7 @@ class CreditCardTest < Test::Unit::TestCase
     assert !card.valid?
     assert_equal "", card.number
   end
-  
+
   def test_brand_is_aliased_as_type
     assert_deprecation_warning("CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead.", CreditCard) do
       assert_equal @visa.type, @visa.brand
@@ -392,5 +392,29 @@ class CreditCardTest < Test::Unit::TestCase
     assert_deprecation_warning("CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead.", CreditCard) do
       assert_equal @solo.type, @solo.brand
     end
+  end
+
+  def test_month_and_year_are_immediately_converted_to_integers
+    card = CreditCard.new
+
+    card.month = "1"
+    assert_equal 1, card.month
+    card.year = "1"
+    assert_equal 1, card.year
+
+    card.month = ""
+    assert_nil card.month
+    card.year = ""
+    assert_nil card.year
+
+    card.month = nil
+    assert_nil card.month
+    card.year = nil
+    assert_nil card.year
+
+    card.start_month = "1"
+    assert_equal 1, card.start_month
+    card.start_year = "1"
+    assert_equal 1, card.start_year
   end
 end


### PR DESCRIPTION
While this was being done before validation previously, if an unvalidated card was passed to a gateway it could end up having to deal with Strings, which would entail type conversion sprinkled all over the place.

This ensures that month, year, start_month, and start_year are all converted when set, so that we can always assume those fields are either an Integer or nil.

See #1214 for the motivation for this change.

While this should be a no-op for most library consumers, @bslobodin it would be great to get a review before I merge.
