### PR TITLE
Raven: Use TLS 1.2 endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Stripe: Set `receipt_email` to Stripe request if receipt delivery is requested [miccheng]
 * Worldpay US: Add eCheck support [mrezentes]
 * FirstData_e4: add level_3 data [mrezentes]
+* Raven: Use TLS 1.2 endpoint [bslobodin]
 
 
 == Version 1.53.0 (September 1, 2015)

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -25,14 +25,14 @@ module ActiveMerchant #:nodoc:
         'cvv2_not_checked' => 'X'
       }
 
-      self.test_url = 'https://raven.deepcovelabs.com/realtime/'
-      self.live_url = 'https://raven.deepcovelabs.com/realtime/'
+      self.live_url = 'https://raven.deepcovelabs.net/realtime/'
+      self.test_url = self.live_url
 
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master]
       self.money_format = :cents
       self.default_currency = 'USD'
-      self.homepage_url = 'http://www.deepcovelabs.com/raven'
+      self.homepage_url = 'https://www.deepcovelabs.com/raven'
       self.display_name = 'Raven'
 
       def initialize(options = {})

--- a/test/remote/gateways/remote_pac_net_raven_test.rb
+++ b/test/remote/gateways/remote_pac_net_raven_test.rb
@@ -143,14 +143,14 @@ class RemotePacNetRavenGatewayTest < Test::Unit::TestCase
   def test_authorize_and_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert void = @gateway.void(auth.authorization)
-    assert_failure void
+    assert_success void
     assert void.params['ApprovalCode']
     assert void.params['TrackingNumber']
-    assert_equal 'error:canNotBeVoided', void.params['ErrorCode']
+    assert_nil void.params['ErrorCode']
     assert_equal 'ok', void.params['RequestResult']
-    assert_equal "Error processing transaction because the payment may not be voided.", void.params['Message']
-    assert_equal 'Approved', void.params['Status']
-    assert_equal "Error processing transaction because the payment may not be voided.", void.message
+    assert_nil void.params['Message']
+    assert_equal 'Voided', void.params['Status']
+    assert_equal "This transaction has been voided", void.message
   end
 
   def test_authorize_capture_and_void


### PR DESCRIPTION
We are going to begin migrating all clients over to a new API endpoint, which is configured for TLS 1.2 only as per PCI 3.1 requirements. This changes the URL for the integration, and also fixes one remote integration test, as we now allow voiding of unsettled authorization.

@ntalbott @girasquid to review please.

/cc @jbeeko @kevinneufeld.

```
➜  active_merchant git:(raven-tls-12) bundle exec rake test:units TEST=test/unit/gateways/pac_net_raven_test.rb
Started
..........................................
Finished in 0.015131 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
42 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2775.76 tests/s, 8723.81 assertions/s

➜  active_merchant git:(raven-tls-12) bundle exec rake test:remote TEST=test/remote/gateways/remote_pac_net_raven_test.rb
Started
................
Finished in 15.551343 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
16 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.03 tests/s, 8.49 assertions/s
```