### PR TITLE
GlobalCollect: Pass options to Refund

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options={})
         post = nestable_hash
-        add_amount(post, money, options={})
+        add_amount(post, money, options)
         add_refund_customer_data(post, options)
         commit(:refund, post, authorization)
       end
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def add_amount(post, money, options)
+      def add_amount(post, money, options={})
         post["amountOfMoney"] = {
           "amount" => amount(money),
           "currencyCode" => options[:currency] || currency(money)

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -127,6 +127,14 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_refund_passes_currency_code
+    stub_comms do
+      @gateway.refund(@accepted_amount, '000000142800000000920000100001', {currency: 'COP'})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"currencyCode\":\"COP\"/, data)
+    end.respond_with(failed_refund_response)
+  end
+
   def test_failed_refund
     response = stub_comms do
       @gateway.refund(nil, "")


### PR DESCRIPTION
Refund had been calling add_amount with the argument setting options to
an empty hash. Now options (namely currency) will be passed correctly
when Refunding, and the default happens in the add_amount method.

@davidsantoso to confirm and merge.