### PR TITLE
Credorax: Map order_id to field H9

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         reference_action = add_reference(post, authorization)
         add_echo(post, options)
-        post[:a1] = options[:order_id] || generate_unique_id
+        post[:a1] = generate_unique_id
 
         commit(:void, post, reference_action)
       end
@@ -109,8 +109,9 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:a4] = amount(money)
-        post[:a1] = options[:order_id] || generate_unique_id
+        post[:a1] = generate_unique_id
         post[:a5] = options[:currency] || currency(money)
+        post[:h9] = options[:order_id]
       end
 
       CARD_TYPES = {

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -8,6 +8,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     @credit_card = credit_card('5223450000000007', verification_value: "090", month: "12", year: "2025")
     @declined_card = credit_card('4000300011112220')
     @options = {
+      order_id: "1",
       currency: "EUR",
       billing_address: address,
       description: 'Store Purchase'
@@ -23,6 +24,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
+    assert_equal "1", response.params["H9"]
     assert_equal "Succeeded", response.message
   end
 


### PR DESCRIPTION
H9 (Merchant Reference Number) is a more suitable field for order_id
than A1. A1 is still sent as a unique ID where required.

@davidsantoso to confirm and merge.