### PR TITLE
Akamai URL update

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
     # 5. Click Submit
     class AuthorizeNetCimGateway < Gateway
       self.test_url = 'https://apitest.authorize.net/xml/v1/request.api'
-      self.live_url = 'https://api.authorize.net/xml/v1/request.api'
+      self.live_url = 'https://api2.authorize.net/xml/v1/request.api'
 
       AUTHORIZE_NET_CIM_NAMESPACE = 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'
 


### PR DESCRIPTION
Authorize.NET sent out email to notify customers that they are switching to Akamai and that the new URL changes are api2 instead of api