### PR TITLE
Fix typo

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -307,7 +307,7 @@ module ActiveMerchant #:nodoc:
             end
             yield(xml)
           end
-        end.to_xml(ident: 0)
+        end.to_xml(indent: 0)
       end
 
       def parse(action, body)


### PR DESCRIPTION
@j-mutter @karlhungus

Nokogiri doesn't have an `ident` option.

indent output:

``` xml
<?xml version="1.0"?>
<createTransactionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
<merchantAuthentication>
<name>name</name>
<transactionKey>key</transactionKey>
</merchantAuthentication>
</createTransactionRequest>
```

ident output:

``` xml
<?xml version="1.0"?>
<createTransactionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
  <merchantAuthentication>
    <name>name</name>
    <transactionKey>key</transactionKey>
  </merchantAuthentication>
</createTransactionRequest>
```
