### PR TITLE
send amount to refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -113,6 +113,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, options)
         add_reference(post, identification)
+        add_amount(post, money, options)
         commit('refund', money, post)
       end
 

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
           :dateq => Time.now.strftime('%d%m%Y%H%M%S'),
           :numquestion => unique_id(parameters[:order_id]),
           :site => @options[:login].to_s[0,7],
-          :rang => @options[:login].to_s[7..-1],
+          :rang => @options[:rang] || @options[:login].to_s[7..-1],
           :cle => @options[:password],
           :pays => '',
           :archivage => parameters[:order_id]

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -546,8 +546,9 @@ pay_secure:
   password: PASSWORD
 
 paybox_direct:
-  login: 199988899
+  login: 199988863
   password: 1999888I
+  rang: 85
 
 # Working credentials, no need to replace
 payeezy:

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -55,7 +55,7 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
   def test_failed_capture
     assert response = @gateway.capture(@amount, '', :order_id => '1')
     assert_failure response
-    assert_equal "Mandatory values missing keyword:13 Type:1", response.message
+    assert_equal "Invalid data", response.message
   end
   
   def test_purchase_and_partial_credit
@@ -71,11 +71,22 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayboxDirectGateway.new(
-                :login => '199988899',
-                :password => '1999888F'
+                login: '199988899',
+                password: '1999888F',
+                rang: 100
               )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal "PAYBOX : Accès refusé ou site/rang/clé invalide", response.message
+    assert_equal "Non autorise", response.message
+  end
+
+  def test_invalid_login_without_rang
+    gateway = PayboxDirectGateway.new(
+                login: '199988899',
+                password: '1999888F',
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Non autorise", response.message
   end
 end

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -28,7 +28,7 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal "PAYBOX : Numéro de porteur invalide", response.message
+    assert_equal "PAYBOX : Num\xE9ro de porteur invalide".force_encoding('ASCII-8BIT'), response.message
   end
 
   def test_authorize_and_capture

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class RemotePayboxDirectTest < Test::Unit::TestCase
-  
 
   def setup
     @gateway = PayboxDirectGateway.new(fixtures(:paybox_direct))
@@ -68,6 +67,27 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
     assert_success credit
   end
   
+  def test_successful_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, order_id: '1')
+    assert_success refund
+  end
+
+  def test_partial_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount/2, purchase.authorization, order_id: '1')
+    assert_success refund
+  end
+
+  def test_failed_refund
+    refund = @gateway.refund(@amount, '', order_id: '2') 
+    assert_failure refund
+    assert_equal 'Invalid data', refund.message
+  end
 
   def test_invalid_login
     gateway = PayboxDirectGateway.new(

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -63,7 +63,11 @@ class PayboxDirectTest < Test::Unit::TestCase
   end
 
   def test_refund
-    @gateway.expects(:ssl_post).with(anything, regexp_matches(/NUMAPPEL=transid/), anything).returns("")
+    @gateway.expects(:ssl_post).with(anything) do |_, body|
+      body.include?('NUMAPPEL=transid')
+      body.include?('MONTANT=0000000100&DEVISE=97')
+    end.returns("")
+
     @gateway.expects(:parse).returns({})
     @gateway.refund(@amount, "transid", @options)
   end


### PR DESCRIPTION
missed refunds back in https://github.com/activemerchant/active_merchant/pull/1887. Interestingly enough refunds still work without the amount category but this would allow partial refunds.

@aprofeit @girasquid 