### PR TITLE
TransFirst: Add support for ACH and more operations

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -1,7 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class TransFirstGateway < Gateway
-      self.live_url = self.test_url = 'https://webservices.primerchants.com/creditcard.asmx/CCSale'
+      self.test_url = 'https://ws.cert.transfirst.com'
+      self.live_url = 'https://webservices.primerchants.com'
 
       self.supported_countries = ['US']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
@@ -12,25 +13,59 @@ module ActiveMerchant #:nodoc:
 
       DECLINED = 'The transaction was declined'
 
+      ACTIONS = {
+        purchase: "CCSale",
+        purchase_echeck: "ACHDebit",
+        refund: "CreditCardAutoRefundorVoid",
+        refund_echeck: "ACHVoidTransaction",
+        void: "CreditCardAutoRefundorVoid",
+      }
+
+      ENDPOINTS = {
+        purchase: "creditcard.asmx",
+        purchase_echeck: "checkverifyws/checkverifyws.asmx",
+        refund: "creditcard.asmx",
+        refund_echeck: "checkverifyws/checkverifyws.asmx",
+        void: "creditcard.asmx"
+      }
+
       def initialize(options = {})
         requires!(options, :login, :password)
         super
       end
 
-      def purchase(money, credit_card, options = {})
+      def purchase(money, payment, options = {})
         post = {}
 
         add_amount(post, money)
         add_invoice(post, options)
-        add_credit_card(post, credit_card)
+        add_payment(post, payment)
         add_address(post, options)
 
-        commit(post)
+        commit((payment.is_a?(Check) ? :purchase_echeck : :purchase), post)
+      end
+
+      def refund(money, authorization, options={})
+        post = {}
+        transaction_id, payment_type = split_authorization(authorization)
+        add_amount(post, money)
+        add_invoice(post, options)
+        add_pair(post, :TransID, transaction_id)
+        commit((payment_type == "check" ? :refund_echeck : :refund), post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        transaction_id, _ = split_authorization(authorization)
+        add_pair(post, :TransID, transaction_id)
+
+        commit(:void, post)
       end
 
       private
+
       def add_amount(post, money)
-        add_pair(post, :Amount, amount(money), :required => true)
+        add_pair(post, :Amount, amount(money), required: true)
       end
 
       def add_address(post, options)
@@ -43,19 +78,38 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, options)
-        add_pair(post, :RefID, options[:order_id], :required => true)
-        add_pair(post, :PONumber, options[:invoice], :required => true)
+        add_pair(post, :RefID, options[:order_id], required: true)
+        add_pair(post, :SECCCode, options[:invoice], required: true)
+        add_pair(post, :PONumber, options[:invoice], required: true)
         add_pair(post, :SaleTaxAmount, amount(options[:tax] || 0))
-        add_pair(post, :PaymentDesc, options[:description], :required => true)
+        add_pair(post, :PaymentDesc, options[:description], required: true)
         add_pair(post, :TaxIndicator, 0)
+        add_pair(post, :CompanyName, options[:company_name] || "", required: true)
       end
 
-      def add_credit_card(post, credit_card)
-        add_pair(post, :CardHolderName, credit_card.name, :required => true)
-        add_pair(post, :CardNumber, credit_card.number, :required => true)
+      def add_payment(post, payment)
+        if payment.is_a?(Check)
+          add_echeck(post, payment)
+        else
+          add_credit_card(post, payment)
+        end
+      end
 
-        add_pair(post, :Expiration, expdate(credit_card), :required => true)
-        add_pair(post, :CVV2, credit_card.verification_value)
+      def add_credit_card(post, payment)
+        add_pair(post, :CardHolderName, payment.name, required: true)
+        add_pair(post, :CardNumber, payment.number, required: true)
+        add_pair(post, :Expiration, expdate(payment), required: true)
+        add_pair(post, :CVV2, payment.verification_value)
+      end
+
+      def add_echeck(post, payment)
+        add_pair(post, :TransRoute, payment.routing_number, required: true)
+        add_pair(post, :BankAccountNo, payment.account_number, required: true)
+        add_pair(post, :BankAccountType, payment.account_type.capitalize, required: true)
+        add_pair(post, :CheckType, payment.account_holder_type.capitalize, required: true)
+        add_pair(post, :Name, payment.name, required: true)
+        add_pair(post, :ProcessDate, Time.now.strftime("%m%d%y"), required: true)
+        add_pair(post, :Description, "", required: true)
       end
 
       def add_unused_fields(post)
@@ -75,7 +129,7 @@ module ActiveMerchant #:nodoc:
         response = {}
 
         xml = REXML::Document.new(data)
-        root = REXML::XPath.first(xml, "//CCSaleDebitResponse")
+        root = REXML::XPath.first(xml, "*")
 
         if root.nil?
           response[:message] = data.to_s.strip
@@ -88,15 +142,41 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(params)
-        response = parse( ssl_post(self.live_url, post_data(params)) )
+      def commit(action, params)
+        response = parse(ssl_post(url(action), post_data(params)))
 
-        Response.new(response[:status] == "Authorized", message_from(response), response,
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
           :test => test?,
-          :authorization => response[:trans_id],
+          :authorization => authorization_from(response),
           :avs_result => { :code => response[:avs_code] },
           :cvv_result => response[:cvv2_code]
         )
+      end
+
+      def authorization_from(response)
+        if response[:status] == "APPROVED"
+          "#{response[:trans_id]}|check"
+        else
+          "#{response[:trans_id]}|creditcard"
+        end
+      end
+
+      def success_from(response)
+        case response[:status]
+        when "Authorized"
+          true
+        when "Voided"
+          true
+        when "APPROVED"
+          true
+        when "VOIDED"
+          true
+        else
+          false
+        end
       end
 
       def message_from(response)
@@ -119,6 +199,15 @@ module ActiveMerchant #:nodoc:
 
       def add_pair(post, key, value, options = {})
         post[key] = value if !value.blank? || options[:required]
+      end
+
+      def url(action)
+        base_url = test? ? test_url : live_url
+        "#{base_url}/#{ENDPOINTS[action]}/#{ACTIONS[action]}"
+      end
+
+      def split_authorization(authorization)
+        authorization.split("|")
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -923,8 +923,8 @@ tns:
   password: 3f34fe50334fbe6cbe04c283411a5860
 
 trans_first:
-  login: LOGIN
-  password: PASSWORD
+  login: 45567
+  password: TNYYKYMFZ59HSN7Q
 
 # Transact Pro doesn't provide public testing data
 transact_pro:

--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -5,21 +5,45 @@ class RemoteTransFirstTest < Test::Unit::TestCase
   def setup
     @gateway = TransFirstGateway.new(fixtures(:trans_first))
 
-    @credit_card = credit_card('4111111111111111')
-    @amount = 100
-    @options = { 
+    @credit_card = credit_card('4485896261017708', verification_value: 999)
+    @check = check
+    @amount = 1201
+    @options = {
       :order_id => generate_unique_id,
       :invoice => 'ActiveMerchant Sale',
       :billing_address => address
     }
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_equal 'test transaction', response.message
     assert response.test?
     assert_success response
     assert !response.authorization.blank?
+
+    @gateway.void(response.authorization)
+  end
+
+  def test_successful_purchase_with_echeck
+    assert response = @gateway.purchase(@amount, @check, @options)
+    assert response.test?
+    assert_success response
+    assert !response.authorization.blank?
+  end
+
+  def test_failed_purchase
+    @amount = 21
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Insufficient funds', response.message
+  end
+
+  def test_successful_refund_with_echeck
+    assert purchase = @gateway.purchase(@amount, @check, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
   end
 
   def test_invalid_login
@@ -27,8 +51,7 @@ class RemoteTransFirstTest < Test::Unit::TestCase
       :login => '',
       :password => ''
     )
-    assert response = gateway.purchase(@amount, @credit_card, @options)
-    assert_equal 'invalid account', response.message
+    assert response = gateway.purchase(1100, @credit_card, @options)
     assert_failure response
   end
 end

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -9,104 +9,196 @@ class TransFirstTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card('4242424242424242')
+    @check = check
     @options = {
       :billing_address => address
     }
     @amount = 100
   end
-  
+
   def test_missing_field_response
     @gateway.stubs(:ssl_post).returns(missing_field_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
-    
+
     assert_failure response
     assert response.test?
     assert_equal 'Missing parameter: UserId.', response.message
   end
-  
+
   def test_successful_purchase
     @gateway.stubs(:ssl_post).returns(successful_purchase_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
-    
+
     assert_success response
     assert response.test?
     assert_equal 'test transaction', response.message
-    assert_equal '355', response.authorization
+    assert_equal '355|creditcard', response.authorization
   end
-  
+
   def test_failed_purchase
     @gateway.stubs(:ssl_post).returns(failed_purchase_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
-    
+
     assert_failure response
     assert response.test?
-    assert_equal '29005716', response.authorization
+    assert_equal '29005716|creditcard', response.authorization
     assert_equal 'Invalid cardholder number', response.message
   end
-  
+
+  def test_successful_purchase_with_echeck
+    @gateway.stubs(:ssl_post).returns(successful_purchase_echeck_response)
+    response = @gateway.purchase(@amount, @check, @options)
+
+    assert_success response
+  end
+
+  def test_failed_purchase_with_echeck
+    @gateway.stubs(:ssl_post).returns(failed_purchase_echeck_response)
+    response = @gateway.purchase(@amount, @check, @options)
+
+    assert_failure response
+  end
+
+  def test_successful_refund
+    @gateway.stubs(:ssl_post).returns(successful_refund_response)
+
+    response = @gateway.refund(@amount, "TransID")
+    assert_success response
+    assert_equal '207686608|creditcard', response.authorization
+  end
+
+  def test_failed_refund
+    @gateway.stubs(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.refund(@amount, "TransID")
+    assert_failure response
+  end
+
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'X', response.avs_result['code']
   end
-  
+
   def test_cvv_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'M', response.cvv_result['code']
   end
-  
+
   private
   def missing_field_response
     "Missing parameter: UserId.\r\n"
   end
-  
+
   def successful_purchase_response
     <<-XML
-<?xml version="1.0" encoding="utf-8"?> 
-<CCSaleDebitResponse xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.paymentresources.com/webservices/"> 
-  <TransID>355</TransID> 
-  <RefID>c2535abbf0bb38005a14fd575553df65</RefID> 
-  <Amount>1.00</Amount> 
-  <AuthCode>Test00</AuthCode> 
-  <Status>Authorized</Status> 
-  <AVSCode>X</AVSCode> 
-  <Message>test transaction</Message> 
-  <CVV2Code>M</CVV2Code> 
-  <ACI /> 
-  <AuthSource /> 
-  <TransactionIdentifier /> 
-  <ValidationCode /> 
-  <CAVVResultCode /> 
-</CCSaleDebitResponse>
+    <?xml version="1.0" encoding="utf-8"?>
+    <CCSaleDebitResponse xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.paymentresources.com/webservices/">
+      <TransID>355</TransID>
+      <RefID>c2535abbf0bb38005a14fd575553df65</RefID>
+      <Amount>1.00</Amount>
+      <AuthCode>Test00</AuthCode>
+      <Status>Authorized</Status>
+      <AVSCode>X</AVSCode>
+      <Message>test transaction</Message>
+      <CVV2Code>M</CVV2Code>
+      <ACI />
+      <AuthSource />
+      <TransactionIdentifier />
+      <ValidationCode />
+      <CAVVResultCode />
+    </CCSaleDebitResponse>
     XML
   end
-  
+
   def failed_purchase_response
     <<-XML
-<?xml version="1.0" encoding="utf-8" ?>  
-<CCSaleDebitResponse xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.paymentresources.com/webservices/"> 
-  <TransID>29005716</TransID> 
-  <RefID>0610</RefID>  
-  <PostedDate>2005-09-29T15:16:23.7297658-07:00</PostedDate>  
-  <SettledDate>2005-09-29T15:16:23.9641468-07:00</SettledDate>  
-  <Amount>0.02</Amount>  
-  <AuthCode />  
-  <Status>Declined</Status>  
-  <AVSCode />  
-  <Message>Invalid cardholder number</Message>  
-  <CVV2Code />  
-  <ACI />  
-  <AuthSource />  
-  <TransactionIdentifier />  
-  <ValidationCode />  
-  <CAVVResultCode />  
-</CCSaleDebitResponse>
+    <?xml version="1.0" encoding="utf-8" ?>
+    <CCSaleDebitResponse xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.paymentresources.com/webservices/">
+      <TransID>29005716</TransID>
+      <RefID>0610</RefID>
+      <PostedDate>2005-09-29T15:16:23.7297658-07:00</PostedDate>
+      <SettledDate>2005-09-29T15:16:23.9641468-07:00</SettledDate>
+      <Amount>0.02</Amount>
+      <AuthCode />
+      <Status>Declined</Status>
+      <AVSCode />
+      <Message>Invalid cardholder number</Message>
+      <CVV2Code />
+      <ACI />
+      <AuthSource />
+      <TransactionIdentifier />
+      <ValidationCode />
+      <CAVVResultCode />
+    </CCSaleDebitResponse>
+    XML
+  end
+
+  def successful_purchase_echeck_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CheckStatus>
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema- instance" xmlns="http://www.paymentresources.com/webservices/">
+        <Success>1</Success>
+        <TransID>11996</TransID>
+        <RefID>PRICreditTest</RefID>
+        <PostedDate>004-02-04T08:23:02.9467720-08:00</PostedDate>
+        <AuthCode> CHECK IS NOT VERIFIED </AuthCode>
+        <Status>APPROVED</Status>
+        <Message />
+        <Amount>1.01</Amount>
+      </CheckStatus>
+    XML
+  end
+
+  def failed_purchase_echeck_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CheckStatus>
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema- instance" xmlns="http://www.paymentresources.com/webservices/">
+        <Success>0</Success>
+        <TransID>0</TransID>
+        <RefID>PRICreditTest</RefID>
+        <PostedDate>2004-02-04T08:23:02.9467720-08:00</PostedDate>
+        <AuthCode> CHECK IS NOT VERIFIED </AuthCode>
+        <Status>DENIED</Status>
+        <Message> Error Message </Message>
+        <Amount>1.01</Amount>
+      </CheckStatus>
+    XML
+  end
+
+  def successful_refund_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <BankCardRefundStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.paymentresources.com/webservices/">
+        <TransID>207686608</TransID>
+        <CreditID>5681409</CreditID>
+        <RefID />
+        <PostedDate>2010-08-09T15:20:50.9740575-06:00</PostedDate> <SettledDate>0001-01-01T00:00:00</SettledDate>
+        <Amount>1.0000</Amount>
+        <Status>Authorized</Status>
+      </BankCardRefundStatus>
+    XML
+  end
+
+  def failed_refund_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <BankCardRefundStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.paymentresources.com/webservices/">
+        <TransID>0</TransID>
+        <CreditID>0</CreditID>
+        <PostedDate>0001-01-01T00:00:00</PostedDate> <SettledDate>0001-01-01T00:00:00</SettledDate>
+        <Amount>0</Amount>
+        <Status>Canceled</Status>
+        <Message>Transaction Is Not Allowed To Void or Refund</Message>
+      </BankCardRefundStatus>
     XML
   end
 end


### PR DESCRIPTION
@duff and/or @rwdaigle this updates the TransFirst Transaction Central adapter. Could things to note:

1. There's no `authorize` with the Transaction Central API- all "Sale" actions are first authorizations, then at midnight TransFirst will automatically settle them.
1. Since there is so `authorize` there's also no `capture`.
1. Unfortunately, TransFirst accounts (test or prod) are unable to immediately settle credit card sale transactions, so I can't write a remote refund tests because all test `purchases` aren't settled and they'll always fail. But, I was able to get those responses for the unit tests so at least they're there. Remote tests are just a bit lacking.

Let me know if you have any other question/concerns/comments.