### PR TITLE
Authorize.net: Map to standard `AVSResult` codes

### DIFF
--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -680,6 +680,16 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card)
     assert_equal 'X', response.avs_result['code']
+    assert_equal 'Y', response.avs_result['street_match']
+    assert_equal 'Y', response.avs_result['postal_match']
+
+
+    @gateway.expects(:ssl_post).returns(address_not_provided_avs_response)
+
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_equal 'I', response.avs_result['code']
+    assert_equal nil, response.avs_result['street_match']
+    assert_equal nil, response.avs_result['postal_match']
   end
 
   def test_cvv_result
@@ -1080,6 +1090,43 @@ class AuthorizeNetTest < Test::Unit::TestCase
         <responseCode>4</responseCode>
         <authCode>GSOFTZ</authCode>
         <avsResultCode>X</avsResultCode>
+        <cvvResultCode>M</cvvResultCode>
+        <cavvResultCode>2</cavvResultCode>
+        <transId>508141795</transId>
+          <refTransID/>
+          <transHash>655D049EE60E1766C9C28EB47CFAA389</transHash>
+        <testRequest>0</testRequest>
+        <accountNumber>XXXX2224</accountNumber>
+        <accountType>Visa</accountType>
+        <messages>
+          <message>
+            <code>1</code>
+            <description>Thank you! For security reasons your order is currently being reviewed</description>
+          </message>
+        </messages>
+      </transactionResponse>
+      </createTransactionResponse>
+    eos
+  end
+
+  def address_not_provided_avs_response
+    <<-eos
+      <?xml version="1.0" encoding="utf-8"?>
+      <createTransactionResponse
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+      xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+      <refId>1</refId>
+      <messages>
+        <resultCode>Ok</resultCode>
+          <message>
+          <code>I00001</code>
+          <text>Successful.</text>
+          </message>
+      </messages>
+      <transactionResponse>
+        <responseCode>4</responseCode>
+        <authCode>GSOFTZ</authCode>
+        <avsResultCode>B</avsResultCode>
         <cvvResultCode>M</cvvResultCode>
         <cavvResultCode>2</cavvResultCode>
         <transId>508141795</transId>
@@ -2009,5 +2056,4 @@ class AuthorizeNetTest < Test::Unit::TestCase
       </authenticateTestResponse>
     eos
   end
-
 end


### PR DESCRIPTION
@davidsantoso 

`B, E, and P` are the ones that have slightly different definitions.

[Authorize.net's](https://support.authorize.net/authkb/index?page=content&id=A378&actp=search&viewlocale=en_US&searchid=1478095028647) (vs) [Active Merchant's](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/avs_result.rb#L14-L39)