### PR TITLE
Mercury: No longer default to allow partial auth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * SagePay: Add apply_avscv2 field [anellis]
 * S5: Add Store [anellis]
 * Merchant Ware v4: Add support for verify [davidsantoso]
+* Mercury: No longer default to allow partial auth [duff]
 
 
 == Version 1.51.0 (July 2, 2015)

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! "Transaction" do
             xml.tag! 'TranType', 'Credit'
             xml.tag! 'TranCode', action
-            if action == 'PreAuth' || action == 'Sale'
+            if options[:allow_partial_auth] && (action == 'PreAuth' || action == 'Sale')
               xml.tag! "PartialAuth", "Allow"
             end
             add_invoice(xml, options[:order_id], nil, options)
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! "TStream" do
           xml.tag! "Transaction" do
             xml.tag! 'TranType', 'Credit'
-            if action == 'PreAuthCapture'
+            if options[:allow_partial_auth] && (action == 'PreAuthCapture')
               xml.tag! "PartialAuth", "Allow"
             end
             xml.tag! 'TranCode', (@use_tokenization ? (action + "ByRecordNo") : action)

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -33,6 +33,16 @@ class MercuryTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_allow_partial_auth
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(allow_partial_auth: true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/PartialAuth>Allow</, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Most customers don't want to allow partial auths.  The mercury docs
state:

Supporting partial authorizations is required for all POS systems.

Mercury tech support reported that for an eCommerce transaction, that
allow partial auth flag should not be passed.  Then when a customer uses
a gift card with insufficient funds, they'd get an expected decline
response.