### PR TITLE
Minor updates to eWAY Rapid - support for Singapore, JCB and Invoice Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [ePay](http://epay.dk/) - DK, SE, NO
 * [EVO Canada](http://www.evocanada.com/) - CA
 * [eWAY](http://www.eway.com.au/) - AU, NZ, GB
-* [eWAY Rapid 3.0](http://www.eway.com.au/) - AU
+* [eWAY Rapid 3.1](http://www.eway.com.au/) - AU, NZ, GB, SG
 * [E-xact](http://www.e-xact.com) - CA, US
 * [Fat Zebra](https://www.fatzebra.com.au/) - AU
 * [Federated Canada](http://www.federatedcanada.com/) - CA

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -7,8 +7,8 @@ module ActiveMerchant #:nodoc:
       self.live_url = "https://api.ewaypayments.com/"
 
       self.money_format = :cents
-      self.supported_countries = ['AU', 'NZ', 'GB']
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+      self.supported_countries = ['AU', 'NZ', 'GB', 'SG']
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
       self.homepage_url = "http://www.eway.com.au/"
       self.display_name = "eWAY Rapid 3.1"
       self.default_currency = "AUD"
@@ -179,6 +179,7 @@ module ActiveMerchant #:nodoc:
         params[key] = {
           'TotalAmount' => localized_amount(money, currency_code),
           'InvoiceReference' => truncate(options[:order_id]),
+          'InvoiceNumber' => truncate(options[:order_id], 12),
           'InvoiceDescription' => truncate(options[:description], 64),
           'CurrencyCode' => currency_code,
         }
@@ -346,7 +347,7 @@ module ActiveMerchant #:nodoc:
         'D4403' => 'No Merchant Failed',
         'D4404' => 'Pick Up Card  Failed',
         'D4405' => 'Do Not Honour Failed',
-        'D4406' => 'Error   Failed',
+        'D4406' => 'Error Failed',
         'D4407' => 'Pick Up Card, Special Failed',
         'D4409' => 'Request In Progress Failed',
         'D4412' => 'Invalid Transaction Failed',
@@ -400,6 +401,8 @@ module ActiveMerchant #:nodoc:
         'D4498' => 'PayPal Create Transaction Error Failed',
         'D4499' => 'Invalid Transaction for Auth/Void Failed',
         'S5000' => 'System Error',
+        'S5011' => 'PayPal Connection Error',
+        'S5012' => 'PayPal Settings Error',
         'S5085' => 'Started 3dSecure',
         'S5086' => 'Routed 3dSecure',
         'S5087' => 'Completed 3dSecure',

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -120,6 +120,7 @@ class EwayRapidTest < Test::Unit::TestCase
       assert_match(%r{"TotalAmount":"200"}, data)
       assert_match(%r{"InvoiceDescription":"The Really Long Description More Than Sixty Four Characters Gets"}, data)
       assert_match(%r{"InvoiceReference":"orderid1"}, data)
+      assert_match(%r{"InvoiceNumber":"orderid1"}, data)
       assert_match(%r{"CurrencyCode":"INR"}, data)
 
       assert_match(%r{"Title":"Mr."}, data)
@@ -384,7 +385,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": 100,
-          "InvoiceNumber": "",
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"
@@ -470,7 +471,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": -100,
-          "InvoiceNumber": null,
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"
@@ -529,7 +530,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount":100,
-          "InvoiceNumber": "",
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
         "CurrencyCode": "AUD"
@@ -582,7 +583,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": -100,
-          "InvoiceNumber": null,
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"
@@ -689,7 +690,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": 0,
-          "InvoiceNumber": "",
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"
@@ -742,7 +743,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": 0,
-          "InvoiceNumber": null,
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"
@@ -801,7 +802,7 @@ class EwayRapidTest < Test::Unit::TestCase
         },
         "Payment": {
           "TotalAmount": 0,
-          "InvoiceNumber": "",
+          "InvoiceNumber": "1",
           "InvoiceDescription": "Store Purchase",
           "InvoiceReference": "1",
           "CurrencyCode": "AUD"


### PR DESCRIPTION
eWAY is in Singapore! http://www.ewaypayments.com/
This pull also adds JCB and missing validation error codes. Added Invoice Number (same value as Invoice Reference) as this is sent in eWAY transaction emails.
