### PR TITLE
Merchant Ware: Update credentials for remote tests

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -2,7 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MerchantWareVersionFourGateway < Gateway
       self.live_url = 'https://ps1.merchantware.net/Merchantware/ws/RetailTransaction/v4/Credit.asmx'
-      self.test_url = 'https://staging.merchantware.net/Merchantware/ws/RetailTransaction/v4/Credit.asmx'
+      self.test_url = 'https://ps1.merchantware.net/Merchantware/ws/RetailTransaction/v4/Credit.asmx'
 
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -350,9 +350,9 @@ merchant_ware:
  name:
 
 merchant_ware_version_four:
- login:
- password:
- name:
+ login: 'BK34Z768'
+ password: 'TCTTS-IDYQV-RDFY1-6DS01-WTPVH'
+ name: 'Test Spreedly PayItSimple'
 
 merchant_warrior:
   merchant_uuid: '50c5b9f0b52ea'


### PR DESCRIPTION
@duff: Quick update to Merchant Ware (version 4) adapter to use active/valid credentials. Remote tests should now pass again.