### PR TITLE
Bug Fix: valid_checksum? crash on non-digits

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -174,6 +174,7 @@ module ActiveMerchant #:nodoc:
         # Please see http://en.wikipedia.org/wiki/Luhn_algorithm for details.
         # This implementation is from the luhn_checksum gem, https://github.com/zendesk/luhn_checksum.
         def valid_checksum?(numbers) #:nodoc:
+          return false if numbers.to_s.match(/\D/)
           sum = 0
 
           odd = true

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -69,7 +69,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_false valid_card_verification_value?(123, 'american_express')
     assert_false valid_card_verification_value?(12345, 'american_express')
   end
-  
+
   def test_should_be_able_to_identify_valid_issue_numbers
     assert valid_issue_number?(1)
     assert valid_issue_number?(10)
@@ -184,6 +184,11 @@ class CreditCardMethodsTest < Test::Unit::TestCase
 
     assert_not_equal 'discover', CreditCard.brand?('6010000000000000')
     assert_not_equal 'discover', CreditCard.brand?('6600000000000000')
+  end
+
+  def test_matching_invalid_card
+    assert_nil CreditCard.brand?("XXXXXXXXXXXX0000")
+    assert !CreditCard.valid_number?("XXXXXXXXXXXX0000")
   end
 
   def test_16_digit_maestro_uk


### PR DESCRIPTION
When upgrading ActiveMerchant on a few different Rails applications I found that the new `CreditCard.valid_checksum?` method crashes when you pass it obfuscated or otherwise funky card numbers with non-digits in them.  The older 1.4.x version of this method would just return false.

Anyhow this fixes this the issue by just checking to see if there are non-digit characters in the card number before trying to compute the checksum.