### PR TITLE
Fixing list of currencies without fractions

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
         'TW' => 'zh_TW'
       }
 
-      CURRENCIES_WITHOUT_FRACTIONS = %w(BRL HUF JPY MYR TWD TRY)
+      CURRENCIES_WITHOUT_FRACTIONS = %w(HUF JPY TWD)
 
       self.test_redirect_url = 'https://www.sandbox.paypal.com/cgi-bin/webscr'
       self.supported_countries = ['US']


### PR DESCRIPTION
The current list for currencies without fractions is not correct, as per paypal documentation: https://developer.paypal.com/webapps/developer/docs/classic/api/currency_codes/

Only `%w(HUF JPY TWD)` do not support decimals. As of now, having this list would throw errors as the total amount and the line items would be rounded, resulting in a `The totals of the cart item amounts do not match order amounts.` error from paypal.

I've tested out this fix with sandbox accounts located with these appropriate currencies and confirmed the bug by having sandbox accounts with the remaining currencies, located in the appropriate countries.

@duff @girasquid for review please.