### PR TITLE
Allow to use this gem with Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
 - Gemfile.rails40
 - Gemfile.rails41
 - Gemfile.rails42
+- Gemfile.rails5
 
 matrix:
   include:
@@ -17,6 +18,8 @@ matrix:
       gemfile: Gemfile.rails32
     - rvm: "2.2"
       gemfile: Gemfile.rails32
+    - rvm: "2.2.3"
+      gemfile: Gemfile.rails5
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 script: "bundle exec rake test:units"
 sudo: false
+cache: bundler
 
 rvm:
-- "2.0"
+- 2.0
+- 2.1
+- 2.2.3
 
 gemfile:
 - Gemfile.rails32
@@ -13,12 +16,10 @@ gemfile:
 - Gemfile.rails5
 
 matrix:
-  include:
-    - rvm: "2.1"
-      gemfile: Gemfile.rails32
-    - rvm: "2.2"
-      gemfile: Gemfile.rails32
-    - rvm: "2.2.3"
+  exclude:
+    - rvm: 2.0
+      gemfile: Gemfile.rails5
+    - rvm: 2.1
       gemfile: Gemfile.rails5
 
 notifications:

--- a/Gemfile.rails5
+++ b/Gemfile.rails5
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'jruby-openssl', :platforms => :jruby
+
+group :test, :remote_test do
+  # gateway-specific dependencies, keeping these gems out of the gemspec
+  gem 'braintree', '>= 2.50.0'
+end
+
+gem 'rails', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
+gem 'rack', github: 'rack/rack'

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.0.0')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")

--- a/circle.yml
+++ b/circle.yml
@@ -8,11 +8,13 @@ dependencies:
     - 'vendor/bundle_40'
     - 'vendor/bundle_41'
     - 'vendor/bundle_42'
+    - 'vendor/bundle_5'
   override:
     - bundle check --path=vendor/bundle_32 --gemfile Gemfile.rails32 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails32 --path=vendor/bundle_32
     - bundle check --path=vendor/bundle_40 --gemfile Gemfile.rails40 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails40 --path=vendor/bundle_40
     - bundle check --path=vendor/bundle_41 --gemfile Gemfile.rails41 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails41 --path=vendor/bundle_41
     - bundle check --path=vendor/bundle_42 --gemfile Gemfile.rails42 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails42 --path=vendor/bundle_42
+    - bundle check --path=vendor/bundle_5 --gemfile Gemfile.rails5 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails5 --path=vendor/bundle_5
 
 test:
   override:
@@ -31,3 +33,7 @@ test:
     - bundle check --path=vendor/bundle_42 && bundle exec rake test:
         environment:
           BUNDLE_GEMFILE: Gemfile.rails42
+
+    - bundle check --path=vendor/bundle_5 && bundle exec rake test:
+        environment:
+          BUNDLE_GEMFILE: Gemfile.rails5

--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -33,7 +33,6 @@ if(!defined?(ActiveSupport::VERSION) || (ActiveSupport::VERSION::STRING < "4.1")
   require 'active_support/core_ext/class/attribute_accessors'
 end
 
-require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/module/attribute_accessors'
 
 require 'base64'


### PR DESCRIPTION
The only required changes were to remove an unused require that was removed in Rails 5 and to change the gemspec to allow this gem to be installed with that version.