### PR TITLE
TransFirst: Fix missing address and remove CC only fields for ACH

### DIFF
--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -24,6 +24,16 @@ class RemoteTransFirstTest < Test::Unit::TestCase
     @gateway.void(response.authorization)
   end
 
+  def test_successful_purchase_no_address
+    @options.delete(:billing_address)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response.test?
+    assert_success response
+    assert !response.authorization.blank?
+
+    @gateway.void(response.authorization)
+  end
+
   def test_successful_purchase_sans_cvv
     @credit_card.verification_value = ""
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -31,6 +41,14 @@ class RemoteTransFirstTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_echeck
+    assert response = @gateway.purchase(@amount, @check, @options)
+    assert response.test?
+    assert_success response
+    assert !response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_echeck_no_address
+    @options.delete(:billing_address)
     assert response = @gateway.purchase(@amount, @check, @options)
     assert response.test?
     assert_success response
@@ -50,6 +68,14 @@ class RemoteTransFirstTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Insufficient funds', response.message
+  end
+
+  def test_successful_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
   end
 
   def test_successful_refund_with_echeck


### PR DESCRIPTION
@rwdaigle or @duff: 2 fixes for TransFirst: 

* Missing `Address` if no address is included as an option to purchase requests
* Removed some credit card only fields from an ACH transaction.