### PR TITLE
Stripe: don't send blank, non-nil values

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -383,7 +383,7 @@ module ActiveMerchant #:nodoc:
         return nil unless params
 
         params.map do |key, value|
-          next if value.nil?
+          next if value != false && value.blank?
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|
@@ -391,7 +391,7 @@ module ActiveMerchant #:nodoc:
             end
             post_data(h)
           elsif value.is_a?(Array)
-            value.map { |v| "#{key}[]=#{CGI.escape(v.to_s)}" }.join("&") unless value.blank?
+            value.map { |v| "#{key}[]=#{CGI.escape(v.to_s)}" }.join("&")
           else
             "#{key}=#{CGI.escape(value.to_s)}"
           end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -37,6 +37,17 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "wow@example.com", response.params["metadata"]["email"]
   end
 
+  def test_successful_purchase_with_blank_referer
+    options = @options.merge({referrer: ""})
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert_equal response.authorization, response.params["id"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+  end
+
   def test_successful_purchase_with_recurring_flag
     custom_options = @options.merge(:eci => 'recurring')
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -189,6 +189,16 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_empty_values_not_sent
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, referrer: "")
+    end.check_request do |method, endpoint, data, headers|
+      refute_match(/referrer/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_authorization
     @gateway.expects(:add_creditcard)
     @gateway.expects(:ssl_request).returns(successful_authorization_response)


### PR DESCRIPTION
@anellis I noticed for https://github.com/activemerchant/active_merchant/pull/1807/files that the way that values are passed in to Stripe was changed - when we went to deploy that a lot of requests started failing with the error `You passed an empty string for 'referrer'. We assume empty values are an attempt to unset a parameter; however 'referrer' cannot be unset. You should remove 'referrer' from your request or supply a non-empty value` - so this restores the old logic and includes a change to also let `false` get in. Open to suggestions on a cleaner way to do this.

@aprofeit @anellis for review please.