### PR TITLE
Add InContextPaypalExpressGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
@@ -1,0 +1,15 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class InContextPaypalExpressGateway < PaypalExpressGateway
+      self.test_redirect_url = 'https://www.sandbox.paypal.com/checkoutnow'
+      self.live_redirect_url = 'https://www.paypal.com/checkoutnow'
+
+      def redirect_url_for(token, options = {})
+        options = {review: true}.update(options)
+        url  = "#{redirect_url}?token=#{token}"
+        url += '&useraction=commit' unless options[:review]
+        url
+      end
+    end
+  end
+end

--- a/test/unit/gateways/in_context_paypal_express_test.rb
+++ b/test/unit/gateways/in_context_paypal_express_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class InContextPaypalExpressTest < Test::Unit::TestCase
+  TEST_REDIRECT_URL = 'https://www.sandbox.paypal.com/checkoutnow?token=1234567890'
+  LIVE_REDIRECT_URL = 'https://www.paypal.com/checkoutnow?token=1234567890'
+  TEST_REDIRECT_URL_WITHOUT_REVIEW = 'https://www.sandbox.paypal.com/checkoutnow?token=1234567890&useraction=commit'
+  LIVE_REDIRECT_URL_WITHOUT_REVIEW = 'https://www.paypal.com/checkoutnow?token=1234567890&useraction=commit'
+
+  def setup
+    @gateway = InContextPaypalExpressGateway.new(
+      :login => 'cody',
+      :password => 'test',
+      :pem => 'PEM'
+    )
+
+    Base.mode = :test
+  end
+
+  def teardown
+    Base.mode = :test
+  end
+
+  def test_live_redirect_url
+    Base.mode = :production
+    assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+  end
+
+  def test_test_redirect_url
+    assert_equal :test, Base.mode
+    assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
+  end
+
+  def test_live_redirect_url_without_review
+    Base.mode = :production
+    assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+  end
+
+  def test_test_redirect_url_without_review
+    assert_equal :test, Base.mode
+    assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+  end
+end
+


### PR DESCRIPTION
Context in #1992

This PR adds a new `InContextPaypalExpressGateway` which inherits from `PaypalExpressGateway`

They behave the same except for the test and live redirect urls. The `redirect_url_for` method is also changed and do not append the `cmd` query param we have in other places.

Let me know if I am forgetting something in the creation of a new gateway.

@girasquid @krystosterone