### PR TITLE
pag_seguro removing excessive whitespace in customer name

### DIFF
--- a/lib/active_merchant/billing/integrations/pag_seguro/helper.rb
+++ b/lib/active_merchant/billing/integrations/pag_seguro/helper.rb
@@ -45,11 +45,12 @@ module ActiveMerchant #:nodoc:
 
           def customer(params = {})
             phone = area_code_and_number(params[:phone])
+            full_name = remove_excessive_whitespace("#{params[:first_name]} #{params[:last_name]}")
 
             add_field("senderAreaCode", phone[0])
             add_field("senderPhone", phone[1])
             add_field("senderEmail", params[:email])
-            add_field('senderName', "#{params[:first_name]} #{params[:last_name]}")
+            add_field('senderName', full_name)
           end
 
           def fetch_token
@@ -114,6 +115,9 @@ module ActiveMerchant #:nodoc:
             end.join(", ")
           end
 
+          def remove_excessive_whitespace(text)
+            text.gsub(/\s{2,}/, ' ').strip
+          end
         end
       end
     end

--- a/test/unit/integrations/helpers/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/helpers/pag_seguro_helper_test.rb
@@ -151,4 +151,9 @@ class PagSeguroHelperTest < Test::Unit::TestCase
       @helper.fetch_token
     end
   end
+
+  def test_name_white_spaces_should_be_stripped
+    @helper.customer :first_name => '  Cody  Yo ', :last_name => 'Fau  ser     ', :email => 'cody@example.com', phone: "71 98765432"
+    assert_field 'senderName', 'Cody Yo Fau ser'
+  end
 end


### PR DESCRIPTION
@bslobodin @odorcicd 
PagSeguro doesn't like customers name with excessive white spaces. So it fails if we submit "Celso    Dantas" with "invalid value" error. ¬¬
