### PR TITLE
Stripe: Fixes activemerchant/active_merchant#1903

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -499,7 +499,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def card_from_response(response)
-        response["card"] || response["active_card"] || response["source"] || {}
+        response["card"] || response["active_card"] || response["source"] || response["sources"]["data"].first rescue nil || {}
       end
 
       def emv_authorization_from_response(response)


### PR DESCRIPTION
Accounting for an additional card data format in the response. This will allow the card data to be set in the commit method (line 444) in the event that the card was stored through the 'customers' url without specifying a customer (e.g. storing a new card for a new customer).
