### PR TITLE
Send customer IP address to CyberSource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -460,6 +460,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
           xml.tag! 'phoneNumber',           address[:phone]                   unless address[:phone].blank?
           xml.tag! 'email',                 options[:email]
+          xml.tag! 'ipAddress',             options[:ip]                      unless options[:ip].blank? || shipTo
           xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
           xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?
         end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -12,6 +12,7 @@ class CyberSourceTest < Test::Unit::TestCase
     )
 
     @amount = 100
+    @customer_ip = '127.0.0.1'
     @credit_card = credit_card('4111111111111111', :brand => 'visa')
     @declined_card = credit_card('801111111111111', :brand => 'visa')
     @check = check()
@@ -28,6 +29,7 @@ class CyberSourceTest < Test::Unit::TestCase
                },
 
                :email => 'someguy1232@fakeemail.net',
+               :ip => @customer_ip,
                :order_id => '1000',
                :line_items => [
                    {
@@ -71,6 +73,15 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success response
     assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']}", response.authorization
     assert response.test?
+  end
+
+  def test_purchase_includes_customer_ip
+    customer_ip_regexp = /<ipAddress>#{@customer_ip}<\//
+    @gateway.expects(:ssl_post).
+      with(anything, regexp_matches(customer_ip_regexp), anything).
+      returns("")
+    @gateway.expects(:parse).returns({})
+    @gateway.purchase(@amount, @credit_card, @options)
   end
 
   def test_successful_check_purchase


### PR DESCRIPTION
Allow passing customer IP address to Cybersource via options[:ip], which
appears to be the active_merchant convention.