### PR TITLE
Force TLSv1 For Money Movers Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -9,6 +9,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'MoneyMovers'
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.ssl_version = :TLSv1
 
       def initialize(options = {})
         requires!(options, :login, :password)


### PR DESCRIPTION
The money movers gateway is depreciating support for SSLv3. This PR sets the gateway to use tlsv1 by default. Here is the e-mail Money Movers sent to it's clients:

> We are reaching out because one of your merchants are using SSLv3.  Due to the age and weakness of this protocol, we will no longer be supporting SSLv3 in the upcoming weeks.  Please note, any security concerns are theoretical and there are no current known risks for you or your merchants.  However, in order to stay ahead of any potential security issues and protect our Affiliate’s customers, we are planning on removing support for SSLv3 effective December 10th 2014.
