### PR TITLE
Adyen: Add support for verify operation

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:modificationRequest] = modification_request(authorization, options)
         post[:modificationRequest][:modificationAmount] = amount_hash(money, options[:currency])
-        
+
         commit('Payment.capture', post)
       end
 
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:modificationRequest] = modification_request(authorization, options)
         post[:modificationRequest][:modificationAmount] = amount_hash(money, options[:currency])
-        
+
         commit('Payment.refund', post)
       end
 
@@ -72,6 +72,10 @@ module ActiveMerchant #:nodoc:
         post[:modificationRequest] = modification_request(identification, options)
 
         commit('Payment.cancel', post)
+      end
+
+      def verify(creditcard, options = {})
+        authorize(0, creditcard, options)
       end
 
       private

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -87,6 +87,20 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal "Authorised", response.message
+    assert response.authorization
+  end
+
+  def test_unsuccessful_verify
+    assert response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_equal "Refused", response.message
+  end
+
   def test_invalid_login
     gateway = AdyenGateway.new(
       company: '',

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -67,13 +67,28 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
     assert response.test?
   end
-  
+
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
 
     response = @gateway.void('7914002629995504', @options)
     assert_success response
     assert response.test?
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_unsuccessful_verify
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+    assert_equal "Refused", response.message
   end
 
   def test_fractional_currency


### PR DESCRIPTION
Adyen supports a $0 authorization so we use that.  Relevant docs from
their PDF:

http://cl.ly/image/193d1U371T2X/content.png
