### PR TITLE
Map standard error codes for paypal gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -43,17 +43,16 @@ module ActiveMerchant #:nodoc:
       STANDARD_ERROR_CODE_MAPPING = {
         '15005' => :card_declined,
         '10754' => :card_declined,
-        '10756' => :card_declined,
         '10752' => :card_declined,
         '10759' => :card_declined,
         '10761' => :card_declined,
-        '10762' => :card_declined,
         '15002' => :card_declined,
-        '15004' => :card_declined,
-        '11084' => :card_declined
+        '11084' => :card_declined,
+        '15004' => :incorrect_cvc,
+        '10762' => :invalid_cvc,
       }
 
-      DEFAULT_ERROR_CODE = :processing_error
+      STANDARD_ERROR_CODE_MAPPING.default = :processing_error
 
       def self.included(base)
         base.default_currency = 'USD'
@@ -659,7 +658,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def standardized_error_code(response)
-        STANDARD_ERROR_CODE_MAPPING[error_codes(response).first] || DEFAULT_ERROR_CODE
+        STANDARD_ERROR_CODE_MAPPING[error_codes(response).first]
       end
 
       def error_codes(response)

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -40,6 +40,19 @@ module ActiveMerchant #:nodoc:
 
       FRAUD_REVIEW_CODE = "11610"
 
+      STANDARD_ERROR_CODE_MAPPING = {
+        '15005' => :card_declined,
+        '10754' => :card_declined,
+        '10756' => :card_declined,
+        '10752' => :card_declined,
+        '10759' => :card_declined,
+        '10761' => :card_declined,
+        '10762' => :card_declined,
+        '15002' => :card_declined,
+        '15004' => :card_declined,
+        '11084' => :card_declined
+      }
+
       def self.included(base)
         base.default_currency = 'USD'
         base.cattr_accessor :pem_file
@@ -637,9 +650,14 @@ module ActiveMerchant #:nodoc:
           :test => test?,
           :authorization => authorization_from(response),
           :fraud_review => fraud_review?(response),
+          :error_code => error_code(response),
           :avs_result => { :code => response[:avs_code] },
           :cvv_result => response[:cvv2_code]
         )
+      end
+
+      def error_code(response)
+        STANDARD_ERROR_CODE_MAPPING[response[:error_codes]] || response[:error_codes]
       end
 
       def fraud_review?(response)

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -11,11 +11,11 @@ module ActiveMerchant
         end
         base.live_redirect_url = 'https://www.paypal.com/cgi-bin/webscr'
       end
-      
+
       def redirect_url
         test? ? test_redirect_url : live_redirect_url
       end
-      
+
       def redirect_url_for(token, options = {})
         options = {:review => true, :mobile => false}.update(options)
 

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -584,11 +584,11 @@ class PaypalTest < Test::Unit::TestCase
     end
   end
 
-  def test_unmapped_error_returns_original_error_code
+  def test_error_code_with_no_mapping_returns_standardized_processing_error
     @gateway.expects(:ssl_request).returns(response_with_error_code("999999"))
 
     response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_equal("999999", response.error_code)
+    assert_equal(:processing_error, response.error_code)
   end
 
   private

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -180,11 +180,11 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_paypal_timeout_error
@@ -574,6 +574,22 @@ class PaypalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_card_declined
+    ["15005", "10754", "10756", "10752", "10759", "10761", "10762", "15002", "15004", "11084"].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_with_error_code(error_code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+      assertion_failed_message = "error_code #{error_code} should have been translated to :card_declined"
+      assert_equal(:card_declined, response.error_code, assertion_failed_message)
+    end
+  end
+
+  def test_unmapped_error_returns_original_error_code
+    @gateway.expects(:ssl_request).returns(response_with_error_code("999999"))
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal("999999", response.error_code)
+  end
 
   private
 
@@ -841,6 +857,41 @@ class PaypalTest < Test::Unit::TestCase
         <ShortMessage xsi:type="xs:string">Invalid Data</ShortMessage>
         <LongMessage xsi:type="xs:string">This transaction cannot be processed. Please enter a valid credit card number and type.</LongMessage>
         <ErrorCode xsi:type="xs:token">10527</ErrorCode>
+        <SeverityCode>Error</SeverityCode>
+      </Errors>
+      <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>
+      <Build xmlns="urn:ebay:apis:eBLBaseComponents">11660982</Build>
+      <Amount xsi:type="cc:BasicAmountType" currencyID="USD">1.00</Amount>
+    </DoDirectPaymentResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def response_with_error_code(error_code)
+    <<-RESPONSE
+    <?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ns="urn:ebay:api:PayPalAPI" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <SOAP-ENV:Header>
+    <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType" />
+    <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+      <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+        <Username xsi:type="xs:string" />
+        <Password xsi:type="xs:string" />
+        <Signature xsi:type="xs:string" />
+        <Subject xsi:type="xs:string" />
+      </Credentials>
+    </RequesterCredentials>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body id="_0">
+    <DoDirectPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+      <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2014-06-27T18:47:18Z</Timestamp>
+      <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Failure</Ack>
+      <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">f3ab2d6fc76e4</CorrelationID>
+      <Errors xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:ErrorType">
+        <ShortMessage xsi:type="xs:string">Invalid Data</ShortMessage>
+        <LongMessage xsi:type="xs:string">This transaction cannot be processed. Please enter a valid credit card number and type.</LongMessage>
+        <ErrorCode xsi:type="xs:token">#{error_code}</ErrorCode>
         <SeverityCode>Error</SeverityCode>
       </Errors>
       <Version xmlns="urn:ebay:apis:eBLBaseComponents">72</Version>

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -575,12 +575,32 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_card_declined
-    ["15005", "10754", "10756", "10752", "10759", "10761", "10762", "15002", "15004", "11084"].each do |error_code|
+    ["15005", "10754", "10752", "10759", "10761", "15002", "11084"].each do |error_code|
       @gateway.expects(:ssl_request).returns(response_with_error_code(error_code))
 
       response = @gateway.purchase(@amount, @credit_card, @options)
       assertion_failed_message = "error_code #{error_code} should have been translated to :card_declined"
       assert_equal(:card_declined, response.error_code, assertion_failed_message)
+    end
+  end
+
+  def test_incorrect_cvc
+    ["15004"].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_with_error_code(error_code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+      assertion_failed_message = "error_code #{error_code} should have been translated to :card_declined"
+      assert_equal(:incorrect_cvc, response.error_code, assertion_failed_message)
+    end
+  end
+
+  def test_invalid_cvc
+    ["10762"].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_with_error_code(error_code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+      assertion_failed_message = "error_code #{error_code} should have been translated to :card_declined"
+      assert_equal(:invalid_cvc, response.error_code, assertion_failed_message)
     end
   end
 


### PR DESCRIPTION
This does not map all of the error codes for paypal, but it provides a framework for providing mappings in the future. Right now, this commit includes mappings for a bunch of paypal error codes which translate to `:card_declined`.

If there is no mapping for the error code, ~~I return the original error code instead~~ I return a processing error.

@girasquid @etiennebarrie
