### PR TITLE
USAePay: Use names from the given billing and shipping address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@
 * Monei: Add default options argument [davidgf]
 * Ogone: Add additional 3d-secure parameters [ntalbott]
 * Ogone: Refactor signature calculation [ntalbott]
+* USAePay: Use names from the given billing and shipping address [marquisong]
 
 
 == Version 1.52.0 (July 20, 2015)

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -141,9 +141,10 @@ module ActiveMerchant #:nodoc:
 
       def add_address_for_type(type, post, credit_card, address)
         prefix = address_key_prefix(type)
+        first_name, last_name = split_names(address[:name])
 
-        post[address_key(prefix, 'fname')]    = credit_card.first_name
-        post[address_key(prefix, 'lname')]    = credit_card.last_name
+        post[address_key(prefix, 'fname')]    = first_name.blank? && last_name.blank? ? credit_card.first_name : first_name
+        post[address_key(prefix, 'lname')]    = first_name.blank? && last_name.blank? ? credit_card.last_name : last_name
         post[address_key(prefix, 'company')]  = address[:company]   unless address[:company].blank?
         post[address_key(prefix, 'street')]   = address[:address1]  unless address[:address1].blank?
         post[address_key(prefix, 'street2')]  = address[:address2]  unless address[:address2].blank?
@@ -152,6 +153,15 @@ module ActiveMerchant #:nodoc:
         post[address_key(prefix, 'zip')]      = address[:zip]       unless address[:zip].blank?
         post[address_key(prefix, 'country')]  = address[:country]   unless address[:country].blank?
         post[address_key(prefix, 'phone')]    = address[:phone]     unless address[:phone].blank?
+      end
+
+      def split_names(full_name)
+        names = (full_name || '').split
+        return [nil, nil] if names.size == 0
+
+        last_name = names.pop
+        first_name = names.join(' ')
+        [first_name, last_name]
       end
 
       def address_key_prefix(type)

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -6,7 +6,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
     @credit_card_with_track_data = credit_card_with_track_data('4000100011112224')
-    @options = { :billing_address => address(:zip => "27614", :state => "NC")}
+    @options = { :billing_address => address(:zip => "27614", :state => "NC"), :shipping_address => address }
     @amount = 100
   end
 


### PR DESCRIPTION
This PR updates the add_address_for_type() to use the names from billing and shipping address, instead of credit card's name. It will fall back to current behaviour if names in billing and shipping address are blank.