### PR TITLE
Stripe: Allow custom zero decimal currencies

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
       include CreditCardFormatting
 
       DEBIT_CARDS = [ :switch, :solo ]
-      CURRENCIES_WITHOUT_FRACTIONS = [ 'BIF', 'BYR', 'CLP', 'CVE', 'DJF', 'GNF', 'HUF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'TWD', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' ]
+      CURRENCIES_WITHOUT_FRACTIONS = %w(BIF BYR CLP CVE DJF GNF HUF ISK JPY KMF KRW PYG RWF TWD UGX VND VUV XAF XOF XPF)
 
       CREDIT_DEPRECATION_MESSAGE = "Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead."
       RECURRING_DEPRECATION_MESSAGE = "Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it."
@@ -144,10 +144,6 @@ module ActiveMerchant #:nodoc:
       def self.card_brand(source)
         result = source.respond_to?(:brand) ? source.brand : source.type
         result.to_s.downcase
-      end
-
-      def self.non_fractional_currency?(currency)
-        CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s)
       end
 
       def self.supported_countries=(country_codes)
@@ -255,10 +251,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def non_fractional_currency?(currency)
+        CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s)
+      end
+
       def localized_amount(money, currency)
         amount = amount(money)
 
-        return amount unless Gateway.non_fractional_currency?(currency)
+        return amount unless non_fractional_currency?(currency)
 
         if self.money_format == :cents
           sprintf("%.0f", amount.to_f / 100)

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -692,7 +692,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def item_amount(amount, currency_code)
-        if amount.to_i < 0 && Gateway.non_fractional_currency?(currency_code)
+        if amount.to_i < 0 && non_fractional_currency?(currency_code)
           amount(amount).to_f.floor
         else
           localized_amount(amount, currency_code)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -21,8 +21,7 @@ module ActiveMerchant #:nodoc:
         'unchecked' => 'P'
       }
 
-      # Source: https://support.stripe.com/questions/which-zero-decimal-currencies-does-stripe-support
-      CURRENCIES_WITHOUT_FRACTIONS = ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'VUV', 'XAF', 'XOF', 'XPF']
+      CURRENCIES_WITHOUT_FRACTIONS = %w(BIF CLP DJF GNF JPY KMF KRW MGA PYG RWF VND VUV XAF XOF XPF)
 
       self.supported_countries = %w(AT AU BE CA CH DE DK ES FI FR GB IE IT LU NL NO SE US)
       self.default_currency = 'USD'

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -90,11 +90,6 @@ class GatewayTest < Test::Unit::TestCase
     assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
   end
 
-  def test_non_fractional_currencies_accessor
-    assert Gateway.non_fractional_currency?('JPY')
-    refute Gateway.non_fractional_currency?('CAD')
-  end
-
   def test_split_names
     assert_equal ["Longbob", "Longsen"], @gateway.send(:split_names, "Longbob Longsen")
   end


### PR DESCRIPTION
The Stripe adapter has been overriding which currencies are zero decimal
currencies for awhile.  The parent Gateway class defines a default list
but Stripe has its own list:

https://support.stripe.com/questions/which-zero-decimal-currencies-does-stripe-support

The ability to override was broken in this commit:
https://github.com/activemerchant/active_merchant/commit/2a35543b4a8348cd115f4b2f138731e5f3c4a080

since the `non_fractional_currency?` method was changed to a class
method.

This commit allows us to override it again.  It also adds the VND
currency to Stripe's list since they now list that currency in their
docs.