### PR TITLE
Authentication for HTTP requests through proxy

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -30,6 +30,8 @@ module ActiveMerchant
     attr_accessor :tag
     attr_accessor :ignore_http_status
     attr_accessor :max_retries
+    attr_accessor :proxy_address
+    attr_accessor :proxy_port
     attr_reader :proxy
 
     def initialize(endpoint)
@@ -43,6 +45,8 @@ module ActiveMerchant
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
+      @proxy_address = nil
+      @proxy_port = nil
       @proxy = nil
     end
 
@@ -96,7 +100,7 @@ module ActiveMerchant
 
     private
     def http
-      http = new_http_agent(endpoint, proxy)
+      http = new_http_agent
       configure_debugging(http)
       configure_timeouts(http)
       configure_ssl(http)
@@ -171,9 +175,16 @@ module ActiveMerchant
       logger.send(level, message) if logger
     end
 
-    def new_http_agent(endpoint, proxy)
-      args = [endpoint.host, endpoint.port]
-      args += [proxy.host, proxy.port, proxy.user, proxy.password] if proxy
+    def new_http_agent
+      args =
+        if proxy
+          [
+            endpoint.host, endpoint.port, proxy.host, proxy.port, proxy.user,
+            proxy.password
+          ]
+        else
+          [endpoint.host, endpoint.port, proxy_address, proxy_port]
+        end
       Net::HTTP.new(*args)
     end
   end

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -30,8 +30,7 @@ module ActiveMerchant
     attr_accessor :tag
     attr_accessor :ignore_http_status
     attr_accessor :max_retries
-    attr_accessor :proxy_address
-    attr_accessor :proxy_port
+    attr_reader :proxy
 
     def initialize(endpoint)
       @endpoint     = endpoint.is_a?(URI) ? endpoint : URI.parse(endpoint)
@@ -44,8 +43,7 @@ module ActiveMerchant
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
-      @proxy_address = nil
-      @proxy_port = nil
+      @proxy = nil
     end
 
     def request(method, body, headers = {})
@@ -92,9 +90,13 @@ module ActiveMerchant
       info "connection_request_total_time=%.4fs" % [Time.now.to_f - request_start], tag
     end
 
+    def proxy=(proxy)
+      @proxy = URI.parse(proxy) if proxy
+    end
+
     private
     def http
-      http = Net::HTTP.new(endpoint.host, endpoint.port, proxy_address, proxy_port)
+      http = new_http_agent(endpoint, proxy)
       configure_debugging(http)
       configure_timeouts(http)
       configure_ssl(http)
@@ -167,6 +169,12 @@ module ActiveMerchant
     def log(level, message, tag)
       message = "[#{tag}] #{message}" if tag
       logger.send(level, message) if logger
+    end
+
+    def new_http_agent(endpoint, proxy)
+      args = [endpoint.host, endpoint.port]
+      args += [proxy.host, proxy.port, proxy.user, proxy.password] if proxy
+      Net::HTTP.new(*args)
     end
   end
 end

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -23,8 +23,8 @@ module ActiveMerchant #:nodoc:
       base.class_attribute :logger
       base.class_attribute :wiredump_device
 
-      base.class_attribute :proxy_address
-      base.class_attribute :proxy_port
+      # A ruby URI String
+      base.class_attribute :proxy
     end
 
     def ssl_get(endpoint, headers={})
@@ -59,8 +59,7 @@ module ActiveMerchant #:nodoc:
 
       connection.ignore_http_status = @options[:ignore_http_status] if @options
 
-      connection.proxy_address = proxy_address
-      connection.proxy_port    = proxy_port
+      connection.proxy = proxy
 
       connection.request(method, data, headers)
     end

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -23,6 +23,8 @@ module ActiveMerchant #:nodoc:
       base.class_attribute :logger
       base.class_attribute :wiredump_device
 
+      base.class_attribute :proxy_address
+      base.class_attribute :proxy_port
       # A ruby URI String
       base.class_attribute :proxy
     end
@@ -59,6 +61,8 @@ module ActiveMerchant #:nodoc:
 
       connection.ignore_http_status = @options[:ignore_http_status] if @options
 
+      connection.proxy_address = proxy_address
+      connection.proxy_port = proxy_port
       connection.proxy = proxy
 
       connection.request(method, data, headers)

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -178,4 +178,26 @@ class ConnectionTest < Test::Unit::TestCase
     end
   end
 
+  def test_proxy_transformed_to_uri
+    proxy_url = 'https://michaelscott:office@proxy.com:1234'
+    connection = ActiveMerchant::Connection.new(@endpoint)
+    connection.proxy = proxy_url
+
+    assert_equal URI.parse(proxy_url), connection.proxy
+  end
+
+  def test_http_agent_created_with_proxy_arguments
+    http_stub = stub_everything(get: @ok)
+    connection = ActiveMerchant::Connection.new(@endpoint)
+    connection.proxy = 'https://michaelscott:office@proxy.com:1234'
+
+    Net::HTTP.
+      expects(:new).
+      with('example.com', 443, 'proxy.com', 1234, 'michaelscott', 'office').
+      returns(http_stub)
+
+    response = connection.request(:get, nil, {})
+
+    assert_equal 'success', response.body
+  end
 end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -186,7 +186,7 @@ class ConnectionTest < Test::Unit::TestCase
     assert_equal URI.parse(proxy_url), connection.proxy
   end
 
-  def test_http_agent_created_with_proxy_arguments
+  def test_http_agent_created_with_proxy_attribute
     http_stub = stub_everything(get: @ok)
     connection = ActiveMerchant::Connection.new(@endpoint)
     connection.proxy = 'https://michaelscott:office@proxy.com:1234'
@@ -194,6 +194,22 @@ class ConnectionTest < Test::Unit::TestCase
     Net::HTTP.
       expects(:new).
       with('example.com', 443, 'proxy.com', 1234, 'michaelscott', 'office').
+      returns(http_stub)
+
+    response = connection.request(:get, nil, {})
+
+    assert_equal 'success', response.body
+  end
+
+  def test_http_agent_created_with_proxy_address_and_proxy_port_attributes
+    http_stub = stub_everything(get: @ok)
+    connection = ActiveMerchant::Connection.new(@endpoint)
+    connection.proxy_address = 'proxy.com'
+    connection.proxy_port = 1234
+
+    Net::HTTP.
+      expects(:new).
+      with('example.com', 443, 'proxy.com', 1234).
       returns(http_stub)
 
     response = connection.request(:get, nil, {})

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -61,11 +61,9 @@ class PostsDataTests < Test::Unit::TestCase
   end
 
   def test_setting_proxy_settings
-    @gateway.class.proxy_address = 'http://proxy.com'
-    @gateway.class.proxy_port = 1234
+    @gateway.class.proxy = 'http://proxy.com'
     ActiveMerchant::Connection.any_instance.expects(:request).returns(@ok)
-    ActiveMerchant::Connection.any_instance.expects(:proxy_address=).with('http://proxy.com')
-    ActiveMerchant::Connection.any_instance.expects(:proxy_port=).with(1234)
+    ActiveMerchant::Connection.any_instance.expects(:proxy=).with('http://proxy.com')
 
     assert_nothing_raised do
       @gateway.ssl_post(@url, '')

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -61,6 +61,18 @@ class PostsDataTests < Test::Unit::TestCase
   end
 
   def test_setting_proxy_settings
+    @gateway.class.proxy_address = 'http://proxy.com'
+    @gateway.class.proxy_port = 1234
+    ActiveMerchant::Connection.any_instance.expects(:request).returns(@ok)
+    ActiveMerchant::Connection.any_instance.expects(:proxy_address=).with('http://proxy.com')
+    ActiveMerchant::Connection.any_instance.expects(:proxy_port=).with(1234)
+
+    assert_nothing_raised do
+      @gateway.ssl_post(@url, '')
+    end
+  end
+
+  def test_setting_proxy_uri_settings
     @gateway.class.proxy = 'http://proxy.com'
     ActiveMerchant::Connection.any_instance.expects(:request).returns(@ok)
     ActiveMerchant::Connection.any_instance.expects(:proxy=).with('http://proxy.com')


### PR DESCRIPTION
Allow passing a user and a password along address and port for proxies.

Remove previous :proxy_address and :proxy_port accessors and replace them with :proxy, a Ruby URI String to be parsed for proxy information.
