### PR TITLE
fix to handle MX or Mexico in pagofacil gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/pago_facil.rb
+++ b/lib/active_merchant/billing/gateways/pago_facil.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         post[:colonia] = address[:address2]
         post[:municipio] = address[:city]
         post[:estado] = address[:state]
-        post[:pais] = address[:country]
+        post[:pais] = country_code(address[:country])
         post[:telefono] = address[:phone]
         post[:cp] = address[:zip]
       end
@@ -116,6 +116,14 @@ module ActiveMerchant #:nodoc:
           "texto" => 'Invalid response received from the PagoFacil API.',
           "raw_response" => response
         }
+      end
+
+      def country_code(country)
+        if country
+          country = ActiveMerchant::Country.find(country)
+          country.to_s
+        end
+      rescue InvalidCountryCodeError
       end
     end
   end

--- a/test/remote/gateways/remote_pago_facil_test.rb
+++ b/test/remote/gateways/remote_pago_facil_test.rb
@@ -76,6 +76,17 @@ class RemotePagoFacilTest < Test::Unit::TestCase
     assert_equal 'Transaction has been successful!-Approved', response.message
   end
 
+  def test_successful_purchased_country_mx
+    @options[:billing_address].merge!(country: 'MX')
+
+    response = successful_response_to do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+
+    assert response.authorization
+    assert_equal 'Transaction has been successful!-Approved', response.message
+  end
+
   # Even when all the parameters are correct the PagoFacil's test service will
   # respond randomly (can be approved or declined). When for this reason the
   # service returns a "declined" response, the response should have the error

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -65,6 +65,17 @@ class CountryTest < Test::Unit::TestCase
     end
   end
 
+  def test_find_mexico
+    country = ActiveMerchant::Country.find('MX')
+    assert_equal 'MX', country.code(:alpha2).value
+
+    country = ActiveMerchant::Country.find('Mexico')
+    assert_equal 'MX', country.code(:alpha2).value
+
+    country = ActiveMerchant::Country.find('MX')
+    assert_equal 'Mexico', country.to_s
+  end
+
   def test_country_names_are_alphabetized
     country_names = ActiveMerchant::Country::COUNTRIES.map { | each | each[:name] }
     assert_equal(country_names.sort, country_names)


### PR DESCRIPTION
This will addressed the issue mentioned here https://github.com/activemerchant/active_merchant/issues/2271
About passing an abbreviature or a FullName for PagoFacil gateway.