### PR TITLE
NAB Transact: Allow timeout customization

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -16,18 +16,10 @@ module ActiveMerchant #:nodoc:
       self.live_periodic_url = 'https://transact.nab.com.au/xmlapi/periodic'
 
       self.supported_countries = ['AU']
-
-      # The card types supported by the payment gateway
-      # Note that support for Diners, Amex, and JCB require extra
-      # steps in setting up your account, as detailed in the NAB Transact API
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
 
       self.homepage_url = 'http://transact.nab.com.au'
       self.display_name = 'NAB Transact'
-
-      cattr_accessor :request_timeout
-      self.request_timeout = 60
-
       self.money_format = :cents
       self.default_currency = 'AUD'
 
@@ -272,6 +264,10 @@ module ActiveMerchant #:nodoc:
       def generate_timestamp
         time = Time.now.utc
         time.strftime("%Y%d%m%H%M%S#{time.usec}+000")
+      end
+
+      def request_timeout
+        @options[:request_timeout] || 60
       end
 
     end


### PR DESCRIPTION
Allow a custom request timeout.  NAB Transact support has said:

"... the time out value set in the API message simply determines how long we
will wait before returning a timeout response to you, the transaction
still remains in flight and can still be processed even after this
occurs."

We default to 60 seconds but we now allow other values to be specified.
