### PR TITLE
Braintree: Add ability to verify a card

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -110,6 +110,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       def store(creditcard, options = {})
         if options[:customer].present?
           MultiResponse.new.tap do |r|

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -77,6 +77,12 @@ module ActiveMerchant #:nodoc:
         commit('refund', money, post)
       end
 
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
 
       # Update the values (such as CC expiration) stored at
       # the gateway.  The CC number must be supplied in the

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -79,6 +79,18 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal customer_vault_id, response.params["braintree_transaction"]["customer_details"]["id"]
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal "1000 Approved", response.message
+  end
+
+  def test_failed_verify
+    assert response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match /number is not an accepted test number/, response.message
+  end
+
   def test_successful_validate_on_store
     card = credit_card('4111111111111111', :verification_value => '101')
     assert response = @gateway.store(card, :verify_card => true)

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -142,6 +142,19 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
     assert  response.message.match(/Invalid Transaction ID \/ Object ID specified:/)
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal "This transaction has been approved", response.message
+  end
+
+  def test_failed_verify
+    bogus_card = credit_card('4424222222222222')
+    assert response = @gateway.verify(bogus_card, @options)
+    assert_failure response
+    assert_match /Invalid Credit Card Number/, response.message
+  end
+
   def test_invalid_login
     gateway = BraintreeOrangeGateway.new(
                 :login => '',

--- a/test/remote/gateways/remote_transax_test.rb
+++ b/test/remote/gateways/remote_transax_test.rb
@@ -100,6 +100,19 @@ class RemoteTransaxTest < Test::Unit::TestCase
     assert !response.params['customer_vault_id'].blank?
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal "This transaction has been approved", response.message
+  end
+
+  def test_failed_verify
+    bogus_card = credit_card('4424222222222222')
+    assert response = @gateway.verify(bogus_card, @options)
+    assert_failure response
+    assert_match /Invalid Credit Card Number/, response.message
+  end
+
   def test_invalid_login
     gateway = TransaxGateway.new(
                 :login => '',

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class BraintreeOrangeTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = BraintreeOrangeGateway.new(
       :login => 'LOGIN',
@@ -46,6 +48,29 @@ class BraintreeOrangeTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
+  end
+
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_authorization_response, successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorization_response, failed_void_response)
+    assert_success response
+    assert_match /This transaction has been approved/, response.message
+  end
+
+  def test_unsuccessful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(failed_authorization_response, successful_void_response)
+    assert_failure response
+    assert_match /Invalid Credit Card Number/, response.message
   end
 
   def test_add_address
@@ -131,6 +156,22 @@ class BraintreeOrangeTest < Test::Unit::TestCase
 
   def failed_purchase_response
     'response=2&responsetext=DECLINE&authcode=&transactionid=510695919&avsresponse=N&cvvresponse=N&orderid=50357660b0b3ef16f72a3d3b83c46983&type=sale&response_code=200'
+  end
+
+  def successful_authorization_response
+    'response=1&responsetext=SUCCESS&authcode=123456&transactionid=2313367000&avsresponse=N&cvvresponse=N&orderid=fb5fa6d66bf82a6ea48e425e5f79095c&type=auth&response_code=100'
+  end
+
+  def failed_authorization_response
+    'response=3&responsetext=Invalid Credit Card Number REFID:127210770&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=0cfae165b48be9467b26dcb920bf05d6&type=auth&response_code=300'
+  end
+
+  def successful_void_response
+    'response=1&responsetext=Transaction Void Successful&authcode=123456&transactionid=2313367000&avsresponse=&cvvresponse=&orderid=fb5fa6d66bf82a6ea48e425e5f79095c&type=void&response_code=100'
+  end
+
+  def failed_void_response
+    'response=3&responsetext=Only transactions pending settlement can be voided REFID:127210798&authcode=&transactionid=2313369860&avsresponse=&cvvresponse=&orderid=&type=void&response_code=300'
   end
 
   def successful_store_response


### PR DESCRIPTION
It looks like Braintree has some support for zero dollar authorizations:

https://support.braintreepayments.com/customer/portal/articles/1429320-card-verification

However, the feature depends on the card type and is hampered by the
fact that some underlying processors don't support it.  Braintree
accommodates this by attempting a zero dollar `auth` and if that fails
they then attempt a $1 `auth`.

We're going to stick with a simpler approach.  Do a $1 `auth` and then a
`void`.  It'll always work, and it's only one `auth` API call.

This adds `verify` to both Braintree Blue and Braintree Orange.  Added
bonus is that Transax gets it too since it shares behavior with
Braintree Orange.

Remote tests are working across the board.  I didn't add unit tests for
Braintree Blue because those unit tests are somewhat off the beaten path
than our unit tests for other gateways due to the fact that we're using
the Braintree gem.  The unit tests there aren't the easiest to mock out.
I suspect we're relying on the remote tests for Braintree Blue in the
cases where the unit tests are deficient.  Long term, I suspect we'd
like to move away from using the gem, but I'm not sure how feasible that
is at this point.
