### PR TITLE
Worldpay: Use updated address format

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -210,14 +210,8 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'firstName', m[1]
               xml.tag! 'lastName', m[2]
             end
-            if m = /^\s*(\d+)\s+(.+)$/.match(address[:address1])
-              xml.tag! 'street', m[2]
-              house_number = m[1]
-            else
-              xml.tag! 'street', address[:address1]
-            end
-            xml.tag! 'houseName', address[:address2] if address[:address2]
-            xml.tag! 'houseNumber', house_number if house_number.present?
+            xml.tag! 'address1', address[:address1]
+            xml.tag! 'address2', address[:address2] if address[:address2]
             xml.tag! 'postalCode', (address[:zip].present? ? address[:zip] : "0000")
             xml.tag! 'city', address[:city] if address[:city]
             xml.tag! 'state', (address[:state].present? ? address[:state] : 'N/A')

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -195,9 +195,8 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
-      assert_match %r(<street>My Street</street>), data
-      assert_match %r(<houseNumber>1234</houseNumber>), data
-      assert_match %r(<houseName>Apt 1</houseName>), data
+      assert_match %r(<address1>1234 My Street</address1>), data
+      assert_match %r(<address2>Apt 1</address2>), data
       assert_match %r(<postalCode>K1C2N6</postalCode>), data
       assert_match %r(<city>Ottawa</city>), data
       assert_match %r(<state>ON</state>), data
@@ -210,9 +209,8 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
-      assert_match %r(<street>My Street</street>), data
-      assert_match %r(<houseNumber>1234</houseNumber>), data
-      assert_match %r(<houseName>Apt 1</houseName>), data
+      assert_match %r(<address1>1234 My Street</address1>), data
+      assert_match %r(<address2>Apt 1</address2>), data
       assert_match %r(<postalCode>K1C2N6</postalCode>), data
       assert_match %r(<city>Ottawa</city>), data
       assert_match %r(<state>ON</state>), data
@@ -225,10 +223,10 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
-      assert_no_match %r(houseName), data
+      assert_no_match %r(address2), data
       assert_no_match %r(city), data
       assert_no_match %r(telephoneNumber), data
-      assert_match %r(<street>Anystreet</street>), data
+      assert_match %r(<address1>Anystreet</address1>), data
       assert_match %r(<postalCode>0000</postalCode>), data
       assert_match %r(<state>N/A</state>), data
     end.respond_with(successful_authorize_response)


### PR DESCRIPTION
The original handling of address was added to Worldpay in April, 2011.
In September, 2011, Worldpay updated their API and changed some of the
names of the fields used:

http://support.worldpay.com/support/gg/index.php?page=news&sub=payment-page-changes-details-sep2011

The old fields still work (for now).  Even so, the new fields simplify
our logic some and make things more consistent with their current API
docs:

http://support.worldpay.com/support/kb/gg/pdf/dxml.pdf

Those docs no longer even refer to houseName, houseNumber, or street
fields.
