### PR TITLE
Updated MerchantWare to skip zip code for international addresses

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -218,7 +218,10 @@ module ActiveMerchant #:nodoc:
       def add_address(xml, options)
         if address = options[:billing_address] || options[:address]
           xml.tag! "strAVSStreetAddress", address[:address1]
-          xml.tag! "strAVSZipCode", address[:zip]
+
+          if address[:country].upcase == 'US'
+            xml.tag! "strAVSZipCode", address[:zip]
+          end
         end
       end
 

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -15,7 +15,8 @@ class MerchantWareTest < Test::Unit::TestCase
 
     @options = {
       :order_id => '1',
-      :billing_address => address
+      :billing_address => address(country: "US",
+                                  zip: "12345")
     }
   end
 
@@ -29,6 +30,20 @@ class MerchantWareTest < Test::Unit::TestCase
     assert_equal '4706382;1', response.authorization
     assert_equal "APPROVED", response.message
     assert response.test?
+  end
+
+  def test_skip_zip_for_international
+    options = {
+      order_id: '1',
+      billing_address: address(country: "UK")
+    }
+
+    @gateway
+      .expects(:ssl_post)
+      .with(anything, Not(regexp_matches(/<strAVSZipCode>/)), anything)
+      .returns(successful_authorization_response)
+
+    @gateway.authorize(@amount, @credit_card, options)
   end
 
   def test_soap_fault_during_authorization


### PR DESCRIPTION
When sending a zip code for international address, it resulted in
an error "field format error".