### PR TITLE
Braintree: bump gem to an official release (2.50.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  # gem 'braintree', '>= 2.0.0'
-  gem 'braintree', github: "braintree/braintree_ruby", branch: "raw_apple_pay_preview" # for apple pay support in braintree
+  gem 'braintree', '>= 2.50.0'
 end

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -5,8 +5,7 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  # gem 'braintree', '>= 2.0.0'
-  gem 'braintree', github: "braintree/braintree_ruby", branch: "raw_apple_pay_preview" # for apple pay support in braintree
+  gem 'braintree', '>= 2.50.0'
 end
 
 gem 'rails', '~> 3.2.0'

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -5,8 +5,7 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  # gem 'braintree', '>= 2.0.0'
-  gem 'braintree', github: "braintree/braintree_ruby", branch: "raw_apple_pay_preview" # for apple pay support in braintree
+  gem 'braintree', '>= 2.50.0'
 end
 
 gem 'rails', '~> 4.0.0'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -5,8 +5,7 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  # gem 'braintree', '>= 2.0.0'
-  gem 'braintree', github: "braintree/braintree_ruby", branch: "raw_apple_pay_preview" # for apple pay support in braintree
+  gem 'braintree', '>= 2.50.0'
 end
 
 gem 'rails', '~> 4.1.0'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -5,8 +5,7 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  # gem 'braintree', '>= 2.0.0'
-  gem 'braintree', github: "braintree/braintree_ruby", branch: "raw_apple_pay_preview" # for apple pay support in braintree
+  gem 'braintree', '>= 2.50.0'
 end
 
 gem 'rails', '~> 4.2.0'


### PR DESCRIPTION
@jnormore @ntalbott for review.

`braintree` 2.50.0 includes the apple pay functions that we're using, so we don't need to run off of a side branch anymore.