### PR TITLE
Adds application_id functionality to Braintree Blue

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -495,6 +495,7 @@ module ActiveMerchant #:nodoc:
         end
         parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address]
         parameters[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
+        parameters[:channel] = application_id if application_id.present? && application_id != "ActiveMerchant"
         parameters
       end
     end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -187,6 +187,17 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'submitted_for_settlement', response.params["braintree_transaction"]["status"]
   end
 
+  def test_successful_purchase_with_solution_id
+    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'ABC123'
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params["braintree_transaction"]["status"]
+    binding.pry
+  ensure
+    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
+  end
+
   def test_avs_match
     assert response = @gateway.purchase(@amount, @credit_card,
       @options.merge(

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -506,6 +506,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     end
   end
 
+  def test_solution_id_is_added_to_create_transaction_parameters
+    assert_nil @gateway.send(:create_transaction_parameters, 100, credit_card("41111111111111111111"),{})[:channel]
+    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'ABC123'
+    assert_equal @gateway.send(:create_transaction_parameters, 100, credit_card("41111111111111111111"),{})[:channel], "ABC123"
+  ensure
+    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
+  end
+
   private
 
   def braintree_result(options = {})


### PR DESCRIPTION
This adds the ability to pass the `channel` option to `BraintreeBlue` if one is stored in the `application_id` setting.

BraintreeBlueGateway.application_id was previously unused.
