### PR TITLE
Fix variables in generated remote gateway tests

### DIFF
--- a/generators/gateway/templates/remote_gateway_test.rb
+++ b/generators/gateway/templates/remote_gateway_test.rb
@@ -72,7 +72,7 @@ class Remote<%= class_name %>Test < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_success refund
-    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', response.message
+    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', refund.message
   end
 
   def test_partial_refund
@@ -95,7 +95,7 @@ class Remote<%= class_name %>Test < Test::Unit::TestCase
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
-    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', response.message
+    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', void.message
   end
 
   def test_failed_void


### PR DESCRIPTION
From the generator the remote test has some `response.message` assertions that run into errors because those tests don't have a response variable set.