### PR TITLE
Change FirstData gateway to use the 'currency' value specified in options hash

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
       def build_sale_or_authorization_request(money, credit_card_or_store_authorization, options)
         xml = Builder::XmlMarkup.new
 
-        add_amount(xml, money)
+        add_amount(xml, money, options)
 
         if credit_card_or_store_authorization.is_a? String
           add_credit_card_token(xml, credit_card_or_store_authorization)
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
 
         add_identification(xml, identification)
-        add_amount(xml, money)
+        add_amount(xml, money, options)
         add_customer_data(xml, options)
         add_card_authentication_data(xml, options)
 
@@ -208,8 +208,10 @@ module ActiveMerchant #:nodoc:
         xml.tag! "Transaction_Tag", transaction_tag
       end
 
-      def add_amount(xml, money)
-        xml.tag! "DollarAmount", amount(money)
+      def add_amount(xml, money, options)
+        currency_code = options[:currency] || currency(money)
+        xml.tag! 'DollarAmount', localized_amount(money, currency_code)
+        xml.tag! 'Currency', currency_code
       end
 
       def add_credit_card(xml, credit_card, options)

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -25,6 +25,14 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_specified_currency
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    assert response = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+    assert_equal 'GBP', response.params['currency']
+  end
+
   def test_successful_purchase_with_track_data
     assert response = @gateway.purchase(@amount, @credit_card_with_track_data, @options)
     assert_match(/Transaction Normal/, response.message)
@@ -69,6 +77,17 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert purchase.authorization
     assert credit = @gateway.refund(@amount, purchase.authorization)
     assert_success credit
+  end
+
+  def test_purchase_and_credit_with_specified_currency
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    assert purchase = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
+    assert_success purchase
+    assert purchase.authorization
+    assert_equal 'GBP', purchase.params['currency']
+    assert credit = @gateway.refund(@amount, purchase.authorization, options_with_specified_currency)
+    assert_success credit
+    assert_equal 'GBP', credit.params['currency']
   end
 
   def test_purchase_and_void
@@ -133,6 +152,20 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_success response
     assert_match(/Transaction Normal/, response.message)
     assert response.authorization
+  end
+
+  def test_refund_with_specified_currency
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    assert purchase = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+    assert_equal 'GBP', purchase.params['currency']
+
+    assert response = @gateway.refund(50, purchase.authorization, options_with_specified_currency)
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+    assert_equal 'GBP', response.params['currency']
   end
 
   def test_refund_with_track_data

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -40,10 +40,32 @@ class FirstdataE4Test < Test::Unit::TestCase
     FirstdataE4Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
   end
 
+  def test_successful_purchase_with_specified_currency
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
+    assert response = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
+    assert_success response
+    assert_equal 'ET1700;106625152;4738', response.authorization
+    assert response.test?
+    assert_equal 'Transaction Normal - Approved', response.message
+    assert_equal 'GBP', response.params['currency']
+
+    FirstdataE4Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+  end
+
   def test_successful_purchase_with_token
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014')
     assert_success response
+  end
+
+  def test_successful_purchase_with_specified_currency_and_token
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
+    assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014',
+                                        options_with_specified_currency)
+    assert_success response
+    assert_equal 'GBP', response.params['currency']
   end
 
   def test_successful_void
@@ -56,6 +78,14 @@ class FirstdataE4Test < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_refund_response)
     assert response = @gateway.refund(@amount, @authorization)
     assert_success response
+  end
+
+  def test_successful_refund_with_specified_currency
+    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    @gateway.expects(:ssl_post).returns(successful_refund_with_specified_currency_response)
+    assert response = @gateway.refund(@amount, @authorization, options_with_specified_currency)
+    assert_success response
+    assert_equal 'GBP', response.params['currency']
   end
 
   def test_successful_store
@@ -379,6 +409,94 @@ issuer pursuant to cardholder agreement.
   </TransactionResult>
     RESPONSE
   end
+  def successful_purchase_with_specified_currency_response
+    <<-RESPONSE
+  <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>00</Transaction_Type>
+    <DollarAmount>47.38</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>106625152</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET1700</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <VerificationStr1></VerificationStr1>
+    <VerificationStr2>773</VerificationStr2>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No>77</Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000040</SequenceNo>
+    <AVS>U</AVS>
+    <CVV2>M</CVV2>
+    <Retrieval_Ref_No>3146117</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>GBP</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>Friendly Inc DEMO0983</MerchantName>
+    <MerchantAddress>123 King St</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>L7Z 3K8</MerchantPostal>
+    <MerchantURL></MerchantURL>
+    <TransarmorToken>8938737759041111</TransarmorToken>
+    <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Purchase
+
+ACCT: Visa  £ 47.38 GBP
+
+CARD NUMBER : ############1111
+DATE/TIME   : 28 Sep 12 07:54:48
+REFERENCE # :  000040 M
+AUTHOR. #   : ET120454
+TRANS. REF. : 77
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+  </TransactionResult>
+    RESPONSE
+  end
   def successful_purchase_response_without_transarmor
     <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>
@@ -536,6 +654,92 @@ Canada
 TYPE: Refund
 
 ACCT: Visa  $ 23.69 USD
+
+CARD NUMBER : ############1111
+DATE/TIME   : 28 Sep 12 08:31:23
+REFERENCE # :  000041 M
+AUTHOR. #   : ET112216
+TRANS. REF. :
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+=========================================</CTR>
+  </TransactionResult>
+    RESPONSE
+  end
+
+  def successful_refund_with_specified_currency_response
+    <<-RESPONSE
+  <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>34</Transaction_Type>
+    <DollarAmount>123</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>888</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET112216</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <VerificationStr1></VerificationStr1>
+    <VerificationStr2></VerificationStr2>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No></Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000041</SequenceNo>
+    <AVS></AVS>
+    <CVV2>I</CVV2>
+    <Retrieval_Ref_No>9176784</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>GBP</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>Friendly Inc DEMO0983</MerchantName>
+    <MerchantAddress>123 King St</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>L7Z 3K8</MerchantPostal>
+    <MerchantURL></MerchantURL>
+    <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Refund
+
+ACCT: Visa  £ 23.69 GBP
 
 CARD NUMBER : ############1111
 DATE/TIME   : 28 Sep 12 08:31:23


### PR DESCRIPTION
Use the 'currency' value specified in the options hash param, if available, otherwise use default_currency ('USD'). Although not recommended, if the amount passed into purchase or refund requests is a Money object, and a currency isn't included in the options hash param, the currency is extracted from the amount Money object.

Unit & remote tests have been added to verify that specifying a currency in the options hash param will result in the response confirming the transaction.

NOTE: with my test credentials, the remote test that checks the AVS result code returns '4' instead of '1'. As this test is unrelated to these changes, I'm assuming the cause is related to the test credentials (or the test was previously broken).