### PR TITLE
make error handling for Quickpay gateway more idiomatic

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -10,16 +10,16 @@ module ActiveMerchant #:nodoc:
       self.abstract_class = true
 
       def self.new(options = {})
-        options.fetch(:login) rescue raise ArgumentError.new("Missing required parameter: login")
+        options.fetch(:login) { raise ArgumentError.new("Missing required parameter: login") }
 
         version = options[:login].to_i < 10000000 ? 10 : 7
         if version <= 7
           QuickpayV4to7Gateway.new(options)
         else
-          QuickpayV10Gateway.new(options)     
+          QuickpayV10Gateway.new(options)
         end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
It doesn't change much, but I was reading code for Quickpay gateway and found rescuing and raising another error not that idiomatic if it can be just raised in the block argument for `Hash#fetch`. It makes code more readable I think.
