### PR TITLE
Revert "Cashnet: Default custcode option and proper redirect handling"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,7 +38,6 @@
 * Cardstream: Add AVS code and message [anellis]
 * Barclaycard Smartpay: New gateway support [curiousepic]
 * Transfirst: Fix missing address and remove CC only fields for ACH [davidsantoso]
-* Cashnet: Encode redirect_to response before parsing [hoenth]
 
 
 == Version 1.56.0 (December 1, 2015)

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -33,7 +33,6 @@ module ActiveMerchant #:nodoc:
           :merchant_gateway_name
         )
         options[:default_item_code] ||= "FEE"
-        options[:default_custcode] ||= "ActiveMerchant/#{ActiveMerchant::VERSION}"
         super
       end
 
@@ -81,8 +80,7 @@ module ActiveMerchant #:nodoc:
         post[:operator]       = @options[:operator]
         post[:password]       = @options[:password]
         post[:station]        = (@options[:station] || "WEB")
-        post[:itemcode]       = (@options[:item_code] || @options[:default_item_code])
-        post[:custcode]       = (@options[:custcode] || @options[:default_custcode])
+        post[:custcode]       = (@options[:custcode] || "ActiveMerchant/#{ActiveMerchant::VERSION}")
         post.merge(parameters).collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&")
       end
 
@@ -132,8 +130,7 @@ module ActiveMerchant #:nodoc:
         if (200...300).include?(response.code.to_i)
           return response.body
         elsif 302 == response.code.to_i
-          encoded_url = CGI::escape(response['location'])
-          return ssl_get(URI.parse(encoded_url))
+          return ssl_get(URI.parse(response['location']))
         end
         raise ResponseError.new(response)
       end

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -141,15 +141,6 @@ class Cashnet < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_location_with_non_parsable_characters_gets_encoded_before_parsing
-    gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', custcode: "TheCustCode")
-    stub_comms(gateway, :raw_ssl_request) do
-      stub_comms(gateway, :ssl_get) do
-        gateway.purchase(@amount, @credit_card, custcode: "OveriddenCustCode")
-      end.respond_with(successful_purchase_response)
-    end.respond_with(success_with_unparsable_location)
-  end
-
   private
   def expected_expiration_date
     '%02d%02d' % [@credit_card.month, @credit_card.year.to_s[2..4]]
@@ -177,9 +168,5 @@ class Cashnet < Test::Unit::TestCase
 
   def invalid_response
     "A String without a cngateway tag"
-  end
-
-  def success_with_unparsable_location
-    OpenStruct.new(code: "302", 'location' => "https://not a valid url")
   end
 end


### PR DESCRIPTION
@duff / @rwdaigle reverting this PR in light of recent issues it's caused with the CashNet gateway.

This reverts commit a75f2716cfd1535792f4e0cec68e369b42e7282a.