### PR TITLE
Include PartnerID param in eway_rapid requests if set

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -13,6 +13,8 @@ module ActiveMerchant #:nodoc:
       self.display_name = "eWAY Rapid 3.1"
       self.default_currency = "AUD"
 
+      class_attribute :partner_id
+
       def initialize(options = {})
         requires!(options, :login, :password)
         super
@@ -174,6 +176,10 @@ module ActiveMerchant #:nodoc:
         params['CustomerIP'] = options[:ip] if options[:ip]
         params['TransactionType'] = options[:transaction_type] || 'Purchase'
         params['DeviceID'] = options[:application_id] || application_id
+        if partner = options[:partner_id] || partner_id
+          params['PartnerID'] = truncate(partner, 50)
+        end
+        params
       end
 
       def add_invoice(params, money, options, key = "Payment")

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -27,6 +27,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
       redirect_url: "http://awesomesauce.com",
       ip: "0.0.0.0",
       application_id: "Woohoo",
+      partner_id: "Woohoo",
       transaction_type: "Purchase",
       description: "Description",
       order_id: "orderid1",


### PR DESCRIPTION
Adds the ability to specify an optional `PartnerID` to be sent with requests to eWAY Rapid as per [their docs](http://api-portal.anypoint.mulesoft.com/eway/api/eway-rapid-31-api/docs/reference/direct-connection)

Currently we use `application_id` as the `DeviceID`, which is defined as:

> DeviceID  |  O  |  50  |  string  |  The identification name/number for the device or application used to process the transaction

So I think it makes sense to leave this as-is.

Remote tests passed with the new field locally, but the current ActiveMerchant credentials don't work.

Plz 2 review @girasquid @ntalbott @edward 
cc @mhashemi86 
