### PR TITLE
Fat Zebra: Fix extra descriptor fields

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -3,7 +3,7 @@ require 'json'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class FatZebraGateway < Gateway
-      self.live_url    = "https://gateway.fatzebra.com.au/v1.0"
+      self.live_url = "https://gateway.fatzebra.com.au/v1.0"
       self.test_url = "https://gateway.sandbox.fatzebra.com.au/v1.0"
 
       self.supported_countries = ['AU']
@@ -121,10 +121,16 @@ module ActiveMerchant #:nodoc:
 
       def add_extra_options(post, options)
         extra = {}
-        extra[:name] = options[:merchant] if options[:merchant]
-        extra[:location] = options[:merchant_location] if options[:merchant_location]
         extra[:ecm] = "32" if options[:recurring]
+        add_descriptor(extra, options)
         post[:extra] = extra if extra.any?
+      end
+
+      def add_descriptor(extra, options)
+        descriptor = {}
+        descriptor[:name] = options[:merchant] if options[:merchant]
+        descriptor[:location] = options[:merchant_location] if options[:merchant_location]
+        extra[:descriptor] = descriptor if descriptor.any?
       end
 
       def add_order_id(post, options)

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -27,12 +27,6 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert_equal 'USD', response.params['response']['currency']
   end
 
-  def test_successful_purchase_with_descriptor
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))
-    assert_success response
-    assert_equal 'Approved', response.message
-  end
-
   def test_unsuccessful_multi_currency_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'XYZ'))
     assert_failure response
@@ -125,6 +119,12 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert card = @gateway.store(@credit_card)
     assert purchase = @gateway.purchase(@amount, card.authorization, @options.merge(:cvv => 123))
     assert_success purchase
+  end
+
+  def test_successful_purchase_with_descriptor
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))
+    assert_success response
+    assert_equal 'Approved', response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -76,7 +76,7 @@ class FatZebraTest < Test::Unit::TestCase
   def test_successful_purchase_with_descriptor
     @gateway.expects(:ssl_request).with { |method, url, body, headers|
       json = JSON.parse(body)
-      json['extra']['name'] == 'Merchant' && json['extra']['location'] == 'Location'
+      json['extra']['descriptor']['name'] == 'Merchant' && json['extra']['descriptor']['location'] == 'Location'
     }.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, "e1q7dbj2", @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))
@@ -84,7 +84,6 @@ class FatZebraTest < Test::Unit::TestCase
 
     assert_equal '001-P-12345AA', response.authorization
     assert response.test?
-
   end
 
   def test_successful_authorization


### PR DESCRIPTION
These fields were previously implemented, but were not nested within a `descriptor` key.

@davidsantoso to confirm and merge.