### PR TITLE
Raven: update description, test url, and routing; fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The [ActiveMerchant Wiki](http://github.com/activemerchant/active_merchant/wikis
 * [Quantum Gateway](http://www.quantumgateway.com) - US
 * [QuickPay](http://quickpay.net/) - DE, DK, ES, FI, FR, FO, GB, IS, NO, SE
 * [Qvalent](https://www.qvalent.com/) - AU
-* [Raven PacNet](http://www.pacnetservices.com/) - US
+* [Raven](http://www.deepcovelabs.com/raven) - AI, AN, AT, AU, BE, BG, BS, BZ, CA, CH, CR, CY, CZ, DE, DK, DM, DO, EE, EL, ES, FI, FR, GB, GG, GI, HK, HR, HU, IE, IL, IM, IN, IT, JE, KN, LI, LT, LU, LV, MH, MT, MY, NL, NO, NZ, PA, PE, PH, PL, PT, RO, RS, SC, SE, SG, SI, SK, UK, US, VG, ZA
 * [Realex](http://www.realexpayments.com/) - IE, GB, FR, BE, NL, LU, IT
 * [Redsys](http://www.redsys.es/) - ES
 * [S5](http://www.s5.dk/) - DK

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         post = {}
         post['TrackingNumber'] = authorization
-        post['PymtType'] = options[:pymt_type] || 'cc_debit'
+        post['PymtType'] = options[:pymt_type]
 
         commit('void', nil, post)
       end

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -25,15 +25,15 @@ module ActiveMerchant #:nodoc:
         'cvv2_not_checked' => 'X'
       }
 
-      self.test_url = 'https://demo.deepcovelabs.com/realtime/'
-      self.live_url = 'https://raven.pacnetservices.com/realtime/'
+      self.test_url = 'https://raven.deepcovelabs.com/realtime/'
+      self.live_url = 'https://raven.deepcovelabs.com/realtime/'
 
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master]
       self.money_format = :cents
       self.default_currency = 'USD'
-      self.homepage_url = 'http://www.pacnetservices.com/'
-      self.display_name = 'Raven PacNet'
+      self.homepage_url = 'http://www.deepcovelabs.com/raven'
+      self.display_name = 'Raven'
 
       def initialize(options = {})
         requires!(options, :user, :secret, :prn)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -714,7 +714,7 @@ qvalent:
 raven_pac_net:
   user: ernest
   secret: "all good men die young"
-  prn: 840033
+  prn: 987743
 
 realex:
   login: X

--- a/test/remote/gateways/remote_pac_net_raven_test.rb
+++ b/test/remote/gateways/remote_pac_net_raven_test.rb
@@ -129,7 +129,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_purchase_and_void
     purchase = @gateway.purchase(@amount, @credit_card, @options)
-    assert void = @gateway.void(purchase.authorization, {:pymt_type =>  purchase.params['PymtType']})
+    assert void = @gateway.void(purchase.authorization)
     assert_success void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']
@@ -142,7 +142,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_authorize_and_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
-    assert void = @gateway.void(auth.authorization, {:pymt_type => auth.params['PymtType']})
+    assert void = @gateway.void(auth.authorization)
     assert_failure void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']
@@ -156,7 +156,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
   def test_authorize_capture_and_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert capture = @gateway.capture(@amount, auth.authorization)
-    assert void = @gateway.void(capture.authorization, {:pymt_type => capture.params['PymtType']})
+    assert void = @gateway.void(capture.authorization)
     assert_success void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']

--- a/test/remote/gateways/remote_pac_net_raven_test.rb
+++ b/test/remote/gateways/remote_pac_net_raven_test.rb
@@ -50,10 +50,10 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
     assert_equal "Invalid because the card expiry date (mmyy) \"0912\" is not a date in the future", purchase.params['Message']
   end
 
-  def test_declined_purchese
+  def test_declined_purchase
     assert purchase = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure purchase
-    assert_equal 'RepeatDeclined', purchase.message
+    assert_equal 'This transaction has been declined', purchase.message
   end
 
   def test_successful_authorization
@@ -96,7 +96,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
   def test_declined_authorization
     assert auth = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure auth
-    assert_equal 'RepeatDeclined', auth.message
+    assert_equal 'This transaction has been declined', auth.message
   end
 
   def test_successful_refund
@@ -142,7 +142,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_authorize_and_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
-    assert void = @gateway.void(auth.authorization)
+    assert void = @gateway.void(auth.authorization, {:pymt_type => auth.params['PymtType']})
     assert_failure void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']
@@ -156,15 +156,15 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
   def test_authorize_capture_and_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert capture = @gateway.capture(@amount, auth.authorization)
-    assert void = @gateway.void(capture.authorization, {:pymt_type =>  capture.params['PymtType']})
-    assert_failure void
+    assert void = @gateway.void(capture.authorization, {:pymt_type => capture.params['PymtType']})
+    assert_success void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']
-    assert_equal 'error:canNotBeVoided', void.params['ErrorCode']
+    assert_nil void.params['ErrorCode']
     assert_equal 'ok', void.params['RequestResult']
-    assert_equal "Error processing transaction because the payment may not be voided.", void.params['Message']
-    assert_equal 'Approved', void.params['Status']
-    assert_equal "Error processing transaction because the payment may not be voided.", void.message
+    assert_nil void.params['Message']
+    assert_equal 'Voided', void.params['Status']
+    assert_equal "This transaction has been voided", void.message
   end
 
   def test_successful_capture
@@ -185,11 +185,11 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
     assert_failure capture
     assert_nil capture.params['ApprovalCode']
     assert capture.params['TrackingNumber']
-    assert_equal 'invalid:PreAuthNumber', capture.params['ErrorCode']
-    assert_equal 'Invalid:PreauthNumber', capture.params['Status']
+    assert_equal 'rejected:UnknownPreauthNumber', capture.params['ErrorCode']
+    assert_equal 'Rejected:UnknownPreauthNumber', capture.params['Status']
     assert_equal 'ok', capture.params['RequestResult']
-    assert_equal "Error processing transaction because the pre-auth number \"0\" does not correspond to a pre-existing payment.", capture.params['Message']
-    assert capture.message.include?('Error processing transaction because the pre-auth number')
+    assert_equal 'Invalid because the preauthorization # does not exist', capture.params['Message']
+    assert_equal 'Invalid because the preauthorization # does not exist', capture.message
   end
 
   def test_insufficient_preauth_amount_capture
@@ -201,7 +201,7 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
     assert_equal 'rejected:PreauthAmountInsufficient', capture.params['ErrorCode']
     assert_equal 'Rejected:PreauthAmountInsufficient', capture.params['Status']
     assert_equal 'ok', capture.params['RequestResult']
-    assert_equal "Invalid because the preauthorization amount 100 is insufficient", capture.params['Message']
-    assert_equal 'Invalid because the preauthorization amount 100 is insufficient', capture.message
+    assert_equal 'Invalid because the preauthorization amount 100 is not identical to the amount to be settled', capture.params['Message']
+    assert_equal 'Invalid because the preauthorization amount 100 is not identical to the amount to be settled', capture.message
   end
 end


### PR DESCRIPTION
@girasquid @bizla this fixes remote integration tests for `pac_net_raven` and updates description to be less about "PacNet" since other entities out there use this as their gateway.

:bow: 

```
➜  active_merchant git:(fix_raven_remote_tests) bundle exec rake test:units TEST=test/unit/gateways/pac_net_raven_test.rb
Started
..........................................
Finished in 0.018617 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
42 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2256.00 tests/s, 7090.29 assertions/s

➜  active_merchant git:(fix_raven_remote_tests) bundle exec rake test:remote TEST=test/remote/gateways/remote_pac_net_raven_test.rb
Started
................
Finished in 26.262058 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
16 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.61 tests/s, 5.03 assertions/s
```