### PR TITLE
Payflow: Add fraud_review support

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -197,12 +197,23 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request, headers))
 
-        build_response(response[:result] == "0", response[:message], response,
-          :test => test?,
-          :authorization => response[:pn_ref] || response[:rp_ref],
-          :cvv_result => CVV_CODE[response[:cv_result]],
-          :avs_result => { :code => response[:avs_result] }
+        build_response(
+          success_for(response),
+          response[:message], response,
+          test: test?,
+          authorization: response[:pn_ref] || response[:rp_ref],
+          cvv_result: CVV_CODE[response[:cv_result]],
+          avs_result: { code: response[:avs_result] },
+          fraud_review: under_fraud_review?(response)
         )
+      end
+
+      def success_for(response)
+        %w(0 126).include?(response[:result])
+      end
+
+      def under_fraud_review?(response)
+        (response[:result] == "126")
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -445,9 +445,10 @@ payex:
   # encryption key is generated via the PayEx Admin console
   encryption_key: ENCRYPTION_KEY
 
+# Working credentials, no need to replace
 payflow:
-  login: LOGIN
-  password: PASSWORD
+  login: spreedly
+  password: 'ibB4Z8=d;G'
   partner: PayPal
 
 payflow_uk:

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -29,6 +29,26 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
     assert_not_nil response.authorization
+    assert !response.fraud_review?
+  end
+
+  # In order for this remote test to pass, you must go into your Payflow test
+  # backend and enable the correct filter. Once logged in:
+  # "Service Settings" ->
+  #   "Fraud Protection" ->
+  #     "Test Setup" ->
+  #       "Edit Standard Filters" ->
+  #         Check "BIN Risk List Match" filter *only*, set to "Review" ->
+  #           "Deploy" ->
+  #             WAIT AT LEAST AN HOUR. FOR REALZ.
+  def test_successful_purchase_with_fraud_review
+    assert response = @gateway.purchase(
+      100000,
+      credit_card("5555555555554444", verification_value: "")
+    )
+    assert_success response, "This is probably failing due to your Payflow test account not being set up for fraud filters."
+    assert_equal "126", response.params["result"]
+    assert response.fraud_review?
   end
 
   def test_declined_purchase
@@ -46,8 +66,8 @@ class RemotePayflowTest < Test::Unit::TestCase
   # This can be accomplished by sending an email to payflow-support@paypal.com with your Merchant Login.
   def test_successful_ach_purchase
     assert response = @gateway.purchase(50, @check)
+    assert_success response, "This is probably failing due to your Payflow test account not being set up for ACH."
     assert_equal "Approved", response.message
-    assert_success response
     assert response.test?
     assert_not_nil response.authorization
   end
@@ -105,8 +125,8 @@ class RemotePayflowTest < Test::Unit::TestCase
   end
 
   def test_duplicate_request_id
-    request_id = Digest::MD5.hexdigest(rand.to_s)
-    @gateway.expects(:generate_unique_id).times(2).returns(request_id)
+    request_id = SecureRandom.hex(16)
+    SecureRandom.expects(:hex).times(2).returns(request_id)
 
     response1 = @gateway.purchase(100, @credit_card, @options)
     assert  response1.success?
@@ -114,18 +134,22 @@ class RemotePayflowTest < Test::Unit::TestCase
 
     response2 = @gateway.purchase(100, @credit_card, @options)
     assert response2.success?
-    assert response2.params['duplicate']
+    assert response2.params['duplicate'], response2.inspect
   end
 
   def test_create_recurring_profile
-    response = @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+    end
     assert_success response
     assert !response.params['profile_id'].blank?
     assert response.test?
   end
 
   def test_create_recurring_profile_with_invalid_date
-    response = @gateway.recurring(1000, @credit_card, :periodicity => :monthly, :starting_at => Time.now)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(1000, @credit_card, :periodicity => :monthly, :starting_at => Time.now)
+    end
     assert_failure response
     assert_equal 'Field format error: Start or next payment date must be a valid future date', response.message
     assert response.params['profile_id'].blank?
@@ -133,12 +157,16 @@ class RemotePayflowTest < Test::Unit::TestCase
   end
 
   def test_create_and_cancel_recurring_profile
-    response = @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+    end
     assert_success response
     assert !response.params['profile_id'].blank?
     assert response.test?
 
-    response = @gateway.cancel_recurring(response.params['profile_id'])
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.cancel_recurring(response.params['profile_id'])
+    end
     assert_success response
     assert response.test?
   end
@@ -151,7 +179,9 @@ class RemotePayflowTest < Test::Unit::TestCase
       :starting_at => Time.now + 1.day,
       :comment => "Test Profile"
     )
-    response = @gateway.recurring(100, @credit_card, @options)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(100, @credit_card, @options)
+    end
     assert_equal "Approved", response.params['message']
     assert_equal "0", response.params['result']
     assert_success response
@@ -166,26 +196,34 @@ class RemotePayflowTest < Test::Unit::TestCase
       :payments => '4',
       :profile_id => @recurring_profile_id
     )
-    response = @gateway.recurring(400, @credit_card, @options)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(400, @credit_card, @options)
+    end
     assert_equal "Approved", response.params['message']
     assert_equal "0", response.params['result']
     assert_success response
     assert response.test?
 
     # Test inquiry
-    response = @gateway.recurring_inquiry(@recurring_profile_id)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring_inquiry(@recurring_profile_id)
+    end
     assert_equal "0", response.params['result']
     assert_success response
     assert response.test?
 
     # Test payment history inquiry
-    response = @gateway.recurring_inquiry(@recurring_profile_id, :history => true)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring_inquiry(@recurring_profile_id, :history => true)
+    end
     assert_equal '0', response.params['result']
     assert_success response
     assert response.test?
 
     # Test cancel
-    response = @gateway.cancel_recurring(@recurring_profile_id)
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.cancel_recurring(@recurring_profile_id)
+    end
     assert_equal "Approved", response.params['message']
     assert_equal "0", response.params['result']
     assert_success response
@@ -208,26 +246,15 @@ class RemotePayflowTest < Test::Unit::TestCase
   end
 
   def test_recurring_with_initial_authorization
-    response = @gateway.recurring(1000, @credit_card,
-      :periodicity => :monthly,
-      :initial_transaction => {
-        :type => :authorization
-      }
-    )
-
-    assert_success response
-    assert !response.params['profile_id'].blank?
-    assert response.test?
-  end
-
-  def test_recurring_with_initial_authorization
-    response = @gateway.recurring(1000, @credit_card,
-      :periodicity => :monthly,
-      :initial_transaction => {
-        :type => :purchase,
-        :amount => 500
-      }
-    )
+    response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
+      @gateway.recurring(1000, @credit_card,
+        :periodicity => :monthly,
+        :initial_transaction => {
+          :type => :purchase,
+          :amount => 500
+        }
+      )
+    end
 
     assert_success response
     assert !response.params['profile_id'].blank?
@@ -253,13 +280,13 @@ class RemotePayflowTest < Test::Unit::TestCase
   # check) unless Allow non-referenced credits = Yes in PayPal manager
   def test_purchase_and_credit
     assert credit = @gateway.credit(100, @credit_card, @options)
-    assert_success credit
+    assert_success credit, "This is probably failing due to your Payflow test account not being set up to allow non-referenced credits."
   end
 
   def test_successful_ach_credit
     assert response = @gateway.credit(50, @check)
+    assert_success response, "This is probably failing due to your Payflow test account not being set up for ACH."
     assert_equal "Approved", response.message
-    assert_success response
     assert response.test?
     assert_not_nil response.authorization
   end

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -23,6 +23,7 @@ class PayflowTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
     assert_equal "VUJN1A6E11D9", response.authorization
+    refute response.fraud_review?
   end
 
   def test_failed_authorization
@@ -32,6 +33,15 @@ class PayflowTest < Test::Unit::TestCase
     assert_equal "Declined", response.message
     assert_failure response
     assert response.test?
+  end
+
+  def test_successful_purchase_with_fraud_review
+    @gateway.stubs(:ssl_post).returns(successful_purchase_with_fraud_review_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "126", response.params["result"]
+    assert response.fraud_review?
   end
 
   def test_credit
@@ -115,7 +125,7 @@ class PayflowTest < Test::Unit::TestCase
       :password => 'PASSWORD'
     )
 
-    assert !gateway.test?
+    refute gateway.test?
   end
 
   def test_partner_class_accessor
@@ -437,6 +447,46 @@ class PayflowTest < Test::Unit::TestCase
     <StreetMatch>Match</StreetMatch>
     <CvResult>Match</CvResult>
 </ResponseData>
+    XML
+  end
+
+  def successful_purchase_with_fraud_review_response
+    <<-XML
+      <XMLPayResponse  xmlns="http://www.paypal.com/XMLPay">
+        <ResponseData>
+          <Vendor>spreedly</Vendor>
+          <Partner>paypal</Partner>
+          <TransactionResults>
+            <TransactionResult>
+              <Result>126</Result>
+              <ProcessorResult>
+                <HostCode>A</HostCode>
+              </ProcessorResult>
+              <FraudPreprocessResult>
+                <Message>Review HighRiskBinCheck</Message>
+                <XMLData>
+                  <triggeredRules>
+                    <rule num="1">
+                      <ruleId>13</ruleId>
+                      <ruleID>13</ruleID>
+                      <ruleAlias>HighRiskBinCheck</ruleAlias>
+                      <ruleDescription>BIN Risk List Match</ruleDescription>
+                      <action>R</action>
+                      <triggeredMessage>The card number is in a high risk bin list</triggeredMessage>
+                    </rule>
+                  </triggeredRules>
+                </XMLData>
+              </FraudPreprocessResult>
+              <FraudPostprocessResult>
+                <Message>Review</Message>
+              </FraudPostprocessResult>
+              <Message>Under review by Fraud Service</Message>
+              <PNRef>A71A7B022DC0</PNRef>
+              <AuthCode>907PNI</AuthCode>
+            </TransactionResult>
+          </TransactionResults>
+        </ResponseData>
+      </XMLPayResponse>
     XML
   end
 


### PR DESCRIPTION
This adds support for the Response#fraud_review? flag in Payflow so
that merchants can be notified a "successful" transaction has been
flagged for further review before shipping.

Also cleans up a few things in the remote Payflow tests.

@girasquid since Shopify uses this flag I want to make double-sure that activating it for Payflow won't affect you. Since this doesn't actually affect what Payflow's doing, but just exposes it, I can't imagine it will, but better safe than sorry.

Please review @girasquid @duff.
