### PR TITLE
Quickpay v10 fixes

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -206,14 +206,14 @@ module ActiveMerchant
           success ? 'OK' : (response['message'] || invalid_operation_message(response))
         end
         
-        def invalid_operation_code response
+        def invalid_operation_code(response)
           if response['operations']
             operation = response['operations'].last
             operation && operation['qp_status_code'] != "20000"
           end
         end
 
-        def invalid_operation_message response
+        def invalid_operation_message(response)
           response['operations'].last['qp_status_msg']
         end
 

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -19,8 +19,12 @@ module ActiveMerchant
           r.process { create_payment(money, options) }
           r.process {
             post = authorization_params(money, credit_card, options)
-            add_autocapture(post, true)
+            add_autocapture(post, false)
             commit(synchronized_path("/payments/#{r.authorization}/authorize"), post)
+          }
+          r.process {
+            post = capture_params(money, credit_card, options)
+            commit(synchronized_path("/payments/#{r.authorization}/capture"), post)            
           }
         end
       end
@@ -45,9 +49,7 @@ module ActiveMerchant
       end
 
       def capture(money, identification, options = {})
-        post = {}
-        add_amount(post, money, options)
-        add_additional_params(:capture, post, options)
+        post = capture_params(money, identification, options)
         commit(synchronized_path("/payments/#{identification}/capture"), post)
       end
 
@@ -83,17 +85,30 @@ module ActiveMerchant
           post
         end
 
-        def create_subscription(options = {})
+        def capture_params(money, credit_card, options = {})
           post = {}
 
+          add_amount(post, money, options)
+          add_additional_params(:capture, post, options)
+
+          post
+        end
+                
+        def create_subscription(options = {})
+          requires!(options, :currency)  
+          post = {}            
+
+          add_currency(post, nil, options)
           add_subscription_invoice(post, options)
           commit('/subscriptions', post)
         end
 
         def authorize_subscription(identification, credit_card, options = {})
+          requires!(options, :amount)
           post = {}
 
-          add_credit_card(post, credit_card, options)
+          add_amount(post, nil, options)                    
+          add_credit_card(post, credit_card, options)          
           add_additional_params(:authorize_subscription, post, options)
           commit(synchronized_path("/subscriptions/#{identification}/authorize"), post)
         end
@@ -133,7 +148,7 @@ module ActiveMerchant
         end
 
         def add_amount(post, money, options)
-          post[:amount] = amount(money)
+          post[:amount] = options[:amount] || amount(money)
         end
 
         def add_autocapture(post, value)
@@ -182,13 +197,24 @@ module ActiveMerchant
 
         def successful?(response)
           has_error    = response['errors']
-          invalid_code = (response.key?('qp_status_code') and response['qp_status_code'] != "20000")
+          invalid_code = invalid_operation_code(response)
 
           !(has_error || invalid_code)
         end
 
         def message_from(success, response)
-          success ? 'OK' : (response['message'] || response['qp_status_msg'])
+          success ? 'OK' : (response['message'] || invalid_operation_message(response))
+        end
+        
+        def invalid_operation_code response
+          if response['operations']
+            operation = response['operations'].last
+            operation && operation['qp_status_code'] != "20000"
+          end
+        end
+
+        def invalid_operation_message response
+          response['operations'].last['qp_status_msg']
         end
 
         def map_address(address)

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -20,7 +20,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     @invalid_address = address(:phone => '4500000002')
   end
 
-  def card_brand response
+  def card_brand(response)
     response.params['metadata']['brand']
   end
 
@@ -153,13 +153,13 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   
   def test_successful_store
     assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
-    assert_success response  
+    assert_success response
   end
 
   def test_successful_unstore
     assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :amount => @amount, :currency => 'USD'))
-    assert_success response  
-    
+    assert_success response
+
     assert response = @gateway.unstore(response.authorization)
     assert_success response
   end

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -12,7 +12,9 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
 
     @valid_card    = credit_card('1000000000000008')
     @invalid_card  = credit_card('1000000000000016')
-    @expeired_card = credit_card('1000000000000024')
+    @expired_card = credit_card('1000000000000024')
+    @capture_rejected_card = credit_card('1000000000000032')
+    @refund_rejected_card = credit_card('1000000000000040')
 
     @valid_address   = address(:phone => '4500000001')
     @invalid_address = address(:phone => '4500000002')
@@ -54,7 +56,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   def test_unsuccessful_purchase_with_invalid_card
     assert response = @gateway.purchase(@amount, @invalid_card, @options)
     assert_failure response
-    assert_match /Rejected by acquirer/, response.message
+    assert_match(/Rejected test operation/, response.message)
   end
 
   def test_successful_usd_purchase
@@ -80,7 +82,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   def test_unsuccessful_authorize_with_invalid_card
     assert response = @gateway.authorize(@amount, @invalid_card, @options)
     assert_failure response
-    assert_match /Rejected by acquirer/, response.message
+    assert_match /Rejected test operation/, response.message
   end
 
   def test_successful_authorize_and_capture
@@ -91,6 +93,16 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal 'OK', capture.message
+  end
+
+  def test_unsuccessful_authorize_and_capture
+    assert auth = @gateway.authorize(@amount, @capture_rejected_card, @options)
+    assert_success auth
+    assert_equal 'OK', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_failure capture
+    assert_equal 'Rejected test operation', capture.message
   end
 
   def test_failed_capture
@@ -128,15 +140,26 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert_success credit
   end
 
+  def test_unsuccessful_authorization_capture_and_credit
+    assert auth = @gateway.authorize(@amount, @refund_rejected_card, @options)
+    assert_success auth
+    assert !auth.authorization.blank?
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert refund = @gateway.refund(@amount, auth.authorization)
+    assert_failure refund
+    assert_equal 'Rejected test operation', refund.message
+  end
+  
   def test_successful_store
-    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test'))
-    assert_success response
+    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
+    assert_success response  
   end
 
   def test_successful_unstore
-    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test'))
-    assert_success response
-
+    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :amount => @amount, :currency => 'USD'))
+    assert_success response  
+    
     assert response = @gateway.unstore(response.authorization)
     assert_success response
   end

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -35,7 +35,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_order_id_format
-    options = @options.merge({order_id: "#1001.1"})
+    options = @options.merge({order_id: "##{Time.new.to_f}"})
     assert response = @gateway.purchase(@amount, @valid_card, options)
 
     assert_equal 'OK', response.message

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -32,9 +32,11 @@ class QuickpayV10Test < Test::Unit::TestCase
       parsed = parse(data)
       if parsed['order_id']
         assert_match %r{/payments}, endpoint
-      else
+      elsif !parsed['auto_capture'].nil?
         assert_match %r{/payments/\d+/authorize}, endpoint
-        assert_equal parsed['auto_capture'], true 
+        assert_equal parsed['auto_capture'], false 
+      else
+        assert_match %r{/payments/\d+/capture}, endpoint        
       end
     end.respond_with(successful_payment_response, successful_authorization_response)
   end
@@ -84,7 +86,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def test_successful_store
     stub_comms do 
-      assert response = @gateway.store(@credit_card, @options.merge(:description => 'test'))
+      assert response = @gateway.store(@credit_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
       assert_success response
       assert response.test?
     end.check_request do |endpoint, data, headers|

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -34,7 +34,7 @@ class QuickpayV10Test < Test::Unit::TestCase
         assert_match %r{/payments}, endpoint
       elsif !parsed['auto_capture'].nil?
         assert_match %r{/payments/\d+/authorize}, endpoint
-        assert_equal parsed['auto_capture'], false 
+        assert_equal false, parsed['auto_capture']
       else
         assert_match %r{/payments/\d+/capture}, endpoint        
       end


### PR DESCRIPTION
This PR makes all Payments/Operations requests to QuickPay v10 platform synchronous ensuring that the payment's status is in sync between AM and QuickPay