### PR TITLE
Check `:pem` exists before trying to mutate to strip

### DIFF
--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -143,9 +143,9 @@ module ActiveMerchant #:nodoc:
           :pem => LinkpointGateway.pem_file
         }.update(options)
 
-        @options[:pem].strip!
-
         raise ArgumentError, "You need to pass in your pem file using the :pem parameter or set it globally using ActiveMerchant::Billing::LinkpointGateway.pem_file = File.read( File.dirname(__FILE__) + '/../mycert.pem' ) or similar" if @options[:pem].blank?
+
+        @options[:pem].strip!
       end
 
       # Send a purchase request with periodic options

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -14,6 +14,12 @@ class LinkpointTest < Test::Unit::TestCase
     @options = { :order_id => 1000, :billing_address => address }
   end
 
+  def test_instantiating_without_credential_raises
+    assert_raise ArgumentError do
+      LinkpointGateway.new(login: 123123)
+    end
+  end
+
   def test_credit_card_formatting
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, 2004)
     assert_equal '04', @gateway.send(:format_creditcard_expiry_year, '2004')


### PR DESCRIPTION
Introduced in https://github.com/activemerchant/active_merchant/commit/df2fc16cd7b1e7791d6073e4bbf712c1795f5b6e this regressed the ArgumentError that was raised if no `pem` option was provided.

/cc @curiousepic 