### PR TITLE
Elavon: Make void work for authorizations too

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
         :refund => 'CCRETURN',
         :authorize => 'CCAUTHONLY',
         :capture => 'CCFORCE',
-        :void => 'CCVOID',
+        :void => 'CCDELETE',
         :store => 'CCGETTOKEN',
         :update => 'CCUPDATETOKEN',
       }

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -103,6 +103,16 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_equal 'The transaction ID is invalid for this transaction type', response.message
   end
 
+  def test_authorize_and_successful_void
+    assert authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    assert response = @gateway.void(authorize.authorization)
+
+    assert_success response
+    assert response.authorization
+  end
+
   def test_successful_store_without_verify
     assert response = @gateway.store(@credit_card, @options)
     assert_success response


### PR DESCRIPTION
The void operation we had worked for purchases but not for
authoriztions.  We were using a CCVOID operation.  Now we're using a
CCDELETE operation.

From the Elavon docs:
The `ccvoid` is a transaction that removes a Sale, Credit or Force
transaction from the open batch... The `ccvoid` command is typically
used for same day returns or to correct cashier mistakes.

The `ccdelete` is a transaction that deletes and attempts a reversal on a
Sale or Auth Only Credit transaction.
