### PR TITLE
Ogone: Pass along a timeout value on each request

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -335,6 +335,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters)
+        add_pair parameters, 'RTIMEOUT', @options[:timeout] if @options[:timeout]
         add_pair parameters, 'PSPID',  @options[:login]
         add_pair parameters, 'USERID', @options[:user]
         add_pair parameters, 'PSWD',   @options[:password]

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -7,7 +7,9 @@ class OgoneTest < Test::Unit::TestCase
                      :user => 'username',
                      :password => 'password',
                      :signature => 'mynicesig',
-                     :signature_encryptor => 'sha512' }
+                     :signature_encryptor => 'sha512',
+                     :timeout => '30' }
+
     @gateway = OgoneGateway.new(@credentials)
     @credit_card = credit_card
     @amount = 100
@@ -87,6 +89,16 @@ class OgoneTest < Test::Unit::TestCase
     assert_equal '3014726;SAL', response.authorization
     assert response.params['HTML_ANSWER']
     assert_equal nil, response.params['HTML_ANSWER'] =~ /<HTML_ANSWER>/
+    assert response.test?
+  end
+
+  def test_successful_with_timeout
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'RTIMEOUT', '30')
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '3014726;SAL', response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
Hey,

I have come across the need to specify a timeout in requests to Ogone. This feature is supported in their API and aims to ensure that a response is always returned. In the case **they** are having trouble acquiring funds, our application will receive and know to start polling for the end result.

Sadly I am unable to write the full test I would like (with actual response) because I cannot simulate the gateway's time out response. There is no way I can see to mark a specific request to behave like a timed out request and respect the `RTIMEOUT` value provided.

This change conforms to their documentation found at the top of page 9 here: http://www.barclaycard.co.uk/business/files/ePDQ_Direct_Link_Guide.pdf

I will be using this change in the wild to see if it works, I'd appreciate any help in creating a valid test response for this.

Cheers.

ActiveMerchant: 1.49.0 
Ruby: 2.1.2p95
ActiveSupport: 4.2.1
Nokogiri: 1.6.6.2