### PR TITLE
Braintree: update Android Pay

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -582,7 +582,7 @@ module ActiveMerchant #:nodoc:
                 :cryptogram => credit_card_or_vault_id.payment_cryptogram,
                 :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
                 :expiration_year => credit_card_or_vault_id.year.to_s,
-                :google_transaction_id => options[:google_transaction_id]
+                :google_transaction_id => credit_card_or_vault_id.transaction_id
               }
             end
           else

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -374,11 +374,11 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       :payment_cryptogram => "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
       :month              => "01",
       :year               => "2024",
-      :source             => :android_pay
+      :source             => :android_pay,
+      :transaction_id     => "123456789"
     )
-    options = @options.merge({ :google_transaction_id => "123456789" })
 
-    assert auth = @gateway.authorize(@amount, credit_card, options)
+    assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
     assert_equal '1000 Approved', auth.message
     assert auth.authorization

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -638,10 +638,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :transaction_id     => "123",
       :eci                => "05",
       :payment_cryptogram => "111111111100cryptogram",
-      :source             => :android_pay
+      :source             => :android_pay,
+      :transaction_id     => '1234567890'
     )
 
-    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1', :google_transaction_id => '1234567890')
+    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1')
     assert_equal "transaction_id", response.authorization
   end
 


### PR DESCRIPTION
The google_transaction_id should be taken from the card not from the options
All tests passing.

