### PR TITLE
filter more invalid characters in epay url

### DIFF
--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
         # Authorize gives the response back by redirecting with the values in
         # the URL query
         if location = response['Location']
-          query = CGI::parse(URI.parse(location.gsub(' ', '%20')).query)
+          query = CGI::parse(URI.parse(location.gsub(' ', '%20').gsub('<', '%3C').gsub('>', '%3E')).query)
         else
           return {
             'accept' => '0',

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -29,6 +29,15 @@ class EpayTest < Test::Unit::TestCase
                  response.message
   end
 
+  def test_invalid_characters_in_response
+    @gateway.expects(:raw_ssl_request).returns(invalid_authorize_response_with_invalid_characters)
+
+    assert response = @gateway.authorize(100, @credit_card)
+    assert_failure response
+    assert_equal 'The payment was declined of unknown reasons. For more information contact the bank. E.g. try with another credit card.<br />Denied - Call your bank for information',
+                 response.message
+  end
+
   def test_failed_response_on_purchase
     @gateway.expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 400,'Bad Request'))
 
@@ -113,6 +122,10 @@ class EpayTest < Test::Unit::TestCase
 
   def invalid_authorize_response
     { 'Location' => 'https://ssl.ditonlinebetalingssystem.dk/auth/default.aspx?decline=1&error=102&errortext=The payment was declined. Try again in a moment or try with another credit card.' }
+  end
+
+  def invalid_authorize_response_with_invalid_characters
+    { 'Location' => 'https://ssl.ditonlinebetalingssystem.dk/auth/default.aspx?decline=1&error=209&errortext=The payment was declined of unknown reasons. For more information contact the bank. E.g. try with another credit card.<br />Denied - Call your bank for information' }
   end
 
   def valid_capture_response


### PR DESCRIPTION
Problem: epay is now sending < and > in the url also

Example: `https://ssl.ditonlinebetalingssystem.dk/auth/default.aspx?decline=1&error=209&orderid=xxxxxxxxxxx&errortext=The%20payment%20was%20declined%20of%20unknown%20reasons.%20For%20more%20information%20contact%20the%20bank.%20E.g.%20try%20with%20another%20credit%20card.<br%20/>Denied%20-%20Call%20your%20bank%20for%20information`

Solution: This patch replaces those characters with the appropriate escape codes.

r: @mutemule @Shopify/active-merchant 

