### PR TITLE
Wirecard: Fix instances of 'amex' - will be 'american_express'

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -119,7 +119,7 @@ module ActiveMerchant #:nodoc:
         options[:recurring] = 'Initial'
         money = options.delete(:amount) || 100
         # Amex does not support authorization_check
-        if creditcard.brand == 'amex'
+        if creditcard.brand == 'american_express'
           commit(:preauthorization, money, options)
         else
           commit(:authorization_check, money, options)

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -9,7 +9,7 @@ class RemoteWirecardTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4200000000000000')
     @declined_card = credit_card('4000300011112220')
-    @amex_card = credit_card('370000000000010', brand: 'amex')
+    @amex_card = credit_card('370000000000010', brand: 'american_express')
 
     @options = {
       order_id: 1,

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -13,7 +13,7 @@ class WirecardTest < Test::Unit::TestCase
     @credit_card = credit_card('4200000000000000')
     @declined_card = credit_card('4000300011112220')
     @unsupported_card = credit_card('4200000000000000', brand: :maestro)
-    @amex_card = credit_card('370000000000000', brand: "amex")
+    @amex_card = credit_card('370000000000000', brand: "american_express")
 
     @amount = 111
 


### PR DESCRIPTION
Fix instances of `amex` card brand in the Wirecard gateway.

Will be returned as `american_express` by CreditCard#brand. (see: [[1]](https://github.com/Shopify/active_merchant/blob/1e2bcde60d3a461656a046275012cd09fb980c1b/lib/active_merchant/billing/credit_card.rb#L81) [[2]](https://github.com/Shopify/active_merchant/blob/1e2bcde60d3a461656a046275012cd09fb980c1b/lib/active_merchant/billing/credit_card_methods.rb#L9))
