### PR TITLE
TransFirst: Remove unused fields for echeck

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.transfirst.com/'
       self.display_name = 'TransFirst'
 
-      UNUSED_FIELDS = %w(ECIValue UserId CAVVData TrackData POSInd EComInd MerchZIP MerchCustPNum MCC InstallmentNum InstallmentOf POSEntryMode POSConditionCode AuthCharInd CardCertData)
+      UNUSED_CREDIT_CARD_FIELDS = %w(UserId TrackData TaxIndicator MerchZIP MerchCustPNum MCC InstallmentNum InstallmentOf POSInd POSConditionCode EComInd AuthCharInd CardCertData CAVVData)
 
       DECLINED = 'The transaction was declined'
 
@@ -91,12 +91,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, options)
-        add_pair(post, :RefID, options[:order_id], required: true)
-        add_pair(post, :SECCCode, options[:invoice], required: true)
-        add_pair(post, :PONumber, options[:invoice], required: true)
+        add_pair(post, :RefID, options[:order_id], required: true) if options[:order_id]
+        add_pair(post, :SECCCode, options[:invoice], required: true) if options[:invoice]
+        add_pair(post, :PONumber, options[:invoice], required: true) if options[:invoice]
         add_pair(post, :SaleTaxAmount, amount(options[:tax] || 0))
-        add_pair(post, :PaymentDesc, options[:description], required: true)
-        add_pair(post, :TaxIndicator, 0)
+        add_pair(post, :PaymentDesc, options[:description] || "", required: true)
         add_pair(post, :CompanyName, options[:company_name] || "", required: true)
       end
 
@@ -131,7 +130,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_unused_fields(post)
-        UNUSED_FIELDS.each do |f|
+        return if post[:TransRoute]
+
+        UNUSED_CREDIT_CARD_FIELDS.each do |f|
           post[f] = ""
         end
       end


### PR DESCRIPTION
@duff update to TransFirst to stop sending blank values for credit card fields on ACH purchases. Unfortunately I can't really test because it was actually working fine before when we were sending unnecessary fields. Hopefully this clears up any issues that people might have when moving to a production account with TransFirst Classic.