### PR TITLE
PayPal have disabled SSLv3, use TLS instead.

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -12,6 +12,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['US']
       self.homepage_url = 'https://www.paypal.com/us/webapps/mpp/paypal-payments-pro'
       self.display_name = 'PayPal Payments Pro (US)'
+      self.ssl_version = :TLSv1_2
 
       def authorize(money, credit_card_or_referenced_id, options = {})
         requires!(options, :ip)


### PR DESCRIPTION
Since PayPal have disabled SSLv3, we have been seeing the occasional:

`OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3
read server certificate B: certificate verify failed`

by forcing TLS 1.2 as in other gateway providers, we are hoping this has fixed the issue.

We are open to better suggestions??
