### PR TITLE
Stripe: Map test_mode_live_card error code to new standard error code

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -76,6 +76,7 @@ module ActiveMerchant #:nodoc:
       # :processing_error - Processor error
       # :call_issuer - Transaction requires voice authentication, call issuer
       # :pickup_card - Issuer requests that you pickup the card from merchant
+      # :test_mode_live_card - Card was declined. Request was in test mode, but used a non test card.
 
       STANDARD_ERROR_CODE = {
         :incorrect_number => 'incorrect_number',
@@ -91,7 +92,8 @@ module ActiveMerchant #:nodoc:
         :processing_error => 'processing_error',
         :call_issuer => 'call_issuer',
         :pickup_card => 'pick_up_card',
-        :config_error => 'config_error'
+        :config_error => 'config_error',
+        :test_mode_live_card => 'test_mode_live_card'
       }
 
       cattr_reader :implementations

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -42,7 +42,8 @@ module ActiveMerchant #:nodoc:
         'card_declined' => STANDARD_ERROR_CODE[:card_declined],
         'call_issuer' => STANDARD_ERROR_CODE[:call_issuer],
         'processing_error' => STANDARD_ERROR_CODE[:processing_error],
-        'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin]
+        'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin],
+        'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card]
       }
 
       BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {


### PR DESCRIPTION
Adds a new standard error code called `test_mode_live_card` and maps it from Stripe.

This is used to inform the user that they are using a real credit card number but the gateway is in test mode. We would like to translate this error to provide better UX, and we need to add the error to the list for it to be picked up as `error_code` [here](https://github.com/activemerchant/active_merchant/blob/16d8557dea8957263d72793dbb63394f3560b9e7/lib/active_merchant/billing/gateways/stripe.rb#L562-L569)

A similar PR is here #1777
Please review @bizla @girasquid 
/cc @emilienoel @Amos47