### PR TITLE
Stripe: Update minimum amount during verify

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -142,7 +142,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(payment, options = {})
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(50, payment, options) }
+          r.process { authorize(100, payment, options.merge(currency: "USD")) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end


### PR DESCRIPTION
Stripe has varying minimum amounts for charges which take into account the currency sent in the API request as well as the location of the Stripe account holder. For more information, see the Stripe documentation:

https://support.stripe.com/questions/what-is-the-minimum-amount-i-can-charge-with-stripe

This change forces all `verify` requests to be made in USD which provides a baseline regardless of where the business is located and the currency of the Stripe account holder. In addition, bumping the amount to $1.00 USD ensures that regardless of the exchange rate, it should be above the minimum in local currency.

Unfortunately remote tests are a bit difficult for this since the test Stripe account key in the fixtures file belong to a US based account so it will always pass verification. It would also be a bit much to have multiple accounts for each different currency as the default to test the `verify` against.