### PR TITLE
Stripe: Make #unstore signature consistent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * Openpay: Add support for device session id [guillermo-delucio, ismaelem]
 * Redsys: Add support for verify [duff]
 * Redsys: Handle unknown currencies [duff]
+* [POSSIBLE BREAKAGE] Stripe: Make #unstore signature consistent [duff]
 
 == Version 1.44.1 (Aug 28, 2014)
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -146,11 +146,11 @@ module ActiveMerchant #:nodoc:
         commit(:post, "customers/#{CGI.escape(customer_id)}", options, options)
       end
 
-      def unstore(customer_id, card_id = nil, options = {})
-        if card_id.nil?
-          commit(:delete, "customers/#{CGI.escape(customer_id)}", nil, options)
+      def unstore(customer_id, options = {})
+        if options[:card_id]
+          commit(:delete, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(options[:card_id])}", nil, options)
         else
-          commit(:delete, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", nil, options)
+          commit(:delete, "customers/#{CGI.escape(customer_id)}", nil, options)
         end
       end
 

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -147,7 +147,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     card_id = creation.params['cards']['data'].first['id']
 
     # Unstore the card
-    assert response = @gateway.unstore(customer_id, card_id)
+    assert response = @gateway.unstore(customer_id, card_id: card_id)
     assert_success response
     assert_equal card_id, response.params['id']
     assert_equal true, response.params['deleted']


### PR DESCRIPTION
There are more than 15 gateways now that have an #unstore method and
almost all of them have 2 parameters.  This commit makes the Stripe
unstore method consistent so the gateways can be used interchangeably.
