### PR TITLE
psigate: Force SSL to SSLv3

### DIFF
--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -42,6 +42,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['CA']
       self.homepage_url = 'http://www.psigate.com/'
       self.display_name = 'Psigate'
+      self.ssl_version = :SSLv3
 
       SUCCESS_MESSAGE = 'Success'
       FAILURE_MESSAGE = 'The transaction was declined'


### PR DESCRIPTION
The PsiGate payment gateway currently requires SSLv3, which is not supported by default in SSL connections in Ruby 2.

@fw42 @odorcicd 
