### PR TITLE
PayU LATAM: Count pending refunds as succeeded

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -321,6 +321,8 @@ module ActiveMerchant #:nodoc:
           response["code"] == "SUCCESS" && response["creditCardToken"] && response["creditCardToken"]["creditCardTokenId"].present?
         when 'verify_credentials'
           response["code"] == "SUCCESS"
+        when 'refund'
+        response["code"] == "SUCCESS" && response["transactionResponse"] && (response["transactionResponse"]["state"] == "PENDING" || response["transactionResponse"]["state"] == "APPROVED")
         else
           response["code"] == "SUCCESS" && response["transactionResponse"] && (response["transactionResponse"]["state"] == "APPROVED")
         end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -64,12 +64,12 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal "PENDING", response.params["transactionResponse"]["state"]
   end
 
-  def test_successful_refund
-    @gateway.expects(:ssl_post).returns(dummy_successful_refund_response)
+  def test_pending_refund
+    @gateway.expects(:ssl_post).returns(pending_refund_response)
 
     response = @gateway.refund(@amount, "7edbaf68-8f3a-4ae7-b9c7-d1e27e314999")
     assert_success response
-    assert_equal "APPROVED", response.message
+    assert_equal "PENDING", response.params["transactionResponse"]["state"]
   end
 
   def test_failed_refund
@@ -313,30 +313,31 @@ class PayuLatamTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def dummy_successful_refund_response
+  def pending_refund_response
     <<-RESPONSE
     {
       "code": "SUCCESS",
       "error": null,
-      "transactionResponse": {
-        "orderId": 840434914,
-        "transactionId": "e66fd9aa-f485-4f10-b1d6-be8e9e354b63",
-        "state": "APPROVED",
-        "paymentNetworkResponseCode": "0",
+      "transactionResponse":
+      {
+        "orderId": 924877963,
+        "transactionId": null,
+        "state": "PENDING",
+        "paymentNetworkResponseCode": null,
         "paymentNetworkResponseErrorMessage": null,
-        "trazabilityCode": "49263990",
-        "authorizationCode": "NPS-011111",
-        "pendingReason": null,
-        "responseCode": "APPROVED",
+        "trazabilityCode": null,
+        "authorizationCode": null,
+        "pendingReason": "PENDING_REVIEW",
+        "responseCode": null,
         "errorCode": null,
-        "responseMessage": "APROBADA - Autorizada",
+        "responseMessage": "924877963",
         "transactionDate": null,
         "transactionTime": null,
-        "operationDate": 1486655230074,
+        "operationDate": null,
         "referenceQuestionnaire": null,
         "extraParameters": null,
         "additionalInfo": null
-       }
+      }
     }
     RESPONSE
   end


### PR DESCRIPTION
The adapter's success_from method wasn't accounting for responses
in the "pending" state, which seems to be the default for refund
requests.

@davidsantoso to confirm and merge.