### PR TITLE
USAePay: add line items and a couple of other properties. Bump advanced (soap) api version from 1.4 to 1.6.

### DIFF
--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -43,6 +43,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     @options = {
       :client_ip => '127.0.0.1',
       :billing_address => address,
+      :line_items => [product_name: 'line item name']
     }
 
     @transaction_options = {

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -98,7 +98,8 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
       :billing_address => address,
 
       :customer_number => 298741,
-      :reference_number => 9999
+      :reference_number => 9999,
+      :line_items => [product_name: 'line item name']
     }
   end
 


### PR DESCRIPTION
USAePay: add line items and a couple of other properties. Bump advanced (soap) api version from 1.4 to 1.6.
