### PR TITLE
QuickpayV10: Remove currency requirement from store.

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -113,7 +113,6 @@ module ActiveMerchant
         end
 
         def create_store(options = {})
-          requires!(options, :currency)
           post = {}
           commit('/cards', post)
         end

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -164,19 +164,19 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
+    assert response = @gateway.store(@valid_card, @options.merge(:amount => @amount))
     assert_success response
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@valid_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
+    assert store = @gateway.store(@valid_card, @options.merge(:amount => @amount))
     assert_success store
     assert purchase = @gateway.purchase(@amount, store.authorization, @options)
     assert_success purchase
   end
 
   def test_successful_unstore
-    assert response = @gateway.store(@valid_card, @options.merge(:description => 'test', :amount => @amount, :currency => 'USD'))
+    assert response = @gateway.store(@valid_card, @options.merge(:amount => @amount))
     assert_success response
 
     assert response = @gateway.unstore(response.authorization)

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -86,7 +86,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def test_successful_store
     stub_comms do
-      assert response = @gateway.store(@credit_card, @options.merge(:description => 'test', :currency => 'USD', :amount => @amount))
+      assert response = @gateway.store(@credit_card, @options.merge(:amount => @amount))
       assert_success response
       assert response.test?
     end.check_request do |endpoint, data, headers|


### PR DESCRIPTION
@duff Currency isn't actually required with this new quickpay store method (was in the old) so removing that. 