### PR TITLE
Stripe: Migrate from /refund to /refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -115,9 +115,10 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         post[:refund_application_fee] = true if options[:refund_application_fee]
         post[:reverse_transfer] = options[:reverse_transfer] if options[:reverse_transfer]
+        post[:metadata] = options[:metadata] if options[:metadata]
 
         MultiResponse.run(:first) do |r|
-          r.process { commit(:post, "charges/#{CGI.escape(identification)}/refund", post, options) }
+          r.process { commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options) }
 
           return r unless options[:refund_fee_amount]
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(identification, options = {})
-        commit(:post, "charges/#{CGI.escape(identification)}/refund", {}, options)
+        commit(:post, "charges/#{CGI.escape(identification)}/refunds", {}, options)
       end
 
       def refund(money, identification, options = {})
@@ -470,8 +470,6 @@ module ActiveMerchant #:nodoc:
           [response["id"], response["sources"]["data"].first["id"]].join("|")
         elsif method == :post && url.match(/customers\/.*\/cards/)
           [response["customer"], response["id"]].join("|")
-        elsif url.include?("refund") && response["refunds"]
-          response["refunds"]["data"].first["id"]
         else
           response["id"]
         end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -105,7 +105,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
     assert refund = @gateway.refund(@amount - 20, response.authorization)
-    refund_id = refund.params["refunds"]["data"].first["id"]
+    refund_id = refund.params["id"]
     assert_equal refund.authorization, refund_id
     assert_success refund
   end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -134,7 +134,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "wow@example.com", response.params["metadata"]["email"]
     assert_equal "charge", response.params["object"]
     assert_success response.responses.last, "The void should succeed"
-    assert response.responses.last.params["refunded"]
+    assert_equal "refund", response.responses.last.params["object"]
   end
 
   def test_unsuccessful_verify

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1396,44 +1396,16 @@ class StripeTest < Test::Unit::TestCase
   def successful_void_response
     <<-RESPONSE
     {
-      "id": "ch_4IrhQMqukqu7C2",
-      "object": "charge",
-      "created": 1403816613,
-      "livemode": false,
-      "paid": true,
-      "amount": 50,
+      "id": "re_173VMpAWOtgoysogOSE7Hzss",
+      "object": "refund",
+      "amount": 100,
+      "balance_transaction": "txn_173VMpAWOtgoysog3QNrt0xD",
+      "charge": "ch_173VMpAWOtgoysogrTPZT1YP",
+      "created": 1446659295,
       "currency": "usd",
-      "refunded": true,
-      "card": {
-        "id": "card_4IKht2vQlbJms9",
-        "object": "card",
-        "last4": "4242",
-        "brand": "Visa",
-        "funding": "credit",
-        "exp_month": 9,
-        "exp_year": 2015,
-        "fingerprint": "6nTaMxIBAdBvfy2i",
-        "country": "US",
-        "name": "Longbob Longsen",
-        "address_city": null,
-        "cvc_check": "pass",
-        "customer": null,
-        "type": "Visa"
-      },
-      "captured": false,
-      "balance_transaction": null,
-      "failure_code": null,
-      "description": "ActiveMerchant Test Purchase",
-      "dispute": null,
-      "metadata": {
-        "email": "wow@example.com"
-      },
-      "statement_description": null,
-      "receipt_email": null,
-      "fee": 0,
-      "fee_details": [],
-      "uncaptured": true,
-      "disputed": false
+      "metadata": {},
+      "reason": null,
+      "receipt_number": null
     }
     RESPONSE
   end
@@ -1443,7 +1415,7 @@ class StripeTest < Test::Unit::TestCase
     {
       "error": {
         "type": "invalid_request_error",
-        "message": "Charge ch_4IL0vZWdcx45qO has already been refunded."
+        "message": "Charge ch_173VPSAWOtgoysoggGxIDRIq has already been refunded."
       }
     }
     RESPONSE

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -342,8 +342,7 @@ class StripeTest < Test::Unit::TestCase
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge')
     assert_success response
 
-    assert_equal 'ch_test_charge', response.authorization
-    assert response.test?
+    assert_equal 're_test_refund', response.authorization
   end
 
   def test_unsuccessful_refund
@@ -359,6 +358,15 @@ class StripeTest < Test::Unit::TestCase
     end.returns(successful_partially_refunded_response)
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_application_fee => true)
+    assert_success response
+  end
+
+  def test_successful_refund_with_metadata
+    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+      post.include?("metadata[first_value]=true")
+    end.returns(successful_partially_refunded_response)
+
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', {metadata: {first_value: true}})
     assert_success response
   end
 
@@ -388,7 +396,7 @@ class StripeTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
     assert_success response
-    assert_equal 'ch_test_charge', response.authorization
+    assert_equal 're_test_refund', response.authorization
   end
 
   def test_unsuccessful_refund_with_refund_fee_amount_when_application_fee_id_not_found
@@ -1371,24 +1379,16 @@ class StripeTest < Test::Unit::TestCase
     options = {:livemode=>false}.merge!(options)
     <<-RESPONSE
     {
-      "amount": 400,
-      "amount_refunded": 200,
-      "created": 1309131571,
+      "id": "re_test_refund",
+      "object": "refund",
+      "amount": 80,
+      "balance_transaction": "txn_1737ZdAWOtgoysogRvA3jg6b",
+      "charge": "ch_1737ZcAWOtgoysogGRRsFjN9",
+      "created": 1446567833,
       "currency": "usd",
-      "description": "Test Purchase",
-      "id": "ch_test_charge",
-      "livemode": #{options[:livemode]},
-      "object": "charge",
-      "paid": true,
-      "refunded": true,
-      "card": {
-        "country": "US",
-        "exp_month": 9,
-        "exp_year": #{Time.now.year + 1},
-        "last4": "4242",
-        "object": "card",
-        "type": "Visa"
-      }
+      "metadata": {},
+      "reason": null,
+      "receipt_number": null
     }
     RESPONSE
   end


### PR DESCRIPTION
This PR updates the Stripe endpoint we use for creating refunds. The previous endpoint returned the Charge object, while the new endpoint returns the Refund object, so as a result the test and fixtures have been updated. Will this change be a problem for clients using Active Merchant?

This PR also includes the metadata object in the `/refunds` request, which is added in this new endpoint.

*Before*
`https://api.stripe.com/v1/charges/{CHARGE_ID}/refund`

*After*
`https://api.stripe.com/v1/charges/{CHARGE_ID}/refunds`