### PR TITLE
Braintree: Add Android Pay meta data fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -582,7 +582,9 @@ module ActiveMerchant #:nodoc:
                 :cryptogram => credit_card_or_vault_id.payment_cryptogram,
                 :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
                 :expiration_year => credit_card_or_vault_id.year.to_s,
-                :google_transaction_id => credit_card_or_vault_id.transaction_id
+                :google_transaction_id => credit_card_or_vault_id.transaction_id,
+                :source_card_type => credit_card_or_vault_id.brand,
+                :source_card_last_four => credit_card_or_vault_id.last_digits
               }
             end
           else

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -635,7 +635,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
           :expiration_month => '09',
           :expiration_year => (Time.now.year + 1).to_s,
           :cryptogram => '111111111100cryptogram',
-          :google_transaction_id => '1234567890'
+          :google_transaction_id => '1234567890',
+          :source_card_type => "visa",
+          :source_card_last_four => "1111"
         }
       ).
       returns(braintree_result(:id => "transaction_id"))


### PR DESCRIPTION
Braintree requested two additional fields be added for Android Pay
requests - `source_card_type` and `source_card_last_four`.

From Braintree:

For Android Pay, we noticed that when we are passed decrypted
tokens, there are two fields missing from your payload. Both fields are
related to the details of the source card that is in the user's Android
Pay wallet.

* `source_card_type`
* `source_card_last_four`

We currently use these fields within our search functionality, as such
it'd be super helpful if you could make this update.

@davidsantoso see spreedly/core#2379