### PR TITLE
add track1 support to first data gge4

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -182,7 +182,7 @@ module ActiveMerchant #:nodoc:
       def add_credit_card(xml, credit_card, options)
 
         if credit_card.respond_to?(:track_data) && credit_card.track_data.present?
-          xml.tag! "Track1" = credit_card.track_data
+          xml.tag! "Track1", credit_card.track_data
         else
           xml.tag! "Card_Number", credit_card.number
           xml.tag! "Expiry_Date", expdate(credit_card)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -153,6 +153,16 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert_equal 'Discover', @gateway.send(:card_type, 'discover')
   end
 
+  def test_add_swipe_data_with_creditcard
+    @credit_card.track_data = "Track Data"
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Track1>Track Data</Track1>", data
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Adds track1 support to the first data gge4 gateway, as documented in their [API](https://firstdata.zendesk.com/entries/407571-First-Data-Global-Gateway-e4-Web-Service-API-Reference-Guide#4)

Please review @odorcicd @melari 
cc @davidseal 
