### PR TITLE
Braintree: Allow dynamic descriptors

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -500,6 +500,14 @@ module ActiveMerchant #:nodoc:
         parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address] && !options[:payment_method_token]
         parameters[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
         parameters[:channel] = application_id if application_id.present? && application_id != "ActiveMerchant"
+
+        if options[:descriptor_name] || options[:descriptor_phone]
+          parameters[:descriptor] = {
+            name: options[:descriptor_name],
+            phone: options[:descriptor_phone]
+          }
+        end
+
         parameters
       end
     end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -553,10 +553,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal fixtures(:braintree_blue)[:merchant_account_id], response.params["braintree_transaction"]["merchant_account_id"]
   end
 
+  def test_authorize_with_descriptor
+    assert auth = @gateway.authorize(@amount, @credit_card, descriptor_name: "company*theproduct", descriptor_phone: "1331131131")
+    assert_success auth
+  end
+
   def test_successful_validate_on_store_with_verification_merchant_account
     card = credit_card('4111111111111111', :verification_value => '101')
     assert response = @gateway.store(card, :verify_card => true, :verification_merchant_account_id => fixtures(:braintree_blue)[:merchant_account_id])
     assert_success response, "You must specify a valid :merchant_account_id key in your fixtures.yml for this to pass."
     assert_equal 'OK', response.message
   end
+
 end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -534,6 +534,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
   end
 
+  def test_successful_purchase_with_descriptor
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:descriptor][:name] == 'wow*productname') &&
+      (params[:descriptor][:phone] == '4443331112')
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), descriptor_name: 'wow*productname', descriptor_phone: '4443331112')
+  end
+
   private
 
   def braintree_result(options = {})


### PR DESCRIPTION
Docs for it:
https://www.braintreepayments.com/docs/ruby/transactions/dynamic_descriptors

Braintree added the ability to also specify a descriptor url here:
https://github.com/braintree/braintree_ruby/commit/7a336acb9eecc4293e05af2c43a8f15848cf6f55#diff-bf222cdd67b742610b54bdf5774362fc

but Active Merchant is using an older version of the Braintree gem.  Not
sure if we want to upgrade to a more recent version.
