### PR TITLE
Auth.net: Mask card number if length == 4 when building credit card XML

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -799,7 +799,7 @@ module ActiveMerchant #:nodoc:
         return unless credit_card
         xml.tag!('creditCard') do
           # The credit card number used for payment of the subscription
-          xml.tag!('cardNumber', credit_card.number)
+          xml.tag!('cardNumber', full_or_masked_card_number(credit_card.number))
           # The expiration date of the credit card used for the subscription
           xml.tag!('expirationDate', expdate(credit_card))
           # Note that Authorize.net does not save CVV codes as part of the
@@ -966,6 +966,10 @@ module ActiveMerchant #:nodoc:
         end
 
         response
+      end
+
+      def full_or_masked_card_number(card_number)
+        !card_number.nil? && card_number.length == 4 ? "XXXX#{card_number}" : card_number
       end
     end
   end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -420,6 +420,52 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     # Show that the billing address on the payment profile was updated
     assert_equal "Frank", response.params['payment_profile']['bill_to']['first_name'], "The billing address should contain the first name we passed in: Frank"
   end
+  
+  def test_successful_update_customer_payment_profile_request_with_credit_card_last_four
+    # Create a new Customer Profile with Payment Profile
+    assert response = @gateway.create_customer_profile(@options)
+    @customer_profile_id = response.authorization
+
+    # Get the customerPaymentProfileId
+    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
+
+    # Get the customerPaymentProfile
+    assert response = @gateway.get_customer_payment_profile(
+      :customer_profile_id => @customer_profile_id,
+      :customer_payment_profile_id => customer_payment_profile_id
+    )
+
+    # Card number last 4 digits is 4242 
+    assert_equal "XXXX4242", response.params['payment_profile']['payment']['credit_card']['card_number'], "The card number should contain the last 4 digits of the card we passed in 4242"
+    
+    new_billing_address = response.params['payment_profile']['bill_to']
+    new_billing_address.update(:first_name => 'Frank', :last_name => 'Brown')
+
+    # Initialize credit card with only last 4 digits as the number 
+    last_four_credit_card = ActiveMerchant::Billing::CreditCard.new(:number => "4242") #Credit card with only last four digits
+
+    # Update only the billing address with a card with the last 4 digits and expiration date
+    assert response = @gateway.update_customer_payment_profile(
+      :customer_profile_id => @customer_profile_id,
+      :payment_profile => {
+        :customer_payment_profile_id => customer_payment_profile_id,
+        :bill_to => new_billing_address,
+        :payment => {
+          :credit_card => last_four_credit_card
+        }
+      }
+    )
+
+    # Get the updated payment profile
+    assert response = @gateway.get_customer_payment_profile(
+      :customer_profile_id => @customer_profile_id,
+      :customer_payment_profile_id => customer_payment_profile_id
+    )
+
+    # Show that the billing address on the payment profile was updated
+    assert_equal "Frank", response.params['payment_profile']['bill_to']['first_name'], "The billing address should contain the first name we passed in: Frank"
+  end
 
   def test_successful_update_customer_shipping_address_request
     # Create a new Customer Profile with Shipping Address


### PR DESCRIPTION
In order to use the same card number when updating a payment profile (a "partial update"), you must send the last-four digits of the card as the CreditCard#number, masked (e.g. `XXXX11234`).

This change checks if the card number being passed into `add_credit_card` is 4 digits. If it is, we assume a partial update is being attempted, and we mask this value in the way Auth.Net expects.

See http://www.authorize.net/support/CIM_XML_guide.pdf, page 70, under `cardNumber`.

Previously, you could pass in `XXXXXXXXXXXX1234` as the `number` when instantiating a `CreditCard` object, which would eventually be used in the `add_credit_card` method, but as of https://github.com/Shopify/active_merchant/commit/077a2216064438c69703d777f2d6312edce7cfd1 this is no longer possible. Hence this PR.
