### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ cache: bundler
 
 rvm:
 - 2.1
-- 2.2.3
-- 2.3.3
+- 2.2.7
+- 2.3.4
+- 2.4.1
 
 gemfile:
 - Gemfile.rails32
@@ -19,6 +20,17 @@ matrix:
   exclude:
     - rvm: 2.1
       gemfile: Gemfile.rails50
+    - rvm: 2.4.1
+      gemfile: Gemfile.rails32
+    - rvm: 2.4.1
+      gemfile: Gemfile.rails40
+    - rvm: 2.4.1
+      gemfile: Gemfile.rails41
+  include:
+    - rvm: 2.4.1
+      gemfile: Gemfile.rails51
+  allow_failures:
+    - gemfile: Gemfile.rails51
 
 notifications:
   email:

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'rails', '~> 3.2.0'
+gem 'activesupport', '~> 3.2.0'

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'rails', '~> 4.0.0'
+gem 'activesupport', '~> 4.0.0'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'rails', '~> 4.1.0'
+gem 'activesupport', '~> 4.1.0'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'rails', '~> 4.2.0'
+gem 'activesupport', '~> 4.2.0'

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'rails', '~> 5.0.0'
+gem 'activesupport', '~> 5.0.0'

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'jruby-openssl', :platforms => :jruby
+
+group :test, :remote_test do
+  # gateway-specific dependencies, keeping these gems out of the gemspec
+  gem 'braintree', '>= 2.50.0'
+end
+
+gem 'activesupport', gem 'activesupport', '~> 5.1.0.rc1'


### PR DESCRIPTION
- Add Ruby 2.4 to the test matrix
- Use latest Rubies
- Use release version of Active Support 5
- Add a canary build of Active Support 5.1 that is in the RC stage before release