### PR TITLE
[Paybox] set currency from request options

### DIFF
--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -67,6 +67,8 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, options)
         add_creditcard(post, creditcard)
+        add_amount(post, money, options)
+
         commit('authorization', money, post)
       end
 
@@ -74,6 +76,8 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, options)
         add_creditcard(post, creditcard)
+        add_amount(post, money, options)
+
         commit('purchase', money, post)
       end
 
@@ -81,8 +85,10 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
         post = {}
         add_invoice(post, options)
+        add_amount(post, money, options)
         post[:numappel] = authorization[0,10]
         post[:numtrans] = authorization[10,10]
+
         commit('capture', money, post)
       end
 
@@ -91,8 +97,10 @@ module ActiveMerchant #:nodoc:
         post ={}
         add_invoice(post, options)
         add_reference(post, identification)
+        add_amount(post, options[:amount], options)
         post[:porteur] = '000000000000000'
         post[:dateval] = '0000'
+
         commit('void', options[:amount], post)
       end
 
@@ -125,6 +133,11 @@ module ActiveMerchant #:nodoc:
         post[:numtrans] = identification[10,10]
       end
 
+      def add_amount(post, money, options)
+        post[:montant] = ('0000000000' + (money ? amount(money) : ''))[-10..-1]
+        post[:devise] = CURRENCY_CODES[options[:currency] || currency(money)]
+      end
+
       def parse(body)
         results = {}
         body.split(/&/).each do |pair|
@@ -135,8 +148,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, money = nil, parameters = nil)
-        parameters[:montant] = ('0000000000' + (money ? amount(money) : ''))[-10..-1]
-        parameters[:devise] = CURRENCY_CODES[options[:currency] || currency(money)]
         request_data = post_data(action,parameters)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request_data))
         response = parse(ssl_post(self.live_url_backup, request_data)) if service_unavailable?(response) && !test?

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -36,6 +36,24 @@ class PayboxDirectTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_purchase_with_default_currency
+    @gateway.expects(:ssl_post).with do |_, body|
+      body.include?('DEVISE=978')
+    end.returns(purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
+  def test_purchase_with_set_currency
+    @options.update(currency: 'GBP')
+
+    @gateway.expects(:ssl_post).with do |_, body|
+      body.include?('DEVISE=826')
+    end.returns(purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
   def test_deprecated_credit
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/NUMAPPEL=transid/), anything).returns("")
     @gateway.expects(:parse).returns({})


### PR DESCRIPTION
## Issue
Paybox Integration doesn't respect currency because it's drawing from the credentials `options` hash instead of the request `options`

## Fix
extract money parameters, and test that it works

@aprofeit @girasquid 