### PR TITLE
Move Electron check out of CreditCard into CreditCardMethods

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -111,11 +111,6 @@ module ActiveMerchant #:nodoc:
         @brand = (value.respond_to?(:downcase) ? value.downcase : value)
       end
 
-      # Returns if the card matches known Electron BINs
-      def electron?
-        self.class.electron?(number)
-      end
-
       # Returns or sets the first name of the card holder.
       #
       # @return [String]

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -78,6 +78,11 @@ module ActiveMerchant #:nodoc:
         (number.to_s =~ /^\d{1,2}$/)
       end
 
+      # Returns if the card matches known Electron BINs
+      def electron?
+        self.class.electron?(number)
+      end
+
       module ClassMethods
         # Returns true if it validates. Optionally, you can pass a card brand as an argument and
         # make sure it is of the correct brand.


### PR DESCRIPTION
Moves `electron?` check to `CreditCardMethods`, to live near where `ELECTRON_RANGES` is defined so other credit-card like objects can be substituted for Active Merchant's credit card implementation without breaking.

**Attn:**
@girasquid @aprofeit @andrewpaliga 