### PR TITLE
Undefined variable in gateway generator remote test template

### DIFF
--- a/generators/gateway/templates/remote_gateway_test.rb
+++ b/generators/gateway/templates/remote_gateway_test.rb
@@ -43,7 +43,7 @@ class Remote<%= class_name %>Test < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', capture.message
   end
 
   def test_failed_authorize


### PR DESCRIPTION
In `test_successful_authorize_and_capture` test assigns the response to `capture` but `response` is used in the response message assertion. Replace `response` with `capture`.
