### PR TITLE
Omise: Add a new optional api_version config.

### DIFF
--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -176,12 +176,14 @@ module ActiveMerchant #:nodoc:
 
       def headers(options={})
         key = options[:key] || @secret_key
-        {
+        h = {
           'Content-Type'    => 'application/json;utf-8',
           'User-Agent'      => "ActiveMerchantBindings/#{ActiveMerchant::VERSION} Ruby/#{RUBY_VERSION}",
           'Authorization'   => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
           'Accept-Encoding' => 'utf-8'
         }
+        h['Omise-Version'] = @api_version if @api_version
+        h
       end
 
       def url_for(endpoint)
@@ -194,10 +196,8 @@ module ActiveMerchant #:nodoc:
 
       def https_request(method, endpoint, parameters=nil, options={})
         raw_response = response = nil
-        req_headers  = headers(options)
         begin
-          req_headers['Omise-Version'] = @api_version if @api_version
-          raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), req_headers)
+          raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), headers(options))
           response = parse(raw_response)
         rescue ResponseError => e
           raw_response = e.response.body

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -176,14 +176,13 @@ module ActiveMerchant #:nodoc:
 
       def headers(options={})
         key = options[:key] || @secret_key
-        h = {
+        {
           'Content-Type'    => 'application/json;utf-8',
+          'Omise-Version'   => @api_version || "2014-07-27",
           'User-Agent'      => "ActiveMerchantBindings/#{ActiveMerchant::VERSION} Ruby/#{RUBY_VERSION}",
           'Authorization'   => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
           'Accept-Encoding' => 'utf-8'
         }
-        h['Omise-Version'] = @api_version if @api_version
-        h
       end
 
       def url_for(endpoint)

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -3,7 +3,6 @@ require 'active_merchant/billing/rails'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class OmiseGateway < Gateway
-      API_VERSION = '1.0'
       API_URL     = 'https://api.omise.co/'
       VAULT_URL   = 'https://vault.omise.co/'
 
@@ -45,8 +44,9 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options={})
         requires!(options, :public_key, :secret_key)
-        @public_key = options[:public_key]
-        @secret_key = options[:secret_key]
+        @public_key  = options[:public_key]
+        @secret_key  = options[:secret_key]
+        @api_version = options[:api_version]
         super
       end
 
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         key = options[:key] || @secret_key
         {
           'Content-Type'    => 'application/json;utf-8',
-          'User-Agent'      => "Omise/v#{API_VERSION} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'User-Agent'      => "ActiveMerchantBindings/#{ActiveMerchant::VERSION} Ruby/#{RUBY_VERSION}",
           'Authorization'   => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
           'Accept-Encoding' => 'utf-8'
         }
@@ -194,8 +194,10 @@ module ActiveMerchant #:nodoc:
 
       def https_request(method, endpoint, parameters=nil, options={})
         raw_response = response = nil
+        req_headers  = headers(options)
         begin
-          raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), headers(options))
+          req_headers['Omise-Version'] = @api_version if @api_version
+          raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), req_headers)
           response = parse(raw_response)
         rescue ResponseError => e
           raw_response = e.response.body

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -501,6 +501,7 @@ ogone:
 omise:
   public_key: pkey_test_4zt0fss8gs0z6b4zlsq
   secret_key: skey_test_4zt0fss8eklsj88dx9l
+  api_version: '2015-11-17'
 
 # Working credentials, no need to replace
 openpay:

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -35,7 +35,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Success', response.message
     assert_equal response.params['amount'], @amount
-    assert response.params['captured'], 'captured should be true'
+    assert response.params['paid'], 'paid should be true'
     assert response.params['authorized'], 'authorized should be true'
   end
 
@@ -78,7 +78,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
     authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
     assert_equal authorize.params['amount'], @amount
-    assert !authorize.params['captured'], 'captured should be false'
+    assert !authorize.params['paid'], 'paid should be false'
     assert authorize.params['authorized'], 'authorized should be true'
   end
 
@@ -86,7 +86,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
     authorize = @gateway.authorize(@amount, @credit_card, @options)
     capture   = @gateway.capture(@amount, authorize.authorization, @options)
     assert_success capture
-    assert capture.params['captured'], 'captured should be true'
+    assert capture.params['paid'], 'paid should be true'
     assert capture.params['authorized'], 'authorized should be true'
   end
 

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -349,7 +349,7 @@ class OmiseTest < Test::Unit::TestCase
           "description": "Charge for order 3947",
           "capture": true,
           "authorized": true,
-          "captured": true,
+          "paid": true,
           "transaction": "trxn_test_4zguktuecyuo77xgq38",
           "refunded": 0,
           "refunds": {
@@ -405,7 +405,7 @@ class OmiseTest < Test::Unit::TestCase
       "description": null,
       "capture": true,
       "authorized": true,
-      "captured": true,
+      "paid": true,
       "transaction": "trxn_test_4zgf1d3f7t9k6gk8hn8",
       "refunded": 0,
       "refunds": {
@@ -504,7 +504,7 @@ class OmiseTest < Test::Unit::TestCase
       "description": null,
       "capture": false,
       "authorized": true,
-      "captured": true,
+      "paid": true,
       "transaction": "trxn_test_4zmqf6njyokta57ljs1",
       "refunded": 0,
       "refunds": {
@@ -558,7 +558,7 @@ class OmiseTest < Test::Unit::TestCase
       "description": null,
       "capture": false,
       "authorized": true,
-      "captured": false,
+      "paid": false,
       "transaction": null,
       "refunded": 0,
       "refunds": {
@@ -611,7 +611,7 @@ class OmiseTest < Test::Unit::TestCase
       "description": "Charge for order 3947",
       "capture": false,
       "authorized": true,
-      "captured": true,
+      "paid": true,
       "transaction": "trxn_test_4z5gp0t3mpfsu28u8jo",
       "refunded": 0,
       "refunds": {
@@ -749,7 +749,7 @@ class OmiseTest < Test::Unit::TestCase
       "description": "activemerchant testing",
       "capture": true,
       "authorized": false,
-      "captured": false,
+      "paid": false,
       "transaction": null,
       "refunded": 0,
       "refunds": {


### PR DESCRIPTION
Hi,

Regarding new Omise API version, I have created the relevant update in this PR.

The main change is adding the configurable `api_version` for the Omise gateway.
So, `api_version` can be set in activemerchant if it's needed.

Following are changes made in this PR:
* Add `Omise-Version` header if `api_version` is set.
* Remove unused API_VERSION variable.
* Add Ruby/#{RUBY_VERSION} to User-Agent.
* Modify remote test and refactor.

All unit tests:
```
active_merchant|omise-v2 ⇒ bundle exec rake test:units TEST=test/unit/gateways/omise_test.rb
/Users/di/.rbenv/versions/2.2.2/bin/ruby -I"lib:test" -rubygems -w -I"/Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0" "/Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/unit/gateways/omise_test.rb"
Loaded suite /Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader
Started
................................

Finished in 0.022835 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
32 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1401.36 tests/s, 2321.00 assertions/s
```

Omise remote tests:

```
active_merchant|omise-v2 ⇒ bundle exec rake test:remote TEST=test/remote/gateways/remote_omise_test.rb
/Users/di/.rbenv/versions/2.2.2/bin/ruby -I"lib:test" -rubygems -w -I"/Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0" "/Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/remote/gateways/remote_omise_test.rb"
Loaded suite /Users/di/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader
Started
............

Finished in 12.280202 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
12 tests, 29 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.98 tests/s, 2.36 assertions/s
```

Hope this makes sense.
Thanks!