### PR TITLE
Leading zeroes stripped from currency codes

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -38,10 +38,10 @@ module ActiveMerchant #:nodoc:
       self.display_name        = "Redsys"
 
       CURRENCY_CODES = {
-        "ARS" => '032',
+        "ARS" => '32',
         "AUD" => '36',
         "BRL" => '986',
-        "BOB" => '068',
+        "BOB" => '68',
         "CAD" => '124',
         "CHF" => '756',
         "CLP" => '152',

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
 
       CURRENCY_CODES = {
         "ARS" => '032',
-        "AUD" => '036',
+        "AUD" => '36',
         "BRL" => '986',
         "BOB" => '068',
         "CAD" => '124',


### PR DESCRIPTION
As opposed to what is specified in the CatalunyaCaixa/Redsys documentation, our agent has confirmed us that currency codes must be specified without any leading ```0```.

Otherwise transactions will fail with ```SIS0042```error.