### PR TITLE
Add all optional fields to SagePay requests

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -43,6 +43,26 @@ module ActiveMerchant #:nodoc:
         "NOTMATCHED" => 'N'
       }
 
+      OPTIONAL_REQUEST_FIELDS = {
+        paypal_callback_url: :PayPalCallbackURL,
+        basket: :Basket,
+        gift_aid_payment: :GiftAidPayment ,
+        apply_avscv2: :ApplyAVSCV2 ,
+        apply_3d_secure: :Apply3DSecure,
+        account_type: :AccountType,
+        billing_agreement: :BillingAgreement,
+        basket_xml: :BasketXML,
+        customer_xml: :CustomerXML,
+        surcharge_xml: :SurchargeXML,
+        vendor_data: :VendorData,
+        language: :Language,
+        website: :Website,
+        recipient_account_number: :FIRecipientAcctNumber ,
+        recipient_surname: :FIRecipientSurname ,
+        recipient_postcode: :FIRecipientPostcode ,
+        recipient_dob: :FIRecipientDoB
+      }
+
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :switch, :solo, :maestro, :diners_club]
       self.supported_countries = ['GB', 'IE']
       self.default_currency = 'GBP'
@@ -195,14 +215,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_optional_data(post, options)
-        add_pair(post, :GiftAidPayment, options[:gift_aid_payment]) unless options[:gift_aid_payment].blank?
-        add_pair(post, :ApplyAVSCV2, options[:apply_avscv2]) unless options[:apply_avscv2].blank?
-        add_pair(post, :Apply3DSecure, options[:apply_3d_secure]) unless options[:apply_3d_secure].blank?
         add_pair(post, :CreateToken, 1) unless options[:store].blank?
-        add_pair(post, :FIRecipientAcctNumber, options[:recipient_account_number])
-        add_pair(post, :FIRecipientSurname, options[:recipient_surname])
-        add_pair(post, :FIRecipientPostcode, options[:recipient_postcode])
-        add_pair(post, :FIRecipientDoB, options[:recipient_dob])
+
+        OPTIONAL_REQUEST_FIELDS.each do |gateway_option, sagepay_field|
+          add_pair(post, sagepay_field, options[gateway_option])
+        end
       end
 
       def add_address(post, options)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -226,9 +226,91 @@ class RemoteSagePayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apply_avscv2_field
-    response = @gateway.purchase(@amount, @visa, @options.merge({apply_avscv2: 1}))
+    @options[:apply_avscv2] = 1
+    response = @gateway.purchase(@amount, @visa, @options)
     assert_success response
     assert_equal "Y", response.cvv_result['code']
+  end
+
+  def test_successful_purchase_with_pay_pal_callback_url
+    @options[:paypal_callback_urll] = 'callback.com'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_basket
+    # Example from "Sage Pay Direct Integration and Protocol Guidelines 3.00"
+    # Published: 27/08/2015
+    @options[:basket] = '4:Pioneer NSDV99 DVD-Surround Sound System:1:424.68:' \
+      '74.32:499.00: 499.00:Donnie Darko Director’s Cut:3:11.91:2.08:13.99:' \
+      '41.97: Finding Nemo:2:11.05:1.94:12.99:25.98: Delivery:---:---:---:---' \
+      ':4.99'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_gift_aid_payment
+    @options[:gift_aid_payment] = 1
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_transaction_registration_with_apply_3d_secure
+    @options[:apply_3d_secure] = 1
+    response = @gateway.purchase(@amount, @visa, @options)
+    # We receive a different type of response for 3D Secure requiring to
+    # redirect the user to the ACSURL given inside the response
+    assert response.params.include?('ACSURL')
+    assert_equal 'OK', response.params['3DSecureStatus']
+    assert_equal '3DAUTH', response.params['Status']
+  end
+
+  def test_successful_purchase_with_account_type
+    @options[:account_type] = 'E'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_billing_agreement
+    @options[:billing_agreement] = 1
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_basket_xml
+    @options[:basket_xml] = basket_xml
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_customer_xml
+    @options[:customer_xml] = customer_xml
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_surcharge_xml
+    @options[:surcharge_xml] = surcharge_xml
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_vendor_data
+    @options[:vendor_data] = 'Data displayed against the transaction in MySagePay'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_language
+    @options[:language] = 'FR'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_website
+    @options[:website] = 'origin-of-transaction.com'
+    response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
   end
 
   def test_invalid_login
@@ -304,5 +386,61 @@ class RemoteSagePayTest < Test::Unit::TestCase
 
   def next_year
     Date.today.year + 1
+  end
+
+  # Based on example from http://www.sagepay.co.uk/support/basket-xml
+  # Only kept required fields to make sense
+  def basket_xml
+    <<-XML
+<basket>
+  <item>
+    <description>DVD 1</description>
+    <quantity>2</quantity>
+    <unitNetAmount>24.50</unitNetAmount>
+    <unitTaxAmount>00.50</unitTaxAmount>
+    <unitGrossAmount>25.00</unitGrossAmount>
+    <totalGrossAmount>50.00</totalGrossAmount>
+  </item>
+ </basket>
+    XML
+  end
+
+  # Example from http://www.sagepay.co.uk/support/customer-xml
+  def customer_xml
+    <<-XML
+<customer> 
+  <customerMiddleInitial>W</customerMiddleInitial> 
+  <customerBirth>1983-01-01</customerBirth> 
+  <customerWorkPhone>020 1234567</customerWorkPhone> 
+  <customerMobilePhone>0799 1234567</customerMobilePhone> 
+  <previousCust>0</previousCust> 
+  <timeOnFile>10</timeOnFile> 
+  <customerId>CUST123</customerId>
+</customer>
+    XML
+  end
+
+  # Example from https://www.sagepay.co.uk/support/12/36/protocol-3-00-surcharge-xml
+  def surcharge_xml
+    <<-XML
+<surcharges>
+  <surcharge>
+    <paymentType>DELTA</paymentType>
+    <fixed>2.50</fixed>
+  </surcharge>
+  <surcharge>
+    <paymentType>VISA</paymentType>
+    <fixed>2.50</fixed>
+  </surcharge>
+  <surcharge>
+    <paymentType>AMEX</paymentType>
+    <percentage>1.50</percentage>
+  </surcharge>
+  <surcharge>
+    <paymentType>MC</paymentType>
+    <percentage>1.50</percentage>
+  </surcharge>
+</surcharges>
+    XML
   end
 end

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -89,9 +89,25 @@ class SagePayTest < Test::Unit::TestCase
     @gateway.send(:add_amount, {}, @amount, @options)
   end
 
+  def test_paypal_callback_url_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(paypal_callback_url: 'callback.com')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/PayPalCallbackURL=callback\.com/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_basket_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(basket: 'A1.2 Basket section')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/Basket=A1\.2\+Basket\+section/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_gift_aid_payment_is_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:gift_aid_payment => 1}))
+      purchase_with_options(gift_aid_payment: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/GiftAidPayment=1/, data)
     end.respond_with(successful_purchase_response)
@@ -99,15 +115,97 @@ class SagePayTest < Test::Unit::TestCase
 
   def test_apply_avscv2_is_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:apply_avscv2 => 1}))
+      purchase_with_options(apply_avscv2: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ApplyAVSCV2=1/, data)
     end.respond_with(successful_purchase_response)
   end
 
+  def test_disable_3d_security_flag_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(apply_3d_secure: 1)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/Apply3DSecure=1/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_account_type_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(account_type: 'M')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/AccountType=M/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_billing_agreement_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(billing_agreement: 1)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/BillingAgreement=1/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_store_token_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(store: true)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/CreateToken=1/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_basket_xml_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(basket_xml: 'A1.3 BasketXML section')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/BasketXML=A1\.3\+BasketXML\+section/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_customer_xml_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(customer_xml: 'A1.4 CustomerXML section')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/CustomerXML=A1\.4\+CustomerXML\+section/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_surcharge_xml_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(surcharge_xml: 'A1.1 SurchargeXML section')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/SurchargeXML=A1\.1\+SurchargeXML\+section/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_vendor_data_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(vendor_data: 'any data')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/VendorData=any\+data/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_language_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(language: 'FR')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/Language=FR/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_website_is_submitted
+    stub_comms(@gateway, :ssl_request) do
+      purchase_with_options(website: 'transaction-origin.com')
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/Website=transaction-origin\.com/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_FIxxxx_optional_fields_are_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:recipient_account_number => '1234567890', :recipient_surname => 'Withnail', :recipient_postcode => 'AB11AB', :recipient_dob => '19701223'}))
+      purchase_with_options(recipient_account_number: '1234567890',
+        recipient_surname: 'Withnail', recipient_postcode: 'AB11AB',
+        recipient_dob: '19701223')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/FIRecipientAcctNumber=1234567890/, data)
       assert_match(/FIRecipientSurname=Withnail/, data)
@@ -116,17 +214,9 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_disable_3d_security_flag_is_submitted
-    stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:apply_3d_secure => 1}))
-    end.check_request do |method, endpoint, data, headers|
-      assert_match(/Apply3DSecure=1/, data)
-    end.respond_with(successful_purchase_response)
-  end
-
   def test_description_is_truncated
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge(description: "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters."))
+      purchase_with_options(description: "SagePay transactions fail if the description is more than 100 characters. Therefore, we truncate it to 100 characters.")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/&Description=SagePay\+transactions\+fail\+if\+the\+description\+is\+more\+than\+100\+characters.\+Therefore%2C\+we\+truncate\+it\+&/, data)
     end.respond_with(successful_purchase_response)
@@ -189,6 +279,10 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   private
+
+  def purchase_with_options(optional)
+    @gateway.purchase(@amount, @credit_card, @options.merge(optional))
+  end
 
   def successful_purchase_response
     <<-RESP


### PR DESCRIPTION
SagePay direct integration allows sending multiple optional fields with requests. This PR add all missing optional fields available with SagePay's protocol version 3.00 as described in the "Sage Pay Direct Integration and Protocol Guidelines 3.00" appendix "A1. You submit your transaction registration POST"