### PR TITLE
Beanstream: Add Network Tokenization support

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -206,6 +206,11 @@ module ActiveMerchant #:nodoc:
           post[:trnExpMonth] = format(credit_card.month, :two_digits)
           post[:trnExpYear] = format(credit_card.year, :two_digits)
           post[:trnCardCvd] = credit_card.verification_value
+          if credit_card.is_a?(NetworkTokenizationCreditCard)
+            post[:"3DSecureXID"] = credit_card.transaction_id
+            post[:"3DSecureECI"] = credit_card.eci
+            post[:"3DSecureCAVV"] = credit_card.payment_cryptogram
+          end
         end
       end
 


### PR DESCRIPTION
@duff @andrewpaliga 

Beanstream tells me that there's no way to do an automated remote test for this, so I haven't (but I'm open to suggestions).