### PR TITLE
Transfirst: use default values for some eCheck data

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -105,11 +105,16 @@ module ActiveMerchant #:nodoc:
       def add_echeck(post, payment)
         add_pair(post, :TransRoute, payment.routing_number, required: true)
         add_pair(post, :BankAccountNo, payment.account_number, required: true)
-        add_pair(post, :BankAccountType, payment.account_type.capitalize, required: true) if payment.account_type
-        add_pair(post, :CheckType, payment.account_holder_type.capitalize, required: true) if payment.account_holder_type
+        add_pair(post, :BankAccountType, add_or_use_default(payment.account_type, "Checking"), required: true)
+        add_pair(post, :CheckType, add_or_use_default(payment.account_holder_type, "Personal"), required: true)
         add_pair(post, :Name, payment.name, required: true)
         add_pair(post, :ProcessDate, Time.now.strftime("%m%d%y"), required: true)
         add_pair(post, :Description, "", required: true)
+      end
+
+      def add_or_use_default(payment_data, default_value)
+        return payment_data.capitalize if payment_data
+        return default_value
       end
 
       def add_unused_fields(post)

--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -31,6 +31,14 @@ class RemoteTransFirstTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_purchase_with_echeck_defaults
+    @check = check(account_holder_type: nil, account_type: nil)
+    assert response = @gateway.purchase(@amount, @check, @options)
+    assert response.test?
+    assert_success response
+    assert !response.authorization.blank?
+  end
+
   def test_failed_purchase
     @amount = 21
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
@duff: Updating TransFirst to use some default values for eCheck data if it's not present.