### PR TITLE
Add configuration of required name fields

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -52,6 +52,9 @@ module ActiveMerchant #:nodoc:
       cattr_accessor :require_verification_value
       self.require_verification_value = true
 
+      cattr_accessor :required_name_fields
+      self.required_name_fields = [:first_name, :last_name]
+
       # Returns or sets the credit card number.
       #
       # @return [String]
@@ -248,8 +251,9 @@ module ActiveMerchant #:nodoc:
       def validate_essential_attributes #:nodoc:
         errors = []
 
-        errors << [:first_name, "cannot be empty"] if first_name.blank?
-        errors << [:last_name,  "cannot be empty"] if last_name.blank?
+        self.class.required_name_fields.each do |field|
+          errors << [field, "cannot be empty"] if send(field).blank?
+        end
 
         if(empty?(month) || empty?(year))
           errors << [:month, "is required"] if empty?(month)

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -333,6 +333,50 @@ class CreditCardTest < Test::Unit::TestCase
     assert_equal "Twiggy", c.last_name
   end
 
+  def test_card_should_be_valid_with_both_first_and_last_name
+    card = credit_card
+    assert_valid card
+
+    card.last_name = nil
+    errors = assert_not_valid card
+    assert_equal ['cannot be empty'], errors[:last_name]
+
+    card.first_name = nil
+    card.last_name = 'Herdman'
+    errors = assert_not_valid card
+    assert_equal ['cannot be empty'], errors[:first_name]
+
+    card.last_name = nil
+    errors = assert_not_valid card
+    assert_equal ['cannot be empty'], errors[:first_name]
+    assert_equal ['cannot be empty'], errors[:last_name]
+
+  end
+
+  def test_card_should_be_valid_when_only_name_is_required
+    default_name_validation_fields = CreditCard.required_name_fields
+
+    CreditCard.required_name_fields = [:name]
+    card = credit_card
+
+    card.first_name = 'James'
+    card.last_name = 'Herdman'
+    assert_valid card
+
+    card.last_name = nil
+    assert_valid card
+
+    card.last_name = 'Herdman'
+    card.first_name = nil
+    assert_valid card
+
+    card.last_name = nil
+    errors = assert_not_valid card
+    assert_equal ['cannot be empty'], errors[:name]
+
+    CreditCard.required_name_fields = default_name_validation_fields
+  end
+
   # The following is a regression for a bug that raised an exception when
   # a new credit card was validated
   def test_validate_new_card


### PR DESCRIPTION
The required name fields can be configured by setting required_name_fields on the CreditCard class

It looks like around 2/3 of the supported gateways accept a single name input. This PR allows a single name to be used with Gateways that support it.

This has been checked against the payment express test gateway
