### PR TITLE
Implemented Realex 3ds-verifysig request.

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -83,6 +83,13 @@ module ActiveMerchant
         commit(request)
       end
 
+      def verify_sig(money, creditcard, options = {})
+        requires!(options, :order_id, :pares)
+
+        request = build_verify_sig_request(money, creditcard, options)
+        commit(request)
+      end
+
       def supports_scrubbing
         true
       end
@@ -184,6 +191,19 @@ module ActiveMerchant
           add_transaction_identifiers(xml, authorization, options)
           add_comments(xml, options)
           add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), nil, nil, nil)
+        end
+        xml.target!
+      end
+
+      def build_verify_sig_request(money, credit_card, options)
+        timestamp = new_timestamp
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'request', 'timestamp' => timestamp, 'type' => '3ds-verifysig' do
+          add_merchant_details(xml, options)
+          xml.tag! 'orderid', sanitize_order_id(options[:order_id])
+          add_amount(xml, money, options)
+          xml.tag! 'pares', sanitize_order_id(options[:pares])
+          add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), amount(money), (options[:currency] || currency(money)), credit_card.number)
         end
         xml.target!
       end


### PR DESCRIPTION
This request is there to check the results of a 3D secure verification from the user. It needs a 'PaRes'
attribute that the redirect callback got back from the verified by visa
flow.

Details about the Realex API:
https://developer.realexpayments.com/#!/api/3d-secure/3ds-verifysig