### PR TITLE
Fix warning: URI.escape is obsolete

### DIFF
--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -96,7 +96,7 @@ module ActiveMerchant #:nodoc:
         else
           raise 'Unknown Action'
         end
-        txnRequest = URI.encode(xml)
+        txnRequest = URI::Parser.new.escape(xml)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, "txnMode=#{action}&txnRequest=#{txnRequest}"))
 
         Response.new(successful?(response), message_from(response), hash_from_xml(response),


### PR DESCRIPTION
Fix warning when execute unit test.

```
active_merchant/lib/active_merchant/billing/gateways/optimal_payment.rb:99:in `commit': warning: URI.escape is obsolete
```
