### PR TITLE
Add 2Checkout language support

### DIFF
--- a/lib/active_merchant/billing/integrations/two_checkout/helper.rb
+++ b/lib/active_merchant/billing/integrations/two_checkout/helper.rb
@@ -61,6 +61,9 @@ module ActiveMerchant #:nodoc:
           # Allow referral partners to indicate their shopping cart
           mapping :cart_type, '2co_cart_type'
 
+          # Allow sellers to pass in the hosted checkout language
+          mapping :lang, 'lang'
+
           def customer(params = {})
             add_field(mappings[:customer][:email], params[:email])
             add_field(mappings[:customer][:phone], params[:phone])

--- a/test/unit/integrations/helpers/two_checkout_helper_test.rb
+++ b/test/unit/integrations/helpers/two_checkout_helper_test.rb
@@ -24,6 +24,7 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     @helper.notify_url 'https://notify.url/'
     @helper.cart_type 'shopify'
     @helper.purchase_step 'payment-method'
+    @helper.lang 'en'
 
     assert_field 'currency_code', 'ZAR'
     assert_field 'cart_order_id', '123'
@@ -31,6 +32,7 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     assert_field 'x_receipt_link_url', 'https://return.url/'
     assert_field '2co_cart_type', 'shopify'
     assert_field 'purchase_step', 'payment-method'
+    assert_field 'lang', 'en'
   end
 
   def test_customer_fields


### PR DESCRIPTION
2Checkout's hosted checkout supports [multiple languages](http://help.2checkout.com/articles/FAQ/Do-you-offer-any-languages-other-than-English/). This PR would allow the merchant to pass in the language to display to the customer.
