### PR TITLE
Securenet: add test_mode parameters for TEST element tag.

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -208,8 +208,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_more_required_params(xml, options)
+        test_mode = options[:test_mode].nil? ? test? : options[:test_mode]
         xml.tag! 'RETAIL_LANENUM', '0'
-        xml.tag! 'TEST', 'TRUE' if test?
+        xml.tag! 'TEST', test_mode ? 'TRUE' : 'FALSE'
         xml.tag! 'TOTAL_INSTALLMENTCOUNT', 0
         xml.tag! 'TRANSACTION_SERVICE', 0
         xml.tag! 'DEVELOPERID', options[:developer_id] if options[:developer_id]

--- a/test/unit/gateways/secure_net_test.rb
+++ b/test/unit/gateways/secure_net_test.rb
@@ -166,6 +166,22 @@ class SecureNetTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_passes_with_test_mode
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, test_mode: false)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<TEST>FALSE</TEST>}, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passes_without_test_mode
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<TEST>TRUE</TEST>}, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   # Place raw successful response from gateway here


### PR DESCRIPTION
Securenet allows us to set TEST = true in production mode, and i think the code should allow us to do so.
please see:  https://github.com/activemerchant/active_merchant/issues/1827
