### PR TITLE
Clearhaus: Copy private_key when stripping

### DIFF
--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options={})
         requires!(options, :api_key)
-        options[:private_key].strip! if options[:private_key]
+        options[:private_key] = options[:private_key].strip if options[:private_key]
         super
       end
 


### PR DESCRIPTION
Modifying it in place was causing issues with frozen strings.

@duff to confirm and merge.