### PR TITLE
Add token support for KomojuGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -41,6 +41,13 @@ module ActiveMerchant #:nodoc:
         commit("/payments/#{identification}/refund", {})
       end
 
+      def store(payment, options = {})
+        post = {}
+        add_payment_details(post, payment, options)
+
+        commit("/tokens", post)
+      end
+
       private
 
       def add_payment_details(post, payment, options)

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -51,17 +51,21 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_payment_details(post, payment, options)
-        details = {}
+        case payment
+        when CreditCard
+          details = {}
 
-        details[:type] = 'credit_card'
-        details[:number] = payment.number
-        details[:month] = payment.month
-        details[:year] = payment.year
-        details[:verification_value] = payment.verification_value
-        details[:given_name] = payment.first_name
-        details[:family_name] = payment.last_name
-        details[:email] = options[:email] if options[:email]
-
+          details[:type] = 'credit_card'
+          details[:number] = payment.number
+          details[:month] = payment.month
+          details[:year] = payment.year
+          details[:verification_value] = payment.verification_value
+          details[:given_name] = payment.first_name
+          details[:family_name] = payment.last_name
+          details[:email] = options[:email] if options[:email]
+        else
+          details = payment
+        end
         post[:payment_details] = details
       end
 

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -66,6 +66,17 @@ class KomojuTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_credit_card_store
+    successful_response = successful_credit_card_store_response
+    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    assert_equal "tok_e4075d73cd3767a57d324ac38b16d203b7ab2c4c6208d039356451578f236d85a6fd1af715ffef3ccd4b37d3d2456002", response.authorization
+    assert response.test?
+  end
+
   private
 
   def successful_credit_card_purchase_response
@@ -120,6 +131,15 @@ class KomojuTest < Test::Unit::TestCase
       "metadata" => {
         "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
       },
+      "created_at" => "2015-03-20T04:51:48Z"
+    }
+  end
+
+  def successful_credit_card_store_response
+    {
+      "id" => "tok_e4075d73cd3767a57d324ac38b16d203b7ab2c4c6208d039356451578f236d85a6fd1af715ffef3ccd4b37d3d2456002",
+      "resource" => "token",
+      "used" => false,
       "created_at" => "2015-03-20T04:51:48Z"
     }
   end

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class KomojuTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = KomojuGateway.new(:login => 'login')
 
@@ -27,6 +29,14 @@ class KomojuTest < Test::Unit::TestCase
 
     assert_equal successful_response["id"], response.authorization
     assert response.test?
+  end
+
+  def test_successful_credit_card_purchase_with_token
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, "tok_xxx", @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match('"payment_details":"tok_xxx"', data)
+    end.respond_with(JSON.generate(successful_credit_card_purchase_response))
   end
 
   def test_failed_purchase


### PR DESCRIPTION
This adds a `store` method to the Komoju gateway (see #1638) so that merchants can enable payment        profiles. It also allows that stored token string to be passed in place of payment details when purchasing.

For more information see the Komoju docs on Tokens: https://docs.komoju.com/api/overview
