### PR TITLE
Authorize.Net: Update to new Akamai URL for ARB

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
       API_VERSION = '3.1'
 
       self.test_url = 'https://apitest.authorize.net/xml/v1/request.api'
-      self.live_url = 'https://api.authorize.net/xml/v1/request.api'
+      self.live_url = 'https://api2.authorize.net/xml/v1/request.api'
 
       self.default_currency = 'USD'
 


### PR DESCRIPTION
@duff: looks like these changes have already been made for the standard Authorize.net and CIM adapter:

https://github.com/activemerchant/active_merchant/commit/93251aaf947361f3cab3be4d2356ecc636d928c7
https://github.com/activemerchant/active_merchant/commit/64034cfd64ea20cc327c5ce6251522ec539b79b1

but it wasn't done yet for ARB.