### PR TITLE
Remove supported countries from bogus gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
       REFUND_ERROR_MESSAGE = "Bogus Gateway: Use trans_id number ending in 1 for exception, 2 for error and anything else for success"
       CHECK_ERROR_MESSAGE = "Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error"
 
-      self.supported_countries = ['US']
+      self.supported_countries = []
       self.supported_cardtypes = [:bogus]
       self.homepage_url = 'http://example.com'
       self.display_name = 'Bogus'

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -98,7 +98,7 @@ class BogusTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['US'], BogusGateway.supported_countries
+    assert_equal [], BogusGateway.supported_countries
   end
 
   def test_supported_card_types


### PR DESCRIPTION
Fixes an issue in Shopify where this gateway shows up as a supported gateway in the US only. But really, this is just a test gateway so it's supported everywhere and nowhere. 

Any objections to setting the supported countries for bogus as empty?
