### PR TITLE
Missing phone/fax number check in Authorize.net test

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -182,7 +182,7 @@ module ActiveMerchant #:nodoc:
           if regex.match(credit_card.track_data)
             @valid_track_data = true
             xml.trackData do
-              xml.send(:"track#{key}", credit_card.track_data)
+              xml.public_send(:"track#{key}", credit_card.track_data)
             end
           end
         end

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -86,7 +86,6 @@ class AuthorizeNetTest < Test::Unit::TestCase
         end
       end.respond_with(successful_purchase_response)
     end
-
   end
 
   def test_successful_echeck_authorization
@@ -254,12 +253,14 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
+      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444'})
     end.check_request do |endpoint, data, headers|
       parse(data) do |doc|
         assert_equal "CO", doc.at_xpath("//billTo/state").content, data
         assert_equal "164 Waverley Street", doc.at_xpath("//billTo/address").content, data
         assert_equal "US", doc.at_xpath("//billTo/country").content, data
+        assert_equal "(555)555-5555", doc.at_xpath("//billTo/phoneNumber").content
+        assert_equal "(555)555-4444", doc.at_xpath("//billTo/faxNumber").content
       end
     end.respond_with(successful_authorize_response)
   end


### PR DESCRIPTION
@edward pointed out that I forgot to add the phone/fax numbers to the unit tests. Hawkward.

CC @ntalbott @girasquid 
