### PR TITLE
Use In-Context Express redirect url for PaypalExpressGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow_express.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express.rb
@@ -69,6 +69,11 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.paypal.com/cgi-bin/webscr?cmd=xpt/merchant/ExpressCheckoutIntro-outside'
       self.display_name = 'PayPal Express Checkout'
 
+      def redirect_url_for(token, options = {})
+        cmd = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
+        build_redirect_url_for(token, options: options, cmd: cmd)
+      end
+
       def authorize(money, options = {})
         requires!(options, :token, :payer_id)
         request = build_sale_or_authorization_request('Authorization', money, options)

--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -14,7 +14,8 @@ module ActiveMerchant #:nodoc:
 
       def redirect_url_for(token, options = {})
         options[:review] ||= false
-        super
+        cmd = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
+        build_redirect_url_for(token, options: options, cmd: cmd)
       end
 
       # GATEWAY.setup_purchase(100,

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -27,11 +27,15 @@ module ActiveMerchant #:nodoc:
       }
 
       CURRENCIES_WITHOUT_FRACTIONS = %w(BRL HUF JPY MYR TWD TRY)
-
-      self.test_redirect_url = 'https://www.sandbox.paypal.com/cgi-bin/webscr'
+      self.live_redirect_url = 'https://www.paypal.com/checkoutnow'
+      self.test_redirect_url = 'https://www.sandbox.paypal.com/checkoutnow'
       self.supported_countries = ['US']
       self.homepage_url = 'https://www.paypal.com/cgi-bin/webscr?cmd=xpt/merchant/ExpressCheckoutIntro-outside'
       self.display_name = 'PayPal Express Checkout'
+
+      def redirect_url_for(token, options = {})
+        build_redirect_url_for(token, options: options)
+      end
 
       def setup_authorization(money, options = {})
         requires!(options, :return_url, :cancel_return_url)

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -16,13 +16,11 @@ module ActiveMerchant
         test? ? test_redirect_url : live_redirect_url
       end
 
-      def redirect_url_for(token, options = {})
-        options = {:review => true, :mobile => false}.update(options)
-
-        cmd  = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
-        url  = "#{redirect_url}?cmd=#{cmd}&token=#{token}"
+      def build_redirect_url_for(token, options: {}, cmd: nil)
+        options = {review: true}.update(options)
+        url = "#{redirect_url}?token=#{token}"
         url += '&useraction=commit' unless options[:review]
-
+        url += "&cmd=#{cmd}" if cmd
         url
       end
     end

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -1,19 +1,19 @@
 require 'test_helper'
 
 class PayflowExpressTest < Test::Unit::TestCase
-  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
-  TEST_REDIRECT_URL_MOBILE = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
-  LIVE_REDIRECT_URL        = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
-  LIVE_REDIRECT_URL_MOBILE = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
-  
-  TEST_REDIRECT_URL_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL}&useraction=commit"
-  LIVE_REDIRECT_URL_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL}&useraction=commit"
-  TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_MOBILE}&useraction=commit"
-  LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE}&useraction=commit"
-  
+  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/cgi-bin/webscr?token=1234567890&cmd=_express-checkout'
+  TEST_REDIRECT_URL_MOBILE = 'https://www.sandbox.paypal.com/cgi-bin/webscr?token=1234567890&cmd=_express-checkout-mobile'
+  LIVE_REDIRECT_URL        = 'https://www.paypal.com/cgi-bin/webscr?token=1234567890&cmd=_express-checkout'
+  LIVE_REDIRECT_URL_MOBILE = 'https://www.paypal.com/cgi-bin/webscr?token=1234567890&cmd=_express-checkout-mobile'
+
+  TEST_REDIRECT_URL_WITHOUT_REVIEW = 'https://www.sandbox.paypal.com/cgi-bin/webscr?token=1234567890&useraction=commit&cmd=_express-checkout'
+  LIVE_REDIRECT_URL_WITHOUT_REVIEW = 'https://www.paypal.com/cgi-bin/webscr?token=1234567890&useraction=commit&cmd=_express-checkout'
+  TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = 'https://www.sandbox.paypal.com/cgi-bin/webscr?token=1234567890&useraction=commit&cmd=_express-checkout-mobile'
+  LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = 'https://www.paypal.com/cgi-bin/webscr?token=1234567890&useraction=commit&cmd=_express-checkout-mobile'
+
   def setup
     Base.mode = :test
-  
+
     @gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD'
@@ -29,61 +29,61 @@ class PayflowExpressTest < Test::Unit::TestCase
                  :phone => '(555)555-5555'
                }
   end
-  
+
   def teardown
     Base.mode = :test
   end
-  
+
   def test_using_test_mode
     assert @gateway.test?
   end
-  
+
   def test_overriding_test_mode
     Base.mode = :production
-    
+
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD',
       :test => true
     )
-    
+
     assert gateway.test?
   end
-  
+
   def test_using_production_mode
     Base.mode = :production
-    
+
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD'
     )
-    
+
     assert !gateway.test?
   end
-  
+
   def test_live_redirect_url
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
-  
+
   def test_test_redirect_url
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
-  
+
   def test_live_redirect_url_without_review
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
-  
+
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
-  
+
   def test_invalid_get_express_details_request
     @gateway.expects(:ssl_post).returns(invalid_get_express_details_response)
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
@@ -91,20 +91,20 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Field format error: Invalid Token', response.message
   end
-  
+
   def test_get_express_details
     @gateway.expects(:ssl_post).returns(successful_get_express_details_response)
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
     assert_instance_of PayflowExpressResponse, response
     assert_success response
     assert response.test?
-    
+
     assert_equal 'EC-2OPN7UJGFWK9OYFV', response.token
     assert_equal '12345678901234567', response.payer_id
     assert_equal 'Buyer1@paypal.com', response.email
     assert_equal 'Joe Smith', response.full_name
     assert_equal 'US', response.payer_country
-    
+
     assert address = response.address
     assert_equal 'Joe Smith', address['name']
     assert_nil address['company']
@@ -134,9 +134,9 @@ class PayflowExpressTest < Test::Unit::TestCase
     xml_doc = REXML::Document.new(xml.target!)
     assert_equal 'ActiveMerchant', REXML::XPath.first(xml_doc, '/PayPal/ButtonSource').text
   end
-  
+
   private
-  
+
   def successful_get_express_details_response(options={:street => "111 Main St."})
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
@@ -172,7 +172,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   </XMLPayResponse>
     RESPONSE
   end
-  
+
   def invalid_get_express_details_response
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
@@ -186,7 +186,7 @@ class PayflowExpressTest < Test::Unit::TestCase
       </TransactionResult>
     </TransactionResults>
   </ResponseData>
-</XMLPayResponse>    
+</XMLPayResponse>
     RESPONSE
   end
 end

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class PaypalDigitalGoodsTest < Test::Unit::TestCase
-  TEST_REDIRECT_URL         = 'https://www.sandbox.paypal.com/incontext?cmd=_express-checkout&token=1234567890&useraction=commit'
-  MOBILE_TEST_REDIRECT_URL  = 'https://www.sandbox.paypal.com/incontext?cmd=_express-checkout-mobile&token=1234567890&useraction=commit'
-  LIVE_REDIRECT_URL         = 'https://www.paypal.com/incontext?cmd=_express-checkout&token=1234567890&useraction=commit'
-  MOBILE_LIVE_REDIRECT_URL  = 'https://www.paypal.com/incontext?cmd=_express-checkout-mobile&token=1234567890&useraction=commit'
+  TEST_REDIRECT_URL         = 'https://www.sandbox.paypal.com/incontext?token=1234567890&useraction=commit&cmd=_express-checkout'
+  MOBILE_TEST_REDIRECT_URL  = 'https://www.sandbox.paypal.com/incontext?token=1234567890&useraction=commit&cmd=_express-checkout-mobile'
+  LIVE_REDIRECT_URL         = 'https://www.paypal.com/incontext?token=1234567890&useraction=commit&cmd=_express-checkout'
+  MOBILE_LIVE_REDIRECT_URL  = 'https://www.paypal.com/incontext?token=1234567890&useraction=commit&cmd=_express-checkout-mobile'
 
   def setup
     @gateway = PaypalDigitalGoodsGateway.new(

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -2,15 +2,11 @@ require 'test_helper'
 require 'nokogiri'
 
 class PaypalExpressTest < Test::Unit::TestCase
-  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
-  TEST_REDIRECT_URL_MOBILE = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
-  LIVE_REDIRECT_URL        = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
-  LIVE_REDIRECT_URL_MOBILE = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
+  TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/checkoutnow?token=1234567890'
+  LIVE_REDIRECT_URL        = 'https://www.paypal.com/checkoutnow?token=1234567890'
 
   TEST_REDIRECT_URL_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL}&useraction=commit"
   LIVE_REDIRECT_URL_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL}&useraction=commit"
-  TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_MOBILE}&useraction=commit"
-  LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE}&useraction=commit"
 
   def setup
     @gateway = PaypalExpressGateway.new(
@@ -39,13 +35,11 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_live_redirect_url
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
 
   def test_live_redirect_url_without_review
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
 
   def test_force_sandbox_redirect_url
@@ -60,19 +54,16 @@ class PaypalExpressTest < Test::Unit::TestCase
 
     assert gateway.test?
     assert_equal TEST_REDIRECT_URL, gateway.redirect_url_for('1234567890')
-    assert_equal TEST_REDIRECT_URL_MOBILE, gateway.redirect_url_for('1234567890', :mobile => true)
   end
 
   def test_test_redirect_url
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
 
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
 
   def test_get_express_details


### PR DESCRIPTION
### Context
We want to enable the In-Context Checkout in Express Checkout (https://developer.paypal.com/docs/classic/express-checkout/in-context/) on Shopify checkout. To do so, our base url, live and sandbox, must change to `https://www.paypal.com/checkoutnow` and `http://www.sandbox.paypal.com/checkoutnow` respectively.

The in-context checkout needs a paypal js library to work, but the new url doesn't affect going through a standard checkout without the library for the popup. This shouldn't affect other flows.

We also can't send the `&cmd=_express-checkout`, which kicks in the old express checkout flow when using In-Context. We therefore don't need a mobile / non-mobile url for paypal_express only.

### Solution proposed
We only need `paypal_express` to change. Digital goods need to stay as they are, same with payflow, and paypal.

I've changed `paypal_express_common` with a new method `base_redirect_url_for` which returns the basic url for all express gateways. 

Each gateway then implements his own `redirect_url_for` method, that can add query params or change options to the base redirect url.


I need to test this extensively to see if the new URL does indeed work in all flows, but im creating this PR to get some feedback meanwhile.

@girasquid 
cc @Krystosterone



 