### PR TITLE
Stripe: Set minimum authorize amount depending on currency

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -51,6 +51,22 @@ module ActiveMerchant #:nodoc:
         "business" => "company",
       }
 
+      MINIMUM_AUTHORIZE_AMOUNTS = {
+        "USD" => 100,
+        "CAD" => 100,
+        "GBP" => 60,
+        "EUR" => 100,
+        "DKK" => 500,
+        "NOK" => 600,
+        "SEK" => 600,
+        "CHF" => 100,
+        "AUD" => 100,
+        "JPY" => 100,
+        "MXN" => 2000,
+        "SGD" => 100,
+        "HKD" => 800
+      }
+
       def initialize(options = {})
         requires!(options, :login)
         @api_key = options[:login]
@@ -142,7 +158,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(payment, options = {})
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, payment, options.merge(currency: "USD")) }
+          r.process { authorize(auth_minimum_amount(options), payment, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end
@@ -599,6 +615,11 @@ module ActiveMerchant #:nodoc:
         else
           card_brand(payment_method) == "check"
         end
+      end
+
+      def auth_minimum_amount(options)
+        return 100 unless options[:currency]
+        return MINIMUM_AUTHORIZE_AMOUNTS[options[:currency].upcase] || 100
       end
     end
   end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -191,6 +191,90 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "refund", response.responses.last.params["object"]
   end
 
+  def test_successful_verify_cad
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "cad"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "cad", response.params["currency"]
+  end
+
+  def test_successful_verify_gbp
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "gbp"))
+    assert_success response
+    assert_equal 60, response.params["amount"]
+    assert_equal "gbp", response.params["currency"]
+  end
+
+  def test_successful_verify_eur
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "eur"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "eur", response.params["currency"]
+  end
+
+  def test_successful_verify_dkk
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "dkk"))
+    assert_success response
+    assert_equal 500, response.params["amount"]
+    assert_equal "dkk", response.params["currency"]
+  end
+
+  def test_successful_verify_nok
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "nok"))
+    assert_success response
+    assert_equal 600, response.params["amount"]
+    assert_equal "nok", response.params["currency"]
+  end
+
+  def test_successful_verify_sek
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "sek"))
+    assert_success response
+    assert_equal 600, response.params["amount"]
+    assert_equal "sek", response.params["currency"]
+  end
+
+  def test_successful_verify_chf
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "chf"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "chf", response.params["currency"]
+  end
+
+  def test_successful_verify_aud
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "aud"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "aud", response.params["currency"]
+  end
+
+  def test_successful_verify_jpy
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "jpy"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "jpy", response.params["currency"]
+  end
+
+  def test_successful_verify_mxn
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "mxn"))
+    assert_success response
+    assert_equal 2000, response.params["amount"]
+    assert_equal "mxn", response.params["currency"]
+  end
+
+  def test_successful_verify_sgd
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "sgd"))
+    assert_success response
+    assert_equal 100, response.params["amount"]
+    assert_equal "sgd", response.params["currency"]
+  end
+
+  def test_successful_verify_hkd
+    assert response = @gateway.verify(@credit_card, @options.merge(currency: "hkd"))
+    assert_success response
+    assert_equal 800, response.params["amount"]
+    assert_equal "hkd", response.params["currency"]
+  end
+
   def test_unsuccessful_verify
     assert response = @gateway.verify(@declined_card, @options)
     assert_failure response


### PR DESCRIPTION
Previously the Stripe `verify` action was updated to default to authorizing an amount of $1 USD. Increasing the authorize amount and forcing the USD currency was done primarily to overcome currency exchange rate issues for the required minimum charge amount. See documentation below for more details:

https://support.stripe.com/questions/what-is-the-minimum-amount-i-can-charge-with-stripe

However, some Stripe accounts do not support the USD currency so forcing that during `verify` caused those accounts to break. This change allows for the authorize amount during verify to be dynamically set depending on the currency passed in, defaulting to `50` if none is given. It also doubles the minimum amounts shown in the Stripe documentation in an effort to keep currency exchange rates from becoming an issue when running the authorize in non USD.

@duff any other thoughts?