### PR TITLE
Orbital: Fix CC num leak on profile calls

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
       USE_ORDER_ID         = 'O' #  Use OrderID field
       USE_COMMENTS         = 'D' #  Use Comments field
 
-      SENSITIVE_FIELDS = [:account_num]
+      SENSITIVE_FIELDS = [:account_num, :cc_account_num]
 
       def initialize(options = {})
         requires!(options, :merchant_id)

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -619,6 +619,21 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_nil response.params['account_num']
   end
 
+  def test_cc_account_num_is_removed_from_response
+    @gateway.expects(:ssl_post).returns(successful_profile_response)
+
+    response = nil
+
+    assert_deprecation_warning do
+      response = @gateway.add_customer_profile(credit_card,
+          :billing_address => address)
+    end
+
+    assert_instance_of Response, response
+    assert_success response
+    assert_nil response.params['cc_account_num']
+  end
+
   def test_successful_verify
     response = stub_comms do
       @gateway.verify(credit_card, @options)


### PR DESCRIPTION
Orbital returns the full card number on any call
involving the profile using a different field name
than in other calls.  It wasn't marked as 
sensitive, causing it to be leaked into logs.