### PR TITLE
Paypal: Add ability to verify a card

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -7,12 +7,12 @@ module ActiveMerchant #:nodoc:
     class PaypalGateway < Gateway
       include PaypalCommonAPI
       include PaypalRecurringApi
-      
+
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
       self.supported_countries = ['US']
       self.homepage_url = 'https://www.paypal.com/us/webapps/mpp/paypal-payments-pro'
       self.display_name = 'PayPal Payments Pro (US)'
-      
+
       def authorize(money, credit_card_or_referenced_id, options = {})
         requires!(options, :ip)
         commit define_transaction_type(credit_card_or_referenced_id), build_sale_or_authorization_request('Authorization', money, credit_card_or_referenced_id, options)
@@ -22,13 +22,24 @@ module ActiveMerchant #:nodoc:
         requires!(options, :ip)
         commit define_transaction_type(credit_card_or_referenced_id), build_sale_or_authorization_request('Sale', money, credit_card_or_referenced_id, options)
       end
-      
+
+      def verify(credit_card, options = {})
+        if %w(visa master).include?(credit_card.brand)
+          authorize(0, credit_card, options)
+        else
+          MultiResponse.run(:use_first_response) do |r|
+            r.process { authorize(100, credit_card, options) }
+            r.process(:ignore_result) { void(r.authorization, options) }
+          end
+        end
+      end
+
       def express
         @express ||= PaypalExpressGateway.new(@options)
       end
-      
+
       private
-      
+
       def define_transaction_type(transaction_arg)
         if transaction_arg.is_a?(String)
           return 'DoReferenceTransaction'
@@ -36,14 +47,14 @@ module ActiveMerchant #:nodoc:
           return 'DoDirectPayment'
         end
       end
-      
+
       def build_sale_or_authorization_request(action, money, credit_card_or_referenced_id, options)
         transaction_type = define_transaction_type(credit_card_or_referenced_id)
         reference_id = credit_card_or_referenced_id if transaction_type == "DoReferenceTransaction"
-        
+
         billing_address = options[:billing_address] || options[:address]
         currency_code = options[:currency] || currency(money)
-       
+
         xml = Builder::XmlMarkup.new :indent => 2
         xml.tag! transaction_type + 'Req', 'xmlns' => PAYPAL_NAMESPACE do
           xml.tag! transaction_type + 'Request', 'xmlns:n2' => EBAY_NAMESPACE do
@@ -58,9 +69,9 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-        xml.target!        
+        xml.target!
       end
-      
+
       def add_credit_card(xml, credit_card, address, options)
         xml.tag! 'n2:CreditCard' do
           xml.tag! 'n2:CreditCardType', credit_card_type(card_brand(credit_card))
@@ -68,19 +79,19 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'n2:ExpMonth', format(credit_card.month, :two_digits)
           xml.tag! 'n2:ExpYear', format(credit_card.year, :four_digits)
           xml.tag! 'n2:CVV2', credit_card.verification_value
-          
+
           if [ 'switch', 'solo' ].include?(card_brand(credit_card).to_s)
             xml.tag! 'n2:StartMonth', format(credit_card.start_month, :two_digits) unless credit_card.start_month.blank?
             xml.tag! 'n2:StartYear', format(credit_card.start_year, :four_digits) unless credit_card.start_year.blank?
             xml.tag! 'n2:IssueNumber', format(credit_card.issue_number, :two_digits) unless credit_card.issue_number.blank?
           end
-          
+
           xml.tag! 'n2:CardOwner' do
             xml.tag! 'n2:PayerName' do
               xml.tag! 'n2:FirstName', credit_card.first_name
               xml.tag! 'n2:LastName', credit_card.last_name
             end
-            
+
             xml.tag! 'n2:Payer', options[:email]
             add_address(xml, 'n2:Address', address)
           end
@@ -97,7 +108,7 @@ module ActiveMerchant #:nodoc:
         when 'solo'             then 'Solo'
         end
       end
-      
+
       def build_response(success, message, response, options = {})
          Response.new(success, message, response, options)
       end

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -2,24 +2,15 @@ require 'test_helper'
 
 class PaypalTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
-    
     @gateway = PaypalGateway.new(fixtures(:paypal_signature))
 
-    @creditcard = CreditCard.new(
-      :brand                => "visa",
-      :number              => "4381258770269608", # Use a generated CC from the paypal Sandbox
-      :verification_value => "000",
-      :month               => 1,
-      :year                => Time.now.year + 1,
-      :first_name          => 'Fred',
-      :last_name           => 'Brooks'
-    )
-       
+    @credit_card = credit_card("4381258770269608") # Use a generated CC from the paypal Sandbox
+    @declined_card = credit_card('234234234234')
+
     @params = {
       :order_id => generate_unique_id,
       :email => 'buyer@jadedpallet.com',
-      :billing_address => { :name => 'Fred Brooks',
+      :billing_address => { :name => 'Longbob Longsen',
                     :address1 => '1234 Penny Lane',
                     :city => 'Jonsetown',
                     :state => 'NC',
@@ -29,47 +20,39 @@ class PaypalTest < Test::Unit::TestCase
       :description => 'Stuff that you purchased, yo!',
       :ip => '10.0.0.1'
     }
-      
+
     @amount = 100
+
     # test re-authorization, auth-id must be more than 3 days old.
     # each auth-id can only be reauthorized and tested once.
     # leave it commented if you don't want to test reauthorization.
-    # 
-    #@three_days_old_auth_id  = "9J780651TU4465545" 
-    #@three_days_old_auth_id2 = "62503445A3738160X" 
+    #
+    #@three_days_old_auth_id  = "9J780651TU4465545"
+    #@three_days_old_auth_id2 = "62503445A3738160X"
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
     assert response.params['transaction_id']
   end
-  
-  def test_successful_purchase_with_api_signature
-    gateway = PaypalGateway.new(fixtures(:paypal_signature))
-    response = gateway.purchase(@amount, @creditcard, @params)
-    assert_success response
-    assert response.params['transaction_id']
-  end
-  
+
   def test_failed_purchase
-    @creditcard.number = '234234234234'
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @declined_card, @params)
     assert_failure response
     assert_nil response.params['transaction_id']
   end
 
   def test_successful_authorization
-    response = @gateway.authorize(@amount, @creditcard, @params)
+    response = @gateway.authorize(@amount, @credit_card, @params)
     assert_success response
     assert response.params['transaction_id']
     assert_equal '1.00', response.params['amount']
     assert_equal 'USD', response.params['amount_currency_id']
   end
-  
+
   def test_failed_authorization
-    @creditcard.number = '234234234234'
-    response = @gateway.authorize(@amount, @creditcard, @params)
+    response = @gateway.authorize(@amount, @declined_card, @params)
     assert_failure response
     assert_nil response.params['transaction_id']
   end
@@ -79,23 +62,23 @@ class PaypalTest < Test::Unit::TestCase
     auth = @gateway.reauthorize(1000, @three_days_old_auth_id)
     assert_success auth
     assert auth.authorization
-    
+
     response = @gateway.capture(1000, auth.authorization)
     assert_success response
     assert response.params['transaction_id']
     assert_equal '10.00', response.params['gross_amount']
     assert_equal 'USD', response.params['gross_amount_currency_id']
   end
-  
+
   def test_failed_reauthorization
     return if not @three_days_old_auth_id2  # was authed for $10, attempt $20
     auth = @gateway.reauthorize(2000, @three_days_old_auth_id2)
     assert_false auth?
     assert !auth.authorization
   end
-      
+
   def test_successful_capture
-    auth = @gateway.authorize(@amount, @creditcard, @params)
+    auth = @gateway.authorize(@amount, @credit_card, @params)
     assert_success auth
     response = @gateway.capture(@amount, auth.authorization)
     assert_success response
@@ -105,7 +88,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_successful_incomplete_captures
-    auth = @gateway.authorize(100, @creditcard, @params)
+    auth = @gateway.authorize(100, @credit_card, @params)
     assert_success auth
     response = @gateway.capture(60, auth.authorization, {:complete_type => "NotComplete"})
     assert_success response
@@ -116,12 +99,12 @@ class PaypalTest < Test::Unit::TestCase
     assert response_2.params['transaction_id']
     assert_equal '0.40', response_2.params['gross_amount']
   end
-  
+
   # NOTE THIS SETTING: http://skitch.com/jimmybaker/nysus/payment-receiving-preferences-paypal
   # PayPal doesn't return the InvoiceID in the response, so I am unable to check for it. Looking at the transaction
   # on PayPal's site will show "NEWID123" as the InvoiceID.
   def test_successful_capture_updating_the_invoice_id
-    auth = @gateway.authorize(@amount, @creditcard, @params)
+    auth = @gateway.authorize(@amount, @credit_card, @params)
     assert_success auth
     response = @gateway.capture(@amount, auth.authorization, :order_id => "NEWID123")
     assert_success response
@@ -129,18 +112,18 @@ class PaypalTest < Test::Unit::TestCase
     assert_equal '1.00', response.params['gross_amount']
     assert_equal 'USD', response.params['gross_amount_currency_id']
   end
-  
+
   def test_successful_voiding
-    auth = @gateway.authorize(@amount, @creditcard, @params)
+    auth = @gateway.authorize(@amount, @credit_card, @params)
     assert_success auth
     response = @gateway.void(auth.authorization)
     assert_success response
   end
-  
+
   def test_purchase_and_full_credit
-    purchase = @gateway.purchase(@amount, @creditcard, @params)
+    purchase = @gateway.purchase(@amount, @credit_card, @params)
     assert_success purchase
-    
+
     credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
     assert_success credit
     assert credit.test?
@@ -151,16 +134,38 @@ class PaypalTest < Test::Unit::TestCase
     assert_equal 'USD',  credit.params['fee_refund_amount_currency_id']
     assert_equal '0.33', credit.params['fee_refund_amount']
   end
-  
+
   def test_failed_voiding
     response = @gateway.void('foo')
     assert_failure response
   end
-  
-  def test_successful_transfer
-    response = @gateway.purchase(@amount, @creditcard, @params)
+
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @params)
     assert_success response
-    
+    assert_equal "0.00", response.params['amount']
+    assert_match /This card authorization verification is not a payment transaction/, response.message
+  end
+
+  def test_failed_verify
+    assert response = @gateway.verify(@declined_card, @params)
+    assert_failure response
+    assert_match /This transaction cannot be processed/, response.message
+  end
+
+  def test_successful_verify_non_visa_mc
+    amex_card = credit_card('371449635398431', brand: nil, verification_value: '1234')
+    assert response = @gateway.verify(amex_card, @params)
+    assert_success response
+    assert_equal "1.00", response.params['amount']
+    assert_match /Success/, response.message
+    assert_success response.responses.last, "The void should succeed"
+  end
+
+  def test_successful_transfer
+    response = @gateway.purchase(@amount, @credit_card, @params)
+    assert_success response
+
     response = @gateway.transfer(@amount, 'joe@example.com', :subject => 'Your money', :note => 'Thanks for taking care of that')
     assert_success response
   end
@@ -170,19 +175,19 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.transfer(1000001, 'joe@example.com')
     assert_failure response
   end
-  
+
   def test_successful_multiple_transfer
-    response = @gateway.purchase(900, @creditcard, @params)
+    response = @gateway.purchase(900, @credit_card, @params)
     assert_success response
-    
+
     response = @gateway.transfer([@amount, 'joe@example.com'],
       [600, 'jane@example.com', {:note => 'Thanks for taking care of that'}],
       :subject => 'Your money')
     assert_success response
   end
-  
+
   def test_failed_multiple_transfer
-    response = @gateway.purchase(25100, @creditcard, @params)
+    response = @gateway.purchase(25100, @credit_card, @params)
     assert_success response
 
     # You can only include up to 250 recipients
@@ -192,7 +197,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_successful_email_transfer
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
     response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'EmailAddress', :subject => 'Your money', :note => 'Thanks for taking care of that')
@@ -200,7 +205,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_successful_userid_transfer
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
     response = @gateway.transfer([@amount, '4ET96X3PQEN8H'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
@@ -208,19 +213,19 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_failed_userid_transfer
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
     response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
     assert_failure response
   end
-  
+
   # Makes a purchase then makes another purchase adding $1.00 using just a reference id (transaction id)
   def test_successful_referenced_id_purchase
-    response = @gateway.purchase(@amount, @creditcard, @params)
+    response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
     id_for_reference = response.params['transaction_id']
-    
+
     @params.delete(:order_id)
     response2 = @gateway.purchase(@amount + 100, id_for_reference, @params)
     assert_success response2

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -4,7 +4,6 @@ class PaypalTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.mode = :test
     PaypalGateway.pem_file = nil
 
     @amount = 100
@@ -415,7 +414,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_status_recurring_response
-    @gateway.expects(:ssl_post).returns(succesful_get_recurring_payments_profile_response)
+    @gateway.expects(:ssl_post).returns(successful_get_recurring_payments_profile_response)
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.status_recurring('I-M1L3RX91DPDD')
     end
@@ -460,6 +459,54 @@ class PaypalTest < Test::Unit::TestCase
       assert_match %r{<ReceiverID>fred@example\.com</ReceiverID>}, data
     end.respond_with(successful_purchase_response)
   end
+
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_zero_dollar_auth_response)
+    assert_success response
+    assert_equal "This card authorization verification is not a payment transaction.", response.message
+    assert_equal "0.00", response.params["amount"]
+  end
+
+  def test_failed_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(failed_zero_dollar_auth_response)
+    assert_failure response
+    assert_match /This transaction cannot be processed/, response.message
+  end
+
+  def test_successful_verify_non_visa_mc
+    amex_card = credit_card('371449635398431', brand: nil, verification_value: '1234')
+    response = stub_comms do
+      @gateway.verify(amex_card, @options)
+    end.respond_with(successful_one_dollar_auth_response, successful_void_response)
+    assert_success response
+    assert_equal "Success", response.message
+    assert_equal "1.00", response.params["amount"]
+  end
+
+  def test_successful_verify_non_visa_mc_failed_void
+    amex_card = credit_card('371449635398431', brand: nil, verification_value: '1234')
+    response = stub_comms do
+      @gateway.verify(amex_card, @options)
+    end.respond_with(successful_one_dollar_auth_response, failed_void_response)
+    assert_success response
+    assert_equal "Success", response.message
+    assert_equal "1.00", response.params["amount"]
+  end
+
+  def test_failed_verify_non_visa_mc
+    amex_card = credit_card('371449635398431', brand: nil, verification_value: '1234')
+    response = stub_comms do
+      @gateway.verify(amex_card, @options)
+    end.respond_with(failed_one_dollar_auth_response, successful_void_response)
+    assert_failure response
+    assert_match /This transaction cannot be processed/, response.message
+    assert_equal "1.00", response.params["amount"]
+  end
+
 
   private
 
@@ -550,6 +597,209 @@ class PaypalTest < Test::Unit::TestCase
       <AVSCode xsi:type="xs:string">X</AVSCode>
       <CVV2Code xsi:type="xs:string">M</CVV2Code>
     </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_zero_dollar_auth_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string"> </Username>
+        <Password xsi:type="xs:string"></Password>
+        <Signature xsi:type="xs:string"> </Signature>
+        <Subject xsi:type="xs:string"> </Subject>
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoDirectPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:14:48Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">SuccessWithWarning</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">e33ce283dd3d3</CorrelationID>
+      <Errors xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:ErrorType">
+        <ShortMessage xsi:type="xs:string">Credit card verified.</ShortMessage>
+        <LongMessage xsi:type="xs:string">This card authorization verification is not a payment transaction.</LongMessage>
+        <ErrorCode xsi:type="xs:token">10574</ErrorCode>
+        <SeverityCode xmlns="urn:ebay:apis:eBLBaseComponents">Warning</SeverityCode>
+      </Errors>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11660982</Build>
+      <Amount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</Amount>
+      <AVSCode xsi:type="xs:string">X</AVSCode><CVV2Code xsi:type="xs:string">M</CVV2Code>
+      <TransactionID>86D41672SH9764158</TransactionID>
+    </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def failed_zero_dollar_auth_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoDirectPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:25:51Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Failure</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">5dda14853a55d</CorrelationID>
+      <Errors xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:ErrorType">
+        <ShortMessage xsi:type="xs:string">Invalid Data</ShortMessage>
+        <LongMessage xsi:type="xs:string">This transaction cannot be processed. Please enter a valid credit card number and type.</LongMessage>
+        <ErrorCode xsi:type="xs:token">10527</ErrorCode>
+        <SeverityCode>Error</SeverityCode>
+      </Errors>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11660982</Build>
+      <Amount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</Amount>
+    </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_one_dollar_auth_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoDirectPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:39:40Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">814bcb1ced3d</CorrelationID>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11660982</Build>
+      <Amount xsi:type="cc:BasicAmountType" currencyID="USD">1.00</Amount>
+      <AVSCode xsi:type="xs:string">X</AVSCode>
+      <CVV2Code xsi:type="xs:string">M</CVV2Code>
+      <TransactionID>521683708W7313256</TransactionID>
+    </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def failed_one_dollar_auth_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoDirectPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:47:18Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Failure</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">f3ab2d6fc76e4</CorrelationID>
+      <Errors xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:ErrorType">
+        <ShortMessage xsi:type="xs:string">Invalid Data</ShortMessage>
+        <LongMessage xsi:type="xs:string">This transaction cannot be processed. Please enter a valid credit card number and type.</LongMessage>
+        <ErrorCode xsi:type="xs:token">10527</ErrorCode>
+        <SeverityCode>Error</SeverityCode>
+      </Errors>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11660982</Build>
+      <Amount xsi:type="cc:BasicAmountType" currencyID="USD">1.00</Amount>
+    </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoVoidResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:39:41Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">5c184c86a25bc</CorrelationID>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11624049</Build>
+      <AuthorizationID xsi:type="xs:string">521683708W7313256</AuthorizationID>
+    </DoVoidResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def failed_void_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoVoidResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:50:11Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Failure</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">e99444d222eaf</CorrelationID>
+      <Errors xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:ErrorType">
+        <ShortMessage xsi:type="xs:string">Transaction refused because of an invalid argument. See additional error messages for details.</ShortMessage>
+        <LongMessage xsi:type="xs:string">The transaction id is not valid</LongMessage>
+        <ErrorCode xsi:type="xs:token">10004</ErrorCode>
+        <SeverityCode>Error</SeverityCode>
+      </Errors>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11624049</Build>
+      <AuthorizationID xsi:type="xs:string" />
+    </DoVoidResponse>
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
     RESPONSE
@@ -980,7 +1230,7 @@ class PaypalTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def succesful_get_recurring_payments_profile_response
+  def successful_get_recurring_payments_profile_response
     <<-RESPONSE
     <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><GetRecurringPaymentsProfileDetailsResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2012-03-19T21:34:40Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">6f24b53c49232</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">2649250</Build><GetRecurringPaymentsProfileDetailsResponseDetails xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:GetRecurringPaymentsProfileDetailsResponseDetailsType\"><ProfileID xsi:type=\"xs:string\">I-M1L3RX91DPDD</ProfileID><ProfileStatus xsi:type=\"ebl:RecurringPaymentsProfileStatusType\">CancelledProfile</ProfileStatus><Description xsi:type=\"xs:string\">A description</Description><AutoBillOutstandingAmount xsi:type=\"ebl:AutoBillType\">NoAutoBill</AutoBillOutstandingAmount><MaxFailedPayments>0</MaxFailedPayments><RecurringPaymentsProfileDetails xsi:type=\"ebl:RecurringPaymentsProfileDetailsType\"><SubscriberName xsi:type=\"xs:string\">Ryan Bates</SubscriberName><SubscriberShippingAddress xsi:type=\"ebl:AddressType\"><Name xsi:type=\"xs:string\"></Name><Street1 xsi:type=\"xs:string\"></Street1><Street2 xsi:type=\"xs:string\"></Street2><CityName xsi:type=\"xs:string\"></CityName><StateOrProvince xsi:type=\"xs:string\"></StateOrProvince><CountryName></CountryName><Phone xsi:type=\"xs:string\"></Phone><PostalCode xsi:type=\"xs:string\"></PostalCode><AddressID xsi:type=\"xs:string\"></AddressID><AddressOwner xsi:type=\"ebl:AddressOwnerCodeType\">PayPal</AddressOwner><ExternalAddressID xsi:type=\"xs:string\"></ExternalAddressID><AddressStatus xsi:type=\"ebl:AddressStatusCodeType\">Unconfirmed</AddressStatus></SubscriberShippingAddress><BillingStartDate xsi:type=\"xs:dateTime\">2012-03-19T11:00:00Z</BillingStartDate></RecurringPaymentsProfileDetails><CurrentRecurringPaymentsPeriod xsi:type=\"ebl:BillingPeriodDetailsType\"><BillingPeriod xsi:type=\"ebl:BillingPeriodTypeType\">Month</BillingPeriod><BillingFrequency>1</BillingFrequency><TotalBillingCycles>0</TotalBillingCycles><Amount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</Amount><ShippingAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</ShippingAmount><TaxAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TaxAmount></CurrentRecurringPaymentsPeriod><RecurringPaymentsSummary xsi:type=\"ebl:RecurringPaymentsSummaryType\"><NumberCyclesCompleted>1</NumberCyclesCompleted><NumberCyclesRemaining>-1</NumberCyclesRemaining><OutstandingBalance xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</OutstandingBalance><FailedPaymentCount>1</FailedPaymentCount></RecurringPaymentsSummary><CreditCard xsi:type=\"ebl:CreditCardDetailsType\"><CreditCardType xsi:type=\"ebl:CreditCardTypeType\">Visa</CreditCardType><CreditCardNumber xsi:type=\"xs:string\">3576</CreditCardNumber><ExpMonth>1</ExpMonth><ExpYear>2013</ExpYear><CardOwner xsi:type=\"ebl:PayerInfoType\"><PayerStatus xsi:type=\"ebl:PayPalUserStatusCodeType\">unverified</PayerStatus><PayerName xsi:type=\"ebl:PersonNameType\"><FirstName xmlns=\"urn:ebay:apis:eBLBaseComponents\">Ryan</FirstName><LastName xmlns=\"urn:ebay:apis:eBLBaseComponents\">Bates</LastName></PayerName><Address xsi:type=\"ebl:AddressType\"><AddressOwner xsi:type=\"ebl:AddressOwnerCodeType\">PayPal</AddressOwner><AddressStatus xsi:type=\"ebl:AddressStatusCodeType\">Unconfirmed</AddressStatus></Address></CardOwner><StartMonth>0</StartMonth><StartYear>0</StartYear><ThreeDSecureRequest xsi:type=\"ebl:ThreeDSecureRequestType\"></ThreeDSecureRequest></CreditCard><RegularRecurringPaymentsPeriod xsi:type=\"ebl:BillingPeriodDetailsType\"><BillingPeriod xsi:type=\"ebl:BillingPeriodTypeType\">Month</BillingPeriod><BillingFrequency>1</BillingFrequency><TotalBillingCycles>0</TotalBillingCycles><Amount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">1.23</Amount><ShippingAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</ShippingAmount><TaxAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TaxAmount></RegularRecurringPaymentsPeriod><TrialAmountPaid xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</TrialAmountPaid><RegularAmountPaid xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</RegularAmountPaid><AggregateAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</AggregateAmount><AggregateOptionalAmount xsi:type=\"cc:BasicAmountType\" currencyID=\"USD\">0.00</AggregateOptionalAmount><FinalPaymentDueDate xsi:type=\"xs:dateTime\">1970-01-01T00:00:00Z</FinalPaymentDueDate></GetRecurringPaymentsProfileDetailsResponseDetails></GetRecurringPaymentsProfileDetailsResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
     RESPONSE


### PR DESCRIPTION
Paypal supports zero dollar authorizations, but only for mastercard and
visa.  Relevant docs:

https://developer.paypal.com/docs/classic/paypal-payments-pro/integration-guide/WPDPGettingStarted/#cardverifications

To verify a card, we do a zero dollar `auth` if it's mastercard or visa.
Otherwise, we do a $1 `auth` followed by a `void`.
