### PR TITLE
Stripe: implement scrubbing for track + EMV data

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -225,7 +225,10 @@ module ActiveMerchant #:nodoc:
           gsub(%r((card\[number\]=)\d+), '\1[FILTERED]').
           gsub(%r((card\[cvc\]=)\d+), '\1[FILTERED]').
           gsub(%r((&?three_d_secure\[cryptogram\]=)[\w=]*(&?)), '\1[FILTERED]\2').
-          gsub(%r((card\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\2')
+          gsub(%r((card\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\2').
+          gsub(%r((card\[encrypted_pin\]=)[^&]+(&?)), '\1[FILTERED]\2').
+          gsub(%r((card\[encrypted_pin_key_id\]=)[\w=]+(&?)), '\1[FILTERED]\2').
+          gsub(%r((card\[emv_auth_data\]=)[^&]+(&?)), '\1[FILTERED]\2')
       end
 
       def supports_network_tokenization?

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -224,7 +224,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((card\[number\]=)\d+), '\1[FILTERED]').
           gsub(%r((card\[cvc\]=)\d+), '\1[FILTERED]').
-          gsub(%r((&?three_d_secure\[cryptogram\]=)[\w=]*(&?)), '\1[FILTERED]\2')
+          gsub(%r((&?three_d_secure\[cryptogram\]=)[\w=]*(&?)), '\1[FILTERED]\2').
+          gsub(%r((card\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\2')
       end
 
       def supports_network_tokenization?

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -808,6 +808,10 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed_with_track_data), post_scrubbed_with_track_data
   end
 
+  def test_scrubs_emv_data
+    assert_equal @gateway.scrub(pre_scrubbed_with_emv_data), post_scrubbed_with_emv_data
+  end
+
   def test_supports_scrubbing?
     assert @gateway.supports_scrubbing?
   end
@@ -941,6 +945,64 @@ class StripeTest < Test::Unit::TestCase
       read 1446 bytes
       Conn close
     PRE_SCRUBBED
+  end
+
+  def pre_scrubbed_with_emv_data
+    <<-PRE_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established
+      <- "POST /v1/charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic c2tfdGVzdF8zT0Q0VGRLU0lPaERPTDIxNDZKSmNDNzk6\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.54.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.54.0\",\"lang\":\"ruby\",\"lang_version\":\"2.1.1 p76 (2014-02-24)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.stripe.com\r\nContent-Length: 713\r\n\r\n"
+      <- "card[emv_auth_data]=500B56495341204352454449545F201A56495341204143515549524552205445535420434152442030315F24031512315F280208405F2A0208265F300202015F34010182025C008407A0000000031010950502000080009A031408259B02E8009C01009F02060000000734499F03060000000000009F0607A00000000310109F0902008C9F100706010A03A080009F120F4352454449544F20444520564953419F1A0208269F1C0831373030303437309F1E0831373030303437309F2608EB2EC0F472BEA0A49F2701809F3303E0B8C89F34031E03009F3501229F360200C39F37040A27296F9F4104000001319F4502DAC5DFAE5711476173FFFFFF0119D15122011758989389DFAE5A08476173FFFFFF011957114761739001010119D151220117589893895A084761739001010119&card[encrypted_pin]=8b68af72199529b8&card[encrypted_pin_key_id]=ffff0102628d12000001"
+      -> "HTTP/1.1 402 Payment Required\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 21 Oct 2015 17:39:02 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 195\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Max-Age: 300\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Request-Id: req_7CqEdcyzeRNGQO\r\n"
+      -> "Stripe-Version: 2015-04-07\r\n"
+      -> "\r\n"
+      reading 195 bytes...
+      -> "{\n  \"error\": {\n    \"message\": \"Your card was declined.\",\n    \"type\": \"card_error\",\n    \"code\": \"card_declined\",\n    \"charge\": \"ch_16yQYEAWOtgoysogscsBRQwg\",\n    \"emv_auth_data\": \"8A023035\"\n  }\n}\n"
+      read 195 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_with_emv_data
+    <<-POST_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established
+      <- "POST /v1/charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic [FILTERED]\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.54.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.54.0\",\"lang\":\"ruby\",\"lang_version\":\"2.1.1 p76 (2014-02-24)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.stripe.com\r\nContent-Length: 713\r\n\r\n"
+      <- "card[emv_auth_data]=[FILTERED]&card[encrypted_pin]=[FILTERED]&card[encrypted_pin_key_id]=[FILTERED]"
+      -> "HTTP/1.1 402 Payment Required\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 21 Oct 2015 17:39:02 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 195\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Max-Age: 300\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Request-Id: req_7CqEdcyzeRNGQO\r\n"
+      -> "Stripe-Version: 2015-04-07\r\n"
+      -> "\r\n"
+      reading 195 bytes...
+      -> "{\n  \"error\": {\n    \"message\": \"Your card was declined.\",\n    \"type\": \"card_error\",\n    \"code\": \"card_declined\",\n    \"charge\": \"ch_16yQYEAWOtgoysogscsBRQwg\",\n    \"emv_auth_data\": \"8A023035\"\n  }\n}\n"
+      read 195 bytes
+      Conn close
+    POST_SCRUBBED
   end
 
   def post_scrubbed_with_track_data

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -804,6 +804,10 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_scrubs_track_data
+    assert_equal @gateway.scrub(pre_scrubbed_with_track_data), post_scrubbed_with_track_data
+  end
+
   def test_supports_scrubbing?
     assert @gateway.supports_scrubbing?
   end
@@ -907,6 +911,66 @@ class StripeTest < Test::Unit::TestCase
       read 1303 bytes
       Conn close
     PRE_SCRUBBED
+  end
+
+  def pre_scrubbed_with_track_data
+    <<-PRE_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established
+      <- "POST /v1/charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic c2tfdGVzdF8zT0Q0VGRLU0lPaERPTDIxNDZKSmNDNzk6\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.54.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.54.0\",\"lang\":\"ruby\",\"lang_version\":\"2.1.1 p76 (2014-02-24)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.stripe.com\r\nContent-Length: 165\r\n\r\n"
+      <- "card[swipe_data]=%25B378282246310005%5ELONGSON%2FLONGBOB%5E1705101130504392%3F&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.54.0"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 21 Oct 2015 17:22:09 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1446\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Max-Age: 300\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Request-Id: req_7CpxqdRGPV3xWh\r\n"
+      -> "Stripe-Version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains\r\n"
+      -> "\r\n"
+      reading 1446 bytes...
+      -> "{\n  \"id\": \"ch_16yQHtAWOtgoysogh1YOAtDB\",\n  \"object\": \"charge\",\n  \"amount\": 100,\n  \"amount_refunded\": 0,\n  \"application_fee\": null,\n  \"balance_transaction\": \"txn_16yQHtAWOtgoysogTNhtGJBn\",\n  \"captured\": true,\n  \"created\": 1445448129,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"destination\": null,\n  \"dispute\": null,\n  \"failure_code\": null,\n  \"failure_message\": null,\n  \"fraud_details\": {},\n  \"invoice\": null,\n  \"livemode\": false,\n  \"metadata\": {},\n  \"paid\": true,\n  \"receipt_email\": null,\n  \"receipt_number\": null,\n  \"refunded\": false,\n  \"refunds\": {\n    \"object\": \"list\",\n    \"data\": [],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/charges/ch_16yQHtAWOtgoysogh1YOAtDB/refunds\"\n  },\n  \"shipping\": null,\n  \"source\": {\n    \"id\": \"card_16yQHtAWOtgoysogdSGVCkXK\",\n    \"object\": \"card\",\n    \"address_city\": null,\n    \"address_country\": null,\n    \"address_line1\": null,\n    \"address_line1_check\": null,\n    \"address_line2\": null,\n    \"address_state\": null,\n    \"address_zip\": null,\n    \"address_zip_check\": null,\n    \"brand\": \"American Express\",\n    \"country\": \"US\",\n    \"customer\": null,\n    \"cvc_check\": null,\n    \"dynamic_last4\": null,\n    \"exp_month\": 5,\n    \"exp_year\": 2017,\n    \"fingerprint\": \"DjZpoV89lmOMsJLF\",\n    \"funding\": \"credit\",\n    \"last4\": \"0005\",\n    \"metadata\": {},\n    \"name\": \"LONGSON/LONGBOB\",\n    \"tokenization_method\": null\n  },\n  \"statement_descriptor\": null,\n  \"status\": \"succeeded\"\n}\n"
+      read 1446 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_with_track_data
+    <<-POST_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established
+      <- "POST /v1/charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic [FILTERED]\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.54.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.54.0\",\"lang\":\"ruby\",\"lang_version\":\"2.1.1 p76 (2014-02-24)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.stripe.com\r\nContent-Length: 165\r\n\r\n"
+      <- "card[swipe_data]=[FILTERED]&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.54.0"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 21 Oct 2015 17:22:09 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1446\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Max-Age: 300\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Request-Id: req_7CpxqdRGPV3xWh\r\n"
+      -> "Stripe-Version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains\r\n"
+      -> "\r\n"
+      reading 1446 bytes...
+      -> "{\n  \"id\": \"ch_16yQHtAWOtgoysogh1YOAtDB\",\n  \"object\": \"charge\",\n  \"amount\": 100,\n  \"amount_refunded\": 0,\n  \"application_fee\": null,\n  \"balance_transaction\": \"txn_16yQHtAWOtgoysogTNhtGJBn\",\n  \"captured\": true,\n  \"created\": 1445448129,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"destination\": null,\n  \"dispute\": null,\n  \"failure_code\": null,\n  \"failure_message\": null,\n  \"fraud_details\": {},\n  \"invoice\": null,\n  \"livemode\": false,\n  \"metadata\": {},\n  \"paid\": true,\n  \"receipt_email\": null,\n  \"receipt_number\": null,\n  \"refunded\": false,\n  \"refunds\": {\n    \"object\": \"list\",\n    \"data\": [],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/charges/ch_16yQHtAWOtgoysogh1YOAtDB/refunds\"\n  },\n  \"shipping\": null,\n  \"source\": {\n    \"id\": \"card_16yQHtAWOtgoysogdSGVCkXK\",\n    \"object\": \"card\",\n    \"address_city\": null,\n    \"address_country\": null,\n    \"address_line1\": null,\n    \"address_line1_check\": null,\n    \"address_line2\": null,\n    \"address_state\": null,\n    \"address_zip\": null,\n    \"address_zip_check\": null,\n    \"brand\": \"American Express\",\n    \"country\": \"US\",\n    \"customer\": null,\n    \"cvc_check\": null,\n    \"dynamic_last4\": null,\n    \"exp_month\": 5,\n    \"exp_year\": 2017,\n    \"fingerprint\": \"DjZpoV89lmOMsJLF\",\n    \"funding\": \"credit\",\n    \"last4\": \"0005\",\n    \"metadata\": {},\n    \"name\": \"LONGSON/LONGBOB\",\n    \"tokenization_method\": null\n  },\n  \"statement_descriptor\": null,\n  \"status\": \"succeeded\"\n}\n"
+      read 1446 bytes
+      Conn close
+    POST_SCRUBBED
   end
 
   def post_scrubbed


### PR DESCRIPTION
@bizla @aprofeit for review - I wouldn't mind a sanity check from @anellis or @duff either if you're up for it.

To get a transcript for EMV, I did this using values from `remote_stripe_emv_test.rb`:

```ruby
  def test_emv_scrubbing
    credit_card = ActiveMerchant::Billing::CreditCard.new(icc_data: '500B56495341204352454449545F201A56495341204143515549524552205445535420434152442030315F24031512315F280208405F2A0208265F300202015F34010182025C008407A0000000031010950502000080009A031408259B02E8009C01009F02060000000734499F03060000000000009F0607A00000000310109F0902008C9F100706010A03A080009F120F4352454449544F20444520564953419F1A0208269F1C0831373030303437309F1E0831373030303437309F2608EB2EC0F472BEA0A49F2701809F3303E0B8C89F34031E03009F3501229F360200C39F37040A27296F9F4104000001319F4502DAC5DFAE5711476173FFFFFF0119D15122011758989389DFAE5A08476173FFFFFF011957114761739001010119D151220117589893895A084761739001010119')
    credit_card.encrypted_pin_cryptogram = "8b68af72199529b8"
    credit_card.encrypted_pin_ksn = "ffff0102628d12000001"
    dump_transcript_and_fail(@gateway, @amount, credit_card, {})
  end
```

For `track_data`, I did:
```ruby
def test_track_data_scrubbing
  @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
  dump_transcript_and_fail(@gateway, @amount, @credit_card, {})
end
```