### PR TITLE
Verify the length/format of the card verification value

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -320,10 +320,15 @@ module ActiveMerchant #:nodoc:
       def validate_verification_value #:nodoc:
         errors = []
 
-        if CreditCard.requires_verification_value?
-          errors << [:verification_value, "is required"] if !verification_value?
+        if verification_value?
+          unless valid_card_verification_value?(@verification_value, @brand)
+            errors << [:verification_value, "should be #{card_verification_value_length(@brand)} digits"]
+          end
+        else
+          if CreditCard.requires_verification_value?
+            errors << [:verification_value, "is required"]
+          end
         end
-
         errors
       end
 

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -33,6 +33,27 @@ module ActiveMerchant #:nodoc:
         ((year.to_s =~ /^\d{4}$/) && (year.to_i > 1987))
       end
 
+      # Credit card providers have 3 digit verification values
+      # This isn't standardised, these are called various names such as
+      # CVC, CVV, CID, CSC and more
+      # See: http://en.wikipedia.org/wiki/Card_security_code
+      # American Express is the exception with 4 digits
+      #
+      # Below are links from the card providers with their requirements
+      # visa:             http://usa.visa.com/personal/security/3-digit-security-code.jsp
+      # master:           http://www.mastercard.com/ca/merchant/en/getstarted/Anatomy_MasterCard.html
+      # jcb:              http://www.jcbcard.com/security/info.html
+      # diners_club:      http://www.dinersclub.com/assets/DinersClub_card_ID_features.pdf
+      # discover:         https://www.discover.com/credit-cards/help-center/glossary.html
+      # american_express: https://online.americanexpress.com/myca/fuidfyp/us/action?request_type=un_fuid&Face=en_US
+      def valid_card_verification_value?(cvv, brand)
+        cvv.to_s =~ /^\d{#{card_verification_value_length(brand)}}$/
+      end
+      
+      def card_verification_value_length(brand)
+        brand == 'american_express' ? 4 : 3
+      end
+      
       def valid_issue_number?(number)
         (number.to_s =~ /^\d{1,2}$/)
       end

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -59,6 +59,17 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert valid_expiry_year?(year.to_s)
   end
 
+  def test_should_validate_card_verification_value
+    assert valid_card_verification_value?(123, 'visa')
+    assert valid_card_verification_value?('123', 'visa')
+    assert valid_card_verification_value?(1234, 'american_express')
+    assert valid_card_verification_value?('1234', 'american_express')
+    assert_false valid_card_verification_value?(12, 'visa')
+    assert_false valid_card_verification_value?(1234, 'visa')
+    assert_false valid_card_verification_value?(123, 'american_express')
+    assert_false valid_card_verification_value?(12345, 'american_express')
+  end
+  
   def test_should_be_able_to_identify_valid_issue_numbers
     assert valid_issue_number?(1)
     assert valid_issue_number?(10)

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -206,7 +206,18 @@ class CreditCardTest < Test::Unit::TestCase
     card = credit_card('4242424242424242', :verification_value => nil)
     assert_not_valid card
 
+    card.verification_value = '1234'
+    errors = assert_not_valid card
+    assert_equal errors[:verification_value], ['should be 3 digits']
+
     card.verification_value = '123'
+    assert_valid card
+
+    card = credit_card('341111111111111', :verification_value => '123', :brand => 'american_express')
+    errors = assert_not_valid card
+    assert_equal errors[:verification_value], ['should be 4 digits']
+
+    card.verification_value = '1234'
     assert_valid card
   end
 


### PR DESCRIPTION
I've made this PR as customers on our website are getting an error because they are typing their credit card wrong.

I noticed ActiveMerchant doesn't yet validate the card verification value but does validate everything else and it makes sense to validate this field as well, however I do acknowledge it's changing the core of the system (not just adding/tweaking an individual gateway) so I'm open for suggestions.
