### PR TITLE
Braintree supports network tokenization

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -185,7 +185,7 @@ module ActiveMerchant
 
       def supports_network_tokenization?
         request = post_data(:authorize) do |xml|
-          add_auth_purchase(xml, "authOnlyTransaction", 1, Billing::NetworkTokenizationCreditCard.test_credit_card, {})
+          add_auth_purchase(xml, "authOnlyTransaction", 1, NetworkTokenizationCreditCard.test_credit_card, {})
         end
         raw_response = ssl_post(url, request, headers)
         response = parse(:authorize, raw_response)

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -184,18 +184,8 @@ module ActiveMerchant
       end
 
       def supports_network_tokenization?
-        card = Billing::NetworkTokenizationCreditCard.new({
-          :number => "4111111111111111",
-          :month => 12,
-          :year => 20,
-          :first_name => 'John',
-          :last_name => 'Smith',
-          :brand => 'visa',
-          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-        })
-
         request = post_data(:authorize) do |xml|
-          add_auth_purchase(xml, "authOnlyTransaction", 1, card, {})
+          add_auth_purchase(xml, "authOnlyTransaction", 1, Billing::NetworkTokenizationCreditCard.test_credit_card, {})
         end
         raw_response = ssl_post(url, request, headers)
         response = parse(:authorize, raw_response)

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -1,4 +1,9 @@
 module BraintreeCommon
+
+  ERROR_CODES = {
+    payment_instrument_not_supported: '91577'
+  }.freeze
+
   def self.included(base)
     base.supported_countries = %w(US CA AD AT BE BG HR CY CZ DK EE FI FR GI DE GR GG HU IS IM IE IT JE LV LI LT LU MT MC NL NO PL PT RO SM SK SI ES SE CH TR GB SG HK MY AU NZ)
     base.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
@@ -17,5 +22,10 @@ module BraintreeCommon
       gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
       gsub(%r((&?ccnumber=)\d*(&?)), '\1[FILTERED]\2').
       gsub(%r((&?cvv=)\d*(&?)), '\1[FILTERED]\2')
+  end
+
+  def supports_network_tokenization?
+    response = authorize(1, ActiveMerchant::Billing::NetworkTokenizationCreditCard.test_credit_card)
+    response.params['braintree_transaction']['processor_response_code'] != ERROR_CODES.fetch(:payment_instrument_not_supported)
   end
 end

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -26,9 +26,9 @@ module BraintreeCommon
 
   def supports_network_tokenization?
     response = authorize(1, ActiveMerchant::Billing::NetworkTokenizationCreditCard.test_credit_card)
-    response_code = response.params['braintree_transaction'].try!(:[], 'processor_response_code')
+    response_code = response.params['braintree_transaction'].try(:[], 'processor_response_code')
     raise(ActiveMerchant::InvalidResponseError, response.message) unless response_code
 
-    response.params['braintree_transaction']['processor_response_code'] != ERROR_CODES.fetch(:payment_instrument_not_supported)
+    response_code != ERROR_CODES.fetch(:payment_instrument_not_supported)
   end
 end

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -27,7 +27,7 @@ module BraintreeCommon
   def supports_network_tokenization?
     response = authorize(1, ActiveMerchant::Billing::NetworkTokenizationCreditCard.test_credit_card)
     response_code = response.params['braintree_transaction'].try(:[], 'processor_response_code')
-    raise(ActiveMerchant::InvalidResponseError, response.message) unless response_code
+    raise(ActiveMerchant::ActiveMerchantError, response.message) unless response_code
 
     response_code != ERROR_CODES.fetch(:payment_instrument_not_supported)
   end

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -26,6 +26,9 @@ module BraintreeCommon
 
   def supports_network_tokenization?
     response = authorize(1, ActiveMerchant::Billing::NetworkTokenizationCreditCard.test_credit_card)
+    response_code = response.params['braintree_transaction'].try!(:[], 'processor_response_code')
+    raise(ActiveMerchant::InvalidResponseError, response.message) unless response_code
+
     response.params['braintree_transaction']['processor_response_code'] != ERROR_CODES.fetch(:payment_instrument_not_supported)
   end
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -171,10 +171,6 @@ module ActiveMerchant #:nodoc:
       end
       alias_method :delete, :unstore
 
-      def supports_network_tokenization?
-        true
-      end
-
       def verify_credentials
         begin
           @braintree_gateway.transaction.find("non_existent_token")

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -34,6 +34,18 @@ module ActiveMerchant #:nodoc:
       def type
         "network_tokenization"
       end
+
+      def self.test_credit_card
+        new(
+          :number => "4111111111111111",
+          :month => 12,
+          :year => 20,
+          :first_name => 'John',
+          :last_name => 'Smith',
+          :brand => 'visa',
+          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+        )
+      end
     end
   end
 end

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -14,6 +14,18 @@ module ActiveMerchant #:nodoc:
       self.require_verification_value = false
       self.require_name = false
 
+      def self.test_credit_card
+        new(
+          :number => "4111111111111111",
+          :month => 12,
+          :year => 20,
+          :first_name => 'John',
+          :last_name => 'Smith',
+          :brand => 'visa',
+          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+        )
+      end
+
       attr_accessor :payment_cryptogram, :eci, :transaction_id
       attr_writer :source
 
@@ -33,18 +45,6 @@ module ActiveMerchant #:nodoc:
 
       def type
         "network_tokenization"
-      end
-
-      def self.test_credit_card
-        new(
-          :number => "4111111111111111",
-          :month => 12,
-          :year => 20,
-          :first_name => 'John',
-          :last_name => 'Smith',
-          :brand => 'visa',
-          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-        )
       end
     end
   end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -646,10 +646,6 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal "transaction_id", response.authorization
   end
 
-  def test_supports_network_tokenization
-    assert_instance_of TrueClass, @gateway.supports_network_tokenization?
-  end
-
   def test_unsuccessful_transaction_returns_id_when_available
     Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_error_result(transaction: {id: 'transaction_id'}))
     assert response = @gateway.purchase(100, credit_card("41111111111111111111"))

--- a/test/unit/gateways/braintree_test.rb
+++ b/test/unit/gateways/braintree_test.rb
@@ -34,4 +34,17 @@ class BraintreeTest < Test::Unit::TestCase
   def test_should_have_default_currency
     assert_equal "USD", BraintreeGateway.default_currency
   end
+
+  def test_supports_network_tokenization_when_not_supported
+    gateway = BraintreeGateway.new(
+      :merchant_id => 'MERCHANT_ID',
+      :public_key => 'PUBLIC_KEY',
+      :private_key => 'PRIVATE_KEY'
+    )
+    response = ActiveMerchant::Billing::Response.new(false,
+      'Merchant account does not support payment instrument. (91577)',
+      {"braintree_transaction"=>{"processor_response_code"=>"91577"}})
+    gateway.stubs(authorize: response)
+    assert_equal false, gateway.supports_network_tokenization?
+  end
 end

--- a/test/unit/gateways/braintree_test.rb
+++ b/test/unit/gateways/braintree_test.rb
@@ -44,10 +44,8 @@ class BraintreeTest < Test::Unit::TestCase
   end
 
   def test_supports_network_tokenization_should_raise_when_network_error
-    response = ActiveMerchant::Billing::Response.new(false,
-      'Merchant account does not support payment instrument. (91577)',
-      {"braintree_invalid_response"=> nil})
-    assert_raises ActiveMerchant::InvalidResponseError do
+    Braintree::Http.any_instance.expects(:post).raises(Braintree::ServerError)
+    assert_raises ActiveMerchant::ActiveMerchantError do
       gateway.supports_network_tokenization?
     end
   end


### PR DESCRIPTION
Verify that braintree gateways supports network tokenization, similar to what was done for auth.net (https://github.com/activemerchant/active_merchant/pull/1766)

ping @Krystosterone @duff @lyverovski @jnormore 
