### PR TITLE
Add unmaskExpirationDate option to AuthorizeNetCimGateway 

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -574,7 +574,7 @@ module ActiveMerchant #:nodoc:
       def build_get_customer_payment_profile_request(xml, options)
         xml.tag!('customerProfileId', options[:customer_profile_id])
         xml.tag!('customerPaymentProfileId', options[:customer_payment_profile_id])
-        xml.tag!('unmaskExpirationDate', options[:unmask_expiration_date])
+        xml.tag!('unmaskExpirationDate', options[:unmask_expiration_date]) if options[:unmask_expiration_date]
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -574,6 +574,7 @@ module ActiveMerchant #:nodoc:
       def build_get_customer_payment_profile_request(xml, options)
         xml.tag!('customerProfileId', options[:customer_profile_id])
         xml.tag!('customerPaymentProfileId', options[:customer_payment_profile_id])
+        xml.tag!('unmaskExpirationDate', options[:unmask_expiration_date])
         xml.target!
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -145,6 +145,10 @@ module ActiveMerchant
       @default_expiration_date ||= Date.new((Time.now.year + 1), 9, 30)
     end
 
+    def formatted_expiration_date(credit_card)
+      credit_card.expiry_date.expiration.strftime('%Y-%m')
+    end
+
     def credit_card(number = '4242424242424242', options = {})
       defaults = {
         :number => number,

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -368,12 +368,14 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response = @gateway.get_customer_payment_profile(
       :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id
+      :customer_payment_profile_id => @customer_payment_profile_id,
+      :unmask_expiration_date => true
     )
     assert_instance_of Response, response
     assert_success response
     assert_nil response.authorization
     assert_equal @customer_payment_profile_id, response.params['profile']['payment_profiles']['customer_payment_profile_id']
+    assert_equal formatted_expiration_date(@credit_card), response.params['profile']['payment_profiles']['payment']['credit_card']['expiration_date']
   end
 
   def test_should_get_customer_shipping_address_request


### PR DESCRIPTION
Add support for recently introduced "unmaskExpirationDate" option for AuthorizeNetCimGateway "get_customer_payment_profile" request

Reference: http://developer.authorize.net/api/reference/index.html?utm_campaign=November%202015%20Developer%20Newsletter&utm_medium=email&utm_source=Eloqua&elq=bd005706e5e048c5b532a59630590118&elqCampaignId=310&elqaid=454&elqat=1&elqTrackId=f3687d9f5ed34606a56edfb6baf22562#customer-profiles-get-customer-payment-profile