### PR TITLE
Do not set x_test_request to true for Authorize.net CIM transactions. Ever.

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -613,7 +613,6 @@ module ActiveMerchant #:nodoc:
 
       def build_create_customer_profile_transaction_request(xml, options)
         options[:extra_options] ||= {}
-        options[:extra_options].merge!('x_test_request' => 'TRUE') if @options[:test_requests]
 
         add_transaction(xml, options[:transaction])
         tag_unless_blank(xml, 'extraOptions', format_extra_options(options[:extra_options]))


### PR DESCRIPTION
See this comment for more info: https://github.com/Shopify/active_merchant/pull/924#issuecomment-44330931
