### PR TITLE
Add QUERYTXN to Elavon Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -53,6 +53,7 @@ module ActiveMerchant #:nodoc:
         :void => 'CCDELETE',
         :store => 'CCGETTOKEN',
         :update => 'CCUPDATETOKEN',
+        :query => 'TXNQUERY',
       }
 
       # Initialize the Gateway
@@ -160,6 +161,21 @@ module ActiveMerchant #:nodoc:
         add_txn_id(form, identification)
         add_test_mode(form, options)
         commit(:void, nil, form)
+      end
+
+      # Queries a transaction based on the original transaction id.
+      #
+      # This returns useful information such as trans_status which allows
+      # the client insight into whether a transaction is settled or not.
+      #
+      # ==== Parameters
+      #
+      # * <tt>identification</tt> - The ID of the original transaction.
+      def query(identification, options = {})
+        form = {}
+        add_txn_id(form, identification)
+        add_test_mode(form, options)
+        commit(:query, nil, form)
       end
 
       # Make a credit to a card.  Use the refund method if you'd like to credit using

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -196,4 +196,21 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response.test?
     assert_match %r{invalid}i, response.message
   end
+
+  def test_successful_query
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert response = @gateway.query(auth.params['txn_id'])
+
+    assert response.test?
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
+  def test_unsuccessful_query
+    assert response = @gateway.query("ABC")
+
+    assert_failure response
+    assert response.test?
+    assert_equal 'The transaction ID is invalid for this transaction type', response.message
+  end
 end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -265,6 +265,23 @@ class ElavonTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, @options)
   end
 
+  def test_successful_query
+    @gateway.expects(:ssl_post).returns(successful_query_response)
+
+    assert response = @gateway.query('123')
+    assert_success response
+    assert_equal 'APPROVAL', response.message
+    assert_equal 'OPN', response.params['trans_status']
+  end
+
+  def test_failed_query
+    @gateway.expects(:ssl_post).returns(failed_query_response)
+
+    assert response = @gateway.query('123')
+    assert_instance_of Response, response
+    assert_failure response
+  end
+
   private
   def successful_purchase_response
     "ssl_card_number=42********4242
@@ -383,7 +400,7 @@ class ElavonTest < Test::Unit::TestCase
     errorName=Credit Card Number Invalid
     errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
   end
-  
+
   def successful_capture_response
     "ssl_card_number=42********4242
     ssl_exp_date=0910
@@ -450,5 +467,29 @@ class ElavonTest < Test::Unit::TestCase
     "errorCode=5000
     errorName=Credit Card Number Invalid
     errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+  end
+
+  def successful_query_response
+    "ssl_txn_id=456
+    ssl_trans_status=OPN
+    ssl_transaction_type=SALE
+    ssl_is_voidable=TRUE
+    ssl_card_number=42********4242
+    ssl_exp_date=0910
+    ssl_amount=1.00
+    ssl_description=Test Transaction
+    ssl_result=0
+    ssl_result_message=APPROVAL
+    ssl_approval_code=123456
+    ssl_cvv2_response=P
+    ssl_avs_response=X
+    ssl_account_balance=0.00
+    ssl_txn_time=08/07/2009 09:54:18 PM"
+  end
+
+  def failed_query_response
+    "errorCode=5040
+    errorName=Invalid Transaction ID
+    errorMessage=The transaction ID is invalid for this transaction type"
   end
 end


### PR DESCRIPTION
The Elavon/Converge developer's guide
(https://www.myvirtualmerchant.com/VirtualMerchant/download/developerGuide.pdf)
supports the method TXNQUERY which allows (as one option) a
transaction_id to be passed to the API and returns status information
such as the current status of the transaction.

Currently, ElavonGateway does not support this. This commit adds the
query method, which takes in a transaction_id and sets up the mapping
for query to TXNQUERY.

This is useful for being able to determine if a transaction is still
open or if it has been settled already, which you may want to know before
attempting a void or a refund.