### PR TITLE
eWAY: Update country list

### DIFF
--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
       self.live_url = 'https://www.eway.com.au'
 
       self.money_format = :cents
-      self.supported_countries = ['AU', 'NZ', 'GB']
+      self.supported_countries = ['AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
       self.homepage_url = 'http://www.eway.com.au/'
       self.display_name = 'eWAY'


### PR DESCRIPTION
Heard from the folks at eWAY.  The eWAY gateway is only available in AU.
eWAY Rapid is available in AU, GB, and NZ.
