### PR TITLE
Orbital customer profiles is confusing

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -488,10 +488,10 @@ optimal_payment:
   password: test
   account_number: ACCOUNTNUMBER
 
-orbital_gateway:
+orbital:
   login: LOGIN
   password: PASSWORD
-  merchant_id: MERCHANTID
+  merchant_id: "MERCHANTID"
 
 # Working credentials, no need to replace
 pago_facil:


### PR DESCRIPTION
`@options` for the gateway vs. local `options` to purchase/authorize is pretty confusing.

not sure if adding a comment is enough to make this clear for people trying to figure out usage.