### PR TITLE
Add support for nonce payment method to braintree blue gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -66,8 +66,8 @@ module ActiveMerchant #:nodoc:
         @braintree_gateway = Braintree::Gateway.new( @configuration )
       end
 
-      def authorize(money, credit_card_or_vault_id, options = {})
-        create_transaction(:sale, money, credit_card_or_vault_id, options)
+      def authorize(money, payment, options = {})
+        create_transaction(:sale, money, payment, options)
       end
 
       def capture(money, authorization, options = {})
@@ -77,12 +77,12 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def purchase(money, credit_card_or_vault_id, options = {})
-        authorize(money, credit_card_or_vault_id, options.merge(:submit_for_settlement => true))
+      def purchase(money, payment, options = {})
+        authorize(money, payment, options.merge(:submit_for_settlement => true))
       end
 
-      def credit(money, credit_card_or_vault_id, options = {})
-        create_transaction(:credit, money, credit_card_or_vault_id, options)
+      def credit(money, payment, options = {})
+        create_transaction(:credit, money, payment, options)
       end
 
       def refund(*args)
@@ -392,8 +392,8 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def create_transaction(transaction_type, money, credit_card_or_vault_id, options)
-        transaction_params = create_transaction_parameters(money, credit_card_or_vault_id, options)
+      def create_transaction(transaction_type, money, payment, options)
+        transaction_params = create_transaction_parameters(money, payment, options)
         commit do
           result = @braintree_gateway.transaction.send(transaction_type, transaction_params)
           response = Response.new(result.success?, message_from_transaction_result(result), response_params(result), response_options(result))
@@ -502,7 +502,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def create_transaction_parameters(money, credit_card_or_vault_id, options)
+      def create_transaction_parameters(money, payment, options)
         parameters = {
           :amount => amount(money).to_s,
           :order_id => options[:order_id],
@@ -526,16 +526,18 @@ module ActiveMerchant #:nodoc:
           parameters[:recurring] = true
         end
 
-        if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
+        if payment.is_a?(String) || payment.is_a?(Integer)
           if options[:payment_method_token]
-            parameters[:payment_method_token] = credit_card_or_vault_id
+            parameters[:payment_method_token] = payment
+          elsif options[:payment_method_nonce]
+            parameters[:payment_method_nonce] = payment
           else
-            parameters[:customer_id] = credit_card_or_vault_id
+            parameters[:customer_id] = payment
           end
         else
           parameters[:customer].merge!(
-            :first_name => credit_card_or_vault_id.first_name,
-            :last_name => credit_card_or_vault_id.last_name
+            :first_name => payment.first_name,
+            :last_name => payment.last_name
           )
           parameters[:credit_card] = {
             :number => credit_card_or_vault_id.number,

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -540,10 +540,10 @@ module ActiveMerchant #:nodoc:
             :last_name => payment.last_name
           )
           parameters[:credit_card] = {
-            :number => credit_card_or_vault_id.number,
-            :cvv => credit_card_or_vault_id.verification_value,
-            :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
-            :expiration_year => credit_card_or_vault_id.year.to_s
+            :number => payment.number,
+            :cvv => payment.verification_value,
+            :expiration_month => payment.month.to_s.rjust(2, "0"),
+            :expiration_year => payment.year.to_s
           }
         end
         parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address] && !options[:payment_method_token]


### PR DESCRIPTION
This change enables using the payment_method_nonce option available in the Braintree v zero API.