### PR TITLE
Added partial capture support for the Litle gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -50,6 +50,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options={})
         transaction_id, _, _ = split_authorization(authorization)
+        options[:partial] = true if money
 
         request = build_xml_request do |doc|
           add_authentication(doc)
@@ -338,6 +339,7 @@ module ActiveMerchant #:nodoc:
         attributes[:id] = truncate(options[:id] || options[:order_id], 24)
         attributes[:reportGroup] = options[:merchant] || 'Default Report Group'
         attributes[:customerId] = options[:customer]
+        attributes[:partial] = options[:partial]
         attributes.delete_if { |key, value| value == nil }
         attributes
       end


### PR DESCRIPTION
Added support for partial capture of an authorization for a Litle Capture Transaction. According to the Litle documentation:

> 1.12.3 Capture Transaction
> 
> You can submit a Capture transaction for the full amount of the Authorization, or for a lesser amount by setting the partial attribute to true.