### PR TITLE
set :fraud_remote_addr to options[:ip]

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -290,7 +290,7 @@ module ActiveMerchant #:nodoc:
 
       def add_fraud_parameters(post, options)
         if @protocol >= 4
-          post[:fraud_remote_addr] = options[:fraud_remote_addr] if options[:fraud_remote_addr]
+          post[:fraud_remote_addr] = options[:ip] if options[:ip]
           post[:fraud_http_accept] = options[:fraud_http_accept] if options[:fraud_http_accept]
           post[:fraud_http_accept_language] = options[:fraud_http_accept_language] if options[:fraud_http_accept_language]
           post[:fraud_http_accept_encoding] = options[:fraud_http_accept_encoding] if options[:fraud_http_accept_encoding]

--- a/test/remote/gateways/remote_quickpay_v7_test.rb
+++ b/test/remote/gateways/remote_quickpay_v7_test.rb
@@ -38,8 +38,8 @@ class RemoteQuickpayV7Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_all_fraud_parameters
+    @options[:ip] = '127.0.0.1' # will set :fraud_remote_addr
     @options[:fraud_http_referer] = 'http://www.excample.com'
-    @options[:fraud_remote_addr] = '127.0.0.1'
     @options[:fraud_http_accept] = 'foo'
     @options[:fraud_http_accept_language] = "DK"
     @options[:fraud_http_accept_encoding] = "UFT8"


### PR DESCRIPTION
As mentioned in subject, simply set `:fraud_remote_addr` to `options[:ip]`. Will enable QuickPay to do some fraud filtering. Thanks.
