### PR TITLE
Authorize.net: Add ability to verify a card

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -159,6 +159,13 @@ module ActiveMerchant #:nodoc:
         refund(money, identification, options)
       end
 
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       private
 
       def commit(action, money, parameters)

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -72,6 +72,20 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', void.message
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal "This transaction has been approved", response.message
+    assert_success response.responses.last, "The void should succeed"
+  end
+
+  def test_failed_verify
+    bogus_card = credit_card('4424222222222222')
+    assert response = @gateway.verify(bogus_card, @options)
+    assert_failure response
+    assert_match /The credit card number is invalid/, response.message
+  end
+
   def test_bad_login
     gateway = AuthorizeNetGateway.new(
       :login => 'X',

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -107,6 +107,29 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_authorization_response, successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_verify_failed_void
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorization_response, failed_void_response)
+    assert_success response
+    assert_equal "This transaction has been approved", response.message
+  end
+
+  def test_unsuccessful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(failed_authorization_response, successful_void_response)
+    assert_failure response
+    assert_equal "This transaction was declined", response.message
+  end
+
   def test_add_address_outsite_north_america
     result = {}
 
@@ -375,8 +398,16 @@ class AuthorizeNetTest < Test::Unit::TestCase
     '$1$,$1$,$1$,$This transaction has been approved.$,$d1GENk$,$Y$,$508141795$,$32968c18334f16525227$,$Store purchase$,$1.00$,$CC$,$auth_capture$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$269862C030129C1173727CC10B1935ED$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
   end
 
+  def successful_void_response
+    '$1$,$1$,$1$,$This transaction has been approved.$,$O39YT0$,$P$,$2215573915$,$823f2867c0cd10cf6e7e$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$K1C2N6$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$C9C5D270851F841D0CD9E64542D8D3BC$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$XXXX4242$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  end
+
   def failed_authorization_response
     '$2$,$1$,$1$,$This transaction was declined.$,$advE7f$,$Y$,$508141794$,$5b3fe66005f3da0ebe51$,$$,$1.00$,$CC$,$auth_only$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$2860A297E0FE804BCB9EF8738599645C$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  end
+
+  def failed_void_response
+    '$1$,$1$,$310$,$This transaction has already been voided.$,$$,$P$,$0$,$$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$02AA39F01BE7579FCBE318A14D516F9C$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
   end
 
   def already_actioned_capture_response


### PR DESCRIPTION
I see some discussion out there on the interwebs around Authorize.net
supporting $0 authorizations for Visa only but it looks like support for
it is dependent on the merchant account sitting behind the gateway
account.

To make `verify` work for all authorize.net accounts, it's implemented
as a $1.00 `auth` followed by a `void`.
