### PR TITLE
Add delayed-error testing feature to bogus gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -2,16 +2,16 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # Bogus Gateway
     class BogusGateway < Gateway
-      AUTHORIZATION = '53433'
+      AUTHORIZATION = '53434'
 
       SUCCESS_MESSAGE = "Bogus Gateway: Forced success"
       FAILURE_MESSAGE = "Bogus Gateway: Forced failure"
-      ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error"
-      UNSTORE_ERROR_MESSAGE = "Bogus Gateway: Use trans_id ending in 1 for success, 2 for exception and anything else for error"
-      CAPTURE_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error and anything else for success"
-      VOID_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error and anything else for success"
-      REFUND_ERROR_MESSAGE = "Bogus Gateway: Use trans_id number ending in 1 for exception, 2 for error and anything else for success"
-      CHECK_ERROR_MESSAGE = "Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error"
+      ERROR_MESSAGE = "Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception, x3 for x-second timeout, and anything else for error"
+      UNSTORE_ERROR_MESSAGE = "Bogus Gateway: Use trans_id ending in 1 for success, 2 for exception, x3 for x-second timeout, and anything else for error"
+      CAPTURE_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error, x3 for x-second timeout, and anything else for success"
+      VOID_ERROR_MESSAGE = "Bogus Gateway: Use authorization number ending in 1 for exception, 2 for error, x3 for x-second timeout, and anything else for success"
+      REFUND_ERROR_MESSAGE = "Bogus Gateway: Use trans_id number ending in 1 for exception, 2 for error, x3 for x-second timeout, and anything else for success"
+      CHECK_ERROR_MESSAGE = "Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception, x3 for x-second timeout, and anything else for error"
 
       self.supported_countries = []
       self.supported_cardtypes = [:bogus]
@@ -25,6 +25,9 @@ module ActiveMerchant #:nodoc:
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, error_message(paysource)
         else
           raise Error, error_message(paysource)
         end
@@ -37,6 +40,9 @@ module ActiveMerchant #:nodoc:
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, error_message(paysource)
         else
           raise Error, error_message(paysource)
         end
@@ -54,6 +60,9 @@ module ActiveMerchant #:nodoc:
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true )
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, error_message(paysource)
         else
           raise Error, error_message(paysource)
         end
@@ -66,6 +75,9 @@ module ActiveMerchant #:nodoc:
           raise Error, REFUND_ERROR_MESSAGE
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, REFUND_ERROR_MESSAGE
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         end
@@ -78,6 +90,9 @@ module ActiveMerchant #:nodoc:
           raise Error, CAPTURE_ERROR_MESSAGE
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, CAPTURE_ERROR_MESSAGE
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         end
@@ -89,6 +104,9 @@ module ActiveMerchant #:nodoc:
           raise Error, VOID_ERROR_MESSAGE
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, VOID_ERROR_MESSAGE
         else
           Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
         end
@@ -100,6 +118,9 @@ module ActiveMerchant #:nodoc:
           Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, error_message(paysource)
         else
           raise Error, error_message(paysource)
         end
@@ -111,6 +132,9 @@ module ActiveMerchant #:nodoc:
           Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE },:test => true)
+        when /^(\d+)3$/
+          Kernel.sleep $1.to_i
+          raise Error, UNSTORE_ERROR_MESSAGE
         else
           raise Error, UNSTORE_ERROR_MESSAGE
         end

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -21,18 +21,20 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.authorize(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     assert !@gateway.authorize(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.authorize(1000, credit_card('123'))
     end
-    assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use CreditCard number/, e.message)
   end
 
   def test_purchase
     assert  @gateway.purchase(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     assert !@gateway.purchase(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.purchase(1000, credit_card('123'))
     end
-    assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use CreditCard number/, e.message)
   end
 
   def test_capture
@@ -40,7 +42,8 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.capture(1000, @response.params["transid"]).success?
     assert !@gateway.capture(1000, CC_FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.capture(1000, CC_SUCCESS_PLACEHOLDER)
+      Kernel.expects(:sleep).with(22)
+      @gateway.capture(1000, '223')
     end
   end
 
@@ -48,9 +51,10 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.credit(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     assert !@gateway.credit(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.credit(1000, credit_card('123'))
     end
-    assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use CreditCard number/, e.message)
   end
 
   def test_refund
@@ -58,7 +62,8 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.refund(1000, @response.params["transid"]).success?
     assert !@gateway.refund(1000, CC_FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.refund(1000, CC_SUCCESS_PLACEHOLDER)
+      Kernel.expects(:sleep).with(22)
+      @gateway.refund(1000, '223')
     end
   end
 
@@ -75,7 +80,9 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.void(@response.params["transid"]).success?
     assert !@gateway.void(CC_FAILURE_PLACEHOLDER).success?
     assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.void(CC_SUCCESS_PLACEHOLDER)
+      Kernel.expects(:sleep).with(22)
+      @gateway.refund(1000, '223')
+      @gateway.void('22')
     end
   end
 
@@ -83,9 +90,10 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.store(credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     assert !@gateway.store(credit_card(CC_FAILURE_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.store(credit_card('123'))
     end
-    assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use CreditCard number/, e.message)
   end
 
   def test_unstore
@@ -109,9 +117,10 @@ class BogusTest < Test::Unit::TestCase
     assert  @gateway.authorize(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
     assert !@gateway.authorize(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.authorize(1000, check(:account_number => '123', :number => nil))
     end
-    assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use bank account number/, e.message)
   end
 
   def test_purchase_with_check
@@ -122,27 +131,30 @@ class BogusTest < Test::Unit::TestCase
     assert !@gateway.purchase(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => CHECK_FAILURE_PLACEHOLDER)).success?
     assert  @gateway.purchase(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => CHECK_SUCCESS_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.purchase(1000, check(:account_number => '123', :number => nil))
     end
-    assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use bank account number/, e.message)
   end
 
   def test_store_with_check
     assert  @gateway.store(check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
     assert !@gateway.store(check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.store(check(:account_number => '123', :number => nil))
     end
-    assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use bank account number/, e.message)
   end
 
   def test_credit_with_check
     assert  @gateway.credit(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
     assert !@gateway.credit(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
+      Kernel.expects(:sleep).with(12)
       @gateway.credit(1000, check(:account_number => '123', :number => nil))
     end
-    assert_equal("Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error", e.message)
+    assert_match(/Bogus Gateway: Use bank account number/, e.message)
   end
 
   def test_store_then_purchase_with_check


### PR DESCRIPTION
Values of the form 3x now cause the gateway to sleep x seconds before raising,
in order to test behaviour of callers under high timeouts.

@jnormore @fw42 @girasquid @louiskearns 
