### PR TITLE
Stripe: Remove metadata restriction from EMV transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -287,7 +287,6 @@ module ActiveMerchant #:nodoc:
         unless emv_payment?(payment)
           add_amount(post, money, options, true)
           add_customer_data(post, options)
-          add_metadata(post, options)
           post[:description] = options[:description]
           post[:statement_descriptor] = options[:statement_description]
           post[:receipt_email] = options[:receipt_email] if options[:receipt_email]
@@ -295,6 +294,7 @@ module ActiveMerchant #:nodoc:
           add_flags(post, options)
         end
 
+        add_metadata(post, options)
         add_application_fee(post, options)
         add_destination(post, options)
         post

--- a/test/remote/gateways/remote_stripe_emv_test.rb
+++ b/test/remote/gateways/remote_stripe_emv_test.rb
@@ -143,4 +143,9 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
     assert_success void
   end
 
+  def test_authorization_emv_credit_card_in_us_with_metadata
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"}))
+    assert_success authorization
+  end
 end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -690,6 +690,30 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_purchase
+    stub_comms(@gateway, :ssl_request) do
+      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
+      @gateway.purchase(@amount, @emv_credit_card, updated_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
+      assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
+      assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
+      assert_match(/metadata\[order_id\]=42/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_authorize
+    stub_comms(@gateway, :ssl_request) do
+      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
+      @gateway.authorize(@amount, @emv_credit_card, updated_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
+      assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
+      assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
+      assert_match(/metadata\[order_id\]=42/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_add_address
     post = {:card => {}}
     @gateway.send(:add_address, post, @options)


### PR DESCRIPTION
Closes https://github.com/activemerchant/active_merchant/issues/2080. 

During development of the EMV APIs for Stripe, metadata was not submitted. Now that EMV is live, this patch restores metadata submission for all transactions. 

**To do:**
- [x] Perform remote test (I'll do this) 
- [x] Code review @ryanbalsdon @timbeiko 

/cc @Amos47