### PR TITLE
Forte: Add gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -1,0 +1,245 @@
+require 'json'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class ForteGateway < Gateway
+      self.test_url = 'https://sandbox.forte.net/api/v2'
+      self.live_url = 'https://api.forte.net/v2'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'https://www.forte.net'
+      self.display_name = 'Forte'
+
+      def initialize(options={})
+        requires!(options, :api_key, :secret, :location_id, :account_id)
+        super
+      end
+
+      def purchase(money, payment_method, options={})
+        post = {}
+        add_amount(post, money, options)
+        add_payment_method(post, payment_method)
+        add_billing_address(post, options)
+        add_shipping_address(post, options)
+        post[:action] = "sale"
+
+        commit(:post, post)
+      end
+
+      def authorize(money, payment_method, options={})
+        post = {}
+        add_amount(post, money, options)
+        add_payment_method(post, payment_method)
+        add_billing_address(post, options)
+        add_shipping_address(post, options)
+        post[:action] = "authorize"
+
+        commit(:post, post)
+      end
+
+      def capture(money, authorization, options={})
+        post = {}
+        post[:transaction_id] = transaction_id_from(authorization)
+        post[:authorization_code] = authorization_code_from(authorization)
+        post[:action] = "capture"
+
+        commit(:put, post)
+      end
+
+      def credit(money, payment_method, options={})
+        post = {}
+        add_amount(post, money, options)
+        add_payment_method(post, payment_method)
+        add_billing_address(post, options)
+        post[:action] = "disburse"
+
+        commit(:post, post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        post[:transaction_id] = transaction_id_from(authorization)
+        post[:authorization_code] = authorization_code_from(authorization)
+        post[:action] = "void"
+
+        commit(:put, post)
+      end
+
+      def verify(credit_card, options={})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((account_number)\W+\d+), '\1[FILTERED]').
+          gsub(%r((card_verification_value)\W+\d+), '\1[FILTERED]')
+      end
+
+      private
+
+      def add_auth(post)
+        post[:account_id] = "act_#{@options[:account_id]}"
+        post[:location_id] = "loc_#{@options[:location_id]}"
+      end
+
+      def add_amount(post, money, options)
+        post[:authorization_amount] = amount(money)
+      end
+
+      def add_billing_address(post, options)
+        if address = options[:billing_address] || options[:address]
+          post[:billing_address] = {}
+          post[:billing_address][:first_name] = address[:name].split(" ").first if address[:name]
+          post[:billing_address][:last_name] = address[:name].split(" ").last if address[:name]
+          post[:billing_address][:address_line1] = address[:address1] if address[:address1]
+          post[:billing_address][:address_line2] = address[:address2] if address[:address2]
+          post[:billing_address][:address_country] = address[:country] if address[:country]
+          post[:billing_address][:address_zip] = address[:zip] if address[:zip]
+          post[:billing_address][:address_state] = address[:state] if address[:state]
+          post[:billing_address][:address_city] = address[:city] if address[:city]
+        end
+      end
+
+      def add_shipping_address(post, options)
+        return unless options[:shipping_address]
+        address = options[:shipping_address]
+
+        post[:shipping_address] = {}
+        post[:shipping_address][:first_name] = address[:name].split(" ").first if address[:name]
+        post[:shipping_address][:last_name] = address[:name].split(" ").last if address[:name]
+        post[:shipping_address][:address_line1] = address[:address1] if address[:address1]
+        post[:shipping_address][:address_line2] = address[:address2] if address[:address2]
+        post[:shipping_address][:address_country] = address[:country] if address[:country]
+        post[:shipping_address][:address_zip] = address[:zip] if address[:zip]
+        post[:shipping_address][:address_state] = address[:state] if address[:state]
+        post[:shipping_address][:address_city] = address[:city] if address[:city]
+      end
+
+      def add_payment_method(post, payment_method)
+        if payment_method.respond_to?(:brand)
+          add_credit_card(post, payment_method)
+        else
+          add_echeck(post, payment_method)
+        end
+      end
+
+      def add_echeck(post, payment)
+        post[:echeck] = {}
+        post[:echeck][:account_holder] = payment.name
+        post[:echeck][:account_number] = payment.account_number
+        post[:echeck][:routing_number] = payment.routing_number
+        post[:echeck][:account_type] = payment.account_type
+        post[:echeck][:check_number] = payment.number
+      end
+
+      def add_credit_card(post, payment)
+        post[:card] = {}
+        post[:card][:card_type] = format_card_brand(payment.brand)
+        post[:card][:name_on_card] = payment.name
+        post[:card][:account_number] = payment.number
+        post[:card][:expire_month] = payment.month
+        post[:card][:expire_year] = payment.year
+        post[:card][:card_verification_value] = payment.verification_value
+      end
+
+      def commit(type, parameters)
+        add_auth(parameters)
+
+        url = (test? ? test_url : live_url)
+        response = parse(handle_resp(raw_ssl_request(type, url + endpoint, parameters.to_json, headers)))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response["response"]["avs_result"]),
+          cvv_result: CVVResult.new(response["response"]["cvv_code"]),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def handle_resp(response)
+        case response.code.to_i
+        when 200..499
+          response.body
+        else
+          raise ResponseError.new(response)
+        end
+      end
+
+      def parse(response_body)
+        JSON.parse(response_body)
+      end
+
+      def success_from(response)
+        response["response"]["response_code"] == "A01"
+      end
+
+      def message_from(response)
+        response["response"]["response_desc"]
+      end
+
+      def authorization_from(response)
+        [response["transaction_id"], response["authorization_code"]].join("#")
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          response["response"]["response_code"]
+        end
+      end
+
+      def endpoint
+        "/accounts/act_#{@options[:account_id]}/locations/loc_#{@options[:location_id]}/transactions/"
+      end
+
+      def headers
+        {
+          'Authorization' => ("Basic " + Base64.strict_encode64("#{@options[:api_key]}:#{@options[:secret]}")),
+          'X-Forte-Auth-Account-Id' => "act_#{@options[:account_id]}",
+          'Content-Type' => 'application/json'
+        }
+      end
+
+      def format_card_brand(card_brand)
+        case card_brand
+        when 'visa'
+          return 'visa'
+        when 'master'
+          return 'mast'
+        when 'american_express'
+          return 'amex'
+        when 'discover'
+          return 'disc'
+        end
+      end
+
+      def split_authorization(authorization)
+        authorization.split("#")
+      end
+
+      def authorization_code_from(authorization)
+        _, authorization_code = split_authorization(authorization)
+        authorization_code
+      end
+
+      def transaction_id_from(authorization)
+        transaction_id, _ = split_authorization(authorization)
+        transaction_id
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -257,6 +257,12 @@ flo2cash_simple:
   password: ANOTHERCREDENTIAL
   account_id: ANOTHERCREDENTIAL
 
+forte:
+  location_id: "176008"
+  account_id: "300111"
+  api_key: "f087a90f00f0ae57050c937ed3815c9f"
+  secret: "d793d64064e3113a74fa72035cfc3a1d"
+
 garanti:
   login: "PROVAUT"
   terminal_id: 111995

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -1,0 +1,180 @@
+require 'test_helper'
+
+class RemoteForteTest < Test::Unit::TestCase
+  def setup
+    @gateway = ForteGateway.new(fixtures(:forte))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+    @declined_card = credit_card('1111111111111111')
+
+    @check = check
+    @bad_check = check({
+      :name => 'Jim Smith',
+      :bank_name => 'Bank of Elbonia',
+      :routing_number => '1234567890',
+      :account_number => '0987654321',
+      :account_holder_type => '',
+      :account_type => 'checking',
+      :number => '0'
+    })
+
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_invalid_login
+    gateway = ForteGateway.new(api_key: "InvalidKey", secret: "InvalidSecret", location_id: "11", account_id: "323")
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "UserName and Password combination not found.", response.message
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'TEST APPROVAL', response.message
+  end
+
+  def test_successful_purchase_with_echeck
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_failed_purchase_with_echeck
+    response = @gateway.purchase(@amount, @bad_check, @options)
+    assert_failure response
+    assert_equal 'INVALID TRN', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com",
+      address: address
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'TEST APPROVAL', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'INVALID CREDIT CARD NUMBER', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    wait_for_authorization_to_clear
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'APPROVED', capture.message
+  end
+
+  def test_failed_authorize
+    @amount = 1985
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'INVALID CREDIT CARD NUMBER', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    wait_for_authorization_to_clear
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'The field transaction_id is required.', response.message
+  end
+
+  def test_successful_credit
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.credit(@amount, @credit_card, @options)
+    assert_success refund
+    assert_equal 'TEST APPROVAL', refund.message
+  end
+
+  def test_partial_credit
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.credit(@amount-1, @credit_card, @options)
+    assert_success refund
+  end
+
+  def test_failed_credit
+    response = @gateway.credit(@amount, @declined_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    wait_for_authorization_to_clear
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'APPROVED', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'The field transaction_id is required.', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{TEST APPROVAL}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{INVALID CREDIT CARD NUMBER}, response.message
+  end
+
+  def test_transcript_scrubbing
+    # We need to use a different default value for the cvc because
+    # Forte tends to return 123456 for the authorization code which
+    # makes the assert_scrubbed fail for cvc since the transcript
+    # does indeed include "123" somewhere in the string
+    @credit_card.verification_value = 789
+
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+  end
+
+  private
+
+  def wait_for_authorization_to_clear
+    sleep(5)
+  end
+
+end

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -1,0 +1,523 @@
+require 'test_helper'
+
+class ForteTest < Test::Unit::TestCase
+  def setup
+    @gateway = ForteGateway.new(location_id: 'location_id', account_id: 'account_id', api_key: 'api_key', secret: 'secret')
+    @credit_card = credit_card
+    @check = check
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:handle_resp).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'trn_bb7687a7-3d3a-40c2-8fa9-90727a814249#123456', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:handle_resp).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "U20", response.error_code
+  end
+
+  def test_successful_purchase_with_echeck
+    @gateway.expects(:handle_resp).returns(successful_echeck_purchase_response)
+
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+
+    assert_equal 'trn_bb7687a7-3d3a-40c2-8fa9-90727a814249#123456', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase_with_echeck
+    @gateway.expects(:handle_resp).returns(failed_echeck_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "U19", response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:handle_resp).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:handle_resp).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "U20", response.error_code
+  end
+
+  def test_successful_capture
+    @gateway.expects(:handle_resp).returns(successful_capture_response)
+
+    response = @gateway.capture(@amount, "authcode")
+    assert_success response
+  end
+
+  def test_failed_capture
+    @gateway.expects(:handle_resp).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, "authcode")
+    assert_failure response
+  end
+
+  def test_successful_credit
+    @gateway.expects(:handle_resp).returns(successful_credit_response)
+
+    response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_credit
+    @gateway.expects(:handle_resp).returns(failed_credit_response)
+
+    response = @gateway.credit(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_void
+    @gateway.expects(:handle_resp).returns(successful_credit_response)
+
+    response = @gateway.void("authcode")
+    assert_success response
+  end
+
+  def test_failed_void
+    @gateway.expects(:handle_resp).returns(failed_credit_response)
+
+    response = @gateway.void("authcode")
+    assert_failure response
+  end
+
+  def test_successful_verify
+    @gateway.expects(:handle_resp).times(2).returns(successful_authorize_response, successful_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    @gateway.expects(:handle_resp).times(2).returns(successful_authorize_response, failed_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_verify
+    @gateway.expects(:handle_resp).returns(failed_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+<- "POST /api/v2/accounts/act_300111/locations/loc_176008/transactions/ HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic ZjA4N2E5MGYwMGYwYWU1NzA1MGM5MzdlZDM4MTVjOWY6ZDc5M2Q2NDA2NGUzMTEzYTc0ZmE3MjAzNWNmYzNhMWQ=\r\nX-Forte-Auth-Account-Id: act_300111\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.forte.net\r\nContent-Length: 471\r\n\r\n"
+<- "{\"authorization_amount\":\"1.00\",\"card\":{\"card_type\":\"visa\",\"name_on_card\":\"Longbob Longsen\",\"account_number\":\"4000100011112224\",\"expire_month\":9,\"expire_year\":2016,\"card_verification_value\":\"123\"},\"billing_address\":{\"first_name\":\"Jim\",\"last_name\":\"Smith\",\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"address_country\":\"CA\",\"address_zip\":\"K1C2N6\",\"address_state\":\"ON\",\"address_city\":\"Ottawa\"},\"action\":\"sale\",\"account_id\":\"act_300111\",\"location_id\":\"loc_176008\"}"
+    )
+  end
+
+  def post_scrubbed
+    %q(
+<- "POST /api/v2/accounts/act_300111/locations/loc_176008/transactions/ HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]=\r\nX-Forte-Auth-Account-Id: act_300111\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.forte.net\r\nContent-Length: 471\r\n\r\n"
+<- "{\"authorization_amount\":\"1.00\",\"card\":{\"card_type\":\"visa\",\"name_on_card\":\"Longbob Longsen\",\"account_number[FILTERED]\",\"expire_month\":9,\"expire_year\":2016,\"card_verification_value[FILTERED]\"},\"billing_address\":{\"first_name\":\"Jim\",\"last_name\":\"Smith\",\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"address_country\":\"CA\",\"address_zip\":\"K1C2N6\",\"address_state\":\"ON\",\"address_city\":\"Ottawa\"},\"action\":\"sale\",\"account_id\":\"act_300111\",\"location_id\":\"loc_176008\"}"
+    )
+  end
+
+  def successful_purchase_response
+    %q(
+      {
+        "transaction_id":"trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount":1.0,
+        "authorization_code":"123456",
+        "billing_address":{
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_purchase_response
+    %q(
+      {
+        "transaction_id":"trn_e9ea64c4-5c2c-43dd-9138-f2661b59947c",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount":1.0,
+        "billing_address": {
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****1111",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "environment":"sandbox",
+          "response_type":"D",
+          "response_code":"U20",
+          "response_desc": "INVALID TRN"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_e9ea64c4-5c2c-43dd-9138-f2661b59947c",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_e9ea64c4-5c2c-43dd-9138-f2661b59947c/settlements"
+        }
+      }
+    )
+  end
+
+  def successful_echeck_purchase_response
+    %q(
+      {
+        "transaction_id":"trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount":1.0,
+        "authorization_code":"123456",
+        "billing_address":{
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "echeck": {
+          "account_holder": "Jim Smith",
+          "masked_account_number":"****8535",
+          "routing_number":"244183602",
+          "account_type":"checking",
+          "check_number":"1"
+        },
+        "echeck": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_echeck_purchase_response
+    %q(
+      {
+        "transaction_id":"trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount":1.0,
+        "authorization_code":"123456",
+        "billing_address":{
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "echeck": {
+          "account_holder": "Jim Smith",
+          "masked_account_number":"****8535",
+          "routing_number":"244183602",
+          "account_type":"checking",
+          "check_number":"1"
+        },
+        "echeck": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "environment":"sandbox",
+          "response_type":"D",
+          "response_code":"U19",
+          "response_desc":"INVALID CREDIT CARD NUMBER"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249/settlements"
+        }
+      }
+    )
+  end
+
+  def successful_authorize_response
+    %q(
+      {
+        "transaction_id":"trn_527fdc8a-d3d0-4680-badc-bfa784c63c13",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"authorize",
+        "authorization_amount":1.0,
+        "authorization_code":"123456",
+        "billing_address": {
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
+        },
+        "links":{
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_527fdc8a-d3d0-4680-badc-bfa784c63c13",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_527fdc8a-d3d0-4680-badc-bfa784c63c13/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_authorize_response
+    %q(
+      {
+        "transaction_id":"trn_7c045645-98b3-4c8a-88d6-e8d686884564",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"authorize",
+        "authorization_amount":19.85,
+        "billing_address": {
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****1111",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response":{
+          "environment":"sandbox",
+          "response_type":"D",
+          "response_code":"U20",
+          "response_desc":"INVALID CREDIT CARD NUMBER"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_7c045645-98b3-4c8a-88d6-e8d686884564",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_7c045645-98b3-4c8a-88d6-e8d686884564/settlements"
+        }
+      }
+    )
+  end
+
+  def successful_capture_response
+    %q(
+      {
+        "transaction_id":"trn_94a04a97-c847-4420-820b-fb153a1f0f64",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "original_transaction_id":"trn_e5e3b23d-3e13-44d4-bce1-4b9aaa466a5d",
+        "action":"capture",
+        "authorization_code":"13844235",
+        "response": {
+          "authorization_code":"13844235",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"APPROVED"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_94a04a97-c847-4420-820b-fb153a1f0f64",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_94a04a97-c847-4420-820b-fb153a1f0f64/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_capture_response
+    %q(
+      {
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"capture",
+        "authorization_code":"",
+        "response":{
+          "environment":"sandbox",
+          "response_desc":"The field transaction_id is required."
+        }
+      }
+    )
+  end
+
+  def successful_credit_response
+    %q(
+      {
+        "transaction_id":"trn_357b284e-1dde-42ba-b0a5-5f66e08c7d9f",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"disburse",
+        "authorization_amount":1.0,
+        "authorization_code":"123456",
+        "billing_address": {
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_357b284e-1dde-42ba-b0a5-5f66e08c7d9f",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_357b284e-1dde-42ba-b0a5-5f66e08c7d9f/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_credit_response
+    %q(
+      {
+        "transaction_id":"trn_ce70ce9a-6265-4892-9a83-5825cb869ed5",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"disburse",
+        "authorization_amount":1.0,
+        "billing_address": {
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "response": {
+          "environment":"sandbox",
+          "response_type":"E",
+          "response_code":"F01",
+          "response_desc":"MANDITORY FIELD MISSING:card.card_type,MANDITORY FIELD MISSING:card.account_number,MANDITORY FIELD MISSING:card.expire_year,MANDITORY FIELD MISSING:card.expire_month"
+          },
+          "links": {
+            "self":"https://sandbox.forte.net/API/v2/transactions/trn_ce70ce9a-6265-4892-9a83-5825cb869ed5",
+            "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_ce70ce9a-6265-4892-9a83-5825cb869ed5/settlements"
+          }
+        }
+    )
+  end
+
+  def successful_void_response
+    %q(
+      {
+        "transaction_id":"trn_6c9d049e-1971-45fb-a4da-a0c35c4ed274",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"void",
+        "authorization_code":"13802096",
+        "response": {
+          "authorization_code":"13802096",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"APPROVED"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_6c9d049e-1971-45fb-a4da-a0c35c4ed274",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_6c9d049e-1971-45fb-a4da-a0c35c4ed274/settlements"
+        }
+      }
+    )
+  end
+
+  def failed_void_response
+    %q(
+      {
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"void",
+        "authorization_code":"",
+        "response": {
+          "environment":"sandbox",
+          "response_desc":"The field transaction_id is required."
+        }
+      }
+    )
+  end
+end


### PR DESCRIPTION
@duff adding the Forte gateway. It has a few quirks, so let me know if you have any thoughts on these:

1. All failures respond with a 4xx HTTP response code, so I did an override of the `handle_response` method originally in `posts_data.rb`. I'm not sure if this was the best way to go, but it seemed as though errors like a declined card shouldn't raise an `ActiveMerchant::ResponseError`? It didn't seem like a response error to me and more of a "processing error"?

2. If you run the tests, unfortunately sometimes you may get a `401 Unauthorized` on some requests. But then other times it'll pass. While testing, I noticed that adding a `sleep(5)` helped with the remote tests passing more often so that's why those are there. Really meh but there's something strange going on with their API that most of the time you'll get failures unless you wait a few seconds between some API calls- like an authorize and capture.

3. There's no refund. Just credit which requires the credit card to be submitted in the request.

4. I symbolized the response keys, but I'm not sure if that's generally not good practice. Not a quirk, but something I did that I thought I'd see if it was not really inline with how most AM adapters work.