### PR TITLE
Payflow: Allow passing of 3D Secure via options to payment gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Braintree: Update country list [duff]
 * NMI: Don't include dup_seconds if nil [rwdaigle]
 * QuickPay: Make all operations to v10 platform synchronous [ta]
+* Payflow: Allow passing of 3D Secure details via options [marquisong]
 
 == Version 1.52.0 (July 20, 2015)
 

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -89,6 +89,15 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_and_capture_with_three_d_secure_option
+    assert auth = @gateway.authorize(100, @credit_card, @options.merge(three_d_secure_option))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(100, auth.authorization)
+    assert_success capture
+  end
+
   def test_authorize_and_partial_capture
     assert auth = @gateway.authorize(100 * 2, @credit_card, @options)
     assert_success auth
@@ -285,6 +294,18 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_success credit
   end
 
+  def test_purchase_and_refund_with_three_d_secure_option
+    amount = 100
+
+    assert purchase = @gateway.purchase(amount, @credit_card, @options.merge(three_d_secure_option))
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert !purchase.authorization.blank?
+
+    assert credit = @gateway.refund(amount, purchase.authorization)
+    assert_success credit
+  end
+
   # The default security setting for Payflow Pro accounts is Allow
   # non-referenced credits = No.
   #
@@ -309,5 +330,17 @@ class RemotePayflowTest < Test::Unit::TestCase
     @gateway.options[:verbosity] = 'HIGH'
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_match %r{^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}, response.params['transaction_time']
+  end
+
+  def three_d_secure_option
+    {
+        :three_d_secure => {
+            :status => 'Y',
+            :authentication_id => 'QvDbSAxSiaQs241899E0',
+            :eci => '02',
+            :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+            :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+        }
+    }
   end
 end

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -37,10 +37,34 @@ class PayflowTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_authorization_with_three_d_secure_option
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option))
+    end.check_request do |endpoint, data, headers|
+      assert_three_d_secure REXML::Document.new(data), authorize_buyer_auth_result_path
+    end.respond_with(successful_authorization_response)
+    assert_equal "Approved", response.message
+    assert_success response
+    assert response.test?
+    assert_equal "VUJN1A6E11D9", response.authorization
+    refute response.fraud_review?
+  end
+
   def test_successful_purchase_with_fraud_review
     @gateway.stubs(:ssl_post).returns(successful_purchase_with_fraud_review_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "126", response.params["result"]
+    assert response.fraud_review?
+  end
+
+  def test_successful_purchase_with_three_d_secure_option
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option))
+    end.check_request do |endpoint, data, headers|
+      assert_three_d_secure REXML::Document.new(data), purchase_buyer_auth_result_path
+    end.respond_with(successful_purchase_with_fraud_review_response)
     assert_success response
     assert_equal "126", response.params["result"]
     assert response.fraud_review?
@@ -326,6 +350,17 @@ class PayflowTest < Test::Unit::TestCase
     assert_equal '01', node.attributes['Value']
   end
 
+  def test_add_credit_card_with_three_d_secure
+    xml = Builder::XmlMarkup.new
+    credit_card = credit_card("5641820000000005",
+                              :brand => "switch",
+                              :issue_number => 1
+    )
+
+    @gateway.send(:add_credit_card, xml, credit_card, @options.merge(three_d_secure_option))
+    assert_three_d_secure REXML::Document.new(xml.target!), '/Card/BuyerAuthResult'
+  end
+
   def test_duplicate_response_flag
     @gateway.expects(:ssl_post).returns(successful_duplicate_response)
 
@@ -585,5 +620,37 @@ class PayflowTest < Test::Unit::TestCase
   </ResponseData>
 </XMLPayResponse>
     XML
+  end
+  
+  def assert_three_d_secure(xml_doc, buyer_auth_result_path)
+    assert_equal 'Y', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/Status").text
+    assert_equal 'QvDbSAxSiaQs241899E0', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/AuthenticationId").text
+    assert_equal 'pareq block', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/PAReq").text
+    assert_equal 'https://bankacs.bank.com/ascurl', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/ACSUrl").text
+    assert_equal '02', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/ECI").text
+    assert_equal 'jGvQIvG/5UhjAREALGYa6Vu/hto=', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/CAVV").text
+    assert_equal 'UXZEYlNBeFNpYVFzMjQxODk5RTA=', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/XID").text
+  end
+
+  def authorize_buyer_auth_result_path
+    '/XMLPayRequest/RequestData/Transactions/Transaction/Authorization/PayData/Tender/Card/BuyerAuthResult'
+  end
+
+  def purchase_buyer_auth_result_path
+    '/XMLPayRequest/RequestData/Transactions/Transaction/Sale/PayData/Tender/Card/BuyerAuthResult'
+  end
+
+  def three_d_secure_option
+    {
+        :three_d_secure => {
+            :status => 'Y',
+            :authentication_id => 'QvDbSAxSiaQs241899E0',
+            :pareq => 'pareq block',
+            :acs_url => 'https://bankacs.bank.com/ascurl',
+            :eci => '02',
+            :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+            :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+        }
+    }
   end
 end


### PR DESCRIPTION
This PR allows the passing of 3D Secure details via options to Payflow gateway. Unit tests and remote tests has been added as well to this PR.

Documentation can be found in Payflow's docs, https://www.paypalobjects.com/webstatic/en_US/developer/docs/pdf/pp_payflowpro_xmlpay_guide.pdf, page 58, 79.
