### PR TITLE
[Stripe] Add Apple Pay Payment Token exchanging

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -140,10 +140,17 @@ module ActiveMerchant #:nodoc:
       end
 
       # Note: creating a new credit card will not change the customer's existing default credit card (use :set_default => true)
-      def store(creditcard, options = {})
-        post = {}
+      def store(payment, options = {})
         card_params = {}
-        add_creditcard(card_params, creditcard, options)
+        post = {}
+
+        if payment.is_a?(ApplePayPaymentToken)
+          token_exchange_response = tokenize_apple_pay_token(payment)
+          card_params = { card: token_exchange_response.params["token"]["id"] } if token_exchange_response.success?
+        else
+          add_creditcard(card_params, payment, options)
+        end
+
         post[:description] = options[:description] if options[:description]
         post[:email] = options[:email] if options[:email]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -186,7 +186,7 @@ module ActiveMerchant
     def apple_pay_payment_token(options = {})
       # apple_pay_json_raw should contain the JSON serialization of the object described here
       # https://developer.apple.com/library/IOs//documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.htm
-      apple_pay_json_raw = '{"version":"EC_v1","data":"","header":"","signature":""}'
+      apple_pay_json_raw = '{"version":"EC_v1","data":"","signature":""}'
       defaults = {
         payment_data: ActiveSupport::JSON.decode(apple_pay_json_raw),
         payment_instrument_name: "Visa 2424",


### PR DESCRIPTION
Stripe requires that inbound Apple Pay Payment Token data be exchanged for a Stripe payment token for use with their money-transaction endpoints, like any other card data you wish to tokenize when using Stripe. 

This adds the necessary POST to the Stripe Tokens API when Apple Pay Payment Tokens are involved.

@j-mutter @jnormore /cc @Shopify/active-merchant @ntalbott 
