### PR TITLE
USA ePay advanced: added quickUpdateCustomer API call

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -348,27 +348,69 @@ module ActiveMerchant #:nodoc:
       #  * Same as add_customer
       #
       def update_customer(options={})
+        ActiveMerchant.deprecated "update_customer is deprecated and will be removed from a future release of ActiveMerchant. Please use update instead."
         requires! options, :customer_number
 
         request = build_request(__method__, options)
         commit(__method__, request)
       end
 
-      # Update a customer by changing only a few fields.
+      # Update a customer by replacing either all of the customer details or changing only a few fields
+      #
       #
       # ==== Required
       # * <tt>:customer_number</tt> -- customer to update
       #
+      # 
+      # To update only a few fields use this set of options
+      #
       # ==== Options
       # * <tt>:fields</tt> -- array of 2 element long arrays representing FieldValue object
       #   * <tt>:Field</tt> -- name of the field
-      #   * <tt>:Value</tt> -- field value
+      #   * <tt>:Value</tt> -- field value 
       #
-      def quick_update_customer(options={})
-        requires! options, :customer_number
+      # To replace customer details use this set of options
+      #
+      # ==== Options
+      # * <tt>:id</tt> -- merchant assigned id
+      # * <tt>:notes</tt> -- notes about customer
+      # * <tt>:data</tt> -- base64 data about customer
+      # * <tt>:url</tt> -- customer website
+      # * <tt>:billing_address</tt> -- usual options
+      # * <tt>:payment_methods</tt> -- array of payment method hashes.
+      #   * <tt>:method</tt> -- credit_card or check
+      #   * <tt>:name</tt> -- optional name/label for the method
+      #   * <tt>:sort</tt> -- optional integer value specifying the backup sort order, 0 is default
+      #
+      # ==== Recurring Options
+      # * <tt>:enabled</tt> -- +true+ enables recurring
+      # * <tt>:schedule</tt> -- daily, weekly, bi-weekly (every two weeks), monthly, bi-monthly (every two months), quarterly, bi-annually (every six months), annually, first of month, last day of month
+      # * <tt>:number_left</tt> -- number of payments left; -1 for unlimited
+      # * <tt>:next</tt> -- date of next payment (Date/Time)
+      # * <tt>:amount</tt> -- amount of recurring payment
+      # * <tt>:tax</tt> -- tax portion of amount
+      # * <tt>:currency</tt> -- numeric currency code
+      # * <tt>:description</tt> -- description of transaction
+      # * <tt>:order_id</tt> -- transaction order id
+      # * <tt>:user</tt> -- merchant username assigned to transaction
+      # * <tt>:source</tt> -- name of source key assigned to billing
+      # * <tt>:send_receipt</tt> -- +true+ to send client a receipt
+      # * <tt>:receipt_note</tt> -- leave a note on the receipt
+      #
+      # ==== Point of Sale Options
+      # * <tt>:price_tier</tt> -- name of customer price tier
+      # * <tt>:tax_class</tt> -- tax class
+      # * <tt>:lookup_code</tt> -- lookup code from customer/member id card; barcode or magnetic stripe; can be assigned by merchant; defaults to system assigned if blank
+      #
+      # ==== Response
+      # * <tt>#message</tt> -- customer number assigned by gateway
 
-        request = build_request(__method__, options)
-        commit(__method__, request)
+      def update(options={})
+        if options[:fields].blank?
+          update_customer(options)
+        else
+          quick_update_customer(options)
+        end
       end
 
       # Enable a customer for recurring billing.
@@ -961,6 +1003,15 @@ module ActiveMerchant #:nodoc:
       # Builders ======================================================
 
       private
+
+      #there is wrapper method named update that wraps this method and update_customer into one method
+      #update_customer is still public but is going to be deprecated.
+      def quick_update_customer(options={})
+        requires! options, :customer_number
+
+        request = build_request(__method__, options)
+        commit(__method__, request)
+      end
 
       # Build soap header, etc.
       def build_request(action, options = {})

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -406,7 +406,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>#message</tt> -- customer number assigned by gateway
 
       def update(identifier, options={})
-        options[customer_number] = identifier
+        options.merge!(customer_number: identifier)
         if options[:fields].blank?
           update_customer(options)
         else

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -358,8 +358,8 @@ module ActiveMerchant #:nodoc:
       # Update a customer by replacing either all of the customer details or changing only a few fields
       #
       #
-      # ==== Required
-      # * <tt>:customer_number</tt> -- customer to update
+      # ==== Identifier
+      # * <tt>:identifier</tt> -- customer number of the customer to be updated
       #
       # 
       # To update only a few fields use this set of options
@@ -405,7 +405,8 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- customer number assigned by gateway
 
-      def update(options={})
+      def update(identifier, options={})
+        options[customer_number] = identifier
         if options[:fields].blank?
           update_customer(options)
         else

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -175,7 +175,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     customer_number = response.params['add_customer_return']
 
     @options.merge!(@update_customer_options.merge!(:customer_number => customer_number))
-    response = @gateway.update_customer(@options)
+    response = @gateway.update(@options)
     assert response.params['update_customer_return']
   end
 
@@ -183,7 +183,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.quick_update_customer(customer_number: customer_number, fields: @quick_update_customer_options)
+    response = @gateway.update(customer_number: customer_number, fields: @quick_update_customer_options)
 
     assert response.params['quick_update_customer_return']
   end

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -62,6 +62,10 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
       :notes => "NEW NOTE!"
     }
 
+    @quick_update_customer_options = {
+      :notes => "QUICK UPDATE NOTE!"
+    }
+
     @add_payment_options = {
       :make_default => true,
       :payment_method => {
@@ -173,6 +177,15 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@update_customer_options.merge!(:customer_number => customer_number))
     response = @gateway.update_customer(@options)
     assert response.params['update_customer_return']
+  end
+
+  def test_quick_update_customer
+    response = @gateway.add_customer(@options.merge(@customer_options))
+    customer_number = response.params['add_customer_return']
+
+    response = @gateway.quick_update_customer(customer_number: customer_number, fields: @quick_update_customer_options)
+
+    assert response.params['quick_update_customer_return']
   end
 
   def test_enable_disable_customer

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -174,8 +174,8 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    @options.merge!(@update_customer_options.merge!(:customer_number => customer_number))
-    response = @gateway.update(@options)
+    @options.merge!(@update_customer_options)
+    response = @gateway.update(customer_number, @options)
     assert response.params['update_customer_return']
   end
 
@@ -183,7 +183,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.update(customer_number: customer_number, fields: @quick_update_customer_options)
+    response = @gateway.update(customer_number, {fields: @quick_update_customer_options})
 
     assert response.params['quick_update_customer_return']
   end

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -195,7 +195,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@customer_options)
     @gateway.expects(:ssl_post).returns(successful_customer_response('updateCustomer'))
 
-    assert response = @gateway.update(@options)
+    assert response = @gateway.update(@options[:customer_number], @options)
     assert_instance_of Response, response
     assert response.test?
     assert_success response
@@ -207,7 +207,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@customer_options)
     @gateway.expects(:ssl_post).returns(successful_quick_update_customer_response('quickUpdateCustomer'))
 
-    assert response = @gateway.update(customer_number: @options[:customer_number], fields: @quick_update_customer_options)
+    assert response = @gateway.update(@options[:customer_number], fields: @quick_update_customer_options)
     assert_instance_of Response, response
     assert response.test?
     assert_success response

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -63,6 +63,10 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
       :payment_methods => payment_methods # optional
     }
 
+    @quick_update_customer_options = [
+          [:notes, "Quick note about customer"]
+    ]
+
     @payment_options = {
       :payment_method => payment_method
     }
@@ -192,6 +196,18 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_customer_response('updateCustomer'))
 
     assert response = @gateway.update_customer(@options)
+    assert_instance_of Response, response
+    assert response.test?
+    assert_success response
+    assert_equal 'true', response.message
+    assert_nil response.authorization
+  end
+
+  def test_successful_quick_update_customer
+    @options.merge!(@customer_options)
+    @gateway.expects(:ssl_post).returns(successful_quick_update_customer_response('quickUpdateCustomer'))
+
+    assert response = @gateway.quick_update_customer(customer_number: @options[:customer_number], fields: @quick_update_customer_options)
     assert_instance_of Response, response
     assert response.test?
     assert_success response
@@ -617,6 +633,12 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
   end
 
   def successful_customer_response(method)
+    <<-XML
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:usaepay" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:#{method}Response><#{method}Return xsi:type="xsd:boolean">true</#{method}Return></ns1:#{method}Response></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    XML
+  end
+
+  def successful_quick_update_customer_response(method)
     <<-XML
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:usaepay" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:#{method}Response><#{method}Return xsi:type="xsd:boolean">true</#{method}Return></ns1:#{method}Response></SOAP-ENV:Body></SOAP-ENV:Envelope>
     XML

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -195,7 +195,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@customer_options)
     @gateway.expects(:ssl_post).returns(successful_customer_response('updateCustomer'))
 
-    assert response = @gateway.update_customer(@options)
+    assert response = @gateway.update(@options)
     assert_instance_of Response, response
     assert response.test?
     assert_success response
@@ -207,7 +207,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@customer_options)
     @gateway.expects(:ssl_post).returns(successful_quick_update_customer_response('quickUpdateCustomer'))
 
-    assert response = @gateway.quick_update_customer(customer_number: @options[:customer_number], fields: @quick_update_customer_options)
+    assert response = @gateway.update(customer_number: @options[:customer_number], fields: @quick_update_customer_options)
     assert_instance_of Response, response
     assert response.test?
     assert_success response


### PR DESCRIPTION
Added a missing call to "quickUpdateCustomer" on USA ePay Advanced gateway, since it was missing in original implementation of usa_epay_advanced.rb. Unit/remote tests added to corresponding files.