### PR TITLE
Authorize.Net - Add invoice to refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * S5: Make scrubbing regex less greedy [duff]
 * CardStream: Add support for verify [anellis]
 * Authorize.net: UTF-8 encode requests [duff]
+* Authorize.net: Add invoice information to refund [marquisong]
 * Banwire: Add default email [anellis]
 * PayU India: Handle bad JSON [ntalbott]
 * Dibs: Pass CVC param only if there's a value [bruno]

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -123,6 +123,7 @@ module ActiveMerchant #:nodoc:
             end
             xml.refTransId(transaction_id)
 
+            add_invoice(xml, options)
             add_customer_data(xml, nil, options)
             add_user_fields(xml, amount, options)
           end

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -426,13 +426,14 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: "Bob", last_name: "Smith", zip: "12345")
+      @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: "Bob", last_name: "Smith", zip: "12345", order_id: "1")
     end.check_request do |endpoint, data, headers|
       parse(data) do |doc|
         assert_equal "Bob", doc.at_xpath("//billTo/firstName").content, data
         assert_equal "Smith", doc.at_xpath("//billTo/lastName").content, data
         assert_equal "12345", doc.at_xpath("//billTo/zip").content, data
         assert_equal "0.50", doc.at_xpath("//transactionRequest/amount").content
+        assert_equal "1", doc.at_xpath("//transactionRequest/order/invoiceNumber").content
       end
     end.respond_with(successful_purchase_response)
     assert_success response


### PR DESCRIPTION
This PR adds a small update to Authorize.Net, specifically the refund method, to allow the passing of invoice information in the options over to Authorize.Net during refund action.

As a result, the invoice information will be displayed in Authorize.Net's dashboard under transaction detail and report page.
I have tested this change using Authorize.Net's sandbox testing.
