### PR TITLE
fix handling of nonfractional currencies and remove non-existent subunit concept for those

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -260,14 +260,24 @@ module ActiveMerchant #:nodoc:
       end
 
       def localized_amount(money, currency)
-        amount = amount(money)
-
-        return amount unless non_fractional_currency?(currency)
-
-        if self.money_format == :cents
-          sprintf("%.0f", amount.to_f / 100)
+        return nil if money.nil?
+        amount = if money.respond_to?(:cents)
+          ActiveMerchant.deprecated "Support for Money objects is deprecated and will be removed from a future release of ActiveMerchant. Please use an Integer value in cents"
+          money.cents.to_s
         else
+          money.to_s
+        end
+
+        if money.is_a?(String)
+          raise ArgumentError, 'money amount must be a positive Integer in cents.'
+        end
+
+        if non_fractional_currency?(currency)
           amount.split('.').first
+        elsif money_format == :cents
+          amount
+        else
+          sprintf("%.2f", amount.to_f / 100)
         end
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -395,7 +395,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_nonfractional_currency_handling
     @gateway.expects(:ssl_post).with do |host, request_body|
-      assert_match %r(<grandTotalAmount>1</grandTotalAmount>), request_body
+      assert_match %r(<grandTotalAmount>100</grandTotalAmount>), request_body
       assert_match %r(<currency>JPY</currency>), request_body
       true
     end.returns(successful_nonfractional_authorization_response)

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -35,7 +35,7 @@ class EwayRapidTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @credit_card, :currency => 'JPY')
     end.check_request do |endpoint, data, headers|
-      assert_match '"TotalAmount":"1"', data
+      assert_match '"TotalAmount":"100"', data
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -82,12 +82,12 @@ class GatewayTest < Test::Unit::TestCase
 
   def test_localized_amount_should_ignore_money_format_for_non_fractional_currencies
     Gateway.money_format = :dollars
-    assert_equal '1', @gateway.send(:localized_amount, 100, 'JPY')
-    assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
+    assert_equal '100', @gateway.send(:localized_amount, 100, 'JPY')
+    assert_equal '1234', @gateway.send(:localized_amount, 1234, 'HUF')
 
     Gateway.money_format = :cents
-    assert_equal '1', @gateway.send(:localized_amount, 100, 'JPY')
-    assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
+    assert_equal '100', @gateway.send(:localized_amount, 100, 'JPY')
+    assert_equal '1234', @gateway.send(:localized_amount, 1234, 'HUF')
   end
 
   def test_split_names

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -275,7 +275,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_amount_format_for_jpy_currency
-    @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_authorization_response)
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>100<\/n2:OrderTotal>/), {}).returns(successful_authorization_response)
     response = @gateway.authorize(100, :token => 'EC-6WS104951Y388951L', :payer_id => 'FWRVKNRRZ3WUC', :currency => 'JPY')
     assert response.success?
   end
@@ -283,7 +283,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_removes_fractional_amounts_with_twd_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, {:currency => 'TWD'}))
 
-    assert_equal '1', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '150', REXML::XPath.first(xml, '//n2:OrderTotal').text
   end
 
   def test_fractional_discounts_are_correctly_calculated_with_jpy_currency
@@ -292,10 +292,10 @@ class PaypalExpressTest < Test::Unit::TestCase
                              {:name => 'Discount', :description => 'Discount', :amount => -750, :number => 2, :quantity => 1}],
                              :subtotal => 14250, :currency => 'JPY', :shipping => 0, :handling => 0, :tax => 0 }))
 
-    assert_equal '142', REXML::XPath.first(xml, '//n2:OrderTotal').text
-    assert_equal '142', REXML::XPath.first(xml, '//n2:ItemTotal').text
+    assert_equal '14250', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '14250', REXML::XPath.first(xml, '//n2:ItemTotal').text
     amounts = REXML::XPath.match(xml, '//n2:Amount')
-    assert_equal '150', amounts[0].text
+    assert_equal '15000', amounts[0].text
     assert_equal '-8', amounts[1].text
   end
 
@@ -305,10 +305,10 @@ class PaypalExpressTest < Test::Unit::TestCase
                              {:name => 'Discount', :description => 'Discount', :amount => -700, :number => 2, :quantity => 1}],
                              :subtotal => 14300, :currency => 'JPY', :shipping => 0, :handling => 0, :tax => 0 }))
 
-    assert_equal '143', REXML::XPath.first(xml, '//n2:OrderTotal').text
-    assert_equal '143', REXML::XPath.first(xml, '//n2:ItemTotal').text
+    assert_equal '14300', REXML::XPath.first(xml, '//n2:OrderTotal').text
+    assert_equal '14300', REXML::XPath.first(xml, '//n2:ItemTotal').text
     amounts = REXML::XPath.match(xml, '//n2:Amount')
-    assert_equal '150', amounts[0].text
+    assert_equal '15000', amounts[0].text
     assert_equal '-7', amounts[1].text
   end
 

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -371,7 +371,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_amount_format_for_jpy_currency
-    @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_purchase_response)
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>100<\/n2:OrderTotal>/), {}).returns(successful_purchase_response)
     response = @gateway.purchase(100, @credit_card, @options.merge(:currency => 'JPY'))
     assert response.success?
   end

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -76,7 +76,7 @@ class SagePayTest < Test::Unit::TestCase
     @amount = 100_00  # 100 YEN
     @options[:currency] = 'JPY'
 
-    @gateway.expects(:add_pair).with({}, :Amount, '100', :required => true)
+    @gateway.expects(:add_pair).with({}, :Amount, '10000', :required => true)
     @gateway.expects(:add_pair).with({}, :Currency, 'JPY', :required => true)
 
     @gateway.send(:add_amount, {}, @amount, @options)

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -60,7 +60,7 @@ class SecurePayAuTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(:currency => 'JPY'))
     end.check_request do |endpoint, data, headers|
-      assert_match %r{<amount>1<\/amount>}, data
+      assert_match %r{<amount>100<\/amount>}, data
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -431,7 +431,7 @@ class StripeTest < Test::Unit::TestCase
   def test_amount_localization
     @gateway.expects(:ssl_request).returns(successful_purchase_response(true))
     @gateway.expects(:post_data).with do |params|
-      '4' == params[:amount]
+      '400' == params[:amount]
     end
 
     @options[:currency] = 'JPY'

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -204,7 +204,7 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))
     end.check_request do |endpoint, data, headers|
       assert_tag_with_attributes 'amount',
-          {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
+          {'value' => '10000', 'exponent' => '0', 'currencyCode' => 'JPY'},
         data
     end.respond_with(successful_authorize_response)
   end


### PR DESCRIPTION
Thanks for this awesome gem. I found one issue which looks like a serious problem.

I think the current way of handling non-fractional currencies is quite troublesome and the behaviour is really surprising. I believe there shouldn't be a concept of subunits for currencies that, well, don't have it. When passing e.g. 1000 JPY it should be 1000 regardless if the expected amount is dollars or cents and it's the application's responsibility to pass it in a right format. 

This is really a problem when using a user is supposed to pay 1000 JPY, but then the payment is executed for 10 JPY. I For these currencies it's highly unlikely that the amount would need any conversion, the amount passed as the input most likely won't be in a wrong format. 

Such change probably introduces a big change and is not backwards compatible, but I think it's worth going that way as conversions for such currencies is probably unexpected.

Thoughts?