### PR TITLE
Worldpay: Format non-fractional currency amounts correctly

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
         currency = options[:currency] || currency(money)
 
         amount_hash = {
-          :value => amount(money),
+          :value => localized_amount(money, currency),
           'currencyCode' => currency,
           'exponent' => non_fractional_currency?(currency) ? 0 : 2
         }

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -190,9 +190,20 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_non_fractional_amount_handling_with_moneylike
+    amount = OpenStruct.new(cents: 10000)
+    stub_comms do
+      @gateway.authorize(amount, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |endpoint, data, headers|
+      assert_tag_with_attributes 'amount',
+          {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
+        data
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_currency_exponent_handling
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(currency: :JPY))
+      @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))
     end.check_request do |endpoint, data, headers|
       assert_tag_with_attributes 'amount',
           {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},


### PR DESCRIPTION
https://github.com/activemerchant/active_merchant/pull/2084 introduced a regression to the Worldpay gateway wherein it was no longer implementing the correct contract for non-fractional currencies.

Our [base gateway tests](https://github.com/jasonwebster/active_merchant/blob/07e28c4936c2ae46f0470d878c19f36564c3df6e/test/unit/gateways/gateway_test.rb#L83-L91) and [Stripe tests](https://github.com/jasonwebster/active_merchant/blob/07e28c4936c2ae46f0470d878c19f36564c3df6e/test/unit/gateways/stripe_test.rb#L431-L440) for example, which is another gateway with a `:cents` money format, ensure that you want to charge ¥100, you actually have to pass in `10000`, as if the non-fractional currency _was_ fractional. That's the external contract of Active Merchant--all transaction amounts accepted by the public API methods are expected to be in cents, period.