### PR TITLE
[Bugfix] Payment Token metadata hash should be with indifferent access

### DIFF
--- a/lib/active_merchant/billing/apple_pay_payment_token.rb
+++ b/lib/active_merchant/billing/apple_pay_payment_token.rb
@@ -10,7 +10,6 @@ module ActiveMerchant #:nodoc:
 
       def initialize(payment_data, options = {})
         super
-        @metadata.symbolize_keys!
         @payment_instrument_name = @metadata[:payment_instrument_name]
         @payment_network = @metadata[:payment_network]
       end

--- a/lib/active_merchant/billing/payment_token.rb
+++ b/lib/active_merchant/billing/payment_token.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
 
       def initialize(payment_data, options = {})
         @payment_data = payment_data
-        @metadata = options
+        @metadata = options.with_indifferent_access
       end
 
       def type


### PR DESCRIPTION
**Problem** 
If a `Billing::PaymentToken` is initialized with an `ActiveSupport::HashWithIndifferentAccess`, you cannot `symbolize_keys!` ...[because it's peculiarly absent from that class.](http://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html)

**Solution** 
Force the Payment Token `@metadata` hash to be initialized with indifferent access. 
(Bonus: any subclass won't need to worry about stringifying or symbolizing, which is probably the way it should've been from the start.)

Please review @girasquid @edward 
