### PR TITLE
Quickpay v10: Remove amount requirement for store

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -118,10 +118,8 @@ module ActiveMerchant
         end
 
         def authorize_store(identification, credit_card, options = {})
-          requires!(options, :amount)
           post = {}
 
-          add_amount(post, nil, options)
           add_credit_card_or_reference(post, credit_card, options)
           commit(synchronized_path("/cards/#{identification}/authorize"), post)
         end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -773,11 +773,11 @@ quickbooks:
 # Quickpay offers a test account.
 # To log in to the manager, use demo@quickpay.net and test234
 quickpay:
-  login: 89898978
-  password: "29p61DveBZ79c3144LW61lVz1qrwk2gfAFCxPyi5sn49m3Y3IRK5M6SN5d8a68u7"
+  login: 15936
+  password: "965fa95aa8ba44fb736053631703071b4e1e7a2beb64ab2bef83dde49b68bb2f"
 
 quickpay_v10_api_key:
-  api_key: "03508e7791ba6c9d0e6830716e650f35c4342c4b3576723ad556e236ca4c7788"
+  api_key: "6e4e4f0a7cf692b0118ffe2c56c45b0cd3171badf65626de2ead023fd99b8bbc"
 
 # To get the right apikey, log in to the manager.
 # Go to Indstillinger > API adgang and make sure you have the right key in the fixture.

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -163,19 +163,19 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@valid_card, @options.merge(:amount => @amount))
+    assert response = @gateway.store(@valid_card, @options)
     assert_success response
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@valid_card, @options.merge(:amount => @amount))
+    assert store = @gateway.store(@valid_card, @options)
     assert_success store
     assert purchase = @gateway.purchase(@amount, store.authorization, @options)
     assert_success purchase
   end
 
   def test_successful_unstore
-    assert response = @gateway.store(@valid_card, @options.merge(:amount => @amount))
+    assert response = @gateway.store(@valid_card, @options)
     assert_success response
 
     assert response = @gateway.unstore(response.authorization)

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -76,7 +76,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   def test_unsuccessful_purchase_with_invalid_acquirers
     assert response = @gateway.purchase(@amount, @valid_card, @options.update(:acquirer => "invalid"))
     assert_failure response
-    assert_equal 'Validation error: Unknown acquirer name', response.message
+    assert_equal 'Validation error', response.message
   end
 
   def test_unsuccessful_authorize_with_invalid_card
@@ -106,10 +106,9 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    assert response = @gateway.capture(@amount, '*****')
+    assert response = @gateway.capture(@amount, '1111')
     assert_failure response
-    assert_equal 'Validation error', response.message
-    assert_equal 'is invalid', response.params['errors']['id'][0]
+    assert_equal 'Unknown error - please contact QuickPay', response.message
   end
 
   def test_successful_purchase_and_void

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -86,7 +86,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def test_successful_store
     stub_comms do
-      assert response = @gateway.store(@credit_card, @options.merge(:amount => @amount))
+      assert response = @gateway.store(@credit_card, @options)
       assert_success response
       assert response.test?
     end.check_request do |endpoint, data, headers|


### PR DESCRIPTION
When the store action replaced subscriptions, a requirement for amount
was left in unnecessarily, causing errors when not provided.

@duff to confirm and merge