### PR TITLE
Quickpay: enable recurring payments

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -16,25 +16,33 @@ module ActiveMerchant
 
       def purchase(money, credit_card_or_reference, options = {})
         MultiResponse.run(true) do |r|
+          if credit_card_or_reference.is_a?(String)
+            r.process { create_token(credit_card_or_reference, options) }
+            credit_card_or_reference = r.authorization
+          end
           r.process { create_payment(money, options) }
           r.process {
             post = authorization_params(money, credit_card_or_reference, options)
             add_autocapture(post, false)
-            commit(synchronized_path("/payments/#{r.authorization}/authorize"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/authorize"), post)
           }
           r.process {
             post = capture_params(money, credit_card_or_reference, options)
-            commit(synchronized_path("/payments/#{r.authorization}/capture"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/capture"), post)
           }
         end
       end
 
       def authorize(money, credit_card_or_reference, options = {})
         MultiResponse.run(true) do |r|
+          if credit_card_or_reference.is_a?(String)
+            r.process { create_token(credit_card_or_reference, options) }
+            credit_card_or_reference = r.authorization
+          end
           r.process { create_payment(money, options) }
           r.process {
             post = authorization_params(money, credit_card_or_reference, options)
-            commit(synchronized_path("/payments/#{r.authorization}/authorize"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/authorize"), post)
           }
         end
       end
@@ -71,12 +79,10 @@ module ActiveMerchant
         MultiResponse.run do |r|
           r.process { create_store(options) }
           r.process { authorize_store(r.authorization, credit_card, options)}
-          r.process { create_token(r.authorization, options.merge({id: r.authorization}))}
         end
       end
 
       def unstore(identification)
-        identification = identification.split(";").last
         commit(synchronized_path "/cards/#{identification}/cancel")
       end
 
@@ -150,15 +156,15 @@ module ActiveMerchant
 
           Response.new(success, message_from(success, response), response,
             :test => test?,
-            :authorization => authorization_from(response, params[:id])
+            :authorization => authorization_from(response)
           )
         end
 
-        def authorization_from(response, auth_id)
+        def authorization_from(response)
           if response["token"]
-            "#{response["token"]};#{auth_id}"
+            response["token"].to_s
           else
-             response["id"]
+             response["id"].to_s
           end
         end
 
@@ -205,8 +211,7 @@ module ActiveMerchant
         def add_credit_card_or_reference(post, credit_card_or_reference, options = {})
           post[:card]             ||= {}
           if credit_card_or_reference.is_a?(String)
-            reference = credit_card_or_reference.split(";").first
-            post[:card][:token] = reference
+            post[:card][:token] = credit_card_or_reference
           else
             post[:card][:number]     = credit_card_or_reference.number
             post[:card][:cvd]        = credit_card_or_reference.verification_value

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -174,6 +174,23 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_store_and_reference_recurring_purchase
+    assert store = @gateway.store(@valid_card, @options)
+    assert_success store
+    assert signup = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success signup
+    @options[:order_id] = generate_unique_id[0...10]
+    assert renewal = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success renewal
+  end
+
+  def test_successful_store_and_reference_authorize
+    assert store = @gateway.store(@valid_card, @options)
+    assert_success store
+    assert authorization = @gateway.authorize(@amount, store.authorization, @options)
+    assert_success authorization
+  end
+
   def test_successful_unstore
     assert response = @gateway.store(@valid_card, @options)
     assert_success response


### PR DESCRIPTION
As discussed in
- https://github.com/activemerchant/active_merchant/pull/1873 and
- https://github.com/activemerchant/active_merchant/issues/2172

The current implementation of store for QuickPay v10 is returning a single-use token, which prevents using the stored card details for recurring payments.  We should be storing the card id instead.

This moves the single-use token into 'purchase' and 'authorize' where the stored card id is swapped for a token just before the authorization/capture is done.
