### PR TITLE
Remove weak hard-coded TLS versions

### DIFF
--- a/lib/active_merchant/billing/gateways/citrus_pay.rb
+++ b/lib/active_merchant/billing/gateways/citrus_pay.rb
@@ -16,7 +16,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :laser]
-      self.ssl_version = :TLSv1
 
     end
   end

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -9,7 +9,6 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ["US", "FI", "NO", "SE", "GB"]
       self.default_currency = "USD"
       self.money_format = :cents
-      self.ssl_version = :TLSv1
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/global_transport.rb
+++ b/lib/active_merchant/billing/gateways/global_transport.rb
@@ -9,7 +9,6 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(CA PR US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
-      self.ssl_version = :TLSv1
 
       self.homepage_url = 'https://www.globalpaymentsinc.com'
       self.display_name = 'Global Transport'

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -31,7 +31,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'NETbilling'
       self.homepage_url = 'http://www.netbilling.com'
       self.supported_countries = ['US']
-      self.ssl_version = :TLSv1
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
 
       def initialize(options = {})

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -141,7 +141,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Ogone'
       self.default_currency = 'EUR'
       self.money_format = :cents
-      self.ssl_version = :TLSv1
 
       def initialize(options = {})
         requires!(options, :login, :user, :password)

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -16,7 +16,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :laser]
-      self.ssl_version = :TLSv1
 
     end
   end

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -114,8 +114,12 @@ module ActiveMerchant
     def configure_ssl(http)
       return unless endpoint.scheme == "https"
 
+      ssl_options_mask = OpenSSL::SSL::OP_NO_SSLv2 + OpenSSL::SSL::OP_NO_SSLv3
+      ssl_options_mask += OpenSSL::SSL::OP_NO_COMPRESSION if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
+
       http.use_ssl = true
       http.ssl_version = ssl_version if ssl_version
+      http.ssl_options = ssl_options_mask
 
       if verify_peer
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER


### PR DESCRIPTION
All modified gateways support up to TLSv1.2, so let's not keep some capped at TLSv1.

As far as I can tell, all these gateways were forced to TLSv1 as a way to avoid SSLv3. Since then, modern versions of Ruby [only support TLSv1+](https://github.com/ruby/ruby/blob/61a3fff66141ffc0b6e384729456c6ca87f61776/ext/openssl/lib/openssl/ssl.rb#L61), so let's not punish more modern Rubys by capping the TLS version allowed by a specific gateway.

I'm also considering added specific TLS version negotiation into `Connection::configure_ssl`, so we have a consistent experience across all of AM, regardless of the underlying Ruby.

@duff @ntalbott
