### PR TITLE
Authorize.net: add eCheck credit

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -445,7 +445,6 @@ module ActiveMerchant #:nodoc:
             xml.routingNumber(check.routing_number)
             xml.accountNumber(check.account_number)
             xml.nameOnAccount(check.name)
-            xml.echeckType("WEB")
             xml.bankName(check.bank_name)
             xml.checkNumber(check.number)
           end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -450,6 +450,12 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_echeck_credit
+    response = @gateway.credit(@amount, @check, @options)
+    assert_equal 'The transaction is currently under review', response.message
+    assert response.authorization
+  end
+
   def test_failed_credit
     response = @gateway.credit(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -154,7 +154,6 @@ class AuthorizeNetTest < Test::Unit::TestCase
         assert_equal "15378535", doc.at_xpath("//accountNumber").content
         assert_equal "Bank of Elbonia", doc.at_xpath("//bankName").content
         assert_equal "Jim Smith", doc.at_xpath("//nameOnAccount").content
-        assert_equal "WEB", doc.at_xpath("//echeckType").content
         assert_equal "1", doc.at_xpath("//checkNumber").content
         assert_equal "1.00", doc.at_xpath("//transactionRequest/amount").content
       end
@@ -176,7 +175,6 @@ class AuthorizeNetTest < Test::Unit::TestCase
         assert_equal "15378535", doc.at_xpath("//accountNumber").content
         assert_equal "Bank of Elbonia", doc.at_xpath("//bankName").content
         assert_equal "Jim Smith", doc.at_xpath("//nameOnAccount").content
-        assert_equal "WEB", doc.at_xpath("//echeckType").content
         assert_equal "1", doc.at_xpath("//checkNumber").content
         assert_equal "1.00", doc.at_xpath("//transactionRequest/amount").content
       end


### PR DESCRIPTION
@rwdaigle adding eCheck credit support to Authorize.net. Two things:

1. I talked to Authorize.net support and they have limited support for eChecks in sandbox. So even though the remote test returns an error, according to Authorize.net support, if we get back the message, "The transaction is currently under review" then it should process in production. So pretty janky but I don't think there's much we can do about that.
1. If you run the full remote tests, the Apple Pay tests fail due to an expired credit card. It shouldn't cause any issues with this AFAICT. Not quite sure if that's something that needs to be fixed with this.