### PR TITLE
Fixing a copy-paste error in the Stripe handling of track-only contactless EMV data

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -361,7 +361,7 @@ module ActiveMerchant #:nodoc:
             card[:swipe_data] = creditcard.track_data
             card[:fallback_reason] = creditcard.fallback_reason if creditcard.fallback_reason
             card[:read_method] = "contactless" if creditcard.contactless_emv
-            post[:read_method] = "contactless_magstripe_mode" if creditcard.contactless_magstripe
+            card[:read_method] = "contactless_magstripe_mode" if creditcard.contactless_magstripe
           else
             card[:number] = creditcard.number
             card[:exp_month] = creditcard.month

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -585,8 +585,10 @@ class StripeTest < Test::Unit::TestCase
   def test_add_creditcard_with_track_data
     post = {}
     @credit_card.stubs(:track_data).returns("Tracking data")
+    @credit_card.stubs(:contactless_magstripe).returns(true)
     @gateway.send(:add_creditcard, post, @credit_card, {})
     assert_equal @credit_card.track_data, post[:card][:swipe_data]
+    assert_equal "contactless_magstripe_mode", post[:card][:read_method]
     assert_nil post[:card][:number]
     assert_nil post[:card][:exp_year]
     assert_nil post[:card][:exp_month]


### PR DESCRIPTION
I think the title says it all! This was a really dumb mistake on my part... Fortunately, using raw track data for Contactless EMV transactions is not legal so this fix is not a high-priority.
