### PR TITLE
Use authorization instead of authorization_check for Amex on store

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -118,7 +118,12 @@ module ActiveMerchant #:nodoc:
         options[:credit_card] = creditcard
         options[:recurring] = 'Initial'
         money = options.delete(:amount) || 100
-        commit(:authorization_check, money, options)
+        # Amex does not support authorization_check
+        if creditcard.brand == 'amex'
+          commit(:preauthorization, money, options)
+        else
+          commit(:authorization_check, money, options)
+        end
       end
 
       private

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -9,7 +9,7 @@ class RemoteWirecardTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4200000000000000')
     @declined_card = credit_card('4000300011112220')
-    @amex_card = credit_card('370000000000010')
+    @amex_card = credit_card('370000000000010', brand: 'amex')
 
     @options = {
       order_id: 1,
@@ -169,6 +169,12 @@ class RemoteWirecardTest < Test::Unit::TestCase
 
   def test_successful_store
     assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert response.authorization
+  end
+
+  def test_successful_store_with_amex
+    assert response = @gateway.store(@amex_card)
     assert_success response
     assert response.authorization
   end


### PR DESCRIPTION
Amex does not support authorization_check, so an authorization is done
instead.
