### PR TITLE
supports_network_tokenization? implementation for Braintree

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -193,6 +193,10 @@ module ActiveMerchant #:nodoc:
         raise RuntimeError.new("This gateway does not support scrubbing.")
       end
 
+      def network_tokenization_supported
+        []
+      end
+
       def supports_network_tokenization?
         false
       end

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -193,10 +193,6 @@ module ActiveMerchant #:nodoc:
         raise RuntimeError.new("This gateway does not support scrubbing.")
       end
 
-      def network_tokenization_supported
-        []
-      end
-
       def supports_network_tokenization?
         false
       end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -171,17 +171,8 @@ module ActiveMerchant #:nodoc:
       end
       alias_method :delete, :unstore
 
-      def network_tokenization_supported
-        result = Braintree::MerchantGateway.new(@braintree_gateway).provision_raw_apple_pay
-        if result.success?
-          result.supported_networks.map { |brand| format_card_brand(brand) }
-        else
-          []
-        end
-      end
-
       def supports_network_tokenization?
-        network_tokenization_supported.present?
+        supports_network_tokenization_brands.present?
       end
 
       def verify_credentials
@@ -197,6 +188,15 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def supports_network_tokenization_brands
+        result = Braintree::MerchantGateway.new(@braintree_gateway).provision_raw_apple_pay
+        if result.success?
+          result.supported_networks.map { |brand| format_card_brand(brand) }
+        else
+          []
+        end
+      end
 
       def check_customer_exists(customer_vault_id)
         commit do

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -191,11 +191,7 @@ module ActiveMerchant #:nodoc:
 
       def supports_network_tokenization_brands
         result = Braintree::MerchantGateway.new(@braintree_gateway).provision_raw_apple_pay
-        if result.success?
-          result.supported_networks.map { |brand| format_card_brand(brand) }
-        else
-          []
-        end
+        result.success? ? result.supported_networks : []
       end
 
       def check_customer_exists(customer_vault_id)
@@ -618,19 +614,6 @@ module ActiveMerchant #:nodoc:
         end
 
         parameters
-      end
-
-      def format_card_brand(card_brand)
-        case card_brand
-        when 'visa'
-          :visa
-        when 'mastercard'
-          :master
-        when 'amex'
-          :american_express
-        when 'discover'
-          :discover
-        end
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -171,8 +171,17 @@ module ActiveMerchant #:nodoc:
       end
       alias_method :delete, :unstore
 
+      def network_tokenization_supported
+        result = Braintree::MerchantGateway.new(@braintree_gateway).provision_raw_apple_pay
+        if result.success?
+          result.supported_networks.map { |brand| format_card_brand(brand) }
+        else
+          []
+        end
+      end
+
       def supports_network_tokenization?
-        true
+        network_tokenization_supported.present?
       end
 
       def verify_credentials
@@ -609,6 +618,19 @@ module ActiveMerchant #:nodoc:
         end
 
         parameters
+      end
+
+      def format_card_brand(card_brand)
+        case card_brand
+        when 'visa'
+          :visa
+        when 'mastercard'
+          :master
+        when 'amex'
+          :american_express
+        when 'discover'
+          :discover
+        end
       end
     end
   end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -17,12 +17,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     }
   end
 
-  def test_supports_network_tokenization_brands
-    brands = @gateway.send(:supports_network_tokenization_brands)
-    assert_includes brands, :visa
-    assert_includes brands, :master
-    assert_includes brands, :american_express
-    assert_includes brands, :discover
+  def test_supports_network_tokenization
+    provision_raw_apple_pay
+    assert_equal true, @gateway.supports_network_tokenization?
   end
 
   def test_credit_card_details_on_store
@@ -669,4 +666,21 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal expected_avs_code, response.avs_result['code']
   end
 
+  def provision_raw_apple_pay
+    options = fixtures(:braintree_blue)
+    configuration = Braintree::Configuration.new(
+      :merchant_id       => options[:merchant_id],
+      :public_key        => options[:public_key],
+      :private_key       => options[:private_key],
+      :environment       => :sandbox,
+      :custom_user_agent => "ActiveMerchant #{ActiveMerchant::VERSION}"
+    )
+    braintree_gateway = Braintree::Gateway.new( configuration )
+    result = Braintree::MerchantGateway.new(braintree_gateway).provision_raw_apple_pay
+    brands = result.supported_networks
+    assert_includes brands, 'visa'
+    assert_includes brands, 'mastercard'
+    assert_includes brands, 'amex'
+    assert_includes brands, 'discover'
+  end
 end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -17,6 +17,10 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     }
   end
 
+  def test_network_tokenization_supported
+    assert_includes @gateway.network_tokenization_supported, :visa
+  end
+
   def test_credit_card_details_on_store
     assert response = @gateway.store(@credit_card)
     assert_success response

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -17,8 +17,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     }
   end
 
-  def test_network_tokenization_supported
-    assert_includes @gateway.network_tokenization_supported, :visa
+  def test_supports_network_tokenization_brands
+    brands = @gateway.send(:supports_network_tokenization_brands)
+    assert_includes brands, :visa
+    assert_includes brands, :master
+    assert_includes brands, :american_express
+    assert_includes brands, :discover
   end
 
   def test_credit_card_details_on_store

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -647,12 +647,12 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_supports_network_tokenization_true
-    @gateway.stubs(network_tokenization_supported: [:visa])
+    @gateway.stubs(supports_network_tokenization_brands: [:visa])
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
   end
 
   def test_supports_network_tokenization_false
-    @gateway.stubs(network_tokenization_supported: [])
+    @gateway.stubs(supports_network_tokenization_brands: [])
     assert_instance_of FalseClass, @gateway.supports_network_tokenization?
   end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -646,8 +646,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal "transaction_id", response.authorization
   end
 
-  def test_supports_network_tokenization
+  def test_supports_network_tokenization_true
+    @gateway.stubs(network_tokenization_supported: [:visa])
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
+  end
+
+  def test_supports_network_tokenization_false
+    @gateway.stubs(network_tokenization_supported: [])
+    assert_instance_of FalseClass, @gateway.supports_network_tokenization?
   end
 
   def test_unsuccessful_transaction_returns_id_when_available

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -647,12 +647,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_supports_network_tokenization_true
-    @gateway.stubs(supports_network_tokenization_brands: [:visa])
+    mock_result = Braintree::SuccessfulResult.new(supported_networks: %w(visa))
+    Braintree::MerchantGateway.any_instance.expects(:provision_raw_apple_pay).returns(mock_result)
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
   end
 
   def test_supports_network_tokenization_false
-    @gateway.stubs(supports_network_tokenization_brands: [])
+    mock_result = Braintree::ErrorResult.new(:gateway, :errors => {})
+    Braintree::MerchantGateway.any_instance.expects(:provision_raw_apple_pay).returns(mock_result)
     assert_instance_of FalseClass, @gateway.supports_network_tokenization?
   end
 


### PR DESCRIPTION
Verify that braintree gateways supports network tokenization, similar to what was done for auth.net.
Implementation using `provision_raw_apple_pay` following discussion in https://github.com/activemerchant/active_merchant/pull/2241

ping @Krystosterone @duff @jasonwebster @chrisboulton