### PR TITLE
non-reference credit support for Network Merchants

### DIFF
--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -42,6 +42,11 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
+      def credit(money, creditcard_or_vault_id, options= {})
+        post = build_credit_post(money, creditcard_or_vault_id, options)
+        commit('credit', post)
+      end
+
       def store(creditcard, options = {})
         post = build_store_post(creditcard, options)
         commit_vault('add_customer', post)
@@ -86,6 +91,10 @@ module ActiveMerchant #:nodoc:
         post[:transactionid] = authorization
         add_amount(post, money, options)
         post
+      end
+
+      def build_credit_post(money, creditcard_or_vault_id, options)
+        build_auth_post(money, creditcard_or_vault_id, options)
       end
 
       def build_store_post(creditcard_or_check, options)
@@ -239,4 +248,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/remote/gateways/remote_network_merchants_test.rb
+++ b/test/remote/gateways/remote_network_merchants_test.rb
@@ -41,6 +41,12 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_check_credit
+    assert response = @gateway.credit(@amount, @check, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@decline_amount, @credit_card, @options)
     assert_failure response


### PR DESCRIPTION
This adds a #credit method to the NetworkMerchantsGateway for non-reference credits.  Since the API didn't previously have a #credit method I didn't add a deprecation warning for reference credits (refunds).

I Verified this works against my merchant account, and verified that the remote test still passes after my addition.