### PR TITLE
adding funding sources to paypal express

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -154,6 +154,13 @@ module ActiveMerchant #:nodoc:
               if !options[:allow_note].nil?
                 xml.tag! 'n2:AllowNote', options[:allow_note] ? '1' : '0'
               end
+
+              if options[:funding_sources]
+                xml.tag! 'n2:FundingSourceDetails' do
+                  xml.tag! 'n2:UserSelectedFundingSource', options[:funding_sources][:source]
+                end
+              end
+              
               xml.tag! 'n2:CallbackURL', options[:callback_url] unless options[:callback_url].blank?
 
               add_payment_details(xml, money, currency_code, options)

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -579,6 +579,7 @@ class PaypalExpressTest < Test::Unit::TestCase
         :callback_url => "http://example.com/update_callback",
         :callback_timeout => 2,
         :callback_version => '53.0',
+        :funding_sources => {:source => 'BML'},
         :shipping_options => [{:default => true,
                                :name => "first one",
                                :amount => 10}]


### PR DESCRIPTION
This will add the ability to perform PayPal gateway setup with funding options like PayPal Bill Me Later
https://www.paypal.com/webapps/mpp/billmelater-productoverview
