### PR TITLE
Braintree Blue support for transaction option eci: 'recurring'

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -534,10 +534,8 @@ module ActiveMerchant #:nodoc:
         if merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)
           parameters[:merchant_account_id] = merchant_account_id
         end
-
-        if options[:recurring]
-          parameters[:recurring] = true
-        end
+        
+        parameters[:recurring] = true if (options[:eci] == 'recurring' || options[:recurring])
 
         if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
           if options[:payment_method_token]

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -498,10 +498,22 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"), :recurring => true)
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
+        with(has_entries(:recurring => true)).
+        returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"), :eci => 'recurring')
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
       with(Not(has_entries(:recurring => true))).
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card("41111111111111111111"))
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+        with(Not(has_entries(:recurring => true))).
+        returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"), :eci => 'nonsense')
   end
 
   def test_configured_logger_has_a_default


### PR DESCRIPTION
Braintree Blue needs to support the `eci: 'recurring'` option when procession transaction parameters.  This aligns with the current behaviour of other gateways like Stripe e.g.

https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/stripe.rb#L384

@girasquid @aprofeit 

/cc @jeromecornet 