### PR TITLE
Adds support for HMAC Authentication to the Paystation Gateway

### DIFF
--- a/test/remote/gateways/remote_paystation_test.rb
+++ b/test/remote/gateways/remote_paystation_test.rb
@@ -4,7 +4,8 @@ class RemotePaystationTest < Test::Unit::TestCase
   
 
   def setup
-    @gateway = PaystationGateway.new(fixtures(:paystation))
+    @gateway      = PaystationGateway.new(fixtures(:paystation))
+    @hmac_gateway = PaystationGateway.new(fixtures(:hmac_paystation))
     
     @credit_card = credit_card('5123456789012346', :month => 5, :year => 13, :verification_value => 123)
   
@@ -102,6 +103,15 @@ class RemotePaystationTest < Test::Unit::TestCase
   
     assert_failure response
     assert_nil response.authorization
+  end
+
+  def test_store_with_hmac
+    time = Time.now.to_i
+    assert response = @hmac_gateway.store(@credit_card, @options.merge(:order_id => get_uid, :token => "justatest#{time}"))
+    assert_success response
+  
+    assert_equal "Future Payment Saved Ok", response.message
+    assert_equal "justatest#{time}", response.token
   end
   
   private

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -78,6 +78,23 @@ class PaystationTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_store_with_hmac_authentication
+    hmac_gateway = PaystationGateway.new(
+     :paystation_id           => 'some_id_number',
+     :gateway_id              => 'another_id_number',
+     :hmac_authentication_key => '12345'
+    )
+
+    signature         = "cc9ac7aea51761dddb45b601d9830ce7d3df1762855120b2355291c2ccbe36a203bd5d403911d38f5cf3cd32c68a0c42b3ccb64572f387c18d3c810f38df480c"
+    timestamp         = 1426683881
+    expected_endpoint = PaystationGateway.live_url + "?pstn_HMAC=#{signature}&pstn_HMACTimestamp=#{timestamp}"
+    hmac_gateway.expects(:ssl_post).with { |endpoint, data| endpoint == expected_endpoint }.returns(successful_store_response)
+    Time.any_instance.expects(:to_i).returns(timestamp)
+
+    assert response = hmac_gateway.store(@credit_card, @options.merge(:token => "justatest1310263135"))
+    assert_success response
+  end
+
   private
 
     def successful_purchase_response


### PR DESCRIPTION
Hi!

Paystation have (recently?) added a new authentication method as an alternative to whitelisting your server IP.

This PR implements that HMAC signature authentication method. If you specify the `:hmac_authentication_key` option when creating your Gateway instance, then the new authentication method will be used. If that option is not specified then there is no change.

Comes with tests, and _most_ of the remote tests pass (there are two that rely on Merchant account settings on Paystation's end, which I'm working on changing so that I can get them to 100%).

(I actually noticed PR #1592 after I'd already written this, whoops - but I think this is potentially more idiomatic?)

Thanks!

Nik
