### PR TITLE
Remove ActiveMerchant::Billing::Base.integration_mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@
 * Micropayment: Support Micropayment gateway [rwdaigle]
 * USAePay: Use names from the given billing and shipping address [marquisong]
 * Stripe: Add application fee on EMV authorize calls [bizla]
+* ActiveMerchant: Replace Base.integration_mode and Base.gateway_mode with just Base.mode [aprofeit]
 
 
 == Version 1.52.0 (July 20, 2015)

--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -1,32 +1,21 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module Base
+      GATEWAY_MODE_DEPRECATION_MESSAGE = 'Base#gateway_mode is deprecated in favor of Base#mode and will be removed in a future version'
+
       # Set ActiveMerchant gateways in test mode.
       #
-      #   ActiveMerchant::Billing::Base.gateway_mode = :test
-      mattr_accessor :gateway_mode
+      #   ActiveMerchant::Billing::Base.mode = :test
+      mattr_accessor :mode
 
-      # Set ActiveMerchant integrations in test mode.
-      #
-      #   ActiveMerchant::Billing::Base.integration_mode = :test
-      def self.integration_mode=(mode)
-        ActiveMerchant.deprecated(OFFSITE_PAYMENT_EXTRACTION_MESSAGE)
-        @@integration_mode = mode
-      end
-
-      def self.integration_mode
-        ActiveMerchant.deprecated(OFFSITE_PAYMENT_EXTRACTION_MESSAGE)
-        @@integration_mode
-      end
-
-      # Set both the mode of both the gateways and integrations
-      # at once
-      mattr_reader :mode
-
-      def self.mode=(mode)
+      def self.gateway_mode=(mode)
+        ActiveMerchant.deprecated(GATEWAY_MODE_DEPRECATION_MESSAGE)
         @@mode = mode
-        self.gateway_mode = mode
-        @@integration_mode = mode
+      end
+
+      def self.gateway_mode
+        ActiveMerchant.deprecated(GATEWAY_MODE_DEPRECATION_MESSAGE)
+        @@mode
       end
 
       self.mode = :production
@@ -65,7 +54,7 @@ module ActiveMerchant #:nodoc:
 
       # A check to see if we're in test mode
       def self.test?
-        self.gateway_mode == :test
+        mode == :test
       end
     end
   end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteCyberSourceTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = CyberSourceGateway.new({nexus: "NC"}.merge(fixtures(:cyber_source)))
 

--- a/test/remote/gateways/remote_efsnet_test.rb
+++ b/test/remote/gateways/remote_efsnet_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RemoteEfsnetTest < Test::Unit::TestCase
   
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = EfsnetGateway.new(fixtures(:efsnet))
     

--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteEpayTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = EpayGateway.new(fixtures(:epay))
 

--- a/test/remote/gateways/remote_ideal_rabobank_test.rb
+++ b/test/remote/gateways/remote_ideal_rabobank_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteIdealRabobankTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = IdealRabobankGateway.new(fixtures(:ideal_rabobank))
 

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteLitleCertification < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     @gateway = LitleGateway.new(fixtures(:litle).merge(:url => "https://cert.litle.com/vap/communicator/online"))
   end
 

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteMerchantESolutionTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = MerchantESolutionsGateway.new(fixtures(:merchant_esolutions))
 

--- a/test/remote/gateways/remote_payflow_express_test.rb
+++ b/test/remote/gateways/remote_payflow_express_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemotePayflowExpressTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     
     @gateway = PayflowExpressGateway.new(fixtures(:payflow))
 

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemotePayflowTest < Test::Unit::TestCase
   def setup
-    ActiveMerchant::Billing::Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = PayflowGateway.new(fixtures(:payflow))
 

--- a/test/remote/gateways/remote_payflow_uk_test.rb
+++ b/test/remote/gateways/remote_payflow_uk_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemotePayflowUkTest < Test::Unit::TestCase
   def setup
-    ActiveMerchant::Billing::Base.gateway_mode = :test
+    Base.mode = :test
 
     # The default partner is PayPalUk
     @gateway = PayflowUkGateway.new(fixtures(:payflow_uk))

--- a/test/remote/gateways/remote_paypal_express_test.rb
+++ b/test/remote/gateways/remote_paypal_express_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PaypalExpressTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     
     @gateway = PaypalExpressGateway.new(fixtures(:paypal_certificate))
   

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -49,23 +49,20 @@ class BaseTest < Test::Unit::TestCase
   def test_should_set_modes
     Base.mode = :test
     assert_equal :test, Base.mode
-    assert_equal :test, Base.gateway_mode
 
     Base.mode = :production
     assert_equal :production, Base.mode
-    assert_equal :production, Base.gateway_mode
 
-    Base.mode             = :development
-    Base.gateway_mode     = :test
+    assert_deprecation_warning(Base::GATEWAY_MODE_DEPRECATION_MESSAGE) { Base.gateway_mode = :development }
+    assert_deprecation_warning(Base::GATEWAY_MODE_DEPRECATION_MESSAGE) { assert_equal :development, Base.gateway_mode }
     assert_equal :development, Base.mode
-    assert_equal :test,        Base.gateway_mode
   end
 
   def test_should_identify_if_test_mode
-    Base.gateway_mode = :test
+    Base.mode = :test
     assert Base.test?
 
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_false Base.test?
   end
 end

--- a/test/unit/gateways/card_save_test.rb
+++ b/test/unit/gateways/card_save_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CardSaveTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     @gateway = CardSaveGateway.new(:login => 'login', :password => 'password')
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -4,7 +4,7 @@ class CyberSourceTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = CyberSourceGateway.new(
       :login => 'l',

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class EpayTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = EpayGateway.new(
       :login    => '10100111001',

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class EwayManagedTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = EwayManagedGateway.new(:username => 'username', :login => 'login', :password => 'password')
 

--- a/test/unit/gateways/garanti_test.rb
+++ b/test/unit/gateways/garanti_test.rb
@@ -10,7 +10,7 @@ class GarantiTest < Test::Unit::TestCase
       $KCODE = 'u'
     end
 
-    Base.gateway_mode = :test
+    Base.mode = :test
     @gateway = GarantiGateway.new(:login => 'a', :password => 'b', :terminal_id => 'c', :merchant_id => 'd')
 
     @credit_card = credit_card(4242424242424242)

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -38,10 +38,10 @@ class GatewayTest < Test::Unit::TestCase
   end
 
   def test_should_be_able_to_look_for_test_mode
-    Base.gateway_mode = :test
+    Base.mode = :test
     assert @gateway.test?
 
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_false @gateway.test?
   end
 

--- a/test/unit/gateways/global_transport_test.rb
+++ b/test/unit/gateways/global_transport_test.rb
@@ -4,7 +4,7 @@ class GlobalTransportTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     @gateway = GlobalTransportGateway.new(global_user_name: 'login', global_password: 'password', term_type: "ABC")
 
     @options = {

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class IridiumTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = IridiumGateway.new(:login => 'login', :password => 'password')
 

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -4,7 +4,7 @@ class JetpayTest < Test::Unit::TestCase
   include ActiveMerchant::Billing
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = JetpayGateway.new(:login => 'login')
 

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -133,7 +133,7 @@ class LinkpointTest < Test::Unit::TestCase
   end
 
   def test_overriding_test_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
 
     gateway = LinkpointGateway.new(
       :login => 'LOGIN',
@@ -145,7 +145,7 @@ class LinkpointTest < Test::Unit::TestCase
   end
 
   def test_using_production_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
 
     gateway = LinkpointGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class MerchantESolutionsTest < Test::Unit::TestCase
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = MerchantESolutionsGateway.new(
                  :login => 'login',

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -4,7 +4,7 @@ class MercuryTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = MercuryGateway.new(fixtures(:mercury))
 

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -5,7 +5,7 @@ class PayJunctionTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = PayJunctionGateway.new(
                  :login      => "pj-ql-01",

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -12,7 +12,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE}&useraction=commit"
   
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
   
     @gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
@@ -31,7 +31,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
   
   def teardown
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
   
   def test_using_test_mode
@@ -39,7 +39,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
   
   def test_overriding_test_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
     
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
@@ -51,7 +51,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
   
   def test_using_production_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
     
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
@@ -62,7 +62,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
   
   def test_live_redirect_url
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
@@ -73,13 +73,13 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
   
   def test_live_redirect_url_without_review
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
   
   def test_test_redirect_url_without_review
-    assert_equal :test, Base.gateway_mode
+    assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -108,7 +108,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_overriding_test_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
 
     gateway = PayflowGateway.new(
       :login => 'LOGIN',
@@ -120,7 +120,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_using_production_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
 
     gateway = PayflowGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -13,21 +13,21 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
       :pem => 'PEM'
     )
 
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
 
   def teardown
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
 
   def test_live_redirect_url
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal MOBILE_LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_test_redirect_url
-    assert_equal :test, Base.gateway_mode
+    assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal MOBILE_TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890', mobile: true)
   end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -29,27 +29,27 @@ class PaypalExpressTest < Test::Unit::TestCase
                  :phone => '(555)555-5555'
                }
 
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
 
   def teardown
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
 
   def test_live_redirect_url
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
 
   def test_live_redirect_url_without_review
-    Base.gateway_mode = :production
+    Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
 
   def test_force_sandbox_redirect_url
-    Base.gateway_mode = :production
+    Base.mode = :production
 
     gateway = PaypalExpressGateway.new(
       :login => 'cody',
@@ -64,13 +64,13 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_test_redirect_url
-    assert_equal :test, Base.gateway_mode
+    assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
 
   def test_test_redirect_url_without_review
-    assert_equal :test, Base.gateway_mode
+    assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end

--- a/test/unit/gateways/plugnpay_test.rb
+++ b/test/unit/gateways/plugnpay_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PlugnpayTest < Test::Unit::TestCase
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = PlugnpayGateway.new(
       :login => 'X',

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -4,7 +4,7 @@ class RedsysTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
     @credentials = {
       :login      => '091952713',
       :secret_key => "qwertyasdf0123456789",
@@ -208,7 +208,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_overriding_options
-    Base.gateway_mode = :production
+    Base.mode = :production
     gw = RedsysGateway.new(
       :terminal => 1,
       :login => '1234',
@@ -220,7 +220,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_production_mode
-    Base.gateway_mode = :production
+    Base.mode = :production
     gw = RedsysGateway.new(
       :terminal => 1,
       :login => '1234',

--- a/test/unit/gateways/skip_jack_test.rb
+++ b/test/unit/gateways/skip_jack_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class SkipJackTest < Test::Unit::TestCase
 
   def setup
-    Base.gateway_mode = :test
+    Base.mode = :test
 
     @gateway = SkipJackGateway.new(:login => 'X', :password => 'Y')
 

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -59,13 +59,13 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_test_flag_should_be_set_when_using_test_login_in_production
-    Base.gateway_mode = :production
+    Base.mode = :production
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card)
     assert_success response
     assert response.test?
   ensure
-    Base.gateway_mode = :test
+    Base.mode = :test
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
It doesn't look like `ActiveMerchant::Billing::Base.integration_mode` is used any longer and it errors out if you try to use it since `OFFSITE_PAYMENT_EXTRACTION_MESSAGE` is no longer defined.

`ActiveMerchant::Billing::Base.mode` used to set both `integration_mode` and `gateway_mode`, I changed it to just be an alias for `gateway_mode` now.

Review please @girasquid @ntalbott 

Closes #1661