### PR TITLE
Don't require active_support's delegating_attributes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * WePay: Handle JSON::ParserError exceptions [duff]
 * Borgun: Update country list and homepage url [mrezentes]
 * AuthorizeNet: Add cvv to request only if it's valid [tjstankus]
+* Remove requirement of ActiveSupport's `delegating_attributes` [larrylv]
 
 == Version 1.48.0 (April 8, 2015)
 

--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -33,7 +33,6 @@ if(!defined?(ActiveSupport::VERSION) || (ActiveSupport::VERSION::STRING < "4.1")
   require 'active_support/core_ext/class/attribute_accessors'
 end
 
-require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/module/attribute_accessors'
 
 require 'base64'


### PR DESCRIPTION
Class#superclass_delegating_accessor from Rails is now deprecated.

https://github.com/rails/rails/pull/14271

And uses of `superclass_delegating_accessor` use has been removed in ffca0ca615bfa7bc99f8faae9b4ae95514a6604d and ae02c93aaa52e4a63326d4b399bd8a9dd3977ed5