### PR TITLE
BridgePay: Add support for verify

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -68,6 +68,13 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
+      def verify(creditcard, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, creditcard, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       private
 
       def post_required_fields(transaction_type)

--- a/test/remote/gateways/remote_bridge_pay_test.rb
+++ b/test/remote/gateways/remote_bridge_pay_test.rb
@@ -87,6 +87,21 @@ class RemoteBridgePayTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal "Approved", response.message
+
+    assert_success response.responses.last, "The void should succeed"
+    assert_equal "Approved", response.responses.last.params["respmsg"]
+  end
+
+  def test_unsuccessful_verify
+    assert response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{Invalid Account Number}, response.message
+  end
+
   def test_invalid_login
     gateway = BridgePayGateway.new(
       user_name: '',


### PR DESCRIPTION
I don't see any zero dollar auth capability in BridgePay; underneath the
covers, we do a $1.00 auth followed by a void.

If the void fails, the overall transaction still succeeds (like the
verify operation for other gateways).  In BridgePay's case, this is
particularly useful since we've been told that some of BridgePay's
backend processors (like First Data Omaha) do not allow voids of
authorizations.
