### PR TITLE
Wirecard gateway: Add card store and purchase/authorize by reference

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -44,8 +44,16 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def authorize(money, creditcard, options = {})
-        options[:credit_card] = creditcard
+      # Authorization - the second parameter may be a CreditCard or
+      # a String which represents a GuWID reference to an earlier
+      # transaction.  If a GuWID is given, rather than a CreditCard,
+      # then then the :recurring option will be forced to "Repeated"
+      def authorize(money, payment_method, options = {})
+        if payment_method.respond_to?(:number)
+          options[:credit_card] = payment_method
+        else
+          options[:preauthorization] = payment_method
+        end
         commit(:preauthorization, money, options)
       end
 
@@ -54,6 +62,10 @@ module ActiveMerchant #:nodoc:
         commit(:capture, money, options)
       end
 
+      # Purchase - the second parameter may be a CreditCard or
+      # a String which represents a GuWID reference to an earlier
+      # transaction.  If a GuWID is given, rather than a CreditCard,
+      # then then the :recurring option will be forced to "Repeated"
       def purchase(money, payment_method, options = {})
         if payment_method.respond_to?(:number)
           options[:credit_card] = payment_method
@@ -73,6 +85,41 @@ module ActiveMerchant #:nodoc:
         commit(:bookback, money, options)
       end
 
+      # Store card - Wirecard supports the notion of "Recurring
+      # Transactions" by allowing the merchant to provide a reference
+      # to an earlier transaction (the GuWID) rather than a credit
+      # card.  A reusable reference (GuWID) can be obtained by sending
+      # a purchase or authorization transaction with the element
+      # "RECURRING_TRANSACTION/Type" set to "Initial".  Subsequent
+      # transactions can then use the GuWID in place of a credit
+      # card by setting "RECURRING_TRANSACTION/Type" to "Repeated".
+      #
+      # This implementation of card store utilizes a Wirecard
+      # "Authorization Check" (a Preauthorization that is automatically
+      # reversed).  It defaults to a check amount of "100" (i.e.
+      # $1.00) but this can be overriden (see below).
+      #
+      # IMPORTANT: In order to reuse the stored reference, the
+      # +authorization+ from the response should be saved by
+      # your application code.
+      #
+      # ==== Options specific to +store+
+      #
+      # * <tt>:amount</tt> -- The amount, in cents, that should be
+      #   "validated" by the Authorization Check.  This amount will
+      #   be reserved and then reversed.  Default is 100.
+      #
+      # Note: This is not the only way to achieve a card store
+      # operation at Wirecard.  Any +purchase+ or +authorize+
+      # can be sent with +options[:recurring] = 'Initial'+ to make
+      # the returned authorization/GuWID usable in later transactions
+      # with +options[:recurring] = 'Repeated'+.
+      def store(creditcard, options = {})
+        options[:credit_card] = creditcard
+        options[:recurring] = 'Initial'
+        money = options.delete(:amount) || 100
+        commit(:authorization_check, money, options)
+      end
 
       private
       def clean_description(description)
@@ -92,6 +139,13 @@ module ActiveMerchant #:nodoc:
         options[:shipping_address] = options[:shipping_address] || {}
         # Include Email in address-hash from options-hash
         options[:billing_address][:email] = options[:email] if options[:email]
+      end
+
+      # If a GuWID (string-based reference) is passed rather than a
+      # credit card, then the :recurring type needs to be forced to
+      # "Repeated"
+      def setup_recurring_flag(options)
+        options[:recurring] = 'Repeated' if options[:preauthorization].present?
       end
 
       # Contact WireCard, make the XML request, and parse the
@@ -151,13 +205,16 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'CC_TRANSACTION' do
             xml.tag! 'TransactionID', options[:order_id]
             case options[:action]
-            when :preauthorization, :purchase
+            when :preauthorization, :purchase, :authorization_check
+              setup_recurring_flag(options)
               add_invoice(xml, money, options)
+
               if options[:credit_card]
                 add_creditcard(xml, options[:credit_card])
               else
                 xml.tag! 'GuWID', options[:preauthorization]
               end
+
               add_address(xml, options[:billing_address])
             when :capture, :bookback
               xml.tag! 'GuWID', options[:preauthorization]

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -161,6 +161,32 @@ class RemoteWirecardTest < Test::Unit::TestCase
     assert_equal "U", response.avs_result["code"]
   end
 
+  def test_successful_store
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert response.authorization
+  end
+
+  def test_successful_store_then_purchase_by_reference
+    assert auth = @gateway.store(@credit_card, @options.dup)
+    assert_success auth
+    assert auth.authorization
+    assert purchase = @gateway.purchase(@amount, auth.authorization, @options.dup)
+    assert_success purchase
+  end
+
+  def test_successful_authorization_as_recurring_transaction_type_initial
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:recurring => "Initial"))
+    assert_success response
+    assert response.authorization
+  end
+
+  def test_successful_purchase_as_recurring_transaction_type_initial
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:recurring => "Initial"))
+    assert_success response
+    assert response.authorization
+  end
+
   # Failure tested
 
   def test_wrong_creditcard_authorization
@@ -176,6 +202,13 @@ class RemoteWirecardTest < Test::Unit::TestCase
     assert_failure response
     assert response.message[ /Credit card number not allowed in demo mode/ ], "Got wrong response message"
     assert_equal "24997", response.params['ErrorCode']
+  end
+
+  def test_wrong_creditcard_store
+    assert response = @gateway.store(@declined_card, @options)
+    assert response.test?
+    assert_failure response
+    assert response.message[ /Credit card number not allowed in demo mode/ ], "Got wrong response message"
   end
 
   def test_unauthorized_capture
@@ -194,6 +227,12 @@ class RemoteWirecardTest < Test::Unit::TestCase
     assert void = @gateway.void('C428094138244444404448')
     assert_failure void
     assert_match /Could not find referenced transaction/, void.message
+  end
+
+  def test_unauthorized_purchase
+    assert response = @gateway.purchase(@amount, "1234567890123456789012")
+    assert_failure response
+    assert_equal "Could not find referenced transaction for GuWID 1234567890123456789012.", response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Wirecard supports the notion of "Recurring Transactions" by allowing
the merchant to provide a reference to an earlier transaction
(the GuWID) rather than a credit card.  A reusable reference (GuWID)
can be obtained by sending a purchase or authorization transaction
with the element "RECURRING_TRANSACTION/Type" set to "Initial".
Subsequent transactions can then use the GuWID in place of a credit
card by setting "RECURRING_TRANSACTION/Type" to "Repeated".

This implementation of card store utilizes a Wirecard "Authorization
Check" (a Preauthorization that is automatically reversed).
It defaults to a check amount of "100" (i.e. $1.00) but this can be
overriden.  In order to reuse the stored reference, the
+authorization+ from the response should be saved by application
code.

Already present was the ability to run a purchase transaction using
a GuWID.  This commit adds the ability to do the same for an
authorization transaction.

Note: any transaction can generate a reusable GuWID reference by
setting the option :recurring to "Initial".  This functionality
already existed but is now documented.
