### PR TITLE
TransFirst Transaction Express: add gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -1,0 +1,597 @@
+require "nokogiri"
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class TransFirstTransactionExpressGateway < Gateway
+      self.display_name = "TransFirst Transaction Express"
+      self.homepage_url = "http://transactionexpress.com/"
+
+      self.test_url = "https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl"
+      self.live_url = "https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl"
+
+      self.supported_countries = ["US"]
+      self.default_currency = "USD"
+      self.money_format = :cents
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club]
+
+      APPROVAL_CODES = %w(00 10)
+
+      RESPONSE_MESSAGES = {
+        "00" => "Approved",
+        "01" => "Refer to card issuer",
+        "02" => "Refer to card issuer, special condition",
+        "03" => "Invalid merchant",
+        "04" => "Pick-up card",
+        "05" => "Do not honor",
+        "06" => "Error",
+        "07" => "Pick-up card, special condition",
+        "08" => "Honor with identification",
+        "09" => "Request in progress",
+        "10" => "Approved, partial authorization",
+        "11" => "VIP Approval",
+        "12" => "Invalid transaction",
+        "13" => "Invalid amount",
+        "14" => "Invalid card number",
+        "15" => "No such issuer",
+        "16" => "Approved, update track 3",
+        "17" => "Customer cancellation",
+        "18" => "Customer dispute",
+        "19" => "Re-enter transaction",
+        "20" => "Invalid response",
+        "21" => "No action taken",
+        "22" => "Suspected malfunction",
+        "23" => "Unacceptable transaction fee",
+        "24" => "File update not supported",
+        "25" => "Unable to locate record",
+        "26" => "Duplicate record",
+        "27" => "File update field edit error",
+        "28" => "File update file locked",
+        "29" => "File update failed",
+        "30" => "Format error",
+        "31" => "Bank not supported",
+        "33" => "Expired card, pick-up",
+        "34" => "Suspected fraud, pick-up",
+        "35" => "Contact acquirer, pick-up",
+        "36" => "Restricted card, pick-up",
+        "37" => "Call acquirer security, pick-up",
+        "38" => "PIN tries exceeded, pick-up",
+        "39" => "No credit account",
+        "40" => "Function not supported",
+        "41" => "Lost card, pick-up",
+        "42" => "No universal account",
+        "43" => "Stolen card, pick-up",
+        "44" => "No investment account",
+        "45" => "Account closed",
+        "46" => "Identification required",
+        "47" => "Identification cross-check required",
+        "48" => "No customer record",
+        "49" => "Reserved for future Realtime use",
+        "50" => "Reserved for future Realtime use",
+        "51" => "Not sufficient funds",
+        "52" => "No checking account",
+        "53" => "No savings account",
+        "54" => "Expired card",
+        "55" => "Incorrect PIN",
+        "56" => "No card record",
+        "57" => "Transaction not permitted to cardholder",
+        "58" => "Transaction not permitted on terminal",
+        "59" => "Suspected fraud",
+        "60" => "Contact acquirer",
+        "61" => "Exceeds withdrawal limit",
+        "62" => "Restricted card",
+        "63" => "Security violation",
+        "64" => "Original amount incorrect",
+        "65" => "Exceeds withdrawal frequency",
+        "66" => "Call acquirer security",
+        "67" => "Hard capture",
+        "68" => "Response received too late",
+        "69" => "Advice received too late (the response from a request was received too late )",
+        "70" => "Reserved for future use",
+        "71" => "Reserved for future Realtime use",
+        "72" => "Reserved for future Realtime use",
+        "73" => "Reserved for future Realtime use",
+        "74" => "Reserved for future Realtime use",
+        "75" => "PIN tries exceeded",
+        "76" => "Reversal: Unable to locate previous message (no match on Retrieval Reference Number)/ Reserved for future Realtime use",
+        "77" => "Previous message located for a repeat or reversal, but repeat or reversal data is inconsistent with original message/ Intervene, bank approval required",
+        "78" => "Invalid/non-existent account – Decline (MasterCard specific)/ Intervene, bank approval required for partial amount",
+        "79" => "Already reversed (by Switch)/ Reserved for client-specific use (declined)",
+        "80" => "No financial Impact (Reserved for declined debit)/ Reserved for client-specific use (declined)",
+        "81" => "PIN cryptographic error found by the Visa security module during PIN decryption/ Reserved for client-specific use (declined)",
+        "82" => "Incorrect CVV/ Reserved for client-specific use (declined)",
+        "83" => "Unable to verify PIN/ Reserved for client-specific use (declined)",
+        "84" => "Invalid Authorization Life Cycle – Decline (MasterCard) or Duplicate Transaction Detected (Visa)/ Reserved for client-specific use (declined)",
+        "85" => "No reason to decline a request for Account Number Verification or Address Verification/ Reserved for client-specific use (declined)",
+        "86" => "Cannot verify PIN/ Reserved for client-specific use (declined)",
+        "87" => "Reserved for client-specific use (declined)",
+        "88" => "Reserved for client-specific use (declined)",
+        "89" => "Reserved for client-specific use (declined)",
+        "90" => "Cut-off in progress",
+        "91" => "Issuer or switch inoperative",
+        "92" => "Routing error",
+        "93" => "Violation of law",
+        "94" => "Duplicate Transmission (Integrated Debit and MasterCard)",
+        "95" => "Reconcile error",
+        "96" => "System malfunction",
+        "97" => "Reserved for future Realtime use",
+        "98" => "Exceeds cash limit",
+        "99" => "Reserved for future Realtime use",
+        "1106" => "Reserved for future Realtime use",
+        "0A" => "Reserved for future Realtime use",
+        "A0" => "Reserved for future Realtime use",
+        "A1" => "ATC not incremented",
+        "A2" => "ATC limit exceeded",
+        "A3" => "ATC configuration error",
+        "A4" => "CVR check failure",
+        "A5" => "CVR configuration error",
+        "A6" => "TVR check failure",
+        "A7" => "TVR configuration error",
+        "A8" => "Reserved for future Realtime use",
+        "B1" => "Surcharge amount not permitted on Visa cards or EBT Food Stamps/ Reserved for future Realtime use",
+        "B2" => "Surcharge amount not supported by debit network issuer/ Reserved for future Realtime use",
+        "C1" => "Unacceptable PIN",
+        "C2" => "PIN Change failed",
+        "C3" => "PIN Unblock failed",
+        "D1" => "MAC Error",
+        "E1" => "Prepay error",
+        "N1" => "Network Error within the TXP platform",
+        "N0" => "Force STIP/ Reserved for client-specific use (declined)",
+        "N3" => "Cash service not available/ Reserved for client-specific use (declined)",
+        "N4" => "Cash request exceeds Issuer limit/ Reserved for client-specific use (declined)",
+        "N5" => "Ineligible for re-submission/ Reserved for client-specific use (declined)",
+        "N7" => "Decline for CVV2 failure/ Reserved for client-specific use (declined)",
+        "N8" => "Transaction amount exceeds preauthorized approval amount/ Reserved for client-specific use (declined)",
+        "P0" => "Approved; PVID code is missing, invalid, or has expired",
+        "P1" => "Declined; PVID code is missing, invalid, or has expired/ Reserved for client-specific use (declined)",
+        "P2" => "Invalid biller Information/ Reserved for client-specific use (declined)/ Reserved for client-specific use (declined)",
+        "R0" => "The transaction was declined or returned, because the cardholder requested that payment of a specific recurring or installment payment transaction be stopped/ Reserved for client-specific use (declined)",
+        "R1" => "The transaction was declined or returned, because the cardholder requested that payment of all recurring or installment payment transactions for a specific merchant account be stopped/ Reserved for client-specific use (declined)",
+        "Q1" => "Card Authentication failed/ Reserved for client-specific use (declined)",
+        "XA" => "Forward to Issuer/ Reserved for client-specific use (declined)",
+        "XD" => "Forward to Issuer/ Reserved for client-specific use (declined)",
+      }
+
+      EXTENDED_RESPONSE_MESSAGES = {
+        "B40K" => "Declined Post – Credit linked to unextracted settle transaction"
+      }
+
+      TRANSACTION_CODES = {
+        authorize: 0,
+        void_authorization: 2,
+
+        purchase: 1,
+        capture: 3,
+        void_purchase: 6,
+        void_capture: 6,
+
+        refund: 4,
+        blind_credit: 5,
+        void_refund: 13,
+        void_credit: 13,
+
+        verify: 9,
+
+        wallet_sale: 14,
+      }
+
+      def initialize(options={})
+        requires!(options, :gateway_id, :reg_key)
+        super
+      end
+
+      def purchase(amount, payment_method, options={})
+        if credit_card? payment_method
+          request = build_xml_transaction_request do |doc|
+            add_transaction_code(doc, :purchase)
+            add_payment_method(doc, payment_method)
+            add_contact(doc, payment_method.name, options)
+            add_amount(doc, amount)
+            add_order_number(doc, options)
+          end
+        else
+          request = build_xml_transaction_request do |doc|
+            add_transaction_code(doc, :wallet_sale)
+            add_amount(doc, amount)
+            add_wallet_id(doc, payment_method)
+          end
+        end
+
+        commit(request)
+      end
+
+      def authorize(amount, payment_method, options={})
+        if credit_card? payment_method
+          request = build_xml_transaction_request do |doc|
+            add_transaction_code(doc, :authorize)
+            add_payment_method(doc, payment_method)
+            add_contact(doc, payment_method.name, options)
+            add_amount(doc, amount)
+          end
+        else
+          request = build_xml_transaction_request do |doc|
+            add_transaction_code(doc, :authorize)
+            add_amount(doc, amount)
+            add_wallet_id(doc, payment_method)
+          end
+        end
+
+        commit(request)
+      end
+
+      def capture(amount, authorization, options={})
+        request = build_xml_transaction_request do |doc|
+          add_transaction_code(doc, :capture)
+          add_amount(doc, amount)
+          add_original_transaction_data(doc, authorization)
+        end
+
+        commit(request)
+      end
+
+      # Transaction Express has three types of possible void
+      # - void_authorization
+      # - void_purchase (alias: void_capture)
+      # - void_refund (alias: void_credit)
+      def void(authorization, options={})
+        void_type = (options[:void_type] || :void_purchase)
+
+        request = build_xml_transaction_request do |doc|
+          add_transaction_code(doc, void_type)
+          add_original_transaction_data(doc, authorization)
+        end
+
+        commit(request)
+      end
+
+      def refund(amount, authorization, options={})
+        request = build_xml_transaction_request do |doc|
+          add_transaction_code(doc, :refund)
+          add_amount(doc, amount)
+          add_original_transaction_data(doc, authorization)
+          add_order_number(doc, options)
+        end
+
+        commit(request)
+      end
+
+      def credit(amount, payment_method, options={})
+        request = build_xml_transaction_request do |doc|
+          add_transaction_code(doc, :blind_credit)
+          add_pan(doc, payment_method)
+          add_amount(doc, amount)
+        end
+
+        commit(request)
+      end
+
+      def verify(credit_card, options={})
+        request = build_xml_transaction_request do |doc|
+          add_transaction_code(doc, :verify)
+          add_payment_method(doc, credit_card)
+          add_contact(doc, credit_card.name, options)
+        end
+
+        commit(request)
+      end
+
+      def store(payment_method, options={})
+        store_customer_request = build_xml_payment_storage_request do |doc|
+          store_customer_details(doc, payment_method.name, options)
+        end
+
+        MultiResponse.run do |r|
+          r.process { commit(store_customer_request) }
+          return r unless r.success? && r.params["custId"]
+          customer_id = r.params["custId"]
+
+          store_payment_method_request = build_xml_payment_storage_request do |doc|
+            doc.tag! "v1:cust" do
+              add_customer_id(doc, customer_id)
+              doc.tag! "v1:pmt" do
+                doc.tag! "v1:type", 0 # add
+                add_payment_method(doc, payment_method)
+              end
+            end
+          end
+
+          r.process { commit(store_payment_method_request) }
+        end
+      end
+
+      def update(token, payment_method, options={})
+        wallet_details_request = build_xml_payment_search_request do |doc|
+          doc.tag! "v1:type", 1 # recurring profile
+          doc.tag! "v1:pmtCrta" do
+            doc.tag! "v1:pmtId", token
+          end
+        end
+
+        MultiResponse.run do |r|
+          r.process { commit(wallet_details_request) }
+          return r unless r.success? && r.params["FndRecurrProfResponse"]
+
+          update_payment_method_request = build_xml_payment_update_request do |doc|
+            doc.tag! "v1:cust" do
+              doc.tag! "v1:contact" do
+                doc.tag! "v1:id", r.params["contact_id"]
+              end
+
+              doc.tag! "v1:pmt" do
+                doc.tag! "v1:id", token
+                doc.tag! "v1:type", 1 # update
+                add_payment_method(doc, payment_method)
+              end
+            end
+          end
+
+          r.process { commit(update_payment_method_request) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<[^>]+pan>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<[^>]+sec>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<[^>]+id>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<[^>]+regKey>)[^<]+(<))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      CURRENCY_CODES = Hash.new{|h,k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES["USD"] = "840"
+
+      def credit_card?(payment_method)
+        payment_method.respond_to?(:number)
+      end
+
+      def headers
+        {
+          "Content-Type" => "text/xml"
+        }
+      end
+
+      def commit(request)
+        raw_response = begin
+          ssl_post(url, request, headers)
+        rescue ActiveMerchant::ResponseError => e
+          e.response.body
+        end
+
+        response = parse(raw_response)
+
+        succeeded = success_from(response)
+
+        Response.new(
+          succeeded,
+          message_from(succeeded, response),
+          response,
+          error_code: error_code_from(succeeded, response),
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response["AVSCode"]),
+          cvv_result: CVVResult.new(response["CVV2Response"]),
+          test: test?
+        )
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def parse(xml)
+        response = {}
+        doc = Nokogiri::XML(xml).remove_namespaces!
+
+        doc.css("Envelope Body *").each do |node|
+          # node.name is more readable, but uniq_name is occasionally necessary
+          uniq_name = [node.parent.name, node.name].join('_')
+          response[uniq_name] = node.text
+          response[node.name] = node.text
+        end
+
+        response
+      end
+
+      def success_from(response)
+        fault = response["Fault"]
+        approved_transaction = APPROVAL_CODES.include?(response["rspCode"])
+        found_contact = response["FndRecurrProfResponse"]
+
+        return !fault && (approved_transaction || found_contact)
+      end
+
+      def error_code_from(succeeded, response)
+        return if succeeded
+        response["errorCode"] || response["rspCode"]
+      end
+
+      def message_from(succeeded, response)
+        if succeeded
+          if response["rspCode"] == "10"
+            "Succeeded, partial capture"
+          else
+            "Succeeded"
+          end
+        elsif response["rspCode"]
+          code = response["rspCode"]
+          extended_code = response["extRspCode"]
+
+          message = RESPONSE_MESSAGES[code]
+          extended = EXTENDED_RESPONSE_MESSAGES[extended_code]
+
+          [message, extended].compact.join('. ')
+        elsif response["faultstring"]
+          response["faultstring"]
+        elsif response.empty?
+          "Empty response received from Transaction Express gateway."
+        else
+          "Unknown response received from Transaction Express gateway."
+        end
+      end
+
+      def authorization_from(response)
+        response["tranNr"] || response["pmtId"]
+      end
+
+      # -- request methods ---------------------------------------------------
+      def build_xml_transaction_request
+        build_xml_request("v1:SendTranRequest") do |doc|
+          yield doc
+        end
+      end
+
+      def build_xml_payment_storage_request
+        build_xml_request("v1:UpdtRecurrProfRequest") do |doc|
+          yield doc
+        end
+      end
+
+      def build_xml_payment_update_request
+        merchant_product_type = 5 # credit card
+        build_xml_request("v1:UpdtRecurrProfRequest", merchant_product_type) do |doc|
+          yield doc
+        end
+      end
+
+      def build_xml_payment_search_request
+        build_xml_request("v1:FndRecurrProfRequest") do |doc|
+          yield doc
+        end
+      end
+
+      def build_xml_request(wrapper, merchant_product_type=nil)
+        xml = Builder::XmlMarkup.new
+        soapenv = "http://schemas.xmlsoap.org/soap/envelope/"
+        v1 = "http://postilion/realtime/merchantframework/xsd/v1/"
+
+        xml.tag! "soapenv:Envelope", "xmlns:soapenv" => soapenv do
+          xml.tag! "soapenv:Body" do
+            xml.tag! wrapper, "xmlns:v1" => v1 do
+              add_merchant(xml, product_type=merchant_product_type)
+              yield xml
+            end
+          end
+        end
+
+        xml.target!
+      end
+
+
+      def add_merchant(doc, product_type=nil)
+        doc.tag! "v1:merc" do
+          doc.tag! "v1:id", @options[:gateway_id]
+          doc.tag! "v1:regKey", @options[:reg_key]
+          doc.tag! "v1:inType", "1"
+          doc.tag! "v1:prodType", product_type if product_type
+        end
+      end
+
+      def add_transaction_code(doc, action)
+        doc.tag! "v1:tranCode", TRANSACTION_CODES[action]
+      end
+
+      def add_amount(doc, money)
+        doc.tag! "v1:reqAmt", amount(money)
+      end
+
+      def add_order_number(doc, options)
+        return unless options[:order_id]
+
+        doc.tag! "v1:authReq" do
+          doc.tag! "v1:ordNr", options[:order_id]
+        end
+      end
+
+      def add_payment_method(doc, payment_method)
+        doc.tag! "v1:card" do
+          doc.tag! "v1:pan", payment_method.number
+          doc.tag! "v1:sec", payment_method.verification_value
+          doc.tag! "v1:xprDt", expiration_date(payment_method)
+        end
+      end
+
+      def expiration_date(payment_method)
+        yy = format(payment_method.year, :two_digits)
+        mm = format(payment_method.month, :two_digits)
+        yy + mm
+      end
+
+      def add_pan(doc, payment_method)
+        doc.tag! "v1:card" do
+          doc.tag! "v1:pan", payment_method.number
+        end
+      end
+
+      def add_contact(doc, fullname, options)
+        doc.tag! "v1:contact" do
+          doc.tag! "v1:fullName", fullname
+          doc.tag! "v1:coName", options[:company_name] if options[:company_name]
+          doc.tag! "v1:title", options[:title] if options[:title]
+
+          if (billing_address = options[:billing_address])
+            doc.tag! "v1:phone" do
+              doc.tag! "v1:type", (options[:phone_number_type] || "4")
+              doc.tag! "v1:nr", billing_address[:phone].gsub(/\D/, '')
+            end
+            doc.tag! "v1:addrLn1", billing_address[:address1]
+            doc.tag! "v1:addrLn2", billing_address[:address2]
+            doc.tag! "v1:city", billing_address[:city]
+            doc.tag! "v1:state", billing_address[:state]
+            doc.tag! "v1:zipCode", billing_address[:zip]
+            doc.tag! "v1:ctry", "US"
+          end
+
+          doc.tag! "v1:email", options[:email] if options[:email]
+          doc.tag! "v1:type", options[:contact_type] if options[:contact_type]
+          doc.tag! "v1:stat", options[:contact_stat] if options[:contact_stat]
+
+          if (shipping_address = options[:shipping_address])
+            doc.tag! "v1:ship" do
+              doc.tag! "v1:fullName", fullname
+              doc.tag! "v1:addrLn1", shipping_address[:address1]
+              doc.tag! "v1:addrLn2", shipping_address[:address2] if shipping_address[:address2]
+              doc.tag! "v1:city", shipping_address[:city]
+              doc.tag! "v1:state", shipping_address[:state]
+              doc.tag! "v1:zipCode", shipping_address[:zip]
+              doc.tag! "v1:phone", shipping_address[:phone].gsub(/\D/, '') if shipping_address[:phone]
+              doc.tag! "v1:email", shipping_address[:email] if shipping_address[:email]
+            end
+          end
+        end
+      end
+
+      def add_original_transaction_data(doc, authorization)
+        doc.tag! "v1:origTranData" do
+          doc.tag! "v1:tranNr", authorization
+        end
+      end
+
+      def store_customer_details(doc, fullname, options)
+        options[:contact_type] = 1 # recurring
+        options[:contact_stat] = 1 # active
+
+        doc.tag! "v1:cust" do
+          doc.tag! "v1:type", 0 # add
+
+          add_contact(doc, fullname, options)
+        end
+      end
+
+      def add_customer_id(doc, customer_id)
+        doc.tag! "v1:contact" do
+          doc.tag! "v1:id", customer_id
+        end
+      end
+
+      def add_wallet_id(doc, wallet_id)
+        doc.tag! "v1:recurMan" do
+          doc.tag! "v1:id", wallet_id
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(amount, payment_method, options={})
-        if credit_card? payment_method
+        if credit_card?(payment_method)
           request = build_xml_transaction_request do |doc|
             add_transaction_code(doc, :purchase)
             add_payment_method(doc, payment_method)
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize(amount, payment_method, options={})
-        if credit_card? payment_method
+        if credit_card?(payment_method)
           request = build_xml_transaction_request do |doc|
             add_transaction_code(doc, :authorize)
             add_payment_method(doc, payment_method)

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -345,10 +345,6 @@ module ActiveMerchant #:nodoc:
       CURRENCY_CODES = Hash.new{|h,k| raise ArgumentError.new("Unsupported currency: #{k}")}
       CURRENCY_CODES["USD"] = "840"
 
-      def credit_card?(payment_method)
-        payment_method.respond_to?(:number)
-      end
-
       def headers
         {
           "Content-Type" => "text/xml"
@@ -436,6 +432,12 @@ module ActiveMerchant #:nodoc:
       def authorization_from(response)
         response["tranNr"] || response["pmtId"]
       end
+
+      # -- helper methods ----------------------------------------------------
+      def credit_card?(payment_method)
+        payment_method.respond_to?(:number)
+      end
+
 
       # -- request methods ---------------------------------------------------
       def build_xml_transaction_request

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -376,13 +376,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(succeeded, response)
-        if succeeded
-          if response["rspCode"] == "10"
-            "Succeeded, partial capture"
-          else
-            "Succeeded"
-          end
-        elsif response["rspCode"]
+        return "Succeeded" if succeeded
+
+        if response["rspCode"]
           code = response["rspCode"]
           extended_code = response["extRspCode"]
 
@@ -390,12 +386,8 @@ module ActiveMerchant #:nodoc:
           extended = EXTENDED_RESPONSE_MESSAGES[extended_code]
 
           [message, extended].compact.join('. ')
-        elsif response["faultstring"]
-          response["faultstring"]
-        elsif response.empty?
-          "Empty response received from Transaction Express gateway."
         else
-          "Unknown response received from Transaction Express gateway."
+          response["faultstring"]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
         void_capture: 6,
 
         refund: 4,
-        blind_credit: 5,
+        credit: 5,
         void_refund: 13,
         void_credit: 13,
 
@@ -258,7 +258,7 @@ module ActiveMerchant #:nodoc:
           add_amount(doc, amount)
         end
 
-        commit(:blind_credit, request)
+        commit(:credit, request)
       end
 
       def verify(credit_card, options={})

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -6,8 +6,8 @@ module ActiveMerchant #:nodoc:
       self.display_name = "TransFirst Transaction Express"
       self.homepage_url = "http://transactionexpress.com/"
 
-      self.test_url = "https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl"
-      self.live_url = "https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl"
+      self.test_url = "https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1"
+      self.live_url = "https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1"
 
       self.supported_countries = ["US"]
       self.default_currency = "USD"

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -298,36 +298,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def update(token, payment_method, options={})
-        wallet_details_request = build_xml_payment_search_request do |doc|
-          doc["v1"].type 1 # recurring profile
-          doc["v1"].pmtCrta do
-            doc["v1"].pmtId token
-          end
-        end
-
-        MultiResponse.run do |r|
-          r.process { commit(wallet_details_request) }
-          return r unless r.success? && r.params["FndRecurrProfResponse"]
-
-          update_payment_method_request = build_xml_payment_update_request do |doc|
-            doc["v1"].cust do
-              doc["v1"].contact do
-                doc["v1"].id r.params["contact_id"]
-              end
-
-              doc["v1"].pmt do
-                doc["v1"].id token
-                doc["v1"].type 1 # update
-                add_payment_method(doc, payment_method)
-              end
-            end
-          end
-
-          r.process { commit(update_payment_method_request) }
-        end
-      end
-
       def supports_scrubbing?
         true
       end
@@ -480,7 +450,6 @@ module ActiveMerchant #:nodoc:
           end
         end.doc.root.to_xml
       end
-
 
       def add_merchant(doc, product_type=nil)
         doc["v1"].merc do

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -946,6 +946,11 @@ trans_first:
   login: 45567
   password: TNYYKYMFZ59HSN7Q
 
+# Working credentials, no need to replace
+trans_first_transaction_express:
+  gateway_id: 7777778764
+  reg_key: M84PKPDMD5BY86HN
+
 # Transact Pro doesn't provide public testing data
 transact_pro:
   guid: GUID

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -59,7 +59,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal "Succeeded", response.message
-    assert_match %r(^\d+$), response.authorization
+    assert_match %r(^authorize\|\d+$), response.authorization
 
     capture = @gateway.capture(@amount, response.authorization)
     assert_success capture
@@ -87,7 +87,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    void = @gateway.void(response.authorization, void_type: :void_purchase)
+    void = @gateway.void(response.authorization)
     assert_success void
     assert_equal "Succeeded", void.message
   end
@@ -96,7 +96,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
 
-    void = @gateway.void(authorize.authorization, void_type: :void_authorization)
+    void = @gateway.void(authorize.authorization)
     assert_success void
     assert_equal "Succeeded", void.message
   end

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -83,11 +83,32 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "12", response.error_code
   end
 
-  def test_successful_void
+  def test_successful_purchase_void
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
     void = @gateway.void(response.authorization, void_type: :void_purchase)
+    assert_success void
+    assert_equal "Succeeded", void.message
+  end
+
+  def test_successful_authorization_void
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    void = @gateway.void(authorize.authorization, void_type: :void_authorization)
+    assert_success void
+    assert_equal "Succeeded", void.message
+  end
+
+  def test_successful_capture_void
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    capture = @gateway.capture(@amount, authorize.authorization)
+    assert_success capture
+
+    void = @gateway.void(capture.authorization, void_type: :void_capture)
     assert_success void
     assert_equal "Succeeded", void.message
   end

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -44,7 +44,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
   def test_partial_purchase
     response = @gateway.purchase(@partial_amount, @credit_card, @options)
     assert_success response
-    assert_equal "Succeeded, partial capture", response.message
+    assert_equal "Succeeded", response.message
     assert_match /0*555$/, response.params["amt"]
   end
 

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -1,0 +1,262 @@
+require "test_helper"
+
+class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
+  def setup
+    @gateway = TransFirstTransactionExpressGateway.new(fixtures(:trans_first_transaction_express))
+
+    @amount = 100
+    @declined_amount = 21
+    @partial_amount = 1110
+    @credit_card = credit_card("4485896261017708")
+
+    billing_address = address({
+      address1: "450 Main",
+      address2: "Suite 100",
+      city: "Broomfield",
+      state: "CO",
+      zip: "85284",
+      phone: "(333) 444-5555",
+    })
+
+    @options = {
+      order_id: generate_unique_id,
+      company_name: "Acme",
+      title: "QA Manager",
+      billing_address: billing_address,
+      shipping_address: billing_address,
+      email: "example@example.com",
+      description: "Store Purchase"
+    }
+  end
+
+  def test_invalid_login
+    gateway = TransFirstTransactionExpressGateway.new(gateway_id: "", reg_key: "")
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+  end
+
+  def test_partial_purchase
+    response = @gateway.purchase(@partial_amount, @credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded, partial capture", response.message
+    assert_match /0*555$/, response.params["amt"]
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Not sufficient funds", response.message
+    assert_equal "51", response.params["rspCode"]
+  end
+
+  def test_successful_authorize_and_capture
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert_match %r(^\d+$), response.authorization
+
+    capture = @gateway.capture(@amount, response.authorization)
+    assert_success capture
+    assert_equal "Succeeded", capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "Not sufficient funds", response.message
+    assert_equal "51", response.error_code
+  end
+
+  def test_failed_capture
+    authorize = @gateway.authorize(@declined_amount, @credit_card, @options)
+    assert_failure authorize
+
+    response = @gateway.capture(@amount, authorize.authorization)
+    assert_failure response
+    assert_equal "Invalid transaction", response.message
+    assert_equal "12", response.error_code
+  end
+
+  def test_successful_void
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    void = @gateway.void(response.authorization, void_type: :void_purchase)
+    assert_success void
+    assert_equal "Succeeded", void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void("")
+    assert_failure response
+    assert_equal "Validation Failure", response.message
+    assert_equal "50011", response.error_code
+  end
+
+  # gateway does not settle fast enough to test refunds
+  # def test_successful_refund
+  #   response = @gateway.purchase(@amount, @credit_card, @options)
+  #   assert_success response
+
+  #   refund = @gateway.refund(@amount, response.authorization)
+  #   assert_success refund
+  #   assert_equal "Succeeded", refund.message
+  # end
+
+  def test_helpful_message_when_refunding_unsettled_purchase
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    refund = @gateway.refund(@amount, purchase.authorization)
+
+    assert_failure refund
+    assert_equal "Invalid transaction. Declined Post – Credit linked to unextracted settle transaction", refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(nil, "")
+    assert_failure response
+    assert_equal "Validation Failure", response.message
+    assert_equal "50011", response.error_code
+  end
+
+  # Credit is only supported with specific approval from Transaction Express
+  # def test_successful_credit
+  #   response = @gateway.credit(@amount, @credit_card, @options)
+  #   assert_success response
+  #   assert_equal "Succeeded", response.message
+  # end
+
+  def test_failed_credit
+    response = @gateway.credit(0, @credit_card, @options)
+    assert_failure response
+    assert_equal "51334", response.error_code
+    assert_equal "Validation Error", response.message
+  end
+
+  def test_successful_verify
+    visa = credit_card("4485896261017708")
+    amex = credit_card("371449635392376", verification_value: 1234)
+    mastercard = credit_card("5499740000000057")
+    discover = credit_card("6011000991001201")
+
+    [visa, amex, mastercard, discover].each do |credit_card|
+      response = @gateway.verify(credit_card, @options)
+      assert_success response
+      assert_match "Succeeded", response.message
+    end
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(credit_card(""), @options)
+    assert_failure response
+    assert_equal "Validation Failure", response.message
+    assert_equal "50011", response.error_code
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert response.authorization
+  end
+
+  def test_successful_authorize_using_stored_card
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+
+    response = @gateway.authorize(@amount, response.authorization, @options)
+    assert_success response
+    assert_match "Succeeded", response.message
+  end
+
+  def test_failed_authorize_using_stored_card
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+
+    response = @gateway.authorize(@declined_amount, response.authorization, @options)
+    assert_failure response
+    assert_match "Not sufficient funds", response.message
+  end
+
+  def test_successful_purchase_using_stored_card
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+
+    response = @gateway.purchase(@amount, response.authorization, @options)
+    assert_success response
+    assert_match "Succeeded", response.message
+  end
+
+  def test_failed_purchase_using_stored_card
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+
+    response = @gateway.purchase(@declined_amount, response.authorization, @options)
+    assert_failure response
+    assert_match "Not sufficient funds", response.message
+  end
+
+  def test_failed_store
+    response = @gateway.store(credit_card("123"), @options)
+    assert_failure response
+    assert_equal "Validation Failure", response.message
+    assert_equal "50011", response.error_code
+  end
+
+  def test_successful_update
+    initial_card = credit_card("4485896261017708")
+    updated_card = credit_card("371449635392376")
+
+    assert store = @gateway.store(initial_card)
+    assert_success store
+
+    update = @gateway.update(store.authorization, updated_card)
+    assert_success update
+    assert_equal "Succeeded", update.message
+  end
+
+  def test_successful_purchase_using_updated_card
+    initial_card = credit_card("4485896261017708")
+    updated_card = credit_card("371449635392376")
+
+    assert store = @gateway.store(initial_card)
+    assert_success store
+
+    token = store.authorization
+
+    update = @gateway.update(token, updated_card)
+    assert_success update
+
+    response = @gateway.purchase(@amount, token, @options)
+    assert_success response
+    assert_match "Succeeded", response.message
+  end
+
+  # def test_dump_transcript
+  #   skip("Transcript scrubbing for this gateway has been tested.")
+  #   # This test will run a purchase transaction on your gateway
+  #   # and dump a transcript of the HTTP conversation so that
+  #   # you can use that transcript as a reference while
+  #   # implementing your scrubbing logic
+  #   dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  # end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+    assert_scrubbed(@gateway.options[:gateway_id], clean_transcript)
+    assert_scrubbed(@gateway.options[:reg_key], clean_transcript)
+  end
+end

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -210,35 +210,6 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "50011", response.error_code
   end
 
-  def test_successful_update
-    initial_card = credit_card("4485896261017708")
-    updated_card = credit_card("371449635392376")
-
-    assert store = @gateway.store(initial_card)
-    assert_success store
-
-    update = @gateway.update(store.authorization, updated_card)
-    assert_success update
-    assert_equal "Succeeded", update.message
-  end
-
-  def test_successful_purchase_using_updated_card
-    initial_card = credit_card("4485896261017708")
-    updated_card = credit_card("371449635392376")
-
-    assert store = @gateway.store(initial_card)
-    assert_success store
-
-    token = store.authorization
-
-    update = @gateway.update(token, updated_card)
-    assert_success update
-
-    response = @gateway.purchase(@amount, token, @options)
-    assert_success response
-    assert_match "Succeeded", response.message
-  end
-
   # def test_dump_transcript
   #   skip("Transcript scrubbing for this gateway has been tested.")
   #   # This test will run a purchase transaction on your gateway

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -1,0 +1,338 @@
+require "test_helper"
+
+class TransFirstTransactionExpressTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = TransFirstTransactionExpressGateway.new(
+      gateway_id: "gateway_id",
+      reg_key: "reg_key"
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+    @declined_amount = 21
+    @partial_amount = 1110
+  end
+
+  def test_successful_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "000015212561", response.authorization
+    assert response.test?
+  end
+
+  def test_partial_purchase
+    response = stub_comms do
+      @gateway.purchase(@partial_amount, @credit_card)
+    end.respond_with(partial_purchase_response)
+
+    assert_success response
+    assert_equal "000000000555", response.params["amt"]
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@declined_amount, @credit_card)
+    end.respond_with(failed_purchase_response)
+
+    assert_failure response
+    assert_equal "Not sufficient funds", response.message
+    assert_equal "51", response.error_code
+    assert response.test?
+  end
+
+  def test_successful_authorize_and_capture
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal "000015377801", response.authorization
+
+    capture = stub_comms do
+      @gateway.capture(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/000015377801/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
+  def test_failed_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(failed_authorize_response)
+
+    assert_failure response
+    assert_equal "Not sufficient funds", response.message
+    assert_equal "51", response.error_code
+    assert response.test?
+  end
+
+  def test_failed_capture
+    response = stub_comms do
+      @gateway.capture(100, "")
+    end.respond_with(failed_capture_response)
+
+    assert_failure response
+  end
+
+  def test_successful_void
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "000015212561", response.authorization
+
+    void = stub_comms do
+      @gateway.void(response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/000015212561/, data)
+    end.respond_with(successful_void_response)
+
+    assert_success void
+  end
+
+  def test_failed_void
+    response = stub_comms do
+      @gateway.void("5d53a33d960c46d00f5dc061947d998c")
+    end.check_request do |endpoint, data, headers|
+      assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
+    end.respond_with(failed_void_response)
+
+    assert_failure response
+    assert_equal "50011", response.error_code
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "000015212561", response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/000015212561/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = stub_comms do
+      @gateway.refund(nil, "")
+    end.respond_with(failed_refund_response)
+
+    assert_failure response
+    assert_equal "50011", response.error_code
+  end
+
+  def test_successful_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(successful_credit_response)
+
+    assert_success response
+
+    assert_equal "000001677461", response.authorization
+    assert response.test?
+  end
+
+  def test_failed_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(failed_credit_response)
+
+    assert_failure response
+    assert_equal "Validation Error", response.message
+    assert_equal "51334", response.error_code
+    assert response.test?
+  end
+
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_authorize_response, failed_void_response)
+    assert_success response
+    assert_equal "Succeeded", response.message
+  end
+
+  def test_failed_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(failed_authorize_response, successful_void_response)
+    assert_failure response
+    assert_equal "Not sufficient funds", response.message
+  end
+
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+
+    assert_equal "Succeeded", response.message
+    assert_equal "1453495229881170023", response.authorization
+    assert response.test?
+  end
+
+  def test_failed_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(failed_store_response)
+
+    assert_failure response
+    assert_equal "Validation Failure", response.message
+    assert response.test?
+  end
+
+  def test_empty_response_fails
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(empty_purchase_response)
+
+    assert_failure response
+    assert_equal "Empty response received from Transaction Express gateway.", response.message
+  end
+
+  def test_transcript_scrubbing
+    assert_equal scrubbed_transcript, @gateway.scrub(transcript)
+  end
+
+  private
+
+  def successful_purchase_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A1009331525B2A2DBFAF771E2E62B</ns2:swchKey><ns2:tranNr>000015212561</ns2:tranNr><ns2:dtTm>2016-01-19T10:33:57.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>305156</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def partial_purchase_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:SendTranResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:rspCode>10</ns2:rspCode><ns2:authRsp><ns2:secRslt>M</ns2:secRslt><ns2:avsRslt>Z</ns2:avsRslt><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A10092D15279AD062097039A74A15</ns2:swchKey><ns2:tranNr>000015526161</ns2:tranNr><ns2:dtTm>2016-01-25T08:45:28.000-08:00</ns2:dtTm><ns2:amt>000000000555</ns2:amt><ns2:stan>332604</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid><ns2:additionalAmount><ns2:accountType>00</ns2:accountType><ns2:amountType>57</ns2:amountType><ns2:currencyCode>840</ns2:currencyCode><ns2:amountSign>C</ns2:amountSign><ns2:amount>000000001110</ns2:amount></ns2:additionalAmount></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_purchase_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>51</ns2:rspCode><ns2:authRsp><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A1009331525BA8F333FC15F59AB32</ns2:swchKey><ns2:tranNr>000015220671</ns2:tranNr><ns2:dtTm>2016-01-19T12:52:25.000-08:00</ns2:dtTm><ns2:amt>000000000021</ns2:amt><ns2:stan>305918</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def successful_authorize_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:SendTranResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp><ns2:secRslt>M</ns2:secRslt><ns2:avsRslt>Z</ns2:avsRslt><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A10093315265DE34CE542A9E44548</ns2:swchKey><ns2:tranNr>000015377801</ns2:tranNr><ns2:dtTm>2016-01-21T12:26:47.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>319955</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_authorize_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:SendTranResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:rspCode>51</ns2:rspCode><ns2:authRsp><ns2:secRslt>M</ns2:secRslt><ns2:avsRslt>Z</ns2:avsRslt><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A10093315265F2FCEF82DB9231D67</ns2:swchKey><ns2:tranNr>000015378101</ns2:tranNr><ns2:dtTm>2016-01-21T12:49:29.000-08:00</ns2:dtTm><ns2:amt>000000000000</ns2:amt><ns2:stan>319985</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def successful_capture_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:SendTranResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp/><ns2:tranData><ns2:swchKey>0A10093315265DF34907B4587F31D5</ns2:swchKey><ns2:tranNr>000015377821</ns2:tranNr><ns2:dtTm>2016-01-21T12:27:52.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>319958</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_capture_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Failure</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Fault</name><message>cvc-type.3.1.3: The value '' of element 'v1:tranNr' is not valid.</message><errorCode>50011</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def successful_void_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp/><ns2:tranData><ns2:swchKey>0A1009331525BAC88E077EFB8D7542</ns2:swchKey><ns2:tranNr>000015212561</ns2:tranNr><ns2:dtTm>2016-01-19T12:56:20.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>305938</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid><ns2:additionalAmount><ns2:accountType>30</ns2:accountType><ns2:amountType>53</ns2:amountType><ns2:currencyCode>840</ns2:currencyCode><ns2:amountSign>D</ns2:amountSign><ns2:amount>000000000100</ns2:amount></ns2:additionalAmount></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_void_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Failure</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Fault</name><message>cvc-type.3.1.3: The value '' of element 'v1:tranNr' is not valid.</message><errorCode>50011</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def successful_refund_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><SendTranResponse xmlns="http://postilion/realtime/merchantframework/xsd/v1/" xmlns:ns2="http://postilion/realtime/portal/soa/xsd/Faults/2009/01"> <ns2:rspCode>00</ns2:rspCode><ns2:tranData><ns2:swchKey>0A10064112F57B9D997D4D1111888E</ns2:swchKey><ns2:tranNr>000001829611</ns2:tranNr><ns2:dtTm>2011-04-14T22:54:48.000-07:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt></ns2:tranData></SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_refund_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Failure</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Fault</name><message>cvc-type.3.1.3: The value '' of element 'v1:tranNr' is not valid.</message><errorCode>50011</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def successful_credit_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp/><ns2:tranData><ns2:swchKey>0A6E6B4B135B08437C7C1370A116B7</ns2:swchKey><ns2:tranNr>000001677461</ns2:tranNr><ns2:dtTm>2012-02-24T09:59:09.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>000301</ns2:stan></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>7310</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_credit_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Error</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Error</name><message>Validation Error Fault</message><errorCode>51334</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def successful_store_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:UpdtRecurrProfResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:pmtId>1453495229881170023</ns2:pmtId><ns2:rspCode>00</ns2:rspCode></ns2:UpdtRecurrProfResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_store_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Failure</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Fault</name><message>cvc-type.3.1.3: The value '123' of element 'v1:pan' is not valid.</message><errorCode>50011</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def empty_purchase_response
+    %()
+  end
+
+  def transcript
+    <<-PRE_SCRUBBED
+opening connection to ws.cert.transactionexpress.com:443...
+opened
+starting SSL for ws.cert.transactionexpress.com:443...
+SSL established
+<- "POST /portal/merchantframework/MerchantWebServices-v1?wsdl HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: ws.cert.transactionexpress.com\r\nContent-Length: 1186\r\n\r\n"
+<- "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><soapenv:Body><v1:SendTranRequest xmlns:v1=\"http://postilion/realtime/merchantframework/xsd/v1/\"><v1:merc><v1:id>7777778764</v1:id><v1:regKey>M84PKPDMD5BY86HN</v1:regKey><v1:inType>1</v1:inType></v1:merc><v1:tranCode>1</v1:tranCode><v1:card><v1:pan>4485896261017708</v1:pan><v1:xprDt>1709</v1:xprDt></v1:card><v1:contact><v1:fullName>Longbob Longsen</v1:fullName><v1:coName>Acme</v1:coName><v1:title>QA Manager</v1:title><v1:phone><v1:type>4</v1:type><v1:nr>3334445555</v1:nr></v1:phone><v1:addrLn1>450 Main</v1:addrLn1><v1:addrLn2>Suite 100</v1:addrLn2><v1:city>Broomfield</v1:city><v1:state>CO</v1:state><v1:zipCode>85284</v1:zipCode><v1:ctry>US</v1:ctry><v1:email>example@example.com</v1:email><v1:ship><v1:fullName>Longbob Longsen</v1:fullName><v1:addrLn1>450 Main</v1:addrLn1><v1:addrLn2>Suite 100</v1:addrLn2><v1:city>Broomfield</v1:city><v1:state>CO</v1:state><v1:zipCode>85284</v1:zipCode><v1:phone>3334445555</v1:phone></v1:ship></v1:contact><v1:reqAmt>100</v1:reqAmt><v1:authReq><v1:ordNr>7a0f975b6e86aff44364360cbc6d0f00</v1:ordNr></v1:authReq></v1:SendTranRequest></soapenv:Body></soapenv:Envelope>"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Content-Type: text/xml;charset=utf-8\r\n"
+-> "Date: Thu, 21 Jan 2016 20:09:44 GMT\r\n"
+-> "Server: WebServer\r\n"
+-> "Set-Cookie: NSC_UMT12_DFSU-xt.dfsu.UYQ.dpn=ffffffff0918172545525d5f4f58455e445a4a42378b;expires=Thu, 21-Jan-2016 20:17:43 GMT;path=/;secure;httponly\r\n"
+-> "Cache-Control: private\r\n"
+-> "Content-Encoding: gzip\r\n"
+-> "Transfer-Encoding: chunked\r\n"
+-> "\r\n"
+-> "1AA \r\n"
+reading 426 bytes...
+-> ""
+read 426 bytes
+reading 2 bytes...
+-> "\r\n"
+read 2 bytes
+-> "0\r\n"
+-> "\r\n"
+Conn close
+    PRE_SCRUBBED
+  end
+
+  def scrubbed_transcript
+    <<-POST_SCRUBBED
+opening connection to ws.cert.transactionexpress.com:443...
+opened
+starting SSL for ws.cert.transactionexpress.com:443...
+SSL established
+<- "POST /portal/merchantframework/MerchantWebServices-v1?wsdl HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: ws.cert.transactionexpress.com\r\nContent-Length: 1186\r\n\r\n"
+<- "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><soapenv:Body><v1:SendTranRequest xmlns:v1=\"http://postilion/realtime/merchantframework/xsd/v1/\"><v1:merc><v1:id>[FILTERED]</v1:id><v1:regKey>[FILTERED]</v1:regKey><v1:inType>1</v1:inType></v1:merc><v1:tranCode>1</v1:tranCode><v1:card><v1:pan>[FILTERED]</v1:pan><v1:xprDt>1709</v1:xprDt></v1:card><v1:contact><v1:fullName>Longbob Longsen</v1:fullName><v1:coName>Acme</v1:coName><v1:title>QA Manager</v1:title><v1:phone><v1:type>4</v1:type><v1:nr>3334445555</v1:nr></v1:phone><v1:addrLn1>450 Main</v1:addrLn1><v1:addrLn2>Suite 100</v1:addrLn2><v1:city>Broomfield</v1:city><v1:state>CO</v1:state><v1:zipCode>85284</v1:zipCode><v1:ctry>US</v1:ctry><v1:email>example@example.com</v1:email><v1:ship><v1:fullName>Longbob Longsen</v1:fullName><v1:addrLn1>450 Main</v1:addrLn1><v1:addrLn2>Suite 100</v1:addrLn2><v1:city>Broomfield</v1:city><v1:state>CO</v1:state><v1:zipCode>85284</v1:zipCode><v1:phone>3334445555</v1:phone></v1:ship></v1:contact><v1:reqAmt>100</v1:reqAmt><v1:authReq><v1:ordNr>7a0f975b6e86aff44364360cbc6d0f00</v1:ordNr></v1:authReq></v1:SendTranRequest></soapenv:Body></soapenv:Envelope>"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Content-Type: text/xml;charset=utf-8\r\n"
+-> "Date: Thu, 21 Jan 2016 20:09:44 GMT\r\n"
+-> "Server: WebServer\r\n"
+-> "Set-Cookie: NSC_UMT12_DFSU-xt.dfsu.UYQ.dpn=ffffffff0918172545525d5f4f58455e445a4a42378b;expires=Thu, 21-Jan-2016 20:17:43 GMT;path=/;secure;httponly\r\n"
+-> "Cache-Control: private\r\n"
+-> "Content-Encoding: gzip\r\n"
+-> "Transfer-Encoding: chunked\r\n"
+-> "\r\n"
+-> "1AA \r\n"
+reading 426 bytes...
+-> ""
+read 426 bytes
+reading 2 bytes...
+-> "\r\n"
+read 2 bytes
+-> "0\r\n"
+-> "\r\n"
+Conn close
+    POST_SCRUBBED
+  end
+end

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -203,7 +203,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     end.respond_with(empty_purchase_response)
 
     assert_failure response
-    assert_equal "Empty response received from Transaction Express gateway.", response.message
+    assert_equal nil, response.message
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -22,7 +22,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     assert_success response
 
-    assert_equal "000015212561", response.authorization
+    assert_equal "purchase|000015212561", response.authorization
     assert response.test?
   end
 
@@ -53,7 +53,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     assert_success response
-    assert_equal "000015377801", response.authorization
+    assert_equal "authorize|000015377801", response.authorization
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
@@ -89,7 +89,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal "000015212561", response.authorization
+    assert_equal "purchase|000015212561", response.authorization
 
     void = stub_comms do
       @gateway.void(response.authorization)
@@ -102,7 +102,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_failed_void
     response = stub_comms do
-      @gateway.void("5d53a33d960c46d00f5dc061947d998c")
+      @gateway.void("purchase|5d53a33d960c46d00f5dc061947d998c")
     end.check_request do |endpoint, data, headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
@@ -117,7 +117,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal "000015212561", response.authorization
+    assert_equal "purchase|000015212561", response.authorization
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
@@ -144,7 +144,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     assert_success response
 
-    assert_equal "000001677461", response.authorization
+    assert_equal "credit|000001677461", response.authorization
     assert response.test?
   end
 
@@ -183,7 +183,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal "Succeeded", response.message
-    assert_equal "1453495229881170023", response.authorization
+    assert_equal "store|1453495229881170023", response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
This is a new gateway from TransFirst. Their SOAP interface allows the following standard actions:

- purchase
- authorize
- capture
- void
- refund
- credit (requires approval from gateway)
- verify
- store
- update

NOTE Transaction Express will automatically do a partial capture if the purchase amount exceeds the available credit limit. For automatic partial captures the rspCode field will be "10" and there will be an "amt" field in the response containing the balance successfully captured.