### PR TITLE
take out incorrect Pin gateway refund comment

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -44,9 +44,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'customers', post, options)
       end
 
-      # Refund a transaction, note that the money attribute is ignored at the
-      # moment as the API does not support partial refunds. The parameter is
-      # kept for compatibility reasons
+      # Refund a transaction
       def refund(money, token, options = {})
         commit(:post, "charges/#{CGI.escape(token)}/refunds", { :amount => amount(money) }, options)
       end


### PR DESCRIPTION
The Pin Gateway refund method has an incorrect comment according to the Pin gateway people themselves.  Quote:

Calum replied
Jul 25, 10:54am
Hi Mike,

Our refund API does indeed support partial refunds, so I'm not sure what active merchant is referring to. It's possible the documentation for it is out of date or is referring to a different gateway which doesn't support partial refunds. To process one via our API, just define an "amount" value in cents. You can process multiple partial refunds, up to the total of the original charge. No fees are taken to process a refund. 

Cheers,

—
Calum Niblock
Pin Payments - 1300 364 800
FAQ


So I just took out the wrong comments