### PR TITLE
Switch transcript capturing to use wiredump_device; Update scrub tests to not use send

### DIFF
--- a/generators/gateway/templates/gateway_test.rb
+++ b/generators/gateway/templates/gateway_test.rb
@@ -70,7 +70,7 @@ class <%= class_name %>Test < Test::Unit::TestCase
 
   def test_scrub
     assert @gateway.supports_scrubbing?
-    assert_equal @gateway.send(:scrub, pre_scrubbed), post_scrubbed
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
   private

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -508,7 +508,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_scrub
-    assert_equal @gateway.send(:scrub, pre_scrubbed), post_scrubbed
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
   def test_supports_scrubbing?

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -603,7 +603,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_scrub
-    assert_equal @gateway.send(:scrub, pre_scrubbed), post_scrubbed
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
   def test_supports_scrubbing?


### PR DESCRIPTION
It turns out capturing transcripts is easier than what I was doing before; you can use [wiredump_device](https://github.com/Shopify/active_utils/blob/master/lib/active_utils/common/connection.rb#L104) from active_utils.

@edward @ntalbott @karlhungus for review
