### PR TITLE
IPP storage/tokenization

### DIFF
--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -34,7 +34,12 @@ module ActiveMerchant #:nodoc:
             xml.CustRef options[:order_id]
             add_amount(xml, money)
             xml.TrnType "1"
-            add_credit_card(xml, payment)
+            if payment.respond_to?(:number)
+              add_credit_card(xml, payment)
+            else
+              # triggered payment for an tokenised credit card
+              add_token_details(xml, payment)
+            end
             add_credentials(xml)
             xml.TrnSource options[:ip]
           end
@@ -47,7 +52,12 @@ module ActiveMerchant #:nodoc:
             xml.CustRef options[:order_id]
             add_amount(xml, money)
             xml.TrnType "2"
-            add_credit_card(xml, payment)
+            if payment.respond_to?(:number)
+              add_credit_card(xml, payment)
+            else
+              # triggered payment for an tokenised credit card
+              add_token_details(xml, payment)
+            end
             add_credentials(xml)
             xml.TrnSource options[:ip]
           end
@@ -122,6 +132,13 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(xml, money)
         xml.Amount amount(money)
+      end
+
+      def add_token_details(xml, payment)
+        xml.CreditCard do
+          xml.CardNumber payment
+          xml.TokeniseAlgorithmID "2"
+        end
       end
 
       def add_credit_card(xml, payment)

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -14,6 +14,8 @@ module ActiveMerchant #:nodoc:
 
       self.money_format = :cents
 
+      self.default_currency = 'AUD'
+
       STANDARD_ERROR_CODE_MAPPING = {
         "05" => STANDARD_ERROR_CODE[:card_declined],
         "06" => STANDARD_ERROR_CODE[:processing_error],

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -3,8 +3,8 @@ require "nokogiri"
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class IppGateway < Gateway
-      self.live_url = 'https://www.ippayments.com.au/interface/api/dts.asmx'
-      self.test_url = 'https://demo.ippayments.com.au/interface/api/dts.asmx'
+      self.live_url = 'https://www.ippayments.com.au/interface/api'
+      self.test_url = 'https://demo.ippayments.com.au/interface/api'
 
       self.supported_countries = ['AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
@@ -64,12 +64,38 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def void(money, authorization, options={})
+        commit("SubmitSingleVOID") do |xml|
+          xml.Void do
+            xml.Receipt authorization
+            add_amount(xml, money)
+            add_credentials(xml)
+          end
+        end
+      end
+
       def refund(money, authorization, options={})
         commit("SubmitSingleRefund") do |xml|
           xml.Refund do
             xml.Receipt authorization
             add_amount(xml, money)
             add_credentials(xml)
+          end
+        end
+      end
+
+      def store(payment, options={})
+        commit("TokeniseCreditCard", "sipp", "tokeniseCreditCardXML") do |xml|
+          xml.TokeniseCreditCard do
+            xml.UserName @options[:username]
+            xml.Password @options[:password]
+            xml.CardNumber payment.number
+            xml.ExpM format(payment.month, :two_digits)
+            xml.ExpY format(payment.year, :four_digits)
+            xml.TokeniseAlgorithmID "2"
+            if options.has_key?(:customer_storage_number)
+              xml.CustomerStorageNumber options[:customer_storage_number]
+            end
           end
         end
       end
@@ -119,12 +145,12 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(action, &block)
+      def commit(action, api_type="dts", outer_xml="trnXML", &block)
         headers = {
           "Content-Type" => "text/xml; charset=utf-8",
-          "SOAPAction" => "http://www.ippayments.com.au/interface/api/dts/#{action}",
+          "SOAPAction" => "http://www.ippayments.com.au/interface/api/#{api_type}/#{action}",
         }
-        response = parse(ssl_post(commit_url, new_submit_xml(action, &block), headers))
+        response = parse(ssl_post(commit_url(api_type), new_submit_xml(action, api_type, outer_xml, &block), headers))
 
         Response.new(
           success_from(response),
@@ -136,13 +162,13 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def new_submit_xml(action)
+      def new_submit_xml(action, api_type, outer_xml)
         xml = Builder::XmlMarkup.new(indent: 2)
         xml.instruct!
         xml.soap :Envelope, "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance", "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema", "xmlns:soap" => "http://schemas.xmlsoap.org/soap/envelope/" do
           xml.soap :Body do
-            xml.__send__(action, "xmlns" => "http://www.ippayments.com.au/interface/api/dts") do
-              xml.trnXML do
+            xml.__send__(action, "xmlns" => "http://www.ippayments.com.au/interface/api/#{api_type}") do
+              xml.__send__(outer_xml) do
                 inner_xml = Builder::XmlMarkup.new(indent: 2)
                 yield(inner_xml)
                 xml.cdata!(inner_xml.target!)
@@ -153,24 +179,47 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def commit_url
-        (test? ? test_url : live_url)
+      def commit_url(api_type)
+        "#{test? ? test_url : live_url}/#{api_type}.asmx"
       end
 
       def success_from(response)
-        (response[:response_code] == "0")
+        if response.has_key?(:return_value)
+          (response[:return_value] == "0")
+        else
+          (response[:response_code] == "0")
+        end
       end
 
       def error_code_from(response)
-        STANDARD_ERROR_CODE_MAPPING[response[:declined_code]]
+        if response.has_key?(:return_value)
+          case response[:return_value]
+          when '5' then Gateway::STANDARD_ERROR_CODE[:invalid_number]
+          when '99' then Gateway::STANDARD_ERROR_CODE[:processing_error]
+          else response[:return_value]
+          end
+        else
+          STANDARD_ERROR_CODE_MAPPING[response[:declined_code]]
+        end
       end
 
       def message_from(response)
-        response[:declined_message]
+        if response.has_key?(:return_value)
+          case response[:return_value]
+          when '0' then ''
+          when '1' then 'Invalid username/password'
+          when '4' then 'Invalid CustomerStorageNumber'
+          when '5' then 'Invalid Credit Card Number'
+          when '99' then 'Exception encountered'
+          else "Error #{response[:return_value]}"
+          end
+        else
+          response[:declined_message]
+        end
       end
 
       def authorization_from(response)
-        response[:receipt]
+        response[:receipt] || response[:token]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(money, authorization, options={})
-        commit("SubmitSingleVOID") do |xml|
+        commit("SubmitSingleVoid") do |xml|
           xml.Void do
             xml.Receipt authorization
             add_amount(xml, money)

--- a/test/remote/gateways/remote_ipp_test.rb
+++ b/test/remote/gateways/remote_ipp_test.rb
@@ -81,6 +81,28 @@ class RemoteIppTest < Test::Unit::TestCase
     assert_equal '', response.message
   end
 
+  def test_successful_purchase_with_token
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '', response.message
+    customer_token = response.authorization
+
+    assert response = @gateway.purchase(200, customer_token, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_successful_authorize_with_token
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '', response.message
+    customer_token = response.authorization
+
+    assert response = @gateway.authorize(200, customer_token, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
   def test_failed_store
     response = @gateway.store(credit_card(''), @options)
     assert_failure response

--- a/test/remote/gateways/remote_ipp_test.rb
+++ b/test/remote/gateways/remote_ipp_test.rb
@@ -75,6 +75,18 @@ class RemoteIppTest < Test::Unit::TestCase
     assert_equal 'Do Not Honour', response.message
   end
 
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_failed_store
+    response = @gateway.store(credit_card(''), @options)
+    assert_failure response
+    assert_equal 'Exception encountered', response.message
+  end
+
   def test_invalid_login
     gateway = IppGateway.new(
       username: '',

--- a/test/remote/gateways/remote_ipp_test.rb
+++ b/test/remote/gateways/remote_ipp_test.rb
@@ -11,6 +11,8 @@ class RemoteIppTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase',
     }
+
+    @amount = 234
   end
 
   def test_dump_transcript


### PR DESCRIPTION
This adds support for storage (tokenization) to the IPP gateway implementation. It also fixes a warning in the IPP remote test and sets the IPP default currency to AUD.
