### PR TITLE
Quickpay v7 has an "acquirers" field in requests

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
         7 => {
           :authorize => %w(protocol msgtype merchant ordernumber amount
                            currency autocapture cardnumber expirationdate cvd
-                           acquirer cardtypelock testmode fraud_remote_addr
+                           acquirers cardtypelock testmode fraud_remote_addr
                            fraud_http_accept fraud_http_accept_language
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
@@ -137,7 +137,7 @@ module ActiveMerchant #:nodoc:
           :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
           :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                           expirationdate cvd acquirer cardtypelock description testmode
+                           expirationdate cvd acquirers cardtypelock description testmode
                            fraud_remote_addr fraud_http_accept fraud_http_accept_language
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
         post[:cvd]            = credit_card.verification_value
         post[:expirationdate] = expdate(credit_card)
         post[:cardtypelock]   = options[:cardtypelock] unless options[:cardtypelock].blank?
-        post[:acquirer]       = options[:acquirer] unless options[:acquirer].blank?
+        post[:acquirers]      = options[:acquirers] unless options[:acquirers].blank?
       end
 
       def add_reference(post, identification)

--- a/test/remote/gateways/remote_quickpay_v7_test.rb
+++ b/test/remote/gateways/remote_quickpay_v7_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteQuickpayV6Test < Test::Unit::TestCase
+class RemoteQuickpayV7Test < Test::Unit::TestCase
   # These test assumes that you have not added your development IP in
   # the Quickpay Manager.
   def setup
@@ -61,6 +61,18 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
     assert_equal 'USD', response.params['currency']
     assert_success response
     assert !response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_acquirers
+    assert response = @gateway.purchase(@amount, @visa, @options.update(:acquirers => "nets"))
+    assert_equal 'OK', response.message
+    assert_success response
+  end
+
+  def test_unsuccessful_purchase_with_invalid_acquirers
+    assert response = @gateway.purchase(@amount, @visa, @options.update(:acquirers => "invalid"))
+    assert_equal 'Error in field: acquirers', response.message
+    assert_failure response
   end
 
   def test_successful_dankort_authorization
@@ -196,6 +208,11 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
     assert_success store
     assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
     assert_success purchase
+  end
+
+  def test_successful_store_with_acquirers
+    assert store = @gateway.store(@visa, @options.merge(:description => "New subscription", :acquirers => "nets"))
+    assert_success store
   end
 
   def test_invalid_login


### PR DESCRIPTION
The original implementation of protocol v7 called this field "acquirer" (without the "s"), which matched old and incorrect documentation provided in the past by Quickpay. We learned via Quickpay support (through debug of a merchant issue) that the field in the request is called "acquirers", representing a list of acquirers to attempt, ordered by preference (i.e. `acquirers=nets,teller`).  The response will contain a field called "acquirer" which conveys which acquirer was actually used in the transaction.

The correct documentation can now be found on the Quickpay website:
http://doc.quickpay.net/api/messagetypes.html#index1h2
http://doc.quickpay.net/api/messagetypes.html#index2h2

Before this change, attempting to set the old `:acquirer` option would result in an MD5check hash mismatch, since the ActiveMerchant code would use the `acquirer` field in the calculation, but Quickpay would use `acquirers`.

After this change, both ActiveMerchant and Quickpay agree on the MD5check hash when the `:acquirers` option is set, and the `:acquirers` option has the intended effect of setting the preferred acquirers for the transaction. (The latter can be negative-tested by setting the value for acquirers to an invalid acquirer value and observing the error response: "Error in field: acquirers")

Despite the change to the option key (`acquirer` to `acquirers`), I feel this is a safe, backwards compatible change since attempting to set the old option could never result in a successful transaction - the MD5check hash mismatch error would always occur.

Note: I asked Quickpay to update all of their v7 documentation to reflect the correct field name.  At this time it appears they have done so.
