### PR TITLE
Worldpay: Improve address defaulting

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -196,7 +196,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'cardHolderName', payment_method.name
               xml.tag! 'cvc', payment_method.verification_value
 
-              add_address(xml, 'cardAddress', (options[:billing_address] || options[:address]))
+              add_address(xml, (options[:billing_address] || options[:address]))
             end
             if options[:ip]
               xml.tag! 'session', 'shopperIPAddress' => options[:ip]
@@ -212,10 +212,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_address(xml, element, address)
-        return if address.nil?
+      def add_address(xml, address)
+        address = default_address.merge(address || {})
 
-        xml.tag! element do
+        xml.tag! 'cardAddress' do
           xml.tag! 'address' do
             if m = /^\s*([^\s]+)\s+(.+)$/.match(address[:name])
               xml.tag! 'firstName', m[1]
@@ -223,13 +223,23 @@ module ActiveMerchant #:nodoc:
             end
             xml.tag! 'address1', address[:address1]
             xml.tag! 'address2', address[:address2] if address[:address2]
-            xml.tag! 'postalCode', (address[:zip].present? ? address[:zip] : "0000")
-            xml.tag! 'city', address[:city] if address[:city]
-            xml.tag! 'state', (address[:state].present? ? address[:state] : 'N/A')
+            xml.tag! 'postalCode', address[:zip]
+            xml.tag! 'city', address[:city]
+            xml.tag! 'state', address[:state]
             xml.tag! 'countryCode', address[:country]
             xml.tag! 'telephoneNumber', address[:phone] if address[:phone]
           end
         end
+      end
+
+      def default_address
+        {
+          address1: 'N/A',
+          zip: '0000',
+          city: 'N/A',
+          state: 'N/A',
+          country: 'US'
+        }
       end
 
       def parse(action, xml)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -36,7 +36,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_successful_reference_transaction_authorize_with_merchant_code
     response = stub_comms do
-      @gateway.authorize(@amount, @options[:order_id].to_s, @options.merge({ :merchant_code => 'testlogin2'}))
+      @gateway.authorize(@amount, @options[:order_id].to_s, @options.merge({ merchant_code: 'testlogin2'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/testlogin2/, data)
     end.respond_with(successful_authorize_response)
@@ -60,7 +60,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_purchase_passes_correct_currency
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'CAD'))
+      @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
     end.check_request do |endpoint, data, headers|
       assert_match(/CAD/, data)
     end.respond_with(successful_authorize_response, successful_capture_response)
@@ -146,7 +146,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(:description => "Something cool."))
+      @gateway.authorize(@amount, @credit_card, @options.merge(description: "Something cool."))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<description>Something cool.</description>), data
     end.respond_with(successful_authorize_response)
@@ -160,7 +160,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(:order_content => "Lots 'o' crazy <data> stuff."))
+      @gateway.authorize(@amount, @credit_card, @options.merge(order_content: "Lots 'o' crazy <data> stuff."))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<orderContent>\s*<!\[CDATA\[Lots 'o' crazy <data> stuff\.\]\]>\s*</orderContent>), data
     end.respond_with(successful_authorize_response)
@@ -191,7 +191,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_address_handling
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:billing_address => address))
+      @gateway.authorize(100, @credit_card, @options.merge(billing_address: address))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
@@ -205,7 +205,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:address => address))
+      @gateway.authorize(100, @credit_card, @options.merge(address: address))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
@@ -219,22 +219,39 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:address => {:address1 => "Anystreet", :country => "US"}))
+      @gateway.authorize(100, @credit_card, @options.merge(billing_address: { phone: "555-3323" }))
     end.check_request do |endpoint, data, headers|
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
-      assert_no_match %r(city), data
-      assert_no_match %r(telephoneNumber), data
-      assert_match %r(<address1>Anystreet</address1>), data
+      assert_match %r(<address1>N/A</address1>), data
+      assert_match %r(<city>N/A</city>), data
       assert_match %r(<postalCode>0000</postalCode>), data
       assert_match %r(<state>N/A</state>), data
+      assert_match %r(<countryCode>US</countryCode>), data
+      assert_match %r(<telephoneNumber>555-3323</telephoneNumber>), data
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_default_address
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_no_match %r(firstName), data
+      assert_no_match %r(lastName), data
+      assert_no_match %r(address2), data
+      assert_no_match %r(telephoneNumber), data
+      assert_match %r(<address1>N/A</address1>), data
+      assert_match %r(<city>N/A</city>), data
+      assert_match %r(<postalCode>0000</postalCode>), data
+      assert_match %r(<state>N/A</state>), data
+      assert_match %r(<countryCode>US</countryCode>), data
     end.respond_with(successful_authorize_response)
   end
 
   def test_email
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:email => "eggcellent@example.com"))
+      @gateway.authorize(100, @credit_card, @options.merge(email: "eggcellent@example.com"))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<shopperEmailAddress>eggcellent@example.com</shopperEmailAddress>), data
     end.respond_with(successful_authorize_response)
@@ -248,7 +265,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_ip
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:ip => "192.137.11.44"))
+      @gateway.authorize(100, @credit_card, @options.merge(ip: "192.137.11.44"))
     end.check_request do |endpoint, data, headers|
       assert_match %r(<session shopperIPAddress="192.137.11.44"/>), data
     end.respond_with(successful_authorize_response)
@@ -262,7 +279,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_parsing
     response = stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(:address => {:address1 => "123 Anystreet", :country => "US"}))
+      @gateway.authorize(100, @credit_card, @options.merge(address: {address1: "123 Anystreet", country: "US"}))
     end.respond_with(successful_authorize_response)
 
     assert_equal({


### PR DESCRIPTION
We've seen that Worldpay can, without warning, turn on the requirement
for address1 and city.  Previously, we were defaulting things like
postal_code and state.  Now we default more of the address fields if
they're not specified.

In theory, this should help some customers, it shouldn't hurt any
existing customers, and it should help customers down the road if
Worldpay changes the address requirements on an account.
