### PR TITLE
QuickPay v10: support 2-letter country codes

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -6,14 +6,14 @@ module ActiveMerchant
     class QuickpayV10Gateway < Gateway
       include QuickpayCommon
       API_VERSION = 10
-      
+
       self.live_url = self.test_url = 'https://api.quickpay.net'
-      
+
       def initialize(options = {})
         requires!(options, :api_key)
         super
       end
-      
+
       def purchase(money, credit_card, options = {})
         MultiResponse.run(true) do |r|
           r.process { create_payment(money, options) }
@@ -24,7 +24,7 @@ module ActiveMerchant
           }
         end
       end
-      
+
       def authorize(money, credit_card, options = {})
         MultiResponse.run(true) do |r|
           r.process { create_payment(money, options) }
@@ -34,7 +34,7 @@ module ActiveMerchant
           }
         end
       end
-      
+
       def void(identification)
         commit(synchronized_path "/payments/#{identification}/cancel")
       end
@@ -57,47 +57,47 @@ module ActiveMerchant
         add_additional_params(:refund, post, options)
         commit(synchronized_path("/payments/#{identification}/refund"), post)
       end
-      
+
       def store(credit_card, options = {})
-        MultiResponse.run(true) do |r|  
+        MultiResponse.run(true) do |r|
           r.process { create_subscription(options) }
-          r.process { 
-            authorize_subscription(r.authorization, credit_card, options) 
+          r.process {
+            authorize_subscription(r.authorization, credit_card, options)
           }
         end
       end
-      
+
       def unstore(identification)
         commit(synchronized_path "/subscriptions/#{identification}/cancel")
       end
-      
+
       private
-        
+
         def authorization_params(money, credit_card, options = {})
           post = {}
-          
+
           add_amount(post, money, options)
           add_credit_card(post, credit_card)
           add_additional_params(:authorize, post, options)
-          
+
           post
         end
-                
+
         def create_subscription(options = {})
-          post = {}  
-          
+          post = {}
+
           add_subscription_invoice(post, options)
           commit('/subscriptions', post)
         end
-        
+
         def authorize_subscription(identification, credit_card, options = {})
           post = {}
-          
+
           add_credit_card(post, credit_card, options)
           add_additional_params(:authorize_subscription, post, options)
           commit(synchronized_path("/subscriptions/#{identification}/authorize"), post)
         end
-        
+
         def create_payment(money, options = {})
           post = {}
           add_currency(post, money, options)
@@ -106,7 +106,7 @@ module ActiveMerchant
         end
 
         def commit(action, params = {})
-          success = false          
+          success = false
           begin
             response = parse(ssl_post(self.live_url + action, params.to_json, headers))
             success = successful?(response)
@@ -115,59 +115,59 @@ module ActiveMerchant
           rescue JSON::ParserError
             response = json_error(response)
           end
-                    
+
           Response.new(success, message_from(success, response), response,
             :test => test?,
             :authorization => response['id']
           )
         end
-        
+
         def add_subscription_invoice(post, options = {})
-          requires!(options, :order_id, :description)  
+          requires!(options, :order_id, :description)
           post[:order_id]    = options[:order_id]
           post[:description] = options[:description]
         end
-        
+
         def add_currency(post, money, options)
           post[:currency] = options[:currency] || currency(money)
         end
-        
+
         def add_amount(post, money, options)
           post[:amount] = amount(money)
         end
-        
+
         def add_autocapture(post, value)
-          post[:auto_capture] = value  
+          post[:auto_capture] = value
         end
-        
+
         def add_order_id(post, options)
-          requires!(options, :order_id)  
+          requires!(options, :order_id)
           post[:order_id] = options[:order_id]
         end
-        
+
         def add_invoice(post, options)
-          add_order_id(post, options)          
-          
+          add_order_id(post, options)
+
           if options[:billing_address]
             post[:invoice_address]  = map_address(options[:billing_address])
           end
-          
+
           if options[:shipping_address]
             post[:shipping_address] = map_address(options[:shipping_address])
           end
-          
+
           [:metadata, :brading_id, :variables].each do |field|
             post[field] = options[field] if options[field]
           end
         end
-        
+
         def add_additional_params(action, post, options = {})
           MD5_CHECK_FIELDS[API_VERSION][action].each do |key|
             key       = key.to_sym
             post[key] = options[key] if options[key]
           end
         end
-        
+
         def add_credit_card(post, credit_card, options = {})
           post[:card]             ||= {}
           post[:card][:number]     = credit_card.number
@@ -175,32 +175,33 @@ module ActiveMerchant
           post[:card][:expiration] = expdate(credit_card)
           post[:card][:issued_to]  = credit_card.name
         end
-          
+
         def parse(body)
           JSON.parse(body)
         end
-        
+
         def successful?(response)
           has_error    = response['errors']
           invalid_code = (response.key?('qp_status_code') and response['qp_status_code'] != "20000")
-          
+
           !(has_error || invalid_code)
         end
-                         
+
         def message_from(success, response)
           success ? 'OK' : (response['message'] || response['qp_status_msg'])
         end
-        
+
         def map_address(address)
           return {} if address.nil?
           requires!(address, :name, :address1, :city, :zip, :country)
+          country = Country.find(address[:country])
           mapped = {
             :name         => address[:name],
             :street       => address[:address1],
             :city         => address[:city],
             :region       => address[:address2],
             :zip_code     => address[:zip],
-            :country_code => address[:country]
+            :country_code => country.code(:alpha3)
           }
           mapped
         end
@@ -215,7 +216,7 @@ module ActiveMerchant
             "Content-Type"   => "application/json"
           }
         end
-        
+
         def response_error(raw_response)
           begin
             parse(raw_response)
@@ -229,12 +230,12 @@ module ActiveMerchant
           msg += "  (The raw response returned by the API was #{raw_response.inspect})"
           { "message" => msg }
         end
-        
+
         def synchronized_path(path)
           "#{path}?synchronized"
         end
-        
+
     end
-    
+
   end
 end


### PR DESCRIPTION
QuickPay v10 requires 3-letter country codes, but [the documentation on gateway.rb calls for 2-letter](https://github.com/activemerchant/active_merchant/blob/18987d4d599cf3fd7a7e781399d561d110150a5a/lib/active_merchant/billing/gateway.rb#L47); this removes a bunch of extra whitespace and also adds a mapping for that so the interface is consistent with the other gateways.

@aprofeit @ntalbott for review - open to suggestions on more tests to add.

I also left this potentially raising an exception for a country code being passed in that can't be found, vs. [what jetpay does](https://github.com/activemerchant/active_merchant/blob/18987d4d599cf3fd7a7e781399d561d110150a5a/lib/active_merchant/billing/gateways/jetpay.rb#L279) - thoughts?