### PR TITLE
Worldpay: Remove test for Money like object

### DIFF
--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -190,17 +190,6 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
-  def test_non_fractional_amount_handling_with_moneylike
-    amount = OpenStruct.new(cents: 10000)
-    stub_comms do
-      @gateway.authorize(amount, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
-      assert_tag_with_attributes 'amount',
-          {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
-        data
-    end.respond_with(successful_authorize_response)
-  end
-
   def test_currency_exponent_handling
     stub_comms do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))


### PR DESCRIPTION
@davidsantoso 

>Support for Money objects is deprecated and will be removed from a future release of ActiveMerchant. Please use an Integer value in cents

Removed test that triggers above warning. It's targeted to test the handling of money-like object. Modifying makes it equivalent to subsequent test `test_currency_exponent_handling`, makes it redundant, hence removal.

Open to ideas if there is a better alternative to removal.