### PR TITLE
New openpay specific fields (Cabify requirements)

### DIFF
--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -30,6 +30,19 @@ class OpenpayTest < Test::Unit::TestCase
     assert_equal 'tay1mauq3re4iuuk8bm4', response.authorization
     assert response.test?
   end
+  
+  def test_successful_purchase_with_customer
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    @options[:email] = 'john@gmail.com'
+    @options[:name] = 'John Doe'
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal 'tay1mauq3re4iuuk8bm4', response.authorization
+    assert response.test?
+  end
 
   def test_unsuccessful_request
     @gateway.expects(:ssl_request).returns(failed_purchase_response)


### PR DESCRIPTION
- Added fraud_safe.- true if the charge would be free of fraud system
- Creation of the customer when "name" and "email" are in options
http://www.openpay.mx/en/docs/api/#charge-a-new-card
- If shipping_address is in options, it will send as customer address