### PR TITLE
CyberSource: Update test and live URL

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -30,8 +30,8 @@ module ActiveMerchant #:nodoc:
     # * The order of the XML elements does matter, make sure to follow the order in
     #   the documentation exactly.
     class CyberSourceGateway < Gateway
-      self.test_url = 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor'
-      self.live_url = 'https://ics2ws.ic3.com/commerce/1.x/transactionProcessor'
+      self.test_url = 'https://ics2wstesta.ic3.com/commerce/1.x/transactionProcessor'
+      self.live_url = 'https://ics2wsa.ic3.com/commerce/1.x/transactionProcessor'
 
       XSD_VERSION = "1.121"
 


### PR DESCRIPTION
This PR updates the test and live URL of CyberSource to point to new URLs provided by CyberSource.
As announced by CyberSource, they are migrating their infrastructure to Akamai-dedicated URLs and requesting their customers to migrate to these new URLs by June 30, 2016.

I have tested this change using unit and remote tests.