### PR TITLE
[Authorize.net] Include phone/fax in billTo, add retail data for card pr...

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -178,27 +178,26 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_swipe_data(xml, credit_card)
-        if TRACKS[1].match(credit_card.track_data)
-          xml.payment do
+        TRACKS.each do |key, regex|
+          if regex.match(credit_card.track_data)
+            @valid_track_data = true
             xml.trackData do
-              xml.track1 credit_card.track_data
-            end
-          end
-        elsif TRACKS[2].match(credit_card.track_data)
-          xml.payment do
-            xml.trackData do
-              xml.track2 credit_card.track_data
+              xml.send(:"track#{key}", credit_card.track_data)
             end
           end
         end
       end
 
       def add_retail_data(xml, payment)
-        return if card_brand(payment) == "check" || payment.track_data.blank?
+        return unless valid_track_data
         xml.retail do
           # As per http://www.authorize.net/support/CP_guide.pdf, '2' is for Retail, the only current market_type
           xml.marketType 2
         end
+      end
+
+      def valid_track_data
+        @valid_track_data ||= false
       end
 
       def add_check(xml, check)


### PR DESCRIPTION
This adds the `phoneNumber` and `faxNumber` fields to the `billTo` element in Authorize.net requests as defined in [their schema](https://api.authorize.net/xml/v1/schema/AnetApiSchema.xsd):

``` xml
<xs:complexType name="customerAddressType">
  <xs:complexContent>
    <xs:extension base="anet:nameAndAddressType">
      <xs:sequence>
        <xs:element name="phoneNumber" minOccurs="0">
          <xs:simpleType>
            <xs:restriction base="xs:string">
              <xs:maxLength value="255"/>
            </xs:restriction>
          </xs:simpleType>
        </xs:element>
        <xs:element name="faxNumber" minOccurs="0">
          <xs:simpleType>
            <xs:restriction base="xs:string">
              <xs:maxLength value="255"/>
            </xs:restriction>
          </xs:simpleType>
        </xs:element>
      </xs:sequence>
    </xs:extension>
  </xs:complexContent>
</xs:complexType>
```

We [used to have `phone`](https://github.com/Shopify/active_merchant/blob/0b8a0de2e2d547b96e0d1aac63d5ace8baf0e9ff/lib/active_merchant/billing/gateways/authorize_net.rb#L306) but it appears to have been lost in the switchover to the new integration.

I also added the `retail` element with the `market_type` set to `2` which, as per their [Card Present Guide](http://www.authorize.net/support/CP_guide.pdf), is currently the only available `market_type`. This fixes the failing remote test `test_card_present_authorize_and_capture_with_track_data_only`

@girasquid @ntalbott @jnormore 
