### PR TITLE
Stripe: Add ability to verify a card

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -88,6 +88,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def verify(creditcard, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(50, creditcard, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       def application_fee_from_response(response)
         return unless response.success?
 

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -94,6 +94,23 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_match /active_merchant_fake_charge/, refund.message
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal "Transaction approved", response.message
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_equal "charge", response.params["object"]
+    assert_success response.responses.last, "The void should succeed"
+    assert response.responses.last.params["refunded"]
+  end
+
+  def test_unsuccessful_verify
+    assert response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match /Your card was declined/, response.message
+  end
+
   def test_successful_store
     assert response = @gateway.store(@credit_card, {:currency => @currency, :description => "Active Merchant Test Customer", :email => "email@example.com"})
     assert_success response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -197,6 +197,29 @@ class StripeTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_verify
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorization_response, successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorization_response, failed_void_response)
+    assert_success response
+    assert_equal "Transaction approved", response.message
+  end
+
+  def test_unsuccessful_verify
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(declined_authorization_response, successful_void_response)
+    assert_failure response
+    assert_equal "Your card was declined.", response.message
+  end
+
   def test_successful_request_always_uses_live_mode_to_determine_test_request
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response(:livemode => true))
 
@@ -461,237 +484,293 @@ class StripeTest < Test::Unit::TestCase
 
   def successful_new_customer_response
     <<-RESPONSE
-{
-  "object": "customer",
-  "created": 1383137317,
-  "id": "cus_3sgheFxeBgTQ3M",
-  "livemode": false,
-  "description": null,
-  "email": null,
-  "delinquent": false,
-  "metadata": {},
-  "subscription": null,
-  "discount": null,
-  "account_balance": 0,
-  "cards":
-  {
-    "object": "list",
-    "count": 1,
-    "url": "/v1/customers/cus_3sgheFxeBgTQ3M/cards",
-    "data":
-    [
+    {
+      "object": "customer",
+      "created": 1383137317,
+      "id": "cus_3sgheFxeBgTQ3M",
+      "livemode": false,
+      "description": null,
+      "email": null,
+      "delinquent": false,
+      "metadata": {},
+      "subscription": null,
+      "discount": null,
+      "account_balance": 0,
+      "cards":
       {
-        "id": "card_483etw4er9fg4vF3sQdrt3FG",
-        "object": "card",
-        "last4": "4242",
-        "type": "Visa",
-        "exp_month": 11,
-        "exp_year": 2020,
-        "fingerprint": "5dgRQ3dVRGaQWDFb",
-        "customer": "cus_3sgheFxeBgTQ3M",
-        "country": "US",
-        "name": "John Doe",
-        "address_line1": null,
-        "address_line2": null,
-        "address_city": null,
-        "address_state": null,
-        "address_zip": null,
-        "address_country": null,
-        "cvc_check": null,
-        "address_line1_check": null,
-        "address_zip_check": null
-      }
-    ]
-  },
-  "default_card": "card_483etw4er9fg4vF3sQdrt3FG"
-}
+        "object": "list",
+        "count": 1,
+        "url": "/v1/customers/cus_3sgheFxeBgTQ3M/cards",
+        "data":
+        [
+          {
+            "id": "card_483etw4er9fg4vF3sQdrt3FG",
+            "object": "card",
+            "last4": "4242",
+            "type": "Visa",
+            "exp_month": 11,
+            "exp_year": 2020,
+            "fingerprint": "5dgRQ3dVRGaQWDFb",
+            "customer": "cus_3sgheFxeBgTQ3M",
+            "country": "US",
+            "name": "John Doe",
+            "address_line1": null,
+            "address_line2": null,
+            "address_city": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_country": null,
+            "cvc_check": null,
+            "address_line1_check": null,
+            "address_zip_check": null
+          }
+        ]
+      },
+      "default_card": "card_483etw4er9fg4vF3sQdrt3FG"
+    }
     RESPONSE
   end
 
   def successful_new_card_response
     <<-RESPONSE
-{
-  "id": "card_483etw4er9fg4vF3sQdrt3FG",
-  "livemode": false,
-  "object": "card",
-  "last4": "4242",
-  "type": "Visa",
-  "exp_month": 11,
-  "exp_year": 2020,
-  "fingerprint": "5dgRQ3dVRGaQWDFb",
-  "customer": "cus_3sgheFxeBgTQ3M",
-  "country": "US",
-  "name": "John Doe",
-  "address_line1": null,
-  "address_line2": null,
-  "address_city": null,
-  "address_state": null,
-  "address_zip": null,
-  "address_country": null,
-  "cvc_check": null,
-  "address_line1_check": null,
-  "address_zip_check": null
-}
+    {
+      "id": "card_483etw4er9fg4vF3sQdrt3FG",
+      "livemode": false,
+      "object": "card",
+      "last4": "4242",
+      "type": "Visa",
+      "exp_month": 11,
+      "exp_year": 2020,
+      "fingerprint": "5dgRQ3dVRGaQWDFb",
+      "customer": "cus_3sgheFxeBgTQ3M",
+      "country": "US",
+      "name": "John Doe",
+      "address_line1": null,
+      "address_line2": null,
+      "address_city": null,
+      "address_state": null,
+      "address_zip": null,
+      "address_country": null,
+      "cvc_check": null,
+      "address_line1_check": null,
+      "address_zip_check": null
+    }
     RESPONSE
   end
 
   def successful_authorization_response
     <<-RESPONSE
-{
-  "id": "ch_test_charge",
-  "object": "charge",
-  "created": 1309131571,
-  "livemode": false,
-  "paid": true,
-  "amount": 400,
-  "currency": "usd",
-  "refunded": false,
-  "fee": 0,
-  "fee_details": [],
-  "card": {
-    "country": "US",
-    "exp_month": 9,
-    "exp_year": #{Time.now.year + 1},
-    "last4": "4242",
-    "object": "card",
-    "type": "Visa"
-  },
-  "captured": false,
-  "description": "ActiveMerchant Test Purchase",
-  "dispute": null,
-  "uncaptured": true,
-  "disputed": false
-}
+    {
+      "id": "ch_test_charge",
+      "object": "charge",
+      "created": 1309131571,
+      "livemode": false,
+      "paid": true,
+      "amount": 400,
+      "currency": "usd",
+      "refunded": false,
+      "fee": 0,
+      "fee_details": [],
+      "card": {
+        "country": "US",
+        "exp_month": 9,
+        "exp_year": #{Time.now.year + 1},
+        "last4": "4242",
+        "object": "card",
+        "type": "Visa"
+      },
+      "captured": false,
+      "description": "ActiveMerchant Test Purchase",
+      "dispute": null,
+      "uncaptured": true,
+      "disputed": false
+    }
     RESPONSE
   end
 
   def successful_capture_response
     <<-RESPONSE
-{
-  "id": "ch_test_charge",
-  "object": "charge",
-  "created": 1309131571,
-  "livemode": false,
-  "paid": true,
-  "amount": 400,
-  "currency": "usd",
-  "refunded": false,
-  "fee": 0,
-  "fee_details": [],
-  "card": {
-    "country": "US",
-    "exp_month": 9,
-    "exp_year": #{Time.now.year + 1},
-    "last4": "4242",
-    "object": "card",
-    "type": "Visa"
-  },
-  "captured": true,
-  "description": "ActiveMerchant Test Purchase",
-  "dispute": null,
-  "uncaptured": false,
-  "disputed": false
-}
+    {
+      "id": "ch_test_charge",
+      "object": "charge",
+      "created": 1309131571,
+      "livemode": false,
+      "paid": true,
+      "amount": 400,
+      "currency": "usd",
+      "refunded": false,
+      "fee": 0,
+      "fee_details": [],
+      "card": {
+        "country": "US",
+        "exp_month": 9,
+        "exp_year": #{Time.now.year + 1},
+        "last4": "4242",
+        "object": "card",
+        "type": "Visa"
+      },
+      "captured": true,
+      "description": "ActiveMerchant Test Purchase",
+      "dispute": null,
+      "uncaptured": false,
+      "disputed": false
+    }
     RESPONSE
   end
 
   def successful_purchase_response(refunded=false)
     <<-RESPONSE
-{
-  "amount": 400,
-  "created": 1309131571,
-  "currency": "usd",
-  "description": "Test Purchase",
-  "id": "ch_test_charge",
-  "livemode": false,
-  "object": "charge",
-  "paid": true,
-  "refunded": #{refunded},
-  "card": {
-    "country": "US",
-    "exp_month": 9,
-    "exp_year": #{Time.now.year + 1},
-    "last4": "4242",
-    "object": "card",
-    "type": "Visa"
-  }
-}
+    {
+      "amount": 400,
+      "created": 1309131571,
+      "currency": "usd",
+      "description": "Test Purchase",
+      "id": "ch_test_charge",
+      "livemode": false,
+      "object": "charge",
+      "paid": true,
+      "refunded": #{refunded},
+      "card": {
+        "country": "US",
+        "exp_month": 9,
+        "exp_year": #{Time.now.year + 1},
+        "last4": "4242",
+        "object": "card",
+        "type": "Visa"
+      }
+    }
     RESPONSE
   end
 
   def successful_partially_refunded_response(options = {})
     options = {:livemode=>false}.merge!(options)
     <<-RESPONSE
-{
-  "amount": 400,
-  "amount_refunded": 200,
-  "created": 1309131571,
-  "currency": "usd",
-  "description": "Test Purchase",
-  "id": "ch_test_charge",
-  "livemode": #{options[:livemode]},
-  "object": "charge",
-  "paid": true,
-  "refunded": true,
-  "card": {
-    "country": "US",
-    "exp_month": 9,
-    "exp_year": #{Time.now.year + 1},
-    "last4": "4242",
-    "object": "card",
-    "type": "Visa"
-  }
-}
+    {
+      "amount": 400,
+      "amount_refunded": 200,
+      "created": 1309131571,
+      "currency": "usd",
+      "description": "Test Purchase",
+      "id": "ch_test_charge",
+      "livemode": #{options[:livemode]},
+      "object": "charge",
+      "paid": true,
+      "refunded": true,
+      "card": {
+        "country": "US",
+        "exp_month": 9,
+        "exp_year": #{Time.now.year + 1},
+        "last4": "4242",
+        "object": "card",
+        "type": "Visa"
+      }
+    }
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+    {
+      "id": "ch_4IrhQMqukqu7C2",
+      "object": "charge",
+      "created": 1403816613,
+      "livemode": false,
+      "paid": true,
+      "amount": 50,
+      "currency": "usd",
+      "refunded": true,
+      "card": {
+        "id": "card_4IKht2vQlbJms9",
+        "object": "card",
+        "last4": "4242",
+        "brand": "Visa",
+        "funding": "credit",
+        "exp_month": 9,
+        "exp_year": 2015,
+        "fingerprint": "6nTaMxIBAdBvfy2i",
+        "country": "US",
+        "name": "Longbob Longsen",
+        "address_city": null,
+        "cvc_check": "pass",
+        "customer": null,
+        "type": "Visa"
+      },
+      "captured": false,
+      "balance_transaction": null,
+      "failure_code": null,
+      "description": "ActiveMerchant Test Purchase",
+      "dispute": null,
+      "metadata": {
+        "email": "wow@example.com"
+      },
+      "statement_description": null,
+      "receipt_email": null,
+      "fee": 0,
+      "fee_details": [],
+      "uncaptured": true,
+      "disputed": false
+    }
+    RESPONSE
+  end
+
+  def failed_void_response
+    <<-RESPONSE
+    {
+      "error": {
+        "type": "invalid_request_error",
+        "message": "Charge ch_4IL0vZWdcx45qO has already been refunded."
+      }
+    }
     RESPONSE
   end
 
   def successful_refunded_application_fee_response
     <<-RESPONSE
-{
-  "id": "fee_id",
-  "object": "application_fee",
-  "created": 1375375417,
-  "livemode": false,
-  "amount": 10,
-  "currency": "usd",
-  "user": "acct_id",
-  "user_email": "acct_id",
-  "application": "ca_application",
-  "charge": "ch_test_charge",
-  "refunded": false,
-  "amount_refunded": 10
-}
+    {
+      "id": "fee_id",
+      "object": "application_fee",
+      "created": 1375375417,
+      "livemode": false,
+      "amount": 10,
+      "currency": "usd",
+      "user": "acct_id",
+      "user_email": "acct_id",
+      "application": "ca_application",
+      "charge": "ch_test_charge",
+      "refunded": false,
+      "amount_refunded": 10
+    }
     RESPONSE
   end
 
   def successful_application_fee_list_response
     <<-RESPONSE
-{
-  "object": "list",
-  "count": 2,
-  "url": "/v1/application_fees",
-  "data": [
     {
-      "object": "application_fee",
-      "id": "application_fee_id"
-    },
-    {
-      "object": "another_fee",
-      "id": "another_fee_id"
+      "object": "list",
+      "count": 2,
+      "url": "/v1/application_fees",
+      "data": [
+        {
+          "object": "application_fee",
+          "id": "application_fee_id"
+        },
+        {
+          "object": "another_fee",
+          "id": "another_fee_id"
+        }
+      ]
     }
-  ]
-}
     RESPONSE
   end
 
   def unsuccessful_application_fee_list_response
     <<-RESPONSE
-{
-  "object": "list",
-  "count": 0,
-  "url": "/v1/application_fees",
-  "data": []
-}
+    {
+      "object": "list",
+      "count": 0,
+      "url": "/v1/application_fees",
+      "data": []
+    }
     RESPONSE
   end
 
@@ -721,6 +800,18 @@ class StripeTest < Test::Unit::TestCase
     RESPONSE
   end
 
+  def declined_authorization_response
+    <<-RESPONSE
+    {
+      "error": {
+        "message": "Your card was declined.",
+        "type": "card_error",
+        "code": "card_declined",
+        "charge": "ch_4IKxffGOKVRJ4l"
+      }
+    }
+    RESPONSE
+  end
 
   def successful_update_credit_card_response
     <<-RESPONSE

--- a/test/unit/multi_response_test.rb
+++ b/test/unit/multi_response_test.rb
@@ -167,5 +167,7 @@ class MultiResponseTest < Test::Unit::TestCase
     m.process(:ignore_result){r2}
     assert_equal "1", m.message
     assert_equal [r1, r2], m.responses
+
+    assert m.success?
   end
 end


### PR DESCRIPTION
For Stripe, a verification is an `authorization` followed by a `void` of
that authorization.

The minimum authorization Stripe allows is 50 cents so we use that.

Relevant docs:
https://stripe.com/docs/api#create_charge
