### PR TITLE
Return a failure response instead of raising an exception for invalid Clearhaus signing keys

### DIFF
--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -183,7 +183,11 @@ module ActiveMerchant #:nodoc:
         body = parameters.to_query
 
         if signing_key = @options[:signing_key]
-          headers["Signature"] = generate_signature(@options[:api_key], signing_key, body)
+          begin
+            headers["Signature"] = generate_signature(@options[:api_key], signing_key, body)
+          rescue OpenSSL::PKey::RSAError => e
+            return Response.new(false, e.message)
+          end
         end
 
         response = begin

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -16,13 +16,24 @@ class RemoteClearhausTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_signing_request
+  def test_successful_signing_request
     gateway = ClearhausGateway.new(fixtures(:clearhaus_secure))
 
     assert gateway.options[:signing_key]
     assert auth = gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'Approved', auth.message
+  end
+
+  def test_unsuccessful_signing_request
+    credentials = fixtures(:clearhaus_secure)
+    credentials[:signing_key] = "foo"
+    gateway = ClearhausGateway.new(credentials)
+
+    assert gateway.options[:signing_key]
+    assert auth = gateway.authorize(@amount, @credit_card, @options)
+    assert_failure auth
+    assert_equal "Neither PUB key nor PRIV key: not enough data", auth.message
   end
 
   def test_successful_purchase_without_cvv

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -224,6 +224,19 @@ class ClearhausTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_unsuccessful_signing_request_with_invalid_key
+    gateway = ClearhausGateway.new(api_key: "test_key", signing_key: "foo")
+
+    # stub actual network access, but this shouldn't be reached
+    gateway.stubs(:ssl_post).returns(nil)
+
+    card = credit_card("4111111111111111", month: "06", year: "2018", verification_value: "123")
+    options = { currency: "EUR", ip: "1.1.1.1" }
+
+    response = gateway.authorize(2050, card, options)
+    assert_failure response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
If the signing key is invalid return a failure response instead of raising up the exception from OpenSSL.