### PR TITLE
SagePay: Truncate more fields

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -174,8 +174,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        add_pair(post, :CustomerEMail, options[:email][0,255]) unless options[:email].blank?
-        add_pair(post, :BillingPhone, options[:phone].gsub(/[^0-9+]/, '')[0,20]) unless options[:phone].blank?
+        add_pair(post, :CustomerEMail, truncate(options[:email], 255)) unless options[:email].blank?
         add_pair(post, :ClientIPAddress, options[:ip])
       end
 
@@ -190,30 +189,32 @@ module ActiveMerchant #:nodoc:
           first_name, last_name = parse_first_and_last_name(billing_address[:name])
           add_pair(post, :BillingSurname, last_name)
           add_pair(post, :BillingFirstnames, first_name)
-          add_pair(post, :BillingAddress1, billing_address[:address1])
-          add_pair(post, :BillingAddress2, billing_address[:address2])
-          add_pair(post, :BillingCity, billing_address[:city])
-          add_pair(post, :BillingState, billing_address[:state]) if billing_address[:country] == 'US'
-          add_pair(post, :BillingCountry, billing_address[:country])
-          add_pair(post, :BillingPostCode, billing_address[:zip])
+          add_pair(post, :BillingAddress1, truncate(billing_address[:address1], 100))
+          add_pair(post, :BillingAddress2, truncate(billing_address[:address2], 100))
+          add_pair(post, :BillingCity, truncate(billing_address[:city], 40))
+          add_pair(post, :BillingState, truncate(billing_address[:state], 2)) if is_usa(billing_address[:country])
+          add_pair(post, :BillingCountry, truncate(billing_address[:country], 2))
+          add_pair(post, :BillingPhone, sanitize_phone(billing_address[:phone]))
+          add_pair(post, :BillingPostCode, truncate(billing_address[:zip], 10))
         end
 
         if shipping_address = options[:shipping_address] || billing_address
           first_name, last_name = parse_first_and_last_name(shipping_address[:name])
           add_pair(post, :DeliverySurname, last_name)
           add_pair(post, :DeliveryFirstnames, first_name)
-          add_pair(post, :DeliveryAddress1, shipping_address[:address1])
-          add_pair(post, :DeliveryAddress2, shipping_address[:address2])
-          add_pair(post, :DeliveryCity, shipping_address[:city])
-          add_pair(post, :DeliveryState, shipping_address[:state]) if shipping_address[:country] == 'US'
-          add_pair(post, :DeliveryCountry, shipping_address[:country])
-          add_pair(post, :DeliveryPostCode, shipping_address[:zip])
+          add_pair(post, :DeliveryAddress1, truncate(shipping_address[:address1], 100))
+          add_pair(post, :DeliveryAddress2, truncate(shipping_address[:address2], 100))
+          add_pair(post, :DeliveryCity, truncate(shipping_address[:city], 40))
+          add_pair(post, :DeliveryState, truncate(shipping_address[:state], 2)) if is_usa(shipping_address[:country])
+          add_pair(post, :DeliveryCountry, truncate(shipping_address[:country], 2))
+          add_pair(post, :DeliveryPhone, sanitize_phone(shipping_address[:phone]))
+          add_pair(post, :DeliveryPostCode, truncate(shipping_address[:zip], 10))
         end
       end
 
       def add_invoice(post, options)
         add_pair(post, :VendorTxCode, sanitize_order_id(options[:order_id]), :required => true)
-        add_pair(post, :Description, truncate_description(options[:description] || options[:order_id]))
+        add_pair(post, :Description, truncate(options[:description] || options[:order_id], 100))
       end
 
       def add_payment_method(post, payment_method, options)
@@ -225,7 +226,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_credit_card(post, credit_card)
-        add_pair(post, :CardHolder, credit_card.name, :required => true)
+        add_pair(post, :CardHolder, truncate(credit_card.name, 50), :required => true)
         add_pair(post, :CardNumber, credit_card.number, :required => true)
 
         add_pair(post, :ExpiryDate, format_date(credit_card.month, credit_card.year), :required => true)
@@ -249,12 +250,23 @@ module ActiveMerchant #:nodoc:
       end
 
       def sanitize_order_id(order_id)
-        order_id.to_s.gsub(/[^-a-zA-Z0-9._]/, '')
+        cleansed = order_id.to_s.gsub(/[^-a-zA-Z0-9._]/, '')
+        truncate(cleansed, 40)
       end
 
-      def truncate_description(description)
-        return nil unless description
-        description[0, 100]
+      def sanitize_phone(phone)
+        return nil unless phone
+        cleansed = phone.to_s.gsub(/[^0-9+]/, '')
+        truncate(cleansed, 20)
+      end
+
+      def truncate(value, max_size)
+        return nil unless value
+        value[0, max_size]
+      end
+
+      def is_usa(country)
+        truncate(country, 2) == 'US'
       end
 
       def map_card_type(credit_card)
@@ -368,7 +380,7 @@ module ActiveMerchant #:nodoc:
 
         last_name = name.pop || ''
         first_name = name.join(' ')
-        [ first_name[0,20], last_name[0,20] ]
+        [ truncate(first_name, 20), truncate(last_name, 20) ]
       end
 
       def localized_amount(money, currency)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -180,9 +180,36 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
-  def test_successful_purchase_with_long_description
-    description = "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters."
-    assert response = @gateway.purchase(@amount, @visa, @options.merge(description: description))
+  def test_successful_purchase_with_overly_long_fields
+    options = {
+      description: "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters.",
+      order_id: "#{generate_unique_id} SagePay order_id cannot be more than 40 characters.",
+      billing_address: {
+        name: 'FirstNameCannotBeMoreThanTwentyChars SurnameCannotBeMoreThanTwenty',
+        address1: 'The Billing Address 1 Cannot Be More Than One Hundred Characters if it is it will fail.  Therefore, we truncate it.',
+        address2: 'The Billing Address 2 Cannot Be More Than One Hundred Characters if it is it will fail.  Therefore, we truncate it.',
+        phone: "111222333444555666777888999",
+        city: "TheCityCannotBeMoreThanFortyCharactersReally",
+        state: "NCStateIsTwoChars",
+        country: 'USMustBeTwoChars',
+        zip: 'PostalCodeCannotExceedTenChars'
+      },
+      shipping_address: {
+        name: 'FirstNameCannotBeMoreThanTwentyChars SurnameCannotBeMoreThanTwenty',
+        address1: 'The Shipping Address 1 Cannot Be More Than One Hundred Characters if it is it will fail.  Therefore, we truncate it.',
+        address2: 'The Shipping Address 2 Cannot Be More Than One Hundred Characters if it is it will fail.  Therefore, we truncate it.',
+        phone: "111222333444555666777888999",
+        city: "TheCityCannotBeMoreThanFortyCharactersReally",
+        state: "NCStateIsTwoChars",
+        country: 'USMustBeTwoChars',
+        zip: 'PostalCodeCannotExceedTenChars'
+      }
+    }
+
+    @visa.first_name = "FullNameOnACardMustBeLessThanFiftyCharacters"
+    @visa.last_name = "OtherwiseSagePayFailsIt"
+
+    assert response = @gateway.purchase(@amount, @visa, options)
     assert_success response
   end
 


### PR DESCRIPTION
SagePay is somewhat particular about field lengths; transactions are
declined if those lengths are exceeded.  Now we truncate more of the
fields to match their docs:

http://bit.ly/1qSS5DV
