### PR TITLE
create transactions with payment objects

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -127,7 +127,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_amount(post, money, options)
-        post[:token] = card_token
+        add_payment_identifier(post, card_token)
         post[:description] = options[:order_id]
         post[:source] = 'active_merchant'
         commit(:post, 'transactions', post)
@@ -137,7 +137,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_amount(post, money, options)
-        post[:token] = card_token
+        add_payment_identifier(post, card_token)
         post[:description] = options[:order_id]
         post[:source] = 'active_merchant'
         commit(:post, 'preauthorizations', post)
@@ -185,6 +185,15 @@ module ActiveMerchant #:nodoc:
       def add_amount(post, money, options)
         post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_payment_identifier(post, card_token)
+        case card_token
+        when /\Apay_/
+          post[:payment] = card_token
+        else
+          post[:token] = card_token
+        end
       end
 
       def preauth(authorization)


### PR DESCRIPTION
PaymentObjects can be used to create a transaction (for reusable payments) additionally to tokens.
