### PR TITLE
Removed invalid assertions in RemoteBraintreeBlueTest

### DIFF
--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -409,7 +409,6 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'voided', void.params["braintree_transaction"]["status"]
     assert failed_void = @gateway.void(auth.authorization)
     assert_failure failed_void
-    assert failed_void.authorization.present?
     assert_equal 'Transaction can only be voided if status is authorized or submitted_for_settlement. (91504)', failed_void.message
     assert_equal({"processor_response_code"=>"91504"}, failed_void.params["braintree_transaction"])
   end
@@ -575,7 +574,6 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_failed_credit
     assert response = @gateway.credit(@amount, credit_card('5105105105105101'), @options)
     assert_failure response
-    assert response.authorization.present?
     assert_equal 'Credit card number is invalid. (81715)', response.message, "You must get credits enabled in your Sandbox account for this to pass"
   end
 


### PR DESCRIPTION
Fixes https://github.com/activemerchant/active_merchant/issues/2005

@girasquid 

