### PR TITLE
Ogone: query single payments

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -190,6 +190,17 @@ module ActiveMerchant #:nodoc:
         commit('DES', post, end_point: :maintenance)
       end
 
+      # Fetch current state of a transaction
+      def reconcile(key="PAYID", value)
+        post = {}
+        if key.eql?("ORDERID")
+          add_merchant_reference(post, value)
+        else
+          add_authorization(post, value)
+        end
+        commit(nil, post, end_point: :query)
+      end
+
       # Credit the specified account by a specific amount.
       def credit(money, identification_or_credit_card, options = {})
         if reference_transaction?(identification_or_credit_card)
@@ -341,6 +352,10 @@ module ActiveMerchant #:nodoc:
         add_pair post, 'CARDNO', creditcard.number
         add_pair post, 'ED',     "%02d%02s" % [creditcard.month, creditcard.year.to_s[-2..-1]]
         add_pair post, 'CVC',    creditcard.verification_value
+      end
+
+      def add_merchant_reference(post, merchant_reference)
+        add_pair post, 'ORDERID', merchant_reference
       end
 
       def parse(body)

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -167,6 +167,41 @@ class OgoneTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_reconcile
+    @gateway.expects(:ssl_post).returns(successful_reconcile_response)
+    assert response = @gateway.reconcile("3025473")
+    assert_success response
+    assert_equal '3025473;', response.authorization
+    assert_equal '9', response.params["STATUS"]
+    assert response.test?
+  end
+
+  def test_successful_reconcile_with_pay_id
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'PAYID', '3025473')
+    @gateway.expects(:add_pair).with(anything, 'ORDERID', '1234961140253559268757474').never
+    @gateway.expects(:ssl_post).returns(successful_reconcile_response)
+    assert response = @gateway.reconcile("PAYID", "3025473")
+    assert_success response
+    assert_equal '3025473;', response.authorization
+    assert_equal '3025473', response.params["PAYID"]
+    assert_equal '9', response.params["STATUS"]
+    assert response.test?
+  end
+
+  def test_successful_reconcile_with_merchant_reference
+    @gateway.expects(:add_pair).at_least(1)
+    @gateway.expects(:add_pair).with(anything, 'ORDERID', '1234961140253559268757474')
+    @gateway.expects(:add_pair).with(anything, 'PAYID', '3025473').never
+    @gateway.expects(:ssl_post).returns(successful_reconcile_response)
+    assert response = @gateway.reconcile("ORDERID", "1234961140253559268757474")
+    assert_success response
+    assert_equal '3025473;', response.authorization
+    assert_equal "1234961140253559268757474", response.order_id
+    assert_equal '9', response.params["STATUS"]
+    assert response.test?
+  end
+
   def test_deprecated_credit
     @gateway.expects(:ssl_post).returns(successful_referenced_credit_response)
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
@@ -473,6 +508,12 @@ class OgoneTest < Test::Unit::TestCase
   def test_path_for_void
     @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/maintenancedirect.asp", anything).returns(successful_void_response)
     assert response = @gateway.void("3048606")
+    assert_success response
+  end
+
+  def test_path_for_reconcile
+    @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/querydirect.asp", anything).returns(successful_reconcile_response)
+    assert response = @gateway.reconcile("PAYID", "3025473")
     assert_success response
   end
 
@@ -785,4 +826,33 @@ class OgoneTest < Test::Unit::TestCase
     END
   end
 
+  def successful_reconcile_response
+    <<-END
+    <?xml version="1.0"?>
+    <ncresponse
+    orderID="1234961140253559268757474"
+    PAYID="3025473"
+    PAYIDSUB=""
+    NCSTATUS="0"
+    NCERROR="0"
+    NCERRORPLUS="!"
+    ACCEPTANCE="test123"
+    STATUS="9"
+    IPCTY="99"
+    CCCTY="99"
+    ECI="1"
+    CVCCheck="NO"
+    AAVCheck="NO"
+    VC="NO"
+    AAVZIP="NO"
+    AAVADDRESS="NO"
+    AAVNAME="NO"
+    AAVPHONE="NO"
+    AAVMAIL="NO"
+    amount="1"
+    currency="EUR"
+    ALIAS="2">
+    </ncresponse>
+    END
+  end
 end

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -445,6 +445,37 @@ class OgoneTest < Test::Unit::TestCase
     assert_instance_of Hash, response.params
   end
 
+  def test_path_generation
+    assert OGonePath.new(:maintenance).to_s, "maintenancedirect.asp"
+    assert OGonePath.new(:query).to_s, "querydirect.asp"
+    assert OGonePath.new(:order).to_s, "orderdirect.asp"
+    assert OGonePath.new(:unknown).to_s, "#"
+  end
+
+  def test_path_for_purchase
+    @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/orderdirect.asp", anything).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_path_for_authorize
+    @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/orderdirect.asp", anything).returns(successful_purchase_response)
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_path_for_capture
+    @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/maintenancedirect.asp", anything).returns(successful_capture_response)
+    assert response = @gateway.capture(@amount, "3048326")
+    assert_success response
+  end
+
+  def test_path_for_void
+    @gateway.expects(:ssl_post).with("https://secure.ogone.com/ncol/test/maintenancedirect.asp", anything).returns(successful_void_response)
+    assert response = @gateway.void("3048606")
+    assert_success response
+  end
+
   private
 
   def string_to_digest


### PR DESCRIPTION
We found the library lacking the ability to query directly for a single payment, which ogone does support. It's also super handy to be able to search by ORDERID or PAYID.

Been using this in production for around a year now.
