### PR TITLE
Standardizing error codes

### DIFF
--- a/generators/gateway/templates/gateway.rb
+++ b/generators/gateway/templates/gateway.rb
@@ -11,6 +11,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.example.net/'
       self.display_name = 'New Gateway'
 
+      STANDARD_ERROR_CODE_MAPPING = {}
+
       def initialize(options={})
         requires!(options, :some_credential, :another_credential)
         super

--- a/generators/gateway/templates/gateway_test.rb
+++ b/generators/gateway/templates/gateway_test.rb
@@ -32,6 +32,7 @@ class <%= class_name %>Test < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
   def test_successful_authorize

--- a/generators/gateway/templates/remote_gateway_test.rb
+++ b/generators/gateway/templates/remote_gateway_test.rb
@@ -97,6 +97,7 @@ class Remote<%= class_name %>Test < Test::Unit::TestCase
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
     assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
   def test_invalid_login

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -62,6 +62,36 @@ module ActiveMerchant #:nodoc:
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
       RECURRING_DEPRECATION_MESSAGE = "Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it."
 
+      # == Standardized Error Codes
+      #
+      # :incorrect_number - Card number does not comply with ISO/IEC 7812 numbering standard
+      # :invalid_number - Card number was not matched by processor
+      # :invalid_expiry_date - Expiry date deos not match correct formatting
+      # :invalid_cvc - Security codes does not match correct format (3-4 digits)
+      # :expired_card - Card number is expired
+      # :incorrect_cvc - Secerity code was not matched by the processor
+      # :incorrect_zip - Zip code is not in correct format
+      # :incorrect_address - Billing address info was not matched by the processor
+      # :card_declined - Card number declined by processor
+      # :processing_error - Processor error
+      # :call_issuer - Transaction requires voice authentication, call issuer
+      # :pickup_card - Issuer requests that you pickup the card from merchant
+
+      STANDARD_ERROR_CODE = {
+        :incorrect_number => 'incorrect_number',
+        :invalid_number => 'invalid_number',
+        :invalid_expiry_date => 'invalid_expiry_date',
+        :invalid_cvc => 'invalid_cvc',
+        :expired_card => 'expired_card',
+        :incorrect_cvc => 'incorrect_cvc',
+        :incorrect_zip => 'incorrect_zip',
+        :incorrect_address => 'incorrect_address',
+        :card_declined => 'card_declined',
+        :processing_error => 'processing_error',
+        :call_issuer => 'call_issuer',
+        :pickup_card => 'pick_up_card'
+      }
+
       cattr_reader :implementations
       @@implementations = []
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -32,6 +32,19 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://stripe.com/'
       self.display_name = 'Stripe'
 
+      STANDARD_ERROR_CODE_MAPPING = {
+        'incorrect_number' => STANDARD_ERROR_CODE[:incorrect_number],
+        'invalid_number' => STANDARD_ERROR_CODE[:invalid_number],
+        'invalid_expiry_month' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        'invalid_expiry_year' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        'invalid_cvc' => STANDARD_ERROR_CODE[:invalid_cvc],
+        'expired_card' => STANDARD_ERROR_CODE[:expired_card],
+        'incorrect_cvc' => STANDARD_ERROR_CODE[:incorrect_cvc],
+        'incorrect_zip' => STANDARD_ERROR_CODE[:incorrect_zip],
+        'card_declined' => STANDARD_ERROR_CODE[:card_declined],
+        'processing_error' => STANDARD_ERROR_CODE[:processing_error]
+      }
+
       def initialize(options = {})
         requires!(options, :login)
         @api_key = options[:login]
@@ -318,7 +331,8 @@ module ActiveMerchant #:nodoc:
           :test => response.has_key?("livemode") ? !response["livemode"] : false,
           :authorization => success ? response["id"] : response["error"]["charge"],
           :avs_result => { :code => avs_code },
-          :cvv_result => cvc_code
+          :cvv_result => cvc_code,
+          :error_code => success ? nil : STANDARD_ERROR_CODE_MAPPING[response["error"]["code"]]
         )
       end
 

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
     end
 
     class Response
-      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result
+      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code
 
       def success?
         @success
@@ -23,6 +23,7 @@ module ActiveMerchant #:nodoc:
         @test = options[:test] || false
         @authorization = options[:authorization]
         @fraud_review = options[:fraud_review]
+        @error_code = options[:error_code]
 
         @avs_result = if options[:avs_result].kind_of?(AVSResult)
           options[:avs_result].to_hash

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -251,6 +251,7 @@ class StripeTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
     assert !response.test? # unsuccessful request defaults to live
     assert_equal 'ch_test_charge', response.authorization
   end
@@ -513,7 +514,6 @@ class StripeTest < Test::Unit::TestCase
       assert response = @gateway.unstore("CustomerID", "card_id", {})
     end
   end
-
 
   private
 


### PR DESCRIPTION
Adds standardized error codes for the gateway to map to, with an example for Stripe.

@louiskearns @girasquid @mcgain @edward 
