### PR TITLE
Add missing features for Litle

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -75,8 +75,17 @@ module ActiveMerchant #:nodoc:
           add_authentication(doc)
           add_descriptor(doc, options)
           doc.credit(transaction_attributes(options)) do
-            doc.litleTxnId(transaction_id)
-            doc.amount(money) if money
+            if authorization
+              doc.litleTxnId(transaction_id)
+              doc.amount(money) if money
+            elsif options[:litle_token]
+              doc.orderId(truncate(options[:order_id], 24))
+              doc.amount(money) if money
+              doc.orderSource(options.fetch(:order_source, 'ecommerce'))
+              doc.token do
+                doc.litleToken(options[:litle_token])
+              end
+            end
           end
         end
 

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -27,7 +27,34 @@ class LitleTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
+      @gateway.purchase(@amount, "token")
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "100000000000000006;sale", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_token
+    response = stub_comms do
+      @gateway.purchase(@amount, "token0009")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<token>\s*<litleToken>token0009<), data)
+      assert_not_match(%r(<expDate>), data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "100000000000000006;sale", response.authorization
+    assert response.test?
+  end
+
+  def test_successfull_purchase_with_token_and_expdate
+    response = stub_comms do
+      @gateway.purchase(@amount, "token0009", { :exp_month => "01", exp_year: "2017"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<expDate>0117<), data)
     end.respond_with(successful_purchase_response)
 
     assert_success response

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -170,6 +170,17 @@ class LitleTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_successful_token_refund
+    refund = stub_comms do
+      @gateway.refund(@amount, nil, litle_token: '100000000000000007' )
+    end.check_request do |endpoint, data, headers|
+      assert_match(/100000000000000007/, data)
+      assert_match(/ecommerce/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
   def test_failed_refund
     response = stub_comms do
       @gateway.refund(@amount, "SomeAuthorization")


### PR DESCRIPTION
This PR adds enhances the Little Gateway refund method by allowing refunding a tokenized credit card and passing an optional expiration date on purchase.

This PR is adding the purchase expiration date when using a credit card token, because even the docs saying it is optional some banks requires the expiration date in order to complete the purchase transaction.

See https://www.vantiv.com/content/dam/vantiv/developers/Vantiv_LitleXML_Reference_Guide_XML10.1_V1.1.pdf  in **4.162 expDate:**

```
Although the schema defines the expDate element as an optional child of
the card, token and paypage elements, you must submit a value for
card-not-present transactions.
```
