### PR TITLE
Adding #store and #update support for the Elavon gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -47,7 +47,9 @@ module ActiveMerchant #:nodoc:
         :refund => 'CCRETURN',
         :authorize => 'CCAUTHONLY',
         :capture => 'CCFORCE',
-        :void => 'CCVOID'
+        :void => 'CCVOID',
+        :store => 'CCGETTOKEN',
+        :update => 'CCUPDATETOKEN',
       }
 
       # Initialize the Gateway
@@ -67,11 +69,15 @@ module ActiveMerchant #:nodoc:
       end
 
       # Make a purchase
-      def purchase(money, creditcard, options = {})
+      def purchase(money, creditcard_or_token, options = {})
         form = {}
         add_salestax(form, options)
         add_invoice(form, options)
-        add_creditcard(form, creditcard)
+        if creditcard_or_token.is_a?(String)
+          add_token(form, creditcard_or_token)
+        else
+          add_creditcard(form, creditcard_or_token)
+        end
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
@@ -167,7 +173,29 @@ module ActiveMerchant #:nodoc:
       end
 
 
+      def store(creditcard, options = {})
+        form = {}
+        add_creditcard(form, creditcard)
+        add_address(form, options)
+        add_customer_data(form, options)
+        add_test_mode(form, options)
+        add_verification(form, options)
+        form[:add_token] = 'Y'
+        commit(:store, nil, form)
+      end
+
+      def update(token, creditcard, options = {})
+        form = {}
+        add_token(form, token)
+        add_creditcard(form, creditcard)
+        add_address(form, options)
+        add_customer_data(form, options)
+        add_test_mode(form, options)
+        commit(:update, nil, form)
+      end
+
       private
+
       def add_invoice(form,options)
         form[:invoice_number] = (options[:order_id] || options[:invoice]).to_s.slice(0, 10)
         form[:description] = options[:description].to_s.slice(0, 255)
@@ -195,6 +223,10 @@ module ActiveMerchant #:nodoc:
 
         form[:first_name] = creditcard.first_name.to_s.slice(0, 20)
         form[:last_name] = creditcard.last_name.to_s.slice(0, 30)
+      end
+
+      def add_token(form, token)
+        form[:token] = token
       end
 
       def add_verification_value(form, creditcard)
@@ -237,6 +269,10 @@ module ActiveMerchant #:nodoc:
           form[:ship_to_country]        = shipping_address[:country].to_s.slice(0, 50)
           form[:ship_to_zip]            = shipping_address[:zip].to_s.slice(0, 10)
         end
+      end
+
+      def add_verification(form, options)
+        form[:verify] = 'Y' if options[:verify]
       end
 
       def parse_first_and_last_name(value)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -113,6 +113,39 @@ class ElavonTest < Test::Unit::TestCase
     assert_equal 'P', response.cvv_result['code']
   end
 
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '7595301425001111', response.params["token"]
+    assert response.test?
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+
+    assert response = @gateway.store(@credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+  end
+
+  def test_successful_update
+    @gateway.expects(:ssl_post).returns(successful_update_response)
+    token = '7595301425001111'
+    assert response = @gateway.update(token, @credit_card, @options)
+    assert_success response
+    assert response.test?
+  end
+
+  def test_failed_update
+    @gateway.expects(:ssl_post).returns(failed_update_response)
+    token = '7595301425001111'
+    assert response = @gateway.update(token, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+  end
+
   private
   def successful_purchase_response
     "ssl_card_number=42********4242
@@ -227,6 +260,51 @@ class ElavonTest < Test::Unit::TestCase
   end
 
   def failed_authorization_response
+    "errorCode=5000
+    errorName=Credit Card Number Invalid
+    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+  end
+
+  def successful_store_response
+    "ssl_transaction_type=CCGETTOKEN
+     ssl_result=0
+     ssl_token=7595301425001111
+     ssl_card_number=41**********1111
+     ssl_token_response=SUCCESS
+     ssl_add_token_response=Card Updated
+     vu_aamc_id="
+  end
+
+  def failed_store_response
+    "errorCode=5000
+    errorName=Credit Card Number Invalid
+    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+  end
+
+  def successful_update_response
+    "ssl_token=7595301425001111
+    ssl_card_type=VISA
+    ssl_card_number=************1111
+    ssl_exp_date=1015
+    ssl_company=
+    ssl_customer_id=
+    ssl_first_name=John
+    ssl_last_name=Doe
+    ssl_avs_address=
+    ssl_address2=
+    ssl_avs_zip=
+    ssl_city=
+    ssl_state=
+    ssl_country=
+    ssl_phone=
+    ssl_email=
+    ssl_description=
+    ssl_user_id=webpage
+    ssl_token_response=SUCCESS
+    ssl_result=0"
+  end
+
+  def failed_update_response
     "errorCode=5000
     errorName=Credit Card Number Invalid
     errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."


### PR DESCRIPTION
Elavon now supports tokenization. This adds #store and #update methods to Elavon and modifies #purchase to allow token purchases.

Note: This was cherry picked from https://github.com/chargify/active_merchant/pull/20, which we are running in production at Chargify.
