### PR TITLE
Litle - Add support for Auth & Sale with Paypage Registration ID

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'active_merchant/billing/gateways/litle/paypage_registration'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -189,11 +190,15 @@ module ActiveMerchant #:nodoc:
           doc.token do
             doc.litleToken(payment_method)
           end
-        elsif payment_method.is_a?(Hash)
+        elsif payment_method.respond_to?(:paypage_registration_id)
           doc.paypage do
-            doc.paypageRegistrationId(payment_method[:paypage_registration_id])
-            doc.expDate("#{payment_method[:month]}#{payment_method[:year]}")
-            doc.cardValidationNum(payment_method[:verification_value])
+            doc.paypageRegistrationId(payment_method.paypage_registration_id)
+            if payment_method.try(:month) && payment_method.try(:year)
+              doc.expDate("#{payment_method.month}#{payment_method.year}")
+            end
+            if payment_method.try(:verification_value)
+              doc.cardValidationNum(payment_method.verification_value)
+            end
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
@@ -215,10 +220,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_billing_address(doc, payment_method, options)
-        return if payment_method.is_a?(String) || payment_method.is_a?(Hash)
+        return if payment_method.is_a?(String)
 
         doc.billToAddress do
-          doc.name(payment_method.name)
+          doc.name(payment_method.name) if payment_method.respond_to?(:name)
           doc.email(options[:email]) if options[:email]
 
           add_address(doc, options[:billing_address])

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -189,6 +189,12 @@ module ActiveMerchant #:nodoc:
           doc.token do
             doc.litleToken(payment_method)
           end
+        elsif payment_method.is_a?(Hash)
+          doc.paypage do
+            doc.paypageRegistrationId(payment_method.values[0])
+            doc.expDate(exp_date(payment_method))
+            doc.cardValidationNum(payment_method.verification_value)
+          end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
             doc.track(payment_method.track_data)
@@ -209,7 +215,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_billing_address(doc, payment_method, options)
-        return if payment_method.is_a?(String)
+        return if payment_method.is_a?(String) || payment_method.is_a?(Hash)
 
         doc.billToAddress do
           doc.name(payment_method.name)

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -191,9 +191,9 @@ module ActiveMerchant #:nodoc:
           end
         elsif payment_method.is_a?(Hash)
           doc.paypage do
-            doc.paypageRegistrationId(payment_method.values[0])
-            doc.expDate(exp_date(payment_method))
-            doc.cardValidationNum(payment_method.verification_value)
+            doc.paypageRegistrationId(payment_method[:paypage_registration_id])
+            doc.expDate("#{payment_method[:month]}#{payment_method[:year]}")
+            doc.cardValidationNum(payment_method[:verification_value])
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do

--- a/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
+++ b/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
@@ -1,5 +1,14 @@
 module ActiveMerchant
   module Billing
+    # Litle provides functionality to make authorization and sale calls
+    # with a Paypage Registration Id instead of a Litle Token.
+    # This class wraps the required data for such a request.
+    #
+    # The first parameter is the paypage_registration_id and is required.
+    #
+    # The second parameter optionally takes a month, year, and verification_value.
+    # These parameters are allowed by the Litle endpoints but not necessary for
+    # a successful request.
     class LitlePaypageRegistration
       attr_reader :paypage_registration_id, :month, :year, :verification_value
 

--- a/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
+++ b/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
@@ -1,0 +1,14 @@
+module ActiveMerchant
+  module Billing
+    class LitlePaypageRegistration
+      attr_reader :paypage_registration_id, :month, :year, :verification_value
+
+      def initialize(paypage_registration_id, options = {})
+        @paypage_registration_id = paypage_registration_id
+        @month = options[:month]
+        @year = options[:year]
+        @verification_value = options[:verification_value]
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
+++ b/lib/active_merchant/billing/gateways/litle/paypage_registration.rb
@@ -6,17 +6,21 @@ module ActiveMerchant
     #
     # The first parameter is the paypage_registration_id and is required.
     #
-    # The second parameter optionally takes a month, year, and verification_value.
+    # The second parameter optionally takes a month, year, verification_value, and name.
     # These parameters are allowed by the Litle endpoints but not necessary for
     # a successful request.
+    #
+    # The name parameter is allowed by Vantiv as a member of the billToAddress element.
+    # It is passed in here to be consistent with the rest of the Litle gateway and Activemerchant.
     class LitlePaypageRegistration
-      attr_reader :paypage_registration_id, :month, :year, :verification_value
+      attr_reader :paypage_registration_id, :month, :year, :verification_value, :name
 
       def initialize(paypage_registration_id, options = {})
         @paypage_registration_id = paypage_registration_id
         @month = options[:month]
         @year = options[:year]
         @verification_value = options[:verification_value]
+        @name = options[:name]
       end
     end
   end

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -62,6 +62,29 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_authorization_with_paypage_registration_with_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
+      month: '11',
+      year: '12',
+      verification_value: '123'
+    )
+
+    assert response = @gateway.authorize(5090, paypage_registration, billing_address: address)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_authorization_with_paypage_registration_without_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
+    )
+
+    assert response = @gateway.authorize(5090, paypage_registration, billing_address: address)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_avs_and_cvv_result
     assert response = @gateway.authorize(10010, @credit_card1, @options)
     assert_equal "X", response.avs_result["code"]
@@ -111,6 +134,29 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay
     assert response = @gateway.purchase(10010, @decrypted_apple_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_paypage_registration_with_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
+      month: '11',
+      year: '12',
+      verification_value: '123'
+    )
+
+    assert response = @gateway.purchase(5090, paypage_registration, billing_address: address)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_paypage_registration_without_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
+    )
+
+    assert response = @gateway.purchase(5090, paypage_registration, billing_address: address)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -62,12 +62,13 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_successful_authorization_with_paypage_registration_with_month_year_verification
+  def test_successful_authorization_with_paypage_registration_with_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
       month: '11',
       year: '12',
-      verification_value: '123'
+      verification_value: '123',
+      name: 'Joe Payer'
     )
 
     assert response = @gateway.authorize(5090, paypage_registration, billing_address: address)
@@ -75,7 +76,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_successful_authorization_with_paypage_registration_without_month_year_verification
+  def test_successful_authorization_with_paypage_registration_without_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
     )
@@ -138,12 +139,13 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_successful_purchase_with_paypage_registration_with_month_year_verification
+  def test_successful_purchase_with_paypage_registration_with_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
       month: '11',
       year: '12',
-      verification_value: '123'
+      verification_value: '123',
+      name: 'Joe Payer'
     )
 
     assert response = @gateway.purchase(5090, paypage_registration, billing_address: address)
@@ -151,7 +153,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_successful_purchase_with_paypage_registration_without_month_year_verification
+  def test_successful_purchase_with_paypage_registration_without_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
     )

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -36,12 +36,13 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_purchase_with_paypage_registration_with_month_year_verification
+  def test_successful_purchase_with_paypage_registration_with_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
       month: '11',
       year: '12',
-      verification_value: '123'
+      verification_value: '123',
+      name: 'Joe Payer'
     )
 
     response = stub_comms do
@@ -57,7 +58,7 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_purchase_with_paypage_registration_without_month_year_verification
+  def test_successful_purchase_with_paypage_registration_without_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'ZkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
     )
@@ -172,12 +173,13 @@ class LitleTest < Test::Unit::TestCase
     assert_success capture
   end
 
-  def test_successful_authorize_with_paypage_registration_with_month_year_and_verification
+  def test_successful_authorize_with_paypage_registration_with_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
       month: '11',
       year: '12',
-      verification_value: '123'
+      verification_value: '123',
+      name: 'Joe Payer'
     )
 
     response = stub_comms do
@@ -193,7 +195,7 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_authorize_with_paypage_registration_without_month_year_and_verification
+  def test_successful_authorize_with_paypage_registration_without_month_year_verification_name
     paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
       'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
     )

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -153,7 +153,6 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  # TODO: without month year and verification value
   def test_successful_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -36,6 +36,45 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_paypage_registration_with_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
+      month: '11',
+      year: '12',
+      verification_value: '123'
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, paypage_registration, billing_address: address)
+    end.check_request do |endpoint, data, headers|
+      matcher = %r(<paypage>\s*<paypageRegistrationId>XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==</paypageRegistrationId>\s*<expDate>1112</expDate>\s*<cardValidationNum>123</cardValidationNum>\s*</paypage>)
+      assert_match(matcher, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '100000000000000006;sale', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_paypage_registration_without_month_year_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'ZkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw=='
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, paypage_registration, billing_address: address)
+    end.check_request do |endpoint, data, headers|
+      matcher = %r(<paypage>\s*<paypageRegistrationId>ZkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==</paypageRegistrationId>\s*</paypage>)
+      assert_match(matcher, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '100000000000000006;sale', response.authorization
+    assert response.test?
+  end
+
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -114,7 +153,7 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-
+  # TODO: without month year and verification value
   def test_successful_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
@@ -132,6 +171,45 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
 
     assert_success capture
+  end
+
+  def test_successful_authorize_with_paypage_registration_with_month_year_and_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
+      month: '11',
+      year: '12',
+      verification_value: '123'
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, paypage_registration)
+    end.check_request do |endpoint, data, headers|
+      matcher = %r(<paypage>\s*<paypageRegistrationId>XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==</paypageRegistrationId>\s*<expDate>1112</expDate>\s*<cardValidationNum>123</cardValidationNum>\s*</paypage>)
+      assert_match(matcher, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+
+    assert_equal "100000000000000001;authorization", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_authorize_with_paypage_registration_without_month_year_and_verification
+    paypage_registration = ActiveMerchant::Billing::LitlePaypageRegistration.new(
+      'XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==',
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, paypage_registration)
+    end.check_request do |endpoint, data, headers|
+      matcher = %r(<paypage>\s*<paypageRegistrationId>XkNDRGZDTGZyS2RBSTVCazJNSmdWam5TQ2gyTGhydFh0Mk5qZ0Z3cVp5VlNBN00rcGRZdHF6amFRWEttbVBnYw==</paypageRegistrationId>\s*</paypage>)
+      assert_match(matcher, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+
+    assert_equal "100000000000000001;authorization", response.authorization
+    assert response.test?
   end
 
   def test_failed_authorize


### PR DESCRIPTION
The Litle API supports making authorizations and sales using a Paypage Registration ID instead of a LitleToken or a credit card.  This PR adds support for that.

Changes:
-Add `LitlePaypageRegistration` to wrap the requisite data for a request using a Paypage Registration ID
-Modify `add_payment_method` to add XML for a Paypage XML block
-Make `name` element of `billToAddress` element optional (This is consistent with the current Litle XML Schema)
-Add test cases to `litle_test.rb` and `remote_litle_test.rb`
