### PR TITLE
Quickbooks Gateway:   Only add address to post if an address is present.

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
           card_address[:country] = address[:country]
           card_address[:postalCode] = address[:zip] if address[:zip]
         end
-        post[:card][:address] = card_address
+        post[:card][:address] = card_address unless card_address.empty?
       end
 
       def add_amount(post, money, options = {})


### PR DESCRIPTION
Adding an empty address hash to the post causes Quickbooks to reject a card transaction with an error "card.address is invalid".
