### PR TITLE
MONEI: purchase method defaulted to options={}

### DIFF
--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object
-      def purchase(money, credit_card, options)
+      def purchase(money, credit_card, options={})
         execute_new_order(:purchase, money, credit_card, options)
       end
 


### PR DESCRIPTION
Default value for `purchase` method's `options` attribute was missing.