### PR TITLE
Adding Tokenization to Quickbooks Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -136,7 +136,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment(post, payment, options = {})
-        add_creditcard(post, payment, options)
+        if options[:token]
+          add_payment_token(post, options)
+        else
+          add_creditcard(post, payment, options)
+        end
       end
 
       def add_creditcard(post, creditcard, options = {})
@@ -149,6 +153,10 @@ module ActiveMerchant #:nodoc:
         card[:commercialCardCode] = options[:card_code] if options[:card_code]
 
         post[:card] = card
+      end
+
+      def add_payment_token(post, options = {})
+        post[:token] = options[:token]
       end
 
       def parse(body)

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -43,7 +43,16 @@ class QuickBooksTest < Test::Unit::TestCase
 
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
-    response = @gateway.authorize(@amount, @credit_card, @options)
+    response = @gateway.authorize(@amount, @credit_card, @options.merge({token: "1234"}))
+    assert_success response
+
+    assert_equal @authorization, response.authorization
+    assert response.test?
+  end
+
+  def test_successful_authorize_with_token
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+    response = @gateway.authorize(@amount, "", @options)
     assert_success response
 
     assert_equal @authorization, response.authorization

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -43,7 +43,7 @@ class QuickBooksTest < Test::Unit::TestCase
 
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
-    response = @gateway.authorize(@amount, @credit_card, @options.merge({token: "1234"}))
+    response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
 
     assert_equal @authorization, response.authorization
@@ -52,7 +52,7 @@ class QuickBooksTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_token
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
-    response = @gateway.authorize(@amount, "", @options)
+    response = @gateway.authorize(@amount, "", @options.merge({token: "1234"}))
     assert_success response
 
     assert_equal @authorization, response.authorization


### PR DESCRIPTION
Without PCI compliance, the Quickbooks gateway needs to tokenize the CC number in the client JS before sending to the server (https://developer.intuit.com/docs/0150_payments/0300_developer_guides/tokens). This adds support for dealing with the supplied token.