### PR TITLE
Added support for CUSTOM_ID2 field to BluePay transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -430,8 +430,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-          post[:EMAIL]     = options[:email]
-          post[:CUSTOM_ID] = options[:customer]
+        post[:EMAIL]     = options[:email]
+        post[:CUSTOM_ID] = options[:customer]
+        post[:CUSTOM_ID2] = options[:custom_id2]
       end
 
       def add_duplicate_override(post, options)

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class BluePayTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     Base.mode = :test
 
@@ -178,5 +180,17 @@ class BluePayTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+
+  def test_custom_id2_option
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(custom_id2: 'ABC123'))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match('CUSTOM_ID2=ABC123', data)
+    end.respond_with(success_purchase_response)
+  end
+
+  def success_purchase_response
+    'AUTH_CODE=VBLEI&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=SALE&REBID=&STATUS=1&AVS=_&TRANS_ID=100267510339&CVV2=_&MESSAGE=Approved%20Sale'
   end
 end


### PR DESCRIPTION
Currently, the blue_pay gateway included in this activemerchant gem supports passing customer in the options hash, which maps to BluePay's CUSTOM_ID field.  BluePay has a second custom id that can be passed, but there's no current support for it in the gem.  This pull request adds support for it.  I manually verified that this new field does, in fact, display when passed in BluePay's backend.

I also fix the indentation of the add_customer_data method.