### PR TITLE
Enabling daily pay period to match docs

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -293,6 +293,7 @@ module ActiveMerchant #:nodoc:
       def get_pay_period(options)
         requires!(options, [:periodicity, :bimonthly, :monthly, :biweekly, :weekly, :yearly, :daily, :semimonthly, :quadweekly, :quarterly, :semiyearly])
         case options[:periodicity]
+          when :daily then 'Daily'
           when :weekly then 'Weekly'
           when :biweekly then 'Bi-weekly'
           when :semimonthly then 'Semi-monthly'


### PR DESCRIPTION
:daily was listed as an available transaction period but not actually submitted in the request
