### PR TITLE
eWAY Rapid - add :invoice option

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -28,6 +28,8 @@ module ActiveMerchant #:nodoc:
       #                  :transaction_type - One of: Purchase (default), MOTO
       #                                      or Recurring.  For stored card payments (aka - TokenPayments),
       #                                      this must be either MOTO or Recurring.
+      #                  :invoice          - The merchant’s invoice number for this
+      #                                      transaction (optional).
       #                  :order_id         - A merchant-supplied identifier for the
       #                                      transaction (optional).
       #                  :description      - A merchant-supplied description of the
@@ -85,6 +87,8 @@ module ActiveMerchant #:nodoc:
       # identification - The transaction id which is returned in the
       #                  authorization of the successful purchase transaction
       # options        - A standard ActiveMerchant options hash:
+      #                  :invoice          - The merchant’s invoice number for this
+      #                                      transaction (optional).
       #                  :order_id         - A merchant-supplied identifier for the
       #                                      transaction (optional).
       #                  :description      - A merchant-supplied description of the
@@ -187,7 +191,7 @@ module ActiveMerchant #:nodoc:
         params[key] = {
           'TotalAmount' => localized_amount(money, currency_code),
           'InvoiceReference' => truncate(options[:order_id], 50),
-          'InvoiceNumber' => truncate(options[:order_id], 12),
+          'InvoiceNumber' => truncate(options[:invoice] || options[:order_id], 12),
           'InvoiceDescription' => truncate(options[:description], 64),
           'CurrencyCode' => currency_code,
         }

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -10,6 +10,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
 
     @options = {
       order_id: "1",
+      invoice: "I1234",
       billing_address: address,
       description: "Store Purchase",
       redirect_url: "http://bogus.com"
@@ -31,6 +32,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
       transaction_type: "Purchase",
       description: "Description",
       order_id: "orderid1",
+      invoice: "I1234",
       currency: "AUD",
       email: "jim@example.com",
       billing_address: {
@@ -66,6 +68,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
   def test_successful_purchase_with_overly_long_fields
     options = {
       order_id: "OrderId must be less than 50 characters otherwise it fails",
+      invoice: "Max 12 chars",
       description: "EWay Rapid transactions fail if the description is more than 64 characters.",
       billing_address: {
         address1: "The Billing Address 1 Cannot Be More Than Fifty Characters.",

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -82,6 +82,7 @@ class EwayRapidTest < Test::Unit::TestCase
         :partner_id => "SomePartner",
         :description => "The Really Long Description More Than Sixty Four Characters Gets Truncated",
         :order_id => "orderid1",
+        :invoice => "I1234",
         :currency => "INR",
         :email => "jim@example.com",
         :billing_address => {
@@ -121,7 +122,7 @@ class EwayRapidTest < Test::Unit::TestCase
       assert_match(%r{"TotalAmount":"200"}, data)
       assert_match(%r{"InvoiceDescription":"The Really Long Description More Than Sixty Four Characters Gets"}, data)
       assert_match(%r{"InvoiceReference":"orderid1"}, data)
-      assert_match(%r{"InvoiceNumber":"orderid1"}, data)
+      assert_match(%r{"InvoiceNumber":"I1234"}, data)
       assert_match(%r{"CurrencyCode":"INR"}, data)
 
       assert_match(%r{"Title":"Mr."}, data)


### PR DESCRIPTION
Fix for #1770 (more information there).

Falls back to `:order_id` option for backwards compatibility.

Examples of the `:invoice` option used as an invoice number:
* [quantum.rb](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/quantum.rb#L147)
* [skip_jack.rb](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/skip_jack.rb#L368)