### PR TITLE
Update PayPal API live URL

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       URLS = {
         :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',
                    :signature   => 'https://api-3t.sandbox.paypal.com/2.0/' },
-        :live => { :certificate => 'https://api-aa.paypal.com/2.0/',
+        :live => { :certificate => 'https://api.paypal.com/2.0/',
                    :signature   => 'https://api-3t.paypal.com/2.0/' }
       }
 


### PR DESCRIPTION
Starting some time on October 20th, PayPal's legacy API endpoint started to experience SSL connection errors. Presumably, they updated some configuration to avoid POODLE attacks and made a mistake in the configuration of the old endpoint. Switching to the new endpoint, fixes the connection issue. https://developer.paypal.com/webapps/developer/docs/classic/api/endpoints/ None of the other endpoints experienced the same issue.
