### PR TITLE
Added support for Litle sale options

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
         add_order_source(doc, payment_method, options)
         add_billing_address(doc, payment_method, options)
         add_shipping_address(doc, payment_method, options)
-        add_payment_method(doc, payment_method)
+        add_payment_method(doc, payment_method, options)
         add_pos(doc, payment_method)
         add_descriptor(doc, options)
         add_debt_repayment(doc, options)
@@ -200,10 +200,13 @@ module ActiveMerchant #:nodoc:
         doc.debtRepayment(true) if options[:debt_repayment] == true
       end
 
-      def add_payment_method(doc, payment_method)
+      def add_payment_method(doc, payment_method, options)
         if payment_method.is_a?(String)
           doc.token do
             doc.litleToken(payment_method)
+            doc.expDate(options[:expiration_date]) if options[:expiration_date].present?
+            doc.cardValidationNum(options[:card_validation_num]) if options[:card_validation_num].present?
+            doc.type(options[:type]) if options[:type].present?
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do


### PR DESCRIPTION
Litle requires additional options to be sent with purchase request using a token.

>Does the expiration date need to be sent with a token?

>The expiration date must be sent in with a token. We only tokenize the card number. The token does not include the expiration date or card validation number. When the card expires you can simply send in the new expiration date without replacing the token.


Cross referencing: https://github.com/activemerchant/active_merchant/issues/2273