### PR TITLE
Added 3ds-verifyenrolled call to Realex.

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -63,6 +63,13 @@ module ActiveMerchant
         commit(request)
       end
 
+      def verify_enrolled(money, creditcard, options = {})
+        requires!(options, :order_id)
+
+        request = build_verify_enrolled_request(money, creditcard, options)
+        commit(request)
+      end
+
       def capture(money, authorization, options = {})
         request = build_capture_request(authorization, options)
         commit(request)
@@ -184,6 +191,20 @@ module ActiveMerchant
           add_transaction_identifiers(xml, authorization, options)
           add_comments(xml, options)
           add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), nil, nil, nil)
+        end
+        xml.target!
+      end
+
+      def build_verify_enrolled_request(money, credit_card, options)
+        timestamp = new_timestamp
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'request', 'timestamp' => timestamp, 'type' => '3ds-verifyenrolled' do
+          add_merchant_details(xml, options)
+          xml.tag! 'orderid', sanitize_order_id(options[:order_id])
+          add_amount(xml, money, options)
+          add_card(xml, credit_card)
+          add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), amount(money), (options[:currency] || currency(money)), credit_card.number)
+          add_comments(xml, options)
         end
         xml.target!
       end


### PR DESCRIPTION
The call is there to check if the card that will be used to complete the transaction needs 3d secure
verification (verified by visa, etc).

Upon calling this API, the application can either continue with an AUTH request (if card is not enrolled) OR go to the 3DS redirect URL presented by the Realex API. When doing the latter, they need to pass on some of the response parameters received, see the API docs for full details and flow.

Details about the Realex API:
https://developer.realexpayments.com/#!/api/3d-secure/verify-enrolled