### PR TITLE
Set `receipt_email` to Stripe request if email is available.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -368,7 +368,7 @@ module ActiveMerchant #:nodoc:
 
       def add_metadata(post, options = {})
         post[:metadata] = options[:metadata] || {}
-        post[:metadata][:email] = options[:email] if options[:email]
+        post[:metadata][:email] = post[:receipt_email] = options[:email] if options[:email]
         post[:metadata][:order_id] = options[:order_id] if options[:order_id]
         post.delete(:metadata) if post[:metadata].empty?
       end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -580,6 +580,7 @@ class StripeTest < Test::Unit::TestCase
       assert_match(/referrer=http\%3A\%2F\%2Fwww\.shopify\.com/, data)
       assert_match(/payment_user_agent=Stripe\%2Fv1\+ActiveMerchantBindings\%2F\d+\.\d+\.\d+/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
+      assert_match(/receipt_email=foo\%40wonderfullyfakedomain\.com/, data)
       assert_match(/metadata\[order_id\]=42/, data)
     end.respond_with(successful_purchase_response)
   end


### PR DESCRIPTION
To ensure that payer gets an email receipt from Stripe.