### PR TITLE
Add authorize/capture and customer update to Pin Payments gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -75,11 +75,6 @@ module ActiveMerchant #:nodoc:
         commit(:put, "customers/#{CGI.escape(token)}", post, options)
       end
 
-      # Updates other data on the customer such as email address.
-      def update_customer(token, post, options = {})
-        commit(:put, "customers/#{CGI.escape(token)}", post, options)
-      end
-
       private
 
       def add_amount(post, money, options)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -112,18 +112,6 @@ class RemotePinTest < Test::Unit::TestCase
     assert_equal response.params['response']['card']['expiry_year'], @visa_credit_card.year
   end
 
-  def test_store_and_update_customer
-    assert response = @gateway.store(@credit_card, @options)
-    assert_success response
-    assert_not_nil response.authorization
-    assert_equal response.params['response']['email'], @options[:email]
-
-    assert response = @gateway.update_customer(response.authorization, :email => "updated-roland@pin.net.au")
-    assert_success response
-    assert_not_nil response.authorization
-    assert_equal response.params['response']['email'], "updated-roland@pin.net.au"
-  end
-
   def test_refund
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -112,16 +112,6 @@ class PinTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_update_customer
-    token = 'cus_05p0n7UFPmcyCNjD8c6HdA'
-    @gateway.expects(:ssl_request).with(:put, "https://test-api.pin.net.au/1/customers/#{token}", instance_of(String), instance_of(Hash)).returns(successful_customer_store_response)
-    assert response = @gateway.update_customer('cus_05p0n7UFPmcyCNjD8c6HdA', {}, @options)
-    assert_success response
-    assert_equal 'cus_05p0n7UFPmcyCNjD8c6HdA', response.authorization
-    assert_equal JSON.parse(successful_customer_store_response), response.params
-    assert response.test?
-  end
-
   def test_successful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
     @gateway.expects(:ssl_request).with(:post, "https://test-api.pin.net.au/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
@@ -182,11 +172,6 @@ class PinTest < Test::Unit::TestCase
     @gateway.expects(:add_address).with(instance_of(Hash), @credit_card, @options)
     @gateway.expects(:ssl_request).returns(successful_store_response)
     assert_success @gateway.update('cus_XZg1ULpWaROQCOT5PdwLkQ', @credit_card, @options)
-  end
-
-  def test_update_customer_parameters
-    @gateway.expects(:ssl_request).returns(successful_store_response)
-    assert_success @gateway.update_customer('cus_XZg1ULpWaROQCOT5PdwLkQ', { :email => "foo@bar.com" }, @options)
   end
 
   def test_add_amount


### PR DESCRIPTION
Added the following new methods to the Pin Payments gateway:
- `#authorize(money, creditcard, options)`
- `#capture(money, token, options)`
- `#update(customer_token, credit_card, address: { ... })`
- `#update_customer(customer_token, email: "new@email.com")`
