### PR TITLE
Make account a mandatory field for Optimal Payments.

### DIFF
--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -17,7 +17,18 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Optimal Payments'
 
       def initialize(options = {})
-        #requires!(options, :login, :password)
+
+        if(options[:login])
+          ActiveMerchant.deprecated("The 'login' option is deprecated in favor of 'store_id' and will be removed in a future version.")
+          options[:store_id] = options[:login]
+        end
+
+        if(options[:account])
+          ActiveMerchant.deprecated("The 'account' option is deprecated in favor of 'account_number' and will be removed in a future version.")
+          options[:account_number] = options[:account]
+        end
+
+        requires!(options, :account_number, :store_id, :password)
         super
       end
 
@@ -155,7 +166,7 @@ module ActiveMerchant #:nodoc:
 
       def cc_auth_request(money, opts)
         xml_document('ccAuthRequestV1') do |xml|
-          build_merchant_account(xml, @options)
+          build_merchant_account(xml)
           xml.merchantRefNum opts[:order_id]
           xml.amount(money/100.0)
           build_card(xml, opts)
@@ -167,7 +178,7 @@ module ActiveMerchant #:nodoc:
 
       def cc_auth_reversal_request(opts)
         xml_document('ccAuthReversalRequestV1') do |xml|
-          build_merchant_account(xml, @options)
+          build_merchant_account(xml)
           xml.confirmationNumber opts[:confirmationNumber]
           xml.merchantRefNum opts[:order_id]
         end
@@ -175,7 +186,7 @@ module ActiveMerchant #:nodoc:
 
       def cc_post_auth_request(money, opts)
         xml_document('ccPostAuthRequestV1') do |xml|
-          build_merchant_account(xml, @options)
+          build_merchant_account(xml)
           xml.confirmationNumber opts[:confirmationNumber]
           xml.merchantRefNum opts[:order_id]
           xml.amount(money/100.0)
@@ -184,7 +195,7 @@ module ActiveMerchant #:nodoc:
 
       def cc_stored_data_request(money, opts)
         xml_document('ccStoredDataRequestV1') do |xml|
-          build_merchant_account(xml, @options)
+          build_merchant_account(xml)
           xml.merchantRefNum opts[:order_id]
           xml.confirmationNumber opts[:confirmationNumber]
           xml.amount(money/100.0)
@@ -195,14 +206,14 @@ module ActiveMerchant #:nodoc:
       #
       # def cc_cancel_request(opts)
       #   xml_document('ccCancelRequestV1') do |xml|
-      #     build_merchant_account(xml, @options)
+      #     build_merchant_account(xml)
       #     xml.confirmationNumber opts[:confirmationNumber]
       #   end
       # end
       #
       # def cc_payment_request(money, opts)
       #   xml_document('ccPaymentRequestV1') do |xml|
-      #     build_merchant_account(xml, @options)
+      #     build_merchant_account(xml)
       #     xml.merchantRefNum opts[:order_id]
       #     xml.amount(money/100.0)
       #     build_card(xml, opts)
@@ -212,7 +223,7 @@ module ActiveMerchant #:nodoc:
       #
       # def cc_authenticate_request(opts)
       #   xml_document('ccAuthenticateRequestV1') do |xml|
-      #     build_merchant_account(xml, @options)
+      #     build_merchant_account(xml)
       #     xml.confirmationNumber opts[:confirmationNumber]
       #     xml.paymentResponse 'myPaymentResponse'
       #   end
@@ -225,11 +236,11 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def build_merchant_account(xml, opts)
+      def build_merchant_account(xml)
         xml.tag! 'merchantAccount' do
-          xml.tag! 'accountNum' , opts[:account]
-          xml.tag! 'storeID'    , opts[:login]
-          xml.tag! 'storePwd'   , opts[:password]
+          xml.tag! 'accountNum' , @options[:account_number]
+          xml.tag! 'storeID'    , @options[:store_id]
+          xml.tag! 'storePwd'   , @options[:password]
         end
       end
 
@@ -265,20 +276,20 @@ module ActiveMerchant #:nodoc:
 
       def build_address(xml, addr, email=nil)
         if addr[:name]
-          xml.tag! 'firstName', CGI.escape(addr[:name].split(' ').first) # TODO: parse properly
-          xml.tag! 'lastName' , CGI.escape(addr[:name].split(' ').last )
+          xml.tag! 'firstName', addr[:name].split(' ').first
+          xml.tag! 'lastName' , addr[:name].split(' ').last
         end
-        xml.tag! 'street' , CGI.escape(addr[:address1]) if addr[:address1].present?
-        xml.tag! 'street2', CGI.escape(addr[:address2]) if addr[:address2].present?
-        xml.tag! 'city'   , CGI.escape(addr[:city]    ) if addr[:city].present?
+        xml.tag! 'street' , addr[:address1] if addr[:address1].present?
+        xml.tag! 'street2', addr[:address2] if addr[:address2].present?
+        xml.tag! 'city'   , addr[:city]     if addr[:city].present?
         if addr[:state].present?
           state_tag = %w(US CA).include?(addr[:country]) ? 'state' : 'region'
-          xml.tag! state_tag, CGI.escape(addr[:state])
+          xml.tag! state_tag, addr[:state]
         end
-        xml.tag! 'country', CGI.escape(addr[:country] ) if addr[:country].present?
-        xml.tag! 'zip'    , CGI.escape(addr[:zip]     ) if addr[:zip].present?
-        xml.tag! 'phone'  , CGI.escape(addr[:phone]   ) if addr[:phone].present?
-        xml.tag! 'email', CGI.escape(email) if email
+        xml.tag! 'country', addr[:country]  if addr[:country].present?
+        xml.tag! 'zip'    , addr[:zip]      if addr[:zip].present?
+        xml.tag! 'phone'  , addr[:phone]    if addr[:phone].present?
+        xml.tag! 'email', email if email
       end
 
       def card_type(key)
@@ -295,4 +306,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -392,9 +392,9 @@ openpay:
   merchant_id: 'mzdtln0bmtms6o3kck8f'
 
 optimal_payment:
-  login: test
+  store_id: test
   password: test
-  account: 'ACCOUNT_NUMBER'
+  account_number: '12345678'
 
 orbital_gateway:
   login: LOGIN

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -38,27 +38,6 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     assert_equal 'no_error', response.message
   end
 
-  def test_minimal_successful_purchase
-    options = {
-      :order_id => '1',
-      :description => 'Basic Subscription',
-      :billing_address => {
-        :zip      => 'K1C2N6',
-      }
-    }
-    credit_card = CreditCard.new(
-      :number => '4242424242424242',
-      :month => 9,
-      :year => Time.now.year + 1,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :brand => 'visa'
-    )
-    assert response = @gateway.purchase(@amount, credit_card, options)
-    assert_success response
-    assert_equal 'no_error', response.message
-  end
-
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@declined_amount, @credit_card, @options)
     assert_failure response
@@ -149,8 +128,8 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = OptimalPaymentGateway.new(
-                :account => '1',
-                :login => 'bad',
+                :account_number => '1',
+                :store_id => 'bad',
                 :password => 'bad'
               )
     assert response = gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -10,7 +10,8 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def setup
     @gateway = OptimalPaymentGateway.new(
-      :login => 'login',
+      :account_number => '12345678',
+      :store_id => 'login',
       :password => 'password'
     )
 
@@ -143,7 +144,8 @@ class OptimalPaymentTest < Test::Unit::TestCase
     begin
       ActiveMerchant::Billing::Base.mode = :production
       @gateway = OptimalPaymentGateway.new(
-                   :login => 'login',
+                    :account_number => '12345678',
+                   :store_id => 'login',
                    :password => 'password',
                    :test => true
                  )
@@ -180,12 +182,23 @@ class OptimalPaymentTest < Test::Unit::TestCase
     assert !response.cvv_result['code']
   end
 
-  def test_email_being_sent
-    @gateway.expects(:ssl_post).with do |url, data|
-      data =~ /email%3Eemail%2540example.com%3C%2Femail/
+  def test_deprecated_options
+
+    assert_deprecation_warning("The 'account' option is deprecated in favor of 'account_number' and will be removed in a future version.") do
+      @gateway = OptimalPaymentGateway.new(
+        :account => '12345678',
+        :store_id => 'login',
+        :password => 'password'
+      )
     end
 
-    @gateway.purchase(@amount, @credit_card, @options)
+    assert_deprecation_warning("The 'login' option is deprecated in favor of 'store_id' and will be removed in a future version.") do
+      @gateway = OptimalPaymentGateway.new(
+        :account_number => '12345678',
+        :login => 'login',
+        :password => 'password'
+      )
+    end
   end
 
   private
@@ -194,7 +207,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
     str = <<-XML
 <ccAuthRequestV1 xmlns>
   <merchantAccount>
-    <accountNum/>
+    <accountNum>12345678</accountNum>
     <storeID>login</storeID>
     <storePwd>password</storePwd>
   </merchantAccount>
@@ -214,14 +227,14 @@ class OptimalPaymentTest < Test::Unit::TestCase
     <cardPayMethod>WEB</cardPayMethod>
     <firstName>Jim</firstName>
     <lastName>Smith</lastName>
-    <street>1234+My+Street</street>
-    <street2>Apt+1</street2>
+    <street>1234 My Street</street>
+    <street2>Apt 1</street2>
     <city>Ottawa</city>
     <state>ON</state>
     <country>CA</country>
     <zip>K1C2N6</zip>
-    <phone>%28555%29555-5555</phone>
-    <email>email%40example.com</email>
+    <phone>(555)555-5555</phone>
+    <email>email@example.com</email>
   </billingDetails>
 </ccAuthRequestV1>
     XML
@@ -232,7 +245,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
     str = <<-XML
 <ccAuthRequestV1 xmlns>
   <merchantAccount>
-    <accountNum/>
+    <accountNum>12345678</accountNum>
     <storeID>login</storeID>
     <storePwd>password</storePwd>
   </merchantAccount>


### PR DESCRIPTION
The Optimal Payments gateway requires an accountNum field as part of the
credentials. This commit makes it a mandatory field while also deprecating
the existing login field which is called store_id in Optimal vernacular.

Closes #1307
