### PR TITLE
TransFirst Transaction Express: Don't send order_id with refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -248,7 +248,6 @@ module ActiveMerchant #:nodoc:
         request = build_xml_transaction_request do |doc|
           add_amount(doc, amount)
           add_original_transaction_data(doc, transaction_id)
-          add_order_number(doc, options)
         end
 
         commit(:refund, request)


### PR DESCRIPTION
Production refund calls to the gateway are inexplicably throwing a
invalid content error for this element. We cannot reproduced the error
in their sandbox testing environment. For now, we will prevent the
element being sent with refunds.

@davidsantoso to confirm and merge