### PR TITLE
add track data to moneris

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -153,17 +153,16 @@ module ActiveMerchant #:nodoc:
         if source.is_a?(String)
           post[:data_key]   = source
           post[:cust_id]    = options[:customer]
-        elsif source.respond_to?(:track_data) && source.track_data.present?
-          post[:pos_code]   = '00'
-          post[:track2]     = source.track_data
-          post[:pan]        = ''
-          post[:expdate]    = ''
-          post[:cust_id]    = options[:customer] || source.name
         else
-          post[:pan]        = source.number
-          post[:expdate]    = expdate(source)
-          post[:cvd_value]  = source.verification_value if source.verification_value?
-          post[:cust_id]    = options[:customer] || source.name
+          if source.respond_to?(:track_data) && source.track_data.present?
+            post[:pos_code]   = '00'
+            post[:track2]     = source.track_data
+          else
+            post[:pan]        = source.number
+            post[:expdate]    = expdate(source)
+            post[:cvd_value]  = source.verification_value if source.verification_value?
+          end
+          post[:cust_id] = options[:customer] || source.name
         end
       end
 
@@ -285,8 +284,8 @@ module ActiveMerchant #:nodoc:
 
       def actions
         {
-          "purchase"           => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info],
-          "preauth"            => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info],
+          "purchase"           => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code],
+          "preauth"            => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code],
           "command"            => [:order_id],
           "refund"             => [:order_id, :amount, :txn_number, :crypt_type],
           "indrefund"          => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type],

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -290,6 +290,7 @@ class MonerisTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
+      assert_match "<pos_code>00</pos_code>", data
       assert_match "<track2>Track Data</track2>", data
     end.respond_with(successful_purchase_response)
   end


### PR DESCRIPTION
Adds swipe support to Moneris. 
Based on [PHP Example](http://glui.me/?i=c4sjv6vpi56rzvi/2014-08-20_at_1.29_AM_2x_%281%29.png/) from their developer portal. Unfortunately, while they had a ruby example for online transactions, PHP was as good as it gets for Card Present fields.

@odorcicd @melari for review.
cc @davidseal 
