### PR TITLE
Send contactless read_method whenever it is set

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -305,6 +305,7 @@ module ActiveMerchant #:nodoc:
           if creditcard.respond_to?(:track_data) && creditcard.track_data.present?
             card[:swipe_data] = creditcard.track_data
             card[:fallback_reason] = creditcard.fallback_reason if creditcard.fallback_reason
+            card[:read_method] = "contactless" if creditcard.contactless
           else
             card[:number] = creditcard.number
             card[:exp_month] = creditcard.month


### PR DESCRIPTION
Changes stripe.rb to always pass the `read_method` parameter of `contactless` if the credit card says it is a contactless card. This is needed to support contactless magswipe cards where they have track data but we also need to specify that they are contactless.

Please review @bizla @girasquid 