### PR TITLE
Adds standard error codes on purchase and authorize of bogus gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         when /1$/, AUTHORIZATION
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE },:test => true)
+          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true )
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, REFUND_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         end
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, CAPTURE_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         end
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, VOID_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
         end
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true)
+          Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE },:test => true)
+          Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE },:test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, UNSTORE_ERROR_MESSAGE
         end

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -19,7 +19,9 @@ class BogusTest < Test::Unit::TestCase
 
   def test_authorize
     assert  @gateway.authorize(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    assert !@gateway.authorize(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
+    response = @gateway.authorize(1000, credit_card(CC_FAILURE_PLACEHOLDER))
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.authorize(1000, credit_card('123'))
     end
@@ -28,7 +30,9 @@ class BogusTest < Test::Unit::TestCase
 
   def test_purchase
     assert  @gateway.purchase(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    assert !@gateway.purchase(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
+    response = @gateway.purchase(1000, credit_card(CC_FAILURE_PLACEHOLDER))
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.purchase(1000, credit_card('123'))
     end
@@ -38,7 +42,9 @@ class BogusTest < Test::Unit::TestCase
   def test_capture
     assert  @gateway.capture(1000, '1337').success?
     assert  @gateway.capture(1000, @response.params["transid"]).success?
-    assert !@gateway.capture(1000, CC_FAILURE_PLACEHOLDER).success?
+    response =  @gateway.capture(1000, CC_FAILURE_PLACEHOLDER)
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.capture(1000, CC_SUCCESS_PLACEHOLDER)
     end
@@ -46,7 +52,9 @@ class BogusTest < Test::Unit::TestCase
 
   def test_credit
     assert  @gateway.credit(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    assert !@gateway.credit(1000, credit_card(CC_FAILURE_PLACEHOLDER)).success?
+    response =  @gateway.credit(1000, credit_card(CC_FAILURE_PLACEHOLDER))
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.credit(1000, credit_card('123'))
     end
@@ -56,7 +64,9 @@ class BogusTest < Test::Unit::TestCase
   def test_refund
     assert  @gateway.refund(1000, '1337').success?
     assert  @gateway.refund(1000, @response.params["transid"]).success?
-    assert !@gateway.refund(1000, CC_FAILURE_PLACEHOLDER).success?
+    response = @gateway.refund(1000, CC_FAILURE_PLACEHOLDER)
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.refund(1000, CC_SUCCESS_PLACEHOLDER)
     end
@@ -73,7 +83,9 @@ class BogusTest < Test::Unit::TestCase
   def test_void
     assert  @gateway.void('1337').success?
     assert  @gateway.void(@response.params["transid"]).success?
-    assert !@gateway.void(CC_FAILURE_PLACEHOLDER).success?
+    response = @gateway.void(CC_FAILURE_PLACEHOLDER)
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.void(CC_SUCCESS_PLACEHOLDER)
     end
@@ -81,7 +93,9 @@ class BogusTest < Test::Unit::TestCase
 
   def test_store
     assert  @gateway.store(credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    assert !@gateway.store(credit_card(CC_FAILURE_PLACEHOLDER)).success?
+    response = @gateway.store(credit_card(CC_FAILURE_PLACEHOLDER))
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do
       @gateway.store(credit_card('123'))
     end


### PR DESCRIPTION
I'm in the process of testing the integration of active_merchant's standard error codes, so it just seemed natural to add the `processing_error` standard error code to any failure response of bogus gateway.

@girasquid @ntalbott @jnormore 

/cc @mcgain
