### PR TITLE
[Bugfix] Stripe: Allow purchases with tokens without customer specification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Authorize.Net: Allow passing device type through options, make wireless POS the default [abecevello]
 * Authorize.Net: Update to new Akamai URL [taf2]
 * Braintree: Add hold_in_escrow [anellis]
+* Stripe: Allow purchases with tokens without customer specification [bizla]
 
 == Version 1.51.0 (July 2, 2015)
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -331,10 +331,12 @@ module ActiveMerchant #:nodoc:
         elsif creditcard.kind_of?(String)
           if options[:track_data]
             card[:swipe_data] = options[:track_data]
-          else
+          elsif creditcard.include?("|")
             customer_id, card_id = creditcard.split("|")
             card = card_id
             post[:customer] = customer_id
+          else
+            card = creditcard
           end
           post[:card] = card
         end
@@ -351,7 +353,7 @@ module ActiveMerchant #:nodoc:
       def add_customer(post, payment, options)
         if options[:customer] && !payment.respond_to?(:number)
           ActiveMerchant.deprecated "Passing the customer in the options is deprecated. Just use the response.authorization instead."
-          post[:customer] = options[:customer] 
+          post[:customer] = options[:customer]
         end
       end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -276,11 +276,21 @@ class StripeTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, @options)
   end
 
-  def test_successful_purchase_with_token
+  def test_successful_purchase_with_token_including_customer
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, "cus_xxx|card_xxx")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/customer=cus_xxx/, data)
+      assert_match(/card=card_xxx/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_token
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, "card_xxx")
+    end.check_request do |method, endpoint, data, headers|
       assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
 
@@ -486,6 +496,13 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_add_creditcard_with_token
+    post = {}
+    credit_card_token = "card_2iD4AezYnNNzkW"
+    @gateway.send(:add_creditcard, post, credit_card_token, {})
+    assert_equal "card_2iD4AezYnNNzkW", post[:card]
+  end
+
+  def test_add_creditcard_with_token_and_customer
     post = {}
     credit_card_token = "cus_3sgheFxeBgTQ3M|card_2iD4AezYnNNzkW"
     @gateway.send(:add_creditcard, post, credit_card_token, {})


### PR DESCRIPTION
This is a small fix to the changes introduced in https://github.com/activemerchant/active_merchant/commit/808a142691a3f452b07f275aeb1f96e4efe607cd, whereby if the payment was specified by a flat string without a `|`, it would be interpreted as the customer ID rather than the card token. 

This simply restores the previous default but includes the condition from https://github.com/activemerchant/active_merchant/commit/808a142691a3f452b07f275aeb1f96e4efe607cd.

@duff @aprofeit for review please. 