### PR TITLE
Add ACH support to the Stripe Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -46,6 +46,11 @@ module ActiveMerchant #:nodoc:
         'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin]
       }
 
+      BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {
+        "personal" => "individual",
+        "business" => "company",
+      }
+
       def initialize(options = {})
         requires!(options, :login)
         @api_key = options[:login]
@@ -554,7 +559,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def tokenize_bank_account(bank_account, options = {})
-        account_holder_type = bank_account.account_holder_type == "personal" ? "individual" : "company"
+        account_holder_type = BANK_ACCOUNT_HOLDER_TYPE_MAPPING[bank_account.account_holder_type]
+
         post = {
           bank_account: {
             account_number: bank_account.account_number,

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -84,6 +84,8 @@ module ActiveMerchant #:nodoc:
           if payment.is_a?(ApplePayPaymentToken)
             r.process { tokenize_apple_pay_token(payment) }
             payment = StripePaymentToken.new(r.params["token"]) if r.success?
+          elsif ach?(payment)
+            return Response.new(false, "Direct bank account transactions are not supported. Bank accounts must be stored and verified before use.")
           end
           r.process do
             post = create_post_for_auth_or_purchase(money, payment, options)
@@ -155,26 +157,34 @@ module ActiveMerchant #:nodoc:
 
       # Note: creating a new credit card will not change the customer's existing default credit card (use :set_default => true)
       def store(payment, options = {})
-        card_params = {}
+        params = {}
         post = {}
 
-        if payment.is_a?(ApplePayPaymentToken)
+        if card_brand(payment) == "check"
+          bank_token_response = tokenize_bank_account(payment)
+          if bank_token_response.success?
+            params = { source: bank_token_response.params["token"]["id"] }
+          else
+            return bank_token_response
+          end
+        elsif payment.is_a?(ApplePayPaymentToken)
           token_exchange_response = tokenize_apple_pay_token(payment)
-          card_params = { card: token_exchange_response.params["token"]["id"] } if token_exchange_response.success?
+          params = { card: token_exchange_response.params["token"]["id"] } if token_exchange_response.success?
         else
-          add_creditcard(card_params, payment, options)
+          add_creditcard(params, payment, options)
         end
 
         post[:validate] = options[:validate] unless options[:validate].nil?
         post[:description] = options[:description] if options[:description]
         post[:email] = options[:email] if options[:email]
+
         if options[:account]
-          add_external_account(post, card_params, payment)
+          add_external_account(post, params, payment)
           commit(:post, "accounts/#{CGI.escape(options[:account])}/external_accounts", post, options)
         elsif options[:customer]
           MultiResponse.run(:first) do |r|
             # The /cards endpoint does not update other customer parameters.
-            r.process { commit(:post, "customers/#{CGI.escape(options[:customer])}/cards", card_params, options) }
+            r.process { commit(:post, "customers/#{CGI.escape(options[:customer])}/cards", params, options) }
 
             if options[:set_default] and r.success? and !r.params['id'].blank?
               post[:default_card] = r.params['id']
@@ -185,7 +195,7 @@ module ActiveMerchant #:nodoc:
             end
           end
         else
-          commit(:post, 'customers', post.merge(card_params), options)
+          commit(:post, 'customers', post.merge(params), options)
         end
       end
 
@@ -541,6 +551,38 @@ module ActiveMerchant #:nodoc:
         error_code = STANDARD_ERROR_CODE_MAPPING[decline_code]
         error_code ||= STANDARD_ERROR_CODE_MAPPING[code]
         error_code
+      end
+
+      def tokenize_bank_account(bank_account, options = {})
+        account_holder_type = bank_account.account_holder_type == "personal" ? "individual" : "company"
+        post = {
+          bank_account: {
+            account_number: bank_account.account_number,
+            country: 'US',
+            currency: 'usd',
+            routing_number: bank_account.routing_number,
+            name: bank_account.name,
+            account_holder_type: account_holder_type,
+          }
+        }
+
+        token_response = api_request(:post, "tokens?#{post_data(post)}")
+        success = token_response["error"].nil?
+
+        if success && token_response["id"]
+          Response.new(success, nil, token: token_response)
+        else
+          Response.new(success, token_response["error"]["message"])
+        end
+      end
+
+      def ach?(payment_method)
+        case payment_method
+        when String, nil
+          false
+        else
+          card_brand(payment_method) == "check"
+        end
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -937,6 +937,11 @@ stripe_emv_us:
   login:
   fee_refund_login:
 
+# Externally verified bank account for testing
+stripe_verified_bank_account:
+  customer_id: "cus_7s22nNueP2Hjj6"
+  bank_account_id: "ba_17cHxeAWOtgoysogv3NM8CJ1"
+
 # Working credentials, no need to replace
 swipe_checkout:
   login: 2077103073D8B5

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -17,6 +17,12 @@ class StripeTest < Test::Unit::TestCase
 
     @apple_pay_payment_token = apple_pay_payment_token
     @emv_credit_card = credit_card_with_icc_data
+
+    @check = check({
+      bank_name: "STRIPE TEST BANK",
+      account_number: "000123456789",
+      routing_number: "110000000",
+    })
   end
 
   def test_successful_new_customer_with_card
@@ -54,6 +60,13 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_new_customer_with_bank_account
+    @gateway.expects(:ssl_request).twice.returns(successful_bank_token_request, successful_new_customer_bank_account_response)
+
+    response = @gateway.store(@check, @options)
+    assert_success response
+    assert_equal 'cus_7s6levMt8IqhTR|ba_17cMXgAWOtgoysog7UDWXbn4', response.authorization
+  end
 
   def test_successful_new_card
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
@@ -1213,6 +1226,83 @@ class StripeTest < Test::Unit::TestCase
       "cvc_check": null,
       "address_line1_check": null,
       "address_zip_check": null
+    }
+    RESPONSE
+  end
+
+  def successful_bank_token_request
+    <<-RESPONSE
+    {
+      "id": "btok_7s6lmOv1DRUpyG",
+      "object": "token",
+      "bank_account": {
+        "id": "ba_17cMXgAWOtgoysog7UDWXbn4",
+        "object": "bank_account",
+        "account_holder_type": "individual",
+        "bank_name": "STRIPE TEST BANK",
+        "country": "US",
+        "currency": "usd",
+        "fingerprint": "uCkXlMFxqys7GosR",
+        "last4": "6789",
+        "name": "Jim Smith",
+        "routing_number": "110000000",
+        "status": "new"
+      },
+      "client_ip": "24.142.217.2",
+      "created": 1454966852,
+      "livemode": false,
+      "type": "bank_account",
+      "used": false
+    }
+    RESPONSE
+  end
+
+  def successful_new_customer_bank_account_response
+    <<-RESPONSE
+    {
+      "id": "cus_7s6levMt8IqhTR",
+      "object": "customer",
+      "account_balance": 0,
+      "created": 1454966853,
+      "currency": null,
+      "default_source": "ba_17cMXgAWOtgoysog7UDWXbn4",
+      "delinquent": false,
+      "description": null,
+      "discount": null,
+      "email": null,
+      "livemode": false,
+      "metadata": {},
+      "shipping": null,
+      "sources": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ba_17cMXgAWOtgoysog7UDWXbn4",
+            "object": "bank_account",
+            "account_holder_type": "individual",
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "customer": "cus_7s6levMt8IqhTR",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "metadata": {},
+            "name": "Jim Smith",
+            "routing_number": "110000000",
+            "status": "new"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/customers/cus_7s6levMt8IqhTR/sources"
+      },
+      "subscriptions": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/customers/cus_7s6levMt8IqhTR/subscriptions"
+      }
     }
     RESPONSE
   end


### PR DESCRIPTION
Stripe requires that bank accounts be externally verified before they can be used in API transactions. The integration here has the process split into two actions:

1. Store the bank account (kicks off the Stripe verification process)
2. Purchase using the customer id and bank account id

The customer id and bank account id are returned by the `store` method formatted for direct use in `purchase` and `refund` after verification is complete.

Reference:
- https://stripe.com/docs/guides/ach