### PR TITLE
Bring 1stPayGateway implementation up to date w/ supported API

### DIFF
--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -1,169 +1,159 @@
+require 'nokogiri'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class FirstPayGateway < Gateway
-      class FirstPayPostData < PostData
-        # Fields that will be sent even if they are blank
-        self.required_fields = [ :action, :amount, :trackid ]
-      end
+      self.live_url = 'https://secure.1stpaygateway.net/secure/gateway/xmlgateway.aspx'
 
-      # both URLs are IP restricted
-      self.test_url = 'https://apgcert.first-pay.com/AcqENGIN/SecureCapture'
-      self.live_url = 'https://acqengin.first-pay.com/AcqENGIN/SecureCapture'
-
-      # The countries the gateway supports merchants from as 2 digit ISO country codes
       self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.money_format = :dollars
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
-      # The card types supported by the payment gateway
-      self.supported_cardtypes = [:visa, :master]
+      self.homepage_url = 'http://1stpaygateway.net/'
+      self.display_name = '1stPayGateway.Net'
 
-      # The homepage URL of the gateway
-      self.homepage_url = 'http://www.first-pay.com'
-
-      # The name of the gateway
-      self.display_name = 'First Pay'
-
-      # all transactions are in cents
-      self.money_format = :cents
-
-      ACTIONS = {
-        'sale' => 1,
-        'credit' => 2,
-        'void' => 3
-      }
-
-      def initialize(options = {})
-        requires!(options, :login, :password)
+      def initialize(options={})
+        requires!(options, :transaction_center_id, :gateway_id)
         super
       end
 
-      def purchase(money, creditcard, options = {})
-        post = FirstPayPostData.new
-        add_invoice(post, options)
-        add_creditcard(post, creditcard)
-        add_address(post, options)
+      def purchase(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
         add_customer_data(post, options)
 
-        commit('sale', money, post)
+        commit('sale', post)
       end
 
-      def refund(money, reference, options = {})
-        requires!(options, :credit_card)
-
-        post = FirstPayPostData.new
-        add_invoice(post, options)
-        add_creditcard(post, options[:credit_card])
-        add_address(post, options)
-        add_customer_data(post, options)
-        add_credit_data(post, reference)
-
-        commit('credit', money, post)
-      end
-
-      def credit(money, reference, options = {})
-        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
-        refund(money, reference, options)
-      end
-
-      def void(money, creditcard, options = {})
-        post = FirstPayPostData.new
-        add_creditcard(post, creditcard)
-        add_void_data(post, options)
-        add_invoice(post, options)
+      def authorize(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
         add_customer_data(post, options)
 
-        commit('void', money, post)
+        commit('auth', post)
       end
 
+      def capture(money, authorization, options={})
+        post = {}
+        add_reference(post, 'settle', money, authorization)
+        commit('settle', post)
+      end
+
+      def refund(money, authorization, options={})
+        post = {}
+        add_reference(post, 'credit', money, authorization)
+        commit('credit', post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        add_reference(post, 'void', nil, authorization)
+        commit('void', post)
+      end
 
       private
 
+      def add_authentication(post, options)
+        post[:transaction_center_id] = options[:transaction_center_id]
+        post[:gateway_id] = options[:gateway_id]
+      end
+
       def add_customer_data(post, options)
-        post[:cardip] = options[:ip]
-        post[:email] = options[:email]
+        post[:owner_email] = options[:email] if options[:email]
+        post[:remote_ip_address] = options[:ip] if options[:ip]
       end
 
-      def add_address(post, options)
-        if billing_address = options[:billing_address] || options[:address]
-          post[:addr]     = billing_address[:address1].to_s + ' ' + billing_address[:address2].to_s
-          post[:city]     = billing_address[:city]
-          post[:state]    = billing_address[:state]
-          post[:zip]      = billing_address[:zip]
-          post[:country]  = billing_address[:country]
-        end
+      def add_address(post, creditcard, options)
+        address = options[:billing_address] || options[:address]
+        post[:owner_name] = address[:name]
+        post[:owner_street] = address[:address1]
+        post[:owner_street2] = address[:address2] if address[:address2]
+        post[:owner_city] = address[:city]
+        post[:owner_state] = address[:state]
+        post[:owner_zip] = address[:zip]
+        post[:owner_country] = address[:country]
+        post[:owner_phone] = address[:phone] if address[:phone]
       end
 
-      def add_invoice(post, options)
-        post[:trackid] = rand(Time.now.to_i)
+      def add_invoice(post, money, options)
+        post[:order_id] = options[:order_id]
+        post[:total] = amount(money)
       end
 
-      def add_creditcard(post, creditcard)
-        post[:member] = creditcard.first_name.to_s + " " + creditcard.last_name.to_s
-        post[:card] = creditcard.number
-        post[:exp] = expdate(creditcard)
+      def add_payment(post, payment)
+        post[:card_name] = payment.brand # Unclear if need to map to known names or open text field??
+        post[:card_number] = payment.number
+        post[:card_exp] = expdate(payment)
+        post[:cvv2] = payment.verification_value
       end
 
-      def add_credit_data(post, transaction_id)
-        post[:transid] = transaction_id
+      def add_reference(post, action, money, authorization)
+        post[:"#{action}_amount1"] = amount(money) if money
+        post[:total_number_transactions] = 1
+        post[:reference_number1] = authorization
       end
 
-      def add_void_data(post, options)
-        post[:transid] = options[:transactionid]
-      end
-
-      def commit(action, money, post)
-        response = parse( ssl_post(test? ? self.test_url : self.live_url, post_data(action, post, money)) )
-
-        Response.new(response[:response] == 'CAPTURED', response[:message], response,
-          :test => test?,
-          :authorization => response[:authorization],
-          :avs_result => { :code => response[:avsresponse] },
-          :cvv_result => response[:cvvresponse])
-      end
-
-      def parse(body)
+      def parse(xml)
         response = {}
 
-        # check for an error first
-        if body.include?('!ERROR!')
-          response[:response] = 'ERROR'
-          response[:message] = error_message_from(body)
-        else
-          # a capture / not captured response will be : delimited
-          split = body.split(':')
-          response[:response] = split[0]
+        doc = Nokogiri::XML(xml)
+        doc.root.xpath("//RESPONSE/FIELDS/FIELD").each do |field|
+          response[field['KEY']] = field.text
+        end unless doc.root.nil?
 
-          # FirstPay docs are worthless. turns out the transactionid is required for credits
-          # so we need to store that in authorization, not the actual auth.
-          if response[:response] == 'CAPTURED'
-            response[:message] = 'CAPTURED'
-            response[:authorization] = split[9] # actually the transactionid
-            response[:auth] = split[1]
-            response[:avsresponse] = split[3]
-            response[:cvvresponse] = split[17]
-          else
-            # NOT CAPTURED response
-            response[:message] = split[1]
-            response[:transactionid] = split[9]
+        response
+      end
+
+      def commit(action, parameters)
+        response = parse(ssl_post(live_url, post_data(action, parameters)))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?
+        )
+      end
+
+      def success_from(response)
+        response['status'] == '1' || response['status1'] == '1'
+      end
+
+      def message_from(response)
+        # Silly inconsistent gateway. Always make capitalized (but not all caps)
+        msg = response['auth_response'] || response['response1']
+        msg.downcase.capitalize if msg
+      end
+
+      def authorization_from(response)
+        response['reference_number'] || response['reference_number1']
+      end
+
+      def post_data(action, parameters = {})
+
+        # Auth
+        parameters[:transaction_center_id] = @options[:transaction_center_id]
+        parameters[:gateway_id] = @options[:gateway_id]
+
+        parameters[:operation_type] = action
+
+        xml = Builder::XmlMarkup.new
+        xml.instruct!
+        xml.tag! 'TRANSACTION' do
+          xml.tag! 'FIELDS' do
+            parameters.each do |key, value|
+              xml.tag! 'FIELD', value, { 'KEY' => key }
+            end
           end
         end
-
-        return response
-      end
-
-      def error_message_from(response)
-        # error messages use this format - '!ERROR! 704-MISSING BASIC DATA TYPE:card, exp, zip, addr, member, amount\n'
-        response.split("! ")[1].chomp
-      end
-
-      def post_data(action, post, money)
-        post[:vid]        = @options[:login]
-        post[:password]   = @options[:password]
-        post[:action]     = ACTIONS[action]
-        post[:amount]     = amount(money)
-
-        return post.to_post_data
+        xml.target!
       end
     end
   end
 end
-

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -190,8 +190,8 @@ first_giving:
   charity_id: "1234"
 
 first_pay:
-  login:
-  password:
+  transaction_center_id: 1264
+  gateway_id: "a91c38c3-7d7f-4d29-acc7-927b4dca0dbe"
 
 firstdata_e4:
   login:

--- a/test/unit/gateways/first_pay_test.rb
+++ b/test/unit/gateways/first_pay_test.rb
@@ -1,131 +1,349 @@
 require 'test_helper'
 
 class FirstPayTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
-    @gateway = FirstPayGateway.new(:login => 'login', :password => 'password')
+    @gateway = FirstPayGateway.new(
+      transaction_center_id: 1234,
+      gateway_id: 'a91c38c3-7d7f-4d29-acc7-927b4dca0dbe'
+    )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :ip => '127.0.0.1',
-      :email => 'test@test.com'
+      order_id: SecureRandom.hex(24),
+      billing_address: address
     }
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="operation_type">sale<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="order_id">#{@options[:order_id]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="total">1.00<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_name">#{@credit_card.brand}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_number">#{@credit_card.number}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_exp">#{@gateway.expdate(@credit_card)}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="cvv2">#{@credit_card.verification_value}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_name">#{@options[:billing_address][:name]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_street">#{@options[:billing_address][:address1]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_street2">#{@options[:billing_address][:address2]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_city">#{@options[:billing_address][:city]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_state">#{@options[:billing_address][:state]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_zip">#{@options[:billing_address][:zip]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_country">#{@options[:billing_address][:country]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_phone">/, data) # The () in phone num seems to break this?
+    end.respond_with(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response
+    assert_instance_of Response, response
     assert_success response
-
-    # Replace with authorization number from the successful response
-    assert_equal '57097598', response.authorization
-    assert response.test?
+    assert_equal '47913', response.authorization
+    assert_equal 'Approved', response.message
   end
 
   def test_failed_purchase
-    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    @gateway.stubs(:ssl_post).returns(failed_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card, @options)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response
+    assert_instance_of Response, response
     assert_failure response
-    assert_equal('DECLINE', response.message)
-    assert response.test?
+    assert_equal '47915', response.authorization
+    assert_equal 'Declined', response.message
   end
 
-  def test_error_on_purchase
-    @gateway.expects(:ssl_post).returns(error_response)
+  def test_successful_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="operation_type">auth<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="order_id">#{@options[:order_id]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="total">1.00<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_name">#{@credit_card.brand}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_number">#{@credit_card.number}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="card_exp">#{@gateway.expdate(@credit_card)}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="cvv2">#{@credit_card.verification_value}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_name">#{@options[:billing_address][:name]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_street">#{@options[:billing_address][:address1]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_street2">#{@options[:billing_address][:address2]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_city">#{@options[:billing_address][:city]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_state">#{@options[:billing_address][:state]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_zip">#{@options[:billing_address][:zip]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_country">#{@options[:billing_address][:country]}<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="owner_phone">/, data) # The () in phone num seems to break this?
+    end.respond_with(successful_authorize_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert ! response.success?
-    assert_equal('704-MISSING BASIC DATA TYPE:card, exp, zip, addr, member, amount', response.message)
-    assert response.test?
+    assert response
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '47920', response.authorization
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_authorize
+    @gateway.stubs(:ssl_post).returns(failed_authorize_response)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal '47924', response.authorization
+    assert_equal 'Declined', response.message
+  end
+
+  def test_successful_capture
+    response = stub_comms do
+      @gateway.capture(@amount, '47920')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="operation_type">settle<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="total_number_transactions">1<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="reference_number1">47920<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="settle_amount1">1.00<\/FIELD>/, data)
+    end.respond_with(successful_capture_response)
+
+    assert response
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '47920', response.authorization
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_capture
+    @gateway.stubs(:ssl_post).returns(failed_capture_response)
+    response = @gateway.capture(@amount, '47920')
+
+    assert_failure response
+    assert_equal '47920', response.authorization
+    assert response.message.include?('Settle failed')
   end
 
   def test_successful_refund
-    @gateway.expects(:ssl_post).returns(successful_refund_response)
-    @options[:credit_card] = @credit_card
+    response = stub_comms do
+      @gateway.refund(@amount, '47925')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="operation_type">credit<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="total_number_transactions">1<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="reference_number1">47925<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="credit_amount1">1.00<\/FIELD>/, data)
+    end.respond_with(successful_refund_response)
 
-    assert_success(response = @gateway.refund(@amount, '123456', @options))
-
-    assert_equal '53147613', response.authorization
+    assert response
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '47925', response.authorization
+    assert_equal 'Accepted', response.message
   end
 
   def test_failed_refund
-    @options[:credit_card] = @credit_card
-    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    @gateway.stubs(:ssl_post).returns(failed_refund_response)
+    response = @gateway.capture(@amount, '47925')
 
-    assert response = @gateway.refund(@amount, '123456', @options)
     assert_failure response
-    assert_equal('PARENT TRANSACTION NOT FOUND', response.message)
-    assert response.test?
-  end
-
-  def test_failed_unlinked_refund
-    assert_raise ArgumentError do
-      @gateway.refund(@amount, "asdf")
-    end
-  end
-
-  def test_deprecated_credit
-    @gateway.expects(:ssl_post).returns(successful_refund_response)
-    @options[:credit_card] = @credit_card
-    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
-      assert_success(response = @gateway.credit(@amount, '123456', @options))
-    end
+    assert_equal '47925', response.authorization
+    assert response.message.include?('Credit failed')
   end
 
   def test_successful_void
-    @gateway.expects(:ssl_post).returns(successful_void_response)
-    @options[:transactionid] = '123456'
+    response = stub_comms do
+      @gateway.void('47934')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="operation_type">void<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="total_number_transactions">1<\/FIELD>/, data)
+      assert_match(/<FIELD KEY="reference_number1">47934<\/FIELD>/, data)
+    end.respond_with(successful_void_response)
 
-    assert response = @gateway.void(@amount, @credit_card, @options)
+    assert response
+    assert_instance_of Response, response
     assert_success response
-
-    assert_equal '53147623', response.authorization
-    assert response.test?
+    assert_equal '47934', response.authorization
+    assert_equal 'Approved', response.message
   end
 
   def test_failed_void
-    @gateway.expects(:ssl_post).returns(failed_void_response)
+    @gateway.stubs(:ssl_post).returns(failed_void_response)
+    response = @gateway.void('1')
 
-    assert response = @gateway.void(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal('PARENT TRANSACTION NOT FOUND', response.message)
-    assert response.test?
+    assert_equal '1', response.authorization
+    assert response.message.include?('Void failed')
   end
-
 
   private
 
   def successful_purchase_response
-    "CAPTURED:056708:NA:X:Jun 02 2009:241:NLS:NLS:NLS:57097598:9999:NA:NA:NA:NA:NA:NA:NA"
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="status">1</FIELD>
+    <FIELD KEY="auth_code">DEMO48</FIELD>
+    <FIELD KEY="auth_response">APPROVED</FIELD>
+    <FIELD KEY="avs_code">Z</FIELD>
+    <FIELD KEY="cvv2_code"> </FIELD>
+    <FIELD KEY="order_id">#{@options[:order_id]}</FIELD>
+    <FIELD KEY="reference_number">47913</FIELD>
+    <FIELD KEY="error" />
+    <FIELD KEY="available_balance" />
+    <FIELD KEY="is_partial">0</FIELD>
+    <FIELD KEY="partial_amount">0</FIELD>
+    <FIELD KEY="partial_id" />
+    <FIELD KEY="original_full_amount" />
+    <FIELD KEY="outstanding_balance">0</FIELD>
+  </FIELDS>
+</RESPONSE>)
   end
 
   def failed_purchase_response
-    "NOT CAPTURED:DECLINE:NA:NA:Dec 11 2003:278654:NLS:NLS:NLS:53147611:200312111612:NA:NA:NA:NA:NA:NA"
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="status">2</FIELD>
+    <FIELD KEY="auth_code" />
+    <FIELD KEY="auth_response">Declined</FIELD>
+    <FIELD KEY="avs_code"> </FIELD>
+    <FIELD KEY="cvv2_code"> </FIELD>
+    <FIELD KEY="order_id">#{@options[:order_id]}</FIELD>
+    <FIELD KEY="reference_number">47915</FIELD>
+    <FIELD KEY="error" />
+    <FIELD KEY="available_balance" />
+    <FIELD KEY="is_partial">0</FIELD>
+    <FIELD KEY="partial_amount">0</FIELD>
+    <FIELD KEY="partial_id" />
+    <FIELD KEY="original_full_amount" />
+    <FIELD KEY="outstanding_balance">0</FIELD>
+  </FIELDS>
+</RESPONSE>)
+  end
+
+  def successful_authorize_response
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="status">1</FIELD>
+    <FIELD KEY="auth_code">DEMO80</FIELD>
+    <FIELD KEY="auth_response">APPROVED</FIELD>
+    <FIELD KEY="avs_code">Z</FIELD>
+    <FIELD KEY="cvv2_code"> </FIELD>
+    <FIELD KEY="order_id">#{@options[:order_id]}</FIELD>
+    <FIELD KEY="reference_number">47920</FIELD>
+    <FIELD KEY="error" />
+    <FIELD KEY="available_balance" />
+    <FIELD KEY="is_partial">0</FIELD>
+    <FIELD KEY="partial_amount">0</FIELD>
+    <FIELD KEY="partial_id" />
+    <FIELD KEY="original_full_amount" />
+    <FIELD KEY="outstanding_balance">0</FIELD>
+  </FIELDS>
+</RESPONSE>)
+  end
+
+  def failed_authorize_response
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="status">2</FIELD>
+    <FIELD KEY="auth_code" />
+    <FIELD KEY="auth_response">Declined</FIELD>
+    <FIELD KEY="avs_code"> </FIELD>
+    <FIELD KEY="cvv2_code"> </FIELD>
+    <FIELD KEY="order_id">#{@options[:order_id]}</FIELD>
+    <FIELD KEY="reference_number">47924</FIELD>
+    <FIELD KEY="error" />
+    <FIELD KEY="available_balance" />
+    <FIELD KEY="is_partial">0</FIELD>
+    <FIELD KEY="partial_amount">0</FIELD>
+    <FIELD KEY="partial_id" />
+    <FIELD KEY="original_full_amount" />
+    <FIELD KEY="outstanding_balance">0</FIELD>
+  </FIELDS>
+</RESPONSE>)
+  end
+
+  def successful_capture_response
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_settled">1</FIELD>
+    <FIELD KEY="total_amount_settled">1</FIELD>
+    <FIELD KEY="status1">1</FIELD>
+    <FIELD KEY="response1">APPROVED</FIELD>
+    <FIELD KEY="reference_number1">47920</FIELD>
+    <FIELD KEY="batch_number1">20140623</FIELD>
+    <FIELD KEY="settle_amount1">1.00</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
+  end
+
+  def failed_capture_response
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_settled">0</FIELD>
+    <FIELD KEY="total_amount_settled">0</FIELD>
+    <FIELD KEY="status1">2</FIELD>
+    <FIELD KEY="response1">Settle Failed. Transaction cannot be settled. Auth not found. Make sure the settlement amount does not exceed the original auth amount and that is was authorized less then 30 days ago.</FIELD>
+    <FIELD KEY="reference_number1">47920</FIELD>
+    <FIELD KEY="batch_number1" />
+    <FIELD KEY="settle_amount1">1.00</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
   end
 
   def successful_refund_response
-    "CAPTURED:945101216:199641568:NA:Dec 11 2003:278655:NLS:NLS:NLS:53147613:200312111613:NA:NA:NA:NA:NA"
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_credited">1</FIELD>
+    <FIELD KEY="status1">1</FIELD>
+    <FIELD KEY="response1">ACCEPTED</FIELD>
+    <FIELD KEY="reference_number1">47925</FIELD>
+    <FIELD KEY="credit_amount1">1.00</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
   end
 
   def failed_refund_response
-    "NOT CAPTURED:PARENT TRANSACTION NOT FOUND:NA:NA:Dec 11 2003:278614:NLS:NLS:NLS:53147499:200311251526:NA:NA:NA:NA:NA"
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_credited">0</FIELD>
+    <FIELD KEY="status1">2</FIELD>
+    <FIELD KEY="response1">Credit Failed. Transaction cannot be credited.</FIELD>
+    <FIELD KEY="reference_number1">47925</FIELD>
+    <FIELD KEY="credit_amount1">1.00</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
   end
 
   def successful_void_response
-    "CAPTURED:000000:NA:Y:Dec 11 2003:278659:NLS:NLS:NLS:53147623:200312111628:NA:NA:NA:NA:NA"
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_voided">1</FIELD>
+    <FIELD KEY="status1">1</FIELD>
+    <FIELD KEY="response1">APPROVED</FIELD>
+    <FIELD KEY="reference_number1">47934</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
   end
 
   def failed_void_response
-    "NOT CAPTURED:PARENT TRANSACTION NOT FOUND:NA:NA:Dec 11 2003:278644:NLS:NLS:NLS:53147562:200311251526:NA:NA:NA:NA:NA"
-  end
-
-  def error_response
-    '!ERROR! 704-MISSING BASIC DATA TYPE:card, exp, zip, addr, member, amount'
+    %(<RESPONSE>
+  <FIELDS>
+    <FIELD KEY="total_transactions_voided">0</FIELD>
+    <FIELD KEY="status1">2</FIELD>
+    <FIELD KEY="response1">Void Failed. Transaction cannot be voided.</FIELD>
+    <FIELD KEY="reference_number1">1</FIELD>
+    <FIELD KEY="error1" />
+  </FIELDS>
+</RESPONSE>)
   end
 end


### PR DESCRIPTION
This replaces the now broken 1stPayGateway implementation with support for their [current API](https://secure.1stpaygateway.net/secure/transcenter/help/1stpaygateway_gatewayapi_dn_xml.pdf) and all five major transaction types. Closes #1270.
