### PR TITLE
Add authentication credentials to requests if they're present.

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -134,6 +134,7 @@ module ActiveMerchant #:nodoc:
 
         add_customer_data(xml, options)
         add_invoice(xml, options)
+        add_card_authentication_data(xml, options)
 
         xml.target!
       end
@@ -144,6 +145,7 @@ module ActiveMerchant #:nodoc:
         add_identification(xml, identification)
         add_amount(xml, money)
         add_customer_data(xml, options)
+        add_card_authentication_data(xml, options)
 
         xml.target!
       end
@@ -198,6 +200,12 @@ module ActiveMerchant #:nodoc:
           xml.tag! "CVD_Presence_Ind", "1"
           xml.tag! "VerificationStr2", credit_card.verification_value
         end
+      end
+
+      def add_card_authentication_data(xml, options)
+        xml.tag! "CAVV", options[:cavv]
+        xml.tag! "XID", options[:xid]
+        xml.tag! "Ecommerce_Flag", options[:eci]
       end
 
       def add_credit_card_token(xml, store_authorization)

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -11,11 +11,24 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
       :billing_address => address,
       :description => 'Store Purchase'
     }
+    @options_with_authentication_data = @options.merge({
+      eci: "5",
+      cavv: "TESTCAVV",
+      xid: "TESTXID"
+    })
   end
 
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_card_authentication
+    assert response = @gateway.purchase(@amount, @credit_card, @options_with_authentication_data)
+    assert_equal response.params["cavv"], @options_with_authentication_data[:cavv]
+    assert_equal response.params["ecommerce_flag"], @options_with_authentication_data[:eci]
+    assert_equal response.params["xid"], @options_with_authentication_data[:xid]
     assert_success response
   end
 
@@ -100,5 +113,4 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_equal 'M', response.cvv_result["code"]
     assert_equal '1', response.avs_result["code"]
   end
-
 end

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -128,6 +128,23 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_requests_include_card_authentication_data
+    authentication_hash = {
+      eci: "06",
+      cavv: "SAMPLECAVV",
+      xid: "SAMPLEXID"
+    }
+    options_with_authentication_data = @options.merge(authentication_hash)
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_authentication_data)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>06</Ecommerce_Flag>", data
+      assert_match "<CAVV>SAMPLECAVV</CAVV>", data
+      assert_match "<XID>SAMPLEXID</XID>", data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_card_type
     assert_equal 'Visa', @gateway.send(:card_type, 'visa')
     assert_equal 'Mastercard', @gateway.send(:card_type, 'master')


### PR DESCRIPTION
For users who are using Cardinal Commerce to verify credit cards with Verified by Visa and MasterCard Secure there are requirements that the values returned by cardinal are included in the request when authorizing and capturing payments with first data. Without these values present it would behave as a normal unauthenticated transaction.
