### PR TITLE
Fix detecting test refunds for Stripe

### DIFF
--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -105,6 +105,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
     assert refund = @gateway.refund(@amount - 20, response.authorization)
+    assert refund.test?
     refund_id = refund.params["id"]
     assert_equal refund.authorization, refund_id
     assert_success refund


### PR DESCRIPTION
#### Problem
Currently all Stripe refund responses return `test? => false`. This changed [when we switched](https://github.com/activemerchant/active_merchant/commit/f388b95d3495bbbddbcf98dcb3e60624339bf2a3) from using the `/charge/refund` endpoint to the `/charge/refunds` endpoint.

The reason why `test?` always returns `false` is the refund object that's returned by Stripe does not have a `livemode` key which we use to determine whether a response is test or not.

#### Changes
This PR changes the refund action to always include the charge in the refund response. Then, when checking whether a response is test or not, if there's no `livemode` key, check if there's a `charge` object we can look for the `livemode` key in.

#### Review
@berkcaputcu @ivanfer