### PR TITLE
NMI gateway (non-Auth.net mode) support

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -1,256 +1,232 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class NmiGateway < Gateway
-      API_VERSION = '3.1'
 
-      self.test_url = 'https://secure.networkmerchants.com/gateway/transact.dll'
-      self.live_url = 'https://secure.networkmerchants.com/gateway/transact.dll'
+      DUP_WINDOW_DEPRECATION_MESSAGE = "The class-level duplicate_window variable is deprecated. Please use the :dup_seconds transaction option instead."
 
-      class_attribute :duplicate_window
-
-      APPROVED, DECLINED, ERROR, FRAUD_REVIEW = 1, 2, 3, 4
-
-      RESPONSE_CODE, RESPONSE_REASON_CODE, RESPONSE_REASON_TEXT, AUTHORIZATION_CODE = 0, 2, 3, 4
-      AVS_RESULT_CODE, TRANSACTION_ID, CARD_CODE_RESPONSE_CODE, CARDHOLDER_AUTH_CODE = 5, 6, 38, 39
-
+      self.test_url = self.live_url = 'https://secure.nmi.com/api/transact.php'
       self.default_currency = 'USD'
-
+      self.money_format = :dollars
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
       self.homepage_url = 'http://nmi.com/'
       self.display_name = 'NMI'
 
-      CARD_CODE_ERRORS = %w( N S )
-      AVS_ERRORS = %w( A E N R W Z )
-      AVS_REASON_CODES = %w(27 45)
-      TRANSACTION_ALREADY_ACTIONED = %w(310 311)
+      def self.duplicate_window=(seconds)
+        ActiveMerchant.deprecated(DUP_WINDOW_DEPRECATION_MESSAGE)
+        @dup_seconds = seconds
+      end
+
+      def self.duplicate_window
+        instance_variable_defined?(:@dup_seconds) ? @dup_seconds : nil
+      end
 
       def initialize(options = {})
         requires!(options, :login, :password)
         super
       end
 
-      def authorize(money, paysource, options = {})
+      def purchase(amount, payment_method, options={})
         post = {}
-        add_currency_code(post, money, options)
-        add_invoice(post, options)
-        add_payment_source(post, paysource, options)
-        add_address(post, options)
+        add_invoice(post, amount, options)
+        add_payment_method(post, payment_method)
         add_customer_data(post, options)
-        add_duplicate_window(post)
 
-        commit('AUTH_ONLY', money, post)
+        commit("sale", post)
       end
 
-      def purchase(money, paysource, options = {})
+      def authorize(amount, payment_method, options={})
         post = {}
-        add_currency_code(post, money, options)
-        add_invoice(post, options)
-        add_payment_source(post, paysource, options)
-        add_address(post, options)
+        add_invoice(post, amount, options)
+        add_payment_method(post, payment_method)
         add_customer_data(post, options)
-        add_duplicate_window(post)
 
-        commit('AUTH_CAPTURE', money, post)
+        commit("auth", post)
       end
 
-      def capture(money, authorization, options = {})
-        post = {:trans_id => authorization}
+      def capture(amount, authorization, options={})
+        post = {}
+        add_invoice(post, amount, options)
+        add_reference(post, authorization)
+
+        commit("capture", post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        add_reference(post, authorization)
+
+        commit("void", post)
+      end
+
+      def refund(amount, authorization, options={})
+        post = {}
+        add_invoice(post, amount, options)
+        add_reference(post, authorization)
+
+        commit("refund", post)
+      end
+
+      def credit(amount, payment_method, options={})
+        post = {}
+        add_invoice(post, amount, options)
+        add_payment_method(post, payment_method)
         add_customer_data(post, options)
-        add_invoice(post, options)
-        commit('PRIOR_AUTH_CAPTURE', money, post)
+
+        commit("credit", post)
       end
 
-      def void(authorization, options = {})
-        post = {:trans_id => authorization}
-        add_duplicate_window(post)
-        commit('VOID', nil, post)
+      def verify(payment_method, options={})
+        post = {}
+        add_payment_method(post, payment_method)
+        add_customer_data(post, options)
+
+        commit("validate", post)
       end
 
-      def refund(money, identification, options = {})
-        requires!(options, :card_number)
+      def store(payment_method, options = {})
+        post = {}
+        add_invoice(post, nil, options)
+        add_payment_method(post, payment_method)
+        add_customer_data(post, options)
 
-        post = { :trans_id => identification,
-                 :card_num => options[:card_number]
-               }
-
-        post[:first_name] = options[:first_name] if options[:first_name]
-        post[:last_name] = options[:last_name] if options[:last_name]
-        post[:zip] = options[:zip] if options[:zip]
-
-        add_invoice(post, options)
-        add_duplicate_window(post)
-
-        commit('CREDIT', money, post)
+        commit("add_customer", post)
       end
 
-      def credit(money, identification, options = {})
-        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
-        refund(money, identification, options)
+      def supports_scrubbing?
+        true
       end
 
-      def verify(credit_card, options = {})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+      def scrub(transcript)
+        transcript.
+          gsub(%r((password=)\w+), '\1[FILTERED]').
+          gsub(%r((ccnumber=)\d+), '\1[FILTERED]').
+          gsub(%r((cvv=)\d+), '\1[FILTERED]').
+          gsub(%r((checkaba=)\d+), '\1[FILTERED]').
+          gsub(%r((checkaccount=)\d+), '\1[FILTERED]')
       end
 
       private
 
-      def commit(action, money, parameters)
-        parameters[:amount] = amount(money) unless action == 'VOID'
-
-        url = test? ? self.test_url : self.live_url
-        data = ssl_post(url, post_data(action, parameters))
-
-        response          = parse(data)
-        response[:action] = action
-
-        message = message_from(response)
-
-        Response.new(success?(response), message, response,
-          :test => test?,
-          :authorization => response[:transaction_id],
-          :fraud_review => fraud_review?(response),
-          :avs_result => { :code => response[:avs_result_code] },
-          :cvv_result => response[:card_code]
-        )
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+        post[:orderid] = options[:order_id]
+        post[:orderdescription] = options[:description]
+        post[:currency] = options[:currency] || currency(money)
+        post[:billing_method] = "recurring" if options[:recurring]
+        post[:dup_seconds] = options[:dup_seconds] || self.class.duplicate_window
       end
 
-      def success?(response)
-        response[:response_code] == APPROVED && TRANSACTION_ALREADY_ACTIONED.exclude?(response[:response_reason_code])
-      end
-
-      def fraud_review?(response)
-        response[:response_code] == FRAUD_REVIEW
-      end
-
-      def parse(body)
-        fields = split(body)
-
-        results = {
-          :response_code => fields[RESPONSE_CODE].to_i,
-          :response_reason_code => fields[RESPONSE_REASON_CODE],
-          :response_reason_text => fields[RESPONSE_REASON_TEXT],
-          :avs_result_code => fields[AVS_RESULT_CODE],
-          :transaction_id => fields[TRANSACTION_ID],
-          :card_code => fields[CARD_CODE_RESPONSE_CODE],
-          :authorization_code => fields[AUTHORIZATION_CODE],
-          :cardholder_authentication_code => fields[CARDHOLDER_AUTH_CODE]
-        }
-        results
-      end
-
-      def post_data(action, parameters = {})
-        post = {}
-
-        post[:version]        = API_VERSION
-        post[:login]          = @options[:login]
-        post[:tran_key]       = @options[:password]
-        post[:relay_response] = "FALSE"
-        post[:type]           = action
-        post[:delim_data]     = "TRUE"
-        post[:delim_char]     = ","
-        post[:encap_char]     = "$"
-        post[:solution_ID]    = application_id if application_id.present? && application_id != "ActiveMerchant"
-
-        request = post.merge(parameters).collect { |key, value| "x_#{key}=#{CGI.escape(value.to_s)}" }.join("&")
-        request
-      end
-
-      def add_currency_code(post, money, options)
-        post[:currency_code] = options[:currency] || currency(money)
-      end
-
-      def add_invoice(post, options)
-        post[:invoice_num] = options[:order_id]
-        post[:description] = options[:description]
-      end
-
-      def add_creditcard(post, creditcard, options={})
-        post[:card_num]   = creditcard.number
-        post[:card_code]  = creditcard.verification_value if creditcard.verification_value?
-        post[:exp_date]   = expdate(creditcard)
-        post[:first_name] = creditcard.first_name
-        post[:last_name]  = creditcard.last_name
-
-        post[:recurring_billing] = "TRUE" if options[:recurring]
-      end
-
-      def add_payment_source(params, source, options={})
-        add_creditcard(params, source, options)
+      def add_payment_method(post, payment_method)
+        if(payment_method.is_a?(String))
+          post[:customer_vault_id] = payment_method
+        elsif(card_brand(payment_method) == 'check')
+          post[:payment] = 'check'
+          post[:checkname] = payment_method.name
+          post[:checkaba] = payment_method.routing_number
+          post[:checkaccount] = payment_method.account_number
+          post[:account_holder_type] = payment_method.account_holder_type
+          post[:account_type] = payment_method.account_type
+          post[:sec_code] = 'WEB'
+        else
+          post[:payment] = 'creditcard'
+          post[:firstname] = payment_method.first_name
+          post[:lastname] = payment_method.last_name
+          post[:ccnumber] = payment_method.number
+          post[:cvv] = payment_method.verification_value
+          post[:ccexp] = exp_date(payment_method)
+        end
       end
 
       def add_customer_data(post, options)
-        if options.has_key? :email
-          post[:email] = options[:email]
-          post[:email_customer] = false
+        post[:email] = options[:email]
+        post[:ipaddress] = options[:ip]
+        post[:customer_id] = options[:customer_id] || options[:customer]
+
+        if(billing_address = options[:billing_address] || options[:address])
+          post[:company] = billing_address[:company]
+          post[:address1] = billing_address[:address1]
+          post[:address2] = billing_address[:address2]
+          post[:city] = billing_address[:city]
+          post[:state] = billing_address[:state]
+          post[:country] = billing_address[:country]
+          post[:zip]    = billing_address[:zip]
+          post[:phone] = billing_address[:phone]
         end
 
-        if options.has_key? :customer
-          post[:cust_id] = options[:customer] if Float(options[:customer]) rescue nil
-        end
-
-        if options.has_key? :ip
-          post[:customer_ip] = options[:ip]
-        end
-
-        if options.has_key? :cardholder_authentication_value
-          post[:cardholder_authentication_value] = options[:cardholder_authentication_value]
-        end
-
-        if options.has_key? :authentication_indicator
-          post[:authentication_indicator] = options[:authentication_indicator]
-        end
-
-      end
-
-      def add_duplicate_window(post)
-        unless duplicate_window.nil?
-          post[:duplicate_window] = duplicate_window
+        if(shipping_address = options[:shipping_address])
+          post[:shipping_company] = shipping_address[:company]
+          post[:shipping_address1] = shipping_address[:address1]
+          post[:shipping_address2] = shipping_address[:address2]
+          post[:shipping_city] = shipping_address[:city]
+          post[:shipping_state] = shipping_address[:state]
+          post[:shipping_country] = shipping_address[:country]
+          post[:shipping_zip]    = shipping_address[:zip]
+          post[:shipping_phone] = shipping_address[:phone]
         end
       end
 
-      def add_address(post, options)
-        if address = options[:billing_address] || options[:address]
-          post[:address] = address[:address1].to_s
-          post[:company] = address[:company].to_s
-          post[:phone]   = address[:phone].to_s
-          post[:zip]     = address[:zip].to_s
-          post[:city]    = address[:city].to_s
-          post[:country] = address[:country].to_s
-          post[:state]   = address[:state].blank?  ? 'n/a' : address[:state]
-        end
+      def add_reference(post, authorization)
+        post[:transactionid] = authorization
+      end
 
-        if address = options[:shipping_address]
-          post[:ship_to_first_name] = address[:first_name].to_s
-          post[:ship_to_last_name] = address[:last_name].to_s
-          post[:ship_to_address] = address[:address1].to_s
-          post[:ship_to_company] = address[:company].to_s
-          post[:ship_to_phone]   = address[:phone].to_s
-          post[:ship_to_zip]     = address[:zip].to_s
-          post[:ship_to_city]    = address[:city].to_s
-          post[:ship_to_country] = address[:country].to_s
-          post[:ship_to_state]   = address[:state].blank?  ? 'n/a' : address[:state]
+      def exp_date(payment_method)
+        "#{format(payment_method.month, :two_digits)}#{format(payment_method.year, :two_digits)}"
+      end
+
+      def commit(action, params)
+
+        params[action == "add_customer" ? :customer_vault : :type] = action
+        params[:username] = @options[:login]
+        params[:password] = @options[:password]
+
+        raw_response = ssl_post(url, post_data(action, params), headers)
+        response = parse(raw_response)
+        succeeded = success_from(response)
+
+        Response.new(
+          succeeded,
+          message_from(succeeded, response),
+          response,
+          authorization: response[:transactionid],
+          avs_result: AVSResult.new(code: response[:avsresponse]),
+          cvv_result: CVVResult.new(response[:cvvresponse]),
+          error_code: error_code_from(response),
+          test: test?
+        )
+      end
+
+      def headers
+        { "Content-Type"  => "application/x-www-form-urlencoded;charset=UTF-8" }
+      end
+
+      def post_data(action, params)
+        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def parse(body)
+        Hash[CGI::parse(body).map { |k,v| [k.intern, v.first] }]
+      end
+
+      def success_from(response)
+        response[:response] == "1"
+      end
+
+      def message_from(succeeded, response)
+        if succeeded
+          "Succeeded"
+        else
+          response[:responsetext]
         end
       end
 
-      def message_from(results)
-        if results[:response_code] == DECLINED
-          return CVVResult.messages[ results[:card_code] ] if CARD_CODE_ERRORS.include?(results[:card_code])
-          if AVS_REASON_CODES.include?(results[:response_reason_code]) && AVS_ERRORS.include?(results[:avs_result_code])
-            return AVSResult.messages[ results[:avs_result_code] ]
-          end
-        end
-
-        (results[:response_reason_text] ? results[:response_reason_text].chomp('.') : '')
-      end
-
-      def split(response)
-        response[1..-2].split(/\$,\$/)
+      def error_code_from(response)
+        response[:response_code]
       end
     end
   end
 end
-

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -4,7 +4,11 @@ class RemoteNmiTest < Test::Unit::TestCase
   def setup
     @gateway = NmiGateway.new(fixtures(:nmi))
     @amount = 100
-    @credit_card = credit_card('4000100011112224')
+    @credit_card = credit_card('4111111111111111', verification_value: 917)
+    @check = check(
+      :routing_number => '123123123',
+      :account_number => '123123123'
+    )
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,
@@ -12,27 +16,56 @@ class RemoteNmiTest < Test::Unit::TestCase
     }
   end
 
+  def test_invalid_login
+    @gateway = NmiGateway.new(login: "invalid", password: "no")
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Authentication Failed", response.message
+    assert_equal "300", response.error_code
+  end
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert response.test?
-    assert_equal 'This transaction has been approved', response.message
+    assert_equal 'Succeeded', response.message
     assert response.authorization
   end
 
-  def test_forced_test_mode_purchase
-    gateway = NmiGateway.new(fixtures(:nmi).update(:test => true))
-    assert response = gateway.purchase(@amount, @credit_card, @options)
+  def test_failed_purchase
+    assert response = @gateway.purchase(99, @credit_card, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'DECLINE', response.message
+  end
+
+  def test_successful_purchase_with_echeck
+    assert response = @gateway.purchase(@amount, @check, @options)
     assert_success response
     assert response.test?
+    assert_equal 'Succeeded', response.message
     assert response.authorization
+  end
+
+  def test_failed_purchase_with_echeck
+    assert response = @gateway.purchase(99, @check, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'FAILED', response.message
   end
 
   def test_successful_authorization
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'This transaction has been approved', response.message
+    assert_equal 'Succeeded', response.message
     assert response.authorization
+  end
+
+  def test_failed_authorization
+    assert response = @gateway.authorize(99, @credit_card, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'DECLINE', response.message
   end
 
   def test_authorization_and_capture
@@ -41,7 +74,12 @@ class RemoteNmiTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, authorization.authorization)
     assert_success capture
-    assert_equal 'This transaction has been approved', capture.message
+    assert_equal 'Succeeded', capture.message
+  end
+
+  def test_failed_capture
+    assert capture = @gateway.capture(@amount, "badauth")
+    assert_failure capture
   end
 
   def test_authorization_and_void
@@ -50,28 +88,118 @@ class RemoteNmiTest < Test::Unit::TestCase
 
     assert void = @gateway.void(authorization.authorization)
     assert_success void
-    assert_equal 'This transaction has been approved', void.message
+    assert_equal 'Succeeded', void.message
   end
 
-  def test_refund
+  def test_failed_void
+    assert void = @gateway.void("badauth")
+    assert_failure void
+  end
+
+  def test_successful_refund
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    assert response = @gateway.refund(@amount, response.authorization, :card_number => @credit_card.number)
+    assert response = @gateway.refund(@amount, response.authorization)
     assert_success response
-    assert_equal 'This transaction has been approved', response.message
+    assert_equal 'Succeeded', response.message
   end
 
-  def test_bad_login
-    gateway = NmiGateway.new(
-      :login => 'X',
-      :password => 'Y'
-    )
-
-    assert response = gateway.purchase(@amount, @credit_card)
-    assert_equal Response, response.class
-    assert_match(/Authentication Failed/, response.message)
-    assert_equal false, response.success?
+  def test_failed_refund
+    assert response = @gateway.refund(@amount, "badauth")
+    assert_failure response
   end
 
+  def test_successful_credit
+    response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+  end
+
+  def test_failed_credit
+    card = credit_card(year: 2010)
+    response = @gateway.credit(@amount, card, @options)
+    assert_failure response
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match "Succeeded", response.message
+  end
+
+  def test_failed_verify
+    card = credit_card(year: 2010)
+    response = @gateway.verify(card, @options)
+    assert_failure response
+    assert_match "Invalid Credit Card", response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert response.params["customer_vault_id"]
+  end
+
+  def test_failed_store
+    card = credit_card(year: 2010)
+    response = @gateway.store(card, @options)
+    assert_failure response
+    assert_nil response.params["customer_vault_id"]
+  end
+
+  def test_successful_store_with_echeck
+    response = @gateway.store(@check, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert response.params["customer_vault_id"]
+  end
+
+  def test_successful_store_and_purchase
+    vault_id = @gateway.store(@credit_card, @options).params["customer_vault_id"]
+    purchase = @gateway.purchase(@amount, vault_id, @options)
+    assert_success purchase
+    assert_equal "Succeeded", purchase.message
+  end
+
+  def test_successful_store_and_auth
+    vault_id = @gateway.store(@credit_card, @options).params["customer_vault_id"]
+    auth = @gateway.authorize(@amount, vault_id, @options)
+    assert_success auth
+    assert_equal "Succeeded", auth.message
+  end
+
+  def test_successful_store_and_credit
+    vault_id = @gateway.store(@credit_card, @options).params["customer_vault_id"]
+    credit = @gateway.credit(@amount, vault_id, @options)
+    assert_success credit
+    assert_equal "Succeeded", credit.message
+  end
+
+  def test_card_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+
+    # "password=password is filtered, but can't be tested b/c of key match"
+    # assert_scrubbed(@gateway.options[:password], clean_transcript)
+  end
+
+  def test_check_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, clean_transcript)
+    assert_scrubbed(@check.routing_number, clean_transcript)
+
+    # "password=password is filtered, but can't be tested b/c of key match"
+    # assert_scrubbed(@gateway.options[:password], clean_transcript)
+  end
 end

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -1,237 +1,326 @@
 require 'test_helper'
-require 'unit/gateways/authorize_net_test'
 
 class NmiTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = NmiGateway.new(:login => 'X', :password => 'Y')
+    @gateway = NmiGateway.new(fixtures(:nmi))
 
     @amount = 100
     @credit_card = credit_card
+    @check = check
     @options = {}
   end
 
-  def test_credit_card_purchase_no_recurring_flag
+  def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
     end.check_request do |endpoint, data, headers|
-      assert_no_match(/x_recurring_billing/, data)
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=sale/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
+    assert response.test?
+    assert_equal "2762757839", response.authorization
   end
 
-  def test_credit_card_purchase_with_recurring_flag
+  def test_purchase_with_options
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, :recurring => true)
+      @gateway.purchase(@amount, @credit_card,
+        :recurring => true, :order_id => "#1001", :description => "AM test",
+        :currency => "GBP", :dup_seconds => 15, :customer => "123")
     end.check_request do |endpoint, data, headers|
-      assert_match(/x_recurring_billing=TRUE/, data)
+      assert_match(/billing_method=recurring/, data)
+      assert_match(/orderid=#{CGI.escape("#1001")}/, data)
+      assert_match(/orderdescription=AM\+test/, data)
+      assert_match(/currency=GBP/, data)
+      assert_match(/dup_seconds=15/, data)
+      assert_match(/customer_id=123/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
   end
 
-  def test_successful_authorization
-    @gateway.expects(:ssl_post).returns(successful_authorization_response)
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(failed_purchase_response)
 
-    assert response = @gateway.authorize(@amount, @credit_card)
-    assert_instance_of Response, response
-    assert_success response
-    assert_equal '508141794', response.authorization
-  end
-
-  def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-    assert response = @gateway.purchase(@amount, @credit_card)
-    assert_instance_of Response, response
-    assert_success response
-    assert_equal '508141795', response.authorization
-  end
-
-  def test_failed_authorization
-    @gateway.expects(:ssl_post).returns(failed_authorization_response)
-
-    assert response = @gateway.authorize(@amount, @credit_card)
-    assert_instance_of Response, response
     assert_failure response
-    assert_equal '508141794', response.authorization
+    assert response.test?
+    assert_equal "DECLINE", response.message
+    assert_equal "200", response.error_code
   end
 
-  def test_failed_already_actioned_capture
-    @gateway.expects(:ssl_post).returns(already_actioned_capture_response)
+  def test_successful_purchase_with_echeck
+    response = stub_comms do
+      @gateway.purchase(@amount, @check)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=sale/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/payment=check/, data)
+      assert_match(/checkname=#{@check.name}/, CGI.unescape(data))
+      assert_match(/checkaba=#{@check.routing_number}/, data)
+      assert_match(/checkaccount=#{@check.account_number}/, data)
+      assert_match(/account_holder_type=#{@check.account_holder_type}/, data)
+      assert_match(/account_type=#{@check.account_type}/, data)
+      assert_match(/sec_code=WEB/, data)
+    end.respond_with(successful_echeck_purchase_response)
 
-    assert response = @gateway.capture(50, '123456789')
-    assert_instance_of Response, response
+    assert_success response
+    assert response.test?
+    assert_equal "2762759808", response.authorization
+  end
+
+  def test_failed_purchase_with_echeck
+    response = stub_comms do
+      @gateway.purchase(@amount, @check)
+    end.respond_with(failed_echeck_purchase_response)
+
     assert_failure response
+    assert response.test?
+    assert_equal "FAILED", response.message
+    assert_equal "200", response.error_code
+  end
+
+  def test_successful_authorize_and_capture
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=auth/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+    assert_equal "2762787830", response.authorization
+
+    capture = stub_comms do
+      @gateway.capture(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=capture/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/transactionid=2762787830/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
+  def test_failed_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(failed_authorization_response)
+
+    assert_failure response
+    assert_equal "DECLINE", response.message
+    assert response.test?
+  end
+
+  def test_failed_capture
+    response = stub_comms do
+      @gateway.capture(100, "")
+    end.respond_with(failed_capture_response)
+
+    assert_failure response
+  end
+
+  def test_successful_void
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "2762757839", response.authorization
+
+    void = stub_comms do
+      @gateway.void(response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=void/, data)
+      assert_match(/transactionid=2762757839/, data)
+    end.respond_with(successful_void_response)
+
+    assert_success void
+  end
+
+  def test_failed_void
+    response = stub_comms do
+      @gateway.void("5d53a33d960c46d00f5dc061947d998c")
+    end.respond_with(failed_void_response)
+
+    assert_failure response
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "2762757839", response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=refund/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/transactionid=2762757839/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = stub_comms do
+      @gateway.refund(nil, "")
+    end.respond_with(failed_refund_response)
+
+    assert_failure response
+  end
+
+  def test_successful_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=credit/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_credit_response)
+
+    assert_success response
+
+    assert_equal "2762828010", response.authorization
+    assert response.test?
+  end
+
+  def test_failed_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(failed_credit_response)
+
+    assert_failure response
+    assert response.test?
+    assert_match "Invalid Credit Card", response.message
   end
 
   def test_successful_verify
     response = stub_comms do
       @gateway.verify(@credit_card)
-    end.respond_with(successful_authorization_response, successful_void_response)
-    assert_success response
-  end
-
-  def test_successful_verify_failed_void
-    response = stub_comms do
-      @gateway.verify(@credit_card, @options)
-    end.respond_with(successful_authorization_response, failed_void_response)
-    assert_success response
-    assert_equal "This transaction has been approved", response.message
-  end
-
-  def test_unsuccessful_verify
-    response = stub_comms do
-      @gateway.verify(@credit_card, @options)
-    end.respond_with(failed_authorization_response, successful_void_response)
-    assert_failure response
-    assert_equal "This transaction was declined", response.message
-  end
-
-  def test_add_address_outsite_north_america
-    result = {}
-
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'DE', :state => ''} )
-
-    assert_equal ["address", "city", "company", "country", "phone", "state", "zip"], result.stringify_keys.keys.sort
-    assert_equal 'n/a', result[:state]
-    assert_equal '164 Waverley Street', result[:address]
-    assert_equal 'DE', result[:country]
-  end
-
-  def test_add_address
-    result = {}
-
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'} )
-
-    assert_equal ["address", "city", "company", "country", "phone", "state", "zip"], result.stringify_keys.keys.sort
-    assert_equal 'CO', result[:state]
-    assert_equal '164 Waverley Street', result[:address]
-    assert_equal 'US', result[:country]
-  end
-
-  def test_add_invoice
-    result = {}
-    @gateway.send(:add_invoice, result, :order_id => '#1001')
-    assert_equal '#1001', result[:invoice_num]
-  end
-
-  def test_add_description
-    result = {}
-    @gateway.send(:add_invoice, result, :description => 'My Purchase is great')
-    assert_equal 'My Purchase is great', result[:description]
-  end
-
-  def test_add_duplicate_window_without_duplicate_window
-    result = {}
-    @gateway.class.duplicate_window = nil
-    @gateway.send(:add_duplicate_window, result)
-    assert_nil result[:duplicate_window]
-  end
-
-  def test_add_duplicate_window_with_duplicate_window
-    result = {}
-    @gateway.class.duplicate_window = 0
-    @gateway.send(:add_duplicate_window, result)
-    assert_equal 0, result[:duplicate_window]
-  end
-
-  def test_add_cardholder_authentication_value
-    result = {}
-    params = {:cardholder_authentication_value => 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', :authentication_indicator => '2'}
-    @gateway.send(:add_customer_data, result, params)
-    assert_equal 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', result[:cardholder_authentication_value]
-    assert_equal '2', result[:authentication_indicator]
-  end
-
-  def test_purchase_is_valid_csv
-   params = { :amount => '1.01' }
-
-   @gateway.send(:add_creditcard, params, @credit_card)
-
-   assert data = @gateway.send(:post_data, 'AUTH_ONLY', params)
-   assert_equal post_data_fixture.size, data.size
-  end
-
-  def test_purchase_meets_minimum_requirements
-    params = {
-      :amount => "1.01",
-    }
-
-    @gateway.send(:add_creditcard, params, @credit_card)
-
-    assert data = @gateway.send(:post_data, 'AUTH_ONLY', params)
-    minimum_requirements.each do |key|
-      assert_not_nil(data =~ /x_#{key}=/)
-    end
-  end
-
-  def test_action_included_in_params
-   @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-   response = @gateway.capture(50, '123456789')
-   assert_equal('PRIOR_AUTH_CAPTURE', response.params['action'] )
-  end
-
-  def test_authorization_code_included_in_params
-   @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-   response = @gateway.capture(50, '123456789')
-   assert_equal('d1GENk', response.params['authorization_code'] )
-  end
-
-  def test_cardholder_authorization_code_included_in_params
-   @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-   response = @gateway.capture(50, '123456789')
-   assert_equal('2', response.params['cardholder_authentication_code'] )
-  end
-
-  def test_capture_passing_extra_info
-    response = stub_comms do
-      @gateway.capture(50, '123456789', :description => "Yo", :order_id => "Sweetness")
     end.check_request do |endpoint, data, headers|
-      assert_match(/x_description=Yo/, data)
-      assert_match(/x_invoice_num=Sweetness/, data)
-    end.respond_with(successful_capture_response)
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/type=validate/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_validate_response)
+
     assert_success response
+    assert_equal "Succeeded", response.message
   end
 
-  def test_successful_refund
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.refund(@amount, '123456789', :card_number => @credit_card.number)
-    assert_success response
-    assert_equal 'This transaction has been approved', response.message
-  end
-
-  def test_refund_passing_extra_info
+  def test_failed_verify
     response = stub_comms do
-      @gateway.refund(50, '123456789', :card_number => @credit_card.number, :first_name => "Bob", :last_name => "Smith", :zip => "12345")
-    end.check_request do |endpoint, data, headers|
-      assert_match(/x_first_name=Bob/, data)
-      assert_match(/x_last_name=Smith/, data)
-      assert_match(/x_zip=12345/, data)
-    end.respond_with(successful_purchase_response)
-    assert_success response
-  end
+      @gateway.verify(@credit_card)
+    end.respond_with(failed_validate_response)
 
-  def test_failed_refund
-    @gateway.expects(:ssl_post).returns(failed_refund_response)
-
-    assert response = @gateway.refund(@amount, '123456789', :card_number => @credit_card.number)
     assert_failure response
-    assert_equal 'The referenced transaction does not meet the criteria for issuing a credit', response.message
+    assert_match "Invalid Credit Card", response.message
   end
 
-  def test_deprecated_credit
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
-      assert response = @gateway.credit(@amount, '123456789', :card_number => @credit_card.number)
-      assert_success response
-      assert_equal 'This transaction has been approved', response.message
-    end
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/customer_vault=add_customer/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal "Succeeded", response.message
+    assert response.params["customer_vault_id"]
+  end
+
+  def test_failed_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(failed_store_response)
+
+    assert_failure response
+    assert response.test?
+    assert_match "Invalid Credit Card", response.message
+  end
+
+  def test_successful_store_with_echeck
+    response = stub_comms do
+      @gateway.store(@check)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/username=#{@gateway.options[:login]}/, data)
+      assert_match(/password=#{@gateway.options[:password]}/, data)
+      assert_match(/customer_vault=add_customer/, data)
+      assert_match(/payment=check/, data)
+      assert_match(/checkname=#{@check.name}/, CGI.unescape(data))
+      assert_match(/checkaba=#{@check.routing_number}/, data)
+      assert_match(/checkaccount=#{@check.account_number}/, data)
+      assert_match(/account_holder_type=#{@check.account_holder_type}/, data)
+      assert_match(/account_type=#{@check.account_type}/, data)
+      assert_match(/sec_code=WEB/, data)
+    end.respond_with(successful_echeck_store_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal "Succeeded", response.message
+    assert response.params["customer_vault_id"]
+  end
+
+  def test_avs_result
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorization_response)
+
+    assert_equal 'N', response.avs_result['code']
+  end
+
+  def test_cvv_result
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorization_response)
+
+    assert_equal 'N', response.cvv_result['code']
+  end
+
+  def test_transcript_scrubbing
+    assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
   def test_supported_countries
@@ -243,141 +332,105 @@ class NmiTest < Test::Unit::TestCase
     assert_equal [:visa, :master, :american_express, :discover], NmiGateway.supported_cardtypes
   end
 
-  def test_failure_without_response_reason_text
-    assert_nothing_raised do
-      assert_equal '', @gateway.send(:message_from, {})
+  def test_duplicate_window_deprecation
+    assert_deprecation_warning(NmiGateway::DUP_WINDOW_DEPRECATION_MESSAGE) do
+      NmiGateway.duplicate_window = 5
     end
-  end
-
-  def test_response_under_review_by_fraud_service
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
-
-    response = @gateway.purchase(@amount, @credit_card)
-    assert_failure response
-    assert response.fraud_review?
-    assert_equal "Thank you! For security reasons your order is currently being reviewed", response.message
-  end
-
-  def test_avs_result
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
-
-    response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'X', response.avs_result['code']
-  end
-
-  def test_cvv_result
-    @gateway.expects(:ssl_post).returns(fraud_review_response)
-
-    response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'M', response.cvv_result['code']
-  end
-
-  def test_message_from
-    @gateway.class_eval {
-      public :message_from
-    }
-    result = {
-      :response_code => 2,
-      :card_code => 'N',
-      :avs_result_code => 'A',
-      :response_reason_code => '27',
-      :response_reason_text => 'Failure.',
-    }
-    assert_equal "CVV does not match", @gateway.message_from(result)
-
-    result[:card_code] = 'M'
-    assert_equal "Street address matches, but 5-digit and 9-digit postal code do not match.", @gateway.message_from(result)
-
-    result[:response_reason_code] = '22'
-    assert_equal "Failure", @gateway.message_from(result)
-  end
-
-  def test_solution_id_is_added_to_post_data_parameters
-    assert !@gateway.send(:post_data, 'AUTH_ONLY').include?("x_solution_ID=A1000000")
-    @gateway.class.application_id = 'A1000000'
-    assert @gateway.send(:post_data, 'AUTH_ONLY').include?("x_solution_ID=A1000000")
-  ensure
-    @gateway.class.application_id = nil
-  end
-
-  def test_bad_currency
-    @gateway.expects(:ssl_post).returns(bad_currency_response)
-
-    response = @gateway.purchase(@amount, @credit_card, {:currency => "XYZ"})
-    assert_failure response
-    assert_equal 'The supplied currency code is either invalid, not supported, not allowed for this merchant or doesn\'t have an exchange rate', response.message
-  end
-
-  def test_alternate_currency
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-    response = @gateway.purchase(@amount, @credit_card, {:currency => "GBP"})
-    assert_success response
-  end
-
-  def test_include_cust_id_for_numeric_values
-   stub_comms do
-      @gateway.purchase(@amount, @credit_card, {:customer => "123"})
-    end.check_request do |method, data|
-      assert data =~ /x_cust_id=123/
-    end.respond_with(successful_authorization_response)
-  end
-
-  def test_dont_include_cust_id_for_non_numeric_values
-   stub_comms do
-      @gateway.purchase(@amount, @credit_card, {:customer => "bob@test.com"})
-    end.check_request do |method, data|
-      assert data !~ /x_cust_id/
-    end.respond_with(successful_authorization_response)
   end
 
   private
 
-  def post_data_fixture
-    'x_encap_char=%24&x_card_num=4242424242424242&x_exp_date=0806&x_card_code=123&x_type=AUTH_ONLY&x_first_name=Longbob&x_version=3.1&x_login=X&x_last_name=Longsen&x_tran_key=Y&x_relay_response=FALSE&x_delim_data=TRUE&x_delim_char=%2C&x_amount=1.01'
+  def successful_purchase_response
+    'response=1&responsetext=SUCCESS&authcode=123456&transactionid=2762757839&avsresponse=N&cvvresponse=N&orderid=b6c1c57f709cfaa65a5cf5b8532ad181&type=&response_code=100'
   end
 
-  def minimum_requirements
-    %w(version delim_data relay_response login tran_key amount card_num exp_date type)
+  def failed_purchase_response
+    'response=2&responsetext=DECLINE&authcode=&transactionid=2762766725&avsresponse=N&cvvresponse=N&orderid=f4bd34a5a6089aa822d13352807bdf11&type=&response_code=200'
   end
 
-  def failed_refund_response
-    '$3$,$2$,$54$,$The referenced transaction does not meet the criteria for issuing a credit.$,$$,$P$,$0$,$$,$$,$1.00$,$CC$,$credit$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$39265D8BA0CDD4F045B5F4129B2AAA01$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  def successful_echeck_purchase_response
+    'response=1&responsetext=SUCCESS&authcode=123456&transactionid=2762759808&avsresponse=&cvvresponse=&orderid=6780868212a4bc8d3d6ffc52d4873587&type=&response_code=100'
+  end
+
+  def failed_echeck_purchase_response
+    'response=2&responsetext=FAILED&authcode=123456&transactionid=2762783009&avsresponse=&cvvresponse=&orderid=8070b75a09d75c3e84e1c17d44bbbf34&type=&response_code=200'
   end
 
   def successful_authorization_response
-    '$1$,$1$,$1$,$This transaction has been approved.$,$advE7f$,$Y$,$508141794$,$5b3fe66005f3da0ebe51$,$$,$1.00$,$CC$,$auth_only$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$2860A297E0FE804BCB9EF8738599645C$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
-  end
-
-  def successful_purchase_response
-    '$1$,$1$,$1$,$This transaction has been approved.$,$d1GENk$,$Y$,$508141795$,$32968c18334f16525227$,$Store purchase$,$1.00$,$CC$,$auth_capture$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$269862C030129C1173727CC10B1935ED$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
-  end
-
-  def successful_capture_response
-    '$1$,$1$,$1$,$This transaction has been approved.$,$d1GENk$,$Y$,$508141795$,$32968c18334f16525227$,$Store purchase$,$1.00$,$CC$,$auth_capture$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$269862C030129C1173727CC10B1935ED$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
-  end
-
-  def successful_void_response
-    '$1$,$1$,$1$,$This transaction has been approved.$,$O39YT0$,$P$,$2215573915$,$823f2867c0cd10cf6e7e$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$K1C2N6$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$C9C5D270851F841D0CD9E64542D8D3BC$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$XXXX4242$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+    'response=1&responsetext=SUCCESS&authcode=123456&transactionid=2762787830&avsresponse=N&cvvresponse=N&orderid=7655856b032e28d2106d724fc26cd04d&type=&response_code=100'
   end
 
   def failed_authorization_response
-    '$2$,$1$,$1$,$This transaction was declined.$,$advE7f$,$Y$,$508141794$,$5b3fe66005f3da0ebe51$,$$,$1.00$,$CC$,$auth_only$,$$,$Longbob$,$Longsen$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$2860A297E0FE804BCB9EF8738599645C$,$P$,$2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+    'response=2&responsetext=DECLINE&authcode=&transactionid=2762789345&avsresponse=N&cvvresponse=N&orderid=1fe4a8b28a831c6f959d4204158e1ac1&type=&response_code=200'
+  end
+
+  def successful_capture_response
+    'response=1&responsetext=SUCCESS&authcode=123456&transactionid=2762797441&avsresponse=N&cvvresponse=&orderid=&type=&response_code=100'
+  end
+
+  def failed_capture_response
+    'response=2&responsetext=DECLINE&authcode=&transactionid=2762804008&avsresponse=N&cvvresponse=&orderid=&type=&response_code=200'
+  end
+
+  def successful_void_response
+    'response=1&responsetext=Transaction Void Successful&authcode=123456&transactionid=2762811592&avsresponse=&cvvresponse=&orderid=33a327d76cfdb8e98946352607d80eb2&type=void&response_code=100'
   end
 
   def failed_void_response
-    '$1$,$1$,$310$,$This transaction has already been voided.$,$$,$P$,$0$,$$,$$,$0.00$,$CC$,$void$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$02AA39F01BE7579FCBE318A14D516F9C$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$Visa$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+    'response=3&responsetext=Only transactions pending settlement can be voided REFID:3161855545&authcode=&transactionid=2762816924&avsresponse=&cvvresponse=&orderid=&type=void&response_code=300'
   end
 
-  def already_actioned_capture_response
-    '$1$,$2$,$311$,$This transaction has already been captured.$,$$,$P$,$0$,$$,$$,$1.00$,$CC$,$credit$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$39265D8BA0CDD4F045B5F4129B2AAA01$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$'
+  def successful_refund_response
+    'response=1&responsetext=SUCCESS&authcode=&transactionid=2762823772&avsresponse=&cvvresponse=&orderid=&type=refund&response_code=100'
   end
 
-  def fraud_review_response
-    "$4$,$$,$253$,$Thank you! For security reasons your order is currently being reviewed.$,$$,$X$,$0$,$$,$$,$1.00$,$$,$auth_capture$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$207BCBBF78E85CF174C87AE286B472D2$,$M$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$"
+  def failed_refund_response
+    'response=3&responsetext=Invalid Transaction ID specified REFID:3161856100&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=&type=refund&response_code=300'
   end
 
-  def bad_currency_response
-    "$3$,$1$,$39$,$The supplied currency code is either invalid, not supported, not allowed for this merchant or doesn't have an exchange rate.$,$$,$P$,$0$,$$,$$,$1.00$,$$,$auth_capture$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$207BCBBF78E85CF174C87AE286B472D2$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$,$$"
+  def successful_credit_response
+    'response=1&responsetext=SUCCESS&authcode=&transactionid=2762828010&avsresponse=&cvvresponse=&orderid=3deb5bbdcba694a09fd7835263ee83ab&type=credit&response_code=100'
+  end
+
+  def failed_credit_response
+    'response=3&responsetext=Invalid Credit Card Number REFID:3162207528&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=f95e02a07bb77447c8b2001795540771&type=credit&response_code=300'
+  end
+
+  def successful_validate_response
+    'response=1&responsetext=SUCCESS&authcode=&transactionid=2762837000&avsresponse=N&cvvresponse=N&orderid=&type=validate&response_code=100'
+  end
+
+  def failed_validate_response
+    'response=3&responsetext=Invalid Credit Card Number REFID:3162208770&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=&type=validate&response_code=300'
+  end
+
+  def successful_store_response
+    'response=1&responsetext=Customer Added&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=bc28d976f4eb7d379c0dffb5a21342ca&type=&response_code=100&customer_vault_id=256806849'
+  end
+
+  def failed_store_response
+    'response=3&responsetext=Invalid Credit Card Number REFID:3162210328&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=d5efdca79fdc2770fbe56feca8ed5ee6&type=&response_code=300'
+  end
+
+  def successful_echeck_store_response
+    'response=1&responsetext=Customer Added&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=35b5500a13d23a7e9706fdf3518556b3&type=&response_code=100&customer_vault_id=1910603011'
+  end
+
+  def transcript
+    %q(
+      amount=1.00&orderid=c9f2fb356d2a839d315aa6e8d7ed2404&orderdescription=Store+purchase&currency=USD&payment=creditcard&firstname=Longbob&lastname=Longsen&ccnumber=4111111111111111&cvv=917&ccexp=0916&email=&ipaddress=&company=Widgets+Inc&address1=456+My+Street&address2=Apt+1&city=Ottawa&state=ON&country=CA&zip=K1C2N6&phone=%28555%29555-5555&type=sale&username=demo&password=password
+      response=1&responsetext=SUCCESS&authcode=123456&transactionid=2767466670&avsresponse=N&cvvresponse=N&orderid=c9f2fb356d2a839d315aa6e8d7ed2404&type=sale&response_code=100
+      amount=1.00&orderid=e88df316d8ba3c8c6b98aa93b78facc0&orderdescription=Store+purchase&currency=USD&payment=check&checkname=Jim+Smith&checkaba=123123123&checkaccount=123123123&account_holder_type=personal&account_type=checking&sec_code=WEB&email=&ipaddress=&company=Widgets+Inc&address1=456+My+Street&address2=Apt+1&city=Ottawa&state=ON&country=CA&zip=K1C2N6&phone=%28555%29555-5555&type=sale&username=demo&password=password
+      response=1&responsetext=SUCCESS&authcode=123456&transactionid=2767467157&avsresponse=&cvvresponse=&orderid=e88df316d8ba3c8c6b98aa93b78facc0&type=sale&response_code=100
+    )
+  end
+
+  def scrubbed_transcript
+    %q(
+      amount=1.00&orderid=c9f2fb356d2a839d315aa6e8d7ed2404&orderdescription=Store+purchase&currency=USD&payment=creditcard&firstname=Longbob&lastname=Longsen&ccnumber=[FILTERED]&cvv=[FILTERED]&ccexp=0916&email=&ipaddress=&company=Widgets+Inc&address1=456+My+Street&address2=Apt+1&city=Ottawa&state=ON&country=CA&zip=K1C2N6&phone=%28555%29555-5555&type=sale&username=demo&password=[FILTERED]
+      response=1&responsetext=SUCCESS&authcode=123456&transactionid=2767466670&avsresponse=N&cvvresponse=N&orderid=c9f2fb356d2a839d315aa6e8d7ed2404&type=sale&response_code=100
+      amount=1.00&orderid=e88df316d8ba3c8c6b98aa93b78facc0&orderdescription=Store+purchase&currency=USD&payment=check&checkname=Jim+Smith&checkaba=[FILTERED]&checkaccount=[FILTERED]&account_holder_type=personal&account_type=checking&sec_code=WEB&email=&ipaddress=&company=Widgets+Inc&address1=456+My+Street&address2=Apt+1&city=Ottawa&state=ON&country=CA&zip=K1C2N6&phone=%28555%29555-5555&type=sale&username=demo&password=[FILTERED]
+      response=1&responsetext=SUCCESS&authcode=123456&transactionid=2767467157&avsresponse=&cvvresponse=&orderid=e88df316d8ba3c8c6b98aa93b78facc0&type=sale&response_code=100
+    )
   end
 end


### PR DESCRIPTION
This is a rewrite of the NMI adapter to support their native API and not
the previous Auth.net emulation mode API. Every attempt has been made to
retain backwards compatibility. However, there may be small discrepancies
depending on your usage of the API.

What is known is that there are a few fields without a sensible mapping
to the new API. These request params include:

* cardholder_authentication_value and authentication_indicator which are
3D Secure authentication fields. The NMI adapter doesn't yet support 3DS.
* solution_id (application_id), which identifies the agent making the API
call, has no equal in the native API.
* cust_id has no mapping to the native API

Also, the native API does not support the notion of a fraud_review, so that
functionality is not available in the rewritten implementation.

The advantages of using the NMI native API include being on the most
current version which will make future development easier, as well as
support for features such as ACH/echeck payment methods (which this
rewrite does include).

@ntalbott does this pass your sniff test?