### PR TITLE
Remove leading or trailing whitespace from CreditCard name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 * PaymentExpress: Update supported countries [shasum]
 * CyberSource: Add Lebanon to supported countries [shasum]
 * Vanco: Update test URL [davidsantoso]
+* Remove leading or trailing whitespace from credit card name [davidsantoso]
+
 
 == Version 1.62.0 (December 5, 2016)
 * AuthorizeNet: Map to standard AVSResult codes [shasum]

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -245,7 +245,7 @@ module ActiveMerchant #:nodoc:
       #
       # @return [String] the full name of the card holder
       def name
-        [first_name, last_name].compact.join(' ')
+        "#{first_name} #{last_name}".strip
       end
 
       def name=(full_name)

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -346,6 +346,23 @@ class CreditCardTest < Test::Unit::TestCase
     c = CreditCard.new :name => "Twiggy"
     assert_equal "", c.first_name
     assert_equal "Twiggy", c.last_name
+    assert_equal "Twiggy", c.name
+  end
+
+  def test_should_remove_trailing_whitespace_on_name
+    c = CreditCard.new(:last_name => 'Herdman')
+    assert_equal "Herdman", c.name
+
+    c = CreditCard.new(:last_name => 'Herdman', first_name: '')
+    assert_equal "Herdman", c.name
+  end
+
+  def test_should_remove_leading_whitespace_on_name
+    c = CreditCard.new(:first_name => 'James')
+    assert_equal "James", c.name
+
+    c = CreditCard.new(:last_name => '', first_name: 'James')
+    assert_equal "James", c.name
   end
 
   # The following is a regression for a bug that raised an exception when


### PR DESCRIPTION
@rwdaigle @duff @jasonwebster wondering if any of you had thoughts?

---

When a credit card name is set using `name=` method, the first and last
names will be split into their respective fields. For example-

```ruby
card = ActiveMerchant::Billing::CreditCard.new name: "John"
card.first_name # => ""
card.last_name # => "John"
```

The issue is if we call `name` again on the card, we get a leading space-

```ruby
card.name # => " John"
```

This update will remove any leading or trailing whitespaces when calling
the name method regulardless of the value of first and last name or how
it was originally set.

```ruby
card = ActiveMerchant::Billing::CreditCard.new name: "John"
card.first_name # => ""
card.last_name # => "John"
card.name # => "John"
```