### PR TITLE
USAePay: Add test mode setting via options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Braintree: Update country list [duff]
 * NMI: Don't include dup_seconds if nil [rwdaigle]
 * QuickPay: Make all operations to v10 platform synchronous [ta]
+* USAePay: Add test mode setting via options [marquisong] 
 
 == Version 1.52.0 (July 20, 2015)
 

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -42,6 +42,12 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_extra_test_mode
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:test_mode => true))
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
   def test_unsuccessful_purchase
     # For some reason this will fail with "You have tried this card too
     # many times, please contact merchant" unless a unique order id is

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -58,10 +58,20 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match(/UMinvoice=1337/, data)
       assert_match(/UMdescription=socool/, data)
+      assert_match(/UMtestmode=0/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
   end
 
+  def test_successful_purchase_passing_extra_test_mode
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(:test_mode => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMtestmode=1/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+  
   def test_successful_purchase_split_payment
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(
@@ -98,6 +108,119 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_request
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '65074409', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_authorize_passing_extra_info
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(:order_id => "1337", :description => "socool"))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMinvoice=1337/, data)
+      assert_match(/UMdescription=socool/, data)
+      assert_match(/UMtestmode=0/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_successful_authorize_passing_extra_test_mode
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(:test_mode => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMtestmode=1/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_successful_capture_request
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+
+    response = @gateway.capture(@amount, '65074409', @options)
+    assert_success response
+    assert_equal '65074409', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_capture_passing_extra_info
+    response = stub_comms do
+      @gateway.capture(@amount, '65074409', @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMamount=1.00/, data)
+      assert_match(/UMtestmode=0/, data)
+    end.respond_with(successful_capture_response)
+    assert_success response
+  end
+
+  def test_successful_capture_passing_extra_test_mode
+    response = stub_comms do
+      @gateway.capture(@amount, '65074409', @options.merge(:test_mode => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMtestmode=1/, data)
+    end.respond_with(successful_capture_response)
+    assert_success response
+  end
+
+  def test_successful_refund_request
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    response = @gateway.refund(@amount, '65074409', @options)
+    assert_success response
+    assert_equal '63813138', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_refund_passing_extra_info
+    response = stub_comms do
+      @gateway.refund(@amount, '65074409', @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMamount=1.00/, data)
+      assert_match(/UMtestmode=0/, data)
+    end.respond_with(successful_refund_response)
+    assert_success response
+  end
+
+  def test_successful_refund_passing_extra_test_mode
+    response = stub_comms do
+      @gateway.refund(@amount, '65074409', @options.merge(:test_mode => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMtestmode=1/, data)
+    end.respond_with(successful_refund_response)
+    assert_success response
+  end
+
+  def test_successful_void_request
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    response = @gateway.void('65074409', @options)
+    assert_success response
+    assert_equal '63812270', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_void_passing_extra_info
+    response = stub_comms do
+      @gateway.void('65074409', @options.merge(:no_release => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMcommand=cc%3Avoid/, data)
+      assert_match(/UMtestmode=0/, data)
+    end.respond_with(successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_void_passing_extra_test_mode
+    response = stub_comms do
+      @gateway.refund(@amount, '65074409', @options.merge(:test_mode => true))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMtestmode=1/, data)
+    end.respond_with(successful_void_response)
+    assert_success response
+  end
+
   def test_address_key_prefix
     assert_equal 'bill', @gateway.send(:address_key_prefix, :billing)
     assert_equal 'ship', @gateway.send(:address_key_prefix, :shipping)
@@ -128,6 +251,24 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     assert_address(:shipping, post)
     assert_address(:billing, post)
     assert_equal 20, post.keys.size
+  end
+
+  def test_add_test_mode_without_test_mode_option
+    post = {}
+    @gateway.send(:add_test_mode, post, {})
+    assert_nil post[:testmode]
+  end
+
+  def test_add_test_mode_with_true_test_mode_option
+    post = {}
+    @gateway.send(:add_test_mode, post, :test_mode => true)
+    assert_equal 1, post[:testmode]
+  end
+
+  def test_add_test_mode_with_false_test_mode_option
+    post = {}
+    @gateway.send(:add_test_mode, post, :test_mode => false)
+    assert_equal 0, post[:testmode]
   end
 
   def test_amount_style
@@ -243,5 +384,21 @@ private
 
   def unsuccessful_purchase_response
     "UMversion=2.9&UMstatus=Declined&UMauthCode=000000&UMrefNum=55076060&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=Y&UMcvv2Result=Not%20Processed&UMcvv2ResultCode=P&UMvpasResultCode=&UMresult=D&UMerror=Card%20Declined&UMerrorcode=10127&UMbatch=596&UMfiller=filled"
+  end
+  
+  def successful_authorize_response
+    "UMversion=2.9&UMstatus=Approved&UMauthCode=101716&UMrefNum=65074409&UMavsResult=Address%3A%20Match%20%26%205%20Digit%20Zip%3A%20Match&UMavsResultCode=Y&UMcvv2Result=Match&UMcvv2ResultCode=M&UMresult=A&UMvpasResultCode=&UMerror=Approved&UMerrorcode=00000&UMcustnum=&UMbatch=596&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMfiller=filled"
+  end
+
+  def successful_capture_response
+    "UMversion=2.9&UMstatus=Approved&UMauthCode=101716&UMrefNum=65074409&UMavsResult=No%20AVS%20response%20%28Typically%20no%20AVS%20data%20sent%20or%20swiped%20transaction%29&UMavsResultCode=&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=Approved&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMfiller=filled"
+  end
+
+  def successful_refund_response
+    "UMversion=2.9&UMstatus=Approved&UMauthCode=101716&UMrefNum=63813138&UMavsResult=Unmapped%20AVS%20response%20%28%20%20%20%29&UMavsResultCode=%20%20%20&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=1.00&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMfiller=filled"
+  end
+
+  def successful_void_response
+    "UMversion=2.9&UMstatus=Approved&UMauthCode=&UMrefNum=63812270&UMavsResult=No%20AVS%20response%20%28Typically%20no%20AVS%20data%20sent%20or%20swiped%20transaction%29&UMavsResultCode=&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=Transaction%20Voided%20Successfully&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMfiller=filled"
   end
 end


### PR DESCRIPTION
This PR adds the ability to set test_mode flag via options for USAePay Transaction. As a result, it allows the passing of test mode flag over to USAePay for the purpose of simulating a transaction without actually processing the transaction.
Documentation on this field(UMtestmode) can be found at https://wiki.usaepay.com/merchant/epaymentform, under Developer Reference > Form Fields. 