### PR TITLE
Maxipago: Send currency with request

### DIFF
--- a/lib/active_merchant/billing/gateways/maxipago.rb
+++ b/lib/active_merchant/billing/gateways/maxipago.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
           add_order_id(xml, authorization)
           add_reference_num(xml, options)
           xml.payment do
-            add_amount(xml, money)
+            add_amount(xml, money, options)
           end
         end
       end
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
           add_order_id(xml, authorization)
           add_reference_num(xml, options)
           xml.payment do
-            add_amount(xml, money)
+            add_amount(xml, money, options)
           end
         end
       end
@@ -163,7 +163,7 @@ module ActiveMerchant #:nodoc:
           end
         end
         xml.payment do
-          add_amount(xml, money)
+          add_amount(xml, money, options)
           add_installments(xml, options)
         end
         add_billing_address(xml, creditcard, options)
@@ -173,8 +173,9 @@ module ActiveMerchant #:nodoc:
         xml.referenceNum(options[:order_id] || generate_unique_id)
       end
 
-      def add_amount(xml, money)
+      def add_amount(xml, money, options)
         xml.chargeTotal(amount(money))
+        xml.currencyCode(options[:currency] || currency(money) || default_currency)
       end
 
       def add_processor_id(xml)

--- a/test/remote/gateways/remote_maxipago_test.rb
+++ b/test/remote/gateways/remote_maxipago_test.rb
@@ -48,6 +48,11 @@ class RemoteMaxipagoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_currency
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: "CLP"))
+    assert_success response
+  end
+
   def test_failed_purchase
     assert response = @gateway.purchase(@invalid_amount, @credit_card, @options)
     assert_failure response


### PR DESCRIPTION
Maxipago was not sending currency, presumably since it is most often
used with, and the gateway defaults to, the BRL currency. But some
acquirers support additional currencies.

@davidsantoso to confirm and merge.