### PR TITLE
Fix exception when not all eCheck information is present

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -105,8 +105,8 @@ module ActiveMerchant #:nodoc:
       def add_echeck(post, payment)
         add_pair(post, :TransRoute, payment.routing_number, required: true)
         add_pair(post, :BankAccountNo, payment.account_number, required: true)
-        add_pair(post, :BankAccountType, payment.account_type.capitalize, required: true)
-        add_pair(post, :CheckType, payment.account_holder_type.capitalize, required: true)
+        add_pair(post, :BankAccountType, payment.account_type.capitalize, required: true) if payment.account_type
+        add_pair(post, :CheckType, payment.account_holder_type.capitalize, required: true) if payment.account_holder_type
         add_pair(post, :Name, payment.name, required: true)
         add_pair(post, :ProcessDate, Time.now.strftime("%m%d%y"), required: true)
         add_pair(post, :Description, "", required: true)


### PR DESCRIPTION
@rwdaigle quick fix to Trans First. Although all of these fields are required in the API request, if that info is not included in a `Check` then the `capitalize` will be called on a `nil` reference. This will at least allow the request to be made to Trans First instead of throwing an exception.