### PR TITLE
Fix checkout_v2 integration for an empty phone number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Ogone: Add verify [duff]
 * Beanstream: Add verify [mrezentes]
 * PayPal: Map standard error codes [JakeCataford]
+* Checkout.com: Fix an issue with empty phone numbers. [anotherjosmith]
 
 == Version 1.53.0 (September 1, 2015)
 

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
           post[:card][:billingDetails][:state] = address[:state]
           post[:card][:billingDetails][:country] = address[:country]
           post[:card][:billingDetails][:postcode] = address[:zip]
-          post[:card][:billingDetails][:phone] = { number: address[:phone] }
+          post[:card][:billingDetails][:phone] = { number: address[:phone] } unless address[:phone].blank?
         end
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -38,6 +38,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_without_phone_number
+    response = @gateway.purchase(@amount, @credit_card, billing_address: address.update(phone: ''))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
Fixes an issue where sending JSON like this
```json
              "phone" : {
                  "number" : ""
              }
```

with the phone element but with an empty number would fail. The API would return `Validation error: Invalid length for 'phone number'`. Now if the phone number is empty, it will not send the top level "phone" element.

@girasquid @ivanfer for review