### PR TITLE
Move and improve VISA Electron detection from SagePay to CreditCardMethods

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -111,6 +111,11 @@ module ActiveMerchant #:nodoc:
         @brand = (value.respond_to?(:downcase) ? value.downcase : value)
       end
 
+      # Returns if the card matches known Electron BINs
+      def electron?
+        self.class.electron?(number)
+      end
+
       # Returns or sets the first name of the card holder.
       #
       # @return [String]

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -17,6 +17,26 @@ module ActiveMerchant #:nodoc:
         'laser'              => /^(6304|6706|6709|6771(?!89))\d{8}(\d{4}|\d{6,7})?$/
       }
 
+      # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
+      ELECTRON_RANGES = [
+        [400115],
+        (400837..400839),
+        (412921..412923),
+        [417935],
+        (419740..419741),
+        (419773..419775),
+        [424519],
+        (424962..424963),
+        [437860],
+        [444000],
+        [459472],
+        (484406..484411),
+        (484413..484414),
+        (484418..484418),
+        (484428..484455),
+        (491730..491759),
+      ]
+
       def self.included(base)
         base.extend(ClassMethods)
       end
@@ -104,6 +124,17 @@ module ActiveMerchant #:nodoc:
           return 'maestro' if number =~ card_companies['maestro']
 
           return nil
+        end
+
+        def electron?(number)
+          return false unless [16, 19].include?(number.length)
+
+          # don't recalculate for each range
+          bank_identification_number = first_digits(number).to_i
+
+          ELECTRON_RANGES.any? do |range|
+            range.include?(bank_identification_number)
+          end
         end
 
         def type?(number)

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -36,7 +36,25 @@ module ActiveMerchant #:nodoc:
         :jcb => "JCB"
       }
 
-      ELECTRON = /^(424519|42496[23]|450875|48440[6-8]|4844[1-5][1-5]|4917[3-5][0-9]|491880)\d{10}(\d{3})?$/
+      # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
+      ELECTRON_RANGES = [
+        [400115],
+        (400837..400839),
+        (412921..412923),
+        [417935],
+        (419740..419741),
+        (419773..419775),
+        [424519],
+        (424962..424963),
+        [437860],
+        [444000],
+        [459472],
+        (484406..484411),
+        (484413..484414),
+        (484418..484418),
+        (484428..484455),
+        (491730..491759),
+      ]
 
       AVS_CVV_CODE = {
         "NOTPROVIDED" => nil,
@@ -292,8 +310,7 @@ module ActiveMerchant #:nodoc:
 
         card_type = card_brand(credit_card).to_sym
 
-        # Check if it is an electron card
-        if card_type == :visa && credit_card.number =~ ELECTRON
+        if card_type == :visa && electron?(credit_card.number)
           CREDIT_CARDS[:electron]
         else
           CREDIT_CARDS[card_type]
@@ -396,6 +413,15 @@ module ActiveMerchant #:nodoc:
       def localized_amount(money, currency)
         amount = amount(money)
         CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s) ? amount.split('.').first : amount
+      end
+
+      def electron?(number)
+        return false unless [16, 19].include?(number.length)
+
+        first_six = number[0,6]
+        ELECTRON_RANGES.any? do |range|
+          range.include?(first_six.to_i)
+        end
       end
     end
 

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -36,26 +36,6 @@ module ActiveMerchant #:nodoc:
         :jcb => "JCB"
       }
 
-      # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
-      ELECTRON_RANGES = [
-        [400115],
-        (400837..400839),
-        (412921..412923),
-        [417935],
-        (419740..419741),
-        (419773..419775),
-        [424519],
-        (424962..424963),
-        [437860],
-        [444000],
-        [459472],
-        (484406..484411),
-        (484413..484414),
-        (484418..484418),
-        (484428..484455),
-        (491730..491759),
-      ]
-
       AVS_CVV_CODE = {
         "NOTPROVIDED" => nil,
         "NOTCHECKED" => 'X',
@@ -310,7 +290,7 @@ module ActiveMerchant #:nodoc:
 
         card_type = card_brand(credit_card).to_sym
 
-        if card_type == :visa && electron?(credit_card.number)
+        if card_type == :visa && credit_card.electron?
           CREDIT_CARDS[:electron]
         else
           CREDIT_CARDS[card_type]
@@ -413,15 +393,6 @@ module ActiveMerchant #:nodoc:
       def localized_amount(money, currency)
         amount = amount(money)
         CURRENCIES_WITHOUT_FRACTIONS.include?(currency.to_s) ? amount.split('.').first : amount
-      end
-
-      def electron?(number)
-        return false unless [16, 19].include?(number.length)
-
-        first_six = number[0,6]
-        ELECTRON_RANGES.any? do |range|
-          range.include?(first_six.to_i)
-        end
       end
     end
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -208,4 +208,28 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 19, number.length
     assert_equal 'switch', CreditCard.brand?(number)
   end
+
+  def test_electron_cards
+    # return the card number so assert failures are easy to isolate
+    electron_test = Proc.new do |card_number|
+      electron = CreditCard.electron?(card_number)
+      card_number if electron
+    end
+
+    CreditCard::ELECTRON_RANGES.each do |range|
+      range.map { |leader| "#{leader}0000000000" }.each do |card_number|
+        assert_equal card_number, electron_test.call(card_number)
+      end
+    end
+
+    # Visa range
+    assert_false electron_test.call('4245180000000000')
+    assert_false electron_test.call('4918810000000000')
+
+    # 19 PAN length
+    assert electron_test.call('4249620000000000000')
+
+    # 20 PAN length
+    assert_false electron_test.call('42496200000000000')
+  end
 end

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -50,42 +50,26 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_electron_cards
+    electron_test = Proc.new do |card_number|
+      electron = @gateway.send(:electron?, card_number)
+      card_number if electron
+    end
+
+    SagePayGateway::ELECTRON_RANGES.each do |range|
+      range.map { |leader| "#{leader}0000000000" }.each do |card_number|
+        assert_equal card_number, electron_test.call(card_number)
+      end
+    end
+
     # Visa range
-    assert_no_match SagePayGateway::ELECTRON, '4245180000000000'
-
-    # First electron range
-    assert_match SagePayGateway::ELECTRON, '4245190000000000'
-
-    # Second range
-    assert_match SagePayGateway::ELECTRON, '4249620000000000'
-    assert_match SagePayGateway::ELECTRON, '4249630000000000'
-
-    # Third
-    assert_match SagePayGateway::ELECTRON, '4508750000000000'
-
-    # Fourth
-    assert_match SagePayGateway::ELECTRON, '4844060000000000'
-    assert_match SagePayGateway::ELECTRON, '4844080000000000'
-
-    # Fifth
-    assert_match SagePayGateway::ELECTRON, '4844110000000000'
-    assert_match SagePayGateway::ELECTRON, '4844550000000000'
-
-    # Sixth
-    assert_match SagePayGateway::ELECTRON, '4917300000000000'
-    assert_match SagePayGateway::ELECTRON, '4917590000000000'
-
-    # Seventh
-    assert_match SagePayGateway::ELECTRON, '4918800000000000'
-
-    # Visa
-    assert_no_match SagePayGateway::ELECTRON, '4918810000000000'
+    assert_false electron_test.call('4245180000000000')
+    assert_false electron_test.call('4918810000000000')
 
     # 19 PAN length
-    assert_match SagePayGateway::ELECTRON, '4249620000000000000'
+    assert electron_test.call('4249620000000000000')
 
     # 20 PAN length
-    assert_no_match SagePayGateway::ELECTRON, '42496200000000000'
+    assert_false electron_test.call('42496200000000000')
   end
 
   def test_avs_result


### PR DESCRIPTION
The previous regex based Electron ranges were a bit complex to modify and apparently out of date as it was incorrectly identifying some VISA debit cards as VISA Electron.