### PR TITLE
Fix regression for storing stripe cards from tokens.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -167,7 +167,7 @@ module ActiveMerchant #:nodoc:
         params = {}
         post = {}
 
-        if card_brand(payment) == "check"
+        if !payment.is_a?(String) && card_brand(payment) == "check"
           bank_token_response = tokenize_bank_account(payment)
           if bank_token_response.success?
             params = { source: bank_token_response.params["token"]["id"] }

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -306,6 +306,24 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_match "The customer's bank account must be verified", purchase.message
   end
 
+  def test_store_card_from_token
+    test_card = {
+      card: {
+        number: "4242424242424242",
+        exp_month: "12",
+        exp_year: Date.current.year + 5,
+        cvv: "123"
+      }
+    }
+
+    tokenized_card = @gateway.send(:api_request, :post, "tokens?#{test_card.to_query}")
+    assert_equal(tokenized_card["error"], nil)
+    assert(tokenized_card["id"])
+
+    store = @gateway.store(tokenized_card["id"])
+    assert_success(store)
+  end
+
   def test_successful_purchase_from_stored_and_verified_bank_account
     store = @gateway.store(@check)
     assert_success store

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -37,6 +37,15 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_store_with_string_card_token
+    @gateway.expects(:ssl_request).returns(successful_new_customer_response)
+    @gateway.expects(:add_creditcard).with({}, "test_token", {})
+
+    assert response = @gateway.store("test_token")
+    assert_instance_of Response, response
+    assert_success response
+  end
+
   def test_successful_new_customer_with_apple_pay_payment_token
     @gateway.expects(:ssl_request).returns(successful_new_customer_response)
     @gateway.expects(:tokenize_apple_pay_token).returns(Response.new(true, nil, token: successful_apple_pay_token_exchange))


### PR DESCRIPTION
Previously, we could pass in string tokens we received from the frontend
via Stripe.js into the store method. In fact, there is explicit message
handling in `add_creditcard` to handle the case where this is a string. This worked in version 1.48, but does not work in the upgrade to version 1.58. This case is used in https://github.com/solidusio/solidus for the gateway extension.

When `StripePaymentToken` and the `card_brand` method were added, two
things happened:

Firstly, card_brand expects the argument or "payment" to respond to `type` or
`brand` which by default breaks the existing functionality for strings
and raises a `NoMethodError` exception.

Secondly, while a `StripePaymentToken` construct has been provided, it
can't be used as the argument here. While it passes the card_brand
check without throwing an exception the logic falls through to calling
`add_creditcard` where the payment argument is a `StripePaymentToken`.

In this scenario, if it were to work, the argument would have to be
`payment.payment_data` as that's what contains the actual token for
add_creditcard to work.

Additionally, the payment token construct is defined in the private
interace which leads me to believe it should not be directly used.

To ensure backwards compatability, I added the support for string tokens
back, but I wouldn't mind passing an actual object in the future.
However, that sort of change should be reserved for a major release, or
kept backwards compatible.