### PR TITLE
Fat Zebra: De-nest soft descriptor fields

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -136,15 +136,9 @@ module ActiveMerchant #:nodoc:
         extra[:cavv] = options[:cavv] if options[:cavv]
         extra[:xid] = options[:cavv] if options[:xid]
         extra[:sli] = options[:sli] if options[:sli]
-        add_descriptor(extra, options)
+        extra[:name] = options[:merchant] if options[:merchant]
+        extra[:location] = options[:merchant_location] if options[:merchant_location]
         post[:extra] = extra if extra.any?
-      end
-
-      def add_descriptor(extra, options)
-        descriptor = {}
-        descriptor[:name] = options[:merchant] if options[:merchant]
-        descriptor[:location] = options[:merchant_location] if options[:merchant_location]
-        extra[:descriptor] = descriptor if descriptor.any?
       end
 
       def add_order_id(post, options)

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -136,7 +136,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   def test_failed_purchase_with_incomplete_3DS_information
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:cavv => 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', :sli => '05'))
     assert_failure response
-    assert_match %r{Exception caught in application}, response.message
+    assert_match %r{Extra/xid is required for SLI 05}, response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -76,7 +76,7 @@ class FatZebraTest < Test::Unit::TestCase
   def test_successful_purchase_with_descriptor
     @gateway.expects(:ssl_request).with { |method, url, body, headers|
       json = JSON.parse(body)
-      json['extra']['descriptor']['name'] == 'Merchant' && json['extra']['descriptor']['location'] == 'Location'
+      json['extra']['name'] == 'Merchant' && json['extra']['location'] == 'Location'
     }.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, "e1q7dbj2", @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))


### PR DESCRIPTION
Contrary to their documentation, descriptor fields should not be nested
in their own hash. Also updates a test_failed assertion.

@davidsantoso to confirm and merge.