### PR TITLE
Element: Add guard clause so undocumented errors don't cause exceptions

### DIFF
--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -265,7 +265,7 @@ module ActiveMerchant #:nodoc:
         if action == "PaymentAccountCreate"
           response["paymentaccount"]["paymentaccountid"]
         else
-          "#{response['transaction']['transactionid']}|#{amount}"
+          "#{response['transaction']['transactionid']}|#{amount}" if response['transaction']
         end
       end
 


### PR DESCRIPTION
@duff: quick update to Element so exceptions aren't thrown if they return an undocumented error that doesn't include a `transaction` hash.