### PR TITLE
Add metadata, merchant_account_id, customer to Openpay

### DIFF
--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -21,35 +21,39 @@ module ActiveMerchant #:nodoc:
         requires!(options, :key, :merchant_id)
         @api_key = options[:key]
         @merchant_id = options[:merchant_id]
+        @merchant_account_id = options[:merchant_account_id]
         super
       end
 
       def purchase(money, creditcard, options = {})
         post = create_post_for_auth_or_purchase(money, creditcard, options)
-        commit(:post, 'charges', post, options)
+        commit(:post, get_path('charges', options), post, options)
       end
 
       def authorize(money, creditcard, options = {})
         post = create_post_for_auth_or_purchase(money, creditcard, options)
         post[:capture] = false
-        commit(:post, 'charges', post, options)
+        commit(:post, get_path('charges', options), post, options)
       end
 
       def capture(money, authorization, options = {})
         post = {}
         post[:amount] = amount(money) if money
-        commit(:post, "charges/#{CGI.escape(authorization)}/capture", post, options)
+        resource = get_path("charges/#{CGI.escape(authorization)}/capture", options)
+        commit(:post, resource, post, options)
       end
 
       def void(identification, options = {})
-        commit(:post, "charges/#{CGI.escape(identification)}/refund", nil, options)
+        resource = get_path("charges/#{CGI.escape(identification)}/refund", options)
+        commit(:post, resource, nil, options)
       end
 
       def refund(money, identification, options = {})
         post = {}
         post[:description] = options[:description]
         post[:amount] = amount(money)
-        commit(:post, "charges/#{CGI.escape(identification)}/refund", post, options)
+        resource = get_path("charges/#{CGI.escape(identification)}/refund", options)
+        commit(:post, resource, post, options)
       end
 
       def store(creditcard, options = {})
@@ -57,13 +61,14 @@ module ActiveMerchant #:nodoc:
         add_creditcard(card_params, creditcard, options)
         card = card_params[:card]
 
-        if options[:customer].present?
-          commit(:post, "customers/#{CGI.escape(options[:customer])}/cards", card, options)
+        if is_customer(options)
+          commit(:post, "customers/#{CGI.escape(options[:customer][:id])}/cards", card, options)
         else
           requires!(options, :email, :name)
           post = {}
           post[:name] = options[:name]
           post[:email] = options[:email]
+          post[:requires_account] = false
           MultiResponse.run(:first) do |r|
             r.process { commit(:post, 'customers', post, options) }
 
@@ -93,37 +98,53 @@ module ActiveMerchant #:nodoc:
           gsub(%r((card_number\\?":\\?")[^"\\]*)i, '\1[FILTERED]').
           gsub(%r((cvv2\\?":\\?")[^"\\]*)i, '\1[FILTERED]')
       end
+
       private
 
       def create_post_for_auth_or_purchase(money, creditcard, options)
         post = {}
         post[:amount] = amount(money)
         post[:method] = 'card'
-        post[:description] = options[:description]
+        post[:description] = options[:description] || "Active Merchant Purchase"
         post[:order_id] = options[:order_id]
         post[:device_session_id] = options[:device_session_id]
         post[:currency] = (options[:currency] || currency(money)).upcase
+        post[:metadata] = options[:metadata]
         add_customer(post, options)
         add_creditcard(post, creditcard, options)
         post
       end
       
       def add_customer(post, options)
-        if options[:email].to_s  != ''
-          customer = {}
-          customer_name = ''
-          
-          address = options[:billing_address]
-          if !address.nil?
-            customer_name = address[:name].to_s
-            customer[:phone_number] = address[:phone]
+          if !is_customer(options)
+            if(email = options[:email])
+              customer = {}
+              customer[:email] = email
+              if (customer_opt = options[:customer])
+                customer[:external_id] = customer_opt[:external_id] if customer_opt[:external_id]
+                customer[:name] = customer_opt[:name] if customer_opt[:name]
+                customer[:last_name] = customer_opt[:last_name] if customer_opt[:last_name]
+                customer[:phone_number] = customer_opt[:phone_number] if customer_opt[:phone_number]
+              else 
+                #Customer name is required
+                customer[:name] = options[:order_id] || email
+              end
+              add_shipment_address(customer, options)
+              post[:customer] = customer
+            end
           end
-          
-          customer_name = customer_name == '' ? options[:order_id] : customer_name
-          
-          customer[:name] = customer_name
-          customer[:email] = options[:email]
-          post[:customer] = customer
+      end
+
+      def add_shipment_address(post, options)
+        if(address = options[:shipping_address])
+          post[:address] = {}
+          post[:address][:line1] = address[:address1] if address[:address1]
+          post[:address][:line2] = address[:address2] if address[:address2]
+          post[:address][:line3] = address[:name] if address[:name]
+          post[:address][:postal_code] = address[:zip] if address[:zip]
+          post[:address][:state] = address[:state] if address[:state]
+          post[:address][:city] = address[:city] if address[:city]
+          post[:address][:country_code] = address[:country] if address[:country]     
         end
       end
 
@@ -138,14 +159,14 @@ module ActiveMerchant #:nodoc:
             cvv2: creditcard.verification_value,
             holder_name: creditcard.name
           }
-          add_address(card, options)
+          add_billing_address(card, options)
           post[:card] = card
         end
       end
 
-      def add_address(card, options)
+      def add_billing_address(card, options)
         return unless card.kind_of?(Hash)
-        if address = (options[:billing_address] || options[:address])
+        if (address = (options[:billing_address] || options[:address]))
           card[:address] = {
             line1: address[:address1],
             line2: address[:address2],
@@ -156,6 +177,18 @@ module ActiveMerchant #:nodoc:
             country_code: address[:country]
           }
         end
+      end
+
+      def get_path(resource, options) 
+        if is_customer(options)
+          "customers/#{CGI.escape(options[:customer][:id])}/" + resource
+        else
+          resource
+        end
+      end
+
+      def is_customer(options) 
+        return options[:customer].present? && options[:customer].kind_of?(Hash) && options[:customer][:id].present?
       end
 
       def headers(options = {})
@@ -185,7 +218,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def http_request(method, resource, parameters={}, options={})
-        url = (test? ? self.test_url : self.live_url) + @merchant_id + '/' + resource
+        merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)   
+        account_id =  merchant_account_id.present? ? merchant_account_id : @merchant_id
+        url = (test? ? self.test_url : self.live_url) + account_id + '/' + resource
         raw_response = nil
         begin
           raw_response = ssl_request(method, url, (parameters ? parameters.to_json : nil), headers(options))
@@ -218,7 +253,7 @@ module ActiveMerchant #:nodoc:
             'error_code' => '9999',
             'description' => msg
         }
-      end
+      end    
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -102,8 +102,29 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description]
         post[:order_id] = options[:order_id]
         post[:device_session_id] = options[:device_session_id]
+        post[:currency] = (options[:currency] || currency(money)).upcase
+        add_customer(post, options)
         add_creditcard(post, creditcard, options)
         post
+      end
+      
+      def add_customer(post, options)
+        if options[:email].to_s  != ''
+          customer = {}
+          customer_name = ''
+          
+          address = options[:billing_address]
+          if !address.nil?
+            customer_name = address[:name].to_s
+            customer[:phone_number] = address[:phone]
+          end
+          
+          customer_name = customer_name == '' ? options[:order_id] : customer_name
+          
+          customer[:name] = customer_name
+          customer[:email] = options[:email]
+          post[:customer] = customer
+        end
       end
 
       def add_creditcard(post, creditcard, options)

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -16,6 +16,13 @@ class OpenpayTest < Test::Unit::TestCase
     @options = {
       order_id: '1234567890',
       billing_address: address,
+      description: 'Store Purchase',
+      email: 'test@openpay.mx'
+    }
+    
+    @options_missing = {
+      order_id: '1234567890',
+      billing_address: address,
       description: 'Store Purchase'
     }
   end
@@ -139,7 +146,7 @@ class OpenpayTest < Test::Unit::TestCase
     @options[:name] = 'John Doe'
 
     assert_raise(ArgumentError) do
-      @gateway.store(@credit_card, @options)
+      @gateway.store(@credit_card, @options_missing)
     end
   end
 


### PR DESCRIPTION
-Add merchant_account_id param to change dynamically between account
-Add metadata object to receive additional information for fraud. Allow up to 15 fields
-Add customer object to receive name, last name, external id and phone number 
-Add shipment address to customer.
-Refactor customer method.