### PR TITLE
Switched all voids to reversals and updated MID

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -72,13 +72,6 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options={})
         requires!(options, :credit_card) unless @use_tokenization
 
-        if options[:try_reversal]
-          request = build_authorized_request('VoidSale', nil, authorization, options[:credit_card], options.merge(:reversal => true))
-          response = commit('VoidSale', request)
-
-          return response if response.success?
-        end
-
         request = build_authorized_request('VoidSale', nil, authorization, options[:credit_card], options)
         commit('VoidSale', request)
       end
@@ -115,7 +108,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
 
         invoice_no, ref_no, auth_code, acq_ref_data, process_data, record_no, amount = split_authorization(authorization)
-        ref_no = "1" if options[:reversal] #filler value for preauth voids -- not used by mercury but will reject if missing or not numeric
+        ref_no = "1" if ref_no.blank?
 
         xml.tag! "TStream" do
           xml.tag! "Transaction" do
@@ -132,8 +125,8 @@ module ActiveMerchant #:nodoc:
             add_address(xml, options)
             xml.tag! 'TranInfo' do
               xml.tag! "AuthCode", auth_code
-              xml.tag! "AcqRefData", acq_ref_data if options[:reversal]
-              xml.tag! "ProcessData", process_data if options[:reversal]
+              xml.tag! "AcqRefData", acq_ref_data
+              xml.tag! "ProcessData", process_data 
             end
           end
         end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -311,7 +311,7 @@ merchant_warrior:
 
 # Working credentials, no need to replace
 mercury:
-  login: '023358150511666'
+  login: '089716741701445'
   password: 'xyz'
 
 mercury_no_tokenization:

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -50,14 +50,6 @@ class RemoteMercuryTest < Test::Unit::TestCase
     assert_equal "DECLINE", response.message
   end
 
-  def test_reversal
-    response = @gateway.authorize(100, @credit_card, @options)
-    assert_success response
-
-    void = @gateway.void(response.authorization, @options.merge(:try_reversal => true))
-    assert_success void
-  end
-
   def test_purchase_and_void
     response = @gateway.purchase(102, @credit_card, @options)
     assert_success response
@@ -125,7 +117,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
       },
       response.avs_result
     )
-    assert_equal({"code"=>nil, "message"=>nil}, response.cvv_result)
+    assert_equal({"code"=>'P', "message"=>'CVV not processed'}, response.cvv_result)
   end
 
   def test_partial_capture
@@ -227,5 +219,13 @@ class RemoteMercuryTest < Test::Unit::TestCase
     capture = @gateway.capture(nil, response.authorization)
     assert_success capture
     assert_equal '1.00', capture.params['authorize']
+  end
+  def test_authorize_and_void
+    response = @gateway.authorize(100, @credit_card, @options)
+    assert_success response
+    assert_equal '1.00', response.params['authorize']
+
+    void = @gateway.void(response.authorization)
+    assert_success void
   end
 end


### PR DESCRIPTION
These changes make a "reversal" the standard method for voiding a sale. I've also updated the fixtures.yml MID. 

According to Mercury Support:
- A regular VoidSale (vs. a reversal) is considered legacy for Mercury.
- A reversal uses the same TranCode VoidSale, but you also include AcqRefData and ProcessData in the request. This allows us to submit the request to the issuer and not just the host batch. So, instead of funds being released within days they can be released within hours.
- The MID 023358150511666 was configured for brick & mortar accounts while 089716741701445 is for both ecommerce and brick & mortar

@girasquid @bizla can you review? 
