### PR TITLE
First Data E4: Add ability to verify a card

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -6,12 +6,13 @@ module ActiveMerchant #:nodoc:
       self.live_url = "https://api.globalgatewaye4.firstdata.com/transaction/v11"
 
       TRANSACTIONS = {
-        :sale          => "00",
-        :authorization => "01",
-        :capture       => "32",
-        :void          => "33",
-        :credit        => "34",
-        :store         => "05"
+        sale:          "00",
+        authorization: "01",
+        verify:        "05",
+        capture:       "32",
+        void:          "33",
+        credit:        "34",
+        store:         "05"
       }
 
       POST_HEADERS = {
@@ -72,6 +73,10 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options = {})
         commit(:credit, build_capture_or_credit_request(money, authorization, options))
+      end
+
+      def verify(credit_card, options = {})
+        commit(:verify, build_sale_or_authorization_request(0, credit_card, options))
       end
 
       # Tokenize a credit card with TransArmor

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -71,6 +71,21 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_match(/Invalid Authorization Number/i, response.message)
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal "Transaction Normal - Approved", response.message
+    assert_equal "0.0", response.params["dollar_amount"]
+    assert_equal "05", response.params["transaction_type"]
+  end
+
+  def test_failed_verify
+    assert response = @gateway.verify(@bad_credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid Credit Card Number}, response.message
+  end
+
   def test_invalid_login
     gateway = FirstdataE4Gateway.new(:login    => "NotARealUser",
                                      :password => "NotARealPassword" )

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -76,6 +76,13 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_verify_response)
+    assert_success response
+  end
+
   def test_expdate
     assert_equal(
       "%02d%s" % [@credit_card.month, @credit_card.year.to_s[-2..-1]],
@@ -473,6 +480,102 @@ Transaction not approved 605
 Please retain this copy for your records.
 =========================================</CTR>
     </TransactionResult>
+    RESPONSE
+  end
+
+  def successful_verify_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<TransactionResult>
+  <ExactID>AD2552-05</ExactID>
+  <Password></Password>
+  <Transaction_Type>05</Transaction_Type>
+  <DollarAmount>0.0</DollarAmount>
+  <SurchargeAmount></SurchargeAmount>
+  <Card_Number>############4242</Card_Number>
+  <Transaction_Tag>25101911</Transaction_Tag>
+  <Track1></Track1>
+  <Track2></Track2>
+  <PAN></PAN>
+  <Authorization_Num>ET184931</Authorization_Num>
+  <Expiry_Date>0915</Expiry_Date>
+  <CardHoldersName>Longbob Longsen</CardHoldersName>
+  <VerificationStr1>1234 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>
+  <VerificationStr2>123</VerificationStr2>
+  <CVD_Presence_Ind>0</CVD_Presence_Ind>
+  <ZipCode></ZipCode>
+  <Tax1Amount></Tax1Amount>
+  <Tax1Number></Tax1Number>
+  <Tax2Amount></Tax2Amount>
+  <Tax2Number></Tax2Number>
+  <Secure_AuthRequired></Secure_AuthRequired>
+  <Secure_AuthResult></Secure_AuthResult>
+  <Ecommerce_Flag></Ecommerce_Flag>
+  <XID></XID>
+  <CAVV></CAVV>
+  <CAVV_Algorithm></CAVV_Algorithm>
+  <Reference_No>1</Reference_No>
+  <Customer_Ref></Customer_Ref>
+  <Reference_3>Store Purchase</Reference_3>
+  <Language></Language>
+  <Client_IP>75.182.123.244</Client_IP>
+  <Client_Email></Client_Email>
+  <Transaction_Error>false</Transaction_Error>
+  <Transaction_Approved>true</Transaction_Approved>
+  <EXact_Resp_Code>00</EXact_Resp_Code>
+  <EXact_Message>Transaction Normal</EXact_Message>
+  <Bank_Resp_Code>100</Bank_Resp_Code>
+  <Bank_Message>Approved</Bank_Message>
+  <Bank_Resp_Code_2></Bank_Resp_Code_2>
+  <SequenceNo>000040</SequenceNo>
+  <AVS>1</AVS>
+  <CVV2>M</CVV2>
+  <Retrieval_Ref_No>7228838</Retrieval_Ref_No>
+  <CAVV_Response></CAVV_Response>
+  <Currency>USD</Currency>
+  <AmountRequested></AmountRequested>
+  <PartialRedemption>false</PartialRedemption>
+  <MerchantName>FriendlyInc</MerchantName>
+  <MerchantAddress>123 Main Street</MerchantAddress>
+  <MerchantCity>Durham</MerchantCity>
+  <MerchantProvince>North Carolina</MerchantProvince>
+  <MerchantCountry>United States</MerchantCountry>
+  <MerchantPostal>27592</MerchantPostal>
+  <MerchantURL></MerchantURL>
+  <TransarmorToken></TransarmorToken>
+  <CardType>Visa</CardType>
+  <CurrentBalance></CurrentBalance>
+  <PreviousBalance></PreviousBalance>
+  <EAN></EAN>
+  <CardCost></CardCost>
+  <VirtualCard>false</VirtualCard>
+  <CTR>=========== TRANSACTION RECORD ==========
+FriendlyInc DEMO0
+123 Main Street
+Durham, NC 27592
+United States
+
+
+TYPE: Auth Only
+
+ACCT: Visa  $ 0.00 USD
+
+CARDHOLDER NAME : Longbob Longsen
+CARD NUMBER     : ############4242
+DATE/TIME       : 04 Jul 14 14:21:52
+REFERENCE #     :  000040 M
+AUTHOR. #       : ET184931
+TRANS. REF.     : 1
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+</TransactionResult>
     RESPONSE
   end
 


### PR DESCRIPTION
First Data E4 has support for $0 authorizations so we don't need to void
it.  It's a "Pre-Authorization Only" transaction rather than a standard
authorization which is a "Pre-Authorization" transaction.

Docs for it:
https://firstdata.zendesk.com/entries/407571-First-Data-Global-Gateway-e4-Web-Service-API-Reference-Guide
