### PR TITLE
Fat Zebra: Pass 3DS information fields

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -122,6 +122,9 @@ module ActiveMerchant #:nodoc:
       def add_extra_options(post, options)
         extra = {}
         extra[:ecm] = "32" if options[:recurring]
+        extra[:cavv] = options[:cavv] if options[:cavv]
+        extra[:xid] = options[:cavv] if options[:xid]
+        extra[:sli] = options[:sli] if options[:sli]
         add_descriptor(extra, options)
         post[:extra] = extra if extra.any?
       end

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -127,6 +127,18 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_3DS_information
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:cavv => 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', :xid => 'MGVmMmNlMzI4NjAyOWU2ZDgwNTQ=', :sli => '05'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase_with_incomplete_3DS_information
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:cavv => 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', :sli => '05'))
+    assert_failure response
+    assert_match %r{Exception caught in application}, response.message
+  end
+
   def test_invalid_login
     gateway = FatZebraGateway.new(
                 :username => 'invalid',


### PR DESCRIPTION
This is not 3DS support, it only passes these fields along properly
if supplied.  All three fields need to be present to succeed.

@davidsantoso to take a look and merge. There are some alternatives to the behavior if not all fields are present, but I went with the simplest.