### PR TITLE
Add Amazon Payments Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/amazon_payments.rb
+++ b/lib/active_merchant/billing/gateways/amazon_payments.rb
@@ -1,0 +1,350 @@
+require 'active_support/core_ext/string/filters'
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class AmazonPaymentsGateway < Gateway
+      API_VERSION = '2013-01-01'
+
+      self.test_url = 'https://mws.amazonservices.com/OffAmazonPayments_Sandbox/2013-01-01'
+      self.live_url = 'https://mws.amazonservices.com/OffAmazonPayments/2013-01-01'
+
+      self.supported_countries = ['US', 'JP', 'GB', 'DE', 'IN', 'FR', 'IT', 'ES']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
+      self.money_format = :cents
+
+      self.homepage_url = 'https://payments.amazon.com/'
+      self.display_name = 'Amazon Payments'
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      def initialize(options={})
+        requires!(options, :merchant_id, :access_key, :secret_key)
+
+        options[:region] ||= :us
+        options[:currency] ||= self.default_currency
+        options[:max_retries] ||= 0
+        options[:retry_intervals] ||= [1, 2, 4, 8]
+
+        super
+
+        self.test_url = "https://#{endpoint_domain(options[:region])}/#{sandbox_str}/#{API_VERSION}"
+        self.live_url = "https://#{endpoint_domain(options[:region])}/#{sandbox_str}/#{API_VERSION}"
+      end
+
+      def get_order_reference_details(order_reference_id, options={})
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+        add_address_consent_token(post, options[:address_consent_token])
+
+        commit('GetOrderReferenceDetails', post)
+      end
+
+      def set_order_reference_details(order_reference_id, money, options={})
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+        add_order_reference_attributes(post, money, options)
+
+        commit('SetOrderReferenceDetails', post)
+      end
+
+      def confirm_order_reference(order_reference_id)
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+
+        commit('ConfirmOrderReference', post)
+      end
+
+      def purchase(money, order_reference_id, options={})
+        requires!(options, :authorization_reference_id, :capture_reference_id)
+
+        MultiResponse.run do |r|
+          r.process { authorize(money, order_reference_id, options) }
+          r.process { capture(money, r.authorization, options) }
+        end
+      end
+
+      def authorize(money, order_reference_id, options={})
+        requires!(options, :authorization_reference_id)
+
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+        add_authorization_reference_id(post, options[:authorization_reference_id])
+        add_authorization_amount(post, money)
+        add_authorization_options(post, options)
+
+        commit('Authorize', post)
+      end
+
+      def capture(money, authorization_id, options={})
+        requires!(options, :capture_reference_id)
+
+        post = {}
+        add_authorization_id(post, authorization_id)
+        add_capture_reference_id(post, options[:capture_reference_id])
+        add_capture_amount(post, money)
+        add_capture_options(post, options)
+
+        commit('Capture', post)
+      end
+
+      def refund(money, capture_id, options={})
+        requires!(options, :refund_reference_id)
+
+        post = {}
+        add_capture_id(post, capture_id)
+        add_refund_reference_id(post, options[:refund_reference_id])
+        add_refund_amount(post, money)
+        add_refund_options(post, options)
+
+        commit('Refund', post)
+      end
+
+      def close_authorization(authorization_id, options={})
+        post = {}
+        add_authorization_id(post, authorization_id)
+        add_closure_reason(post, options[:closure_reason])
+
+        commit('CloseAuthorization', post)
+      end
+
+      def close_order_reference(order_reference_id, options={})
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+        add_closure_reason(post, options[:closure_reason])
+
+        commit('CloseOrderReference', post)
+      end
+
+      def cancel_order_reference(order_reference_id, options={})
+        post = {}
+        add_order_reference_id(post, order_reference_id)
+        add_cancelation_reason(post, options[:cancelation_reason])
+
+        commit('CancelOrderReference', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.gsub(%r((AWSAccessKeyId=)\w+), '\1[FILTERED]')
+      end
+
+      private
+
+      def add_order_reference_id(post, order_reference_id)
+        post['AmazonOrderReferenceId'] = order_reference_id
+      end
+
+      def add_address_consent_token(post, address_consent_token)
+        post['AddressConsentToken'] = address_consent_token
+      end
+
+      def add_order_reference_attributes(post, money, options)
+        post['OrderReferenceAttributes.OrderTotal.Amount'] = amount(money)
+        post['OrderReferenceAttributes.OrderTotal.CurrencyCode'] = (@options[:currency] || currency(money))
+        post['OrderReferenceAttributes.PlatformId'] = options[:platform_id]
+        post['OrderReferenceAttributes.SellerNote'] = options[:seller_note]
+        post['OrderReferenceAttributes.SellerOrderAttributes.SellerOrderId'] = options[:seller_order_id]
+        post['OrderReferenceAttributes.SellerOrderAttributes.StoreName'] = options[:store_name]
+      end
+
+      def add_authorization_reference_id(post, authorization_reference_id)
+        post['AuthorizationReferenceId'] = authorization_reference_id
+      end
+
+      def add_authorization_amount(post, money)
+        post['AuthorizationAmount.Amount'] = amount(money)
+        post['AuthorizationAmount.CurrencyCode'] = (@options[:currency] || currency(money))
+      end
+
+      def add_authorization_options(post, options)
+        post['SellerAuthorizationNote'] = options[:seller_authorization_note]
+        post['TransactionTimeout'] = options[:transaction_timeout]
+        post['CaptureNow'] = options[:capture_now]
+        post['SoftDescriptor'] = options[:soft_descriptor]
+      end
+
+      def add_authorization_id(post, authorization_id)
+        post['AmazonAuthorizationId'] = authorization_id
+      end
+
+      def add_capture_reference_id(post, capture_reference_id)
+        post['CaptureReferenceId'] = capture_reference_id
+      end
+
+      def add_capture_amount(post, money)
+        post['CaptureAmount.Amount'] = amount(money)
+        post['CaptureAmount.CurrencyCode'] = (@options[:currency] || currency(money))
+      end
+
+      def add_capture_options(post, options)
+        post['SellerCaptureNote'] = options[:seller_capture_note]
+        post['SoftDescriptor'] = options[:soft_descriptor]
+      end
+
+      def add_capture_id(post, capture_id)
+        post['AmazonCaptureId'] = capture_id
+      end
+
+      def add_refund_reference_id(post, refund_reference_id)
+        post['RefundReferenceId'] = refund_reference_id
+      end
+
+      def add_refund_amount(post, money)
+        post['RefundAmount.Amount'] = amount(money)
+        post['RefundAmount.CurrencyCode'] = (@options[:currency] || currency(money))
+      end
+
+      def add_refund_options(post, options)
+        post['SellerRefundNote'] = options[:seller_refund_note]
+        post['SoftDescriptor'] = options[:soft_descriptor]
+      end
+
+      def add_closure_reason(post, closure_reason)
+        post['ClosureReason'] = closure_reason
+      end
+
+      def add_cancelation_reason(post, cancelation_reason)
+        post['CancelationReason'] = cancelation_reason
+      end
+
+      def parse(body, action)
+        results = {}
+        return results unless body
+        xml = Nokogiri::XML(body) do |config|
+          config.options = Nokogiri::XML::ParseOptions::NOBLANKS
+        end
+        xml.remove_namespaces!
+        nodes = xml.xpath("//#{action}Response | //ErrorResponse")
+        nodes.each do |node|
+          results[node.name] = parse_node(node, results[node.name])
+        end
+        results
+      end
+
+      def parse_node(node, results)
+        return node.child.text if node.children.length == 1 && node.child.text?
+        results = {}
+        node.children.each do |child|
+          results[child.name] = parse_node(child, results[child.name])
+        end
+        results
+      end
+
+      def commit(action, parameters)
+        retries = 0
+        begin
+          response = parse(ssl_post(url, post_data(action, parameters)), action)
+        rescue ResponseError => e
+          # see: https://payments.amazon.com/developer/documentation/lpwa/201954950
+          case e.response.code.to_i
+          when 500, 502, 503, 504
+            if retries < options[:max_retries]
+              sleep options[:retry_intervals][retries]
+              retries += 1
+              retry
+            end
+          end
+          response = parse(e.response.body, action)
+        end
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def success_from(response)
+        !response.empty? && !response['ErrorResponse']
+      end
+
+      def message_from(response)
+        if response['ErrorResponse']
+          response['ErrorResponse']['Error']['Message']
+        else
+          'Success'
+        end
+      end
+
+      def authorization_from(response)
+        if response['AuthorizeResponse']
+          response['AuthorizeResponse']['AuthorizeResult']['AuthorizationDetails']['AmazonAuthorizationId']
+        else
+          nil
+        end
+      end
+
+      def post_data(action, parameters = {})
+        parameters.reject! { |k, v| v.nil? }
+        hash = default_parameters.merge(parameters)
+        hash['Action'] = action
+        query_string = hash.sort.map { |k, v| "#{k}=#{ custom_escape(v) }" }.join("&")
+        message = ["POST", "#{endpoint_domain(options[:region])}", "/#{sandbox_str}/#{API_VERSION}", query_string].join("\n")
+        query_string += "&Signature=" + sign(message)
+        query_string
+      end
+
+      def url
+        test? ? self.test_url : self.live_url
+      end
+
+      def sandbox_str
+        test? ? 'OffAmazonPayments_Sandbox' : 'OffAmazonPayments'
+      end
+
+      def default_parameters
+        {
+          'AWSAccessKeyId' => @options[:access_key],
+          'SellerId' => @options[:merchant_id],
+          'SignatureMethod' => 'HmacSHA256',
+          'SignatureVersion' => '2',
+          'Timestamp' => Time.now.utc.iso8601,
+          'Version' => '2013-01-01'
+        }
+      end
+
+      def sign(data)
+        custom_escape(Base64.strict_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, @options[:secret_key], data)))
+      end
+
+      def custom_escape(value)
+        value.to_s.gsub(/([^\w.~-]+)/) do
+          "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
+        end
+      end
+
+      def error_code_from(response)
+        return if success_from(response)
+        return if response.empty?
+        response['ErrorResponse']['Error']['Code']
+      end
+
+      def endpoint_domain(region)
+        case region
+        when :jp
+          'mws.amazonservices.jp'
+        when :uk
+          'mws-eu.amazonservices.com'
+        when :de
+          'mws-eu.amazonservices.com'
+        when :eu
+          'mws-eu.amazonservices.com'
+        when :us
+          'mws.amazonservices.com'
+        when :na
+          'mws.amazonservices.com'
+        else
+          raise ArgumentError, "Unknown region code #{region}"
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -16,6 +16,12 @@ allied_wallet:
   merchant_id: merchant_id
   token: token
 
+# Working credentials, no need to replace
+amazon_payments:
+  merchant_id: 'merchant_id'
+  access_key: 'access_key'
+  secret_key: 'secret_key'
+
 # Working credentials, no need to replace as of Oct 28 2014
 authorize_net:
   login: 7Tt72zseSzH

--- a/test/remote/gateways/remote_amazon_payments_test.rb
+++ b/test/remote/gateways/remote_amazon_payments_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+class RemoteAmazonPaymentsTest < Test::Unit::TestCase
+  def setup
+    @gateway = AmazonPaymentsGateway.new(fixtures(:amazon_payments))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com"
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED PURCHASE MESSAGE', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+  end
+
+  def test_invalid_login
+    gateway = AmazonPaymentsGateway.new(login: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED LOGIN MESSAGE}, response.message
+  end
+
+  def test_dump_transcript
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic.  You can delete
+    # this helper after completing your scrub implementation.
+    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end

--- a/test/unit/gateways/amazon_payments_test.rb
+++ b/test/unit/gateways/amazon_payments_test.rb
@@ -1,0 +1,591 @@
+require 'test_helper'
+require 'active_support/core_ext/string/strip'
+
+class AmazonPaymentsTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = AmazonPaymentsGateway.new(fixtures(:amazon_payments))
+    @amount = 100
+    @order_reference_id = 'ORDER_REFERENCE_ID'
+    @authorization_reference_id = 'AUTHORIZATION_REFERENCE_ID'
+    @capture_reference_id = 'CAPTURE_REFERENCE_ID'
+    @authorization_id = 'P01-1234567-1234567-0000001'
+    @capture_id = 'P01-1234567-1234567-0000002'
+  end
+
+  def test_successful_get_order_reference_details
+    @gateway.expects(:ssl_post).returns(successful_get_order_reference_details_response)
+
+    response = @gateway.get_order_reference_details(@order_reference_id)
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_get_order_reference_details
+    @gateway.expects(:ssl_post).returns(failed_get_order_reference_details_response)
+
+    response = @gateway.get_order_reference_details(@order_reference_id)
+    assert_failure response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_successful_set_order_reference_details
+    @gateway.expects(:ssl_post).returns(successful_set_order_reference_details_response)
+
+    options = {}
+    response = @gateway.set_order_reference_details(@order_reference_id, @amount, options)
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_set_order_reference_details_commit
+    options = {
+      platform_id: 'platform id',
+      seller_note: 'seller note',
+      seller_order_id: 'seller order id',
+      store_name: 'store name',
+    }
+    @gateway.expects(:commit).with('SetOrderReferenceDetails', {
+      'AmazonOrderReferenceId' => @order_reference_id,
+      'OrderReferenceAttributes.OrderTotal.Amount' => @amount.to_s,
+      'OrderReferenceAttributes.OrderTotal.CurrencyCode' => 'USD',
+      'OrderReferenceAttributes.PlatformId' => options[:platform_id],
+      'OrderReferenceAttributes.SellerNote' => options[:seller_note],
+      'OrderReferenceAttributes.SellerOrderAttributes.SellerOrderId' => options[:seller_order_id],
+      'OrderReferenceAttributes.SellerOrderAttributes.StoreName' => options[:store_name]
+    })
+    @gateway.set_order_reference_details(@order_reference_id, @amount, options)
+  end
+
+  def test_successful_confirm_order_reference
+    @gateway.expects(:ssl_post).returns(successful_confirm_order_reference_response)
+
+    response = @gateway.confirm_order_reference(@order_reference_id)
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_successful_purchase
+    options = {
+      authorization_reference_id: @authorization_reference_id,
+      capture_reference_id: @capture_reference_id
+    }
+    response = stub_comms do
+      @gateway.purchase(@amount, @order_reference_id, options)
+    end.respond_with(successful_authorize_response, successful_capture_response)
+
+    assert_success response
+    assert_instance_of MultiResponse, response
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    options = {
+      authorization_reference_id: @authorization_reference_id,
+      capture_reference_id: @capture_reference_id
+    }
+    response = stub_comms do
+      @gateway.purchase(@amount, @order_reference_id, options)
+    end.respond_with(failed_authorize_response, failed_capture_response)
+
+    assert_failure response
+    assert_instance_of MultiResponse, response
+    assert_equal 'TransactionAmountExceeded', response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    options = {
+      authorization_reference_id: @authorization_reference_id
+    }
+    response = @gateway.authorize(@amount, @order_reference_id, options)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert_equal @authorization_id, response.authorization
+    assert response.test?
+  end
+
+  def test_failed_authorize
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+
+    options = {
+      capture_reference_id: @capture_reference_id
+    }
+    response = @gateway.capture(@amount, @authorization_id, options)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_capture
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    options = {
+      refund_reference_id: 'refund_reference_id'
+    }
+    response = @gateway.refund(@amount, @capture_id, options)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    options = {
+      refund_reference_id: 'refund_reference_id'
+    }
+    response = @gateway.refund(@amount, @capture_id, options)
+
+    assert_failure response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_successful_close_authorization
+    @gateway.expects(:ssl_post).returns(successful_close_authorization_response)
+
+    response = @gateway.close_authorization(@authorization_id)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_close_authorization
+    @gateway.expects(:ssl_post).returns(failed_close_authorization_response)
+
+    response = @gateway.close_authorization(@authorization_id)
+
+    assert_failure response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_successful_close_order_reference
+    @gateway.expects(:ssl_post).returns(successful_close_order_reference_response)
+
+    response = @gateway.close_order_reference(@order_reference_id)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_close_order_reference
+    @gateway.expects(:ssl_post).returns(failed_close_order_reference_response)
+
+    response = @gateway.close_order_reference(@order_reference_id)
+
+    assert_failure response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_successful_cancel_order_reference
+    @gateway.expects(:ssl_post).returns(successful_cancel_order_reference_response)
+
+    response = @gateway.cancel_order_reference(@order_reference_id)
+
+    assert_success response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_failed_cancel_order_reference
+    @gateway.expects(:ssl_post).returns(failed_cancel_order_reference_response)
+
+    response = @gateway.cancel_order_reference(@order_reference_id)
+
+    assert_failure response
+    assert_instance_of Response, response
+    assert response.test?
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_parse_successful_response
+    action = 'SetOrderReferenceDetails'
+    response = @gateway.send(:parse, successful_set_order_reference_details_response, action)
+    assert_equal({
+      'SetOrderReferenceDetailsResponse' => {
+        'ResponseMetadata' => {
+          'RequestId' => 'f42df4b1-8047-11df-8d5c-bf56a38ef3b4'
+        },
+        'SetOrderReferenceDetailsResult' => {
+          'OrderReferenceDetails' => {
+            'AmazonOrderReferenceId' => 'P01-1234567-1234567',
+            'CreationTimestamp' => '2012-11-05T20:21:19Z',
+            'Destination' => {
+              'DestinationType' => 'Physical',
+              'PhysicalDestination' => {
+                'City' => 'New York',
+                'CountryCode' => 'US',
+                'PostalCode' => '10101-9876',
+                'StateOrRegion' => 'NY'
+              }
+            },
+            'ExpirationTimestamp' => '2013-05-07T23:21:19Z',
+            'OrderReferenceStatus' => {
+              'State' => 'Draft'
+            },
+            'OrderTotal' => {
+              'Amount' => '106',
+              'CurrencyCode' => 'USD'
+            },
+            'ReleaseEnvironment' => 'Live',
+            'SellerNote' => 'Lorem ipsum',
+            'SellerOrderAttributes' => {
+              'SellerOrderId' => '5678-23'
+            }
+          }
+        }
+      }
+    }, response)
+  end
+
+  def test_parse_failure_response
+    action = 'Authorize'
+    response = @gateway.send(:parse, failed_authorize_response, action)
+    assert_equal({
+      'ErrorResponse' => {
+        'Error' => {
+          'Type' => 'Sender',
+          'Code' => 'TransactionAmountExceeded',
+          'Message' => 'A Authorize request with amount 1000000.00 JPY cannot be accepted.',
+        },
+        'RequestId' => '4281dc31-5863-4d1a-b98f-de7e3c35c054',
+      }
+    }, response)
+  end
+
+  def test_commit_retries
+    gateway = AmazonPaymentsGateway.new(
+      fixtures(:amazon_payments).merge(
+        max_retries: 3,
+        retry_intervals: [0, 0, 0]
+      )
+    )
+    gateway.expects(:raw_ssl_request).returns(retriable_net_httpresponse).times(4)
+
+    response = gateway.send(:commit, 'Action', {})
+
+    assert_failure response
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      <- "AWSAccessKeyId=AKIAJKYFSJU7PEXAMPLE&Action=GetOrderReferenceDetails&AddressConsentToken=YOUR_ACCESS_TOKEN&AmazonOrderReferenceId=P01-1234567-1234567&SellerId=YOUR_SELLER_ID_HERE&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-11-05T19%3A01%3A11Z&Version=2013-01-01&Signature=CLZOdtJGjAo81IxaLoE7af6HqK0EXAMPLE
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      <- "AWSAccessKeyId=[FILTERED]&Action=GetOrderReferenceDetails&AddressConsentToken=YOUR_ACCESS_TOKEN&AmazonOrderReferenceId=P01-1234567-1234567&SellerId=YOUR_SELLER_ID_HERE&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-11-05T19%3A01%3A11Z&Version=2013-01-01&Signature=CLZOdtJGjAo81IxaLoE7af6HqK0EXAMPLE
+    POST_SCRUBBED
+  end
+
+  def successful_get_order_reference_details_response
+    <<-XML
+<GetOrderReferenceDetailsResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+<GetOrderReferenceDetailsResult>
+  <OrderReferenceDetails>
+    <AmazonOrderReferenceId>P01-1234567-1234567</AmazonOrderReferenceId>
+    <CreationTimestamp>2012-11-05T20:21:19Z</CreationTimestamp>
+    <ExpirationTimestamp>2013-05-07T23:21:19Z</ExpirationTimestamp>
+    <OrderReferenceStatus>
+      <State>Draft</State>
+    </OrderReferenceStatus>
+    <Destination>
+      <DestinationType>Physical</DestinationType>
+      <PhysicalDestination>
+        <City>New York</City>
+        <StateOrRegion>NY</StateOrRegion>
+        <PostalCode>10101-9876</PostalCode>
+        <CountryCode>US</CountryCode>
+      </PhysicalDestination>
+    </Destination>
+    <ReleaseEnvironment>Live</ReleaseEnvironment>
+  </OrderReferenceDetails>
+</GetOrderReferenceDetailsResult>
+<ResponseMetadata>
+  <RequestId>5f20169b-7ab2-11df-bcef-d35615e2b044</RequestId>
+</ResponseMetadata>
+</GetOrderReferenceDetailsResponse>
+    XML
+  end
+
+  def failed_get_order_reference_details_response
+    <<-XML
+      <ErrorResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <Error>
+          <Type>Sender</Type>
+          <Code>TransactionAmountExceeded</Code>
+          <Message>A Refund request with amount 646.00 JPY cannot be accepted. Capture S03-4986860-2335791-C014008 has already been refunded for amount 646.00 JPY. The total Refund amount against this Capture cannot exceed 743.00 JPY.</Message>
+        </Error>
+        <RequestId>4281dc31-5863-4d1a-b98f-de7e3c35c054</RequestId>
+      </ErrorResponse>
+    XML
+  end
+
+  def successful_set_order_reference_details_response
+    <<-XML
+      <SetOrderReferenceDetailsResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <SetOrderReferenceDetailsResult>
+          <OrderReferenceDetails>
+            <AmazonOrderReferenceId>P01-1234567-1234567</AmazonOrderReferenceId>
+            <OrderTotal>
+              <Amount>106</Amount>
+              <CurrencyCode>USD</CurrencyCode>
+            </OrderTotal>
+            <SellerOrderAttributes>
+              <SellerOrderId>5678-23</SellerOrderId>
+            </SellerOrderAttributes>
+            <SellerNote>Lorem ipsum</SellerNote>
+            <CreationTimestamp>2012-11-05T20:21:19Z</CreationTimestamp>
+            <ExpirationTimestamp>2013-05-07T23:21:19Z</ExpirationTimestamp>
+            <OrderReferenceStatus>
+              <State>Draft</State>
+            </OrderReferenceStatus>
+            <Destination>
+              <DestinationType>Physical</DestinationType>
+              <PhysicalDestination>
+                <City>New York</City>
+                <StateOrRegion>NY</StateOrRegion>
+                <PostalCode>10101-9876</PostalCode>
+                <CountryCode>US</CountryCode>
+              </PhysicalDestination>
+            </Destination>
+            <ReleaseEnvironment>Live</ReleaseEnvironment>
+          </OrderReferenceDetails>
+        </SetOrderReferenceDetailsResult>
+        <ResponseMetadata>
+          <RequestId>f42df4b1-8047-11df-8d5c-bf56a38ef3b4</RequestId>
+        </ResponseMetadata>
+      </SetOrderReferenceDetailsResponse>
+    XML
+  end
+
+  def successful_confirm_order_reference_response
+    <<-XML
+      <ConfirmOrderReferenceResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <ResponseMetadata>
+          <RequestId>f42df4b1-8047-11df-8d5c-bf56a38ef3b4</RequestId>
+        </ResponseMetadata>
+      </ConfirmOrderReferenceResponse>
+    XML
+  end
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_amazon_payments_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response
+  end
+
+  def successful_authorize_response
+    <<-XML
+      <AuthorizeResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <AuthorizeResult>
+          <AuthorizationDetails>
+            <AmazonAuthorizationId>#{@authorization_id}</AmazonAuthorizationId>
+            <AuthorizationReferenceId>test_authorize_1</AuthorizationReferenceId>
+            <SellerAuthorizationNote>Lorem ipsum</SellerAuthorizationNote>
+            <AuthorizationAmount>
+              <CurrencyCode>USD</CurrencyCode>
+              <Amount>94.50</Amount>
+            </AuthorizationAmount>
+            <AuthorizationFee>
+              <CurrencyCode>USD</CurrencyCode>
+              <Amount>0</Amount>
+            </AuthorizationFee>
+            <SoftDecline>true</SoftDecline>
+            <AuthorizationStatus>
+              <State>Pending</State>
+              <LastUpdateTimestamp>2012-11-03T19:10:16Z</LastUpdateTimestamp>
+            </AuthorizationStatus>
+            <CreationTimestamp>2012-11-02T19:10:16Z</CreationTimestamp>
+            <ExpirationTimestamp>2012-12-02T19:10:16Z</ExpirationTimestamp>
+          </AuthorizationDetails>
+        </AuthorizeResult>
+        <ResponseMetadata>
+          <RequestId>b4ab4bc3-c9ea-44f0-9a3d-67cccef565c6</RequestId>
+        </ResponseMetadata>
+      </AuthorizeResponse>
+    XML
+  end
+
+  def failed_authorize_response
+    <<-XML
+      <ErrorResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <Error>
+          <Type>Sender</Type>
+          <Code>TransactionAmountExceeded</Code>
+          <Message>A Authorize request with amount 1000000.00 JPY cannot be accepted.</Message>
+        </Error>
+        <RequestId>4281dc31-5863-4d1a-b98f-de7e3c35c054</RequestId>
+      </ErrorResponse>
+    XML
+  end
+
+  def successful_capture_response
+    <<-XML
+      <CaptureResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <CaptureResult>
+          <CaptureDetails>
+            <AmazonCaptureId>P01-1234567-1234567-0000002</AmazonCaptureId>
+            <CaptureReferenceId>test_capture_1</CaptureReferenceId>
+            <SellerCaptureNote>Lorem ipsum</SellerCaptureNote>
+            <CaptureAmount>
+              <CurrencyCode>USD</CurrencyCode>
+              <Amount>94.50</Amount>
+            </CaptureAmount>
+            <CaptureStatus>
+              <State>Completed</State>
+              <LastUpdateTimestamp>2012-11-03T19:10:16Z</LastUpdateTimestamp>
+            </CaptureStatus>
+            <CreationTimestamp>2012-11-03T19:10:16Z</CreationTimestamp>
+          </CaptureDetails>
+        </CaptureResult>
+        <ResponseMetadata>
+          <RequestId>b4ab4bc3-c9ea-44f0-9a3d-67cccef565c6</RequestId>
+        </ResponseMetadata>
+      </CaptureResponse>
+    XML
+  end
+
+  def failed_capture_response
+  end
+
+  def successful_refund_response
+    <<-XML
+      <RefundResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <RefundResult>
+          <RefundDetails>
+            <AmazonRefundId>P01-1234567-1234567-0000003</AmazonRefundId>
+            <RefundReferenceId>test_refund_1</RefundReferenceId>
+            <SellerRefundNote>Lorem ipsum</SellerRefundNote>
+            <RefundType>SellerInitiated</RefundType>
+            <RefundedAmount>
+              <CurrencyCode>USD</CurrencyCode>
+              <Amount>94.50</Amount>
+            </RefundedAmount>
+            <FeeRefunded>
+              <CurrencyCode>USD</CurrencyCode>
+              <Amount>0</Amount>
+            </FeeRefunded>
+            <RefundStatus>
+              <State>Pending</State>
+              <LastUpdateTimestamp>2012-11-07T19:10:16Z</LastUpdateTimestamp>
+            </RefundStatus>
+            <CreationTimestamp>2012-11-05T19:10:16Z</CreationTimestamp>
+          </RefundDetails>
+        </RefundResult>
+        <ResponseMetadata>
+          <RequestId>b4ab4bc3-c9ea-44f0-9a3d-67cccef565c6</RequestId>
+        </ResponseMetadata>
+      </RefundResponse>
+    XML
+  end
+
+  def failed_refund_response
+  end
+
+  def successful_close_authorization_response
+    <<-XML
+      <CloseAuthorizationResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <ResponseMetadata>
+          <RequestId>a9aedsd6-a10y-11t8-9a3d-67gggwd565c6</RequestId>
+        </ResponseMetadata>
+      </CloseAuthorizationResponse>
+    XML
+  end
+
+  def failed_close_authorization_response
+  end
+
+  def successful_close_order_reference_response
+    <<-XML
+      <CloseOrderReferenceResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <ResponseMetadata>
+          <RequestId>5f20169b-7ab2-11df-bcef-d35615e2b044</RequestId>
+        </ResponseMetadata>
+      </CloseOrderReferenceResponse>
+    XML
+  end
+
+  def failed_close_order_reference_response
+  end
+
+  def successful_cancel_order_reference_response
+    <<-XML
+      <CancelOrderReferenceResponse xmlns="https://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <ResponseMetadata>
+          <RequestId>5f20169b-7ab2-11df-bcef-d35615e2b044</RequestId>
+        </ResponseMetadata>
+      </CancelOrderReferenceResponse>
+    XML
+  end
+
+  def failed_cancel_order_reference_response
+  end
+
+  def retriable_net_httpresponse
+    str = raw_request_throttled_response.gsub(/\n/, "\r\n")
+    io = Net::BufferedIO.new(StringIO.new(str))
+    res = Net::HTTPResponse.read_new(io)
+    res.reading_body(io, true) { res.read_body }
+    res
+  end
+
+  def raw_request_throttled_response
+    body = request_throttled_response.tr("\n", '')
+    <<-RAW_RESPONSE.strip_heredoc
+      HTTP/1.1 503 RequestThrottled
+      Connection: close
+      Content-Length: #{body.length}
+
+      #{body}
+    RAW_RESPONSE
+  end
+
+  def request_throttled_response
+    <<-XML
+      <ErrorResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <Error>
+          <Type>Server</Type>
+          <Code>RequestThrottled</Code>
+          <Message>The frequency of requests was greater than allowed.</Message>
+        </Error>
+        <RequestId>3a6f041f-2f93-4cc0-b1e5-1e12876b6695</RequestId>
+      </ErrorResponse>
+    XML
+  end
+end


### PR DESCRIPTION
Add Amazon Payments Gateway.
https://payments.amazon.com/developer/documentation/apireference/201751630

Is it possible to merge this PR as ActiveMerchant's policy?
Can someone review it?

Some unit test and remote test are not implemented yet.
I have confirmed that it will run in the Amazon Payments sandbox environment using the development account I have.