### PR TITLE
Remove unused ActiveMerchant::Connection#handle_response method

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -139,19 +139,6 @@ module ActiveMerchant
       end
     end
 
-    def handle_response(response)
-      if @ignore_http_status then
-        return response.body
-      else
-        case response.code.to_i
-        when 200...300
-          response.body
-        else
-          raise ResponseError.new(response)
-        end
-      end
-    end
-
     def debug(message, tag = nil)
       log(:debug, message, tag)
     end


### PR DESCRIPTION
I did a search throught AM and couldn't find anywhere where this code is being used and looks to be dead code. `handle_response` Looks to now be implemented on each gateway within `PostsData` module included on `Billing::Gateway`.

There weren't any tests covering this in the test suite.

**How?**
- :fire: `ActiveMerchant::Connection#handle_response`

**For Review**
@berkcaputcu @jasonwebster 