### PR TITLE
update eway rapid validators

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -280,12 +280,17 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def parse_errors(message)
+        errors = message.split(',').collect{|code| MESSAGES[code.strip]}.flatten.join(',')
+        errors.presence || message
+      end
+
       def message_from(succeeded, response)
         if response['Errors']
-          (MESSAGES[response['Errors']] || response['Errors'])
+          parse_errors(response['Errors'])
         elsif response['ResponseMessage']
-          (MESSAGES[response['ResponseMessage']] || response['ResponseMessage'])
-        elsif response['Responsecode']
+          parse_errors(response['ResponseMessage'])
+        elsif response['ResponseCode']
           ActiveMerchant::Billing::EwayGateway::MESSAGES[response['ResponseCode']]
         elsif succeeded
           "Succeeded"

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -109,7 +109,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@failed_amount, "bogus")
     assert_failure response
-    assert_equal "V6134", response.message
+    assert_equal "Invalid Auth Transaction ID for Capture/Void", response.message
   end
 
   def test_successful_void
@@ -123,7 +123,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void("bogus")
     assert_failure response
-    assert_equal "V6134", response.message
+    assert_equal "Invalid Auth Transaction ID for Capture/Void", response.message
   end
 
   def test_successful_refund
@@ -139,7 +139,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
   def test_failed_refund
     response = @gateway.refund(@amount, 'fakeid', @options)
     assert_failure response
-    assert_equal "V6115", response.message
+    assert_equal "Invalid DirectRefundRequest, Transaction ID", response.message
   end
 
   def test_successful_store

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -49,6 +49,28 @@ class EwayRapidTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_failed_purchase_without_message
+    response = stub_comms do
+      @gateway.purchase(-100, @credit_card)
+    end.respond_with(failed_purchase_response_without_message)
+
+    assert_failure response
+    assert_equal "Do Not Honour", response.message
+    assert_nil response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase_without_message
+    response = stub_comms do
+      @gateway.purchase(-100, @credit_card)
+    end.respond_with(failed_purchase_response_multiple_messages)
+
+    assert_failure response
+    assert_equal "Invalid Customer Phone,Invalid ShippingAddress Phone", response.message
+    assert_nil response.authorization
+    assert response.test?
+  end
+
   def test_purchase_with_all_options
     response = stub_comms do
       @gateway.purchase(200, @credit_card,
@@ -368,6 +390,39 @@ class EwayRapidTest < Test::Unit::TestCase
           "CurrencyCode": "AUD"
         },
         "Errors": null
+      }
+    )
+  end
+
+  def failed_purchase_response_without_message
+    %(
+      {
+        "AuthorisationCode": null,
+        "ResponseCode": "05",
+        "TransactionID": null,
+        "TransactionStatus": null,
+        "TransactionType": "Purchase",
+        "BeagleScore": null,
+        "Verification": null,
+        "Customer": {
+        }
+      }
+    )
+  end
+
+  def failed_purchase_response_multiple_messages
+    %(
+      {
+        "AuthorisationCode": null,
+        "ResponseCode": null,
+        "ResponseMessage": "V6070,V6083",
+        "TransactionID": null,
+        "TransactionStatus": null,
+        "TransactionType": "Purchase",
+        "BeagleScore": null,
+        "Verification": null,
+        "Customer": {
+        }
       }
     )
   end


### PR DESCRIPTION
Only eway_rapid decline codes are being returned on unsuccessful purchases sans [decline strings](https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/gateways/eway_rapid.rb#L333-L419). 

![image](https://cloud.githubusercontent.com/assets/2124226/4272572/84cd5066-3ce3-11e4-983b-6ab14f44348b.png)

We're also only using a subset of the [available codes defined by eway](http://api-portal.anypoint.mulesoft.com/eway/api/eway-rapid-31-api/docs/responses). 

This pr adds the missing codes, and reconfigures the order of message posting so that both the decline code and string are shown. decline number & decline string. 

@jduff -- you mentioned that you would be able to add logic to handle multiple error codes returned, as in the graphic above. 
