### PR TITLE
Authorize.net: Truncate more fields

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -177,16 +177,16 @@ module ActiveMerchant
 
     def address(options = {})
       {
-        :name     => 'Jim Smith',
-        :address1 => '1234 My Street',
-        :address2 => 'Apt 1',
-        :company  => 'Widgets Inc',
-        :city     => 'Ottawa',
-        :state    => 'ON',
-        :zip      => 'K1C2N6',
-        :country  => 'CA',
-        :phone    => '(555)555-5555',
-        :fax      => '(555)555-6666'
+        name:     'Jim Smith',
+        address1: '1234 My Street',
+        address2: 'Apt 1',
+        company:  'Widgets Inc',
+        city:     'Ottawa',
+        state:    'ON',
+        zip:      'K1C2N6',
+        country:  'CA',
+        phone:    '(555)555-5555',
+        fax:      '(555)555-6666'
       }.update(options)
     end
 


### PR DESCRIPTION
Now we truncate more fields to fit within Authorize.net's requirements
and pass schema validation.
