### PR TITLE
Update authorize.net device type to wireless pos

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -217,7 +217,7 @@ module ActiveMerchant #:nodoc:
           add_payment_source(xml, payment)
           add_invoice(xml, options)
           add_customer_data(xml, payment, options)
-          add_market_type_device_type(xml, payment)
+          add_market_type_device_type(xml, payment, options)
           add_settings(xml, payment, options)
           add_user_fields(xml, amount, options)
         end
@@ -426,12 +426,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_market_type_device_type(xml, payment)
+      def add_market_type_device_type(xml, payment, options)
         return if payment.is_a?(String) || card_brand(payment) == 'check' || card_brand(payment) == 'apple_pay'
         if valid_track_data
           xml.retail do
             xml.marketType(MARKET_TYPE[:retail])
-            xml.deviceType(DEVICE_TYPE[:unknown])
+
+            device_type = options[:device_type] || DEVICE_TYPE[:wireless_pos]
+            xml.deviceType(device_type)
           end
         elsif payment.manual_entry
           xml.retail do

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -69,7 +69,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_retail_market_type_included_in_swipe_transactions_with_valid_track_data
+  def test_retail_market_type_device_type_included_in_swipe_transactions_with_valid_track_data
     [BAD_TRACK_DATA, nil].each do |track|
       @credit_card.track_data = track
       stub_comms do
@@ -89,6 +89,22 @@ class AuthorizeNetTest < Test::Unit::TestCase
         parse(data) do |doc|
           assert_not_nil doc.at_xpath('//retail')
           assert_equal "2", doc.at_xpath('//retail/marketType').content
+          assert_equal "7", doc.at_xpath('//retail/deviceType').content
+        end
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
+  def test_device_type_used_from_options_if_included_with_valid_track_data
+    [TRACK1_DATA, TRACK2_DATA].each do |track|
+      @credit_card.track_data = track
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card, {device_type: 1})
+      end.check_request do |endpoint, data, headers|
+        parse(data) do |doc|
+          assert_not_nil doc.at_xpath('//retail')
+          assert_equal "2", doc.at_xpath('//retail/marketType').content
+          assert_equal "1", doc.at_xpath('//retail/deviceType').content
         end
       end.respond_with(successful_purchase_response)
     end


### PR DESCRIPTION
This updates the device type parameter for Authorize.net card present transactions to be wireless pos (code 7). This was suggested to us to use instead of the unknown type.

I'm not sure if there is a way to make this a parameter so we don't need active merchant to hardcode a specific device type. @girasquid do you have any ideas?

Please review @girasquid @bizla 