### PR TITLE
Add #unstore support for AuthorizeNetGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -180,6 +180,12 @@ module ActiveMerchant
         end
       end
 
+      def unstore(authorization)
+        customer_profile_id, _, _ = split_authorization(authorization)
+
+        delete_customer_profile(customer_profile_id)
+      end
+
       def verify_credentials
         response = commit(:verify_credentials) { }
         response.success?
@@ -614,6 +620,12 @@ module ActiveMerchant
         end
       end
 
+      def delete_customer_profile(customer_profile_id)
+        commit(:cim_store_delete_customer) do |xml|
+          xml.customerProfileId(customer_profile_id)
+        end
+      end
+
       def names_from(payment_source, address, options)
         if payment_source && !payment_source.is_a?(PaymentToken) && !payment_source.is_a?(String)
           first_name, last_name = split_names(address[:name])
@@ -681,6 +693,8 @@ module ActiveMerchant
           "createCustomerProfileRequest"
         elsif action == :cim_store_update
           "createCustomerPaymentProfileRequest"
+        elsif action == :cim_store_delete_customer
+          "deleteCustomerProfileRequest"
         elsif action == :verify_credentials
           "authenticateTestRequest"
         elsif is_cim_action?(action)
@@ -825,7 +839,7 @@ module ActiveMerchant
       end
 
       def cim?(action)
-        (action == :cim_store) || (action == :cim_store_update)
+        (action == :cim_store) || (action == :cim_store_update) || (action == :cim_store_delete_customer)
       end
 
       def transaction_id_from(authorization)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -568,6 +568,27 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal("15", store.params["message_code"])
   end
 
+  def test_successful_unstore
+    response = stub_comms do
+      @gateway.unstore('35959426#32506918#cim_store')
+    end.check_request do |endpoint, data, headers|
+      doc = parse(data)
+      assert_equal "35959426", doc.at_xpath("//deleteCustomerProfileRequest/customerProfileId").content
+    end.respond_with(successful_unstore_response)
+
+    assert_success response
+    assert_equal "Successful", response.message
+  end
+
+  def test_failed_unstore
+    @gateway.expects(:ssl_post).returns(failed_unstore_response)
+
+    unstore = @gateway.unstore('35959426#32506918#cim_store')
+    assert_failure unstore
+    assert_match(/The record cannot be found/, unstore.message)
+    assert_equal("40", unstore.params["message_code"])
+  end
+
   def test_successful_store_new_payment_profile
     @gateway.expects(:ssl_post).returns(successful_store_new_payment_profile_response)
 
@@ -1849,6 +1870,36 @@ class AuthorizeNetTest < Test::Unit::TestCase
       <customerShippingAddressIdList />
       <validationDirectResponseList />
       </createCustomerProfileResponse>
+    eos
+  end
+
+  def successful_unstore_response
+    <<-eos
+      <?xml version="1.0" encoding="utf-8"?>
+      <deleteCustomerProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+        <messages>
+          <resultCode>Ok</resultCode>
+          <message>
+            <code>I00001</code>
+            <text>Successful.</text>
+          </message>
+        </messages>
+      </deleteCustomerProfileResponse>
+    eos
+  end
+
+  def failed_unstore_response
+    <<-eos
+      <?xml version="1.0" encoding="utf-8"?>
+      <deleteCustomerProfileResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00040</code>
+            <text>The record cannot be found.</text>
+          </message>
+        </messages>
+      </deleteCustomerProfileResponse>
     eos
   end
 


### PR DESCRIPTION
This adds `#unstore` support for the Authorize.net gateway.

Usage is very simple: Pass the authorization token that is included in the `#store` response to `#unstore` and it will delete the entire customer profile.  This does not support deleting specific payment profiles because I was unsure of how best to expose that.  I'm happy to discuss and work that up as well, but think this PR also stands on its own and adding payment profile support could be tackled in another PR.  