### PR TITLE
Zaakpay

### DIFF
--- a/lib/active_merchant/billing/gateways/zaakpay.rb
+++ b/lib/active_merchant/billing/gateways/zaakpay.rb
@@ -1,0 +1,237 @@
+require 'openssl'
+require 'open-uri'
+require 'nokogiri'
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class ZaakpayGateway < Gateway
+      self.test_url = 'https://api.zaakpay.com/transactD?v=3'
+      self.live_url = 'https://api.zaakpay.com/transactD?v=3'
+
+      self.supported_countries = ['IN']
+      self.default_currency = 'INR'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :maestro]
+
+      self.homepage_url = 'http://www.zaakpay.com/'
+      self.display_name = 'Zaakpay'
+      
+      STANDARD_ERROR_CODE_MAPPING = {}
+      
+      def initialize(options={})
+        requires!(options, :merchantIdentifier, :secretKey)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        post = {}
+        add_params(money, payment, post, options)
+
+        commit('sale', post)
+      end
+
+
+      def encrypt_card(value)
+        zaakpay_js = open('https://api.zaakpay.com/zaakpay.js').read
+        zaakpay_js_split = zaakpay_js.split("'")
+        zaakpay_js_key = zaakpay_js_split[1]
+        value_str = value.to_s
+        encrypted_value = ""
+
+        for index in 0..(value_str.length()-1)
+          encrypted_value += (value_str[index].ord.to_s + zaakpay_js_key[index%(zaakpay_js_key.length())].ord.to_s + ",")
+        end
+
+        encrypted_value
+      end
+
+
+      def add_params(money, payment, post , options)
+        post[:merchantIdentifier] = @options[:merchantIdentifier]
+        for key, value in options
+          post[key] = value
+        end
+        post[:amount]                 = money
+        post[:debitorcredit]          = "credit"
+        post[:encrypted_pan]          = encrypt_card(payment.number)
+        post[:nameoncard]             = payment.first_name
+        post[:encryptedcvv]           = encrypt_card(payment.verification_value)
+        post[:encrypted_expiry_month] = encrypt_card(payment.month)
+        post[:encrypted_expiry_year]  = encrypt_card(payment.year)
+        checksum = calculate_checksum(money, @options[:secretKey], options)
+        post[:checksum]               = checksum
+      end
+
+
+      def calculate_checksum(money, secretKey, options = {})
+        checksum_string = ""
+        checksum_string += ("'" + @options[:merchantIdentifier] + "'")
+        checksum_string += ("'" + options[:orderId] + "'")
+        checksum_string += ("'" + options[:mode] + "'")
+        checksum_string += ("'" + options[:currency] + "'")
+        checksum_string += ("'" + options[:merchantIpAddress] + "'")
+        checksum_string += ("'" + options[:txnDate] + "'")
+        checksum_string += ("'" + money.to_s + "'")
+        
+        OpenSSL::HMAC.hexdigest('sha256', secretKey, checksum_string)
+      end
+
+      def authorize(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        commit('authonly', post)
+      end
+
+      def capture(money, authorization, options={})
+        commit('capture', post)
+      end
+
+      def refund(money, authorization, options={})
+        commit('refund', post)
+      end
+
+      def void(authorization, options={})
+        commit('void', post)
+      end
+
+      def verify(credit_card, options={})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<n1:Password>).+(</n1:Password>)), '\1[FILTERED]\2').
+          gsub(%r((<n1:Username>).+(</n1:Username>)), '\1[FILTERED]\2').
+          gsub(%r((<n2:CreditCardNumber>).+(</n2:CreditCardNumber)), '\1[FILTERED]\2').
+          gsub(%r((<n2:CVV2>).+(</n2:CVV2)), '\1[FILTERED]\2')
+      end
+
+      private
+
+      def add_customer_data(post, options)
+        
+      end
+
+      def add_address(post, creditcard, options)
+      end
+
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+        post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_payment(post, payment)
+      end
+
+      def parse(body)
+        # print "-----------------------body------------------------", body
+        body
+      end
+
+      def commit(action, parameters)
+        url = (test? ? test_url : live_url)
+        # load 'lib/active_merchant/posts_data.rb'
+        response = parse(ssl_post(url, post_data(action, parameters))) #
+
+        return_params = parse_params(response)
+        
+        message = message_from(response)
+        success = success_from(response)
+        authorization = authorization_from(response)
+
+        Response.new(
+          success,
+          message,
+          return_params,
+          authorization: authorization,
+          test: test?
+        )
+      end
+
+      def parse_params(response)
+        params = {}
+        parsed_html = Nokogiri::HTML(response)
+        form_obj = parsed_html.search("form")[0]
+        if form_obj
+          inputs = form_obj.search("input")
+
+          for input in inputs
+            if input.to_s.include? "responseDescription"
+              params["message"] = input.to_s.split('"')[5]
+            end
+          end
+
+          for input in inputs
+            if input.to_s.include? "checksum"
+              params["checksum"] = input.to_s.split('"')[5]
+            end
+          end
+
+        end
+
+        params        
+      end
+
+      def success_from(response)
+        parsed_html = Nokogiri::HTML(response)
+        
+        forms = parsed_html.search("form")
+
+        if forms
+          form_obj = parsed_html.search("form")[0]
+        end
+
+        if form_obj
+          inputs = form_obj.search("input")
+          success = false
+          for input in inputs
+            if input.to_s.include? "responseDescription"
+              if input.to_s.include? "success"
+                success = true
+              end
+            end
+          end
+        end
+
+        success
+      end
+
+      def message_from(response)
+        parsed_html = Nokogiri::HTML(response)
+        forms = parsed_html.search("form")
+
+        if forms
+          form_obj = parsed_html.search("form")[0]
+        end
+
+        if form_obj
+          inputs = form_obj.search("input")
+          for input in inputs
+            if input.to_s.include? "responseDescription"
+              return input.to_s.split('"')[5]
+            end
+          end
+        end
+
+
+      end
+
+      def authorization_from(response)
+        ""
+      end
+
+      def post_data(action, parameters = {})
+        parameters.collect { |key, value| "#{key}=#{ CGI.escape(value.to_s)}" }.join("&")
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -161,11 +161,6 @@ data_cash:
   login: X
   password: Y
 
-# No working test credentials
-dibs:
-  merchant_id: SOMECREDENTIAL
-  secret_key: NOPUBLICCREDENTIAL
-
 direc_pay:
   login: 200904281000001
 
@@ -812,13 +807,9 @@ spreedly_core:
   password: "Y2i7AjgU03SUjwY4xnOPqzdsv4dMbPDCQzorAk8Bcoy0U8EIVE4innGjuoMQv7MN"
   gateway_token: "3gLeg4726V5P0HK7cq7QzHsL0a6"
 
-# Working credentials, no need to replace
 stripe:
-  login: sk_test_3OD4TdKSIOhDOL2146JJcC79
-
-# Working credentials, no need to replace
-stripe_destination:
-  stripe_user_id: "acct_161hWaHIrJcQ9OHT"
+  login:
+  fee_refund_login:
 
 # Used only for remote tests that use EMV credit card mocks
 stripe_emv_uk:
@@ -915,3 +906,8 @@ worldpay_us:
   acctid: MPNAB
   subid: SPREE
   merchantpin: "1234567890"
+
+# Working credentials, no need to replace
+zaakpay:
+  merchantIdentifier: '5c7148b110ee49d7a1a9042db4fbf4ad',
+  secretKey: 'e73be5e3e14a4b548948f899ccde5604',

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -161,6 +161,11 @@ data_cash:
   login: X
   password: Y
 
+# No working test credentials
+dibs:
+  merchant_id: SOMECREDENTIAL
+  secret_key: NOPUBLICCREDENTIAL
+
 direc_pay:
   login: 200904281000001
 
@@ -807,9 +812,13 @@ spreedly_core:
   password: "Y2i7AjgU03SUjwY4xnOPqzdsv4dMbPDCQzorAk8Bcoy0U8EIVE4innGjuoMQv7MN"
   gateway_token: "3gLeg4726V5P0HK7cq7QzHsL0a6"
 
+# Working credentials, no need to replace
 stripe:
-  login:
-  fee_refund_login:
+  login: sk_test_3OD4TdKSIOhDOL2146JJcC79
+
+# Working credentials, no need to replace
+stripe_destination:
+  stripe_user_id: "acct_161hWaHIrJcQ9OHT"
 
 # Used only for remote tests that use EMV credit card mocks
 stripe_emv_uk:

--- a/test/remote/gateways/remote_zaakpay_test.rb
+++ b/test/remote/gateways/remote_zaakpay_test.rb
@@ -1,0 +1,173 @@
+require 'test_helper'
+
+class RemoteZaakpayTest < Test::Unit::TestCase
+  def setup
+    ActiveMerchant::Billing::Base.mode = :test
+    @gateway = ActiveMerchant::Billing::ZaakpayGateway.new(
+      :merchantIdentifier => '5c7148b110ee49d7a1a9042db4fbf4ad', #These credentials are for testing only. 
+                                                                #For your own merchantidentifier and secret key, 
+                                                                #signup here - https://www.zaakpay.com/developers
+      :secretKey          => 'e73be5e3e14a4b548948f899ccde5604',
+    )
+
+    #Valid credit card credentials
+    @credit_card = ActiveMerchant::Billing::CreditCard.new(
+                            :first_name         => 'TestUserFirstName',
+                            :last_name          => 'TestUserLastName',
+                            :number             => '4012888888881881',
+                            :month              => Time.now.month,
+                            :year               => Time.now.year+1,
+                            :verification_value => '123')
+    
+    #Invalid credit card credentials
+    @credit_card2 = ActiveMerchant::Billing::CreditCard.new(
+                            :first_name         => 'TestUserFirstName',
+                            :last_name          => 'TestUserLastName',
+                            :number             => '4012888808881881',
+                            :month              => Time.now.month,
+                            :year               => Time.now.year+1,
+                            :verification_value => '123')
+    
+
+    #Amount in Indian paisa
+    @amount = 10000
+
+
+    @options = {
+      :orderId            => 'ruby'+Time.now.to_i.to_s, #To make the order id unique. 
+                                                                  #Duplicate order ids are not accepted
+      :buyerEmail         => 'your@email.here',
+      :buyerFirstName     => 'YourName',
+      :buyerLastName      => 'LastName',
+      :buyerAddress       => 'YourCompleteAddress',
+      :buyerCity          => 'City',
+      :buyerState         => 'State',
+      :buyerCountry       => 'Country',
+      :buyerPincode       => '110101',
+      :buyerPhoneNumber   => '9999999999',
+      :txnType            => '1',
+      :zpPayOption        => '1',
+      :mode               => '0', # 0 for Testing, 1 for Production
+      :currency           => 'INR',
+      :merchantIpAddress  => Socket::getaddrinfo(Socket.gethostname,"echo",Socket::AF_INET)[0][3].to_s, # Your IP address here
+      :txnDate            => DateTime.now.strftime("%d-%m-%Y").to_s,  
+      :purpose            => '1',
+      :productDescription => 'BriefDescriptionHere'
+    }
+  end
+
+  def test_dump_transcript
+    #skip("Transcript scrubbing for this gateway has been tested.")
+
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic
+    # dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    # transcript = capture_transcript(@gateway) do
+    #   @gateway.purchase(@amount, @credit_card, @options)
+    # end
+    # transcript = @gateway.scrub(transcript)
+
+    # assert_scrubbed(@credit_card.number, transcript)
+    # assert_scrubbed(@credit_card.verification_value, transcript)
+    # assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'The transaction was completed successfully. ', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @credit_card2, @options)
+    assert_failure response
+    assert_equal 'Unfortunately, the transaction has failed. Transaction has failed', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    # auth = @gateway.authorize(@amount, @credit_card, @options)
+    # assert_success auth
+
+    # assert capture = @gateway.capture(nil, auth.authorization)
+    # assert_success capture
+  end
+
+  def test_failed_authorize
+    # response = @gateway.authorize(@amount, @declined_card, @options)
+    # assert_failure response
+  end
+
+  def test_partial_capture
+    # auth = @gateway.authorize(@amount, @credit_card, @options)
+    # assert_success auth
+
+    # assert capture = @gateway.capture(@amount-1, auth.authorization)
+    # assert_success capture
+  end
+
+  def test_failed_capture
+    # response = @gateway.capture(nil, '')
+    # assert_failure response
+  end
+
+  def test_successful_refund
+    # purchase = @gateway.purchase(@amount, @credit_card, @options)
+    # assert_success purchase
+
+    # assert refund = @gateway.refund(nil, purchase.authorization)
+    # assert_success refund
+  end
+
+  def test_partial_refund
+    # purchase = @gateway.purchase(@amount, @credit_card, @options)
+    # assert_success purchase
+
+    # assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    # assert_success refund
+  end
+
+  def test_failed_refund
+    # response = @gateway.refund(nil, '')
+    # assert_failure response
+  end
+
+  def test_successful_void
+    # auth = @gateway.authorize(@amount, @credit_card, @options)
+    # assert_success auth
+
+    # assert void = @gateway.void(auth.authorization)
+    # assert_success void
+  end
+
+  def test_failed_void
+    # response = @gateway.void('')
+    # assert_failure response
+  end
+
+  def test_successful_verify
+    # response = @gateway.verify(@credit_card, @options)
+    # assert_success response
+    # assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+  end
+
+  def test_failed_verify
+    # response = @gateway.verify(@declined_card, @options)
+    # assert_failure response
+    # assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+    # assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_invalid_login
+    gateway = ZaakpayGateway.new(
+      :merchantIdentifier => '',
+      :secretKey => ''
+    )
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+end

--- a/test/unit/gateways/zaakpay_test.rb
+++ b/test/unit/gateways/zaakpay_test.rb
@@ -1,0 +1,169 @@
+require 'test_helper'
+require 'socket'
+class ZaakpayTest < Test::Unit::TestCase
+  def setup
+    ActiveMerchant::Billing::Base.mode = :test
+    @gateway = ActiveMerchant::Billing::ZaakpayGateway.new(
+      :merchantIdentifier => '5c7148b110ee49d7a1a9042db4fbf4ad', #These credentials are for testing only. 
+                                                                #For your own merchantidentifier and secret key, 
+                                                                #signup here - https://www.zaakpay.com/developers
+      :secretKey          => 'e73be5e3e14a4b548948f899ccde5604',
+    )
+
+    #Valid credit card credentials
+    @credit_card = ActiveMerchant::Billing::CreditCard.new(
+                            :first_name         => 'TestUserFirstName',
+                            :last_name          => 'TestUserLastName',
+                            :number             => '4012888888881881',
+                            :month              => Time.now.month,
+                            :year               => Time.now.year+1,
+                            :verification_value => '123')
+    
+    #Invalid credit card credentials
+    @credit_card2 = ActiveMerchant::Billing::CreditCard.new(
+                            :first_name         => 'TestUserFirstName',
+                            :last_name          => 'TestUserLastName',
+                            :number             => '4012888808881881',
+                            :month              => Time.now.month,
+                            :year               => Time.now.year+1,
+                            :verification_value => '123')
+    
+
+    #Amount in Indian paisa
+    @amount = 10000
+
+
+    @options = {
+      :orderId            => 'ruby'+Time.now.to_i.to_s, #To make the order id unique. 
+                                                                  #Duplicate order ids are not accepted
+      :buyerEmail         => 'your@email.here',
+      :buyerFirstName     => 'YourName',
+      :buyerLastName      => 'LastName',
+      :buyerAddress       => 'YourCompleteAddress',
+      :buyerCity          => 'City',
+      :buyerState         => 'State',
+      :buyerCountry       => 'Country',
+      :buyerPincode       => '110101',
+      :buyerPhoneNumber   => '9999999999',
+      :txnType            => '1',
+      :zpPayOption        => '1',
+      :mode               => '0', # 0 for Testing, 1 for Production
+      :currency           => 'INR',
+      :merchantIpAddress  => Socket::getaddrinfo(Socket.gethostname,"echo",Socket::AF_INET)[0][3].to_s, # Your IP address here
+      :txnDate            => DateTime.now.strftime("%d-%m-%Y").to_s,  
+      :purpose            => '1',
+      :productDescription => 'BriefDescriptionHere'
+    }
+    
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_instance_of Response, response
+    assert_success response
+    
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @credit_card2, @options)
+    assert_failure response
+    
+  end
+
+
+
+  def test_successful_authorize
+  end
+
+  def test_failed_authorize
+  end
+
+  def test_successful_capture
+  end
+
+  def test_failed_capture
+  end
+
+  def test_successful_refund
+  end
+
+  def test_failed_refund
+  end
+
+  def test_successful_void
+  end
+
+  def test_failed_void
+  end
+
+  def test_successful_verify
+  end
+
+  def test_successful_verify_with_failed_void
+  end
+
+  def test_failed_verify
+  end
+
+  def test_scrub
+    # assert @gateway.supports_scrubbing?
+    # assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      Run the remote tests for this gateway, and then put the contents of transcript.log here.
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
+      Things to scrub:
+        - Credit card number
+        - CVV
+        - Sensitive authentication details
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_zaakpay_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response
+  end
+
+  def successful_authorize_response
+  end
+
+  def failed_authorize_response
+  end
+
+  def successful_capture_response
+  end
+
+  def failed_capture_response
+  end
+
+  def successful_refund_response
+  end
+
+  def failed_refund_response
+  end
+
+  def successful_void_response
+  end
+
+  def failed_void_response
+  end
+end


### PR DESCRIPTION
Added purchase functionality, with some tests for Zaakpay.

Steps for merchants to integrate:
1. Signup required (https://www.zaakpay.com/)
2. After validation of account, navigate to URL https://www.zaakpay.com/developers
3. Generate secret key
4. Copy merchant identifier and secret key - this would be used while making purchase calls (refer documentation at https://www.zaakpay.com/developers)