### PR TITLE
allow for clearing expiration date on a profile

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -668,7 +668,11 @@ module ActiveMerchant #:nodoc:
             end
 
             xml.tag! :CCAccountNum, creditcard.number if creditcard
-            xml.tag! :CCExpireDate, creditcard.expiry_date.expiration.strftime("%m%y") if creditcard
+            if options[:clear_expiration_date]
+              xml.tag! :CCExpireDate, '~' # ~ means clear this field according to orbital
+            elsif creditcard
+              xml.tag! :CCExpireDate, creditcard.expiry_date.expiration.strftime("%m%y")
+            end
 
             # This has to come after CCExpireDate.
             add_managed_billing(xml, options)


### PR DESCRIPTION
According to the Orbital docs:

To clear any legacy data, the XML tag is submitted with nothing but a tilde (~), as in the 
example below:
<CCExpireDate>~</CCExpireDate>

This is useful in the case of trying to rebill a subscription and the first attempt fails due to an expired card (i.e. `<RespCode>33</RespCode>`)
