### PR TITLE
Add order_id to Stripe metadata

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -164,7 +164,12 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post,options)
         post[:description] = options[:description]
         post[:statement_description] = options[:statement_description]
-        post[:metadata] = { email: options[:email] } if options[:email]
+
+        post[:metadata] = {}
+        post[:metadata][:email] = options[:email] if options[:email]
+        post[:metadata][:order_id] = options[:order_id] if options[:order_id]
+        post.delete(:metadata) if post[:metadata].empty?
+
         add_flags(post, options)
         add_application_fee(post, options)
         post

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -333,8 +333,24 @@ class StripeTest < Test::Unit::TestCase
       assert_match(/referrer=http\%3A\%2F\%2Fwww\.shopify\.com/, data)
       assert_match(/payment_user_agent=Stripe\%2Fv1\+ActiveMerchantBindings\%2F\d+\.\d+\.\d+/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
+      assert_match(/metadata\[order_id\]=42/, data)
     end.respond_with(successful_purchase_response)
   end
+
+  def test_client_data_submitted_with_purchase_without_email_or_order
+    stub_comms(@gateway, :ssl_request) do
+      updated_options = @options.merge({:description => "a test customer",:ip => "127.127.127.127", :user_agent => "some browser", :referrer =>"http://www.shopify.com"})
+      @gateway.purchase(@amount,@credit_card,updated_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/description=a\+test\+customer/, data)
+      assert_match(/ip=127\.127\.127\.127/, data)
+      assert_match(/user_agent=some\+browser/, data)
+      assert_match(/referrer=http\%3A\%2F\%2Fwww\.shopify\.com/, data)
+      assert_match(/payment_user_agent=Stripe\%2Fv1\+ActiveMerchantBindings\%2F\d+\.\d+\.\d+/, data)
+      refute_match(/metadata/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
 
   def test_add_address
     post = {:card => {}}


### PR DESCRIPTION
@odorcicd @bizla 

This adds order_id to the metadata that's passed to Stripe so we can do reconciliation afterwards.
