### PR TITLE
AuthorizeNet: Always pass recurringBilling flag if present

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -323,7 +323,7 @@ module ActiveMerchant #:nodoc:
 
       def add_settings(xml, source, options)
         xml.transactionSettings do
-          if !source.is_a?(String) && card_brand(source) == "check" && options[:recurring]
+          if options[:recurring]
             xml.setting do
               xml.settingName("recurringBilling")
               xml.settingValue("true")


### PR DESCRIPTION
Required change for https://github.com/spreedly/core/issues/1753
@duff to review

Due to the nested structure of Authorize Net requests, this gateway specific field needs this change in AM. This flag was already being passed, but only if the payment type was `check`, so I removed the logic restricting it.