### PR TITLE
Fix Network Merchants currency

### DIFF
--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, options)
         add_shipping_address(post, options)
         add_payment_method(post, creditcard_or_vault_id, options)
-        add_amount(post, money)
+        add_amount(post, money, options)
         post
       end
 
@@ -68,10 +68,10 @@ module ActiveMerchant #:nodoc:
         build_auth_post(money, creditcard, options)
       end
 
-      def build_capture_post(money, authorization, option)
+      def build_capture_post(money, authorization, options)
         post = {}
         post[:transactionid] = authorization
-        add_amount(post, money)
+        add_amount(post, money, options)
         post
       end
 
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
       def build_refund_post(money, authorization, options)
         post = {}
         post[:transactionid] = authorization
-        add_amount(post, money)
+        add_amount(post, money, options)
         post
       end
 
@@ -184,7 +184,7 @@ module ActiveMerchant #:nodoc:
         post[:password] = @options[:password]
       end
 
-      def add_amount(post, money)
+      def add_amount(post, money, options)
         post[:currency] = options[:currency] || currency(money)
         post[:amount] = amount(money)
       end

--- a/test/remote/gateways/remote_network_merchants_test.rb
+++ b/test/remote/gateways/remote_network_merchants_test.rb
@@ -29,6 +29,12 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_non_default_currency
+    @options.update(currency: 'EUR')
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_successful_check_purchase
     assert response = @gateway.purchase(@amount, @check, @options)
     assert_success response
@@ -121,7 +127,7 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
     assert store = @gateway.store(@credit_card, @options)
     assert_failure store
     assert store.message.include?('Invalid Credit Card Number')
-    assert_equal nil, store.params['customer_vault_id']
+    assert store.params['customer_vault_id'].blank?
     assert_nil store.authorization
   end
 

--- a/test/unit/gateways/network_merchants_test.rb
+++ b/test/unit/gateways/network_merchants_test.rb
@@ -163,6 +163,23 @@ class NetworkMerchantsTest < Test::Unit::TestCase
     assert_equal 'Invalid Username', response.message
   end
 
+  def test_currency_uses_default_when_not_provided
+    @gateway.expects(:ssl_post).with do |_, body|
+      assert_match "currency=USD", body
+    end.returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
+  def test_provided_currency_overrides_default
+    @options.update(currency: 'EUR')
+    @gateway.expects(:ssl_post).with do |_, body|
+      assert_match "currency=EUR", body
+    end.returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
   private
 
   # Place raw successful response from gateway here


### PR DESCRIPTION
Use transaction options, not gateway options, for specifying the currency to use

Looks like this has been a bug since this gateway was added :crying_cat_face: 

@ivanfer @girasquid @ntalbott plz 2 review

cc @louiskearns @MonicaGallant @mhashemi86 
