### PR TITLE
Cybersource: All creditcard fields should be optional

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -445,11 +445,11 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard(xml, creditcard)
         xml.tag! 'card' do
-          xml.tag! 'accountNumber', creditcard.number
-          xml.tag! 'expirationMonth', format(creditcard.month, :two_digits)
-          xml.tag! 'expirationYear', format(creditcard.year, :four_digits)
+          xml.tag! 'accountNumber', creditcard.number unless creditcard.number.blank?
+          xml.tag! 'expirationMonth', format(creditcard.month, :two_digits) unless creditcard.month.blank?
+          xml.tag! 'expirationYear', format(creditcard.year, :four_digits)  unless creditcard.year.blank?
           xml.tag!('cvNumber', creditcard.verification_value) unless (@options[:ignore_cvv] || creditcard.verification_value.blank? )
-          xml.tag! 'cardType', @@credit_card_codes[card_brand(creditcard).to_sym]
+          xml.tag! 'cardType', @@credit_card_codes[card_brand(creditcard).to_sym] unless card_brand(creditcard).blank?
         end
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -247,6 +247,19 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_update_subscription_creditcard_exp_only
+    assert response = @gateway.store(@credit_card, @subscription_options)
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+
+    new_exp = ActiveMerchant::Billing::CreditCard.new(month: Date.today.month, year: Date.today.year)
+    assert response = @gateway.update(response.authorization, new_exp, {:order_id => generate_unique_id})
+    assert_equal 'Successful transaction', response.message
+    assert_success response
+    assert response.test?
+  end
+
   def test_successful_update_subscription_billing_address
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_equal 'Successful transaction', response.message


### PR DESCRIPTION
This comes into play when updating a stored payment method.
