### PR TITLE
Revert NetRegistry URL encoding

### DIFF
--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -151,7 +151,7 @@ module ActiveMerchant
       def post_data(action, params)
         params['COMMAND'] = TRANSACTIONS[action]
         params['LOGIN'] = "#{@options[:login]}/#{@options[:password]}"
-        CGI.escape(params.map{|k,v| "#{k}=#{v}"}.join('&'))
+        URI.encode(params.map{|k,v| "#{k}=#{v}"}.join('&'))
       end
 
       def parse(response)


### PR DESCRIPTION
@ntalbott this is the same issue as Optimal, but it actually shows up in remote tests as well, I just didn't notice it. I see that PayScout was also changed, but we don't use it, so I'm leaving it alone for now.
