### PR TITLE
Mercury e2e

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -115,16 +115,6 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(url + action, post.to_param, headers))
 
-        # Debugging stuff
-        # puts "URL:"
-        # puts (url + action)
-        # puts "Headers:"
-        # puts headers.inspect
-        # puts "Request:"
-        # puts post.inspect
-        # puts "Response:"
-        # puts response.inspect
-
         Response.new(
           success_from(response),
           message_from(response),
@@ -132,7 +122,19 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(response),
           test: test?,
           error_code: error_code_from(response)
-        )
+          )
+      rescue ActiveMerchant::ResponseError => e
+        # treat auth failures as an error response
+        if 401 == e.response.code.to_i && "Not Authorized" == e.response.message
+          Response.new(
+            false,
+            e.message,
+            {},
+            { test: test? }
+            )
+        else
+          raise
+        end
       end
 
       def headers

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -2,13 +2,13 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MercuryEncryptedGateway < Gateway
       self.test_url = 'https://w1.mercurycert.net/PaymentsAPI'
-      self.live_url = 'https://example.com/live'
+      self.live_url = 'https://w1.mercurypay.com/PaymentsAPI/'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
-      self.homepage_url = 'http://www.example.net/'
+      self.homepage_url = 'http://mercurypay.com/'
       self.display_name = 'Mercury Gateway E2E'
 
       STANDARD_ERROR_CODE_MAPPING = {

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -1,0 +1,137 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class MercuryEncryptedGateway < Gateway
+      self.test_url = 'https://w1.mercurycert.net/PaymentsAPI/'
+      self.live_url = 'https://example.com/live'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://www.example.net/'
+      self.display_name = 'Mercury Gateway E2E'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '100204' => STANDARD_ERROR_CODE[:invalid_number],
+        '100205' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '000000' => STANDARD_ERROR_CODE[:card_declined]
+      }
+      SUCCESS_CODES = [ 'Approved', 'Success' ]
+
+      def initialize(options={})
+        requires!(options, :some_credential, :another_credential)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+
+        add_payment(post, payment)
+
+
+        commit('/Credit/Sale', post)
+      end
+
+      def authorize(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        commit('authonly', post)
+      end
+
+      def capture(money, authorization, options={})
+        commit('capture', post)
+      end
+
+      def refund(money, authorization, options={})
+        commit('refund', post)
+      end
+
+      def void(authorization, options={})
+        commit('void', post)
+      end
+
+      def verify(credit_card, options={})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+      end
+
+      private
+
+      def add_invoice(post, money, options)
+        post['InvoiceNo'] = options[:invoice_no]
+        post['RefNo'] = (options[:ref_no] || options[:invoice_no])
+        post['OperatorID'] = options[:merchant] if options[:merchant]
+        post['Memo'] = options[:description] if options[:description]
+        post['Purchase'] = amount(money)
+        #post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_payment(post, payment)
+        post['EncryptedBlock'] = payment.split("|")[3]
+        post['EncryptedKey'] = payment.split("|")[9]
+      end
+
+      def commit(action, parameters)
+        url = (test? ? test_url : live_url)
+        parameters["RefNo"]           = "1"
+        parameters["Memo"]            = "MPS Example JSON v1.0"
+        parameters["Purchase"]        = "1.00"
+        parameters["Frequency"]       = "OneTime"
+        parameters["EncryptedFormat"] = "MagneSafe"
+        parameters["AccountSource"]   = "Swiped"
+        parameters["RecordNo"]        = "RecordNumberRequested"
+
+        response = ssl_post(url + action, parameters.to_param, headers)
+        response = CGI.parse(response || "")
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def headers
+        headers = {
+          "Authorization" => "Basic " + Base64.encode64("019588466313922"+":"+ "xyz").strip
+        }
+      end
+
+      def success_from(response)
+        response["CmdStatus"].present? && SUCCESS_CODES.include?(response["CmdStatus"].first)
+      end
+
+      def message_from(response)
+        response[:text_response]
+      end
+
+      def authorization_from(response)
+        response["RecordNo"].first
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          STANDARD_ERROR_CODE_MAPPING[response["DSIXReturnCode"]]
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -2,7 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MercuryEncryptedGateway < Gateway
       self.test_url = 'https://w1.mercurycert.net/PaymentsAPI'
-      self.live_url = 'https://w1.mercurypay.com/PaymentsAPI/'
+      self.live_url = 'https://w1.mercurypay.com/PaymentsAPI'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -26,9 +26,13 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options={})
         post = {}
         add_invoice(post, money, options)
-        add_payment(post, payment)
-
-        commit('/Credit/Sale', post)
+        if payment.include?('|')
+          add_payment(post, payment)
+          commit('/Credit/Sale', post)
+        else
+          post["RecordNo"] = payment
+          commit('/Credit/SaleByRecordNo', post)
+        end
       end
 
       def authorize(money, swiper_output, options={})

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options={})
         post = {}
         add_invoice(post, money, options)
-        if payment.include?('|')
+        if payment.is_a?(Hash) || (payment.is_a?(String) && payment.include?('|'))
           add_payment(post, payment)
           commit('/Credit/Sale', post)
         else
@@ -98,8 +98,13 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(post, payment)
         post["EncryptedFormat"] = "MagneSafe"
-        post['EncryptedBlock'] = payment.split("|")[3]
-        post['EncryptedKey'] = payment.split("|")[9]
+        if payment.is_a?(Hash)
+          post['EncryptedBlock'] = payment[:encrypted_block]
+          post['EncryptedKey'] = payment[:encrypted_key]
+        else
+          post['EncryptedBlock'] = payment.split("|")[3]
+          post['EncryptedKey'] = payment.split("|")[9]
+        end
       end
 
       def add_common_params post

--- a/lib/active_merchant/billing/gateways/mercury_encrypted.rb
+++ b/lib/active_merchant/billing/gateways/mercury_encrypted.rb
@@ -94,6 +94,7 @@ module ActiveMerchant #:nodoc:
         post['Purchase'] = amount(money) if money
         post['Authorize'] = amount(options[:authorized]) if options[:authorized]
         post['Gratuity'] = amount(options[:tip]) if options[:tip]
+        post['LaneID'] = options[:lane_id] if options[:lane_id]
       end
 
       def add_payment(post, payment)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -369,6 +369,11 @@ mercury_no_tokenization:
   password: 'xyz'
   tokenization: false
 
+# Working credentials, no need to replace
+mercury_encrypted:
+  login: '118725340908147'
+  password: 'xyz'
+
 metrics_global:
   login: 'demo'
   password: 'password'

--- a/test/remote/gateways/remote_mercury_encrypted_test.rb
+++ b/test/remote/gateways/remote_mercury_encrypted_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+class RemoteMercuryEncryptedTest < Test::Unit::TestCase
+  def setup
+    @gateway = MercuryEncryptedGateway.new(fixtures(:mercury_encrypted))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com"
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED PURCHASE MESSAGE', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', response.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', response.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+  end
+
+  def test_invalid_login
+    gateway = MercuryEncryptedGateway.new(login: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED LOGIN MESSAGE}, response.message
+  end
+
+  def test_dump_transcript
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic.  You can delete
+    # this helper after completing your scrub implementation.
+    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end

--- a/test/remote/gateways/remote_mercury_encrypted_test.rb
+++ b/test/remote/gateways/remote_mercury_encrypted_test.rb
@@ -4,12 +4,12 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   def setup
     @gateway = MercuryEncryptedGateway.new(fixtures(:mercury_encrypted))
     @amount = 100
+    @declined_amount = 2401
     @swiper_output = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
-    @declined_card = credit_card('4000300011112220')
     @options = {
       invoice_no: "1",
       ref_no: "1",
-      description: "ActiveMerchant Mercury E2E Remote Test",
+      description: "ActiveMerchant Mercury E2E Test",
     }
   end
 
@@ -23,10 +23,11 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    pending
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = @gateway.purchase(@declined_amount, @swiper_output, @options)
 
     assert_failure response
+    assert_equal "DECLINE", response.message
+    assert response.test?
   end
 
   def test_successful_authorize_and_capture
@@ -43,9 +44,9 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    response = @gateway.authorize(@amount, @declined_card, @options)
+    response = @gateway.authorize(@declined_amount, @swiper_output, @options)
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
+    assert_equal 'DECLINE', response.message
   end
 
   def test_partial_capture
@@ -60,9 +61,13 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = @gateway.capture(@amount, '')
+    auth = @gateway.authorize(@declined_amount, @swiper_output, @options)
+    assert_failure auth
+
+    opts = @options.merge({ auth_code: auth.params["AuthCode"], acq_ref_data: auth.params["AcqRefData"] })
+    response = @gateway.capture(@declined_amount, auth.authorization, opts)
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
+    assert_equal "Invalid Field - Auth Code", response.message
   end
 
   def test_successful_refund
@@ -85,9 +90,9 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = @gateway.refund(@amount, '')
+    response = @gateway.refund(@declined_amount, 'invalid record no', @options)
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+    assert_equal "Token Service Unavailable. - 200 Response With Status:Failure Message:Token invalid", response.message
   end
 
   def test_successful_void
@@ -104,16 +109,23 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-    response = @gateway.void('')
+    sale = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success sale
+
+    opts = @options.merge({
+        auth_code: sale.params["AuthCode"],
+        ref_no: sale.params["RefNo"],
+        purchase: @declined_amount })
+    response = @gateway.void(sale.authorization, opts)
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+    assert_equal 'INV AMT MATCH', response.message
   end
 
   def test_invalid_login
     gateway = MercuryEncryptedGateway.new(login: '', password: '')
 
-    response = gateway.purchase(@amount, @credit_card, @options)
+    response = gateway.purchase(@amount, @swiper_output, @options)
     assert_failure response
-    assert_match %r{REPLACE WITH FAILED LOGIN MESSAGE}, response.message
+    assert_match "Failed with 401 Not Authorized", response.message
   end
 end

--- a/test/remote/gateways/remote_mercury_encrypted_test.rb
+++ b/test/remote/gateways/remote_mercury_encrypted_test.rb
@@ -30,6 +30,13 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_from_pre_auth
+    auth = @gateway.authorize(@amount, @swiper_output, @options)
+    assert_success auth
+
+    response = @gateway.purchase(@amount + 1, auth.authorization, @options)
+  end
+
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @swiper_output, @options)
     assert_success auth

--- a/test/remote/gateways/remote_mercury_encrypted_test.rb
+++ b/test/remote/gateways/remote_mercury_encrypted_test.rb
@@ -6,6 +6,7 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
     @amount = 100
     @declined_amount = 2401
     @swiper_output = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
+    @payment = { encrypted_key: "9012090B29C0D1000003", encrypted_block: "9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719" }
     @options = {
       invoice_no: "1",
       ref_no: "1",
@@ -15,6 +16,15 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success response
+
+    assert response.authorization.present?
+    assert_equal "1.00", response.params["Purchase"]
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_hash_payment_object
+    response = @gateway.purchase(@amount, @payment, @options)
     assert_success response
 
     assert response.authorization.present?

--- a/test/remote/gateways/remote_mercury_encrypted_test.rb
+++ b/test/remote/gateways/remote_mercury_encrypted_test.rb
@@ -10,6 +10,8 @@ class RemoteMercuryEncryptedTest < Test::Unit::TestCase
     @options = {
       invoice_no: "1",
       ref_no: "1",
+      merchant: 'test',
+      lane_id: '100',
       description: "ActiveMerchant Mercury E2E Test",
     }
   end

--- a/test/unit/gateways/mercury_encrypted_test.rb
+++ b/test/unit/gateways/mercury_encrypted_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class MercuryEncryptedTest < Test::Unit::TestCase
+  def setup
+    @gateway = MercuryEncryptedGateway.new(some_credential: 'login', another_credential: 'password')
+    @credit_card = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
+    @amount = 100
+
+    @options = {
+      invoice_no: "1",
+      ref_no: "1",
+      memo: "MPS Example JSON v1.0"
+    }
+  end
+
+  def test_successful_purchase
+#    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert response.authorization.present?
+    assert response.test?
+  end
+
+  def test_failed_purchase
+#    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    @credit_card = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8ABD0E223334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+  end
+
+  def test_successful_authorize
+  end
+
+  def test_failed_authorize
+  end
+
+  def test_successful_capture
+  end
+
+  def test_failed_capture
+  end
+
+  def test_successful_refund
+  end
+
+  def test_failed_refund
+  end
+
+  def test_successful_void
+  end
+
+  def test_failed_void
+  end
+
+  def test_successful_verify
+  end
+
+  def test_successful_verify_with_failed_void
+  end
+
+  def test_failed_verify
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      Run the remote tests for this gateway, and then put the contents of transcript.log here.
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
+      Things to scrub:
+        - Credit card number
+        - CVV
+        - Sensitive authentication details
+    )
+  end
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_mercury_encrypted_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response
+  end
+
+  def successful_authorize_response
+  end
+
+  def failed_authorize_response
+  end
+
+  def successful_capture_response
+  end
+
+  def failed_capture_response
+  end
+
+  def successful_refund_response
+  end
+
+  def failed_refund_response
+  end
+
+  def successful_void_response
+  end
+
+  def failed_void_response
+  end
+end

--- a/test/unit/gateways/mercury_encrypted_test.rb
+++ b/test/unit/gateways/mercury_encrypted_test.rb
@@ -1,127 +1,184 @@
 require 'test_helper'
 
 class MercuryEncryptedTest < Test::Unit::TestCase
-  def setup
-    @gateway = MercuryEncryptedGateway.new(some_credential: 'login', another_credential: 'password')
-    @credit_card = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
-    @amount = 100
 
+  def setup
+    @gateway = MercuryEncryptedGateway.new(fixtures(:mercury_encrypted))
+    @amount = 100
+    @declined_amount = 2401
+    @swiper_output   = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8BD0E220334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
     @options = {
       invoice_no: "1",
       ref_no: "1",
-      memo: "MPS Example JSON v1.0"
+      description: "ActiveMerchant Mercury E2E Test",
     }
   end
 
   def test_successful_purchase
-#    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    
+    response = @gateway.purchase(@amount, @swiper_output, @options)
     assert_success response
 
     assert response.authorization.present?
+    assert_equal "1.00", response.params["Purchase"]
     assert response.test?
   end
 
   def test_failed_purchase
-#    @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    @credit_card = "%B4003000050006781^TEST/MPS^19120000000000000?;4003000050006781=19120000000000000000?|0600|7EFC7CD505B74493DC4B01B8506E7B927B947ED2EDBF34E8DB470909238BC1ABAB007BFBB5395A730A48BFC2CD021260|9EF440CE67CAD230A307B5581F063AB8B8971E32F26F7CC64C2C15A274B8ABD0E223334C8E964E719||61401000|C95DAB4041E723946C54A63066108634DD24A93E587BDDCF49A0459C5649464B6ABFE8CB714AEB4B3B7F7F803E22548B7E23292200F92D74|B29C0D1120214AA|8BCE84619C673F4F|9012090B29C0D1000003|D860||1000"
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@declined_amount, @swiper_output, @options)
 
     assert_failure response
+    assert_equal "DECLINE", response.message
+    assert response.test?
   end
 
-  def test_successful_authorize
+  def test_successful_authorize_and_capture
+    @gateway.expects(:ssl_post).twice.returns(successful_authorize_response, successful_capture_response)
+
+    auth = @gateway.authorize(@amount, @swiper_output, @options)
+    assert_success auth
+    assert_equal "PreAuth", auth.params["TranCode"]
+    assert_equal "1.00", auth.params["Authorize"]
+
+    opts = @options.merge({ auth_code: auth.params["AuthCode"], acq_ref_data: auth.params["AcqRefData"] })
+    assert capture = @gateway.capture(@amount, auth.authorization, opts)
+    assert_success capture
+    assert_equal "Captured", capture.params["CaptureStatus"]
+    assert_equal "1.00", capture.params["Authorize"]
   end
 
   def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@declined_amount, @swiper_output, @options)
+    assert_failure response
+    assert_equal 'DECLINE', response.message
   end
 
-  def test_successful_capture
+  def test_partial_capture
+    @gateway.expects(:ssl_post).twice.returns(successful_authorize_response, successful_partial_capture_response)
+
+    auth = @gateway.authorize(@amount, @swiper_output, @options)
+    assert_success auth
+
+    opts = @options.merge({ auth_code: auth.params["AuthCode"], acq_ref_data: auth.params["AcqRefData"] })
+    assert capture = @gateway.capture(@amount-1, auth.authorization, opts)
+    assert_success capture
+    assert_equal "Captured", capture.params["CaptureStatus"]
+    assert_equal "0.99", capture.params["Authorize"]
   end
 
   def test_failed_capture
+    @gateway.expects(:ssl_post).twice.returns(failed_authorize_response, failed_capture_response)
+
+    auth = @gateway.authorize(@declined_amount, @swiper_output, @options)
+    assert_failure auth
+    
+    opts = @options.merge({ auth_code: auth.params["AuthCode"], acq_ref_data: auth.params["AcqRefData"] })
+    response = @gateway.capture(@declined_amount, auth.authorization, opts)
+    assert_failure response
+    assert_equal "Invalid Field - Auth Code", response.message
   end
 
   def test_successful_refund
+    @gateway.expects(:ssl_post).twice.returns(successful_purchase_response, successful_refund_response)
+
+    purchase = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_success refund
+    assert_equal "Return", refund.params["TranCode"]
   end
 
-  def test_failed_refund
+  def test_partial_refund
+    @gateway.expects(:ssl_post).twice.returns(successful_purchase_response, successful_partial_refund_response)
+
+    purchase = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization, @options)
+    assert_success refund
+    assert_equal "Return", refund.params["TranCode"]
+    assert_equal "0.99", refund.params["Purchase"]
   end
 
   def test_successful_void
+    @gateway.expects(:ssl_post).twice.returns(successful_purchase_response, successful_void_response)
+    
+    sale = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success sale
+
+    opts = @options.merge({
+        auth_code: sale.params["AuthCode"],
+        ref_no: sale.params["RefNo"],
+        purchase: @amount })
+    assert void = @gateway.void(sale.authorization, opts)
+    assert_success void
+    assert_equal "VOIDED", void.params["AuthCode"]
   end
 
   def test_failed_void
-  end
+    @gateway.expects(:ssl_post).twice.returns(successful_purchase_response, failed_void_response)
+    
+    sale = @gateway.purchase(@amount, @swiper_output, @options)
+    assert_success sale
 
-  def test_successful_verify
-  end
-
-  def test_successful_verify_with_failed_void
-  end
-
-  def test_failed_verify
-  end
-
-  def test_scrub
-    assert @gateway.supports_scrubbing?
-    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+    opts = @options.merge({
+        auth_code: sale.params["AuthCode"],
+        ref_no: sale.params["RefNo"],
+        purchase: @declined_amount })
+    response = @gateway.void(sale.authorization, opts)
+    assert_failure response
+    assert_equal 'INV AMT MATCH', response.message
   end
 
   private
 
-  def pre_scrubbed
-    %q(
-      Run the remote tests for this gateway, and then put the contents of transcript.log here.
-    )
-  end
-
-  def post_scrubbed
-    %q(
-      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
-      Things to scrub:
-        - Credit card number
-        - CVV
-        - Sensitive authentication details
-    )
-  end
-
   def successful_purchase_response
-    %(
-      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
-      to "true" when running remote tests:
-
-      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
-        test/remote/gateways/remote_mercury_encrypted_test.rb \
-        -n test_successful_purchase
-    )
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=Sale&AuthCode=VI0100&CaptureStatus=Captured&RefNo=0023&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=1.00&Authorize=1.00&AcqRefData=aEb015188177000483cABCAd5e00fJlA++m000005&RecordNo=shftcrAVgTxYHkG81Pg0IWdpxwlDyUe6TA0I5NcmLB0iEgUQECIQGJHU&ProcessData=%7c00%7c210100200000"
   end
 
   def failed_purchase_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Declined&TextResponse=DECLINE&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=Sale&RefNo=1&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=24.01&Authorize=24.01&RecordNo=Mkqt9jm3Ieq1us5p5kRLLWB2e1cz0G%2bPaOPz7mC1PQ0iEgUQECIQGJHl&ProcessData=%7c00%7c210100200000"
   end
 
   def successful_authorize_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=PreAuth&AuthCode=VI0100&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=1.00&Authorize=1.00&AcqRefData=aEb015188177000668cABCAd5e00fJlA++m000005&RecordNo=HWmDILxnQN5iMqvo0g2Y%2btp2aAaKwlgFVe0PDSNTtaQiEgUQECIQGJHp&ProcessData=%7c14%7c210100200000"
   end
 
   def failed_authorize_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Declined&TextResponse=DECLINE&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=PreAuth&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=24.01&Authorize=24.01&RecordNo=2VIckloKHfxgcFWqm4nIi6aePjtPQOHk4a%2bGuYN2rlkiEgUQECIQGJID&ProcessData=%7c14%7c210100200000"
   end
 
   def successful_capture_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP*&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=PreAuthCapture&AuthCode=VI0100&CaptureStatus=Captured&RefNo=0005&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=1.00&Authorize=1.00&AcqRefData=aEb015188177000668cABCAd5e00fJlA++m000005&RecordNo=H3FemaQ%2faMzM4Twue%2frKosfLqZgsZGTKNzXmDh85%2bGUiEgUQECIQGJHs&ProcessData=%7c15%7c210100200000"
+  end
+
+  def successful_partial_capture_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP*&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=PreAuthCapture&AuthCode=VI0100&CaptureStatus=Captured&RefNo=0003&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=0.99&Authorize=0.99&AcqRefData=aEb015188177001524cABCAd5e00fJlA++m000005&RecordNo=fx%2fU7jAqTqf9lwU7sgOZGikiN1nVSa%2fAxaLFVXKYrl4iEgUQECIQGJJR&ProcessData=%7c15%7c210100200000"
   end
 
   def failed_capture_response
+    "ResponseOrigin=Server&DSIXReturnCode=100206&CmdStatus=Error&TextResponse=Invalid+Field+-+Auth+Code"
   end
 
   def successful_refund_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP*&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=Return&AuthCode=C17824&CaptureStatus=Captured&RefNo=0006&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=1.00&Authorize=1.00&AcqRefData=KaN&RecordNo=p6OObsQq7ICAQ3pmBrax50C1QQ69uB4VJCzWqZ%2brGTsiEgUQECIQGJIN&ProcessData=%7c20%7c210100700000"
   end
 
-  def failed_refund_response
+  def successful_partial_refund_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP*&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=Return&AuthCode=C17714&CaptureStatus=Captured&RefNo=0004&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=0.99&Authorize=0.99&AcqRefData=KaN&RecordNo=8LgNj0iJFyAUNRUhcXGEYRSptmev1AeMf35VdEaBooMiEgUQECIQGJJI&ProcessData=%7c20%7c210100700000"
   end
 
   def successful_void_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Approved&TextResponse=AP&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=VoidSale&AuthCode=VOIDED&CaptureStatus=Captured&RefNo=0023&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=1.00&Authorize=1.00&AcqRefData=KaNb015188177000879cABCAd5e00fJj455734150707072119lA++m000005&RecordNo=kA%2fHGw%2fr0KbMIWvxQKwZPGhz%2b3F2kgwYuWsgxJ2%2bJgQiEgUQECIQGJIV&ProcessData=%7cA4%7c210100600000"
   end
 
   def failed_void_response
+    "ResponseOrigin=Processor&DSIXReturnCode=000000&CmdStatus=Declined&TextResponse=INV+AMT+MATCH&MerchantID=118725340908147&AcctNo=400300XXXXXX6781&ExpDate=XXXX&CardType=VISA&TranCode=VoidSale&AuthCode=VI0100&RefNo=0024&InvoiceNo=1&Memo=ActiveMerchant+Mercury+E2E+Test&Purchase=24.01&Authorize=24.01&AcqRefData=KaY&RecordNo=WifH5Isxb%2fVYB6sq0za4BmpYZNdvDocp9xn%2fsKbv%2fMciEgUQECIQGJIX&ProcessData=%7cA4%7c210100600000"
   end
 end

--- a/test/unit/gateways/mercury_encrypted_test.rb
+++ b/test/unit/gateways/mercury_encrypted_test.rb
@@ -10,6 +10,8 @@ class MercuryEncryptedTest < Test::Unit::TestCase
     @options = {
       invoice_no: "1",
       ref_no: "1",
+      merchant: 'test',
+      lane_id: '100',
       description: "ActiveMerchant Mercury E2E Test",
     }
   end


### PR DESCRIPTION
Hey everyone!

We added Mercury end to end encryption support a while back and wanted to see if you wanted this upstream.

This means you can support people with an encrypted card reader using e2e encryption with Mercury using their SOAP API.

We have this in production with them and it's working well. 

Happy to try to answer questions about this..

(tell me if I'm doing this wrong.)
