### PR TITLE
Paystation: Add third party + hmacs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Orbital: Add support for CLP currency [curiousepic]
 * Authorize.net: Add line item fields and additional transaction settings [shasum]
 * Authorize.net: Pass through `header_email_receipt` [shasum]
+* Paystation: Add third party integration + hmacs [paystation]
 
 == Version 1.61.0 (November 7, 2016)
 * Add codes AQ, BQ, SX, and SS to list of countries and update SD numeric code [zxlin]

--- a/test/remote/gateways/remote_paystation_test.rb
+++ b/test/remote/gateways/remote_paystation_test.rb
@@ -4,6 +4,7 @@ class RemotePaystationTest < Test::Unit::TestCase
 
   def setup
     @gateway = PaystationGateway.new(fixtures(:paystation))
+    @hmac_gateway = PaystationGateway.new(fixtures(:hmac_paystation))
 
     @credit_card = credit_card('5123456789012346', :month => 5, :year => 13, :verification_value => 123)
 
@@ -19,15 +20,22 @@ class RemotePaystationTest < Test::Unit::TestCase
     }
   end
 
-  def test_successful_purchase
-    assert response = @gateway.purchase(@successful_amount, @credit_card, @options)
+  def test_successful_purchase_two_party
+    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(:two_party => true))
     assert_success response
 
     assert_equal 'Transaction successful', response.message
   end
 
+  def test_successful_purchase_three_party
+    assert response = @gateway.purchase(@successful_amount, @credit_card, @options)
+    assert_success response
+
+    assert !response.transaction_url.blank?
+  end
+
   def test_successful_purchase_in_gbp
-    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(:currency => "GBP"))
+    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(:currency => "GBP", :two_party => true))
     assert_success response
 
     assert_equal 'Transaction successful', response.message
@@ -41,33 +49,66 @@ class RemotePaystationTest < Test::Unit::TestCase
       ["bank_error", @bank_error_amount, "Error Communicating with Bank"]
     ].each do |name, amount, message|
 
-        assert response = @gateway.purchase(amount, @credit_card, @options)
+        assert response = @gateway.purchase(amount, @credit_card, @options.merge(:two_party => true))
         assert_failure response
         assert_equal message, response.message
 
     end
   end
 
-  def test_storing_token
+  def test_two_party_storing_token
     time = Time.now.to_i
-    assert response = @gateway.store(@credit_card, @options.merge(:token => "justatest#{time}"))
+    assert response = @gateway.store(@credit_card, @options.merge(:token => "justatest#{time}", :two_party => true))
     assert_success response
 
     assert_equal "Future Payment Saved Ok", response.message
     assert_equal "justatest#{time}", response.token
   end
 
-  def test_billing_stored_token
-    assert store_response = @gateway.store(@credit_card, @options)
+  def test_three_party_storing_token
+    time = Time.now.to_i
+    assert response = @gateway.store(@credit_card, @options.merge(:token => "justatest#{time}"))
+    assert_success response
+
+    assert !response.transaction_url.blank?
+  end
+
+  def test_store_with_hmac
+    time = Time.now.to_i
+    assert response = @hmac_gateway.store(@credit_card, @options.merge(:token => "justatest#{time}", :two_party => true))
+    assert_success response
+
+    assert_equal "Future Payment Saved Ok", response.message
+    assert_equal "justatest#{time}", response.token
+  end
+
+  def test_two_party_billing_stored_token
+    assert store_response = @gateway.store(@credit_card, @options.merge(:two_party => true))
     assert_success store_response
 
-    assert charge_response = @gateway.purchase(@successful_amount, store_response.token, @options)
+    assert charge_response = @gateway.purchase(@successful_amount, store_response.token, @options.merge(:two_party => true))
     assert_success charge_response
     assert_equal "Transaction successful", charge_response.message
   end
 
-  def test_authorize_and_capture
+  def test_three_party_billing_stored_token
+    assert store_response = @gateway.store(@credit_card, @options.merge(:two_party => true))
+    assert_success store_response
+
+    assert charge_response = @gateway.purchase(@successful_amount, store_response.token, @options)
+    assert_success charge_response
+    assert !charge_response.transaction_url.blank?
+  end
+
+  def test_third_party_authorize
     assert auth = @gateway.authorize(@successful_amount, @credit_card, @options)
+
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_two_party_authorize_and_capture
+    assert auth = @gateway.authorize(@successful_amount, @credit_card, @options.merge(:two_party => true))
 
     assert_success auth
     assert auth.authorization
@@ -76,28 +117,16 @@ class RemotePaystationTest < Test::Unit::TestCase
     assert_success capture
   end
 
-  def test_capture_without_cvv
-    assert auth = @gateway.authorize(@successful_amount, @credit_card, @options)
-
-    assert_success auth
-    assert auth.authorization
-
-    assert capture = @gateway.capture(@successful_amount, auth.authorization, @options)
-    assert_failure capture
-
-    assert_equal "Card Security Code (CVV/CSC) Required", capture.message
-  end
-
   def test_invalid_login
     gateway = PaystationGateway.new(paystation_id: '', gateway_id: '')
-    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert response = gateway.purchase(@successful_amount, @credit_card, @options)
 
     assert_failure response
     assert_nil response.authorization
   end
 
   def test_successful_refund
-    assert response = @gateway.purchase(@successful_amount, @credit_card, @options)
+    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(:two_party => true))
     assert_success response
     refund = @gateway.refund(@successful_amount, response.authorization, @options)
     assert_success refund


### PR DESCRIPTION
Request for third party integration - https://github.com/activemerchant/active_merchant/issues/562

Old pull request for HMAC's - All credit to the creator of the code - "nikz" https://github.com/activemerchant/active_merchant/pull/1627/commits/cefab84e92f4ac10722b46d9fcee80a64108ff98

This request as above was originally not merged due to having nobody to test it. We have tested the code and it is working. All credit to the creator. Thank you "nikz"

As per the third party integration, this has been implemented as we would expect with the correct input/output through our server and has been tested with unit/remote tests.