### PR TITLE
added test for MasterCard legacy BIN range

### DIFF
--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -193,6 +193,7 @@ class CreditCardTest < Test::Unit::TestCase
   def test_should_correctly_identify_card_brand
     assert_equal 'visa',             CreditCard.brand?('4242424242424242')
     assert_equal 'american_express', CreditCard.brand?('341111111111111')
+    assert_equal 'master', CreditCard.brand?('5105105105105100')
     (222100..272099).each {|bin| assert_equal 'master', CreditCard.brand?(bin.to_s + '1111111111'), "Failed with BIN #{bin}"}
     assert_nil CreditCard.brand?('')
   end


### PR DESCRIPTION
MasterCard is adding a new valid list of credit card number ranges in Oct 2016.   This was noted in May of last year, and support added To ActiveMerchant.   This test just verifies that the old legacy range is still valid.