### PR TITLE
Use the correct param to extract authorization from Payway

### DIFF
--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -194,7 +194,7 @@ module ActiveMerchant
 
         Response.new(success, message, params,
           :test => (@options[:merchant].to_s == "TEST"),
-          :authorization => post[:order_number]
+          :authorization => post['customer.orderNumber']
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'


### PR DESCRIPTION
Payway does not return the authorization from a transaction in its
response, the implementation used the `:order_number` however the right
key is `customer.orderNumber`.