### PR TITLE
PayPal Express: Add support for TotalType in SetExpressCheckout

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -170,9 +170,12 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'n2:CallbackTimeout', options[:callback_timeout] unless options[:callback_timeout].blank?
               xml.tag! 'n2:CallbackVersion', options[:callback_version] unless options[:callback_version].blank?
 
+
               if options.has_key?(:allow_buyer_optin)
                 xml.tag! 'n2:BuyerEmailOptInEnable', (options[:allow_buyer_optin] ? '1' : '0')
               end
+
+              xml.tag! 'n2:TotalType', options[:total_type] unless options[:total_type].blank?
             end
           end
         end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -544,6 +544,14 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '0', REXML::XPath.first(do_not_allow_optin_xml, '//n2:BuyerEmailOptInEnable').text
   end
 
+  def test_add_total_type_if_specified
+    total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:total_type => 'EstimatedTotal'}))
+    no_total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
+
+    assert_equal 'EstimatedTotal', REXML::XPath.first(total_type_xml, '//n2:TotalType').text
+    assert_nil REXML::XPath.first(no_total_type_xml, '//n2:BuyerEmailOptInEnable')
+  end
+
   def test_structure_correct
     all_options_enabled = {
         :allow_guest_checkout => true,
@@ -562,6 +570,7 @@ class PaypalExpressTest < Test::Unit::TestCase
         :shipping => 10,
         :handling => 0,
         :tax => 5,
+        :total_type => 'EstimatedTotal',
         :items => [{:name => 'item one',
                     :number => 'number 1',
                     :quantity => 3,


### PR DESCRIPTION
Adds support for the TotalType field in the PayPal Express SetExpressCheckout API call.

See:

https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_SOAP/