### PR TITLE
PAYMILL: add description when creating preauthorizations

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
                                     GI GR HR HU IE IL IM IS IT LI LT LU LV MC MT
                                     NL NO PL PT RO SE SI SK TR VA)
 
-      self.supported_cardtypes = [:visa, :master]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :union_pay, :jcb]
       self.homepage_url = 'https://paymill.com'
       self.display_name = 'PAYMILL'
       self.money_format = :cents
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         post[:preauthorization] = preauth(authorization)
         post[:description] = options[:description]
+        post[:source] = 'active_merchant'
         commit(:post, 'transactions', post)
       end
 
@@ -116,6 +117,7 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         post[:token] = card_token
         post[:description] = options[:description]
+        post[:source] = 'active_merchant'
         commit(:post, 'transactions', post)
       end
 
@@ -124,6 +126,8 @@ module ActiveMerchant #:nodoc:
 
         add_amount(post, money, options)
         post[:token] = card_token
+        post[:description] = options[:description]
+        post[:source] = 'active_merchant'
         commit(:post, 'preauthorizations', post)
       end
 

--- a/test/remote/gateways/remote_paymill_test.rb
+++ b/test/remote/gateways/remote_paymill_test.rb
@@ -15,6 +15,12 @@ class RemotePaymillTest < Test::Unit::TestCase
     assert_equal 'General success response.', response.message
   end
 
+  def test_successful_purchase_with_token
+    assert response = @gateway.purchase(@amount, '098f6bcd4621d373cade4e832627b4f6', { description: 'from active merchant' } )
+    assert_success response
+    assert_equal 'General success response.', response.message
+  end
+
   def test_failed_store_card_attempting_purchase
     @credit_card.number = ''
     assert response = @gateway.purchase(@amount, @credit_card)
@@ -37,6 +43,24 @@ class RemotePaymillTest < Test::Unit::TestCase
     assert capture_response = @gateway.capture(@amount, response.authorization)
     assert_success capture_response
     assert_equal 'General success response.', capture_response.message
+  end
+
+  def test_successful_authorize_and_capture_with_token
+    assert response = @gateway.authorize(@amount, '098f6bcd4621d373cade4e832627b4f6')
+    assert_success response
+    assert_equal 'General success response.', response.message
+    assert response.authorization
+
+    assert capture_response = @gateway.capture(@amount, response.authorization, { description: 'from active merchant' })
+    assert_success capture_response
+    assert_equal 'General success response.', capture_response.message
+  end
+
+  def test_successful_authorize_with_token
+    assert response = @gateway.authorize(@amount, '098f6bcd4621d373cade4e832627b4f6', { description: 'from active merchant' })
+    assert_success response
+    assert_equal 'General success response.', response.message
+    assert response.authorization
   end
 
   def test_failed_authorize


### PR DESCRIPTION
- add description for preauthorizations
- extend supported cards
- add tests for creating transaction and preauthorization with token
