### PR TITLE
NMI, FirstData: Add verify_credentials

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -129,6 +129,11 @@ module ActiveMerchant #:nodoc:
         commit(:store, build_store_request(credit_card, options), credit_card)
       end
 
+      def verify_credentials
+        response = void("0")
+        response.message != "Unauthorized Request. Bad or missing credentials."
+      end
+
       def supports_scrubbing?
         true
       end

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -101,6 +101,11 @@ module ActiveMerchant #:nodoc:
         commit("add_customer", post)
       end
 
+      def verify_credentials
+        response = void("0")
+        response.message != "Authentication Failed"
+      end
+
       def supports_scrubbing?
         true
       end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -295,8 +295,8 @@ first_pay:
   gateway_id: "a91c38c3-7d7f-4d29-acc7-927b4dca0dbe"
 
 firstdata_e4:
-  login:
-  password:
+  login: SD8821-67
+  password: T6bxSywbcccbJ19eDXNIGaCDOBg1W7T8
 
 flo2cash:
   username: SOMECREDENTIAL

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -217,6 +217,15 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_verify_credentials
+    assert @gateway.verify_credentials
+
+    gateway = FirstdataE4Gateway.new(login: 'unknown', password: 'unknown')
+    assert !gateway.verify_credentials
+    gateway = FirstdataE4Gateway.new(login: fixtures(:firstdata_e4)[:login], password: 'unknown')
+    assert !gateway.verify_credentials
+  end
+
   def test_dump_transcript
     # See firstdata_e4_test.rb for an example of a scrubbed transcript
   end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -209,6 +209,15 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert_success @gateway.purchase(@amount, @credit_card, @options)
   end
 
+  def test_verify_credentials
+    assert @gateway.verify_credentials
+
+    gateway = NmiGateway.new(login: 'unknown', password: 'unknown')
+    assert !gateway.verify_credentials
+    gateway = NmiGateway.new(login: fixtures(:nmi)[:login], password: 'unknown')
+    assert !gateway.verify_credentials
+  end
+
   def test_card_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Also contains fixtures for a new FirstData test account, since they were missing.

@davidsantoso to confirm and merge.