### PR TITLE
PayPal: Allow soft descriptor param for non PayPal Express actions

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -581,6 +581,8 @@ module ActiveMerchant #:nodoc:
           # This value is ignored when set in SetExpressCheckout or GetExpressCheckoutDetails
           xml.tag! 'n2:NotifyURL', options[:notify_url] unless options[:notify_url].blank?
 
+          xml.tag! 'n2:SoftDescriptor', options[:soft_descriptor] unless options[:soft_descriptor].blank?
+
           add_address(xml, 'n2:ShipToAddress', options[:shipping_address]) unless options[:shipping_address].blank?
 
           add_payment_details_items_xml(xml, options, currency_code) unless options[:items].blank?
@@ -604,9 +606,9 @@ module ActiveMerchant #:nodoc:
 
       def add_express_only_payment_details(xml, options = {})
         add_optional_fields(xml,
-                            %w{n2:NoteText          n2:SoftDescriptor
+                            %w{n2:NoteText          n2:PaymentAction
                                n2:TransactionId     n2:AllowedPaymentMethodType
-                               n2:PaymentRequestID  n2:PaymentAction},
+                               n2:PaymentRequestID  },
                             options)
       end
 

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -54,6 +54,13 @@ class PaypalTest < Test::Unit::TestCase
     assert response.params['transaction_id']
   end
 
+  def test_successful_purchase_with_soft_descriptor
+    @params[:soft_descriptor] = "Active Merchant TXN"
+    response = @gateway.purchase(@amount, @credit_card, @params)
+    assert_success response
+    assert response.params['transaction_id']
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @params)
     assert_failure response
@@ -244,6 +251,18 @@ class PaypalTest < Test::Unit::TestCase
     id_for_reference = response.params['transaction_id']
 
     @params.delete(:order_id)
+    response2 = @gateway.purchase(@amount + 100, id_for_reference, @params)
+    assert_success response2
+  end
+
+
+  def test_successful_referenced_id_purchase_with_soft_descriptor
+    response = @gateway.purchase(@amount, @credit_card, @params)
+    assert_success response
+    id_for_reference = response.params['transaction_id']
+
+    @params.delete(:order_id)
+    @params[:soft_descriptor] = "Active Merchant TXN"
     response2 = @gateway.purchase(@amount + 100, id_for_reference, @params)
     assert_success response2
   end


### PR DESCRIPTION
@duff: Here's a quick PR to allow the `<SoftDescriptors>` tag to be passed for PayPal Payments Pro requests. Just to note, it will be passed for both `Direct Transactions` and `Reference Transactions`. Let me know if that shouldn't be the case.