### PR TITLE
Added BIN2 regex range to Mastercard brand detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@
 * BlueSnap: Add gateway [duff]
 * VisaNet Peru: Select the most meaningful gateway error message [shasum]
 * SecurionPay: Update country list [duff]
+* Support for BIN 2 MasterCard brand detection [rbalsdon]
 
 
 == Version 1.58.0 (March 1, 2016)

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
     module CreditCardMethods
       CARD_COMPANIES = {
         'visa'               => /^4\d{12}(\d{3})?(\d{3})?$/,
-        'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
+        'master'             => /^(5[1-5]\d{4}|677189|222[1-9]\d{2}|22[3-9]\d{3}|2[3-6]\d{4}|27[01]\d{3}|2720\d{2})\d{10}$/,
         'discover'           => /^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/,
         'american_express'   => /^3[47]\d{13}$/,
         'diners_club'        => /^3(0[0-5]|[68]\d)\d{11}$/,

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -193,6 +193,7 @@ class CreditCardTest < Test::Unit::TestCase
   def test_should_correctly_identify_card_brand
     assert_equal 'visa',             CreditCard.brand?('4242424242424242')
     assert_equal 'american_express', CreditCard.brand?('341111111111111')
+    (222100..272099).each {|bin| assert_equal 'master', CreditCard.brand?(bin.to_s + '1111111111'), "Failed with BIN #{bin}"}
     assert_nil CreditCard.brand?('')
   end
 


### PR DESCRIPTION
Small snippet from the Mastercard Announcement for context:
> *Supporting Economic Growth with a New BIN Range Expansion*
> To help ensure that MasterCard and its customers are best positioned to enable the next generations of payments, MasterCard is expanding the Bank Identification Number (BIN) range by introducing a new range of 2 series BINs (222100–272099) that will be processed in the same manner as the MasterCard 51–55 series BINs are processed today.

A test with the PAN used in the test addition is now part of the M/Chip certification suite (and is currently failing).

Review please @lyverovski and @davidseal or @bizla 
Ping @girasquid @aprofeit and @rwdaigle