### PR TITLE
Sagepay permit cv2 with token payment

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -264,6 +264,7 @@ module ActiveMerchant #:nodoc:
       def add_token_details(post, token, options)
         add_token(post, token)
         add_pair(post, :StoreToken, options[:customer])
+        add_pair(post, :CV2, options[:verification_value])
       end
 
       def add_token(post, token)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -250,6 +250,15 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_store_and_repurchase_with_resupplied_verification_value
+    assert response = @gateway.store(@visa)
+    assert_success response
+    assert !response.authorization.blank?
+    assert purchase = @gateway.purchase(@amount, response.authorization, @options.merge(customer: 1))
+    assert purchase = @gateway.purchase(@amount, response.authorization, @options.merge(verification_value: '123', order_id: 'foobar123'))
+    assert_success purchase
+  end
+
   def test_successful_store_and_authorize
     assert response = @gateway.store(@visa)
     assert_success response


### PR DESCRIPTION
Currently when posting a purchase transaction using a previously stored SagePay token as the payment method, it is not possible to resupply the CV2 number.

From the SagePay docs:

> The CV2 value is only stored prior to authorisation. After the initial attempted use of the token the CV2 will be deleted to comply with industry regulations. If you have AVS/CV2 checks enabled on your account, you will need to obtain this information from the customer each time the token is used.

So if a token is to be used more than once, it is mandatory to resupply the CV2 number (assuming this is enabled on the account).  The existing gateway does not permit a token to be supplied with a CV2 number.

This patch adds an optional :CV2 field which will be posted with the token, if present.  A remote test is also included.