### PR TITLE
add cardholder IP on purchase and authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -80,6 +80,7 @@ module ActiveMerchant #:nodoc:
         end
         add_address(form, options)
         add_customer_data(form, options)
+        add_ip(form, options)
         add_test_mode(form, options)
         commit(:purchase, money, form)
       end
@@ -98,6 +99,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard(form, creditcard)
         add_address(form, options)
         add_customer_data(form, options)
+        add_ip(form, options)
         add_test_mode(form, options)
         commit(:authorize, money, form)
       end
@@ -201,6 +203,10 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def add_ip(form, options)
+        form[:customer_ip_address]  = options[:ssl_cardholder_ip] if options.has_key(:ssl_cardholder_ip)
+      end
 
       def add_invoice(form,options)
         form[:invoice_number] = (options[:order_id] || options[:invoice]).to_s.slice(0, 10)


### PR DESCRIPTION
Looks to fix #1822 

>We are currently not sending the cardholder's IP when performing an auth or sale.

>[According to the docs](https://www.myvirtualmerchant.com/VirtualMerchant/download/developerGuide.pdf) this can be done by passing `ssl_cardholder_ip`.


@cjoudrey for review