### PR TITLE
Default :state to n/a for NetworkMerchants

### DIFF
--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
         post[:address1] = address[:address1]
         post[:address2] = address[:address2]
         post[:city] = address[:city]
-        post[:state] = address[:state]
+        post[:state] = address[:state].blank? ? 'n/a' : address[:state]
         post[:zip] = address[:zip]
         post[:country] = address[:country]
         post[:phone] = address[:phone]

--- a/test/remote/gateways/remote_network_merchants_test.rb
+++ b/test/remote/gateways/remote_network_merchants_test.rb
@@ -130,4 +130,23 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Invalid Username', response.message
   end
+
+  def test_successful_purchase_without_state
+    @options[:billing_address] = {
+      :name     => 'Jim Smith',
+      :address1 => 'Gullhauggrenda 30',
+      :address2 => 'Apt 1',
+      :company  => 'Widgets Inc',
+      :city     => 'Baerums Verk',
+      :state    => nil,
+      :zip      => '1354',
+      :country  => 'NO',
+      :phone    => '(555)555-5555',
+      :fax      => '(555)555-6666'
+    }
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
 end


### PR DESCRIPTION
NetworkMerchants requires a `:state` to be passed otherwise it will error with `The state field is required`.

This defaults the `:state` to `n/a` when not provided. Looks like we have the same issue with other gateways: https://github.com/Shopify/active_merchant/blob/a6cfae5e77ed249de84dbe46a4a91e3a0903a11d/lib/active_merchant/billing/gateways/secure_net.rb#L153
### Review

@fw42 @jduff 

/cc @mackiec @louiskearns 
