### PR TITLE
Remove payments-dev from the travis build email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ matrix:
 
 notifications:
   email:
-  - payments-dev@shopify.com
   - nathaniel@talbott.ws


### PR DESCRIPTION
There are about twenty people on this mailing list who receive theses emails.

@timbeiko @elfassy Any issues with this? You can add your own emails if you care about receiving them.