### PR TITLE
Add contactless flag to credit card model. Add contactless support to Stripe.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@
 * Cardstream: Add scrubbing [anellis]
 * Stripe: Parse EMV ARC from error response [bizla]
 * Redsys: Add MYR currency [agseco]
+* Add "contactless" flag to credit card model [davidseal]
+* Stripe: Add "contactless" flag support to gateway [davidseal]
 
 
 == Version 1.50.0 (June 1, 2015)
@@ -64,7 +66,6 @@
 * QuickPay: Add support for v10 API [ta]
 * Fat Zebra: Fix refund and store signatures [duff]
 * Fat Zebra: Allow transactions without a CVV [duff]
-
 
 == Version 1.49.0 (May 1, 2015)
 

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -159,6 +159,11 @@ module ActiveMerchant #:nodoc:
       # @return [String]
       attr_accessor :fallback_reason
 
+      # Returns or sets whether card-present card data has been read contactlessly.
+      #
+      # @return [true, false]
+      attr_accessor :contactless
+
       def type
         ActiveMerchant.deprecated "CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead."
         brand

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -295,6 +295,7 @@ module ActiveMerchant #:nodoc:
         card = {}
         if emv_payment?(creditcard)
           add_emv_creditcard(post, creditcard.icc_data)
+          post[:card][:read_method] = "contactless" if creditcard.contactless
         elsif creditcard.respond_to?(:number)
           if creditcard.respond_to?(:track_data) && creditcard.track_data.present?
             card[:swipe_data] = creditcard.track_data

--- a/test/remote/gateways/remote_stripe_emv_test.rb
+++ b/test/remote/gateways/remote_stripe_emv_test.rb
@@ -7,7 +7,8 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
     @amount = 100
     @emv_credit_cards = {
       uk: ActiveMerchant::Billing::CreditCard.new(icc_data: '500B56495341204352454449545F201A56495341204143515549524552205445535420434152442030315F24031512315F280208405F2A0208265F300202015F34010182025C008407A0000000031010950502000080009A031408259B02E8009C01009F02060000000734499F03060000000000009F0607A00000000310109F0902008C9F100706010A03A080009F120F4352454449544F20444520564953419F1A0208269F1C0831373030303437309F1E0831373030303437309F2608EB2EC0F472BEA0A49F2701809F3303E0B8C89F34031E03009F3501229F360200C39F37040A27296F9F4104000001319F4502DAC5DFAE5711476173FFFFFF0119D15122011758989389DFAE5A08476173FFFFFF011957114761739001010119D151220117589893895A084761739001010119'),
-      us: ActiveMerchant::Billing::CreditCard.new(icc_data: '50074D41455354524F571167999989000018123D25122200835506065A0967999989000018123F5F20134D54495032362D204D41455354524F203132415F24032512315F280200565F2A0208405F300202205F340101820278008407A0000000043060950500000080009A031504219B02E8009C01009F02060000000010009F03060000000000009F0607A00000000430609F090200029F10120210A7800F040000000000000000000000FF9F12074D61657374726F9F1A0208409F1C0831303030333331369F1E0831303030333331369F2608460245B808BCA1369F2701809F3303E0B8C89F34034403029F3501229F360200279F3704EA2C3A7A9F410400000094DF280104DFAE5711679999FFFFFFF8123D2512220083550606DFAE5A09679999FFFFFFF8123F')
+      us: ActiveMerchant::Billing::CreditCard.new(icc_data: '50074D41455354524F571167999989000018123D25122200835506065A0967999989000018123F5F20134D54495032362D204D41455354524F203132415F24032512315F280200565F2A0208405F300202205F340101820278008407A0000000043060950500000080009A031504219B02E8009C01009F02060000000010009F03060000000000009F0607A00000000430609F090200029F10120210A7800F040000000000000000000000FF9F12074D61657374726F9F1A0208409F1C0831303030333331369F1E0831303030333331369F2608460245B808BCA1369F2701809F3303E0B8C89F34034403029F3501229F360200279F3704EA2C3A7A9F410400000094DF280104DFAE5711679999FFFFFFF8123D2512220083550606DFAE5A09679999FFFFFFF8123F'),
+      contactless: ActiveMerchant::Billing::CreditCard.new(icc_data: '500D5649534120454C454354524F4E5F20175649534120434445542032312F434152443035202020205F2A0208405F340111820200008407A00000000320109A031505119C01009F02060000000006959F0607A00000000320109F090200019F100706011103A000009F1A0200569F1C0831323334353637389F1E0831303030333236389F260852A5A96394EDA96D9F2701809F3303E0B8C89F3501229F360200069F3704A4428D7A9F410400000289DF280100DF30020301DFAE021885D6E511F8844CEA0DC72883180AC081AF4593A8A3C5FDD8DFAE030AFFFF0102628D1100005EDFAE5712476173FFFFFFFFF2234D151220114524040FDFAE021892FC2C940487F43AC64AB3DFD54C7B72F445FE409D80FDF5DFAE030AFFFF0102628D1100005F')
     }
 
     @options = {
@@ -40,6 +41,19 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
     assert_match CHARGE_ID_REGEX, response.authorization
   end
 
+  # For EMV contactless transactions, generally a purchase is preferred since
+  # a TC is typically generated at the point of sale.
+  def test_successful_purchase_with_emv_contactless_credit_card
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    emv_credit_card = @emv_credit_cards[:contactless]
+    emv_credit_card.contactless = true
+    assert response = @gateway.purchase(@amount, emv_credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
   def test_authorization_and_capture_with_emv_credit_card_in_uk
     @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
     assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
@@ -64,6 +78,20 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
     assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
   end
 
+  def test_authorization_and_capture_with_emv_contactless_credit_card
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    emv_credit_card = @emv_credit_cards[:contactless]
+    emv_credit_card.contactless = true
+    assert authorization = @gateway.authorize(@amount, emv_credit_card, @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+    assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
+  end
+
   def test_authorization_and_void_with_emv_credit_card_in_us
     @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
     assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options)
@@ -78,6 +106,19 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
   def test_authorization_and_void_with_emv_credit_card_in_uk
     @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
     assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
+  def test_authorization_and_void_with_emv_contactless_credit_card
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    emv_credit_card = @emv_credit_cards[:contactless]
+    emv_credit_card.contactless = true
+    assert authorization = @gateway.authorize(@amount, emv_credit_card, @options)
     assert_success authorization
     assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
     refute authorization.params["captured"]

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -637,6 +637,23 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_contactless_flag_is_included_with_emv_card_data
+    stub_comms(@gateway, :ssl_request) do
+      @emv_credit_card.contactless = true
+      @gateway.purchase(@amount, @emv_credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert data =~ /card\[read_method\]=contactless/
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_contactless_flag_is_not_included_with_emv_card_data_by_default
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @emv_credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert data !~ /card\[read_method\]=contactless/
+    end.respond_with(successful_purchase_response)
+  end
+
   def generate_options_should_allow_key
     assert_equal({:key => '12345'}, generate_options({:key => '12345'}))
   end


### PR DESCRIPTION
### Description
Adds flag for tracking whether a swiped or EMV transaction has been done using a contactless method (tapped card or mobile device). While EMV provides some contactless tags, these can't always be relied on since different card and different kernels won't necessarily produce these tags. It's up to the integration solution to track how the card data was read.

cc/ @bizla @ryanbalsdon @abecevello 