### PR TITLE
Remove non-credential information from Paymill fixtures

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -578,17 +578,6 @@ payment_express:
 paymill:
   private_key: PRIVATE_KEY
   public_key: PUBLIC_KEY
-  tokenization.url: https://test-token.paymill.com
-  transaction.mode: CONNECTOR_TEST
-  channel.id:
-  jsonPFunction: paymilljstests
-  account.number: 4111111111111111
-  account.expiry.month: 12
-  account.expiry.year: 2018
-  account.verification: 123
-  account.holder: John%20Rambo
-  presentation.amount3D:
-  presentation.currency3D: EUR
 
 paypal_certificate:
   login: activemerchant-cert-test_api1.example.com

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -576,8 +576,8 @@ payment_express:
   password: PASSWORD
 
 paymill:
-  private_key: PRIVATE_KEY
-  public_key: PUBLIC_KEY
+  private_key: a9580be4a7b9d0151a3da88c6c935ce0
+  public_key: 57313835619696ac361dc591bc973626
 
 paypal_certificate:
   login: activemerchant-cert-test_api1.example.com


### PR DESCRIPTION
@duff @mrezentes

This moves all of the values that were just arguments out into a single HTTP call. It turns out I don't have any Paymill credentials to test this with - do you folks?