### PR TITLE
Braintree blue cardholder name

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -144,6 +144,7 @@ module ActiveMerchant #:nodoc:
           options.merge!(:update_existing_token => braintree_credit_card.token)
           credit_card_params = merge_credit_card_options({
             :credit_card => {
+              :cardholder_name => creditcard.name,
               :number => creditcard.number,
               :cvv => creditcard.verification_value,
               :expiration_month => creditcard.month.to_s.rjust(2, "0"),
@@ -197,6 +198,7 @@ module ActiveMerchant #:nodoc:
             :email => scrub_email(options[:email]),
             :id => options[:customer],
             :credit_card => {
+              :cardholder_name => creditcard.name,
               :number => creditcard.number,
               :cvv => creditcard.verification_value,
               :expiration_month => creditcard.month.to_s.rjust(2, "0"),
@@ -221,6 +223,7 @@ module ActiveMerchant #:nodoc:
           parameters = {
             customer_id: options[:customer],
             token: options[:credit_card_token],
+            cardholder_name: credit_card.name,
             number: credit_card.number,
             cvv: credit_card.verification_value,
             expiration_month: credit_card.month.to_s.rjust(2, "0"),

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -149,6 +149,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options].has_key?(:verify_card)
       assert_equal true, params[:credit_card][:options][:verify_card]
+      assert_equal "Longbob Longsen", params[:credit_card][:cardholder_name]
       params
     end.returns(result)
 
@@ -299,6 +300,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::CreditCardGateway.any_instance.expects(:create).with do |params|
       assert_equal "customerid", params[:customer_id]
       assert_equal "41111111111111111111", params[:number]
+      assert_equal "Longbob Longsen", params[:cardholder_name]
       params
     end.returns(result)
 
@@ -318,6 +320,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     result = Braintree::SuccessfulResult.new(:customer => customer)
     Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
       assert_equal "567", params[:credit_card][:cvv]
+      assert_equal "Longbob Longsen", params[:credit_card][:cardholder_name]
       [vault, params]
     end.returns(result)
 


### PR DESCRIPTION
A user has reported within spree/spree_gateway#164 that the cardholder_name was not being passed in when using Braintree. Upon investigation, I have found that this appears caused by a missing parameter within active_merchant's `braintree_blue.rb` code. 

All the tests pass, and attempting to put a payment through using Spree using this modified version of active_merchant results in the "Cardholder Name" on Braintree no longer being blank.
