### PR TITLE
Braintree Blue: Set a smart default for verification_merchant_account_id

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -258,6 +258,10 @@ module ActiveMerchant #:nodoc:
           valid_options[key] = value if [:update_existing_token, :verify_card, :verification_merchant_account_id].include?(key)
         end
 
+        if valid_options.include?(:verify_card) && @merchant_account_id
+          valid_options[:verification_merchant_account_id] ||= @merchant_account_id
+        end
+
         parameters[:credit_card] ||= {}
         parameters[:credit_card].merge!(:options => valid_options)
         parameters[:credit_card][:billing_address] = map_address(options[:billing_address]) if options[:billing_address]

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -86,6 +86,51 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.authorize(100, credit_card("41111111111111111111"))
   end
 
+  def test_verification_merchant_account_id_exists_when_verify_card_and_merchant_account_id
+    gateway = BraintreeBlueGateway.new(
+      :merchant_id => 'merchant_id',
+      :merchant_account_id => 'merchant_account_id',
+      :public_key => 'public_key',
+      :private_key => 'private_key'
+    )
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal 'merchant_account_id', params[:credit_card][:options][:verification_merchant_account_id]
+    end.returns(result)
+
+    gateway.store(credit_card('41111111111111111111'), :verify_card => true)
+  end
+
+  def test_merchant_account_id_can_be_set_by_options
+    gateway = BraintreeBlueGateway.new(
+      :merchant_id => 'merchant_id',
+      :merchant_account_id => 'merchant_account_id',
+      :public_key => 'public_key',
+      :private_key => 'private_key'
+    )
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal 'value_from_options', params[:credit_card][:options][:verification_merchant_account_id]
+    end.returns(result)
+
+    gateway.store(credit_card('41111111111111111111'), :verify_card => true, :verification_merchant_account_id => 'value_from_options')
+  end
+
   def test_store_with_verify_card_true
     customer = stub(
       :credit_cards => [stub_everything],


### PR DESCRIPTION
If the merchant has configured the `merchant_account_id` and they want to use the `verify_card` option, they probably want that verification run against their configured merchant account, since Braintree Blue allows for multiple merchant accounts.  This sets a smart default for `verification_merchant_account_id`, while still allowing it to be set independently.
