### PR TITLE
QuickPay: fix method signature on #void

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -35,7 +35,7 @@ module ActiveMerchant
         end
       end
 
-      def void(identification)
+      def void(identification, _options = {})
         commit(synchronized_path "/payments/#{identification}/cancel")
       end
 


### PR DESCRIPTION
@aprofeit @ivanfer 

The QuickPay v10 integration's `void` method doesn't accept `options`, which all other integrations do - this brings it into sync with the others.