### PR TITLE
Stripe: Map incorrect_pin error code to new standard error code

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -72,6 +72,7 @@ module ActiveMerchant #:nodoc:
       # :incorrect_cvc - Secerity code was not matched by the processor
       # :incorrect_zip - Zip code is not in correct format
       # :incorrect_address - Billing address info was not matched by the processor
+      # :incorrect_pin - Card PIN is incorrect
       # :card_declined - Card number declined by processor
       # :processing_error - Processor error
       # :call_issuer - Transaction requires voice authentication, call issuer
@@ -86,6 +87,7 @@ module ActiveMerchant #:nodoc:
         :incorrect_cvc => 'incorrect_cvc',
         :incorrect_zip => 'incorrect_zip',
         :incorrect_address => 'incorrect_address',
+        :incorrect_pin => 'incorrect_pin',
         :card_declined => 'card_declined',
         :processing_error => 'processing_error',
         :call_issuer => 'call_issuer',

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -43,7 +43,8 @@ module ActiveMerchant #:nodoc:
         'incorrect_zip' => STANDARD_ERROR_CODE[:incorrect_zip],
         'card_declined' => STANDARD_ERROR_CODE[:card_declined],
         'call_issuer' => STANDARD_ERROR_CODE[:call_issuer],
-        'processing_error' => STANDARD_ERROR_CODE[:processing_error]
+        'processing_error' => STANDARD_ERROR_CODE[:processing_error],
+        'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin]
       }
 
       def initialize(options = {})


### PR DESCRIPTION
Adds a new standard error code called `incorrect_pin` and maps it from Stripe.

This is used for Online PIN transactions to provide a better UX when the gateway lets us know the PIN was incorrect.