### PR TITLE
Update failing PayPal remote refund test

### DIFF
--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -128,11 +128,11 @@ class PaypalTest < Test::Unit::TestCase
     assert_success credit
     assert credit.test?
     assert_equal 'USD',  credit.params['net_refund_amount_currency_id']
-    assert_equal '0.67', credit.params['net_refund_amount']
+    assert_equal '0.97', credit.params['net_refund_amount']
     assert_equal 'USD',  credit.params['gross_refund_amount_currency_id']
     assert_equal '1.00', credit.params['gross_refund_amount']
     assert_equal 'USD',  credit.params['fee_refund_amount_currency_id']
-    assert_equal '0.33', credit.params['fee_refund_amount']
+    assert_equal '0.03', credit.params['fee_refund_amount'] # As of August 2010, PayPal keeps the flat fee ($0.30)
   end
 
   def test_failed_voiding


### PR DESCRIPTION
@karlhungus @ntalbott @duff 

In August 2010 PayPal updated how refunding Purchases work, so that they retained the Fixed Fee portion of the Purchase Payment Fee (the $0.30 in 2.9% + 0.30).

[Here's a link to their documentation on this](https://www.paypalobjects.com/webstatic/ua/pdf/US/en_US/archivepolicies/us_2007-2012.pdf), and the relevant section:

```
Amendment to the PayPal User Agreement
Effective Date: Aug 10, 2010

Refund Fee. Section 8.5 (Additional Fees) is amended to add a new refund fee. If you refund a Purchase Payment, we will retain the Fixed Fee portion of the Purchase Payment Fee. The buyer’s Account will be credited with the full Purchase Payment amount and the Fixed Fee portion of the Purchase Payment Fee will be deducted from your Account in addition to the amount of the refunded payment. The Fixed Fee will depend on the currency of the Purchase Payment and is listed in 8.4(c).
```

This fixes the remote refund test to take into account the 'new' semantics, and adds a comment.
