### PR TITLE
CardStream: Add MXN currency code

### DIFF
--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -25,6 +25,7 @@ module ActiveMerchant #:nodoc:
         "HKD" => "344",
         "ICK" => "352",
         "JPY" => "392",
+        "MXN" => "484",
         "NOK" => "578",
         "NZD" => "554",
         "SEK" => "752",


### PR DESCRIPTION
There's an "unsupported currency" error in remote tests even for USD for no apparent reason (perhaps test account currency whitelisting), but the addition of the currency code should be safe.

@duff to confirm and merge.