### PR TITLE
Added contactless-magstripe option to credit_card model

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Remove AN and KV country codes as they're not recognized by ISO-3166-1 [apdunston]
 * Worldpay: Pass unchanged amount with correct currency exponent [curiousepic]
 * Improve our handling of currencies sans fractions [duff]
+* Stripe: Added support for the contactless magstripe entry mode option [rbalsdon]
 
 
 == Version 1.58.0 (March 1, 2016)

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -182,10 +182,15 @@ module ActiveMerchant #:nodoc:
       # @return [String]
       attr_accessor :fallback_reason
 
-      # Returns or sets whether card-present card data has been read contactlessly.
+      # Returns or sets whether card-present EMV data has been read contactlessly.
       #
       # @return [true, false]
-      attr_accessor :contactless
+      attr_accessor :contactless_emv
+
+      # Returns or sets whether card-present magstripe data has been read contactlessly.
+      #
+      # @return [true, false]
+      attr_accessor :contactless_magstripe
 
       # Returns the ciphertext of the card's encrypted PIN.
       #

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -340,7 +340,8 @@ module ActiveMerchant #:nodoc:
         card = {}
         if emv_payment?(creditcard)
           add_emv_creditcard(post, creditcard.icc_data)
-          post[:card][:read_method] = "contactless" if creditcard.contactless
+          post[:card][:read_method] = "contactless" if creditcard.contactless_emv
+          post[:card][:read_method] = "contactless_magstripe_mode" if creditcard.contactless_magstripe
           if creditcard.encrypted_pin_cryptogram.present? && creditcard.encrypted_pin_ksn.present?
             post[:card][:encrypted_pin] = creditcard.encrypted_pin_cryptogram
             post[:card][:encrypted_pin_key_id] = creditcard.encrypted_pin_ksn
@@ -349,7 +350,8 @@ module ActiveMerchant #:nodoc:
           if creditcard.respond_to?(:track_data) && creditcard.track_data.present?
             card[:swipe_data] = creditcard.track_data
             card[:fallback_reason] = creditcard.fallback_reason if creditcard.fallback_reason
-            card[:read_method] = "contactless" if creditcard.contactless
+            card[:read_method] = "contactless" if creditcard.contactless_emv
+            post[:read_method] = "contactless_magstripe_mode" if creditcard.contactless_magstripe
           else
             card[:number] = creditcard.number
             card[:exp_month] = creditcard.month

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -770,12 +770,21 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_contactless_flag_is_included_with_emv_card_data
+  def test_contactless_emv_flag_is_included_with_emv_card_data
     stub_comms(@gateway, :ssl_request) do
-      @emv_credit_card.contactless = true
+      @emv_credit_card.contactless_emv = true
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       data =~ /card\[read_method\]=contactless/
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_contactless_magstripe_flag_is_included_with_emv_card_data
+    stub_comms(@gateway, :ssl_request) do
+      @emv_credit_card.contactless_magstripe = true
+      @gateway.purchase(@amount, @emv_credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      data =~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
 
@@ -783,7 +792,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      data !~ /card\[read_method\]=contactless/
+      data !~ /card\[read_method\]=contactless/ && data !~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
This is needed to select between the `contactless` and `contactless_magstripe_mode` read methods in the Stripe endpoint.