### PR TITLE
Add the existing XML option AccountUpdaterEligibility Flag to Chase Orbital Profile Transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -290,7 +290,6 @@ module ActiveMerchant #:nodoc:
         order = build_customer_request_xml(nil, options)
         commit(order, :delete_customer_profile)
       end
-        
       private
 
       def authorization_string(*args)
@@ -713,8 +712,7 @@ module ActiveMerchant #:nodoc:
           end
         end
         xml.target!
-      end
-      
+      end      
       # Unfortunately, Orbital uses their own special codes for AVS responses
       # that are different than the standard codes defined in
       # <tt>ActiveMerchant::Billing::AVSResult</tt>.

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -707,7 +707,7 @@ module ActiveMerchant #:nodoc:
 
             # This has to come after CCExpireDate.
             add_managed_billing(xml, options)
-
+            
             xml.tag! :AccountUpdaterEligibility, options[:account_updater_eligibility] if options[:account_updater_eligibility] 
           end
         end

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -175,15 +175,6 @@ module ActiveMerchant #:nodoc:
       USE_ORDER_ID         = 'O' #  Use OrderID field
       USE_COMMENTS         = 'D' #  Use Comments field
 
-      #  Account Updater Transaction for a Profile
-      #  The Account Updater transaction type facilitates an additional account updater request for a specific profile, 
-      #  outside of the selected schedule. The request is included in the next Account Updater submission unless sent 
-      #  with a future scheduled date (Use <scheduledDate> to do so).  A successful Account Updater transaction returns a 
-      #  response record stating the profile is scheduled for Account Updater. Subsequent information provided by Visa or 
-      #  MasterCard is used for a profile update. This information is not returned via a response file.
-     
-      ACCOUNT_UPDATER = 'AU'
-
       SENSITIVE_FIELDS = [:account_num]
 
       def initialize(options = {})
@@ -285,12 +276,6 @@ module ActiveMerchant #:nodoc:
       def update_customer_profile(creditcard, options = {})
         options.merge!(:customer_profile_action => UPDATE)
         order = build_customer_request_xml(creditcard, options)
-        commit(order, :update_customer_profile)
-      end
-      
-      def request_account_update_for_customer_profile(customer_ref_num, options = {})
-        options.merge!(:customer_profile_action => ACCOUNT_UPDATER, :customer_ref_num => customer_ref_num)
-        order = build_customer_account_updater_request_xml(options)
         commit(order, :update_customer_profile)
       end
 
@@ -724,23 +709,7 @@ module ActiveMerchant #:nodoc:
             # This has to come after CCExpireDate.
             add_managed_billing(xml, options)
 
-            # AccountUpdaterEligibility Flag must be Y/N defaults to N at Chase if not passed
             xml.tag! :AccountUpdaterEligibility, options[:account_updater_eligibility] if options[:account_updater_eligibility] 
-          end
-        end
-        xml.target!
-      end
-
-      def build_customer_account_updater_request_xml(options = {})
-        xml = xml_envelope
-        xml.tag! :Request do
-          xml.tag! :AccountUpdater do
-            add_xml_credentials(xml)
-            xml.tag! :CustomerBin, bin
-            xml.tag! :CustomerMerchantID, @options[:merchant_id]
-            xml.tag! :CustomerRefNum, options[:customer_ref_num] if options[:customer_ref_num]
-            xml.tag! :CustomerProfileAction, options[:customer_profile_action]
-            xml.tag! :ScheduledDate, options[:schedule_date] if options[:schedule_date]
           end
         end
         xml.target!

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -645,5 +645,4 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
   end
-  
 end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -645,4 +645,5 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
   end
+  
 end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -530,10 +530,11 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_update_customer_profile
     response = stub_comms do
-      @gateway.update_customer_profile(credit_card)
+      @gateway.update_customer_profile(credit_card, {:account_updater_eligibility => 'Y'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerProfileAction>U/, data)
       assert_match(/<CustomerName>Longbob Longsen/, data)
+      assert_match(/<AccountUpdaterEligibility>Y/, data)
     end.respond_with(successful_profile_response)
     assert_success response
   end
@@ -559,26 +560,6 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_profile_response)
     assert_success response
   end
-
-  def test_request_account_update_for_customer_profile
-    response = stub_comms do
-      @gateway.request_account_update_for_customer_profile(@customer_ref_num)
-    end.check_request do |endpoint, data, headers|
-      assert_match(/<CustomerProfileAction>AU/, data)
-      assert_match(/<CustomerRefNum>ABC/, data)
-    end.respond_with(successful_account_updater_response)
-    assert_success response
-  end
-
-  def test_request_account_update_for_customer_profile_with_schedule_date
-    response = stub_comms do
-      @gateway.request_account_update_for_customer_profile(@customer_ref_num, {:schedule_date => 20150615})
-    end.check_request do |endpoint, data, headers|
-      assert_match(/<CustomerProfileAction>AU/, data)
-      assert_match(/<ScheduledDate>20150615/, data)
-    end.respond_with(successful_account_updater_response)
-    assert_success response
-  end  
 
   def test_attempts_seconday_url
     @gateway.expects(:ssl_post).with(OrbitalGateway.test_url, anything, anything).raises(ActiveMerchant::ConnectionError.new("message", nil))
@@ -672,10 +653,6 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
-  end
-
-  def successful_account_updater_response
-    %q{<?xml version="1.0" encoding="UTF-8"?><Response><AccountUpdaterResp><CustomerBin>000001</CustomerBin><CustomerMerchantID>219980</CustomerMerchantID><CustomerRefNum>50204</CustomerRefNum><CustomerProfileAction>AU</CustomerProfileAction><Status>A</Status><ScheduledDate>20150615</ScheduledDate><ProfileProcStatus>0</ProfileProcStatus><CustomerProfileMessage>Profile Request Scheduled</CustomerProfileMessage><RespTime>20150603 162649</RespTime></AccountUpdaterResp></Response>}
   end
   
 end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -354,15 +354,6 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_profile_response)
     assert_success response
   end
-  
-  def test_account_updater_eligibility
-    response = stub_comms do
-      @gateway.add_customer_profile(credit_card, :account_updater_eligibility => 'Y')
-    end.check_request do |endpoint, data, headers|
-      assert_match(/<AccountUpdaterEligibility>Y/, data)
-    end.respond_with(successful_profile_response)
-    assert_success response
-  end
 
   def test_dont_send_customer_data_by_default
     response = stub_comms do

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -354,6 +354,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_profile_response)
     assert_success response
   end
+  
+  def test_account_updater_eligibility
+    response = stub_comms do
+      @gateway.add_customer_profile(credit_card, :account_updater_eligibility => 'Y')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<AccountUpdaterEligibility>Y/, data)
+    end.respond_with(successful_profile_response)
+    assert_success response
+  end
 
   def test_dont_send_customer_data_by_default
     response = stub_comms do
@@ -551,6 +560,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_request_account_update_for_customer_profile
+    response = stub_comms do
+      @gateway.request_account_update_for_customer_profile(@customer_ref_num)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<CustomerProfileAction>AU/, data)
+      assert_match(/<CustomerRefNum>ABC/, data)
+    end.respond_with(successful_account_updater_response)
+    assert_success response
+  end
+
+  def test_request_account_update_for_customer_profile_with_schedule_date
+    response = stub_comms do
+      @gateway.request_account_update_for_customer_profile(@customer_ref_num, {:schedule_date => 20150615})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<CustomerProfileAction>AU/, data)
+      assert_match(/<ScheduledDate>20150615/, data)
+    end.respond_with(successful_account_updater_response)
+    assert_success response
+  end  
+
   def test_attempts_seconday_url
     @gateway.expects(:ssl_post).with(OrbitalGateway.test_url, anything, anything).raises(ActiveMerchant::ConnectionError.new("message", nil))
     @gateway.expects(:ssl_post).with(OrbitalGateway.secondary_test_url, anything, anything).returns(successful_purchase_response)
@@ -644,4 +673,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
   end
+
+  def successful_account_updater_response
+    %q{<?xml version="1.0" encoding="UTF-8"?><Response><AccountUpdaterResp><CustomerBin>000001</CustomerBin><CustomerMerchantID>219980</CustomerMerchantID><CustomerRefNum>50204</CustomerRefNum><CustomerProfileAction>AU</CustomerProfileAction><Status>A</Status><ScheduledDate>20150615</ScheduledDate><ProfileProcStatus>0</ProfileProcStatus><CustomerProfileMessage>Profile Request Scheduled</CustomerProfileMessage><RespTime>20150603 162649</RespTime></AccountUpdaterResp></Response>}
+  end
+  
 end


### PR DESCRIPTION
The text below, labeled "3.1.9", is copied from the Chase orbital XML guide. The purpose of the pull request is to enhance the activemerchant gem to enable users doing transactions with Chase Orbital to send the "AccountUpdaterEligibility" option to the Chase Orbital Gateway. To accomplish this there was one change that had to be made to the "orbital.rb" class.

The build_customer_request_xml method needs to include the "AccountUpdaterEligibility" parameter. This is the last field in the existing XML schema for the Profile schema found in file "Request_PTI54.xsd". 

The above mentioned flag must be set to "Y" before an Account Updater "AU" transaction can be sent to the Chase Orbital Gateway.  The AU Transaction is beyond the scope of this gem, but the references below describe the requirements in case someone wishes to build their own Account Updater Transaction.

   

3.1.9 Chase Account Updater
This transaction is used to supplement the Account Updater service for customer profiles on a one-off exception basis. Please see section 3.3.4 Account Updater for more details.

3.3.4 Account Updater
Fully managed Account Updater for Profiles is available to Salem (Bin 000001) merchants using customer profiles. The functionality is specifically designed to update merchant or chain level profiles housed on the gateway utilizing the Salem Account Updater process. Visa and MasterCard approval is required for participation. Please contact your account representative for additional details.
Once enabled, update requests are submitted to Visa and MasterCard according to a merchant selected schedule. Visa and MasterCard typically respond to requests within three days, inclusive of the submission day. Visa and MasterCard responses may contain information regarding new card account numbers, expiration dates, account closures, etc. Based upon the actionable information returned, the Gateway automatically updates customer profiles. A scheduled report is available that lists profiles that were updated as a part of the process.
NOTE
NOTE
If the card account number contained within a profile is invalid or not eligible for the Transaction Division’s Account Updater setup, the Account Updater request triggers a host reject.
If the card account number is invalid or the card account is closed, an associated profile is automatically suspended, preventing unsuccessful future auth or capture attempts. As with any suspended profile, the status can easily be changed to active as new information becomes available
CAUTION An Account Updater change of account number update to a profile is suppressed if the merchant initiates a change to the account number after the request is initiated and prior to the update.
The Account Updater transaction type facilitates an additional account updater request for a specific profile, outside of the selected schedule. The request is included in the next Account Updater submission unless sent with a future scheduled date (Use to do so).
A successful Account Updater transaction returns a response record stating the profile is scheduled for Account Updater. Subsequent information provided by Visa or MasterCard is used for a profile update. This information is not returned via a response file.
