### PR TITLE
Stripe: Ensure ECI values for tokenized cards are padded

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -389,7 +389,7 @@ module ActiveMerchant #:nodoc:
 
           if creditcard.is_a?(NetworkTokenizationCreditCard)
             card[:cryptogram] = creditcard.payment_cryptogram
-            card[:eci] = creditcard.eci
+            card[:eci] = creditcard.eci.rjust(2, '0') if creditcard.eci =~ /^[0-9]+$/
             card[:tokenization_method] = creditcard.source.to_s
           end
           post[:card] = card

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -762,6 +762,19 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @emv_credit_card.icc_data, post[:card][:emv_auth_data]
   end
 
+  def test_add_creditcard_pads_eci_value
+    post = {}
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "111111111100cryptogram",
+      verification_value: nil,
+      eci: "7"
+    )
+
+    @gateway.send(:add_creditcard, post, credit_card, {})
+
+    assert_equal "07", post[:card][:eci]
+  end
+
   def test_application_fee_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:application_fee => 144}))


### PR DESCRIPTION
Stripe requires all ECI values to be properly 0 padded strings. They
will silently ignore the value if not (and typically the processor will
decline the transaction as a result).

I had considered changing this at the NetworkTokenizationCreditCard
level (and you can see what that implementation would look like here
https://github.com/activemerchant/active_merchant/compare/master...jasonwebster:ensure_eci_value_format?expand=1),
however, after reading some other gateway's documentation, it became
increasingly unclear if that change would be compatible with them. While
the standard always indicates zero padded values, some gateways such as
[Payeezy](https://support.payeezy.com/hc/en-us/articles/203730589-Ecommerce-Flag-Values)
indicate they don't, so I decided to just leave this as a Stripe
specific change.