### PR TITLE
Return Braintree Blue id for unsuccessful transactions when available

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -321,7 +321,7 @@ module ActiveMerchant #:nodoc:
       def response_from_result(result)
         Response.new(result.success?, message_from_result(result),
           { braintree_transaction: transaction_hash(result) },
-          { authorization: (result.transaction.id if result.success?) }
+          { authorization: (result.transaction.id if result.transaction) }
          )
       end
 
@@ -334,10 +334,8 @@ module ActiveMerchant #:nodoc:
 
       def response_options(result)
         options = {}
-        if result.success?
-          options[:authorization] = result.transaction.id
-        end
         if result.transaction
+          options[:authorization] = result.transaction.id
           options[:avs_result] = { code: avs_code_from(result.transaction) }
           options[:cvv_result] = result.transaction.cvv_response_code
         end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -334,6 +334,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_unsuccessful_purchase_declined
     assert response = @gateway.purchase(@declined_amount, @credit_card, @options)
     assert_failure response
+    assert response.authorization.present?
     assert_equal '2000 Do Not Honor', response.message
   end
 
@@ -408,6 +409,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'voided', void.params["braintree_transaction"]["status"]
     assert failed_void = @gateway.void(auth.authorization)
     assert_failure failed_void
+    assert failed_void.authorization.present?
     assert_equal 'Transaction can only be voided if status is authorized or submitted_for_settlement. (91504)', failed_void.message
     assert_equal({"processor_response_code"=>"91504"}, failed_void.params["braintree_transaction"])
   end
@@ -573,6 +575,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_failed_credit
     assert response = @gateway.credit(@amount, credit_card('5105105105105101'), @options)
     assert_failure response
+    assert response.authorization.present?
     assert_equal 'Credit card number is invalid. (81715)', response.message, "You must get credits enabled in your Sandbox account for this to pass"
   end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -601,10 +601,21 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
   end
 
+  def test_unsuccessful_transaction_returns_id_when_available
+    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_error_result(transaction: {id: 'transaction_id'}))
+    assert response = @gateway.purchase(100, credit_card("41111111111111111111"))
+    refute response.success?
+    assert response.authorization.present?
+  end
+
   private
 
   def braintree_result(options = {})
     Braintree::SuccessfulResult.new(:transaction => Braintree::Transaction._new(nil, {:id => "transaction_id"}.merge(options)))
+  end
+
+  def braintree_error_result(options = {})
+    Braintree::ErrorResult.new(@internal_gateway, {errors: {}}.merge(options))
   end
 
   def with_braintree_configuration_restoration(&block)


### PR DESCRIPTION
The Braintree Blue gateway should return the id of a transaction regardless of whether or not it was successful.  Not having the id in the response makes tracking down issues difficult.  

This is currently how the Braintree Orange gateway works:
https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/smart_ps.rb#L235

@girasquid 