### PR TITLE
Fix auth.net to use just transaction_id for authorization code, not account number too

### DIFF
--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -74,7 +74,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert response
     assert_instance_of Response, response
     assert_success response
-    assert_equal '508141794', response.authorization.split('#')[0]
+    assert_equal '508141794', response.authorization
   end
 
   def test_successful_echeck_purchase
@@ -95,7 +95,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert response
     assert_instance_of Response, response
     assert_success response
-    assert_equal '508141795', response.authorization.split('#')[0]
+    assert_equal '508141795', response.authorization
   end
 
   def test_echeck_passing_recurring_flag
@@ -124,7 +124,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'M', response.cvv_result['code']
     assert_equal 'CVV matches', response.cvv_result['message']
 
-    assert_equal '508141794', response.authorization.split('#')[0]
+    assert_equal '508141794', response.authorization
     assert response.test?
   end
 
@@ -134,7 +134,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card)
     assert_success response
 
-    assert_equal '508141795', response.authorization.split('#')[0]
+    assert_equal '508141795', response.authorization
     assert response.test?
     assert_equal 'Y', response.avs_result['code']
     assert response.avs_result['street_match']
@@ -161,14 +161,14 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
 
-    capture = @gateway.capture(@amount, '2214269051#XXXX1234', @options)
+    capture = @gateway.capture(@amount, '2214269051', @options)
     assert_success capture
   end
 
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_capture_response)
 
-    assert capture = @gateway.capture(@amount, '2214269051#XXXX1234')
+    assert capture = @gateway.capture(@amount, '2214269051')
     assert_failure capture
   end
 
@@ -279,10 +279,10 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_refund
     @gateway.expects(:ssl_post).returns(successful_refund_response)
 
-    assert refund = @gateway.refund(36.40, '2214269051#XXXX1234')
+    assert refund = @gateway.refund(36.40, '2214269051')
     assert_success refund
     assert_equal 'This transaction has been approved', refund.message
-    assert_equal '2214602071#2224', refund.authorization
+    assert_equal '2214602071', refund.authorization
   end
 
   def test_refund_passing_extra_info
@@ -304,7 +304,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     refund = @gateway.refund(nil, '')
     assert_failure refund
     assert_equal 'The sum of credits against the referenced transaction would exceed original debit amount', refund.message
-    assert_equal '0#2224', refund.authorization
+    assert_equal '0', refund.authorization
   end
 
   def test_supported_countries


### PR DESCRIPTION
The update to their XML API changed the way the authorization code was formatted, it joined the transaction_id with the account_number. The previous implementation just used the transaction_id.

I'm not sure why this changed the way the auth code was parsed from their response but it breaks backwards compatibility. There's no reason to not keep it using the transaction_id only.

@louiskearns @girasquid @jduff for review please, thanks!
