### PR TITLE
Add scrubbing to NAB Transact

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -79,6 +79,18 @@ module ActiveMerchant #:nodoc:
         commit_periodic(:deletecrn, build_unstore_request(identification, options))
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        return "" if transcript.blank?
+        transcript.
+          gsub(%r((<cardNumber>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<cvv>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<password>)[^<]+(<))i, '\1[FILTERED]\2')
+      end
+
       private
 
       def add_metadata(xml, options)

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -251,4 +251,14 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert_equal 'Invalid Amount', purchase_response.message
   end
 
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+
 end


### PR DESCRIPTION
This allows scrubbing of NAB transact transcripts.

I've also added a remote test (using the Braintree Gateway as an inspiration) however lots of the other tests seem to fail on that remote file ... that one passes.

Third time lucky.

Replaces #1966 and #2036 
