### PR TITLE
Stripe: Make purchase via vaulted card consistent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Merchant Ware v4: Add support for verify [davidsantoso]
 * Mercury: No longer default to allow partial auth [duff]
 * PayPal: Fix soft_descriptor and support soft_descriptor_city [duff]
+* Stripe: Make purchase via vaulted card consistent [duff]
 
 
 == Version 1.51.0 (July 2, 2015)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -27,7 +27,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal 'cus_3sgheFxeBgTQ3M', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -39,7 +39,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal 'cus_3sgheFxeBgTQ3M', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -50,7 +50,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal 'cus_3sgheFxeBgTQ3M', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -63,7 +63,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -75,7 +75,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -87,7 +87,7 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert response.test?
   end
 
@@ -99,9 +99,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -114,9 +114,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -128,9 +128,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -143,9 +143,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -158,9 +158,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -172,9 +172,9 @@ class StripeTest < Test::Unit::TestCase
     assert_instance_of MultiResponse, response
     assert_success response
 
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.authorization
     assert_equal 2, response.responses.size
-    assert_equal 'card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
+    assert_equal 'cus_3sgheFxeBgTQ3M|card_483etw4er9fg4vF3sQdrt3FG', response.responses[0].authorization
     assert_equal 'cus_3sgheFxeBgTQ3M', response.responses[1].authorization
     assert response.test?
   end
@@ -278,13 +278,12 @@ class StripeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_token
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, "tok_xxx")
+      @gateway.purchase(@amount, "cus_xxx|card_xxx")
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/card=tok_xxx/, data)
+      assert_match(/customer=cus_xxx/, data)
+      assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
 
-    assert response
-    assert_instance_of Response, response
     assert_success response
   end
 
@@ -488,9 +487,10 @@ class StripeTest < Test::Unit::TestCase
 
   def test_add_creditcard_with_token
     post = {}
-    credit_card_token = "card_2iD4AezYnNNzkW"
+    credit_card_token = "cus_3sgheFxeBgTQ3M|card_2iD4AezYnNNzkW"
     @gateway.send(:add_creditcard, post, credit_card_token, {})
-    assert_equal credit_card_token, post[:card]
+    assert_equal "cus_3sgheFxeBgTQ3M", post[:customer]
+    assert_equal "card_2iD4AezYnNNzkW", post[:card]
   end
 
   def test_add_creditcard_with_token_and_track_data
@@ -505,12 +505,6 @@ class StripeTest < Test::Unit::TestCase
     @gateway.send(:add_creditcard, post, @emv_credit_card, {})
 
     assert_equal @emv_credit_card.icc_data, post[:card][:emv_auth_data]
-  end
-
-  def test_add_customer
-    post = {}
-    @gateway.send(:add_customer, post, nil, {:customer => "test_customer"})
-    assert_equal "test_customer", post[:customer]
   end
 
   def test_application_fee_is_submitted_for_purchase
@@ -768,16 +762,6 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_update_credit_card_response)
   end
 
-  def test_deprecated_unstore
-    assert_deprecation_warning do
-      assert @gateway.unstore("CustomerID", "card_id")
-    end
-
-    assert_deprecation_warning do
-      assert @gateway.unstore("CustomerID", "card_id", {})
-    end
-  end
-
   def test_scrub
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
@@ -910,7 +894,7 @@ class StripeTest < Test::Unit::TestCase
       "subscription": null,
       "discount": null,
       "account_balance": 0,
-      "cards":
+      "sources":
       {
         "object": "list",
         "count": 1,

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -59,9 +59,10 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_token
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, "tok_xxx")
+      @gateway.purchase(@amount, "cus_xxx|card_xxx")
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/card=tok_xxx/, data)
+      assert_match(/customer=cus_xxx/, data)
+      assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
 
     assert response


### PR DESCRIPTION
In particular, the way most gateways are using `store` is like this:

```
store = @gateway.store(@credit_card)
response = @gateway.purchase(@amount, store.authorization)
```

This commit adjusts Stripe to behave in this way, such that we don't
need to grab specific parts of the response.params in order to run
purchases against vaulted cards.