### PR TITLE
AndroidPay: Initial support

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -554,13 +554,15 @@ module ActiveMerchant #:nodoc:
             :last_name => credit_card_or_vault_id.last_name
           )
           if credit_card_or_vault_id.is_a?(NetworkTokenizationCreditCard)
-            parameters[:apple_pay_card] = {
-              :number => credit_card_or_vault_id.number,
-              :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
-              :expiration_year => credit_card_or_vault_id.year.to_s,
-              :cardholder_name => "#{credit_card_or_vault_id.first_name} #{credit_card_or_vault_id.last_name}",
-              :cryptogram => credit_card_or_vault_id.payment_cryptogram
-            }
+            if credit_card_or_vault_id.source == :apple_pay
+              parameters[:apple_pay_card] = {
+                :number => credit_card_or_vault_id.number,
+                :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
+                :expiration_year => credit_card_or_vault_id.year.to_s,
+                :cardholder_name => "#{credit_card_or_vault_id.first_name} #{credit_card_or_vault_id.last_name}",
+                :cryptogram => credit_card_or_vault_id.payment_cryptogram
+              }
+            end
           else
             parameters[:credit_card] = {
               :number => credit_card_or_vault_id.number,

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -243,7 +243,7 @@ module ActiveMerchant #:nodoc:
       def add_order_source(doc, payment_method, options)
         if options[:order_source]
           doc.orderSource(options[:order_source])
-        elsif payment_method.is_a?(NetworkTokenizationCreditCard)
+        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :apple_pay
           doc.orderSource('applepay')
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.orderSource('retail')

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -342,7 +342,7 @@ module ActiveMerchant #:nodoc:
           end
           post[:card] = card
 
-          if creditcard.is_a?(NetworkTokenizationCreditCard)
+          if creditcard.is_a?(NetworkTokenizationCreditCard) && creditcard.source == :apple_pay
             post[:three_d_secure] = {
               apple_pay:  true,
               cryptogram: creditcard.payment_cryptogram

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -15,6 +15,17 @@ module ActiveMerchant #:nodoc:
       self.require_name = false
 
       attr_accessor :payment_cryptogram, :eci, :transaction_id
+      attr_writer :source
+
+      SOURCES = [:apple_pay, :android_pay]
+
+      def source
+        if defined?(@source) && SOURCES.include?(@source)
+          @source
+        else
+          :apple_pay
+        end
+      end
 
       def type
         "network_tokenization"

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -8,6 +8,15 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
       month: default_expiration_date.month, year: default_expiration_date.year,
       payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=", eci: "05"
     })
+    @tokenized_apple_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      source: :apple_pay
+    })
+    @tokenized_android_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      source: :android_pay
+    })
+    @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      source: :bogus_pay
+    })
   end
 
   def test_type
@@ -16,5 +25,12 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
 
   def test_optional_validations
     assert_valid @tokenized_card, "Network tokenization card should not require name or verification value"
+  end
+
+  def test_source
+    assert_equal @tokenized_card.source, :apple_pay
+    assert_equal @tokenized_apple_pay_card.source, :apple_pay
+    assert_equal @tokenized_android_pay_card.source, :android_pay
+    assert_equal @tokenized_bogus_pay_card.source, :apple_pay
   end
 end


### PR DESCRIPTION
@rwdaigle  This adds initial support for android pay.  Includes adjustments to the gateways currently using the NetworkTokenizationCreditCard.  