### PR TITLE
Changed Mercury test URL to the current test server

### DIFF
--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
     # and +refund+ will become mandatory.
     class MercuryGateway < Gateway
       URLS = {
-        :test => 'https://w1.mercurydev.net/ws/ws.asmx',
+        :test => 'https://w1.mercurycert.net/ws/ws.asmx',
         :live => 'https://w1.mercurypay.com/ws/ws.asmx'
       }
 


### PR DESCRIPTION
Mercury no longer seems to support the test URL below - when attempting to access that URL, you receive the following message:

We have a new WebServices development environment. Please email IntegrationTeam@mercurypay.com to request new testing credentials. Thank you. 

I have been working with them, and the new URL for testing/development is:
https://w1.mercurycert.net/ws/ws.asmx