### PR TITLE
Update Elavon Integration: Remove customer code, default sales taxes to zero

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_salestax(form, options)
-        form[:salestax] = options[:tax] if options[:tax].present?
+        form[:salestax] =(options[:tax].present? options[:tax] : 0)
       end
 
       def add_address(form, options)

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -254,7 +254,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_salestax(form, options)
-        form[:salestax] =(options[:tax].present? options[:tax] : 0)
+        form[:salestax] = 0
+        form[:salestax] options[:tax] if options[:tax].present?
       end
 
       def add_address(form, options)

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -255,7 +255,7 @@ module ActiveMerchant #:nodoc:
 
       def add_salestax(form, options)
         form[:salestax] = 0
-        form[:salestax] options[:tax] if options[:tax].present?
+        form[:salestax] = options[:tax] if options[:tax].present?
       end
 
       def add_address(form, options)

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -251,7 +251,6 @@ module ActiveMerchant #:nodoc:
 
       def add_customer_data(form, options)
         form[:email] = options[:email].to_s.slice(0, 100) unless options[:email].blank?
-        form[:customer_code] = options[:customer].to_s.slice(0, 10) unless options[:customer].blank?
       end
 
       def add_salestax(form, options)


### PR DESCRIPTION
The Elavon Customer Code is being set as the first ten characters of the customer email. This is incorrect; we do not have a field in Shopify for Customer Code, so generating an incorrect one based on email address is interfering with merchant transactions (specifically, refunds fail for invalid customer code).

As well, refunds on tax-exempt items fail if the tax value is nil; we need to default it to zero instead.

Based on a ZD issue; ping me for context.