### PR TITLE
Fix detecting test voids for Stripe

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -106,7 +106,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(identification, options = {})
-        commit(:post, "charges/#{CGI.escape(identification)}/refunds", {}, options)
+        post = {}
+        post[:expand] = [:charge]
+        commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options)
       end
 
       def refund(money, identification, options = {})

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -91,6 +91,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
     assert void = @gateway.void(response.authorization)
+    assert void.test?
     assert_success void
   end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -336,6 +336,35 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_void_contains_charge_expand
+    @gateway.expects(:ssl_request).with do |_, _, post, _|
+      post.include?("expand[]=charge")
+    end.returns(successful_purchase_response(true))
+
+    assert response = @gateway.void('ch_test_charge')
+    assert_success response
+  end
+
+  def test_void_with_additional_expand_contains_two_expands
+    @gateway.expects(:ssl_request).with do |_, _, post, _|
+      parsed = CGI.parse(post)
+      parsed['expand[]'].sort == ['balance_transaction', 'charge'].sort
+    end.returns(successful_purchase_response(true))
+
+    assert response = @gateway.void('ch_test_charge', expand: :balance_transaction)
+    assert_success response
+  end
+
+  def test_void_with_expand_charge_only_sends_one_charge_expand
+    @gateway.expects(:ssl_request).with do |_, _, post, _|
+      parsed = CGI.parse(post)
+      parsed["expand[]"] == ['charge']
+    end.returns(successful_purchase_response(true))
+
+    assert response = @gateway.void('ch_test_charge', expand: ['charge'])
+    assert_success response
+  end
+
   def test_successful_refund
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response)
 


### PR DESCRIPTION
#### Problem

Currently all Stripe void responses return test? => false. This changed when we switched from using the `/charge/refund` endpoint to the `/charge/refunds` endpoint. This PR is a superset of https://github.com/activemerchant/active_merchant/pull/1937 and the semantics for the charge  [expansion](https://stripe.com/docs/api#refunds) is similar given both `refund` and `void` actions call into the same endpoint and receives a `refund object` as response.

The reason why test? always returns false is the refund object that's returned by Stripe does not have a `livemode` key which we use to determine whether a response is test or not.

#### Changes

This PR changes the `void` action to always include the charge in the refund response. Then, when checking whether a response is test or not, if there's no `livemode` key, check if there's a charge object we can look for the `livemode` key in.

#### Review

@aprofeit @girasquid 