### PR TITLE
Adding customer_ip for authorize action in quickpay

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
@@ -141,7 +141,7 @@ module QuickpayCommon
     
     10 => {
       :authorize => %w(mobile_number acquirer autofee customer_id extras 
-                       zero_auth),
+                       zero_auth customer_ip),
       :capture   => %w( extras ),
       :cancel    => %w( extras ),
       :refund    => %w( extras ),

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -7,7 +7,7 @@ class QuickpayV10Test < Test::Unit::TestCase
     @gateway = QuickpayGateway.new(:api_key => 'APIKEY', :login => 123)
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :order_id => '1', :billing_address => address}
+    @options = { :order_id => '1', :billing_address => address, :customer_ip => '1.1.1.1' }
   end
   
   def parse body
@@ -48,8 +48,10 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert_equal 1145, response.authorization
       assert response.test?
     end.check_request do |endpoint, data, headers|
-      if parse(data)['order_id']
+      parsed_data = parse(data)
+      if parsed_data['order_id']
         assert_match %r{/payments}, endpoint
+        assert_match "1.1.1.1", @options[:customer_ip]
       else
         assert_match %r{/payments/\d+/authorize}, endpoint
       end


### PR DESCRIPTION
This PR adds support for sending `customer_ip` param in `authorize` action (QuickPay v10 Gateway).

Here is the api doc  - [POST /payments/:id/authorize](http://tech.quickpay.net/api/services/?scope=merchant#POST-payments--id-authorize---format-), `customer_ip` is defined as an optional param. 