### PR TITLE
QuickPay: strip # from Order IDs

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -142,7 +142,7 @@ module ActiveMerchant
 
         def add_order_id(post, options)
           requires!(options, :order_id)
-          post[:order_id] = options[:order_id]
+          post[:order_id] = format_order_id(options[:order_id])
         end
 
         def add_invoice(post, options)
@@ -204,6 +204,10 @@ module ActiveMerchant
             :country_code => country.code(:alpha3).value
           }
           mapped
+        end
+
+        def format_order_id(order_id)
+          order_id.to_s.gsub(/#/, '')
         end
 
         def headers

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -32,6 +32,16 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_purchase_with_order_id_format
+    options = @options.merge({order_id: "#1001.1"})
+    assert response = @gateway.purchase(@amount, @valid_card, options)
+
+    assert_equal 'OK', response.message
+    assert_equal 'DKK', response.params['currency']
+    assert_success response
+    assert !response.authorization.blank?
+  end
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @valid_card, @options)
 


### PR DESCRIPTION
@aprofeit @ivanfer 

Discovered while testing that QuickPay doesn't support "#" in order IDs.