### PR TITLE
Pass metadata when voiding an authorization on Stripe

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -117,6 +117,7 @@ module ActiveMerchant #:nodoc:
 
       def void(identification, options = {})
         post = {}
+        post[:metadata] = options[:metadata] if options[:metadata]
         post[:expand] = [:charge]
         commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options)
       end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -121,6 +121,17 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success void
   end
 
+  def test_successful_void_with_metadata
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization
+
+    assert void = @gateway.void(response.authorization, metadata: { test_metadata: 123 })
+    assert void.test?
+    assert_success void
+    assert_equal "123", void.params["metadata"]["test_metadata"]
+  end
+
   def test_unsuccessful_void
     assert void = @gateway.void("active_merchant_fake_charge")
     assert_failure void

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -508,6 +508,15 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_void_with_metadata
+    @gateway.expects(:ssl_request).with do |_, _, post, _|
+      post.include?("metadata[first_value]=true")
+    end.returns(successful_purchase_response(true))
+
+    assert response = @gateway.void('ch_test_charge', {metadata: {first_value: true}})
+    assert_success response
+  end
+
   def test_successful_refund
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response)
 


### PR DESCRIPTION
Currently we're not passing the metadata to Stripe when it's passed as an option. This is something we do for `sale`, `auth` and `refund` transactions. However it's missing for void.

We'd like to make use of this metadata on `void` transactions, so I'd like to add this parameter to `void` requests as well.

@girasquid @emilienoel @Amos47 @timbeiko @lyverovski 