### PR TITLE
Braintree Blue: Pass cardholder_name with card

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -590,7 +590,8 @@ module ActiveMerchant #:nodoc:
               :number => credit_card_or_vault_id.number,
               :cvv => credit_card_or_vault_id.verification_value,
               :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
-              :expiration_year => credit_card_or_vault_id.year.to_s
+              :expiration_year => credit_card_or_vault_id.year.to_s,
+              :cardholder_name => "#{credit_card_or_vault_id.first_name} #{credit_card_or_vault_id.last_name}"
             }
           end
         end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -497,6 +497,13 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:zip => "1234567890"})
   end
 
+  def test_cardholder_name_passing_with_card
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:credit_card][:cardholder_name] == "Longbob Longsen")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :customer => {:first_name => "Longbob", :last_name => "Longsen"})
+  end
+
   def test_passes_recurring_flag
     @gateway = BraintreeBlueGateway.new(
       :merchant_id => 'test',


### PR DESCRIPTION
Previously, cardholder_name was only passed with a credit card on store
actions. Other actions lacked it, which may affect decline rates. It is
also required for AVS.

@dsantoso to confirm and merge