### PR TITLE
Eway Rapid: Truncate some fields

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -178,8 +178,8 @@ module ActiveMerchant #:nodoc:
         currency_code = options[:currency] || currency(money)
         params[key] = {
           'TotalAmount' => localized_amount(money, currency_code),
-          'InvoiceReference' => options[:order_id],
-          'InvoiceDescription' => options[:description],
+          'InvoiceReference' => truncate(options[:order_id]),
+          'InvoiceDescription' => truncate(options[:description], 64),
           'CurrencyCode' => currency_code,
         }
       end
@@ -205,9 +205,9 @@ module ActiveMerchant #:nodoc:
         end
         params['Title'] = address[:title]
         params['CompanyName'] = address[:company] unless options[:skip_company]
-        params['Street1'] = address[:address1]
-        params['Street2'] = address[:address2]
-        params['City'] = address[:city]
+        params['Street1'] = truncate(address[:address1])
+        params['Street2'] = truncate(address[:address2])
+        params['City'] = truncate(address[:city])
         params['State'] = address[:state]
         params['PostalCode'] = address[:zip]
         params['Country'] = address[:country].to_s.downcase
@@ -222,7 +222,7 @@ module ActiveMerchant #:nodoc:
         if credit_card.respond_to? :number
           params['Method'] = 'ProcessPayment'
           card_details = params['Customer']['CardDetails'] = {}
-          card_details['Name'] = credit_card.name
+          card_details['Name'] = truncate(credit_card.name)
           card_details['Number'] = credit_card.number
           card_details['ExpiryMonth'] = "%02d" % (credit_card.month || 0)
           card_details['ExpiryYear'] = "%02d" % (credit_card.year || 0)
@@ -323,6 +323,11 @@ module ActiveMerchant #:nodoc:
         else
           "P"
         end
+      end
+
+      def truncate(value, max_size = 50)
+        return nil unless value
+        value[0, max_size]
       end
 
       MESSAGES = {

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -62,6 +62,29 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_overly_long_fields
+    options = {
+      order_id: "OrderId must be less than 50 characters otherwise it fails",
+      description: "EWay Rapid transactions fail if the description is more than 64 characters.",
+      billing_address: {
+        address1: "The Billing Address 1 Cannot Be More Than Fifty Characters.",
+        address2: "The Billing Address 2 Cannot Be More Than Fifty Characters.",
+        city: "TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart",
+      },
+      shipping_address: {
+        address1: "The Shipping Address 1 Cannot Be More Than Fifty Characters.",
+        address2: "The Shipping Address 2 Cannot Be More Than Fifty Characters.",
+        city: "TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart",
+      }
+    }
+    @credit_card.first_name = "FullNameOnACardMustBeLessThanFiftyCharacters"
+    @credit_card.last_name = "LastName"
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal "Transaction Approved Successful", response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@failed_amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -56,7 +56,7 @@ class EwayRapidTest < Test::Unit::TestCase
         :redirect_url => "http://awesomesauce.com",
         :ip => "0.0.0.0",
         :application_id => "Woohoo",
-        :description => "Description",
+        :description => "The Really Long Description More Than Sixty Four Characters Gets Truncated",
         :order_id => "orderid1",
         :currency => "INR",
         :email => "jim@example.com",
@@ -96,7 +96,7 @@ class EwayRapidTest < Test::Unit::TestCase
       assert_match(%r{"DeviceID":"Woohoo"}, data)
 
       assert_match(%r{"TotalAmount":"200"}, data)
-      assert_match(%r{"InvoiceDescription":"Description"}, data)
+      assert_match(%r{"InvoiceDescription":"The Really Long Description More Than Sixty Four Characters Gets"}, data)
       assert_match(%r{"InvoiceReference":"orderid1"}, data)
       assert_match(%r{"CurrencyCode":"INR"}, data)
 


### PR DESCRIPTION
Eway Rapid transactions fail if the parameters don't fit within the
required boundaries.  Therefore, we now truncate fields to their maximum
length.

In particular, we're now truncating order_id, description, billing_address1,
billing_address2, billing_city, shipping_address1, shipping_address_2,
shipping_city, and card_name.

Relevant docs:
http://api-portal.anypoint.mulesoft.com/eway/api/eway-rapid-31-api/docs/reference/transparent-redirect
