### PR TITLE
Braintree: add support for Android Pay

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -576,6 +576,14 @@ module ActiveMerchant #:nodoc:
                 :cardholder_name => "#{credit_card_or_vault_id.first_name} #{credit_card_or_vault_id.last_name}",
                 :cryptogram => credit_card_or_vault_id.payment_cryptogram
               }
+          elsif credit_card_or_vault_id.source == :android_pay
+              parameters[:android_pay_card] = {
+                :number => credit_card_or_vault_id.number,
+                :cryptogram => credit_card_or_vault_id.payment_cryptogram,
+                :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
+                :expiration_year => credit_card_or_vault_id.year.to_s,
+                :google_transaction_id => options[:google_transaction_id]
+              }
             end
           else
             parameters[:credit_card] = {

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -369,6 +369,23 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_and_capture_with_android_pay_card
+    credit_card = network_tokenization_credit_card('4111111111111111',
+      :payment_cryptogram => "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      :month              => "01",
+      :year               => "2024",
+      :source             => :android_pay
+    )
+    options = @options.merge({ :google_transaction_id => "123456789" })
+
+    assert auth = @gateway.authorize(@amount, credit_card, options)
+    assert_success auth
+    assert_equal '1000 Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
   def test_authorize_and_void
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
@davidsantoso 
All unit tests passing.
Remote tests for Braintree passing.