### PR TITLE
CashNet: Fix URI parse on 302 response

### DIFF
--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
         if (200...300).include?(response.code.to_i)
           return response.body
         elsif 302 == response.code.to_i
-          return ssl_get(URI.parse(response['location']))
+          return ssl_get(URI.parse(URI.encode(response['location'])))
         end
         raise ResponseError.new(response)
       end


### PR DESCRIPTION
@duff and/or @rwdaigle: This fixes the exception we've noticed a few times when CashNet returns a 302 response and the adapter follows it. Not standard AM so let me know if you guys have other thoughts on how you'd like to handle a 302 in this case. But, encoding the `location` should fix any bogus characters in that URL.