### PR TITLE
Adding support for Square's ecommerce payments API and customer card on file

### DIFF
--- a/lib/active_merchant/billing/gateways/square.rb
+++ b/lib/active_merchant/billing/gateways/square.rb
@@ -1,0 +1,396 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class SquareGateway < Gateway
+
+      # test uses a 'sandbox' access token, same URL
+      self.live_url = 'https://connect.squareup.com/v2/'
+
+      self.money_format = :cents
+      self.supported_countries = ['US', 'CA']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
+
+      self.homepage_url = 'https://squareup.com/developers'
+      self.display_name = 'Square'
+
+      # Map to Square's error codes:
+      # https://docs.connect.squareup.com/api/connect/v2/#handlingerrors
+      STANDARD_ERROR_CODE_MAPPING = {
+        'INVALID_CARD' => STANDARD_ERROR_CODE[:invalid_number],
+        'INVALID_EXPIRATION' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        'INVALID_EXPIRATION_DATE' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        'INVALID_EXPIRATION_YEAR' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+
+        # Something invalid in the card, e.g. verify declined when linking card to customer.
+        'INVALID_CARD_DATA' => STANDARD_ERROR_CODE[:processing_error],
+        'CARD_EXPIRED' => STANDARD_ERROR_CODE[:expired_card],
+        'VERIFY_CVV_FAILURE' => STANDARD_ERROR_CODE[:incorrect_cvc],
+        'VERIFY_AVS_FAILURE' => STANDARD_ERROR_CODE[:incorrect_zip],
+        'CARD_DECLINED' => STANDARD_ERROR_CODE[:card_declined],
+        'UNAUTHORIZED' => STANDARD_ERROR_CODE[:config_error]
+      }
+
+      # The `login` key is the client_id (also known as application id) 
+      #   in the dev portal. Get it after you create a new app:
+      #   https://connect.squareup.com/apps/
+      # The `password` is the access token (personal or OAuth)
+      # The `location_id` must be fetched initially 
+      #   https://docs.connect.squareup.com/articles/processing-payment-rest/
+      # The `test` indicates if these credentials are for sandbox or 
+      #   production (money moving) access
+      def initialize(options={})
+        requires!(options, :login, :password, :location_id, :test)
+        @client_id = options[:login].strip
+        @bearer_token = options[:password].strip
+        @location_id = options[:location_id].strip
+
+        super
+      end
+
+      # To create a charge on a card using a card nonce:
+      #     purchase(money, card_nonce, { ...create transaction options... })
+      #
+      # To create a customer and save a card (via card_nonce) to the customer:
+      #     purchase(money, card_nonce, {customer: {...params hash same as in store() method...}, ...})
+      #   Note for US and CA, you must have {customer: {billing_address: {zip: 12345}}} which passes AVS to store a card.
+      #   Note this always creates a new customer, so it may make a duplicate 
+      #   customer if this card was associated to another customer previously.
+      #
+      # To use a customer's card on file:
+      #     purchase(money, nil, {customer: {id: 'customer-id', card_id: 'card-id'}})
+      # Note this does not update any fields on the customer.
+      #
+      # To use a customer, and link a new card to the customer:
+      #     purchase(money, card_nonce, {customer: {id: 'customer-id', billing_address: {zip: 12345}})
+      # Note the zip is required to store the new nonce, and it must pass AVS.
+      # Note this does not update any other fields on the customer.
+      #
+      # As this may make multiple requests, it returns a MultiResponse.
+      def purchase(money, card_nonce, options={})
+        raise ArgumentError('money required') if money.nil?
+        if card_nonce.nil?
+          requires!(options, :customer)
+          requires!(options[:customer], :card_id, :id)
+        end
+        if card_nonce && options[:customer] && options[:customer][:card_id]
+          raise ArgumentError('Cannot call with both card_nonce and' +
+            ' options[:customer][:card_id], choose one.')
+        end
+
+        post = options.slice(:buyer_email_address, :delay_capture, :note,
+            :reference_id)
+        add_idempotency_key(post, options)
+        add_amount(post, money, options)
+        add_address(post, options)
+        post[:reference_id] = options[:order_id] if options[:order_id]
+        post[:note] = options[:description] if options[:description]
+
+        MultiResponse.run do |r|
+          if options[:customer] && card_nonce
+            # Since customer was passed in, create customer (if needed) and 
+            # store card (always in here).
+            options[:customer][:customer_id] = options[:customer][:id] if options[:customer][:id] # To make store() happy.
+            r.process { store(card_nonce, options[:customer]) }
+
+            # If we just created a customer.
+            if options[:customer][:id].nil?
+              options[:customer][:id] =
+                  r.responses.first.params['customer']['id']
+            end
+
+            # We always stored a card, so grab it.
+            options[:customer][:card_id] =
+                r.responses.last.params['card']['id']
+
+            # Empty the card_nonce, since we now have the card on file.
+            card_nonce = nil 
+            
+            # Invariant: we have a customer and a linked card, and our options
+            # hash is correct.
+          end
+
+          add_payment(post, card_nonce, options)
+          r.process { commit(:post, "locations/#{@location_id}/transactions", post) }
+        end
+      end
+
+      # Authorize for Square uses the Charge with delay_capture = true option. 
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-charge
+      # Same as with `purchase`, pass nil for `card_nonce` if using a customer's
+      # stored card on file.
+      # 
+      # See purchase for more details for calling this.
+      def authorize(money, card_nonce, options={})
+        options[:delay_capture] = true
+        purchase(money, card_nonce, options)
+      end
+
+      # Capture is only used if you did an Authorize, (creating a delayed capture).
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-capturetransaction
+      # Both `money` and `options` are unused. Only a full capture is supported.
+      def capture(ignored_money, txn_id, ignored_options={})
+        raise ArgumentError('txn_id required') if txn_id.nil?
+        commit(:post, "locations/#{CGI.escape(@location_id)}/transactions/#{CGI.escape(txn_id)}/capture")
+      end
+
+      # Refund refunds a previously Charged transaction. 
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-createrefund
+      # Options require: `tender_id`, and permit `idempotency_key`, `reason`.
+      def refund(money, txn_id, options={})
+        raise ArgumentError('txn_id required') if txn_id.nil?
+        raise ArgumentError('money required') if money.nil?
+        requires!(options, :tender_id)
+        
+        post = options.slice(:tender_id, :reason)
+        add_idempotency_key(post, options)
+        add_amount(post, money, options)
+        commit(:post, "locations/#{CGI.escape(@location_id)}/transactions/#{CGI.escape(txn_id)}/refund", post)
+      end
+
+      # Void cancels a delayed capture (not-yet-captured) transaction.
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-voidtransaction
+      def void(txn_id, options={})
+        raise ArgumentError('txn_id required') if txn_id.nil?
+        commit(:post, "locations/#{CGI.escape(@location_id)}/transactions/#{CGI.escape(txn_id)}/void")
+      end
+
+      # Do an Authorize (Charge with delayed capture) and then Void.
+      # Storing a card with a customer will do a verify, however a direct
+      # verification only endpoint is not exposed today (Oct '16). 
+      def verify(card_nonce, options={})
+        raise ArgumentError('card_nonce required') if card_nonce.nil?
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, card_nonce, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+     
+      # Required in options hash one of: 
+      # a) :customer_id from the Square CreateCustomer endpoint of customer to link to.
+      #     Required in the US and CA: options[:billing_address][:zip] (AVS must pass to link)
+      #     https://docs.connect.squareup.com/api/connect/v2/#endpoint-createcustomercard
+      # b) :email, :family_name, :given_name, :company_name, :phone_number to create a new customer.
+      #
+      # Optional: :cardholder_name, :address (to store on customer)
+      # Return values (e.g. the card id) are available on the response.params['card']['id']
+      def store(card_nonce, options = {})
+        raise ArgumentError('card_nonce required') if card_nonce.nil?
+        raise ArgumentError.new('card_nonce nil but is a required field.') if card_nonce.nil?
+        if options[:billing_address].nil? || options[:billing_address][:zip].nil?
+          raise ArgumentError.new('options[:billing_address][:zip] nil but is a required field.')
+        end
+
+        MultiResponse.run do |r|
+          if !(options[:customer_id])
+            r.process { create_customer(options) }
+            options[:customer_id] = r.responses.last.params['customer']['id']
+          end
+          post = options.slice(:cardholder_name, :billing_address)
+          post[:billing_address][:postal_code] = options[:billing_address][:zip]
+          post[:card_nonce] = card_nonce
+          r.process { commit(:post, "customers/#{CGI.escape(options[:customer_id])}/cards", post) }
+        end
+      end
+
+      def update(customer_id, card_id, options = {})
+        raise Exception.new('Square API does not currently support updating' +
+          ' a given card_id, instead create a new one and delete the old one.')
+      end
+
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-updatecustomer
+      def update_customer(customer_id, options = {})
+        raise ArgumentError.new('customer_id nil but is a required field.') if customer_id.nil?
+        options[:email_address] = options[:email] if options[:email]
+        options[:note] = options[:description] if options[:description]
+        commit(:put, "customers/#{CGI.escape(customer_id)}", options)
+      end
+
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-deletecustomercard
+      # Required options[:customer][:id] and 'card_id' params.
+      def unstore(card_id, options = {}, deprecated_options = {})
+        raise ArgumentError.new('card_id nil but is a required field.') if card_id.nil?
+        requires!(options, :customer)
+        requires!(options[:customer], :id)
+        commit(:delete, "customers/#{CGI.escape(options[:customer][:id])}/cards/#{CGI.escape(card_id)}", nil)
+      end
+
+      # See also store().
+      # Options hash takes the keys as defined here:
+      # https://docs.connect.squareup.com/api/connect/v2/#endpoint-createcustomer
+      def create_customer(options) 
+        required_one_of = [:email, :email_address, :family_name, :given_name,
+          :company_name, :phone_number]
+        if required_one_of.none?{|k| options.key?(k)}
+          raise ArgumentError.new("one of these options keys required:" +
+            " #{required_one_of} but none included.")
+        end
+
+        MultiResponse.run do |r|
+          post = options.slice(*required_one_of - [:email] +
+              [:phone_number, :reference_id, :note, :nickname])
+          post[:email_address] = options[:email] if options[:email]
+          post[:note] = options[:description] if options[:description]
+          add_address(post, options, :address)
+          r.process{ commit(:post, 'customers', post) }
+        end
+      end
+
+      # Scrubbing removes the access token from the header and the card_nonce.
+      # Square does not let the merchant ever see PCI data. All payment card
+      # data is directly handled on Square's servers via iframes as described
+      # here: https://docs.connect.squareup.com/articles/adding-payment-form/
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Bearer )[^\r\n]+), '\1[FILTERED]').
+          # Extra [\\]* for test. We do an extra escape in the regex of [\\]* 
+          # b/c the remote_square_test.rb seems to double escape the
+          # backslashes before the quote. This ensures tests pass.
+          gsub(%r((\"card_nonce[\\]*\":[\\]*")[^"]+), '\1[FILTERED]')
+      end
+
+      private
+
+      def add_address(post, options, non_billing_addr_key = :shipping_address)
+        if address = options[:billing_address] || options[:address]
+          add_address_for(post, address, :billing_address)
+        end        
+        non_billing_addr_key = non_billing_addr_key.to_sym
+        if address = options[non_billing_addr_key] || options[:address]
+          add_address_for(post, address, non_billing_addr_key)
+        end
+      end
+
+      def add_address_for(post, address, addr_key)
+          addr_key = addr_key.to_sym
+          post[addr_key] ||= {} # Or-Equals in case they passed in using Square's key format
+          post[addr_key][:address_line_1] = address[:address1] if address[:address1]
+          post[addr_key][:address_line_2] = address[:address2] if address[:address2]
+          post[addr_key][:address_line_3] = address[:address3] if address[:address3]
+          
+          post[addr_key][:locality] = address[:city] if address[:city]
+          post[addr_key][:sublocality] = address[:sublocality] if address[:sublocality]
+          post[addr_key][:sublocality_2] = address[:sublocality_2] if address[:sublocality_2]
+          post[addr_key][:sublocality_3] = address[:sublocality_3] if address[:sublocality_3]
+
+          post[addr_key][:administrative_district_level_1] = address[:state] if address[:state]
+          post[addr_key][:administrative_district_level_2] = address[:administrative_district_level_2] if address[:administrative_district_level_2] # In the US, this is the county.
+          post[addr_key][:administrative_district_level_3] = address[:administrative_district_level_3] if address[:administrative_district_level_3] # Used in JP not the US
+          post[addr_key][:postal_code] = address[:zip] if address[:zip]
+          post[addr_key][:country] = address[:country] if address[:country]
+      end
+
+      def add_amount(post, money, options)
+        post[:amount_money] = {}
+        post[:amount_money][:amount] = Integer(amount(money))
+        post[:amount_money][:currency] = 
+          (options[:currency] || currency(money))
+      end
+
+      def add_payment(post, card_nonce, options)
+        if card_nonce.nil?
+          # use card on file
+          requires!(options, :customer)
+          requires!(options[:customer], :id, :card_id)
+          post[:customer_id] = options[:customer][:id]
+          post[:customer_card_id] = options[:customer][:card_id]
+        else
+          # use nonce
+          post[:card_nonce] = card_nonce
+        end          
+      end
+
+      def commit(method, endpoint, parameters=nil)
+        response = api_request(method, endpoint, parameters)
+        success = !response.key?("errors")
+        Response.new(success,
+          message_from(success, response),
+          response,
+          authorization: authorization_from(response),
+          # Neither avs nor cvv match are not exposed in the api.
+          avs_result: nil,
+          cvv_result: nil,
+          test: test?,
+          error_code: success ? nil : error_code_from(response)
+        )
+      end
+
+      def headers
+        {
+          'Authorization' => "Bearer " + @bearer_token,
+          'User-Agent' => 
+            "Square/v2 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'X-Square-Client-User-Agent' => user_agent,
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json',
+          # Uncomment below to generate request/response json for unit tests.
+          # 'Accept-Encoding' => ''
+        }
+      end
+
+      def add_idempotency_key(post, options)
+        post[:idempotency_key] = 
+          (options[:idempotency_key] || generate_unique_id).to_s
+      end
+
+      def message_from(success, response)
+        # e.g. {"errors":[{"category":"INVALID_REQUEST_ERROR","code":"VALUE_TOO_LOW","detail":"`amount_money.amount` must be greater than 100.","field":"amount_money.amount"}]}
+        success ? "Success" : response['errors'].first['detail']
+      end
+
+      def authorization_from(response)
+        if response['transaction'] 
+          # This will return the transaction level identifier, of which there
+          # is >= 1 nested tender id which you may need to look up depending
+          # on your use case (e.g. refunding). That is available in the
+          # response.transaction.tenders array.
+          return response['transaction']['id']
+        end
+      end
+
+      def api_request(method, endpoint, parameters)
+        json_payload = JSON.generate(parameters) if parameters
+        begin
+          raw_response = ssl_request(
+            method, self.live_url + endpoint, json_payload, headers)
+          response = JSON.parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = response_error(raw_response)
+        rescue JSON::ParserError
+          response = json_error(raw_response)
+        end
+        response
+      end
+
+      def response_error(raw_response)
+        JSON.parse(raw_response)          
+      rescue JSON::ParserError
+        json_error(raw_response)
+      end
+
+      def json_error(raw_response)
+        msg = 'Invalid non-parsable json data response from the Square API.' +
+          ' Please contact' +
+          ' squareup.com/help/us/en/contact?prefill=developer_api' +
+          ' if you continue to receive this message.' +
+          "  (The raw API response returned was #{raw_response.inspect})"
+        {
+          "errors" => [{
+            "category" => "API_ERROR",
+            "detail" => msg
+          }]
+        }
+      end
+
+      def error_code_from(response)
+        code = response['errors'].first['code']
+        error_code = STANDARD_ERROR_CODE_MAPPING[code]
+        error_code
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -952,6 +952,19 @@ spreedly_core:
   password: "Y2i7AjgU03SUjwY4xnOPqzdsv4dMbPDCQzorAk8Bcoy0U8EIVE4innGjuoMQv7MN"
   gateway_token: "3gLeg4726V5P0HK7cq7QzHsL0a6"
 
+# Replace login with your app's client_id (also known as app id), create one in
+# the developer portal: https://connect.squareup.com/apps
+# Replace the password with either your Merchant's personal access token or if
+# your app works with many merchant accounts, also 
+# Replace the location_id with the corresponding location you want to use for the
+# merchant's reporting of these sales to be connected to. Read more about locations
+# here: https://docs.connect.squareup.com/articles/processing-payment-rest/
+square:
+  login: sandbox-sq0idp-USE_REAL_SANDBOX_CLIENT_ID
+  password: sandbox-sq0atb-USE_REAL_SANDBOX_ACCESS_TOKEN
+  location_id: USE_A_LOCATION_ID
+  test: true # Square calls test mode "sandbox".
+
 # Working credentials, no need to replace
 stripe:
   login: sk_test_3OD4TdKSIOhDOL2146JJcC79

--- a/test/remote/gateways/remote_square_test.rb
+++ b/test/remote/gateways/remote_square_test.rb
@@ -1,0 +1,425 @@
+require 'test_helper'
+
+# Tip for running just one test:
+#   $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+#     test/remote/gateways/remote_square_test.rb \
+#     -n test_successful_purchase
+
+
+class RemoteSquareTest < Test::Unit::TestCase
+  # include so that we can to use ssl_get()
+  include ActiveMerchant::PostsData
+
+  def setup
+    @gateway = SquareGateway.new(fixtures(:square))
+    @amount = 100
+    # sandbox nonce https://docs.connect.squareup.com/articles/using-sandbox/
+    @credit_card = 'fake-card-nonce-ok'
+    @declined_card = 'fake-card-nonce-declined'
+    @options = {
+      :billing_address => address,
+      :description => 'Store Purchase Note'
+    }
+  end
+
+  def test_only_accepts_card_nonce_not_creditcard_pan
+    credit_card_pan = '4111111111111111' # should be rejected
+    response = @gateway.purchase(@amount, credit_card_pan, @options)
+    assert_failure response
+    assert_not_nil err = response.params['errors'].first
+    assert_equal 'INVALID_REQUEST_ERROR', err['category']
+    assert_equal 'NOT_FOUND', err['code']
+    assert_nil response.error_code
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 1, response.responses.count
+    assert_equal 'Success', response.message
+    assert_nil response.error_code
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      :idemepotency_key => SecureRandom.uuid,
+      :shipping_address => address,
+      :billing_address => address,
+      :buyer_email_address => "joe@example.com",
+      :order_id => 'OrderNum123',
+      :description => 'custom description note you ordered xyz'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_not_nil txn = response.params['transaction']
+    assert_equal 'OrderNum123', txn['reference_id']
+    assert_equal 'CAPTURED', txn['tenders'].first['card_details']['status']
+    assert_equal 'custom description note you ordered xyz', txn['tenders'].first['note']
+    assert_equal 'Success', response.message
+    assert_nil response.error_code
+end
+
+  # General purchase and authorize tests.
+
+  def test_failed_purchase_decline
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 1, response.responses.count
+    assert_equal 'Card declined.', response.message
+    assert_equal 'card_declined', response.error_code
+  end
+
+  def test_failed_purchase_invalid_cvv
+    response = @gateway.purchase(@amount, 'fake-card-nonce-rejected-cvv', @options)
+    assert_failure response
+    assert_equal 'Card verification code check failed.', response.message
+    assert_equal 'incorrect_cvc', response.error_code
+  end
+
+  def test_failed_purchase_rejected_avs_zip
+    response = @gateway.purchase(@amount, 'fake-card-nonce-rejected-postalcode', @options)
+    assert_failure response
+    assert_equal 'Postal code check failed.', response.message
+    assert_equal 'incorrect_zip', response.error_code
+  end
+
+  def test_failed_purchase_expiration_incorrect
+    response = @gateway.purchase(@amount, 'fake-card-nonce-rejected-expiration', @options)
+    assert_failure response
+    assert_equal 'Invalid card expiration date.', response.message
+    assert_equal 'invalid_expiry_date', response.error_code
+  end
+
+  def test_successful_authorize_and_capture
+    @options.merge!({:delay_capture => true})
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 1, auth.responses.count
+    assert_nil auth.error_code
+    assert_equal 'AUTHORIZED', auth.params['transaction']['tenders'].first['card_details']['status']
+    assert_not_nil txn_id = auth.authorization
+
+    assert capture = @gateway.capture(@amount, txn_id)
+    assert_success capture
+
+    assert_equal 'Success', capture.message
+    assert_nil capture.error_code
+    
+    # Does not return the transaction back when capturing, so manually fetch it to verify.
+    location_id = fixtures(:square)[:location_id]
+    resource = SquareGateway::live_url + "locations/#{location_id}/transactions/#{txn_id}"
+    json = JSON.parse(ssl_get(resource, @gateway.send(:headers)))
+    assert_equal 'CAPTURED', json['transaction']['tenders'].first['card_details']['status']
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 1, response.responses.count
+
+    assert_equal 'Card declined.', response.message
+    assert_equal 'card_declined', response.error_code
+  end
+
+  # Not (yet, Q3 '16) Implemented by Square
+  # def test_partial_capture
+  #   auth = @gateway.authorize(@amount, @credit_card, @options)
+  #   assert_success auth
+
+  #   assert capture = @gateway.capture(@amount-1, auth.authorization)
+  #   assert_success capture
+  # end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, 'missing-txn-id')
+    assert_failure response
+    assert_equal "Location `#{fixtures(:square)[:location_id]}` does not have a transaction with ID `missing-txn-id`.", response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    tender_id = purchase.params['transaction']['tenders'].first['id']
+    options = {:tender_id => tender_id, :reason => 'oops!', :idemepotency_key => 'abc12'}
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, options)
+    assert_success refund
+    assert_equal 'Success', refund.message
+    assert_nil refund.error_code
+    assert_equal 'oops!', refund.params['refund']['reason']
+    assert_equal tender_id, refund.params['refund']['tender_id']
+    assert_equal purchase.authorization, refund.params['refund']['transaction_id']
+    assert_equal @amount, refund.params['refund']['amount_money']['amount']
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    tender_id = purchase.params['transaction']['tenders'].first['id']
+    options = {:tender_id => tender_id, :reason => 'oops!', :idemepotency_key => 'abc12'}
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization, options)
+    assert_success refund
+    assert_equal @amount-1, refund.params['refund']['amount_money']['amount']
+  end
+
+  def test_error_refund_required_field
+    expected_called = false
+    begin
+      @gateway.refund(@amount, '')
+    rescue ArgumentError => e
+      expected_called = true
+    end
+    assert_true expected_called
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, 'non-existant-authorization', {:tender_id => 'abc'})
+    assert_failure response
+    assert_equal "Location `#{fixtures(:square)[:location_id]}` does not have a transaction tender with ID `abc`.", response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'Success', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('non-existant-authorization')
+    assert_failure response
+    assert_equal "Location `#{fixtures(:square)[:location_id]}` does not have a transaction with ID `non-existant-authorization`.", response.message
+    assert_nil response.error_code
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{Success}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{Card declined.}, response.message
+  end
+
+
+  # All customer / stored card related below.
+
+
+  def test_store_customer_save_card
+    assert response = @gateway.store(@credit_card, {
+      :given_name => 'fname', :family_name => 'lname', 
+      :company_name => 'abc inc', :nickname => 'fred', 
+      :phone_number => '444-111-1232', :email => 'a@example.com',
+      :description => 'describe me', :reference_id => 'ref-abc01',
+      :billing_address => {
+        :zip => '94103'
+      }, 
+      :cardholder_name => 'Alexander Hamilton',
+      :address => { :address1 => '456 My Street', :address2 => 'Apt 1',
+        :address3 => 'line 3', :city => 'Ottawa', :sublocality => 'county X',
+        :sublocality_2 => 'sublocality 2', :sublocality_3 => 'sublocality 3',
+        :state => 'ON', :administrative_district_level_2 => 'admin district 2',
+        :administrative_district_level_3 => 'admin district 3', 
+        :zip => 'K1C2N6', :country => 'CA'}
+      })
+    assert_equal 2, response.responses.count
+    assert_success first = response.responses[0]
+    assert_success second = response.responses[1]
+    assert_match /Success/, first.message
+    assert_match /Success/, second.message
+
+    assert_equal "describe me", first.params['customer']['note']
+    assert_equal "a@example.com", first.params['customer']['email_address']
+    assert_equal "fname", first.params['customer']['given_name']
+    assert_equal "lname", first.params['customer']['family_name']
+    assert_equal "abc inc", first.params['customer']['company_name']
+    assert_equal "fred", first.params['customer']['nickname']
+    assert_equal "444-111-1232", first.params['customer']['phone_number']
+    assert_equal "ref-abc01", first.params['customer']['reference_id']
+    assert_not_nil first.params['customer']['address']
+    assert_equal '456 My Street', first.params['customer']['address']['address_line_1']
+    assert_equal 'Apt 1', first.params['customer']['address']['address_line_2']
+    assert_equal 'line 3', first.params['customer']['address']['address_line_3']
+    
+    assert_equal 'Ottawa', first.params['customer']['address']['locality']
+    assert_equal 'county X', first.params['customer']['address']['sublocality']
+    assert_equal 'sublocality 2', first.params['customer']['address']['sublocality_2']
+    assert_equal 'sublocality 3', first.params['customer']['address']['sublocality_3']
+
+    assert_equal 'ON', first.params['customer']['address']['administrative_district_level_1']
+    assert_equal 'admin district 2', first.params['customer']['address']['administrative_district_level_2']
+    assert_equal 'admin district 3', first.params['customer']['address']['administrative_district_level_3']
+
+    assert_equal 'K1C2N6', first.params['customer']['address']['postal_code']
+    assert_equal 'CA', first.params['customer']['address']['country']
+
+    assert_not_nil second.params['card']['id']
+    assert_not_nil second.params['card']['last_4']
+    assert_not_nil second.params['card']['exp_month']
+    assert_not_nil second.params['card']['exp_year']
+    assert_not_nil second.params['card']['card_brand']    
+    assert_equal 'Alexander Hamilton', second.params['card']['cardholder_name']
+    assert_equal '94103', second.params['card']['billing_address']['postal_code']
+  end
+
+  def test_failed_store_invalid_card_does_not_validate_when_verify_called_on_storing
+    assert response = @gateway.store(@declined_card, { # minimal fields
+      :billing_address => {:zip => '94103'}, :email => 'a@example.com'})
+    assert_success first = response.responses[0]
+    assert customer_id = first.params['customer']['id']
+    assert_failure second = response.responses[1]
+    assert_equal 'processing_error', second.error_code
+    assert_equal 'Invalid card data.', second.message
+  end
+
+  def test_create_customer_update_customer_add_card_delete_card
+    assert response = @gateway.create_customer({
+      :email => 'a@example.com', :reference_id => 'ref-abc01'})
+    assert_success first = response.responses[0]
+    assert_match /Success/, first.message
+    assert customer_id = first.params['customer']['id']
+    assert_equal "ref-abc01", first.params['customer']['reference_id']
+    assert_equal "a@example.com", first.params['customer']['email_address']
+
+    assert response = @gateway.update_customer(customer_id, 
+      {:email => 'new@me.com'})
+    assert_success response
+    
+    # changed
+    assert_equal "new@me.com", response.params['customer']['email_address'] 
+
+    # didn't change
+    assert_equal "ref-abc01", response.params['customer']['reference_id']
+
+    options = {:customer_id => customer_id, :billing_address => {:zip => '94103'}}
+    assert response = @gateway.store(@credit_card, options)
+    assert_equal 1, response.responses.count
+    assert_success response.responses[0]
+    assert_not_nil card_id = response.params['card']['id']
+
+    assert response = @gateway.unstore(card_id, {:customer => {:id => customer_id}})
+    assert_success response
+  end
+
+  def test_successful_purchase_with_customer_card_on_file__existing_customer_and_card
+    assert response = @gateway.store(@credit_card, { # minimal fields
+      :billing_address => {:zip => '94103'}, :email => 'a@example.com'})
+    assert_success first = response.responses[0]
+    assert customer_id = first.params['customer']['id']
+    assert_success second = response.responses[1]
+    assert card_id = second.params['card']['id']
+
+    assert response = @gateway.purchase(200, nil, {:customer => {:id => customer_id, :card_id => card_id}})
+    assert_success response
+    assert_equal customer_id, response.params['transaction']['tenders'].first['customer_id']
+    assert_equal card_id, response.params['transaction']['tenders'].first['card_details']['card']['id']
+    assert_equal 'CAPTURED', response.params['transaction']['tenders'].first['card_details']['status']
+  end
+
+  def test_successful_purchase_with_customer_card_on_file__existing_customer_new_card_by_nonce
+    assert response = @gateway.store(@credit_card, { # minimal fields
+      :billing_address => {:zip => '94103'}, :email => 'a@example.com'})
+    assert_success first = response.responses[0]
+    assert customer_id = first.params['customer']['id']
+    assert_success second = response.responses[1]
+    assert old_card_id = second.params['card']['id']
+
+    # Must send in the new billing zip for the new card.
+    assert response = @gateway.purchase(200, @credit_card, {:customer => {:id => customer_id,
+      :billing_address => {:zip => '94103'}}})
+    assert_success response
+    assert_equal customer_id, response.params['transaction']['tenders'].first['customer_id']
+    assert new_card_id = response.params['transaction']['tenders'].first['card_details']['card']['id']
+    assert_not_equal old_card_id, new_card_id
+    assert_equal 'CAPTURED', response.params['transaction']['tenders'].first['card_details']['status']
+  end
+
+  def test_successful_purchase_with_customer_card_on_file__new_customer_new_card
+    assert response = @gateway.purchase(200, @credit_card,  :customer => {
+      :given_name => 'fname', :family_name => 'lname', :company_name => 'abc inc',
+      :nickname => 'fred', :phone_number => '444-111-1232', :email => 'a@example.com',
+      :description => 'describe me', :reference_id => 'ref-abc01',
+      :billing_address => {
+        :zip => '94103'
+      }, 
+      :cardholder_name => 'Alexander Hamilton',
+      :address => { :address1 => '456 My Street', :address2 => 'Apt 1', :address3 => 'line 3',
+        :city => 'Ottawa', :sublocality => 'county X', :sublocality_2 => 'sublocality 2', :sublocality_3 => 'sublocality 3',
+        :state => 'ON', :administrative_district_level_2 => 'admin district 2', 
+        :administrative_district_level_3 => 'admin district 3', :zip => 'K1C2N6', :country => 'CA'}
+      })
+    assert_equal 3, response.responses.size #create customer, link card, purchase
+    assert_success first = response.responses[0]
+    assert customer_id = first.params['customer']['id']
+    
+    assert_success second = response.responses[1]
+    assert card_id = second.params['card']['id']
+    
+    assert_success third = response.responses[2]
+    assert_equal customer_id, third.params['transaction']['tenders'].first['customer_id']
+    assert_equal card_id, third.params['transaction']['tenders'].first['card_details']['card']['id']
+    assert_equal 'ON_FILE', third.params['transaction']['tenders'].first['card_details']['entry_method']
+    assert_equal 'CAPTURED', third.params['transaction']['tenders'].first['card_details']['status']
+  end
+
+  def test_successful_authorize_with_customer_card_on_file
+    assert response = @gateway.store(@credit_card, { # minimal fields
+      :billing_address => {:zip => '94103'}, :email => 'a@example.com'})
+    assert_success first = response.responses[0]
+    assert customer_id = first.params['customer']['id']
+    assert_success second = response.responses[1]
+    assert card_id = second.params['card']['id']
+
+    assert response = @gateway.authorize(200, nil, {:customer => {:id => customer_id, :card_id => card_id}})
+    assert_success response
+    assert_equal customer_id, response.params['transaction']['tenders'].first['customer_id']
+    assert_equal card_id, response.params['transaction']['tenders'].first['card_details']['card']['id']
+    assert_equal 'AUTHORIZED', response.params['transaction']['tenders'].first['card_details']['status']
+  end
+
+
+  # Other tests below.
+
+
+  def test_invalid_login
+    gateway = SquareGateway.new(:login => '', :password => '', :location_id => 'fake', :test => false)
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'config_error', response.error_code
+    assert_match %r{The `Authorization` http header of your request was malformed}, response.message
+  end
+
+  # Keeping this in here for when new tests are added, uncomment and run to save
+  # a fresh dump.
+  # def test_dump_transcript
+  #   # This test will run a purchase transaction on your gateway
+  #   # and dump a transcript of the HTTP conversation so that
+  #   # you can use that transcript as a reference while
+  #   # implementing your scrubbing logic.  You can delete
+  #   # this helper after completing your scrub implementation.
+  #   dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  #   # Note, I needed to add to the `headers` method in square.rb a line
+  #   # to prevent gzip in the response: 
+  #   #    'Accept-Encoding' => ''
+  # end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card, transcript) # scrub nonce
+    assert_scrubbed(@gateway.options[:password], transcript) # scrub access token
+  end
+
+end

--- a/test/unit/gateways/square_test.rb
+++ b/test/unit/gateways/square_test.rb
@@ -1,0 +1,428 @@
+require 'test_helper'
+
+class SquareTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = SquareGateway.new(:login => 'sandbox-xxx-client_id',
+      :password => 'access token', :location_id => 'loc-id-xxx', :test => true)
+    @card_nonce_ok = 'fake-card-nonce-ok'
+    @amount = 100
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase Note'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @card_nonce_ok, @options)
+    assert_success response
+
+    assert_equal '1ea0c711-fdc5-5e16-7afe-1c76ad788254', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @card_nonce_ok, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_request).returns(successful_authorize_response)
+    
+    response = @gateway.authorize(@amount, @card_nonce_ok, @options)
+    assert_success response
+
+    assert_equal '2d604106-cccc-5299-4dc7-d0903cdfcb77', response.authorization
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_request).returns(failed_authorize_response)
+
+    response = @gateway.purchase(@amount, @card_nonce_ok, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+    
+    response = @gateway.capture(@amount, 'txn_id', @options)
+    assert_success response
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, 'txn_id', @options)
+    assert_failure response
+    assert_equal "Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction with ID `missing-txn-id`.", response.params['errors'].first['detail']
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+    @options.merge!({:tender_id => 'xyz'})
+
+    response = @gateway.refund(@amount, 'txn_id', @options)
+
+    assert_success response
+    assert_equal 'APPROVED', response.params['refund']['status']
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_request).returns(failed_refund_response)
+    @options.merge!({:tender_id => 'xyz'})
+
+    response = @gateway.refund(@amount, 'txn_id', @options)
+    assert_failure response
+    assert_equal "Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction tender with ID `abc`.", response.params['errors'].first['detail']
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_request).returns(successful_void_response)
+    
+    response = @gateway.void('txn-id', @options)
+    assert_success response
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_request).returns(failed_void_response)
+    
+    response = @gateway.void('txn-id', @options)
+    assert_failure response
+    assert_equal "Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction with ID `non-existant-authorization`.", response.params['errors'].first['detail']
+  end
+
+  def test_successful_verify
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@card_nonce_ok, @options)
+    end.respond_with(successful_authorize_response, successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@card_nonce_ok, @options)
+    end.respond_with(successful_authorize_response, failed_void_response)
+    assert_success response
+  end
+
+  def test_failed_verify
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@card_nonce_ok, @options)
+    end.respond_with(failed_authorize_response, failed_void_response)
+    assert_failure response
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal post_scrubbed_card_nonce, @gateway.scrub(pre_scrubbed_card_nonce)
+  end
+
+  def test_successful_purchase_invalid_json_returned
+    @gateway.expects(:ssl_request).returns("{i am not json / invalid format responded}")
+
+    assert response = @gateway.purchase(@amount, @card_nonce_ok, @options)
+    assert_failure response
+    assert_match(/^Invalid non-parsable json data response from the Square API/, response.message)
+  end
+
+  def test_declined_purchase_invalid_json_returned
+    err = ActiveMerchant::ResponseError.new(stub(:body => "{i am not json / invalid format responded}"))
+    @gateway.expects(:ssl_request).raises(err)
+
+    assert response = @gateway.purchase(@amount, @card_nonce_ok, @options)
+    assert_failure response
+    assert_match(/^Invalid non-parsable json data response from the Square API/, response.message)
+  end
+
+
+  def test_successful_purchase_with_customer_card_on_file__new_customer_new_card
+    s = sequence("request")
+    @gateway.expects(:ssl_request).returns(successful_create_customer_response).in_sequence(s)
+    @gateway.expects(:ssl_request).returns(successful_link_card_to_customer_response).in_sequence(s)
+    @gateway.expects(:ssl_request).returns(successful_purchase_for_customer_card_response).in_sequence(s)
+
+    assert response = @gateway.purchase(100, @card_nonce_ok, {
+      :customer => {
+        :given_name => 'fname', :family_name => 'lname', :company_name => 'abc inc',
+        :nickname => 'fred', :phone_number => '444-111-1232', :email => 'a@example.com',
+        :description => 'describe me', :reference_id => 'ref-abc01',
+        :billing_address => {
+          :zip => '94103'
+        }, 
+        :cardholder_name => 'Alexander Hamilton',
+        :address => { :address1 => '456 My Street', :address2 => 'Apt 1', :address3 => 'line 3',
+          :city => 'Ottawa', :sublocality => 'county X', :sublocality_2 => 'sublocality 2',
+          :sublocality_3 => 'sublocality 3', :state => 'ON',
+          :administrative_district_level_2 => 'admin district 2', 
+          :administrative_district_level_3 => 'admin district 3', :zip => 'K1C2N6', :country => 'CA'}
+      }
+    })
+    assert_equal 3, response.responses.count
+    assert_success first = response.responses[0]
+    assert_match /Success/, first.message
+    assert_success second = response.responses[1]
+    assert_match /Success/, second.message
+    assert_success third = response.responses[2]
+    assert_match /Success/, third.message
+  end
+
+
+  private
+
+  def pre_scrubbed_card_nonce
+    <<-PRE_SCRUBBED
+      opening connection to connect.squareup.com:443...
+      opened
+      starting SSL for connect.squareup.com:443...
+      SSL established
+      <- "POST /v2/locations/CBASEO_-cM-R9G8gM73tbqIzKSU/transactions HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer sandbox-sqXXXX-AA-AA__REDACTED_AABBBQ\r\nUser-Agent: Square/v2 ActiveMerchantBindings/1.60.0\r\nX-Square-Client-User-Agent: {\"bindings_version\":\"1.60.0\",\"lang\":\"ruby\",\"lang_version\":\"2.2.2 p95 (2015-04-13)\",\"platform\":\"x86_64-darwin14\",\"publisher\":\"active_merchant\"}\r\nAccept: application/json\r\nAccept-Encoding: \r\nConnection: close\r\nHost: connect.squareup.com\r\nContent-Length: 359\r\n\r\n"
+      <- "{\"amount_money\":{\"amount\":100,\"currency\":\"USD\"},\"idempotency_key\":\"2175bae5cb8cc73f196733355af0a5ad\",\"card_nonce\":\"fake-card-nonce-ok\",\"billing_address\":{\"address_line_1\":\"456 My Street\",\"address_line_2\":\"Apt 1\",\"administrative_district_level_1\":\"ON\",\"locality\":\"Ottawa\",\"postal_code\":\"K1C2N6\",\"country\":\"CA\"},\"reference_id\":null,\"note\":\"Store Purchase Note\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Vary: Origin, Accept-Encoding\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Download-Options: noopen\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Permitted-Cross-Domain-Policies: none\r\n"
+      -> "X-Xss-Protection: 1; mode=block\r\n"
+      -> "Date: Thu, 15 Sep 2016 03:48:59 GMT\r\n"
+      -> "connection: close\r\n"
+      -> "Strict-Transport-Security: max-age=631152000\r\n"
+      -> "content-length: 554\r\n"
+      -> "\r\n"
+      reading 554 bytes...
+      -> "{\"transaction\":{\"id\":\"ad8a3669-39df-5bb8-737e-d2d1ec11f0e1\",\"location_id\":\"CBASEO_-cM-R9G8gM73tbqIzKSU\",\"created_at\":\"2016-09-15T03:48:59Z\",\"tenders\":[{\"id\":\"561e4358-ef65-5c2d-60b9-af777cea7447\",\"location_id\":\"CBASEO_-cM-R9G8gM73tbqIzKSU\",\"transaction_id\":\"ad8a3669-39df-5bb8-737e-d2d1ec11f0e1\",\"created_at\":\"2016-09-15T03:48:59Z\",\"note\":\"Store Purchase Note\",\"amount_money\":{\"amount\":100,\"currency\":\"USD\"},\"type\":\"CARD\",\"card_details\":{\"status\":\"CAPTURED\",\"card\":{\"card_brand\":\"JCB\",\"last_4\":\"0650\"},\"entry_method\":\"KEYED\"}}],\"product\":\"EXTERNAL_API\"}}"
+      read 554 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_card_nonce
+    <<-POST_SCRUBBED
+      opening connection to connect.squareup.com:443...
+      opened
+      starting SSL for connect.squareup.com:443...
+      SSL established
+      <- "POST /v2/locations/CBASEO_-cM-R9G8gM73tbqIzKSU/transactions HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer [FILTERED]\r\nUser-Agent: Square/v2 ActiveMerchantBindings/1.60.0\r\nX-Square-Client-User-Agent: {\"bindings_version\":\"1.60.0\",\"lang\":\"ruby\",\"lang_version\":\"2.2.2 p95 (2015-04-13)\",\"platform\":\"x86_64-darwin14\",\"publisher\":\"active_merchant\"}\r\nAccept: application/json\r\nAccept-Encoding: \r\nConnection: close\r\nHost: connect.squareup.com\r\nContent-Length: 359\r\n\r\n"
+      <- "{\"amount_money\":{\"amount\":100,\"currency\":\"USD\"},\"idempotency_key\":\"2175bae5cb8cc73f196733355af0a5ad\",\"card_nonce\":\"[FILTERED]\",\"billing_address\":{\"address_line_1\":\"456 My Street\",\"address_line_2\":\"Apt 1\",\"administrative_district_level_1\":\"ON\",\"locality\":\"Ottawa\",\"postal_code\":\"K1C2N6\",\"country\":\"CA\"},\"reference_id\":null,\"note\":\"Store Purchase Note\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Vary: Origin, Accept-Encoding\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Download-Options: noopen\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Permitted-Cross-Domain-Policies: none\r\n"
+      -> "X-Xss-Protection: 1; mode=block\r\n"
+      -> "Date: Thu, 15 Sep 2016 03:48:59 GMT\r\n"
+      -> "connection: close\r\n"
+      -> "Strict-Transport-Security: max-age=631152000\r\n"
+      -> "content-length: 554\r\n"
+      -> "\r\n"
+      reading 554 bytes...
+      -> "{\"transaction\":{\"id\":\"ad8a3669-39df-5bb8-737e-d2d1ec11f0e1\",\"location_id\":\"CBASEO_-cM-R9G8gM73tbqIzKSU\",\"created_at\":\"2016-09-15T03:48:59Z\",\"tenders\":[{\"id\":\"561e4358-ef65-5c2d-60b9-af777cea7447\",\"location_id\":\"CBASEO_-cM-R9G8gM73tbqIzKSU\",\"transaction_id\":\"ad8a3669-39df-5bb8-737e-d2d1ec11f0e1\",\"created_at\":\"2016-09-15T03:48:59Z\",\"note\":\"Store Purchase Note\",\"amount_money\":{\"amount\":100,\"currency\":\"USD\"},\"type\":\"CARD\",\"card_details\":{\"status\":\"CAPTURED\",\"card\":{\"card_brand\":\"JCB\",\"last_4\":\"0650\"},\"entry_method\":\"KEYED\"}}],\"product\":\"EXTERNAL_API\"}}"
+      read 554 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    #   Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+    #   to "true" when running remote tests:
+
+    #   $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+    #     test/remote/gateways/remote_square_test.rb \
+    #     -n test_successful_purchase
+
+    #   Also need to add to square.rb#headers method: 'Accept-Encoding' => ''
+    #   So that the response is not gzipped.
+    <<-RESPONSE
+    {
+      "transaction": {
+        "id": "1ea0c711-fdc5-5e16-7afe-1c76ad788254",
+        "location_id": "CBASEO_-cM-R9G8gM73tbqIzKSU",
+        "created_at": "2016-09-12T04:30:56Z",
+        "tenders": [
+          {
+            "id": "be45871a-9e1b-513c-5972-46427a96a34b",
+            "location_id": "CBASEO_-cM-R9G8gM73tbqIzKSU",
+            "transaction_id": "1ea0c711-fdc5-5e16-7afe-1c76ad788254",
+            "created_at": "2016-09-12T04:30:56Z",
+            "note": "Store Purchase Note",
+            "amount_money": {
+              "amount": 100,
+              "currency": "USD"
+            },
+            "type": "CARD",
+            "card_details": {
+              "status": "CAPTURED",
+              "card": {
+                "card_brand": "MASTERCARD",
+                "last_4": "9029"
+              },
+              "entry_method": "KEYED"
+            }
+          }
+        ],
+        "product": "EXTERNAL_API"
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_response
+    <<-RESPONSE
+       {"errors":[{"category":"PAYMENT_METHOD_ERROR","code":"CARD_DECLINED","detail":"Card declined."}]}
+    RESPONSE
+  end
+
+  def successful_authorize_response
+    <<-RESPONSE
+      {"transaction":{"id":"2d604106-cccc-5299-4dc7-d0903cdfcb77","location_id":"CBASEO_-cM-R9G8gM73tbqIzKSU","created_at":"2016-09-15T04:59:51Z","tenders":[{"id":"38f923c7-4a09-5fb2-4087-05aaecb7dba9","location_id":"CBASEO_-cM-R9G8gM73tbqIzKSU","transaction_id":"2d604106-cccc-5299-4dc7-d0903cdfcb77","created_at":"2016-09-15T04:59:51Z","note":"Store Purchase Note","amount_money":{"amount":100,"currency":"USD"},"type":"CARD","card_details":{"status":"AUTHORIZED","card":{"card_brand":"AMERICAN_EXPRESS","last_4":"6550"},"entry_method":"KEYED"}}],"product":"EXTERNAL_API"}}
+    RESPONSE
+  end
+
+  def failed_authorize_response
+    <<-RESPONSE
+      {"errors":[{"category":"PAYMENT_METHOD_ERROR","code":"CARD_DECLINED","detail":"Card declined."}]}
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+      {}
+    RESPONSE
+  end
+
+  def failed_capture_response
+    <<-RESPONSE
+      {"errors":[{"category":"INVALID_REQUEST_ERROR","code":"NOT_FOUND","detail":"Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction with ID `missing-txn-id`.","field":"transaction_id"}]}
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+      {"refund":{"id":"aa71cea0-8f68-5c4d-6ca5-775dafbfedc9","location_id":"CBASEO_-cM-R9G8gM73tbqIzKSU","transaction_id":"b9347714-3224-5002-557a-accbcb1f016e","tender_id":"d6edb74b-9050-5e2f-7eec-8eb66a0aab4a","created_at":"2016-09-15T05:05:02Z","reason":"oops!","amount_money":{"amount":100,"currency":"USD"},"status":"APPROVED"}}
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+      {"errors":[{"category":"INVALID_REQUEST_ERROR","code":"NOT_FOUND","detail":"Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction tender with ID `abc`."}]}
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+      {}
+    RESPONSE
+  end
+
+  def failed_void_response
+    <<-RESPONSE
+      {"errors":[{"category":"INVALID_REQUEST_ERROR","code":"NOT_FOUND","detail":"Location `CBASEO_-cM-R9G8gM73tbqIzKSU` does not have a transaction with ID `non-existant-authorization`.","field":"transaction_id"}]}
+    RESPONSE
+  end
+
+  def successful_create_customer_response
+    <<-RESPONSE
+      {
+        "customer":{
+          "id":"CBASEGSKal7z6RLe1BPcnXW60t0",
+          "created_at":"2016-09-18T15:34:39.445Z",
+          "updated_at":"2016-09-18T15:34:39.445Z",
+          "given_name":"fname",
+          "family_name":"lname",
+          "nickname":"fred",
+          "email_address":"a@example.com",
+          "address":{
+            "address_line_1":"456 My Street",
+            "address_line_2":"Apt 1",
+            "address_line_3":"line 3",
+            "locality":"Ottawa",
+            "sublocality":"county X",
+            "sublocality_2":"sublocality 2",
+            "sublocality_3":"sublocality 3",
+            "administrative_district_level_1":"ON",
+            "administrative_district_level_2":"admin district 2",
+            "administrative_district_level_3":"admin district 3",
+            "postal_code":"K1C2N6",
+            "country":"CA"
+          },
+          "phone_number":"444-111-1232",
+          "reference_id":"ref-abc01",
+          "preferences":{
+            "email_unsubscribed":false
+          },
+          "note":"describe me"
+        }
+      }
+    RESPONSE
+  end
+
+  def successful_link_card_to_customer_response
+    <<-RESPONSE
+      {
+        "card":{
+          "id":"c9fbd9a7-6cba-5b63-6f65-c9b4c9f37b26",
+          "card_brand":"AMERICAN_EXPRESS",
+          "last_4":"6550",
+          "exp_month":9,
+          "exp_year":2018,
+          "cardholder_name":"Alexander Hamilton",
+          "billing_address":{
+            "postal_code":"94103",
+            "country":"ZZ"
+          }
+        }
+      }
+    RESPONSE
+  end
+
+  def successful_purchase_for_customer_card_response
+    <<-RESPONSE
+      {
+        "transaction":{
+          "id":"9e2bf3d1-c4ae-5966-7f3e-310a2cb36e75",
+          "location_id":"CBASEO_-cM-R9G8gM73tbqIzKSU",
+          "created_at":"2016-09-18T15:34:40Z",
+          "tenders":[
+            {
+              "id":"68b51bc0-5142-5646-5573-c57965d3aef3",
+              "location_id":"CBASEO_-cM-R9G8gM73tbqIzKSU",
+              "transaction_id":"9e2bf3d1-c4ae-5966-7f3e-310a2cb36e75",
+              "created_at":"2016-09-18T15:34:40Z",
+              "note":"Online Transaction",
+              "amount_money":{
+                "amount":200,
+                "currency":"USD"
+              },
+              "customer_id":"CBASEGSKal7z6RLe1BPcnXW60t0",
+              "type":"CARD",
+              "card_details":{
+                "status":"CAPTURED",
+                "card":{
+                  "id":"c9fbd9a7-6cba-5b63-6f65-c9b4c9f37b26",
+                  "card_brand":"AMERICAN_EXPRESS",
+                  "last_4":"6550",
+                  "exp_month":9,
+                  "exp_year":2018
+                },
+                "entry_method":"ON_FILE"
+              }
+            }
+          ],
+          "product":"EXTERNAL_API"
+        }
+      }
+    RESPONSE
+  end
+end


### PR DESCRIPTION
This implements the following features for Squareup.com:

```
      def purchase(money, card_nonce, options={})
      def authorize(money, card_nonce, options={})
      def capture(ignored_money, txn_id, ignored_options={})
      def refund(money, txn_id, options={})
      def void(txn_id, options={})
      def verify(card_nonce, options={})
      def store(card_nonce, options = {})
      def update(customer_id, card_id, options = {})
      def update_customer(customer_id, options = {})
      def unstore(card_id, options = {}, deprecated_options = {})
```

Note it does NOT accept raw PANs because square's payment integration requires an iframe based tokenization approach. This is documented here: read more in https://docs.connect.squareup.com/articles/ecommerce-overview/

Remote tests pass, but the credentials are not shareable. Results here:

```
Loaded suite test/remote/gateways/remote_square_test
Started
...........................

Finished in 167.627982 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
27 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.16 tests/s, 1.04 assertions/s
```

Please let me know if you need anything to improve this so it can be merged in. Thanks!
