### PR TITLE
Wirecard error-only responses without W_JOB element

### DIFF
--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -298,13 +298,19 @@ module ActiveMerchant #:nodoc:
         if root = REXML::XPath.first(xml, "#{basepath}/W_JOB")
           parse_response(response, root)
         elsif root = REXML::XPath.first(xml, "//ERROR")
-          parse_error(response, root)
+          parse_error_only_response(response, root)
         else
           response[:Message] = "No valid XML response message received. \
                                 Propably wrong credentials supplied with HTTP header."
         end
 
         response
+      end
+
+      def parse_error_only_response(response, root)
+        error_code = REXML::XPath.first(root, "Number")
+        response[:ErrorCode] = error_code.text if error_code
+        response[:Message] = parse_error(root)
       end
 
       # Parse the <ProcessingStatus> Element which contains all important information

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -305,6 +305,15 @@ class WirecardTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_system_error_response_without_job
+    @gateway.expects(:ssl_post).returns(system_error_response_without_job)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal "Job Refused", response.params["Message"]
+    assert_equal "10003", response.params["ErrorCode"]
+  end
+
   private
 
   def assert_xml_element_text(xml, xpath, expected_text)
@@ -660,6 +669,21 @@ class WirecardTest < Test::Unit::TestCase
             </CC_TRANSACTION>
           </FNC_CC_PURCHASE>
         </W_JOB>
+      </W_RESPONSE>
+    </WIRECARD_BXML>
+    XML
+  end
+
+def system_error_response_without_job
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <WIRECARD_BXML xmlns:xsi="http://www.w3.org/1999/XMLSchema-instance" xsi:noNamespaceSchemaLocation="wirecard.xsd">
+      <W_RESPONSE>
+        <ERROR>
+          <Type>SYSTEM_ERROR</Type>
+          <Number>10003</Number>
+          <Message>Job Refused</Message>
+        </ERROR>
       </W_RESPONSE>
     </WIRECARD_BXML>
     XML


### PR DESCRIPTION
If Wirecard is having a _really_ bad day it is possible for their API to return error responses that are not contained within the W_JOB element.

The current error parsing logic has a bug causing the stack trace below because L301 calls #parse_error with incorrect arguments, and even if it worked, wouldn't return the ErrorCode.

```
NoMethodError: undefined method `root_node' for {}:Hash
```

```
/opt/rubies/ruby-2.1.2/lib/ruby/2.1.0/rexml/xpath_parser.rb:182 in "expr"
/opt/rubies/ruby-2.1.2/lib/ruby/2.1.0/rexml/xpath_parser.rb:139 in "match"
/opt/rubies/ruby-2.1.2/lib/ruby/2.1.0/rexml/xpath_parser.rb:70 in "parse"
/opt/rubies/ruby-2.1.2/lib/ruby/2.1.0/rexml/xpath.rb:67 in "each"
/bundler/gems/active_merchant-1e2bcde60d3a/lib/active_merchant/billing/gateways/wirecard.rb:361 in "errors_to_string"
/bundler/gems/active_merchant-1e2bcde60d3a/lib/active_merchant/billing/gateways/wirecard.rb:348 in "parse_error"
/bundler/gems/active_merchant-1e2bcde60d3a/lib/active_merchant/billing/gateways/wirecard.rb:301 in "parse"
/bundler/gems/active_merchant-1e2bcde60d3a/lib/active_merchant/billing/gateways/wirecard.rb:164 in "commit"
/bundler/gems/active_merchant-1e2bcde60d3a/lib/active_merchant/billing/gateways/wirecard.rb:75 in "purchase"
```

I have added a new method to correctly parse these Wirecard having-a-bad-day responses, and also pluck out the ErrorCode as well.

Unit test included, repeatable remote test not possible.
