### PR TITLE
removed numeric check on order_id as it's no longer valid

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
 
         invoice_no, ref_no, auth_code, acq_ref_data, process_data, record_no, amount = split_authorization(authorization)
-        ref_no = invoice_no if options[:reversal]
+        ref_no = "1" if options[:reversal] #filler value for preauth voids -- not used by mercury but will reject if missing or not numeric
 
         xml.tag! "TStream" do
           xml.tag! "Transaction" do
@@ -158,10 +158,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(xml, invoice_no, ref_no, options)
-        if /^\d+$/ !~ invoice_no.to_s
-          raise ArgumentError.new("order_id '#{invoice_no}' is not numeric as required by Mercury")
-        end
-
         xml.tag! 'InvoiceNo', invoice_no
         xml.tag! 'RefNo', (ref_no || invoice_no)
         xml.tag! 'OperatorID', options[:merchant] if options[:merchant]

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -14,7 +14,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
     @track_data = "%B4003000123456781^LONGSEN/L. ^15121200000000000000**123******?*"
 
     @options = {
-      :order_id => "1",
+      :order_id => "c111111111.1",
       :description => "ActiveMerchant"
     }
     @options_with_billing = @options.merge(

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -13,7 +13,7 @@ class MercuryTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => '1'
+      :order_id => 'c111111111.1'
     }
   end
 
@@ -21,7 +21,7 @@ class MercuryTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_match(/InvoiceNo>1</, data)
+      assert_match(/InvoiceNo>c111111111.1</, data)
       assert_match(/Frequency>OneTime/, data)
       assert_match(/RecordNo>RecordNumberRequested/, data)
     end.respond_with(successful_purchase_response)
@@ -31,13 +31,6 @@ class MercuryTest < Test::Unit::TestCase
 
     assert_equal '1;0194;000011;KbMCC0742510421  ;|17|410100700000;;100', response.authorization
     assert response.test?
-  end
-
-  def test_order_id_must_be_numeric
-    e = assert_raise(ArgumentError) do
-      @gateway.purchase(@amount, @credit_card, :order_id => "a")
-    end
-    assert_match(/not numeric/, e.message)
   end
 
   def test_unsuccessful_request


### PR DESCRIPTION
The numeric requirement on 'InvoiceNo' and 'RefNo' was since removed by Mercury (discussed with their supports. Removing requirement and updating tests. 

@jnormore @j-mutter review please

@louiskearns 
