### PR TITLE
Elavon: Include IP address

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -82,6 +82,7 @@ module ActiveMerchant #:nodoc:
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
+        add_ip(form, options)
         commit(:purchase, money, form)
       end
 
@@ -100,6 +101,7 @@ module ActiveMerchant #:nodoc:
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
+        add_ip(form, options)
         commit(:authorize, money, form)
       end
 
@@ -294,6 +296,10 @@ module ActiveMerchant #:nodoc:
 
       def add_partial_shipment_flag(form, options)
         form[:partial_shipment_flag] = 'Y' if options[:partial_shipment_flag]
+      end
+
+      def add_ip(form, options)
+        form[:cardholder_ip] = options[:ip] if options.has_key?(:ip)
       end
 
       def message_from(response)

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -10,7 +10,8 @@ class RemoteElavonTest < Test::Unit::TestCase
     @options = {
       :email => "paul@domain.com",
       :description => 'Test Transaction',
-      :billing_address => address
+      :billing_address => address,
+      :ip => '203.0.113.0'
     }
     @amount = 100
   end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -93,6 +93,28 @@ class ElavonTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_ip
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ip: '203.0.113.0'))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = CGI.parse(data)
+      assert_equal ['203.0.113.0'], parsed['ssl_cardholder_ip']
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_authorization_with_ip
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(ip: '203.0.113.0'))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = CGI.parse(data)
+      assert_equal ['203.0.113.0'], parsed['ssl_cardholder_ip']
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
     authorization = '123456INVALID;00000000-0000-0000-0000-00000000000'


### PR DESCRIPTION
#### Changes
Includes the IP in the request to Elavon. Closes https://github.com/activemerchant/active_merchant/issues/1822

#### Testing
I was able to get some credentials from Elavon to run the remote tests, but am waiting on confirmation they're cool with us committing the credentials to AM before I add them.

From my remote test runs I was able to confirm that IP shows up in Elavon.

![elavon](https://cloud.githubusercontent.com/assets/1313339/11430809/5d81452e-945a-11e5-91a4-ddc77cc21364.png)

#### Review
@cjoudrey @girasquid 