### PR TITLE
Issue with Cybersource subscription amount: `money_format = :cents'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Gemfile*.lock
 .rbx/
 *.gem
 .rvmrc
+.ruby-version
+.ruby-gemset

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -523,7 +523,7 @@ module ActiveMerchant #:nodoc:
           end
 
           xml.tag! 'status',            options[:subscription][:status]                         if options[:subscription][:status]
-          xml.tag! 'amount',            options[:subscription][:amount]                         if options[:subscription][:amount]
+          xml.tag! 'amount',            amount(options[:subscription][:amount])                 if options[:subscription][:amount]
           xml.tag! 'numberOfPayments',  options[:subscription][:occurrences]                    if options[:subscription][:occurrences]
           xml.tag! 'automaticRenew',    options[:subscription][:automatic_renew]                if options[:subscription][:automatic_renew]
           xml.tag! 'frequency',         options[:subscription][:frequency]                      if options[:subscription][:frequency]

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CyberSourceTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     Base.gateway_mode = :test
 
@@ -242,6 +244,15 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.validate_pinless_debit_card(@credit_card, @options)
     assert response.success?
     assert_success(@gateway.auth_reversal(@amount, response.authorization, @options))
+  end
+
+  def test_validate_add_subscription_amount
+    stub_comms do
+      @gateway.store(@credit_card, @subscription_options)
+    end.check_request do |endpoint, data, headers|
+      assert_match %r(<grandTotalAmount>1.00<\/grandTotalAmount>), data
+      assert_match %r(<amount>1.00<\/amount>), data
+    end.respond_with(successful_update_subscription_response)
   end
 
   private


### PR DESCRIPTION
Cybersource subscription amount were not being converted to dollars in soap envelope. 
### Example:

``` ruby
{
  :setup_fee => 1000,
  # (...)
  :subscription => {
    # (...)
    :amount => 1000
  }
}
```

generating a request with a wrong amount

``` xml
<purchaseTotals>
  <currency>USD</currency>
  <grandTotalAmount>10.00</grandTotalAmount>
</purchaseTotals>
<!-- (...) -->
<recurringSubscriptionInfo>
  <amount>1000</amount>
  <!-- (...) -->
</recurringSubscriptionInfo>
```

Subscription created with `$1,000.00` instead of `$10.00`
