### PR TITLE
PayU LATAM: Let Refund take amount value

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
-      def refund(authorization, options={})
+      def refund(amount, authorization, options={})
         post = {}
 
         add_credentials(post, 'SUBMIT_TRANSACTION')

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -101,6 +101,35 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_equal "PENDING", response.params["transactionResponse"]["state"]
   end
 
+  def test_well_formed_refund_fails_as_expected
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_equal "The payment plan id cannot be empty", refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_match /property: parentTransactionId, message: must not be null/, response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal "APPROVED", void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_match /property: parentTransactionId, message: must not be null/, response.message
+  end
+
   def test_verify_credentials
     assert @gateway.verify_credentials
 

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -64,6 +64,38 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal "PENDING", response.params["transactionResponse"]["state"]
   end
 
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(dummy_successful_refund_response)
+
+    response = @gateway.refund(@amount, "7edbaf68-8f3a-4ae7-b9c7-d1e27e314999")
+    assert_success response
+    assert_equal "APPROVED", response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.refund(@amount, "")
+    assert_failure response
+    assert_equal "property: order.id, message: must not be null property: parentTransactionId, message: must not be null", response.message
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    response = @gateway.void("7edbaf68-8f3a-4ae7-b9c7-d1e27e314999", @options)
+    assert_success response
+    assert_equal "APPROVED", response.message
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    response = @gateway.void("")
+    assert_failure response
+    assert_equal "property: order.id, message: must not be null property: parentTransactionId, message: must not be null", response.message
+  end
+
   def test_verify_good_credentials
     @gateway.expects(:ssl_post).returns(credentials_are_legit_response)
     assert @gateway.verify_credentials
@@ -277,6 +309,82 @@ class PayuLatamTest < Test::Unit::TestCase
         "referenceQuestionnaire": null,
         "extraParameters": null
       }
+    }
+    RESPONSE
+  end
+
+  def dummy_successful_refund_response
+    <<-RESPONSE
+    {
+      "code": "SUCCESS",
+      "error": null,
+      "transactionResponse": {
+        "orderId": 840434914,
+        "transactionId": "e66fd9aa-f485-4f10-b1d6-be8e9e354b63",
+        "state": "APPROVED",
+        "paymentNetworkResponseCode": "0",
+        "paymentNetworkResponseErrorMessage": null,
+        "trazabilityCode": "49263990",
+        "authorizationCode": "NPS-011111",
+        "pendingReason": null,
+        "responseCode": "APPROVED",
+        "errorCode": null,
+        "responseMessage": "APROBADA - Autorizada",
+        "transactionDate": null,
+        "transactionTime": null,
+        "operationDate": 1486655230074,
+        "referenceQuestionnaire": null,
+        "extraParameters": null,
+        "additionalInfo": null
+       }
+    }
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+    {
+      "code":"ERROR",
+      "error":"property: order.id, message: must not be null property: parentTransactionId, message: must not be null",
+      "transactionResponse": null
+    }
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+    {
+      "code": "SUCCESS",
+      "error": null,
+      "transactionResponse": {
+        "orderId": 840434914,
+        "transactionId": "e66fd9aa-f485-4f10-b1d6-be8e9e354b63",
+        "state": "APPROVED",
+        "paymentNetworkResponseCode": "0",
+        "paymentNetworkResponseErrorMessage": null,
+        "trazabilityCode": "49263990",
+        "authorizationCode": "NPS-011111",
+        "pendingReason": null,
+        "responseCode": "APPROVED",
+        "errorCode": null,
+        "responseMessage": "APROBADA - Autorizada",
+        "transactionDate": null,
+        "transactionTime": null,
+        "operationDate": 1486655230074,
+        "referenceQuestionnaire": null,
+        "extraParameters": null,
+        "additionalInfo": null
+       }
+    }
+    RESPONSE
+  end
+
+  def failed_void_response
+    <<-RESPONSE
+    {
+      "code":"ERROR",
+      "error":"property: order.id, message: must not be null property: parentTransactionId, message: must not be null",
+      "transactionResponse": null
     }
     RESPONSE
   end


### PR DESCRIPTION
The Refund action previously did not take an amount argument, and so was
failing when present. PayU LATAM's sandbox appears to not fully test
refunds, so a remote test to check that it fails in the expected way has
been added. Remote tests for Void and unit tests for both are also
added.

@davidsantoso to confirm and merge.