### PR TITLE
Omise: Update supported country and card type

### DIFF
--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -14,18 +14,20 @@ module ActiveMerchant #:nodoc:
       self.live_url = self.test_url = API_URL
 
       # Currency supported by Omise
-      # * Thai Baht with Satang, i.e. 9000 => 90 THB
+      # * Thai Baht with Satang, 50000 (THB500.00)
+      # * Japanese Yen, 500 (JPY500)
       self.default_currency = 'THB'
       self.money_format     = :cents
 
       #Country supported by Omise
       # * Thailand
-      self.supported_countries = %w( TH )
+      self.supported_countries = %w( TH JP )
 
       # Credit cards supported by Omise
       # * VISA
       # * MasterCard
-      self.supported_cardtypes = [:visa, :master]
+      # * JCB
+      self.supported_cardtypes = [:visa, :master, :jcb]
 
       # Omise main page
       self.homepage_url = 'https://www.omise.co/'
@@ -39,8 +41,10 @@ module ActiveMerchant #:nodoc:
       #
       # ==== Options
       #
-      # * <tt>:public_key</tt> -- Omise's public key (REQUIRED).
-      # * <tt>:secret_key</tt> -- Omise's secret key (REQUIRED).
+      # * <tt>:public_key</tt>  -- Omise's public key  (REQUIRED).
+      # * <tt>:secret_key</tt>  -- Omise's secret key  (REQUIRED).
+      # * <tt>:api_version</tt> -- Omise's API Version (OPTIONAL), default version is '2014-07-27'
+      #                            See version at page https://dashboard.omise.co/api-version/edit
 
       def initialize(options={})
         requires!(options, :public_key, :secret_key)

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -183,7 +183,7 @@ module ActiveMerchant #:nodoc:
         {
           'Content-Type'    => 'application/json;utf-8',
           'Omise-Version'   => @api_version || "2014-07-27",
-          'User-Agent'      => "ActiveMerchantBindings/#{ActiveMerchant::VERSION} Ruby/#{RUBY_VERSION}",
+          'User-Agent'      => "Omise/#{@api_version} ActiveMerchantBindings/#{ActiveMerchant::VERSION} Ruby/#{RUBY_VERSION}",
           'Authorization'   => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
           'Accept-Encoding' => 'utf-8'
         }

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -6,10 +6,11 @@ class RemoteOmiseTest < Test::Unit::TestCase
     @amount  = 8888
     @credit_card   = credit_card('4242424242424242')
     @declined_card = credit_card('4255555555555555')
-    @invalid_cvc   = credit_card('4024007148673576', {verification_value: ''})
+    @invalid_cvc   = credit_card('4111111111160001', {verification_value: ''})
     @options = {
       description: 'Active Merchant',
-      email: 'active.merchant@testing.test'
+      email: 'active.merchant@testing.test',
+      currency: 'thb'
     }
   end
 
@@ -31,7 +32,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(@amount, @credit_card)
+    response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
     assert_equal response.params['amount'], @amount

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -23,7 +23,11 @@ class OmiseTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal @gateway.supported_countries, %w( TH )
+    assert_equal @gateway.supported_countries, %w( TH JP )
+  end
+
+  def test_supported_cardtypes
+    assert_equal @gateway.supported_cardtypes, [:visa, :master, :jcb]
   end
 
   def test_supports_scrubbing
@@ -151,6 +155,13 @@ class OmiseTest < Test::Unit::TestCase
     desc = 'Charge for order 3947'
     @gateway.send(:add_amount, result, @amount, {description: desc})
     assert_equal desc, result[:description]
+  end
+
+  def test_add_amount_with_correct_currency
+    result = {}
+    jpy_currency = 'JPY'
+    @gateway.send(:add_amount, result, @amount, {currency: jpy_currency})
+    assert_equal jpy_currency, result[:currency]
   end
 
   def test_commit_transaction


### PR DESCRIPTION
Ref: https://www.omise.co/currency-and-amount

Changes:
Add Japan as supported country
Add JPY as supported currency
Add JCB as supported card brand
Add test for currency and change test card to fix failed test
Add doc for api_version and update User-Agent header