### PR TITLE
Adding Dynamic Descriptors to Heartland Payment Systems

### DIFF
--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -132,6 +132,10 @@ module ActiveMerchant #:nodoc:
           end
           xml.hps :TokenRequest, (options[:store] ? 'Y' : 'N')
         end
+
+        if options[:descriptor_name]
+          xml.hps :TxnDescriptor, options[:descriptor_name]
+        end
       end
 
       def add_details(xml, options)

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -37,6 +37,14 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_descriptor
+    @options[:descriptor_name] = 'Location Name'
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_purchase_no_address
     options = {
       order_id: '1',


### PR DESCRIPTION
Added dynamic descriptor name (and corresponding test) to the Heartland implementation.