### PR TITLE
adding Errno::ETIMEDOUT rescue for pagseguro

### DIFF
--- a/lib/active_merchant/billing/integrations/pag_seguro/helper.rb
+++ b/lib/active_merchant/billing/integrations/pag_seguro/helper.rb
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
             check_for_errors(response, xml)
 
             extract_token(xml)
-          rescue Timeout::Error, Errno::ECONNRESET => e
+          rescue Timeout::Error, Errno::ECONNRESET, Errno::ETIMEDOUT => e
             raise ActionViewHelperError, "Erro ao conectar-se ao PagSeguro. Por favor, tente novamente."
           end
 

--- a/test/unit/integrations/helpers/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/helpers/pag_seguro_helper_test.rb
@@ -152,6 +152,14 @@ class PagSeguroHelperTest < Test::Unit::TestCase
     end
   end
 
+  def test_fetch_token_raise_view_helper_error_if_ETIMEDOUT_error
+    Net::HTTP.any_instance.expects(:request).raises(Errno::ETIMEDOUT, "Connection timed out")
+
+    assert_raise ActionViewHelperError do
+      @helper.fetch_token
+    end
+  end
+
   def test_name_white_spaces_should_be_stripped
     @helper.customer :first_name => '  Cody  Yo ', :last_name => 'Fau  ser     ', :email => 'cody@example.com', phone: "71 98765432"
     assert_field 'senderName', 'Cody Yo Fau ser'


### PR DESCRIPTION
@odorcicd @bslobodin 

This adds another rescue for PagSeguro in case of a timeout.

Why don't we use a HTTP client like HTTParty to avoid this?
