### PR TITLE
Added support for track 2 to Mercury Payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 = ActiveMerchant CHANGELOG
 
+* Mercury: Add support for card present track 2
 
 == Version 1.55.0 (November 9, 2015)
 * CyberSource: send customer IP address when provided [fastjames]

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -195,7 +195,14 @@ module ActiveMerchant #:nodoc:
       def add_credit_card(xml, credit_card, action)
         xml.tag! 'Account' do
           if credit_card.track_data.present?
-            xml.tag! 'Track1', credit_card.track_data
+            # Track 1 has a start sentinel (STX) of '%' and track 2 is ';'
+            # If the track has no STX or is corrupt, we send it as track 1, to let Mercury
+            #handle with the validation error as it sees fit.
+            if credit_card.track_data[0] == ';' # track 2 start sentinel (STX)
+              xml.tag! 'Track2', credit_card.track_data
+            else # track 1 or a corrupt track
+              xml.tag! 'Track1', credit_card.track_data
+            end
           else
             xml.tag! 'AcctNo', credit_card.number
             xml.tag! 'ExpDate', expdate(credit_card)

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -11,7 +11,8 @@ class RemoteMercuryTest < Test::Unit::TestCase
 
     @credit_card = credit_card("4003000123456781", :brand => "visa", :month => "12", :year => "15")
 
-    @track_data = "%B4003000123456781^LONGSEN/L. ^15121200000000000000**123******?*"
+    @track_1_data = "%B4003000123456781^LONGSEN/L. ^15121200000000000000**123******?*"
+    @track_2_data = ";5413330089010608=2512101097750213?"
 
     @options = {
       :order_id => "c111111111.1",
@@ -104,7 +105,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
   end
 
   def test_avs_and_cvv_results_with_track_data
-    @credit_card.track_data = @track_data
+    @credit_card.track_data = @track_1_data
     response = @gateway.authorize(333, @credit_card, @options_with_billing)
 
     assert_success response
@@ -210,8 +211,8 @@ class RemoteMercuryTest < Test::Unit::TestCase
     assert_equal '1.00', capture.params['authorize']
   end
   
-  def test_successful_authorize_and_capture_with_track_data
-    @credit_card.track_data = @track_data
+  def test_successful_authorize_and_capture_with_track_1_data
+    @credit_card.track_data = @track_1_data
     response = @gateway.authorize(100, @credit_card, @options)
     assert_success response
     assert_equal '1.00', response.params['authorize']
@@ -220,6 +221,18 @@ class RemoteMercuryTest < Test::Unit::TestCase
     assert_success capture
     assert_equal '1.00', capture.params['authorize']
   end
+
+  def test_successful_authorize_and_capture_with_track_2_data
+    @credit_card.track_data = @track_2_data
+    response = @gateway.authorize(100, @credit_card, @options)
+    assert_success response
+    assert_equal '1.00', response.params['authorize']
+
+    capture = @gateway.capture(nil, response.authorization)
+    assert_success capture
+    assert_equal '1.00', capture.params['authorize']
+  end
+
   def test_authorize_and_void
     response = @gateway.authorize(100, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -63,12 +63,39 @@ class MercuryTest < Test::Unit::TestCase
     assert refund.test?
   end
 
-  def test_add_swipe_data_with_credit_card
-    @credit_card.track_data = "data"
+  def test_card_present_with_track_1_data
+    track_data = "%B4003000123456781^LONGSEN/L. ^15121200000000000000123?"
+    @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_match(/Track1>data</, data)
+      assert_match(/<Track1>#{Regexp.escape(track_data)}<\/Track1>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_card_present_with_track_2_data
+    track_data = ";5413330089010608=2512101097750213?"
+    @credit_card.track_data = track_data
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<Track2>#{Regexp.escape(track_data)}<\/Track2>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_card_present_with_invalid_data
+    track_data = "this is not valid track data"
+    @credit_card.track_data = track_data
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<Track1>#{Regexp.escape(track_data)}<\/Track1>/, data)
     end.respond_with(successful_purchase_response)
 
     assert_instance_of Response, response


### PR DESCRIPTION
Review please @bizla @andrewpaliga @datwelk

This feels a bit hacky but it's by far the simplest way to go. Option 2 is to pull in the Magnet gem, which I just added a track1/2 field to for this purpose.