### PR TITLE
Do not allow to install the gem with Ruby 1.9

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage = 'http://activemerchant.org/'
   s.rubyforge_project = 'activemerchant'
 
+  s.required_ruby_version = '>= 2'
+
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 


### PR DESCRIPTION
The support to Ruby 1.9 was removed at 8a6c6ff626ebd292dc50e8e1c074aab49956a42d so we should not allow users to install the gem with that version.