### PR TITLE
fix "==" method bug

### DIFF
--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -47,8 +47,13 @@ module ActiveMerchant #:nodoc:
     end
 
     def ==(other)
-      (@name == other.name)
+      if other.class == ActiveMerchant::Country
+        (@name == other.name)
+      else
+        super
+      end
     end
+
     alias eql? ==
 
     def hash


### PR DESCRIPTION
This bug i found to Rails 4.1.4 and Ruby 2.1.2p95, there's undefined method error to "other" object has not ActiveMerchant::Country object
