### PR TITLE
Add scrubbing to NAB Transact

### DIFF
--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -3,8 +3,8 @@ require "nokogiri"
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class IppGateway < Gateway
-      self.live_url = 'https://www.ippayments.com.au/interface/api/dts.asmx'
-      self.test_url = 'https://demo.ippayments.com.au/interface/api/dts.asmx'
+      self.live_url = 'https://www.ippayments.com.au/interface/api'
+      self.test_url = 'https://demo.ippayments.com.au/interface/api'
 
       self.supported_countries = ['AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
@@ -13,6 +13,8 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'IPP'
 
       self.money_format = :cents
+
+      self.default_currency = 'AUD'
 
       STANDARD_ERROR_CODE_MAPPING = {
         "05" => STANDARD_ERROR_CODE[:card_declined],
@@ -62,12 +64,38 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def void(money, authorization, options={})
+        commit("SubmitSingleVoid") do |xml|
+          xml.Void do
+            xml.Receipt authorization
+            add_amount(xml, money)
+            add_credentials(xml)
+          end
+        end
+      end
+
       def refund(money, authorization, options={})
         commit("SubmitSingleRefund") do |xml|
           xml.Refund do
             xml.Receipt authorization
             add_amount(xml, money)
             add_credentials(xml)
+          end
+        end
+      end
+
+      def store(payment, options={})
+        commit("TokeniseCreditCard", "sipp", "tokeniseCreditCardXML") do |xml|
+          xml.TokeniseCreditCard do
+            xml.UserName @options[:username]
+            xml.Password @options[:password]
+            xml.CardNumber payment.number
+            xml.ExpM format(payment.month, :two_digits)
+            xml.ExpY format(payment.year, :four_digits)
+            xml.TokeniseAlgorithmID "2"
+            if options.has_key?(:customer_storage_number)
+              xml.CustomerStorageNumber options[:customer_storage_number]
+            end
           end
         end
       end
@@ -117,12 +145,12 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(action, &block)
+      def commit(action, api_type="dts", outer_xml="trnXML", &block)
         headers = {
           "Content-Type" => "text/xml; charset=utf-8",
-          "SOAPAction" => "http://www.ippayments.com.au/interface/api/dts/#{action}",
+          "SOAPAction" => "http://www.ippayments.com.au/interface/api/#{api_type}/#{action}",
         }
-        response = parse(ssl_post(commit_url, new_submit_xml(action, &block), headers))
+        response = parse(ssl_post(commit_url(api_type), new_submit_xml(action, api_type, outer_xml, &block), headers))
 
         Response.new(
           success_from(response),
@@ -134,13 +162,13 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def new_submit_xml(action)
+      def new_submit_xml(action, api_type, outer_xml)
         xml = Builder::XmlMarkup.new(indent: 2)
         xml.instruct!
         xml.soap :Envelope, "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance", "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema", "xmlns:soap" => "http://schemas.xmlsoap.org/soap/envelope/" do
           xml.soap :Body do
-            xml.__send__(action, "xmlns" => "http://www.ippayments.com.au/interface/api/dts") do
-              xml.trnXML do
+            xml.__send__(action, "xmlns" => "http://www.ippayments.com.au/interface/api/#{api_type}") do
+              xml.__send__(outer_xml) do
                 inner_xml = Builder::XmlMarkup.new(indent: 2)
                 yield(inner_xml)
                 xml.cdata!(inner_xml.target!)
@@ -151,24 +179,47 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def commit_url
-        (test? ? test_url : live_url)
+      def commit_url(api_type)
+        "#{test? ? test_url : live_url}/#{api_type}.asmx"
       end
 
       def success_from(response)
-        (response[:response_code] == "0")
+        if response.has_key?(:return_value)
+          (response[:return_value] == "0")
+        else
+          (response[:response_code] == "0")
+        end
       end
 
       def error_code_from(response)
-        STANDARD_ERROR_CODE_MAPPING[response[:declined_code]]
+        if response.has_key?(:return_value)
+          case response[:return_value]
+          when '5' then Gateway::STANDARD_ERROR_CODE[:invalid_number]
+          when '99' then Gateway::STANDARD_ERROR_CODE[:processing_error]
+          else response[:return_value]
+          end
+        else
+          STANDARD_ERROR_CODE_MAPPING[response[:declined_code]]
+        end
       end
 
       def message_from(response)
-        response[:declined_message]
+        if response.has_key?(:return_value)
+          case response[:return_value]
+          when '0' then ''
+          when '1' then 'Invalid username/password'
+          when '4' then 'Invalid CustomerStorageNumber'
+          when '5' then 'Invalid Credit Card Number'
+          when '99' then 'Exception encountered'
+          else "Error #{response[:return_value]}"
+          end
+        else
+          response[:declined_message]
+        end
       end
 
       def authorization_from(response)
-        response[:receipt]
+        response[:receipt] || response[:token]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -79,6 +79,18 @@ module ActiveMerchant #:nodoc:
         commit_periodic(:deletecrn, build_unstore_request(identification, options))
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        return "" if transcript.blank?
+        transcript.
+          gsub(%r((<cardNumber>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<cvv>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<password>)[^<]+(<))i, '\1[FILTERED]\2')
+      end
+
       private
 
       def add_metadata(xml, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -787,64 +787,69 @@ realex:
   password: Y
 
 realex_mastercard:
-  number:
+  number: '5425230000004415'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_coms_error:
-  number:
+  number: '5135020000005871'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_declined:
-  number:
+  number: '5114610000004778'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_a:
-  number:
+  number: '5121220000006921'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_b:
-  number:
+  number: '5114630000009791'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 # Realex doesn't provide public testing data
 # Fill in the card numbers with the Realex test
 # data.
 realex_visa:
-  number:
+  number: '4263970000005262'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_coms_error:
-  number:
+  number: '4009830000001985'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_declined:
-  number:
+  number: '4000120000001154'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_a:
-  number:
+  number: '4000160000004147'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_b:
-  number:
+  number: '4000130000001724'
   month: '6'
   year: '2020'
   verification_value: '123'

--- a/test/remote/gateways/remote_ipp_test.rb
+++ b/test/remote/gateways/remote_ipp_test.rb
@@ -11,6 +11,8 @@ class RemoteIppTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase',
     }
+
+    @amount = 234
   end
 
   def test_dump_transcript
@@ -71,6 +73,18 @@ class RemoteIppTest < Test::Unit::TestCase
     response = @gateway.refund(105, response.authorization, @options)
     assert_failure response
     assert_equal 'Do Not Honour', response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_failed_store
+    response = @gateway.store(credit_card(''), @options)
+    assert_failure response
+    assert_equal 'Exception encountered', response.message
   end
 
   def test_invalid_login

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -251,4 +251,14 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert_equal 'Invalid Amount', purchase_response.message
   end
 
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+
 end

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -57,7 +57,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '506', response.params['result']
+    assert_equal '504', response.params['result']
     assert_match %r{no such}i, response.message
   end
 
@@ -70,7 +70,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '506', response.params['result']
+    assert_equal '504', response.params['result']
     assert_match %r{no such}i, response.message
   end
 
@@ -268,7 +268,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_then_refund
     order_id = generate_unique_id
 
-    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:rebate_secret => 'rebate'))
+    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:rebate_secret => 'refund'))
 
     purchase_response = gateway_with_refund_password.purchase(@amount, @visa,
       :order_id => order_id,
@@ -284,9 +284,22 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     assert_not_nil rebate_response
     assert_success rebate_response
-    assert rebate_response.test?
     assert rebate_response.authorization.length > 0
     assert_equal 'Successful', rebate_response.message
+  end
+
+  def test_realex_store
+    response = @gateway.store(@visa,
+        :order_id => generate_unique_id,
+        :customer => generate_unique_id,
+        :cardref  => generate_unique_id)
+    assert_not_nil response
+    assert_instance_of MultiResponse, response
+    assert response.authorization.length > 0
+    customer_stored = response.responses[0]
+    card_stored = response.responses[1]
+    assert_equal 'Successful', customer_stored.message
+    assert_equal 'Successful', card_stored.message
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
This allows scrubbing of NAB transact transcripts.

I've also added a remote test (using the Braintree Gateway as an inspiration) however lots of the other tests seem to fail on that remote file ... that one passes.

Replaces #1966 