### PR TITLE
Cashnet: Don't retry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,7 +33,7 @@
 * NMI: Fix refunds and voids of echecks [duff]
 * VisaNet Peru: Pass dummy email when not present [curiousepic]
 * PayU India: Add Maestro as supported card [curiousepic]
-
+* Cashnet: Don't retry [duff]
 
 == Version 1.58.0 (March 1, 2016)
 * Move Electron check out of CreditCard into CreditCardMethods [ThereExistsX]

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -10,6 +10,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url        = "http://www.higherone.com/"
       self.display_name        = "Cashnet"
       self.money_format        = :dollars
+      self.max_retries         = 0
 
       # Creates a new CashnetGateway
       #


### PR DESCRIPTION
If we timeout on doing the HTTP GET on a transaction, don't retry it
because Cashnet will run the transaction again.