### PR TITLE
WIP - needs Arbab's Auth.net XML jazz for ApplePay

### DIFF
--- a/lib/active_merchant/billing/cryptogram.rb
+++ b/lib/active_merchant/billing/cryptogram.rb
@@ -1,0 +1,25 @@
+require 'time'
+require 'date'
+require "active_merchant/billing/model"
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # A +Cryptogram+ object represents a payment reference like an ApplePay token or Stripe token
+    class Cryptogram < Model
+      attr_reader :encrypted_data, :description, :brand
+
+      def self.from_apple_pay(payment_data, payment_instrument_name, payment_network)
+        ApplePay.new(payment_data, description: payment_instrument_name, brand: payment_network, transaction_id)
+      end
+
+      def initialize(encrypted_data, options={})
+        @encrypted_data = encrypted_data
+        @description = options[:description]
+        @brand = options[:brand]
+      end
+    end
+
+    class ApplePay < Cryptogram
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
           xml.transactionRequest do
             xml.transactionType 'authCaptureTransaction'
             xml.amount amount(amount)
-            add_payment_source(xml, payment)
+            add_payment_source(xml, payment, options)
             add_invoice(xml, options)
             add_customer_data(xml, payment, options)
             add_retail_data(xml, payment)
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
           xml.transactionRequest do
             xml.transactionType 'authOnlyTransaction'
             xml.amount amount(amount)
-            add_payment_source(xml, payment)
+            add_payment_source(xml, payment, options)
             add_invoice(xml, options)
             add_customer_data(xml, payment, options)
             add_settings(xml, payment, options)
@@ -118,8 +118,11 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def add_payment_source(xml, source)
+      def add_payment_source(xml, source, options)
         return unless source
+
+        if source.is_a?(ApplePay)
+          add_apple_pay(xml, source, options[:order_id])
         if card_brand(source) == 'check'
           add_check(xml, source)
         else
@@ -198,6 +201,14 @@ module ActiveMerchant #:nodoc:
 
       def valid_track_data
         @valid_track_data ||= false
+      end
+
+      def add_apple_pay(xml, apple_pay, transaction_identifier)
+        # do things here
+        # Ask Arbab for this
+        # 
+        # Use apple_pay.encrypted_data, apple_pay.description, apple_pay.brand, and transaction_identifier
+        # 
       end
 
       def add_check(xml, check)


### PR DESCRIPTION
- Adds Cryptogram support
- See ActiveMerchant::Billing::AuthorizeNetGateway#add_apple_pay

This is based off of @ntalbott ’s suggestions in https://github.com/Shopify/active_merchant/pull/1433

@bizla Could you please add your magic XML stuff + your tests here?

CC @Shopify/active-merchant 
