### PR TITLE
Support mapping Stripe advanced decline codes to standard codes

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -42,6 +42,7 @@ module ActiveMerchant #:nodoc:
         'incorrect_cvc' => STANDARD_ERROR_CODE[:incorrect_cvc],
         'incorrect_zip' => STANDARD_ERROR_CODE[:incorrect_zip],
         'card_declined' => STANDARD_ERROR_CODE[:card_declined],
+        'call_issuer' => STANDARD_ERROR_CODE[:call_issuer],
         'processing_error' => STANDARD_ERROR_CODE[:processing_error]
       }
 
@@ -430,7 +431,7 @@ module ActiveMerchant #:nodoc:
           :avs_result => { :code => avs_code },
           :cvv_result => cvc_code,
           :emv_authorization => card["emv_auth_data"],
-          :error_code => success ? nil : STANDARD_ERROR_CODE_MAPPING[response["error"]["code"]]
+          :error_code => success ? nil : error_code_from(response)
         )
       end
 
@@ -458,6 +459,15 @@ module ActiveMerchant #:nodoc:
 
       def emv_payment?(payment)
         payment.respond_to?(:emv?) && payment.emv?
+      end
+
+      def error_code_from(response)
+        code = response['error']['code'] 
+        decline_code = response['error']['decline_code'] if code == 'card_declined'
+
+        error_code = STANDARD_ERROR_CODE_MAPPING[decline_code]
+        error_code ||= STANDARD_ERROR_CODE_MAPPING[code]
+        error_code
       end
     end
   end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -419,6 +419,28 @@ class StripeTest < Test::Unit::TestCase
     assert_failure response
 
     assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    refute response.test? # unsuccessful request defaults to live
+    assert_equal 'ch_test_charge', response.authorization
+  end
+
+  def test_declined_request_advanced_decline_codes
+    @gateway.expects(:ssl_request).returns(declined_call_issuer_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal Gateway::STANDARD_ERROR_CODE[:call_issuer], response.error_code
+    refute response.test? # unsuccessful request defaults to live
+    assert_equal 'ch_test_charge', response.authorization
+  end
+
+  def test_declined_request_advanced_decline_code_not_in_standard_mapping
+    @gateway.expects(:ssl_request).returns(declined_generic_decline_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
     assert !response.test? # unsuccessful request defaults to live
     assert_equal 'ch_test_charge', response.authorization
   end
@@ -1286,6 +1308,34 @@ class StripeTest < Test::Unit::TestCase
         "message": "Your card was declined.",
         "type": "card_error",
         "code": "card_declined",
+        "charge": "ch_test_charge"
+      }
+    }
+    RESPONSE
+  end
+
+  def declined_call_issuer_purchase_response
+    <<-RESPONSE
+    {
+      "error": {
+        "message": "Your card was declined.",
+        "type": "card_error",
+        "code": "card_declined",
+        "decline_code": "call_issuer",
+        "charge": "ch_test_charge"
+      }
+    }
+    RESPONSE
+  end
+
+  def declined_generic_decline_purchase_response
+    <<-RESPONSE
+    {
+      "error": {
+        "message": "Your card was declined.",
+        "type": "card_error",
+        "code": "card_declined",
+        "decline_code": "generic_decline",
         "charge": "ch_test_charge"
       }
     }


### PR DESCRIPTION
Adds support for mapping Stripe advanced decline codes to the standard error codes.

Also adds a mapping for the 'call_issuer' advanced decline code to the standardized 'call_issuer' error code.

@bizla @girasquid 