### PR TITLE
Cyber source should store all response elements correctly

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -699,8 +699,8 @@ module ActiveMerchant #:nodoc:
         Response.new(success, message, response,
           :test => test?,
           :authorization => authorization,
-          :avs_result => { :code => response[:avsCode] },
-          :cvv_result => response[:cvCode]
+          :avs_result => { :code => (response[:ccAuthReply] && response[:ccAuthReply][:avsCode]) },
+          :cvv_result => (response[:ccAuthReply] && response[:ccAuthReply][:cvCode])
         )
       end
 
@@ -722,20 +722,24 @@ module ActiveMerchant #:nodoc:
           parse_element(reply, root)
           reply[:message] = "#{reply[:faultcode]}: #{reply[:faultstring]}"
         end
+
         return reply
       end
 
       def parse_element(reply, node)
+        node_name = node.name.to_sym
         if node.has_elements?
-          node.elements.each{|e| parse_element(reply, e) }
+          reply[node_name] = {}
+          node.elements.each{|e| parse_element(reply[node_name], e) }
         else
           if node.parent.name =~ /item/
             parent = node.parent.name + (node.parent.attributes["id"] ? "_" + node.parent.attributes["id"] : '')
             reply[(parent + '_' + node.name).to_sym] = node.text
           else
-            reply[node.name.to_sym] = node.text
+            reply[node_name] = node.text
           end
         end
+
         return reply
       end
     end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -447,17 +447,133 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def successful_purchase_response
     <<-XML
-<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header>
-<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690"><wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26"><c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode><c:requestID>2004333231260008401927</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>123456</c:authorizationCode><c:avsCode>Y</c:avsCode><c:avsCodeRaw>Y</c:avsCodeRaw><c:cvCode>M</c:cvCode><c:cvCodeRaw>M</c:cvCodeRaw><c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime><c:processorResponse>00</c:processorResponse><c:authFactorCode>U</c:authFactorCode></c:ccAuthReply></c:replyMessage></soap:Body></soap:Envelope>
+    <?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Header>
+            <wsse:Security
+                xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+                <wsu:Timestamp
+                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690">
+                    <wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created>
+                </wsu:Timestamp>
+            </wsse:Security>
+        </soap:Header>
+        <soap:Body>
+            <c:replyMessage
+                xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26">
+                <c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode>
+                <c:requestID>2004333231260008401927</c:requestID>
+                <c:decision>ACCEPT</c:decision>
+                <c:reasonCode>100</c:reasonCode>
+                <c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken>
+                <c:purchaseTotals>
+                    <c:currency>USD</c:currency>
+                </c:purchaseTotals>
+                <c:ccAuthReply>
+                    <c:reasonCode>100</c:reasonCode>
+                    <c:amount>1.00</c:amount>
+                    <c:authorizationCode>123456</c:authorizationCode>
+                    <c:avsCode>Y</c:avsCode>
+                    <c:avsCodeRaw>Y</c:avsCodeRaw>
+                    <c:cvCode>M</c:cvCode>
+                    <c:cvCodeRaw>M</c:cvCodeRaw>
+                    <c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime>
+                    <c:processorResponse>00</c:processorResponse>
+                    <c:authFactorCode>U</c:authFactorCode>
+                </c:ccAuthReply>
+                <c:ccCaptureReply>
+                    <c:reasonCode>100</c:reasonCode>
+                    <c:requestDateTime>2008-01-15T21:42:03Z</c:requestDateTime>
+                    <c:amount>1.00</c:amount>
+                    <c:reconciliationID>4660871002726091204009</c:reconciliationID>
+                </c:ccCaptureReply>
+                <c:decisionReply>
+                    <c:casePriority>3</c:casePriority>
+                    <c:activeProfileReply>
+                        <c:selectedBy>Default Active Profile</c:selectedBy>
+                        <c:name>[NI] High Risk</c:name>
+                        <c:rulesTriggered>
+                            <c:ruleResultItem>
+                                <c:name>[NI] MORPH-C +score</c:name>
+                                <c:decision>IGNORE</c:decision>
+                                <c:evaluation>T</c:evaluation>
+                            </c:ruleResultItem>
+                            <c:ruleResultItem>
+                                <c:name>[NI] VEL-NAME + score</c:name>
+                                <c:decision>IGNORE</c:decision>
+                                <c:evaluation>T</c:evaluation>
+                            </c:ruleResultItem>
+                        </c:rulesTriggered>
+                    </c:activeProfileReply>
+                    <c:velocityInfoCode>GVEL-R13^GVEL-R11</c:velocityInfoCode>
+                </c:decisionReply>
+            </c:replyMessage>
+        </soap:Body>
+    </soap:Envelope>
     XML
   end
 
   def successful_authorization_response
     <<-XML
-<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header>
-<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-32551101"><wsu:Created>2007-07-12T18:31:53.838Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26"><c:merchantReferenceCode>TEST11111111111</c:merchantReferenceCode><c:requestID>1842651133440156177166</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>AP4JY+Or4xRonEAOERAyMzQzOTEzMEM0MFZaNUZCBgDH3fgJ8AEGAMfd+AnwAwzRpAAA7RT/</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>004542</c:authorizationCode><c:avsCode>A</c:avsCode><c:avsCodeRaw>I7</c:avsCodeRaw><c:authorizedDateTime>2007-07-12T18:31:53Z</c:authorizedDateTime><c:processorResponse>100</c:processorResponse><c:reconciliationID>23439130C40VZ2FB</c:reconciliationID></c:ccAuthReply></c:replyMessage></soap:Body></soap:Envelope>
+    <?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Header>
+            <wsse:Security
+                xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+                <wsu:Timestamp
+                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690">
+                    <wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created>
+                </wsu:Timestamp>
+            </wsse:Security>
+        </soap:Header>
+        <soap:Body>
+            <c:replyMessage
+                xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26">
+                <c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode>
+                <c:requestID>2004333231260008401927</c:requestID>
+                <c:decision>ACCEPT</c:decision>
+                <c:reasonCode>100</c:reasonCode>
+                <c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken>
+                <c:purchaseTotals>
+                    <c:currency>USD</c:currency>
+                </c:purchaseTotals>
+                <c:ccAuthReply>
+                    <c:reasonCode>100</c:reasonCode>
+                    <c:amount>1.00</c:amount>
+                    <c:authorizationCode>123456</c:authorizationCode>
+                    <c:avsCode>Y</c:avsCode>
+                    <c:avsCodeRaw>Y</c:avsCodeRaw>
+                    <c:cvCode>M</c:cvCode>
+                    <c:cvCodeRaw>M</c:cvCodeRaw>
+                    <c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime>
+                    <c:processorResponse>00</c:processorResponse>
+                    <c:authFactorCode>U</c:authFactorCode>
+                </c:ccAuthReply>
+                <c:decisionReply>
+                    <c:casePriority>3</c:casePriority>
+                    <c:activeProfileReply>
+                        <c:selectedBy>Default Active Profile</c:selectedBy>
+                        <c:name>[NI] High Risk</c:name>
+                        <c:rulesTriggered>
+                            <c:ruleResultItem>
+                                <c:name>[NI] MORPH-C +score</c:name>
+                                <c:decision>IGNORE</c:decision>
+                                <c:evaluation>T</c:evaluation>
+                            </c:ruleResultItem>
+                            <c:ruleResultItem>
+                                <c:name>[NI] VEL-NAME + score</c:name>
+                                <c:decision>IGNORE</c:decision>
+                                <c:evaluation>T</c:evaluation>
+                            </c:ruleResultItem>
+                        </c:rulesTriggered>
+                    </c:activeProfileReply>
+                    <c:velocityInfoCode>GVEL-R13^GVEL-R11</c:velocityInfoCode>
+                </c:decisionReply>
+            </c:replyMessage>
+        </soap:Body>
+    </soap:Envelope>
     XML
   end
 


### PR DESCRIPTION
I got the response from CyberSource that contains multiple 'DECISION' elements in xml (you can find them in updated tests). Due to existing logic in AM module the last parsed decision will be used as a value to see if transaction was 'successful'.

In this PR we store all values according to its hierarchy e.g.:

``` xml
<c:authReply>
  <c:something>bla</c:something>
</c:authReply>
```

will be stored in response as [:authReply][:something] thus we do not overwrite values randomly... and can access values we want.

**Warning** It breaks existing integrations if you use more than just items from 'replyMessage'. Probably alternative fixes are more appropriate due to this incompatibility.... I would like to get some feedback on it.

P.S. here are two alternative ways to fix this:
1. `reply[node.name.to_sym] = node.text unless reply[node.name.to_sym]` durty but tests pass
2. 

```
      def parse(xml)
        reply = {}
        xml = REXML::Document.new(xml)
        if root = REXML::XPath.first(xml, "//c:replyMessage")
          root.elements.to_a.each do |node|
              parse_element(reply, node)
          end
          reply[:decision] = REXML::XPath.first(root, "c:decision").text
          reply[:message] = REXML::XPath.first(root, "c:reasonCode").text
        elsif root = REXML::XPath.first(xml, "//soap:Fault")
          parse_element(reply, root)
          reply[:message] = "#{reply[:faultcode]}: #{reply[:faultstring]}"
        end
        return reply
      end
```

means we parse and store values as it was before (overwriting values ...) but decision and message are taken from the right place. But if c:decision or c:reasonCode do not exist then this method will fail (undefined method `text' for nil:NilClass). 
