### PR TITLE
BraintreeBlue: Use wiredump_device for logging only if present

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
 
         super
 
-        if wiredump_device
+        if wiredump_device.present?
           logger = ((Logger === wiredump_device) ? wiredump_device : Logger.new(wiredump_device))
           logger.level = Logger::DEBUG
         else


### PR DESCRIPTION
This commit fixes some integration tests which were broken by a [previous commit](https://github.com/activemerchant/active_merchant/commit/38ca394d42a55b9dae87598c0c2dec20e00a0e7a). Specifically, all tests in `remote_braintree_blue_test.rb` which run after [this test](https://github.com/activemerchant/active_merchant/commit/38ca394d42a55b9dae87598c0c2dec20e00a0e7a#diff-d3e31ce1d7cbbc102d604bd1b6642dc2R605) fail, without this commit.