### PR TITLE
fix readme sample code response for a .01 transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ if credit_card.validate.empty?
   response = gateway.purchase(amount, credit_card)
 
   if response.success?
-    puts "Successfully charged $#{sprintf("%.2f", amount / 100)} to the credit card #{credit_card.display_number}"
+    puts "Successfully charged $#{sprintf("%.2f", amount / 100.0)} to the credit card #{credit_card.display_number}"
   else
     raise StandardError, response.message
   end


### PR DESCRIPTION
Hi,

When doing a .01 test transaction using the sample code in the README.md the response is:  

Successfully charged $0.00 to the credit card XXXX-XXXX-XXXX-4242

With this change it will be: 

Successfully charged $0.01 to the credit card XXXX-XXXX-XXXX-4242