### PR TITLE
Elavon: Supports capture via CCComplete

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Braintree: Update country list [duff]
 * NMI: Don't include dup_seconds if nil [rwdaigle]
 * QuickPay: Make all operations to v10 platform synchronous [ta]
+* Elavon: Support capture via CCCOMPLETE without credit card [marquisong]
 
 == Version 1.52.0 (July 20, 2015)
 

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -42,6 +42,16 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_and_capture_with_auth_code
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVAL', auth.message
+    assert auth.authorization
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
   def test_unsuccessful_capture
     assert response = @gateway.capture(@amount, '', :credit_card => @credit_card)
     assert_failure response

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -49,6 +49,59 @@ class ElavonTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    authorization = '123456;00000000-0000-0000-0000-00000000000'
+
+    assert response = @gateway.capture(@amount, authorization, :credit_card => @credit_card)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal "APPROVAL", response.message
+    assert response.test?
+  end
+
+  def test_successful_capture_with_auth_code
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    authorization = '123456;00000000-0000-0000-0000-00000000000'
+
+    assert response = @gateway.capture(@amount, authorization)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal "APPROVAL", response.message
+    assert response.test?
+  end
+
+  def test_successful_capture_with_additional_options
+    authorization = '123456;00000000-0000-0000-0000-00000000000'
+    response = stub_comms do
+      @gateway.capture(@amount, authorization, :test_mode => true, :partial_shipment_flag => true)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/ssl_transaction_type=CCCOMPLETE/, data)
+      assert_match(/ssl_test_mode=TRUE/, data)
+      assert_match(/ssl_partial_shipment_flag=Y/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal "APPROVAL", response.message
+    assert response.test?
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_post).returns(failed_authorization_response)
+    authorization = '123456INVALID;00000000-0000-0000-0000-00000000000'
+
+    assert response = @gateway.capture(@amount, authorization, :credit_card => @credit_card)
+    assert_instance_of Response, response
+    assert_failure response
+  end
+
   def test_unsuccessful_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 
@@ -307,6 +360,29 @@ class ElavonTest < Test::Unit::TestCase
     "errorCode=5000
     errorName=Credit Card Number Invalid
     errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+  end
+  
+  def successful_capture_response
+    "ssl_card_number=42********4242
+    ssl_exp_date=0910
+    ssl_amount=1.00
+    ssl_customer_code=
+    ssl_salestax=
+    ssl_invoice_number=
+    ssl_result=0
+    ssl_result_message=APPROVAL
+    ssl_txn_id=00000000-0000-0000-0000-00000000000
+    ssl_approval_code=123456
+    ssl_cvv2_response=P
+    ssl_avs_response=X
+    ssl_account_balance=0.00
+    ssl_txn_time=08/07/2009 09:56:11 PM"
+  end
+
+  def failed_capture_response
+    "errorCode=5040
+    errorName=Invalid Transaction ID
+    errorMessage=The transaction ID is invalid for this transaction type"
   end
 
   def successful_store_response


### PR DESCRIPTION
This PR adds the support to capture payments using CCCOMPLETE when no credit card details being provided in the options.
Currently, in order to capture a payment, the credit card information is required to be supplied in the options.
As a result of this update, if no credit card information being supplied in the capture request, it will use the CCCOMPLETE transaction type instead. I have added and updated all relevant unit and remote tests.

Further details can be found in https://www.myvirtualmerchant.com/VirtualMerchant/download/developerGuide.pdf (Under Credit Card Completion (cccomplete) section).
