### PR TITLE
QuickPayV10: Change tests to point to proper gateway

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -701,7 +701,6 @@ quickpay:
   password: "29p61DveBZ79c3144LW61lVz1qrwk2gfAFCxPyi5sn49m3Y3IRK5M6SN5d8a68u7"
 
 quickpay_v10_api_key:
-  login: 41
   api_key: "03508e7791ba6c9d0e6830716e650f35c4342c4b3576723ad556e236ca4c7788"
 
 # To get the right apikey, log in to the manager.

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RemoteQuickPayV10Test < Test::Unit::TestCase
 
   def setup
-    @gateway = QuickpayGateway.new(fixtures(:quickpay_v10_api_key))
+    @gateway = QuickpayV10Gateway.new(fixtures(:quickpay_v10_api_key))
     @amount = 100
     @options = {
       :order_id => generate_unique_id[0...10],
@@ -162,7 +162,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert_failure response
     assert_equal "Rejected test operation", response.message
   end
-  
+
   def test_successful_store
     assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
     assert_success response
@@ -177,7 +177,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = QuickpayGateway.new(login: 0, api_key: '**')
+    gateway = QuickpayV10Gateway.new(api_key: '**')
     assert response = gateway.purchase(@amount, @valid_card, @options)
     assert_equal 'Invalid API key', response.message
     assert_failure response

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -4,7 +4,7 @@ class QuickpayV10Test < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = QuickpayGateway.new(:api_key => 'APIKEY', :login => 123)
+    @gateway = QuickpayV10Gateway.new(:api_key => 'APIKEY')
     @credit_card = credit_card('4242424242424242')
     @amount = 100
     @options = { :order_id => '1', :billing_address => address}
@@ -274,7 +274,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def transcript
     %q(
-      POST /payments/7452604/authorize?synchronized HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic OjAzNTA4ZTc3OTFiYTZjOWQwZTY4MzA3MTZlNjUwZjM1YzQzNDJjNGIzNTc2NzIzYWQ1NTZlMjM2Y2E0Yzc3ODg=\r\nUser-Agent: Quickpay-v10 ActiveMerchantBindings/1.52.0\r\nAccept: application/json\r\nAccept-Version: v10\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nConnection: close\r\nHost: api.quickpay.net\r\nContent-Length: 136
+      POST /payments/7488279/authorize?synchronized HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic OjAzNTA4ZTc3OTFiYTZjOWQwZTY4MzA3MTZlNjUwZjM1YzQzNDJjNGIzNTc2NzIzYWQ1NTZlMjM2Y2E0Yzc3ODg=\r\nUser-Agent: Quickpay-v10 ActiveMerchantBindings/1.52.0\r\nAccept: application/json\r\nAccept-Version: v10\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nConnection: close\r\nHost: api.quickpay.net\r\nContent-Length: 136\r\n\r\n
       {\"amount\":\"100\",\"card\":{\"number\":\"1000000000000008\",\"cvd\":\"123\",\"expiration\":\"1609\",\"issued_to\":\"Longbob Longsen\"},\"auto_capture\":false}
       D, [2015-08-17T11:44:26.710099 #75027] DEBUG -- : {"amount":"100","card":{"number":"1000000000000008","cvd":"123","expiration":"1609","issued_to":"Longbob Longsen"},"auto_capture":false}
     )
@@ -282,7 +282,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def scrubbed_transcript
     %q(
-      POST /payments/7452604/authorize?synchronized HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]=\r\nUser-Agent: Quickpay-v10 ActiveMerchantBindings/1.52.0\r\nAccept: application/json\r\nAccept-Version: v10\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nConnection: close\r\nHost: api.quickpay.net\r\nContent-Length: 136
+      POST /payments/7488279/authorize?synchronized HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]=\r\nUser-Agent: Quickpay-v10 ActiveMerchantBindings/1.52.0\r\nAccept: application/json\r\nAccept-Version: v10\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nConnection: close\r\nHost: api.quickpay.net\r\nContent-Length: 136\r\n\r\n
       {\"amount\":\"100\",\"card\":{\"number\":\"[FILTERED]\",\"cvd\":\"[FILTERED]\",\"expiration\":\"1609\",\"issued_to\":\"Longbob Longsen\"},\"auto_capture\":false}
       D, [2015-08-17T11:44:26.710099 #75027] DEBUG -- : {"amount":"100","card":{"number":"[FILTERED]","cvd":"[FILTERED]","expiration":"1609","issued_to":"Longbob Longsen"},"auto_capture":false}
     )


### PR DESCRIPTION
The QuickPayV10 gateway tests were previously pointing to the old QuickPay Gateway in their setup.