### PR TITLE
QuickPay: use the value of the alpha3 country code, instead of trying to include the full object

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -201,7 +201,7 @@ module ActiveMerchant
             :city         => address[:city],
             :region       => address[:address2],
             :zip_code     => address[:zip],
-            :country_code => country.code(:alpha3)
+            :country_code => country.code(:alpha3).value
           }
           mapped
         end


### PR DESCRIPTION
@aprofeit @ivanfer 

Open to suggestions on how best to test this - as far as I can tell the remote test that I added in [the previous PR](https://github.com/activemerchant/active_merchant/pull/1805) shouldn't have been passing, because when I dumped the request the country code was being passed in as a string representation of the entire [CountryCode object](https://github.com/activemerchant/active_merchant/blob/fdace518c3e30ee9e248219b926f2cf26f2ed4f5/lib/active_merchant/country.rb#L10).