### PR TITLE
Authorize.net: Add allow_partial_auth field

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -327,6 +327,12 @@ module ActiveMerchant #:nodoc:
               xml.settingValue("true")
             end
           end
+          if options[:disable_partial_auth] == "true"
+            xml.setting do
+              xml.settingName("allowPartialAuth")
+              xml.settingValue("false")
+            end
+          end
           if options[:duplicate_window]
             set_duplicate_window(xml, options[:duplicate_window])
           elsif self.class.duplicate_window

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -81,6 +81,12 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_purchase_with_disable_partial_authorize
+    options = @options.merge({disable_partial_auth: "true"})
+    purchase = @gateway.purchase(46225, @credit_card, options )
+    assert_success purchase
+  end
+
   def test_successful_authorize_with_email_and_ip
     options = @options.merge({email: 'hello@example.com', ip: '127.0.0.1'})
     auth = @gateway.authorize(@amount, @credit_card, options)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -248,6 +248,15 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_passes_partial_auth
+    stub_comms do
+      @gateway.purchase(100, credit_card, @options.merge({disable_partial_auth: "true"}))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<settingName>allowPartialAuth<\/settingName>/, data)
+      assert_match(/<settingValue>false<\/settingValue>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
@duff Here is adding the partial auth gateway specific field. The only slightly strange thing about it is that, when doing a partial auth, until the balance is paid in full the transactions are held instead of approved so it doesn't look like a success.  The message is pretty clear though. 