### PR TITLE
Redsys: Support AED, CZK, HUF, NOK, PLN, SEK and THB currencies

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -38,6 +38,7 @@ module ActiveMerchant #:nodoc:
       self.display_name        = "Redsys"
 
       CURRENCY_CODES = {
+        "AED" => '784',
         "ARS" => '32',
         "AUD" => '36',
         "BRL" => '986',
@@ -46,16 +47,22 @@ module ActiveMerchant #:nodoc:
         "CHF" => '756',
         "CLP" => '152',
         "COP" => '170',
+        "CZK" => '203',
         "EUR" => '978',
         "GBP" => '826',
         "GTQ" => '320',
+        "HUF" => '348',
         "JPY" => '392',
         "MYR" => '458',
         "MXN" => '484',
+        "NOK" => '578',
         "NZD" => '554',
         "PEN" => '604',
+        "PLN" => '616',
         "RUB" => '643',
+        "SEK" => '752',
         "SGD" => '702',
+        "THB" => '764',
         "USD" => '840',
         "UYU" => '858'
       }


### PR DESCRIPTION
Support following currencies:

* AED (United Arab Emirates Dirham)
* CZK (Czech Koruna)
* HUF (Hungarian Forint)
* NOK (Norwegian Krone)
* PLN (Polish Zloty)
* SEK (Swedish Krona)
* THB (Thai Baht)

Currency codes were set according to [CatalunyaCaixa's Spanish documentation](http://www.catalunyacaixa.com/docsdlv/Portal/Ficheros/Pdf/en/tpv_virtual_comercio_esp.pdf) ([English version](http://www.catalunyacaixa.com/docsdlv/Portal/Ficheros/Pdf/en/tpv_virtual_comercio_eng.pdf)).