### PR TITLE
Introduce support for the new Stripe network tokenization APIs

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -369,14 +369,13 @@ module ActiveMerchant #:nodoc:
             card[:cvc] = creditcard.verification_value if creditcard.verification_value?
             card[:name] = creditcard.name if creditcard.name
           end
-          post[:card] = card
 
-          if creditcard.is_a?(NetworkTokenizationCreditCard) && creditcard.source == :apple_pay
-            post[:three_d_secure] = {
-              apple_pay:  true,
-              cryptogram: creditcard.payment_cryptogram
-            }
+          if creditcard.is_a?(NetworkTokenizationCreditCard)
+            card[:cryptogram] = creditcard.payment_cryptogram
+            card[:eci] = creditcard.eci
+            card[:tokenization_method] = creditcard.source.to_s
           end
+          post[:card] = card
 
           add_address(post, options)
         elsif creditcard.kind_of?(String)

--- a/test/remote/gateways/remote_stripe_android_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_android_pay_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class RemoteStripeAndroidPayTest < Test::Unit::TestCase
+  CHARGE_ID_REGEX = /ch_[a-zA-Z\d]{24}/
+
+  def setup
+    @gateway = StripeGateway.new(fixtures(:stripe))
+    @amount = 100
+
+    @options = {
+      :currency => "USD",
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com'
+    }
+  end
+
+  def test_successful_purchase_with_android_pay_raw_cryptogram
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil,
+      eci: '05',
+      source: :android_pay
+    )
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_auth_with_android_pay_raw_cryptogram
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil,
+      eci: '05',
+      source: :android_pay
+    )
+    assert response = @gateway.authorize(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+end

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -103,7 +103,9 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   def test_successful_purchase_with_apple_pay_raw_cryptogram
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
-      verification_value: nil
+      verification_value: nil,
+      eci: '05',
+      source: :apple_pay
     )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
@@ -117,7 +119,9 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   def test_successful_auth_with_apple_pay_raw_cryptogram
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
-      verification_value: nil
+      verification_value: nil,
+      eci: '05',
+      source: :apple_pay
     )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class RemoteStripeApplePayTest < Test::Unit::TestCase
+  CHARGE_ID_REGEX = /ch_[a-zA-Z\d]{24}/
+
   def setup
     @gateway = StripeGateway.new(fixtures(:stripe))
     @amount = 100

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -100,7 +100,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_successful_purchase_with_apple_pay_raw_cryptogram
+  def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
       verification_value: nil,
@@ -116,7 +116,22 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     assert_match CHARGE_ID_REGEX, response.authorization
   end
 
-  def test_successful_auth_with_apple_pay_raw_cryptogram
+  def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil,
+      source: :apple_pay
+    )
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
       verification_value: nil,
@@ -132,6 +147,20 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     assert_match CHARGE_ID_REGEX, response.authorization
   end
 
+  def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil,
+      source: :apple_pay
+    )
+    assert response = @gateway.authorize(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
 
 end
 


### PR DESCRIPTION
Gist of the changes:

* Supports the new network tokenization params for cryptogram, eci and payment source embedded on the card object
* Removes support for the deprecated `three_d_secure` API

@girasquid @ryanbalsdon @rwdaigle @timbeiko @elfassy 