### PR TITLE
Add store method to KomojuGateway

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -44,17 +44,21 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_payment_details(post, payment, options)
-        details = {}
+        case payment
+        when CreditCard
+          details = {}
 
-        details[:type] = 'credit_card'
-        details[:number] = payment.number
-        details[:month] = payment.month
-        details[:year] = payment.year
-        details[:verification_value] = payment.verification_value
-        details[:given_name] = payment.first_name
-        details[:family_name] = payment.last_name
-        details[:email] = options[:email] if options[:email]
-
+          details[:type] = 'credit_card'
+          details[:number] = payment.number
+          details[:month] = payment.month
+          details[:year] = payment.year
+          details[:verification_value] = payment.verification_value
+          details[:given_name] = payment.first_name
+          details[:family_name] = payment.last_name
+          details[:email] = options[:email] if options[:email]
+        else
+          details = payment
+        end
         post[:payment_details] = details
       end
 

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class KomojuTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = KomojuGateway.new(:login => 'login')
 
@@ -27,6 +29,14 @@ class KomojuTest < Test::Unit::TestCase
 
     assert_equal successful_response["id"], response.authorization
     assert response.test?
+  end
+
+  def test_successful_credit_card_purchase_with_token
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, "tok_xxx", @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match('"payment_details":"tok_xxx"', data)
+    end.respond_with(JSON.generate(successful_credit_card_purchase_response))
   end
 
   def test_failed_purchase


### PR DESCRIPTION
This adds a `store` method to the Komoju gateway (see #1638) so that merchants can enable payment profiles.

For more information see the Komoju docs on Tokens: https://docs.komoju.com/api/overview

This PR was closed previously in #1941 due to staleness. Assuming specs pass we'd really appreciate a review!