### PR TITLE
Authorize.net: Add store ability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Stripe: Add encrypted_pin support to gateway [ryanbalsdon]
 * Stripe: Support mapping advanced decline codes to standard codes [abecevello]
 * Epay: filter out invalid characters in returned URLs [dwradcliffe]
+* Authorize.net: Add store ability
 
 
 == Version 1.50.0 (June 1, 2015)

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -62,82 +62,50 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(amount, payment, options = {})
-        commit("AUTH_CAPTURE") do |xml|
-          add_order_id(xml, options)
-          xml.transactionRequest do
-            xml.transactionType('authCaptureTransaction')
-            xml.amount(amount(amount))
-
-            add_payment_source(xml, payment)
-            add_invoice(xml, options)
-            add_customer_data(xml, payment, options)
-            add_market_type(xml, payment)
-            add_settings(xml, payment, options)
-            add_user_fields(xml, amount, options)
+        if payment.is_a?(String)
+          commit(:cim_purchase) do |xml|
+            add_cim_auth_purchase(xml, "profileTransAuthCapture", amount, payment, options)
+          end
+        else
+          commit(:purchase) do |xml|
+            add_auth_purchase(xml, "authCaptureTransaction", amount, payment, options)
           end
         end
       end
 
       def authorize(amount, payment, options={})
-        commit("AUTH_ONLY") do |xml|
-          add_order_id(xml, options)
-          xml.transactionRequest do
-            xml.transactionType('authOnlyTransaction')
-            xml.amount(amount(amount))
-
-            add_payment_source(xml, payment)
-            add_invoice(xml, options)
-            add_customer_data(xml, payment, options)
-            add_market_type(xml, payment)
-            add_settings(xml, payment, options)
-            add_user_fields(xml, amount, options)
+        if payment.is_a?(String)
+          commit(:cim_authorize) do |xml|
+            add_cim_auth_purchase(xml, "profileTransAuthOnly", amount, payment, options)
+          end
+        else
+          commit(:authorize) do |xml|
+            add_auth_purchase(xml, "authOnlyTransaction", amount, payment, options)
           end
         end
       end
 
       def capture(amount, authorization, options={})
-        commit("PRIOR_AUTH_CAPTURE") do |xml|
-          add_order_id(xml, options)
-          xml.transactionRequest do
-            xml.transactionType('priorAuthCaptureTransaction')
-            xml.amount(amount(amount))
-            xml.refTransId(split_authorization(authorization)[0])
-
-            add_invoice(xml, options)
-            add_user_fields(xml, amount, options)
-          end
+        if auth_was_for_cim?(authorization)
+          cim_capture(amount, authorization, options)
+        else
+          normal_capture(amount, authorization, options)
         end
       end
 
       def refund(amount, authorization, options={})
-        transaction_id, card_number = split_authorization(authorization)
-        commit("CREDIT") do |xml|
-          xml.transactionRequest do
-            xml.transactionType('refundTransaction')
-            xml.amount(amount.nil? ? 0 : amount(amount))
-            xml.payment do
-              xml.creditCard do
-                xml.cardNumber(card_number || options[:card_number])
-                xml.expirationDate('XXXX')
-              end
-            end
-            xml.refTransId(transaction_id)
-
-            add_customer_data(xml, nil, options)
-            add_user_fields(xml, amount, options)
-          end
+        if auth_was_for_cim?(authorization)
+          cim_refund(amount, authorization, options)
+        else
+          normal_refund(amount, authorization, options)
         end
       end
 
       def void(authorization, options={})
-        commit("VOID") do |xml|
-          add_order_id(xml, options)
-          xml.transactionRequest do
-            xml.transactionType('voidTransaction')
-            xml.refTransId(split_authorization(authorization)[0])
-
-            add_user_fields(xml, nil, options)
-          end
+        if auth_was_for_cim?(authorization)
+          cim_void(authorization, options)
+        else
+          normal_void(authorization, options)
         end
       end
 
@@ -146,7 +114,7 @@ module ActiveMerchant #:nodoc:
           raise ArgumentError, "Reference credits are not supported. Please supply the original credit card or use the #refund method."
         end
 
-        commit("CREDIT") do |xml|
+        commit(:credit) do |xml|
           add_order_id(xml, options)
           xml.transactionRequest do
             xml.transactionType('refundTransaction')
@@ -168,6 +136,29 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def store(credit_card, options = {})
+        commit(:cim_store) do |xml|
+          xml.profile do
+            xml.merchantCustomerId(truncate(options[:merchant_customer_id], 20) || SecureRandom.hex(10))
+            xml.description(truncate(options[:description], 255)) unless empty?(options[:description])
+            xml.email(options[:email]) unless empty?(options[:email])
+
+            xml.paymentProfiles do
+              xml.customerType("individual")
+              add_billing_address(xml, credit_card, options)
+              add_shipping_address(xml, options, "shipToList")
+              xml.payment do
+                xml.creditCard do
+                  xml.cardNumber(truncate(credit_card.number, 16))
+                  xml.expirationDate(format(credit_card.year, :four_digits) + '-' + format(credit_card.month, :two_digits))
+                  xml.cardCode(credit_card.verification_value) if credit_card.verification_value
+                end
+              end
+            end
+          end
+        end
+      end
+
       def supports_scrubbing?
         true
       end
@@ -180,9 +171,120 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_auth_purchase(xml, transaction_type, amount, payment, options)
+        add_order_id(xml, options)
+        xml.transactionRequest do
+          xml.transactionType(transaction_type)
+          xml.amount(amount(amount))
+          add_payment_source(xml, payment)
+          add_invoice(xml, options)
+          add_customer_data(xml, payment, options)
+          add_market_type(xml, payment)
+          add_settings(xml, payment, options)
+          add_user_fields(xml, amount, options)
+        end
+      end
+
+      def add_cim_auth_purchase(xml, transaction_type, amount, payment, options)
+        add_order_id(xml, options)
+        xml.transaction do
+          xml.send(transaction_type) do
+            xml.amount(amount(amount))
+            add_payment_source(xml, payment)
+            add_invoice(xml, options)
+          end
+        end
+      end
+
+      def cim_capture(amount, authorization, options)
+        commit(:cim_capture) do |xml|
+          add_order_id(xml, options)
+          xml.transaction do
+            xml.profileTransPriorAuthCapture do
+              xml.amount(amount(amount))
+              xml.transId(transaction_id_from(authorization))
+            end
+          end
+        end
+      end
+
+      def normal_capture(amount, authorization, options)
+        commit(:capture) do |xml|
+          add_order_id(xml, options)
+          xml.transactionRequest do
+            xml.transactionType('priorAuthCaptureTransaction')
+            xml.amount(amount(amount))
+            xml.refTransId(transaction_id_from(authorization))
+            add_invoice(xml, options)
+            add_user_fields(xml, amount, options)
+          end
+        end
+      end
+
+      def cim_refund(amount, authorization, options)
+        transaction_id, card_number, _ = split_authorization(authorization)
+
+        commit(:cim_refund) do |xml|
+          add_order_id(xml, options)
+          xml.transaction do
+            xml.profileTransRefund do
+              xml.amount(amount(amount))
+              xml.creditCardNumberMasked(card_number)
+              add_invoice(xml, options)
+              xml.transId(transaction_id)
+            end
+          end
+        end
+      end
+
+      def normal_refund(amount, authorization, options)
+        transaction_id, card_number, _ = split_authorization(authorization)
+
+        commit(:refund) do |xml|
+          xml.transactionRequest do
+            xml.transactionType('refundTransaction')
+            xml.amount(amount.nil? ? 0 : amount(amount))
+            xml.payment do
+              xml.creditCard do
+                xml.cardNumber(card_number || options[:card_number])
+                xml.expirationDate('XXXX')
+              end
+            end
+            xml.refTransId(transaction_id)
+
+            add_customer_data(xml, nil, options)
+            add_user_fields(xml, amount, options)
+          end
+        end
+      end
+
+      def cim_void(authorization, options)
+        commit(:cim_void) do |xml|
+          add_order_id(xml, options)
+          xml.transaction do
+            xml.profileTransVoid do
+              xml.transId(transaction_id_from(authorization))
+            end
+          end
+        end
+      end
+
+      def normal_void(authorization, options)
+        commit(:void) do |xml|
+          add_order_id(xml, options)
+          xml.transactionRequest do
+            xml.transactionType('voidTransaction')
+            xml.refTransId(transaction_id_from(authorization))
+            add_user_fields(xml, nil, options)
+          end
+        end
+      end
+
       def add_payment_source(xml, source)
         return unless source
-        if card_brand(source) == 'check'
+        if source.is_a?(String)
+          add_token_payment_method(xml, source)
+        elsif card_brand(source) == 'check'
           add_check(xml, source)
         elsif card_brand(source) == 'apple_pay'
           add_apple_pay_payment_token(xml, source)
@@ -193,7 +295,7 @@ module ActiveMerchant #:nodoc:
 
       def add_settings(xml, source, options)
         xml.transactionSettings do
-          if card_brand(source) == "check" && options[:recurring]
+          if !source.is_a?(String) && card_brand(source) == "check" && options[:recurring]
             xml.setting do
               xml.settingName("recurringBilling")
               xml.settingValue("true")
@@ -264,7 +366,12 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      # http://developer.authorize.net/api/reference/#apple-pay-transactions
+      def add_token_payment_method(xml, token)
+        customer_profile_id, customer_payment_profile_id, _ = split_authorization(token)
+        xml.customerProfileId(customer_profile_id)
+        xml.customerPaymentProfileId(customer_payment_profile_id)
+      end
+
       def add_apple_pay_payment_token(xml, apple_pay_payment_token)
         xml.payment do
           xml.opaqueData do
@@ -275,7 +382,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_market_type(xml, payment)
-        return if card_brand(payment) == 'check' or card_brand(payment) == 'apple_pay'
+        return if payment.is_a?(String) || card_brand(payment) == 'check' || card_brand(payment) == 'apple_pay'
         if valid_track_data
           xml.retail do
             xml.marketType(MARKET_TYPE[:retail])
@@ -305,47 +412,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(xml, payment_source, options)
-        billing_address = options[:billing_address] || options[:address] || {}
-        shipping_address = options[:shipping_address] || options[:address] || {}
-
         xml.customer do
           xml.id(options[:customer]) unless empty?(options[:customer]) || options[:customer] !~ /^\d+$/
           xml.email(options[:email]) unless empty?(options[:email])
         end
 
-        xml.billTo do
-          first_name, last_name = names_from(payment_source, billing_address, options)
-          xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
-          xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
-
-          xml.company(truncate(billing_address[:company], 50)) unless empty?(billing_address[:company])
-          xml.address(truncate(billing_address[:address1], 60))
-          xml.city(truncate(billing_address[:city], 40))
-          xml.state(empty?(billing_address[:state]) ? 'n/a' : truncate(billing_address[:state], 40))
-          xml.zip(truncate((billing_address[:zip] || options[:zip]), 20))
-          xml.country(truncate(billing_address[:country], 60))
-          xml.phoneNumber(truncate(billing_address[:phone], 25)) unless empty?(billing_address[:phone])
-          xml.faxNumber(truncate(billing_address[:fax], 25)) unless empty?(billing_address[:fax])
-        end
-
-        unless shipping_address.blank?
-          xml.shipTo do
-            (first_name, last_name) = if shipping_address[:name]
-              shipping_address[:name].split
-            else
-              [shipping_address[:first_name], shipping_address[:last_name]]
-            end
-            xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
-            xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
-
-            xml.company(truncate(shipping_address[:company], 50)) unless empty?(shipping_address[:company])
-            xml.address(truncate(shipping_address[:address1], 60))
-            xml.city(truncate(shipping_address[:city], 40))
-            xml.state(truncate(shipping_address[:state], 40))
-            xml.zip(truncate(shipping_address[:zip], 20))
-            xml.country(truncate(shipping_address[:country], 60))
-          end
-        end
+        add_billing_address(xml, payment_source, options)
+        add_shipping_address(xml, options)
 
         xml.customerIP(options[:ip]) unless empty?(options[:ip])
 
@@ -353,6 +426,49 @@ module ActiveMerchant #:nodoc:
           xml.authenticationIndicator(options[:authentication_indicator])
           xml.cardholderAuthenticationValue(options[:cardholder_authentication_value])
         end
+      end
+
+      def add_billing_address(xml, payment_source, options)
+        address = options[:billing_address] || options[:address] || {}
+
+        xml.billTo do
+          first_name, last_name = names_from(payment_source, address, options)
+          xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
+          xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
+
+          xml.company(truncate(address[:company], 50)) unless empty?(address[:company])
+          xml.address(truncate(address[:address1], 60))
+          xml.city(truncate(address[:city], 40))
+          xml.state(empty?(address[:state]) ? 'n/a' : truncate(address[:state], 40))
+          xml.zip(truncate((address[:zip] || options[:zip]), 20))
+          xml.country(truncate(address[:country], 60))
+          xml.phoneNumber(truncate(address[:phone], 25)) unless empty?(address[:phone])
+          xml.faxNumber(truncate(address[:fax], 25)) unless empty?(address[:fax])
+        end
+      end
+
+      def add_shipping_address(xml, options, root_node="shipTo")
+        address = options[:shipping_address] || options[:address]
+        return unless address
+
+        xml.send(root_node) do
+          first_name, last_name = if address[:name]
+            split_names(address[:name])
+          else
+            [address[:first_name], address[:last_name]]
+          end
+
+          xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
+          xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
+
+          xml.company(truncate(address[:company], 50)) unless empty?(address[:company])
+          xml.address(truncate(address[:address1], 60))
+          xml.city(truncate(address[:city], 40))
+          xml.state(truncate(address[:state], 40))
+          xml.zip(truncate(address[:zip], 20))
+          xml.country(truncate(address[:country], 60))
+        end
+
       end
 
       def add_order_id(xml, options)
@@ -367,17 +483,40 @@ module ActiveMerchant #:nodoc:
       end
 
       def names_from(payment_source, address, options)
-        if payment_source && !payment_source.is_a?(PaymentToken)
-          first_name, last_name = (address[:name] || "").split
+        if payment_source && !payment_source.is_a?(PaymentToken) && !payment_source.is_a?(String)
+          first_name, last_name = split_names(address[:name])
           [(payment_source.first_name || first_name), (payment_source.last_name || last_name)]
         else
           [options[:first_name], options[:last_name]]
         end
       end
 
+      def split_names(full_name)
+        names = (full_name || "").split
+        last_name = names.pop
+        first_name = names.join(" ")
+        [first_name, last_name]
+      end
+
+      def headers
+        { 'Content-Type' => 'text/xml' }
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def parse(action, raw_response)
+        if is_cim_action?(action)
+          parse_cim(raw_response)
+        else
+          parse_normal(action, raw_response)
+        end
+      end
+
       def commit(action, &payload)
-        url = (test? ? test_url : live_url)
-        response = parse(action, ssl_post(url, post_data(&payload), 'Content-Type' => 'text/xml'))
+        raw_response = ssl_post(url, post_data(action, &payload), headers)
+        response = parse(action, raw_response)
 
         avs_result = AVSResult.new(code: response[:avs_result_code])
         cvv_result = CVVResult.new(response[:card_code])
@@ -385,10 +524,10 @@ module ActiveMerchant #:nodoc:
           Response.new(false, "Using a live Authorize.net account in Test Mode is not permitted.")
         else
           Response.new(
-            success_from(response),
-            message_from(response, avs_result, cvv_result),
+            success_from(action, response),
+            message_from(action, response, avs_result, cvv_result),
             response,
-            authorization: authorization_from(response),
+            authorization: authorization_from(action, response),
             test: test?,
             avs_result: avs_result,
             cvv_result: cvv_result,
@@ -398,19 +537,37 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def post_data
+      def is_cim_action?(action)
+        action.to_s.start_with?("cim")
+      end
+
+      def post_data(action)
         Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-          xml.createTransactionRequest('xmlns' => 'AnetApi/xml/v1/schema/AnetApiSchema.xsd') do
-            xml.merchantAuthentication do
-              xml.name(@options[:login])
-              xml.transactionKey(@options[:password])
-            end
+          xml.send(root_for(action), 'xmlns' => 'AnetApi/xml/v1/schema/AnetApiSchema.xsd') do
+            add_authentication(xml)
             yield(xml)
           end
         end.to_xml(indent: 0)
       end
 
-      def parse(action, body)
+      def root_for(action)
+        if action == :cim_store
+          "createCustomerProfileRequest"
+        elsif is_cim_action?(action)
+          "createCustomerProfileTransactionRequest"
+        else
+          "createTransactionRequest"
+        end
+      end
+
+      def add_authentication(xml)
+        xml.merchantAuthentication do
+          xml.name(@options[:login])
+          xml.transactionKey(@options[:password])
+        end
+      end
+
+      def parse_normal(action, body)
         doc = Nokogiri::XML(body)
         doc.remove_namespaces!
 
@@ -465,14 +622,50 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def success_from(response)
-        (
-          response[:response_code] == APPROVED &&
-          TRANSACTION_ALREADY_ACTIONED.exclude?(response[:response_reason_code])
-        )
+      def parse_cim(body)
+        response = {}
+
+        doc = Nokogiri::XML(body).remove_namespaces!
+
+        if (element = doc.at_xpath("//messages/message"))
+          response[:message_code] = element.at_xpath("code").content[/0*(\d+)$/, 1]
+          response[:message_text] = element.at_xpath("text").content.chomp('.')
+        end
+
+        response[:result_code] = if(element = doc.at_xpath("//messages/resultCode"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:test_request] = if(element = doc.at_xpath("//testRequest"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:customer_profile_id] = if(element = doc.at_xpath("//customerProfileId"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:customer_payment_profile_id] = if(element = doc.at_xpath("//customerPaymentProfileIdList/numericString"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:direct_response] = if(element = doc.at_xpath("//directResponse"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response.merge!(parse_direct_response_elements(response))
+
+        response
       end
 
-      def message_from(response, avs_result, cvv_result)
+      def success_from(action, response)
+        if action == :cim_store
+          response[:result_code] == "Ok"
+        else
+          response[:response_code] == APPROVED && TRANSACTION_ALREADY_ACTIONED.exclude?(response[:response_reason_code])
+        end
+      end
+
+      def message_from(action, response, avs_result, cvv_result)
         if response[:response_code] == DECLINED
           if CARD_CODE_ERRORS.include?(cvv_result.code)
             return cvv_result.message
@@ -481,30 +674,97 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-        response[:response_reason_text]
+        response[:response_reason_text] || response[:message_text]
       end
 
-      def authorization_from(response)
-        [response[:transaction_id], response[:account_number]].join("#")
+      def authorization_from(action, response)
+        if action == :cim_store
+          [response[:customer_profile_id], response[:customer_payment_profile_id], action].join("#")
+        else
+          [response[:transaction_id], response[:account_number], action].join("#")
+        end
       end
 
       def split_authorization(authorization)
-        transaction_id, card_number = authorization.split("#")
-        [transaction_id, card_number]
+        authorization.split("#")
+      end
+
+      def transaction_id_from(authorization)
+        transaction_id, _, _ = split_authorization(authorization)
+        transaction_id
       end
 
       def fraud_review?(response)
         (response[:response_code] == FRAUD_REVIEW)
       end
 
-
       def using_live_gateway_in_test_mode?(response)
         !test? && response[:test_request] == "1"
       end
 
       def map_error_code(response_code, response_reason_code)
-        STANDARD_ERROR_CODE_MAPPING[response_code.to_s << response_reason_code.to_s]
+        STANDARD_ERROR_CODE_MAPPING["#{response_code}#{response_reason_code}"]
       end
+
+      def auth_was_for_cim?(authorization)
+        _, _, action = split_authorization(authorization)
+        action && is_cim_action?(action)
+      end
+
+      def parse_direct_response_elements(response)
+        params = response[:direct_response]
+        return {} unless params
+
+        parts = params.split(',')
+        {
+          response_code: parts[0].to_i,
+          response_subcode: parts[1],
+          response_reason_code: parts[2],
+          response_reason_text: parts[3],
+          approval_code: parts[4],
+          avs_result_code: parts[5],
+          transaction_id: parts[6],
+          invoice_number: parts[7],
+          order_description: parts[8],
+          amount: parts[9],
+          method: parts[10],
+          transaction_type: parts[11],
+          customer_id: parts[12],
+          first_name: parts[13],
+          last_name: parts[14],
+          company: parts[15],
+          address: parts[16],
+          city: parts[17],
+          state: parts[18],
+          zip_code: parts[19],
+          country: parts[20],
+          phone: parts[21],
+          fax: parts[22],
+          email_address: parts[23],
+          ship_to_first_name: parts[24],
+          ship_to_last_name: parts[25],
+          ship_to_company: parts[26],
+          ship_to_address: parts[27],
+          ship_to_city: parts[28],
+          ship_to_state: parts[29],
+          ship_to_zip_code: parts[30],
+          ship_to_country: parts[31],
+          tax: parts[32],
+          duty: parts[33],
+          freight: parts[34],
+          tax_exempt: parts[35],
+          purchase_order_number: parts[36],
+          md5_hash: parts[37],
+          card_code: parts[38],
+          cardholder_authentication_verification_response: parts[39],
+          account_number: parts[50] || '',
+          card_type: parts[51] || '',
+          split_tender_id: parts[52] || '',
+          requested_amount: parts[53] || '',
+          balance_on_card: parts[54] || '',
+        }
+      end
+
     end
   end
 end

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -278,12 +278,69 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal "Using a live Authorize.net account in Test Mode is not permitted.", response.message
   end
 
+  def test_successful_purchase_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    @gateway.expects(:ssl_post).returns(successful_purchase_using_stored_card_response)
+
+    response = @gateway.purchase(@amount, store.authorization)
+    assert_success response
+
+    assert_equal '2235700270#XXXX2224#cim_purchase', response.authorization
+    assert_equal 'Y', response.avs_result['code']
+    assert response.avs_result['street_match']
+    assert response.avs_result['postal_match']
+    assert_equal 'Street address and 5-digit postal code match.', response.avs_result['message']
+  end
+
+  def test_failed_purchase_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    @gateway.expects(:ssl_post).returns(failed_purchase_using_stored_card_response)
+
+    response = @gateway.purchase(@amount, store.authorization)
+    assert_failure response
+    assert_equal "The credit card number is invalid.", response.message
+    assert_equal "6", response.params["response_reason_code"]
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'incorrect_number', response.error_code
+  end
+
+  def test_successful_authorize_and_capture_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+
+    @gateway.expects(:ssl_post).returns(successful_authorize_using_stored_card_response)
+    auth = @gateway.authorize(@amount, store.authorization)
+    assert_success auth
+    assert_equal "This transaction has been approved.", auth.message
+
+    @gateway.expects(:ssl_post).returns(successful_capture_using_stored_card_response)
+
+    capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal "This transaction has been approved.", capture.message
+  end
+
+  def test_failed_authorize_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+
+    @gateway.expects(:ssl_post).returns(failed_authorize_using_stored_card_response)
+    response = @gateway.authorize(@amount, store.authorization)
+    assert_failure response
+    assert_equal "The credit card number is invalid.", response.message
+    assert_equal "6", response.params["response_reason_code"]
   end
 
   def test_successful_capture
@@ -309,6 +366,19 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_capture_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+
+    @gateway.expects(:ssl_post).returns(successful_authorize_using_stored_card_response)
+    auth = @gateway.authorize(@amount, store.authorization)
+
+    @gateway.expects(:ssl_post).returns(failed_capture_using_stored_card_response)
+    capture = @gateway.capture(@amount, auth.authorization)
+    assert_failure capture
+    assert_match(/The amount requested for settlement cannot be greater/, capture.message)
+  end
+
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
 
@@ -321,6 +391,32 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = @gateway.void('')
     assert_failure response
+  end
+
+  def test_successful_void_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+
+    @gateway.expects(:ssl_post).returns(successful_authorize_using_stored_card_response)
+    auth = @gateway.authorize(@amount, store.authorization)
+
+    @gateway.expects(:ssl_post).returns(successful_void_using_stored_card_response)
+    void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal "This transaction has been approved.", void.message
+  end
+
+  def test_failed_void_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+
+    @gateway.expects(:ssl_post).returns(failed_authorize_using_stored_card_response)
+    auth = @gateway.authorize(@amount, store.authorization)
+
+    @gateway.expects(:ssl_post).returns(failed_void_using_stored_card_response)
+    void = @gateway.void(auth.authorization)
+    assert_failure void
+    assert_equal "This transaction has already been voided.", void.message
   end
 
   def test_successful_verify
@@ -344,6 +440,41 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
     assert_not_nil response.message
+  end
+
+  def test_failed_refund_using_stored_card
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    @gateway.expects(:ssl_post).returns(successful_purchase_using_stored_card_response)
+
+    purchase = @gateway.purchase(@amount, store.authorization)
+    assert_success purchase
+
+    @gateway.expects(:ssl_post).returns(failed_refund_using_stored_card_response)
+    refund = @gateway.refund(@amount, purchase.authorization)
+    assert_failure refund
+    assert_equal "The record cannot be found", refund.message
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+    assert_equal "Successful", store.message
+    assert_equal "35959426", store.params["customer_profile_id"]
+    assert_equal "32506918", store.params["customer_payment_profile_id"]
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+
+    store = @gateway.store(@credit_card, @options)
+    assert_failure store
+    assert_match(/The field length is invalid/, store.message)
+    assert_equal("15", store.params["message_code"])
   end
 
   def test_address
@@ -421,7 +552,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert refund = @gateway.refund(36.40, '2214269051#XXXX1234')
     assert_success refund
     assert_equal 'This transaction has been approved', refund.message
-    assert_equal '2214602071#2224', refund.authorization
+    assert_equal '2214602071#2224#refund', refund.authorization
   end
 
   def test_refund_passing_extra_info
@@ -444,7 +575,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     refund = @gateway.refund(nil, '')
     assert_failure refund
     assert_equal 'The sum of credits against the referenced transaction would exceed original debit amount', refund.message
-    assert_equal '0#2224', refund.authorization
+    assert_equal '0#2224#refund', refund.authorization
   end
 
   def test_successful_credit
@@ -1481,4 +1612,198 @@ class AuthorizeNetTest < Test::Unit::TestCase
       </createTransactionResponse>
     eos
   end
+
+  def successful_store_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+          <code>I00001</code>
+          <text>Successful.</text>
+          </message>
+      </messages>
+      <customerProfileId>35959426</customerProfileId>
+      <customerPaymentProfileIdList>
+          <numericString>32506918</numericString>
+      </customerPaymentProfileIdList>
+      <customerShippingAddressIdList />
+      <validationDirectResponseList />
+      </createCustomerProfileResponse>
+    eos
+  end
+
+  def failed_store_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <messages>
+          <resultCode>Error</resultCode>
+          <message>
+          <code>E00015</code>
+          <text>The field length is invalid for Card Number.</text>
+          </message>
+      </messages>
+      <customerPaymentProfileIdList />
+      <customerShippingAddressIdList />
+      <validationDirectResponseList />
+      </createCustomerProfileResponse>
+    eos
+  end
+
+  def successful_purchase_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <refId>1</refId>
+      <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+          <code>I00001</code>
+          <text>Successful.</text>
+          </message>
+      </messages>
+      <directResponse>1,1,1,This transaction has been approved.,8HUT72,Y,2235700270,1,Store Purchase,1.01,CC,auth_capture,e385c780422f4bd182c4,Longbob,Longsen,,,,n/a,,,,,,,,,,,,,,,,,,,4A20EEAF89018FF075899DDB332E9D35,,2,,,,,,,,,,,XXXX2224,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def failed_purchase_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId>1</refId>
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00027</code>
+            <text>The credit card number is invalid.</text>
+          </message>
+        </messages>
+        <directResponse>3,1,6,The credit card number is invalid.,,P,0,1,Store Purchase,1.01,CC,auth_capture,2da01d7b583c706106e2,Longbob,Longsen,,,,n/a,,,,,,,,,,,,,,,,,,,13BA28EEA3593C13E2E3BC109D16E5D2,,,,,,,,,,,,,XXXX1222,,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def successful_authorize_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId>1</refId>
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+        <directResponse>1,1,1,This transaction has been approved.,GGHQ5R,Y,2235700640,1,Store Purchase,1.01,CC,auth_only,0bde9d39f8eb9443f2af,Longbob,Longsen,,,,n/a,,,,,,,,,,,,,,,,,,,E47E5CA4F1239B00D39A7F8C147215D3,,2,,,,,,,,,,,XXXX2224,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def failed_authorize_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId>1</refId>
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00027</code>
+            <text>The credit card number is invalid.</text>
+          </message>
+        </messages>
+        <directResponse>3,1,6,The credit card number is invalid.,,P,0,1,Store Purchase,1.01,CC,auth_only,f632442ce056f9f82ee9,Longbob,Longsen,,,,n/a,,,,,,,,,,,,,,,,,,,13BA28EEA3593C13E2E3BC109D16E5D2,,,,,,,,,,,,,XXXX1222,,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def successful_capture_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId />
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+        <directResponse>1,1,1,This transaction has been approved.,GGHQ5R,P,2235700640,1,,1.01,CC,prior_auth_capture,0bde9d39f8eb9443f2af,,,,,,,,,,,,,,,,,,,,,,,,,E47E5CA4F1239B00D39A7F8C147215D3,,,,,,,,,,,,,XXXX2224,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def failed_capture_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId />
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00027</code>
+            <text>The amount requested for settlement cannot be greater than the original amount authorized.</text>
+          </message>
+        </messages>
+        <directResponse>3,2,47,The amount requested for settlement cannot be greater than the original amount authorized.,,P,0,,,41.01,CC,prior_auth_capture,,,,,,,,,,,,,,,,,,,,,,,,,,8A556B125A1DA070AF5A84B798B7FBF7,,,,,,,,,,,,,,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def failed_refund_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId>1</refId>
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00040</code>
+            <text>The record cannot be found.</text>
+          </message>
+        </messages>
+      </createCustomerProfileTransactionResponse>
+    eos
+
+  end
+
+  def successful_void_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId />
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+        <directResponse>1,1,1,This transaction has been approved.,3R9YE2,P,2235701141,1,,0.00,CC,void,becdb509b35a32c30e97,,,,,,,,,,,,,,,,,,,,,,,,,C3C4B846B9D5A37D14462C2BF5B924FD,,,,,,,,,,,,,XXXX2224,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+  def failed_void_using_stored_card_response
+    <<-eos
+      <?xml version="1.0" encoding="UTF-8"?>
+      <createCustomerProfileTransactionResponse xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <refId />
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+        <directResponse>1,1,310,This transaction has already been voided.,,P,0,,,0.00,CC,void,,,,,,,,,,,,,,,,,,,,,,,,,,FD9FAE70BEF461997A6C15D7D597658D,,,,,,,,,,,,,,Visa,,,,,,,,,,,,,,,,</directResponse>
+      </createCustomerProfileTransactionResponse>
+    eos
+  end
+
+
 end


### PR DESCRIPTION
This allows us to use the Authorize.net gateway like we always have.  It
also allows us to store cards in CIM and run purchases, auths, voids,
captures, and refunds against those stored cards.