### PR TITLE
Add extra logging for paypal express debugging

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -34,7 +34,10 @@ module ActiveMerchant #:nodoc:
       def setup_authorization(money, options = {})
         requires!(options, :return_url, :cancel_return_url)
 
-        commit 'SetExpressCheckout', build_setup_request('Authorization', money, options)
+        built_request = build_setup_request('Authorization', money, options)
+        ::Rails.logger.info("[PaypalExpress#SetExpressCheckout]: headers:#{@options[:headers]}, request:#{built_request}")
+        commit 'SetExpressCheckout', built_request
+
       end
 
       def setup_purchase(money, options = {})


### PR DESCRIPTION
@odorcicd /cc @Shopify/payments 

This adds extra logging for paypal requests -- I think I really only need `setup_purchase` in order to help debug:  https://github.com/Shopify/shopify/issues/24425

I can narrow this down to just `setup_purchase`; just thought I should get your opinion first.
