### PR TITLE
Add STANDARD_ERROR_CODE: 'api_error' to billing/gateway and gateways/stripe

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -77,6 +77,7 @@ module ActiveMerchant #:nodoc:
       # :call_issuer - Transaction requires voice authentication, call issuer
       # :pickup_card - Issuer requests that you pickup the card from merchant
       # :test_mode_live_card - Card was declined. Request was in test mode, but used a non test card.
+      # :api_error - API responds with generic error
 
       STANDARD_ERROR_CODE = {
         :incorrect_number => 'incorrect_number',
@@ -93,7 +94,8 @@ module ActiveMerchant #:nodoc:
         :call_issuer => 'call_issuer',
         :pickup_card => 'pick_up_card',
         :config_error => 'config_error',
-        :test_mode_live_card => 'test_mode_live_card'
+        :test_mode_live_card => 'test_mode_live_card',
+        :api_error => 'api_error'
       }
 
       cattr_reader :implementations

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/hash/slice'
 
 module ActiveMerchant #:nodoc:
+
   module Billing #:nodoc:
     class StripeGateway < Gateway
       self.live_url = 'https://api.stripe.com/v1/'
@@ -43,7 +44,8 @@ module ActiveMerchant #:nodoc:
         'call_issuer' => STANDARD_ERROR_CODE[:call_issuer],
         'processing_error' => STANDARD_ERROR_CODE[:processing_error],
         'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin],
-        'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card]
+        'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card],
+        'api_error' => STANDARD_ERROR_CODE[:api_error]
       }
 
       BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {
@@ -578,11 +580,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
+        type = response['error']['type']
         code = response['error']['code']
         decline_code = response['error']['decline_code'] if code == 'card_declined'
 
         error_code = STANDARD_ERROR_CODE_MAPPING[decline_code]
         error_code ||= STANDARD_ERROR_CODE_MAPPING[code]
+        error_code ||= STANDARD_ERROR_CODE_MAPPING[type]
         error_code
       end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -719,7 +719,6 @@ class StripeTest < Test::Unit::TestCase
 
     assert_equal Gateway::STANDARD_ERROR_CODE[:api_error], response.error_code
     refute response.test? # unsuccessful request defaults to live
-    #assert_equal 'ch_test_charge', response.authorization
   end
 
   def test_test_mode_live_card_error_response
@@ -730,7 +729,6 @@ class StripeTest < Test::Unit::TestCase
 
     assert_equal Gateway::STANDARD_ERROR_CODE[:test_mode_live_card], response.error_code
     refute response.test? # unsuccessful request defaults to live
-    #assert_equal 'ch_test_charge', response.authorization
   end
 
   def test_add_creditcard_with_credit_card
@@ -2061,7 +2059,7 @@ class StripeTest < Test::Unit::TestCase
         "type": "card_error",
         "code": "card_declined",
         "decline_code": "test_mode_live_card",
-        "message": "Your request was in teset mode but used a non test card"
+        "message": "Your request was in test mode but used a non test card"
       }
     }
     RESPONSE


### PR DESCRIPTION
Currently there doesn't exist any support for handling generic API errors on `Response#error_code`. This PR looks to add an `api_error` code to `billing/gateway`'s standard error codes. This PR also adds support for Stripe's `api_error` response type through the `type` attribute. This implementation is similar to https://github.com/activemerchant/active_merchant/pull/2145.

Currently if Stripe's API response with an error that doesn't include a `code` or `decline_code`, then the error responses result in `Response#error_code == nil`. Stripe's generic API error is one such example of this response.
```ruby
{
  "error": {
    "type": "api_error",
    "message": "This is a Stripe API error resposne"
  }
}
```

These changes will assign the `Response#error_code` to the response `type` if no code is provided. This allows us to have a "default" error code for each Stripe response type when no actual code is provided.

**How?**
- add `api_error` to the `billing/gateway`'s `STANDARD_ERROR_CODE`
- add `api_error` to `gateways/stripe`'s `STANDARD_ERROR_CODE_MAPPING`
- assign `Response#error_code` to response `type` if no `code` or `decline_code` was provided.

Added billing/stripe tests for
- api_error error responseresponse
- test_mode_live_card error response

**For Review**
@berkcaputcu @jasonwebster 