### PR TITLE
ePay: Transaction fee support.

### DIFF
--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -102,4 +102,10 @@ class RemoteEpayTest < Test::Unit::TestCase
     assert_failure response_void
     assert response_void.test?
   end
+
+  def test_transaction_fee
+    response = @gateway.transaction_fee(100, 491761).params.symbolize_keys
+    assert_equal "VISA_ELECTRON_FOREIGN", response[:cardtype]
+    assert_equal "195", response[:fee]
+  end
 end


### PR DESCRIPTION
Retrieves the transaction fee and creditcard-type for a specified prefix of a creditcard.
