### PR TITLE
CardStream: Add dynamic descriptor option fields

### DIFF
--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -154,6 +154,8 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, credit_card_or_reference, money, options)
         add_pair(post, :transactionUnique, options[:order_id], :required => true)
         add_pair(post, :orderRef, options[:description] || options[:order_id], :required => true)
+        add_pair(post, :statementNarrative1, options[:merchant_name]) if options[:merchant_name]
+        add_pair(post, :statementNarrative2, options[:dynamic_descriptor]) if options[:dynamic_descriptor]
         if credit_card_or_reference.respond_to?(:number)
           if ['american_express', 'diners_club'].include?(card_brand(credit_card_or_reference).to_s)
             add_pair(post, :item1Quantity, 1)

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -70,6 +70,18 @@ class RemoteCardStreamTest < Test::Unit::TestCase
       :description => 'AM test purchase'
     }
 
+    @visacredit_descriptor_options = {
+      :billing_address => {
+        :address1 => "Flat 6, Primrose Rise",
+        :address2 => "347 Lavender Road",
+        :city => "",
+        :state => "Northampton",
+        :zip => 'NN17 8YG '
+      },
+      :merchant_name => 'merchant',
+      :dynamic_descriptor => 'product'
+    }
+
     @visacredit_reference_options = {
       :order_id => generate_unique_id,
       :description => 'AM test purchase'
@@ -139,6 +151,14 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
     assert responseRefund.test?
+  end
+
+  def test_successful_visacreditcard_purchase_with_dynamic_descriptors
+    assert responsePurchase = @gateway.purchase(284, @visacreditcard, @visacredit_descriptor_options)
+    assert_equal 'APPROVED', responsePurchase.message
+    assert_success responsePurchase
+    assert responsePurchase.test?
+    assert !responsePurchase.authorization.blank?
   end
 
   def test_successful_visacreditcard_authorization_and_void

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -28,6 +28,18 @@ class CardStreamTest < Test::Unit::TestCase
       :description => 'AM test purchase'
     }
 
+    @visacredit_descriptor_options = {
+      :billing_address => {
+        :address1 => "Flat 6, Primrose Rise",
+        :address2 => "347 Lavender Road",
+        :city => "",
+        :state => "Northampton",
+        :zip => 'NN17 8YG '
+      },
+      :merchant_name => 'merchant',
+      :dynamic_descriptor => 'product'
+    }
+
     @declined_card = credit_card('4000300011112220',
       :month => '9',
       :year => '2014'
@@ -93,6 +105,15 @@ class CardStreamTest < Test::Unit::TestCase
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
     assert responseRefund.test?
+  end
+
+  def test_successful_visacreditcard_purchase_with_descriptors
+    stub_comms do
+      @gateway.purchase(284, @visacreditcard, @visacredit_descriptor_options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/statementNarrative1=merchant/, data)
+      assert_match(/statementNarrative2=product/, data)
+    end.respond_with(successful_purchase_response_with_descriptors)
   end
 
   def test_successful_visacreditcard_purchase_via_reference
@@ -245,6 +266,10 @@ class CardStreamTest < Test::Unit::TestCase
 
   def successful_purchase_response_with_3dsecure
     "responseCode=65802&responseMessage=3DS+AUTHENTICATION+REQUIRED&responseStatus=2&merchantID=103191&threeDSEnabled=Y&threeDSCheckPref=not+known%2Cnot+checked%2Cauthenticated%2Cnot+authenticated%2Cattempted+authentication&avscv2CheckEnabled=N&cv2CheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&addressCheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&postcodeCheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&cardCVVMandatory=Y&customerID=1749&eReceiptsEnabled=N&eReceiptsStoreID=1&amount=1202&currencyCode=826&transactionUnique=42e13d06ce4d5f5e3eb4868d29baa8bb&orderRef=AM+test+purchase&threeDSRequired=Y&customerName=Longbob+Longsen&customerAddress=25+The+Larches&customerPostCode=LE10+2RT&action=SALE&type=1&countryCode=826&customerPostcode=LE10+2RT&customerReceiptsRequired=N&state=finished&remoteAddress=45.37.180.92&requestMerchantID=103191&processMerchantID=103191&xref=15080615RZ18RJ15RJ64YVZ&cardExpiryDate=1220&threeDSXID=MDAwMDAwMDAwMDAwMDg5NjY0OTc%3D&threeDSEnrolled=Y&transactionID=8966497&cardNumberMask=%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A1112&cardType=Visa+Credit&cardTypeCode=VC&cardScheme=Visa+&cardSchemeCode=VC&cardIssuer=Unknown&cardIssuerCountry=Unknown&cardIssuerCountryCode=XXX&threeDSPaReq=eJxVUttuwjAM%2FZWKD2iaQrnJjVQGA7TBGFSTeMxSC8rohTRd2d8vKe0YD5F8jh37%0D%0A%2BCQQHiXidIeilMhghUXBD2jFkd%2FxPNHtCz747EaCdhhsgi1eGHyjLOIsZdR2bBdI%0D%0AC%2FVVKY48VQy4uEyWa%2BYN6LDbA9JASFAup2zk9Tx3pOkbhJQnyHa5FhGdf6wQC2UF%0D%0AQmRlqizdvc5CDeUPG7p9IC2AUp7ZUam8GBNSVZUtuIwKJZEntsgSAsQUALnr2pQm%0D%0AKnTDaxyx1TSoHs%2FBW5%2F2zlsofCCmAiKukLkO9Zyh07dob0yHYzoAUvPAE6OEzScb%0D%0Ai7q2o9U2DORmUHAD1DWZ%2FwxoqyWmot2nRYDXPEtRV%2BgLfzFEWAgWrCxlrMmbFbQG%0D%0AQwO57%2FS0MM4LpU1dxM%2FhrJx9zU8f6%2F3WuZxGL6%2Fvle%2Bbt6gLzKhYe6h3u80yAIhp%0D%0AQZpnJs1X0NHDF%2FkFvj%2B6mg%3D%3D&threeDSACSURL=https%3A%2F%2Fdropit.3dsecure.net%3A9443%2FPIT%2FACS&threeDSVETimestamp=2015-08-06+15%3A18%3A15&threeDSCheck=not+checked&vcsResponseCode=0&vcsResponseMessage=Success+-+no+velocity+check+rules+applied&currencyExponent=2&threeDSMD=UDNLRVk6eHJlZj0xNTA4MDYxNVJaMThSSjE1Uko2NFlWWg%3D%3D&timestamp=2015-08-06+15%3A18%3A17&threeDSResponseCode=65802&threeDSResponseMessage=3DS+AUTHENTICATION+REQUIRED&signature=8551e3f1c77b6cfa78e154d99ffb05fdeabbae48a7ce723a3464047731ad98a1c4bfe0b7dfdf46de7ff3dab66b3e2e365025fc9ff3a74d86ae4378c8cc985d88"
+  end
+
+  def successful_purchase_response_with_descriptors
+    "merchantID=103191&threeDSEnabled=Y&threeDSCheckPref=authenticated&avscv2CheckEnabled=N&cv2CheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&addressCheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&postcodeCheckPref=not+known%2Cnot+checked%2Cmatched%2Cnot+matched%2Cpartially+matched&cardCVVMandatory=Y&customerReceiptsRequired=N&eReceiptsEnabled=N&eReceiptsStoreID=1&captureDelay=0&amount=284&currencyCode=826&statementNarrative1=merchant&statementNarrative2=product&type=1&threeDSRequired=N&customerName=Longbob+Longsen&cardExpiryMonth=12&cardExpiryYear=14&customerAddress=Flat+6%2C+Primrose+Rise+347+Lavender+Road&customerPostCode=NN17+8YG&countryCode=826&action=SALE&customerPostcode=NN17+8YG&requestID=586aae8406720&responseCode=0&responseMessage=AUTHCODE%3A684787&state=captured&requestMerchantID=103191&processMerchantID=103191&xref=17010219YV48VW21QH25TKS&paymentMethod=card&cardExpiryDate=1214&authorisationCode=684787&transactionID=13843073&responseStatus=0&timestamp=2017-01-02+19%3A48%3A21&amountReceived=284&avscv2ResponseCode=222100&avscv2ResponseMessage=ALL+MATCH&avscv2AuthEntity=merchant+host&cv2Check=matched&addressCheck=matched&postcodeCheck=matched&cardNumberMask=492942%2A%2A%2A%2A%2A%2A0821&cardType=Visa+Credit&cardTypeCode=VC&cardScheme=Visa+&cardSchemeCode=VC&cardIssuer=BARCLAYS+BANK+PLC&cardIssuerCountry=United+Kingdom&cardIssuerCountryCode=GBR&vcsResponseCode=0&vcsResponseMessage=Success+-+no+velocity+check+rules+applied&currencyExponent=2&signature=d47c9253d2d9ff6e9464a782b798b3fa699f6ed085eb03d5f87c4cf1f0994efab0c3145236df2163ea2b48fc0232bed25626b7ac331f0c98473ef4b551099eef"
   end
 
   def failed_purchase_card_declined_response


### PR DESCRIPTION
The options merchant_name and dynamic_descriptor correspond to
statementNarrative1 and statementNarrative2 respectively.

@davidsantoso to confirm and merge.