### PR TITLE
Drop Ruby 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 cache: bundler
 
 rvm:
-- 2.0
 - 2.1
 - 2.2.3
+- 2.3.3
 
 gemfile:
 - Gemfile.rails32
@@ -17,8 +17,6 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 2.0
-      gemfile: Gemfile.rails5
     - rvm: 2.1
       gemfile: Gemfile.rails5
 

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://activemerchant.org/'
   s.rubyforge_project = 'activemerchant'
 
-  s.required_ruby_version = '>= 2'
+  s.required_ruby_version = '>= 2.1'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'


### PR DESCRIPTION
2.0 was officially EOL'd February 24th, 2016. Given the sensitive nature
of the information Active Merchant deals with, there's no excuse to be
using unmaintained versions of Ruby. Additionally, the release of
Nokogiri 1.7.0, which dropped support for Ruby =< 2.0 last week forced
this issue for us, since our gemspec only specifies a minimum required
version.

Fixes https://github.com/activemerchant/active_merchant/issues/2297