### PR TITLE
Extra Braintree error messaging

### DIFF
--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -608,6 +608,15 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert response.authorization.present?
   end
 
+  def test_unsuccessful_transaction_returns_message_when_available
+    Braintree::TransactionGateway.any_instance.
+      expects(:sale).
+      returns(braintree_error_result(message: 'Some error message'))
+    assert response = @gateway.purchase(100, credit_card("41111111111111111111"))
+    refute response.success?
+    assert_equal response.message, 'Some error message'
+  end
+
   private
 
   def braintree_result(options = {})


### PR DESCRIPTION
Extra Braintree error messaging

If we can't find an error message from the other methods then we can fall back
to this.

The braintree gem has provided `Braintree::ErrorResult#message` since
version 2.4.0 from July 9, 2010:
https://github.com/braintree/braintree_ruby/blob/2.59.0/CHANGELOG.rdoc#240

See also:
https://developers.braintreepayments.com/reference/general/result-objects/ruby#error-results
which says:

> The errors result object will only be populated if the error is due
> to a failed validation.
> ...
> The message on the error result gives a human-readable description
> of what went wrong, regardless of the cause and nature of the error.
> The message can contain multiple error messages.
> Note: This was added in version 2.4.0

FYI: In `lib/active_merchant/billing/gateways/braintree_blue.rb` I required version 2.4.0 because that's where this feature was introduced in the Braintree gem, but version `2.50.0` is already [required by the ActiveMerchant Gemfile](https://github.com/activemerchant/active_merchant/blob/a405e03/Gemfile#L8).