### PR TITLE
Add SoftDescriptor field to PayPal Express

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -620,7 +620,7 @@ module ActiveMerchant #:nodoc:
         add_optional_fields(xml,
                             %w{n2:NoteText          n2:PaymentAction
                                n2:TransactionId     n2:AllowedPaymentMethod
-                               n2:PaymentRequestID  },
+                               n2:PaymentRequestID  n2:SoftDescriptor  },
                             options)
       end
 


### PR DESCRIPTION
That PR handles the error reported here: https://github.com/activemerchant/active_merchant/issues/2152