### PR TITLE
Strip non digit from zip for elavon

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -255,7 +255,7 @@ module ActiveMerchant #:nodoc:
         if billing_address
           form[:avs_address]    = billing_address[:address1].to_s.slice(0, 30)
           form[:address2]       = billing_address[:address2].to_s.slice(0, 30)
-          form[:avs_zip]        = billing_address[:zip].to_s.gsub(/\W/, '').slice(0, 9)
+          form[:avs_zip]        = billing_address[:zip].to_s.gsub(/[^a-zA-Z0-9]/, '').slice(0, 9)
           form[:city]           = billing_address[:city].to_s.slice(0, 30)
           form[:state]          = billing_address[:state].to_s.slice(0, 10)
           form[:company]        = billing_address[:company].to_s.slice(0, 50)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -183,7 +183,7 @@ class ElavonTest < Test::Unit::TestCase
   end
 
   def test_zip_codes_with_letters_are_left_intact
-    @options[:billing_address][:zip] = 'K1Z 5E3'
+    @options[:billing_address][:zip] = '.K1%Z_5E3-'
 
     @gateway.expects(:commit).with(anything, anything, has_entries(:avs_zip => 'K1Z5E3'))
 


### PR DESCRIPTION
#### Problem

https://github.com/Shopify/active_merchant/issues/1445
#### Changes

Remove any non digit characters from `avs_zip` and `slice` to 9 instead of 10. Intuitively, you'd expect `ship_to_zip` to also have the same requirements, but nope, according to [docs](https://www.myvirtualmerchant.com/VirtualMerchant/download/developerGuide.pdf) p.235-245 only `avs_zip` is limited to 9 digits, `ship_to_zip` can be 10.
#### Review

@bizla @ivanfer
