### PR TITLE
Fixup Clearhaus request signing

### DIFF
--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -44,6 +44,7 @@ module ActiveMerchant #:nodoc:
       #       :signing_key - merchant's private key for optionally signing request
       def initialize(options={})
         requires!(options, :api_key)
+        options[:signing_key].strip! if options[:signing_key]
         super
       end
 

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -183,7 +183,11 @@ module ActiveMerchant #:nodoc:
         body = parameters.to_query
 
         if signing_key = @options[:signing_key]
-          headers["Signature"] = generate_signature(@options[:api_key], signing_key, body)
+          begin
+            headers["Signature"] = generate_signature(@options[:api_key], signing_key, body)
+          rescue OpenSSL::PKey::RSAError => e
+            return Response.new(false, e.message)
+          end
         end
 
         response = begin

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -25,6 +25,17 @@ class RemoteClearhausTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
   end
 
+  def test_cleans_whitespace_from_signing_key
+    credentials = fixtures(:clearhaus_secure)
+    credentials[:signing_key] = "     #{credentials[:signing_key]}     "
+    gateway = ClearhausGateway.new(credentials)
+
+    assert gateway.options[:signing_key]
+    assert auth = gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+  end
+
   def test_unsuccessful_signing_request
     credentials = fixtures(:clearhaus_secure)
     credentials[:signing_key] = "foo"

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -16,13 +16,24 @@ class RemoteClearhausTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_signing_request
+  def test_successful_signing_request
     gateway = ClearhausGateway.new(fixtures(:clearhaus_secure))
 
     assert gateway.options[:signing_key]
     assert auth = gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'Approved', auth.message
+  end
+
+  def test_unsuccessful_signing_request
+    credentials = fixtures(:clearhaus_secure)
+    credentials[:signing_key] = "foo"
+    gateway = ClearhausGateway.new(credentials)
+
+    assert gateway.options[:signing_key]
+    assert auth = gateway.authorize(@amount, @credit_card, @options)
+    assert_failure auth
+    assert_equal "Neither PUB key nor PRIV key: not enough data", auth.message
   end
 
   def test_successful_purchase_without_cvv

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -224,6 +224,19 @@ class ClearhausTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_unsuccessful_signing_request_with_invalid_key
+    gateway = ClearhausGateway.new(api_key: "test_key", signing_key: "foo")
+
+    # stub actual network access, but this shouldn't be reached
+    gateway.stubs(:ssl_post).returns(nil)
+
+    card = credit_card("4111111111111111", month: "06", year: "2018", verification_value: "123")
+    options = { currency: "EUR", ip: "1.1.1.1" }
+
+    response = gateway.authorize(2050, card, options)
+    assert_failure response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -224,6 +224,25 @@ class ClearhausTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_cleans_whitespace_from_signing_key
+    signing_key_with_whitespace = "     #{test_private_signing_key}     "
+    gateway = ClearhausGateway.new(api_key: 'test_key', signing_key: signing_key_with_whitespace)
+    card = credit_card('4111111111111111', month: '06', year: '2018', verification_value: '123')
+    options = { currency: 'EUR', ip: '1.1.1.1' }
+
+    stub_comms gateway, :ssl_request do
+      response = gateway.authorize(2050, card, options)
+      assert_success response
+
+      assert_equal '84412a34-fa29-4369-a098-0165a80e8fda', response.authorization
+      assert response.test?
+    end.check_request do |method, endpoint, data, headers|
+      assert headers["Signature"]
+      assert_match %r{test_key RS256-hex}, headers["Signature"]
+      assert_match %r{02f56ed1f6c60cdefd$}, headers["Signature"]
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_unsuccessful_signing_request_with_invalid_key
     gateway = ClearhausGateway.new(api_key: "test_key", signing_key: "foo")
 


### PR DESCRIPTION
This does a couple things for Clearhaus request signing:

1. Return a failure response instead of raising an OpenSSL exception if there's a problem with the signing key.
2. Help reduce signing key problems by automatically stripping leading and trailing whitespace from signing keys.