### PR TITLE
TNS: Support asia_pacific endpoint

### DIFF
--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -1,11 +1,14 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class TnsGateway < Gateway
+      class_attribute :live_na_url, :live_ap_url
+
       self.display_name = 'TNS'
       self.homepage_url = 'http://www.tnsi.com/'
 
       # Testing is partitioned by account.
-      self.live_url = 'https://secure.na.tnspayments.com/api/rest/version/22/'
+      self.live_na_url = 'https://secure.na.tnspayments.com/api/rest/version/22/'
+      self.live_ap_url = 'https://secure.ap.tnspayments.com/api/rest/version/22/'
 
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
 
@@ -14,6 +17,9 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options={})
         requires!(options, :userid, :password)
+
+        options[:region] = 'north_america' unless options[:region]
+
         super
       end
 
@@ -174,7 +180,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_url(orderid, transactionid)
-        "#{live_url}merchant/#{@options[:userid]}/order/#{orderid}/transaction/#{transactionid}"
+        base_url = @options[:region] == 'asia_pacific' ? live_ap_url : live_na_url
+        "#{base_url}merchant/#{@options[:userid]}/order/#{orderid}/transaction/#{transactionid}"
       end
 
       def build_request(post = {})

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -963,6 +963,10 @@ tns:
   userid: TESTSPREEDLY01
   password: 3f34fe50334fbe6cbe04c283411a5860
 
+tns_ap:
+  userid: TESTUNISOLMAA01
+  password: b7f8119fda3bd27c17656badb52c95bb
+
 trans_first:
   login: 45567
   password: TNYYKYMFZ59HSN7Q

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -6,6 +6,7 @@ class RemoteTnsTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('5123456789012346')
+    @ap_credit_card = credit_card('5424180279791732', month: 05, year: 2017, verification_value: 222)
     @declined_card = credit_card('4000300011112220')
 
     @options = {
@@ -38,6 +39,15 @@ class RemoteTnsTest < Test::Unit::TestCase
     assert_equal "Succeeded", response.message
   end
 
+  # The region-specific credentials will fail OpenSSL certificate verification
+  # To test, in connection.rb, configure_ssl's verify_mode must be VERIFY_NONE
+  def test_successful_purchase_with_region
+    @gateway = TnsGateway.new(fixtures(:tns_ap).merge(region: 'asia_pacific'))
+
+    assert response = @gateway.purchase(@amount, @ap_credit_card, @options.merge(currency: "AUD"))
+    assert_success response
+    assert_equal "Succeeded", response.message
+  end
 
   def test_failed_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -159,6 +159,38 @@ class TnsTest < Test::Unit::TestCase
     assert_equal "FAILURE - DECLINED", response.message
   end
 
+  def test_north_america_region_url
+    @gateway = TnsGateway.new(
+      userid: 'userid',
+      password: 'password',
+      region: 'north_america'
+    )
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/secure.na.tnspayments.com/, endpoint)
+    end.respond_with(successful_capture_response)
+
+    assert_success response
+  end
+
+  def test_asia_pacific_region_url
+    @gateway = TnsGateway.new(
+      userid: 'userid',
+      password: 'password',
+      region: 'asia_pacific'
+    )
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/secure.ap.tnspayments.com/, endpoint)
+    end.respond_with(successful_capture_response)
+
+    assert_success response
+  end
+
   private
 
   def successful_authorize_response


### PR DESCRIPTION
The remote test for this feature will fail by default.
See the comment on test_successful_purchase_with_region.

@duff to review and merge