### PR TITLE
PayPal: Allow specifying ButtonSource at init

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -2,6 +2,8 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # This module is included in both PaypalGateway and PaypalExpressGateway
     module PaypalCommonAPI
+      include Empty
+
       API_VERSION = '72'
 
       URLS = {
@@ -573,7 +575,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'n2:Custom', options[:custom] unless options[:custom].blank?
 
           xml.tag! 'n2:InvoiceID', (options[:order_id] || options[:invoice_id]) unless (options[:order_id] || options[:invoice_id]).blank?
-          xml.tag! 'n2:ButtonSource', application_id.to_s.slice(0,32) unless application_id.blank?
+          add_button_source(xml)
 
           # The notify URL applies only to DoExpressCheckoutPayment.
           # This value is ignored when set in SetExpressCheckout or GetExpressCheckoutDetails
@@ -590,6 +592,13 @@ module ActiveMerchant #:nodoc:
           # the buyer specifying the amount, frequency, and duration of the recurring payment.
           # requires version 80.0 of the API
           xml.tag! 'n2:Recurring', options[:recurring] unless options[:recurring].blank?
+        end
+      end
+
+      def add_button_source(xml)
+        button_source = (@options[:button_source] || application_id)
+        if !empty?(application_id)
+          xml.tag! 'n2:ButtonSource', button_source.to_s.slice(0, 32)
         end
       end
 

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -224,6 +224,19 @@ class PaypalTest < Test::Unit::TestCase
     assert_equal 'ActiveMerchant_DC', REXML::XPath.first(xml, '//n2:ButtonSource').text
   end
 
+  def test_button_source_via_credentials
+    PaypalGateway.application_id = 'ActiveMerchant_DC'
+    gateway = PaypalGateway.new(
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM',
+      button_source: "WOOHOO"
+    )
+
+    xml = REXML::Document.new(gateway.send(:build_sale_or_authorization_request, 'Test', @amount, @credit_card, {}))
+    assert_equal 'WOOHOO', REXML::XPath.first(xml, '//n2:ButtonSource').text
+  end
+
   def test_item_total_shipping_handling_and_tax_not_included_unless_all_are_present
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
       :tax => @amount,


### PR DESCRIPTION
In some environments one may want to set the ButtonSource on a per-
gateway basis; this allows overriding it in the @options has by
passing in a :button_source option.

If no :button_source is provided, application_id continues to be used
if available.

Please review @duff @girasquid.
