### PR TITLE
Add IP address to Optimal gateway requests.

### DIFF
--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -161,6 +161,7 @@ module ActiveMerchant #:nodoc:
           build_card(xml, opts)
           build_billing_details(xml, opts)
           build_shipping_details(xml, opts)
+          xml.customerIP opts[:ip] if opts[:ip]
         end
       end
 

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -12,7 +12,8 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
       :order_id => '1',
       :billing_address => address,
       :description => 'Basic Subscription',
-      :email => 'email@example.com'
+      :email => 'email@example.com',
+      :ip => '1.2.3.4'
     }
   end
 

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -28,6 +28,11 @@ class OptimalPaymentTest < Test::Unit::TestCase
     assert_match full_request, @gateway.cc_auth_request(@amount, @options)
   end
 
+  def test_full_request_with_ip_address
+    @gateway.instance_variable_set('@credit_card', @credit_card)
+    assert_match full_request_with_ip_address, @gateway.cc_auth_request(@amount, @options.merge(:ip => '1.2.3.4'))
+  end
+
   def test_minimal_request
     options = {
       :order_id => '1',
@@ -213,6 +218,45 @@ class OptimalPaymentTest < Test::Unit::TestCase
     <phone>%28555%29555-5555</phone>
     <email>email%40example.com</email>
   </billingDetails>
+</ccAuthRequestV1>
+    XML
+    Regexp.new(Regexp.escape(str).sub('xmlns', '[^>]+').sub('/>', '(/>|></[^>]+>)'))
+  end
+
+  def full_request_with_ip_address
+    str = <<-XML
+<ccAuthRequestV1 xmlns>
+  <merchantAccount>
+    <accountNum/>
+    <storeID>login</storeID>
+    <storePwd>password</storePwd>
+  </merchantAccount>
+  <merchantRefNum>1</merchantRefNum>
+  <amount>1.0</amount>
+  <card>
+    <cardNum>4242424242424242</cardNum>
+    <cardExpiry>
+      <month>9</month>
+      <year>#{Time.now.year + 1}</year>
+    </cardExpiry>
+    <cardType>VI</cardType>
+    <cvdIndicator>1</cvdIndicator>
+    <cvd>123</cvd>
+  </card>
+  <billingDetails>
+    <cardPayMethod>WEB</cardPayMethod>
+    <firstName>Jim</firstName>
+    <lastName>Smith</lastName>
+    <street>1234+My+Street</street>
+    <street2>Apt+1</street2>
+    <city>Ottawa</city>
+    <state>ON</state>
+    <country>CA</country>
+    <zip>K1C2N6</zip>
+    <phone>%28555%29555-5555</phone>
+    <email>email%40example.com</email>
+  </billingDetails>
+  <customerIP>1.2.3.4</customerIP>
 </ccAuthRequestV1>
     XML
     Regexp.new(Regexp.escape(str).sub('xmlns', '[^>]+').sub('/>', '(/>|></[^>]+>)'))


### PR DESCRIPTION
Optimal wants to get IP addresses for fraud verification. There is no difference in the response we get back from them. @bslobodin /cc @Shopify/payments 

@ntalbott I'm sorry about my last two merges being crappy. I'll follow [good practices](http://blog.spreedly.com/2014/06/24/merge-pull-request-considered-harmful) for the next one.
