### PR TITLE
Firstdata E4 (Payeezy): Set correct ECI value for card present swipes

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -226,9 +226,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_credit_card(xml, credit_card, options)
-
         if credit_card.respond_to?(:track_data) && credit_card.track_data.present?
           xml.tag! "Track1", credit_card.track_data
+          xml.tag! "Ecommerce_Flag", "R"
         else
           xml.tag! "Card_Number", credit_card.number
           xml.tag! "Expiry_Date", expdate(credit_card)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -164,8 +164,10 @@ module ActiveMerchant
     end
 
     def credit_card_with_track_data(number = '4242424242424242', options = {})
+      exp_date = default_expiration_date.strftime("%y%m")
+
       defaults = {
-        :track_data => '%B' + number + '^LONGSEN/L. ^15121200000000000000**123******?',
+        :track_data => "%B#{number}^LONGSEN/L. ^#{exp_date}1200000000000000**123******?",
       }.update(options)
 
       Billing::CreditCard.new(defaults)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -265,6 +265,7 @@ class FirstdataE4Test < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card)
     end.check_request do |endpoint, data, headers|
       assert_match "<Track1>Track Data</Track1>", data
+      assert_match "<Ecommerce_Flag>R</Ecommerce_Flag>", data
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
The `Ecommerce_Flag` field was missing for swipe transactions, which was
causing them to be declined. Payeezy requires this is set explicitly to
`R` for any card present retail transaction.

See
https://support.payeezy.com/hc/en-us/articles/203730589-Ecommerce-Flag-Values