### PR TITLE
MIGS redirect failures do not include SecureHash

### DIFF
--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -169,13 +169,17 @@ module ActiveMerchant #:nodoc:
         requires!(@options, :secure_hash)
 
         response_hash = parse(data)
+        response = response_object(response_hash)
 
-        expected_secure_hash = calculate_secure_hash(response_hash.reject{|k, v| k == :SecureHash}, @options[:secure_hash])
+        # Failures don't include a secure hash, so return directly
+        return response unless response.success?
+
+        # Check SecureHash only on success (not returned otherwise)
+        expected_secure_hash = calculate_secure_hash(response_hash, @options[:secure_hash])
         unless response_hash[:SecureHash] == expected_secure_hash
           raise SecurityError, "Secure Hash mismatch, response may be tampered with"
         end
-
-        response_object(response_hash)
+        response
       end
 
       def test?
@@ -262,7 +266,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def calculate_secure_hash(post, secure_hash)
-        sorted_values = post.sort_by(&:to_s).map(&:last)
+        post_without_secure_hash = post.reject{|k, v| k == :SecureHash}
+        sorted_values = post_without_secure_hash.sort_by(&:to_s).map(&:last)
         input = secure_hash + sorted_values.join
         Digest::MD5.hexdigest(input).upcase
       end

--- a/test/unit/gateways/migs_test.rb
+++ b/test/unit/gateways/migs_test.rb
@@ -55,11 +55,6 @@ class MigsTest < Test::Unit::TestCase
     # Below response from instance running remote test
     response_params = "vpc_3DSXID=a1B8UcW%2BKYqkSinLQohGmqQd9uY%3D&vpc_3DSenrolled=U&vpc_AVSResultCode=Unsupported&vpc_AcqAVSRespCode=Unsupported&vpc_AcqCSCRespCode=Unsupported&vpc_AcqResponseCode=00&vpc_Amount=100&vpc_AuthorizeId=367739&vpc_BatchNo=20120421&vpc_CSCResultCode=Unsupported&vpc_Card=MC&vpc_Command=pay&vpc_Locale=en&vpc_MerchTxnRef=9&vpc_Merchant=TESTANZTEST3&vpc_Message=Approved&vpc_OrderInfo=1&vpc_ReceiptNo=120421367739&vpc_SecureHash=8794D9478D030B65F3092282E76283F8&vpc_TransactionNo=2000025183&vpc_TxnResponseCode=0&vpc_VerSecurityLevel=06&vpc_VerStatus=U&vpc_VerType=3DS&vpc_Version=1"
 
-    response_hash = @gateway.send(:parse, response_params)
-    response_hash.delete(:SecureHash)
-    calculated_hash = @gateway.send(:calculate_secure_hash, response_hash, @gateway.options[:secure_hash])
-    assert_equal '8794D9478D030B65F3092282E76283F8', calculated_hash
-
     response = @gateway.purchase_offsite_response(response_params)
     assert_success response
 


### PR DESCRIPTION
You get a 'Secure Hash mismatch' on any error returned
by the gateway.
