### PR TITLE
Add Garanti Sanal POS Offsite for turkish market

### DIFF
--- a/lib/active_merchant/billing/gateways/garanti_offsite.rb
+++ b/lib/active_merchant/billing/gateways/garanti_offsite.rb
@@ -1,0 +1,255 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class GarantiGateway < Gateway
+      self.live_url = self.test_url = 'https://sanalposprov.garanti.com.tr/servlet/gt3dengine'
+
+      # The countries the gateway supports merchants from as 2 digit ISO country codes
+      self.supported_countries = ['US','TR']
+
+      # The card types supported by the payment gateway
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      # The homepage URL of the gateway
+      self.homepage_url = 'https://sanalposweb.garanti.com.tr'
+
+      # The name of the gateway
+      self.display_name = 'Garanti Sanal POS (Offsite)'
+
+      self.default_currency = 'TRL'
+
+      self.money_format = :cents
+
+      CURRENCY_CODES = {
+        'TRL' => 949,
+        'TL'  => 949,
+        'USD' => 840,
+        'EUR' => 978,
+        'GBP' => 826,
+        'JPY' => 392
+      }
+
+
+      def initialize(options = {})
+        requires!(options, :login, :password, :terminal_id, :merchant_id)
+        super
+      end
+
+      def purchase(money, credit_card, options = {})
+        options = options.merge(:gvp_order_type => "sales")
+        commit(money, build_sale_request(money, credit_card, options))
+      end
+
+      def authorize(money, credit_card, options = {})
+        options = options.merge(:gvp_order_type => "preauth")
+        commit(money, build_authorize_request(money, credit_card, options))
+      end
+
+      def capture(money, ref_id, options = {})
+        options = options.merge(:gvp_order_type => "postauth")
+        commit(money, build_capture_request(money, ref_id, options))
+      end
+
+      private
+
+      def security_data
+        rjusted_terminal_id = @options[:terminal_id].to_s.rjust(9, "0")
+        Digest::SHA1.hexdigest(@options[:password].to_s + rjusted_terminal_id).upcase
+      end
+
+      def generate_hash_data(order_id, terminal_id, credit_card_number, amount, security_data)
+        data = [order_id, terminal_id, credit_card_number, amount, security_data].join
+        Digest::SHA1.hexdigest(data).upcase
+      end
+
+      def build_xml_request(money, credit_card, options, &block)
+        card_number = credit_card.respond_to?(:number) ? credit_card.number : ''
+        hash_data   = generate_hash_data(format_order_id(options[:order_id]), @options[:terminal_id], card_number, amount(money), security_data)
+
+        xml = Builder::XmlMarkup.new(:indent => 2)
+        xml.instruct! :xml, :version => "1.0", :encoding => "UTF-8"
+
+        xml.tag! 'GVPSRequest' do
+          xml.tag! 'Mode', test? ? 'TEST' : 'PROD'
+          xml.tag! 'Version', 'V0.01'
+          xml.tag! 'Terminal' do
+            xml.tag! 'ProvUserID', 'PROVOOS'
+            xml.tag! 'HashData', hash_data
+            xml.tag! 'UserID', @options[:login]
+            xml.tag! 'ID', @options[:terminal_id]
+            xml.tag! 'MerchantID', @options[:merchant_id]
+          end
+
+          if block_given?
+            yield xml
+          else
+            xml.target!
+          end
+        end
+      end
+
+      def build_sale_request(money, credit_card, options)
+        build_xml_request(money, credit_card, options) do |xml|
+          add_customer_data(xml, options)
+          add_order_data(xml, options) do
+            add_addresses(xml, options)
+          end
+          add_credit_card(xml, credit_card)
+          add_transaction_data(xml, money, options)
+
+          xml.target!
+        end
+      end
+
+      def build_authorize_request(money, credit_card, options)
+         build_xml_request(money, credit_card, options) do |xml|
+          add_customer_data(xml, options)
+          add_order_data(xml, options)  do
+            add_addresses(xml, options)
+          end
+          add_credit_card(xml, credit_card)
+          add_transaction_data(xml, money, options)
+
+          xml.target!
+        end
+      end
+
+      def build_capture_request(money, ref_id, options)
+        options = options.merge(:order_id => ref_id)
+         build_xml_request(money, ref_id, options) do |xml|
+          add_customer_data(xml, options)
+          add_order_data(xml, options)
+          add_transaction_data(xml, money, options)
+
+          xml.target!
+        end
+      end
+
+      def add_customer_data(xml, options)
+        xml.tag! 'Customer' do
+          xml.tag! 'IPAddress', options[:ip] || '1.1.1.1'
+          xml.tag! 'EmailAddress', options[:email]
+        end
+      end
+
+      def add_order_data(xml, options, &block)
+        xml.tag! 'Order' do
+          xml.tag! 'OrderID', format_order_id(options[:order_id])
+          xml.tag! 'GroupID'
+
+          if block_given?
+            yield xml
+          end
+        end
+      end
+
+      def add_credit_card(xml, credit_card)
+        xml.tag! 'Card' do
+          xml.tag! 'Number', credit_card.number
+          xml.tag! 'ExpireDate', [format_exp(credit_card.month), format_exp(credit_card.year)].join
+          xml.tag! 'CVV2', credit_card.verification_value
+        end
+      end
+
+      def format_exp(value)
+        format(value, :two_digits)
+      end
+
+      # OrderId field must be A-Za-z0-9_ format and max 36 char
+      def format_order_id(order_id)
+        order_id.to_s.gsub(/[^A-Za-z0-9_]/, '')[0...36]
+      end
+
+      def add_addresses(xml, options)
+        xml.tag! 'AddressList' do
+          if billing_address = options[:billing_address] || options[:address]
+            xml.tag! 'Address' do
+              xml.tag! 'Type', 'B'
+              add_address(xml, billing_address)
+            end
+          end
+
+          if options[:shipping_address]
+            xml.tag! 'Address' do
+              xml.tag! 'Type', 'S'
+              add_address(xml, options[:shipping_address])
+            end
+          end
+        end
+      end
+
+      def add_address(xml, address)
+        xml.tag! 'Name', normalize(address[:name])
+        address_text = address[:address1]
+        address_text << " #{ address[:address2]}" if address[:address2]
+        xml.tag! 'Text', normalize(address_text)
+        xml.tag! 'City', normalize(address[:city])
+        xml.tag! 'District', normalize(address[:state])
+        xml.tag! 'PostalCode', address[:zip]
+        xml.tag! 'Country', normalize(address[:country])
+        xml.tag! 'Company', normalize(address[:company])
+        xml.tag! 'PhoneNumber', address[:phone].to_s.gsub(/[^0-9]/, '') if address[:phone]
+      end
+
+      def normalize(text)
+        return unless text
+
+        if ActiveSupport::Inflector.method(:transliterate).arity == -2
+          ActiveSupport::Inflector.transliterate(text,'')
+        elsif RUBY_VERSION >= '1.9'
+          text.gsub(/[^\x00-\x7F]+/, '')
+        else
+          ActiveSupport::Inflector.transliterate(text).to_s
+        end
+      end
+
+      def add_transaction_data(xml, money, options)
+        xml.tag! 'Transaction' do
+          xml.tag! 'Type', options[:gvp_order_type]
+          xml.tag! 'Amount', amount(money)
+          xml.tag! 'CurrencyCode', currency_code(options[:currency] || currency(money))
+          xml.tag! 'CardholderPresentCode', 0
+        end
+      end
+
+      def currency_code(currency)
+        CURRENCY_CODES[currency] || CURRENCY_CODES[default_currency]
+      end
+
+      def commit(money,request)
+        raw_response = ssl_post(self.live_url, "data=" + request)
+        response = parse(raw_response)
+
+        success = success?(response)
+
+        Response.new(success,
+                     success ? 'Approved' : "Declined (Reason: #{response[:reason_code]} - #{response[:error_msg]} - #{response[:sys_err_msg]})",
+                     response,
+                     :test => test?,
+                     :authorization => response[:order_id])
+      end
+
+      def parse(body)
+        xml = REXML::Document.new(body)
+
+        response = {}
+        xml.root.elements.to_a.each do |node|
+          parse_element(response, node)
+        end
+        response
+      end
+
+      def parse_element(response, node)
+        if node.has_elements?
+          node.elements.each{|element| parse_element(response, element) }
+        else
+          response[node.name.underscore.to_sym] = node.text
+        end
+      end
+
+      def success?(response)
+        response[:message] == "Approved"
+      end
+
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -223,6 +223,13 @@ garanti:
   merchant_id: 600218
   password: "123qweASD"
 
+# Working credentials, no need to replace
+garanti_offsite:
+  login: "PROVOOS"
+  terminal_id: 30691300    
+  merchant_id: 7000679    
+  password: "123qweASD"
+
 global_transport:
   global_user_name: "USERNAME"
   global_password: "PASSWORD"

--- a/test/remote/gateways/remote_garanti_offsite_test.rb
+++ b/test/remote/gateways/remote_garanti_offsite_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+# NOTE: tests may fail randomly because Garanti returns random(!) responses for their test server
+class RemoteGarantiTest < Test::Unit::TestCase
+
+  def setup
+    if RUBY_VERSION < '1.9' && $KCODE == "NONE"
+      @original_kcode = $KCODE
+      $KCODE = 'u'
+    end
+
+    @gateway = GarantiGateway.new(fixtures(:garanti_offsite))
+
+    @amount = 1 # 1 cents = 0.01$
+    @declined_card = credit_card('4000100011112224')
+    @credit_card = credit_card('4043089022954014')
+
+    @options = {
+      :order_id => generate_unique_id,
+      :billing_address => address,
+      :description => 'Store Purchase'
+    }
+  end
+
+  def teardown
+    $KCODE = @original_kcode if @original_kcode
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_match %r{Declined}, response.message
+  end
+
+  def test_authorize_and_capture
+    amount = @amount
+    assert auth = @gateway.authorize(amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    assert response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_match %r{Declined}, response.message
+  end
+
+  def test_invalid_login
+    gateway = GarantiGateway.new(
+                :provision_user_id => 'PROVOOS',
+                :user_id => 'PROVOOS',
+                :terminal_id => '10000174',
+                :merchant_id => '',
+                :password => ''
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '0651', response.params["reason_code"]
+  end
+end

--- a/test/unit/gateways/garanti_offsite_test.rb
+++ b/test/unit/gateways/garanti_offsite_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class GarantiOffsiteTest < Test::Unit::TestCase
+  def setup
+    @gateway = GarantiOffsiteGateway.new(
+      some_credential: 'login',
+      another_credential: 'password'
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'REPLACE', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_authorize
+  end
+
+  def test_failed_authorize
+  end
+
+  def test_successful_capture
+  end
+
+  def test_failed_capture
+  end
+
+  def test_successful_refund
+  end
+
+  def test_failed_refund
+  end
+
+  def test_successful_void
+  end
+
+  def test_failed_void
+  end
+
+  def test_successful_verify
+  end
+
+  def test_successful_verify_with_failed_void
+  end
+
+  def test_failed_verify
+  end
+
+  private
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_garanti_offsite_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response
+  end
+
+  def successful_authorize_response
+  end
+
+  def failed_authorize_response
+  end
+
+  def successful_capture_response
+  end
+
+  def failed_capture_response
+  end
+
+  def successful_refund_response
+  end
+
+  def failed_refund_response
+  end
+
+  def successful_void_response
+  end
+
+  def failed_void_response
+  end
+end


### PR DESCRIPTION
Right now Garanti Sanal POS integration for Shopify is pretty useless, since it is integrated as a direct gateway none of the merchants in Turkey is benefiting from the gateway's important features. Financing options and 3D secure authentication are standards for the turkish market and  Shopify is not being chosen as a provider since these features are not available. If we activate the offsite version, problem will be solved.

I guess i made the necessary changes to enable the offsite version
