### PR TITLE
Implementation of new type of Braintree Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_pink.rb
+++ b/lib/active_merchant/billing/gateways/braintree_pink.rb
@@ -1,0 +1,595 @@
+require 'active_merchant/billing/gateways/braintree/braintree_common'
+
+begin
+  require "braintree"
+rescue LoadError
+  raise "Could not load the braintree gem.  Use `gem install braintree` to install it."
+end
+
+unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 4
+  raise "Need braintree gem >= 2.4.0. Run `gem install braintree --version '~>2.4'` to get the correct version."
+end
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # For more information on the Braintree Gateway please visit their
+    # {Developer Portal}[https://www.braintreepayments.com/developers]
+    #
+    # ==== About this implementation
+    #
+    # This implementation leverages the Braintree-authored ruby gem:
+    # https://github.com/braintree/braintree_ruby
+    #
+    # ==== Debugging Information
+    #
+    # Setting an ActiveMerchant +wiredump_device+ will automatically
+    # configure the Braintree logger (via the Braintree gem's
+    # configuration) when the BraintreePinkGateway is instantiated.
+    # Additionally, the log level will be set to +DEBUG+. Therefore,
+    # all you have to do is set the +wiredump_device+ and you'll get
+    # your debug output from your HTTP interactions with the remote
+    # gateway. (Don't enable this in production.) The ActiveMerchant
+    # implementation doesn't mess with the Braintree::Configuration
+    # globals at all, so there won't be any side effects outside
+    # Active Merchant.
+    #
+    # If no +wiredump_device+ is set, the logger in
+    # +Braintree::Configuration.logger+ will be cloned and the log
+    # level set to +WARN+.
+    #
+    class BraintreePinkGateway < Gateway
+      include BraintreeCommon
+
+      self.display_name = 'Braintree (Pink Platform)'
+
+      def initialize(options = {})
+        requires!(options, :access_token)
+        @merchant_account_id = options[:merchant_account_id]
+
+        super
+
+        if wiredump_device.present?
+          logger = ((Logger === wiredump_device) ? wiredump_device : Logger.new(wiredump_device))
+          logger.level = Logger::DEBUG
+        else
+          logger = Braintree::Configuration.logger.clone
+          logger.level = Logger::WARN
+        end
+
+        @configuration = Braintree::Configuration.new(
+          :access_token      => options[:access_token],
+          :environment       => (options[:environment] || (test? ? :sandbox : :production)).to_sym,
+          :custom_user_agent => "ActiveMerchant #{ActiveMerchant::VERSION}",
+          :logger            => options[:logger] || logger,
+        )
+
+        @braintree_gateway = Braintree::Gateway.new( @configuration )
+      end
+
+      def authorize(money, credit_card_or_vault_id, options = {})
+        create_transaction(:sale, money, credit_card_or_vault_id, options)
+      end
+
+      def capture(money, authorization, options = {})
+        commit do
+          result = @braintree_gateway.transaction.submit_for_settlement(authorization, amount(money).to_s)
+          response_from_result(result)
+        end
+      end
+
+      def purchase(money, credit_card_or_vault_id, options = {})
+        authorize(money, credit_card_or_vault_id, options.merge(:submit_for_settlement => true))
+      end
+
+      def credit(money, credit_card_or_vault_id, options = {})
+        create_transaction(:credit, money, credit_card_or_vault_id, options)
+      end
+
+      def refund(*args)
+        # legacy signature: #refund(transaction_id, options = {})
+        # new signature: #refund(money, transaction_id, options = {})
+        money, transaction_id, _ = extract_refund_args(args)
+        money = amount(money).to_s if money
+
+        commit do
+          response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
+        end
+      end
+
+      def void(authorization, options = {})
+        commit do
+          response_from_result(@braintree_gateway.transaction.void(authorization))
+        end
+      end
+
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def store(creditcard, options = {})
+        if options[:customer].present?
+          MultiResponse.new.tap do |r|
+            customer_exists_response = nil
+            r.process{customer_exists_response = check_customer_exists(options[:customer])}
+            r.process do
+              if customer_exists_response.params["exists"]
+                add_credit_card_to_customer(creditcard, options)
+              else
+                add_customer_with_credit_card(creditcard, options)
+              end
+            end
+          end
+        else
+          add_customer_with_credit_card(creditcard, options)
+        end
+      end
+
+      def update(vault_id, creditcard, options = {})
+        braintree_credit_card = nil
+        commit do
+          braintree_credit_card = @braintree_gateway.customer.find(vault_id).credit_cards.detect { |cc| cc.default? }
+          return Response.new(false, 'Braintree::NotFoundError') if braintree_credit_card.nil?
+
+          options.merge!(:update_existing_token => braintree_credit_card.token)
+          credit_card_params = merge_credit_card_options({
+            :credit_card => {
+              :cardholder_name => creditcard.name,
+              :number => creditcard.number,
+              :cvv => creditcard.verification_value,
+              :expiration_month => creditcard.month.to_s.rjust(2, "0"),
+              :expiration_year => creditcard.year.to_s
+            }
+          }, options)[:credit_card]
+
+          result = @braintree_gateway.customer.update(vault_id,
+            :first_name => creditcard.first_name,
+            :last_name => creditcard.last_name,
+            :email => scrub_email(options[:email]),
+            :credit_card => credit_card_params
+          )
+          Response.new(result.success?, message_from_result(result),
+            :braintree_customer => (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
+            :customer_vault_id => (result.customer.id if result.success?)
+          )
+        end
+      end
+
+      def unstore(customer_vault_id, options = {})
+        commit do
+          if(!customer_vault_id && options[:credit_card_token])
+            @braintree_gateway.credit_card.delete(options[:credit_card_token])
+          else
+            @braintree_gateway.customer.delete(customer_vault_id)
+          end
+          Response.new(true, "OK")
+        end
+      end
+      alias_method :delete, :unstore
+
+      def supports_network_tokenization?
+        true
+      end
+
+      def verify_credentials
+        begin
+          @braintree_gateway.transaction.find("non_existent_token")
+        rescue Braintree::AuthenticationError
+          return false
+        rescue Braintree::NotFoundError
+          return true
+        end
+
+        true
+      end
+
+      private
+
+      def check_customer_exists(customer_vault_id)
+        commit do
+          begin
+            @braintree_gateway.customer.find(customer_vault_id)
+            ActiveMerchant::Billing::Response.new(true, "Customer found", {exists: true}, authorization: customer_vault_id)
+          rescue Braintree::NotFoundError
+            ActiveMerchant::Billing::Response.new(true, "Customer not found", {exists: false})
+          end
+        end
+      end
+
+      def add_customer_with_credit_card(creditcard, options)
+        commit do
+          if options[:payment_method_nonce]
+            credit_card_params = { payment_method_nonce: options[:payment_method_nonce] }
+          else
+            credit_card_params = {
+              :credit_card => {
+                :cardholder_name => creditcard.name,
+                :number => creditcard.number,
+                :cvv => creditcard.verification_value,
+                :expiration_month => creditcard.month.to_s.rjust(2, "0"),
+                :expiration_year => creditcard.year.to_s,
+                :token => options[:credit_card_token]
+              }
+            }
+          end
+          parameters = {
+            :first_name => creditcard.first_name,
+            :last_name => creditcard.last_name,
+            :email => scrub_email(options[:email]),
+            :id => options[:customer],
+          }.merge credit_card_params
+          result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
+          Response.new(result.success?, message_from_result(result),
+            {
+              :braintree_customer => (customer_hash(result.customer, :include_credit_cards) if result.success?),
+              :customer_vault_id => (result.customer.id if result.success?),
+              :credit_card_token => (result.customer.payment_methods[0].token if result.success?)
+            },
+            :authorization => (result.customer.id if result.success?)
+          )
+        end
+      end
+
+      def add_credit_card_to_customer(credit_card, options)
+        commit do
+          parameters = {
+            customer_id: options[:customer],
+            token: options[:credit_card_token],
+            cardholder_name: credit_card.name,
+            number: credit_card.number,
+            cvv: credit_card.verification_value,
+            expiration_month: credit_card.month.to_s.rjust(2, "0"),
+            expiration_year: credit_card.year.to_s,
+          }
+          parameters[:billing_address] = map_address(options[:billing_address]) if options[:billing_address]
+
+          result = @braintree_gateway.credit_card.create(parameters)
+          ActiveMerchant::Billing::Response.new(
+            result.success?,
+            message_from_result(result),
+            {
+              customer_vault_id: (result.credit_card.customer_id if result.success?),
+              credit_card_token: (result.credit_card.token if result.success?)
+            },
+            authorization: (result.credit_card.customer_id if result.success?)
+          )
+        end
+      end
+
+      def scrub_email(email)
+        return nil unless email.present?
+        return nil if (
+          email !~ /^.+@[^\.]+(\.[^\.]+)+[a-z]$/i ||
+          email =~ /\.(con|met)$/i
+        )
+        email
+      end
+
+      def scrub_zip(zip)
+        return nil unless zip.present?
+        return nil if(
+          zip.gsub(/[^a-z0-9]/i, '').length > 9 ||
+          zip =~ /[^a-z0-9\- ]/i
+        )
+        zip
+      end
+
+      def merge_credit_card_options(parameters, options)
+        valid_options = {}
+        options.each do |key, value|
+          valid_options[key] = value if [:update_existing_token, :verify_card, :verification_merchant_account_id].include?(key)
+        end
+
+        if valid_options.include?(:verify_card) && @merchant_account_id
+          valid_options[:verification_merchant_account_id] ||= @merchant_account_id
+        end
+
+        parameters[:credit_card] ||= {}
+        parameters[:credit_card].merge!(:options => valid_options)
+        parameters[:credit_card][:billing_address] = map_address(options[:billing_address]) if options[:billing_address]
+        parameters
+      end
+
+      def map_address(address)
+        return {} if address.nil?
+        mapped = {
+          :first_name => address[:first_name],
+          :last_name => address[:last_name],
+          :street_address => address[:address1],
+          :extended_address => address[:address2],
+          :company => address[:company],
+          :locality => address[:city],
+          :region => address[:state],
+          :postal_code => scrub_zip(address[:zip]),
+        }
+        if(address[:country] || address[:country_code_alpha2])
+          mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2])
+        elsif address[:country_name]
+          mapped[:country_name] = address[:country_name]
+        elsif address[:country_code_alpha3]
+          mapped[:country_code_alpha3] = address[:country_code_alpha3]
+        elsif address[:country_code_numeric]
+          mapped[:country_code_numeric] = address[:country_code_numeric]
+        end
+        mapped
+      end
+
+      def commit(&block)
+        yield
+      rescue Braintree::BraintreeError => ex
+        Response.new(false, ex.class.to_s)
+      end
+
+      def message_from_result(result)
+        if result.success?
+          "OK"
+        elsif result.errors.any?
+          result.errors.map { |e| "#{e.message} (#{e.code})" }.join(" ")
+        elsif result.credit_card_verification
+          "Processor declined: #{result.credit_card_verification.processor_response_text} (#{result.credit_card_verification.processor_response_code})"
+        else
+          result.message.to_s
+        end
+      end
+
+      def response_from_result(result)
+        Response.new(result.success?, message_from_result(result),
+          { braintree_transaction: transaction_hash(result) },
+          { authorization: (result.transaction.id if result.transaction) }
+         )
+      end
+
+      def response_params(result)
+        params = {}
+        params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
+        params[:braintree_transaction] = transaction_hash(result)
+        params
+      end
+
+      def response_options(result)
+        options = {}
+        if result.transaction
+          options[:authorization] = result.transaction.id
+          options[:avs_result] = { code: avs_code_from(result.transaction) }
+          options[:cvv_result] = result.transaction.cvv_response_code
+        end
+        options
+      end
+
+      def avs_code_from(transaction)
+        transaction.avs_error_response_code ||
+          avs_mapping["street: #{transaction.avs_street_address_response_code}, zip: #{transaction.avs_postal_code_response_code}"]
+      end
+
+      def avs_mapping
+        {
+          "street: M, zip: M" => "M",
+          "street: M, zip: N" => "A",
+          "street: M, zip: U" => "B",
+          "street: M, zip: I" => "B",
+          "street: M, zip: A" => "B",
+
+          "street: N, zip: M" => "Z",
+          "street: N, zip: N" => "C",
+          "street: N, zip: U" => "C",
+          "street: N, zip: I" => "C",
+          "street: N, zip: A" => "C",
+
+          "street: U, zip: M" => "P",
+          "street: U, zip: N" => "N",
+          "street: U, zip: U" => "I",
+          "street: U, zip: I" => "I",
+          "street: U, zip: A" => "I",
+
+          "street: I, zip: M" => "P",
+          "street: I, zip: N" => "C",
+          "street: I, zip: U" => "I",
+          "street: I, zip: I" => "I",
+          "street: I, zip: A" => "I",
+
+          "street: A, zip: M" => "P",
+          "street: A, zip: N" => "C",
+          "street: A, zip: U" => "I",
+          "street: A, zip: I" => "I",
+          "street: A, zip: A" => "I"
+        }
+      end
+
+      def message_from_transaction_result(result)
+        if result.transaction && result.transaction.status == "gateway_rejected"
+          "Transaction declined - gateway rejected"
+        elsif result.transaction
+          "#{result.transaction.processor_response_code} #{result.transaction.processor_response_text}"
+        else
+          message_from_result(result)
+        end
+      end
+
+      def response_code_from_result(result)
+        if result.transaction
+          result.transaction.processor_response_code
+        elsif result.errors.size == 0 && result.credit_card_verification
+          result.credit_card_verification.processor_response_code
+        elsif result.errors.size > 0
+          result.errors.first.code
+        end
+      end
+
+      def create_transaction(transaction_type, money, credit_card_or_vault_id, options)
+        transaction_params = create_transaction_parameters(money, credit_card_or_vault_id, options)
+        commit do
+          result = @braintree_gateway.transaction.send(transaction_type, transaction_params)
+          response = Response.new(result.success?, message_from_transaction_result(result), response_params(result), response_options(result))
+          response.cvv_result['message'] = ''
+          response
+        end
+      end
+
+      def extract_refund_args(args)
+        options = args.extract_options!
+
+        # money, transaction_id, options
+        if args.length == 1 # legacy signature
+          return nil, args[0], options
+        elsif args.length == 2
+          return args[0], args[1], options
+        else
+          raise ArgumentError, "wrong number of arguments (#{args.length} for 2)"
+        end
+      end
+
+      def customer_hash(customer, include_credit_cards=false)
+        hash = {
+          "email" => customer.email,
+          "first_name" => customer.first_name,
+          "last_name" => customer.last_name,
+          "id" => customer.id
+        }
+
+        if include_credit_cards
+          hash["credit_cards"] = customer.credit_cards.map do |cc|
+            {
+              "bin" => cc.bin,
+              "expiration_date" => cc.expiration_date,
+              "token" => cc.token,
+              "last_4" => cc.last_4,
+              "card_type" => cc.card_type,
+              "masked_number" => cc.masked_number
+            }
+          end
+        end
+
+        hash
+      end
+
+      def transaction_hash(result)
+        unless result.success?
+          return { "processor_response_code" => response_code_from_result(result) }
+        end
+
+        transaction = result.transaction
+        if transaction.vault_customer
+          vault_customer = {
+          }
+          vault_customer["credit_cards"] = transaction.vault_customer.credit_cards.map do |cc|
+            {
+              "bin" => cc.bin
+            }
+          end
+        else
+          vault_customer = nil
+        end
+
+        customer_details = {
+          "id" => transaction.customer_details.id,
+          "email" => transaction.customer_details.email
+        }
+
+        billing_details = {
+          "street_address"   => transaction.billing_details.street_address,
+          "extended_address" => transaction.billing_details.extended_address,
+          "company"          => transaction.billing_details.company,
+          "locality"         => transaction.billing_details.locality,
+          "region"           => transaction.billing_details.region,
+          "postal_code"      => transaction.billing_details.postal_code,
+          "country_name"     => transaction.billing_details.country_name,
+        }
+
+        shipping_details = {
+          "first_name"       => transaction.shipping_details.first_name,
+          "last_name"        => transaction.shipping_details.last_name,
+          "street_address"   => transaction.shipping_details.street_address,
+          "extended_address" => transaction.shipping_details.extended_address,
+          "company"          => transaction.shipping_details.company,
+          "locality"         => transaction.shipping_details.locality,
+          "region"           => transaction.shipping_details.region,
+          "postal_code"      => transaction.shipping_details.postal_code,
+          "country_name"     => transaction.shipping_details.country_name,
+        }
+        credit_card_details = {
+          "masked_number"       => transaction.credit_card_details.masked_number,
+          "bin"                 => transaction.credit_card_details.bin,
+          "last_4"              => transaction.credit_card_details.last_4,
+          "card_type"           => transaction.credit_card_details.card_type,
+          "token"               => transaction.credit_card_details.token
+        }
+
+        {
+          "order_id"                => transaction.order_id,
+          "status"                  => transaction.status,
+          "credit_card_details"     => credit_card_details,
+          "customer_details"        => customer_details,
+          "billing_details"         => billing_details,
+          "shipping_details"        => shipping_details,
+          "vault_customer"          => vault_customer,
+          "merchant_account_id"     => transaction.merchant_account_id,
+          "processor_response_code" => response_code_from_result(result),
+          "id"                      => transaction.id,
+          "type"                    => transaction.type,
+          "status"                  => transaction.status,
+          "created_at"              => transaction.created_at,
+          "updated_at"              => transaction.updated_at,
+          "channel"                 => transaction.channel
+        }
+      end
+
+      def create_transaction_parameters(money, credit_card_or_vault_id, options)
+        parameters = {
+          :amount => amount(money).to_s,
+          :order_id => options[:order_id],
+          :customer => {
+            :id => options[:store] == true ? "" : options[:store],
+            :email => scrub_email(options[:email])
+          },
+          :options => {
+            :submit_for_settlement => options[:submit_for_settlement],
+            :store_in_vault_on_success => options[:store_in_vault_on_success],
+            :hold_in_escrow => options[:hold_in_escrow],
+            :paypal => {
+              :custom_field => options[:custom_field],
+              :description => options[:description]
+            }
+          }
+        }
+
+        parameters[:custom_fields] = options[:custom_fields]
+        parameters[:device_data] = options[:device_data] if options[:device_data]
+        parameters[:service_fee_amount] = options[:service_fee_amount] if options[:service_fee_amount]
+        if merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)
+          parameters[:merchant_account_id] = merchant_account_id
+        end
+
+        if options[:recurring]
+          parameters[:recurring] = true
+        end
+
+        if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
+          if options[:payment_method_token]
+            parameters[:payment_method_token] = credit_card_or_vault_id
+            options.delete(:billing_address)
+          elsif options[:payment_method_nonce]
+            parameters[:payment_method_nonce] = credit_card_or_vault_id
+          else
+            parameters[:customer_id] = credit_card_or_vault_id
+          end
+        end
+        parameters[:billing] = map_address(options[:billing_address]) if options[:billing_address]
+        parameters[:shipping] = map_address(options[:shipping_address]) if options[:shipping_address]
+
+        channel = @options[:channel] || application_id
+        parameters[:channel] = channel if channel
+
+        if options[:descriptor_name] || options[:descriptor_phone] || options[:descriptor_url]
+          parameters[:descriptor] = {
+            name: options[:descriptor_name],
+            phone: options[:descriptor_phone],
+            url: options[:descriptor_url]
+          }
+        end
+        parameters
+      end
+    end
+  end
+end

--- a/test/unit/gateways/braintree_pink_test.rb
+++ b/test/unit/gateways/braintree_pink_test.rb
@@ -1,0 +1,586 @@
+require 'test_helper'
+
+class BraintreePinkTest < Test::Unit::TestCase
+  def setup
+    @old_verbose, $VERBOSE = $VERBOSE, false
+
+    @gateway = BraintreePinkGateway.new(
+      :access_token => 'YOUR_ACCESS_TOKEN'
+    )
+
+    @internal_gateway = @gateway.instance_variable_get( :@braintree_gateway )
+  end
+
+  def teardown
+    $VERBOSE = @old_verbose
+  end
+
+  def test_refund_legacy_method_signature
+    Braintree::TransactionGateway.any_instance.expects(:refund).
+      with('transaction_id', nil).
+      returns(braintree_result(:id => "refund_transaction_id"))
+    response = @gateway.refund('transaction_id', :test => true)
+    assert_equal "refund_transaction_id", response.authorization
+  end
+
+  def test_refund_method_signature
+    Braintree::TransactionGateway.any_instance.expects(:refund).
+      with('transaction_id', '10.00').
+      returns(braintree_result(:id => "refund_transaction_id"))
+    response = @gateway.refund(1000, 'transaction_id', :test => true)
+    assert_equal "refund_transaction_id", response.authorization
+  end
+
+  def test_transaction_uses_customer_id_by_default
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:customer_id => "present")).
+      returns(braintree_result)
+
+    assert response = @gateway.purchase(10, 'present', {})
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_transaction_uses_payment_method_token_when_option
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:payment_method_token => "present")).
+      returns(braintree_result)
+
+    assert response = @gateway.purchase(10, 'present', { payment_method_token: true })
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_transaction_uses_payment_method_nonce_when_option
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:payment_method_nonce => "present")).
+      returns(braintree_result)
+
+    assert response = @gateway.purchase(10, 'present', { payment_method_nonce: true })
+    assert_instance_of Response, response
+    assert_success response
+  end
+
+  def test_void_transaction
+    Braintree::TransactionGateway.any_instance.expects(:void).
+      with('transaction_id').
+      returns(braintree_result(:id => "void_transaction_id"))
+
+    response = @gateway.void('transaction_id', :test => true)
+    assert_equal "void_transaction_id", response.authorization
+  end
+
+  def test_verify_good_credentials
+    Braintree::TransactionGateway.any_instance.expects(:find).
+      with('non_existent_token').
+      raises(Braintree::NotFoundError)
+    assert @gateway.verify_credentials
+  end
+
+  def test_verify_bad_credentials
+    Braintree::TransactionGateway.any_instance.expects(:find).
+      with('non_existent_token').
+      raises(Braintree::AuthenticationError)
+    assert !@gateway.verify_credentials
+  end
+
+  def test_user_agent_includes_activemerchant_version
+    assert @internal_gateway.config.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
+  end
+
+  def test_merchant_account_id_present_when_provided_on_gateway_initialization
+    @gateway = BraintreePinkGateway.new(
+      :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650',
+      :merchant_account_id => 'ellie'
+    )
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:merchant_account_id => 'ellie')).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"))
+  end
+
+  def test_merchant_account_id_on_transaction_takes_precedence
+    @gateway = BraintreePinkGateway.new(
+      :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650',
+      :merchant_account_id => "account_on_transaction"
+    )
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:merchant_account_id => "account_on_transaction")).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :merchant_account_id => "account_on_transaction")
+  end
+
+  def test_merchant_account_id_present_when_provided
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:merchant_account_id => "present")).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :merchant_account_id => "present")
+  end
+
+  def test_service_fee_amount_can_be_specified
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:service_fee_amount => "2.31")).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :service_fee_amount => "2.31")
+  end
+
+  def test_hold_in_escrow_can_be_specified
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:options][:hold_in_escrow] == true)
+    end.returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :hold_in_escrow => true)
+  end
+
+  def test_store_in_vault_on_success_can_be_specified
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:options][:store_in_vault_on_success] == true)
+    end.returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"), :store_in_vault_on_success => true)
+  end
+
+  def test_merchant_account_id_absent_if_not_provided
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      not params.has_key?(:merchant_account_id)
+    end.returns(braintree_result)
+
+    @gateway.authorize(100, credit_card("41111111111111111111"))
+  end
+
+  def test_merchant_account_id_can_be_set_by_options
+    gateway = BraintreePinkGateway.new(
+      :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650'
+    )
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      'value_from_options' == params[:credit_card][:options][:verification_merchant_account_id]
+    end.returns(result)
+
+    gateway.store(credit_card('41111111111111111111'), :verify_card => true, :verification_merchant_account_id => 'value_from_options')
+  end
+
+  def test_store_with_verify_card_true
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      params[:credit_card][:options].has_key?(:verify_card)
+      assert_equal true, params[:credit_card][:options][:verify_card]
+      assert_equal "Longbob Longsen", params[:credit_card][:cardholder_name]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :verify_card => true)
+    assert_equal "123", response.params["customer_vault_id"]
+    assert_equal response.params["customer_vault_id"], response.authorization
+  end
+
+  def test_passes_email
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => "bob@example.com",
+      :first_name => 'John',
+      :last_name => 'Smith',
+      id: "123"
+    )
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal "bob@example.com", params[:email]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :email => "bob@example.com")
+    assert_success response
+  end
+
+  def test_scrubs_invalid_email
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => nil,
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :id => "123"
+    )
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal nil, params[:email]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :email => "bogus")
+    assert_success response
+  end
+
+  def test_store_with_verify_card_false
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      params[:credit_card][:options].has_key?(:verify_card)
+      assert_equal false, params[:credit_card][:options][:verify_card]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :verify_card => false)
+    assert_equal "123", response.params["customer_vault_id"]
+    assert_equal response.params["customer_vault_id"], response.authorization
+  end
+
+  def test_store_with_billing_address_options
+    customer_attributes = {
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    }
+    billing_address = {
+      :address1 => "1 E Main St",
+      :address2 => "Suite 403",
+      :city => "Chicago",
+      :state => "Illinois",
+      :zip => "60622",
+      :country_name => "US"
+    }
+    customer = stub(customer_attributes)
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_not_nil params[:credit_card][:billing_address]
+      [:street_address, :extended_address, :locality, :region, :postal_code, :country_name].each do |billing_attribute|
+        params[:credit_card][:billing_address].has_key?(billing_attribute) if params[:billing_address]
+      end
+      params
+    end.returns(result)
+
+    @gateway.store(credit_card("41111111111111111111"), :billing_address => billing_address)
+  end
+
+  def test_store_with_credit_card_token
+    customer = stub(
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    customer.stubs(:id).returns('123')
+
+    braintree_credit_card = stub_everything(token: "cctoken")
+    customer.stubs(:credit_cards).returns([braintree_credit_card])
+
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal "cctoken", params[:credit_card][:token]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :credit_card_token => "cctoken")
+    assert_success response
+    assert_equal "cctoken", response.params["braintree_customer"]["credit_cards"][0]["token"]
+    assert_equal "cctoken", response.params["credit_card_token"]
+  end
+
+  def test_store_with_customer_id
+    customer = stub(
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :credit_cards => [stub_everything]
+    )
+    customer.stubs(:id).returns("customerid")
+
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:find).
+      with("customerid").
+      raises(Braintree::NotFoundError)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal "customerid", params[:id]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), :customer => "customerid")
+    assert_success response
+    assert_equal "customerid", response.params["braintree_customer"]["id"]
+  end
+
+  def test_store_with_existing_customer_id
+    credit_card = stub(
+      customer_id: "customerid",
+      token: "cctoken"
+    )
+
+    result = Braintree::SuccessfulResult.new(credit_card: credit_card)
+    Braintree::CustomerGateway.any_instance.expects(:find).with("customerid")
+    Braintree::CreditCardGateway.any_instance.expects(:create).with do |params|
+      assert_equal "customerid", params[:customer_id]
+      assert_equal "41111111111111111111", params[:number]
+      assert_equal "Longbob Longsen", params[:cardholder_name]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card("41111111111111111111"), customer: "customerid")
+    assert_success response
+    assert_nil response.params["braintree_customer"]
+    assert_equal "customerid", response.params["customer_vault_id"]
+    assert_equal "cctoken", response.params["credit_card_token"]
+  end
+
+  def test_update_with_cvv
+    stored_credit_card = mock(:token => "token", :default? => true)
+    customer = mock(:credit_cards => [stored_credit_card], :id => '123')
+    Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
+    BraintreePinkGateway.any_instance.stubs(:customer_hash)
+
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
+      assert_equal "567", params[:credit_card][:cvv]
+      assert_equal "Longbob Longsen", params[:credit_card][:cardholder_name]
+      [vault, params]
+    end.returns(result)
+
+    @gateway.update('vault_id', credit_card("41111111111111111111", :verification_value => "567"))
+  end
+
+  def test_update_with_verify_card_true
+    stored_credit_card = stub(:token => "token", :default? => true)
+    customer = stub(:credit_cards => [stored_credit_card], :id => '123')
+    Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
+    BraintreePinkGateway.any_instance.stubs(:customer_hash)
+
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
+      assert_equal true, params[:credit_card][:options][:verify_card]
+      [vault, params]
+    end.returns(result)
+
+    @gateway.update('vault_id', credit_card("41111111111111111111"), :verify_card => true)
+  end
+
+  def test_merge_credit_card_options_ignores_bad_option
+    params = {:first_name => 'John', :credit_card => {:cvv => '123'}}
+    options = {:verify_card => true, :bogus => 'ignore me'}
+    merged_params = @gateway.send(:merge_credit_card_options, params, options)
+    expected_params = {:first_name => 'John', :credit_card => {:cvv => '123', :options => {:verify_card => true}}}
+    assert_equal expected_params, merged_params
+  end
+
+  def test_merge_credit_card_options_handles_nil_credit_card
+    params = {:first_name => 'John'}
+    options = {:verify_card => true, :bogus => 'ignore me'}
+    merged_params = @gateway.send(:merge_credit_card_options, params, options)
+    expected_params = {:first_name => 'John', :credit_card => {:options => {:verify_card => true}}}
+    assert_equal expected_params, merged_params
+  end
+
+  def test_merge_credit_card_options_handles_billing_address
+    billing_address = {
+      :address1 => "1 E Main St",
+      :city => "Chicago",
+      :state => "Illinois",
+      :zip => "60622",
+      :country => "US"
+    }
+    params = {:first_name => 'John'}
+    options = {:billing_address => billing_address}
+    expected_params = {
+      :first_name => 'John',
+      :credit_card => {
+        :billing_address => {
+          :street_address => "1 E Main St",
+          :extended_address => nil,
+          :company => nil,
+          :locality => "Chicago",
+          :region => "Illinois",
+          :postal_code => "60622",
+          :country_code_alpha2 => "US"
+        },
+        :options => {}
+      }
+    }
+    assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
+  end
+
+  def test_merge_credit_card_options_only_includes_billing_address_when_present
+    params = {:first_name => 'John'}
+    options = {}
+    expected_params = {
+      :first_name => 'John',
+      :credit_card => {
+        :options => {}
+      }
+    }
+    assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
+  end
+
+  def test_address_country_handling
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:country_code_alpha2] == "US")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country => "US"})
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:country_code_alpha2] == "US")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_alpha2 => "US"})
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:country_name] == "United States of America")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_name => "United States of America"})
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:country_code_alpha3] == "USA")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_alpha3 => "USA"})
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:country_code_numeric] == 840)
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:country_code_numeric => 840})
+  end
+
+  def test_address_zip_handling
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:postal_code] == "12345")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:zip => "12345"})
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:billing][:postal_code] == nil)
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:zip => "1234567890"})
+  end
+
+  def test_passes_recurring_flag
+    @gateway = BraintreePinkGateway.new(
+      :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650'
+    )
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:recurring => true)).
+      returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"), :recurring => true)
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(Not(has_entries(:recurring => true))).
+      returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"))
+  end
+
+  def test_configured_logger_has_a_default
+    # The default is actually provided by the Braintree gem, but we
+    # assert its presence in order to show ActiveMerchant need not
+    # configure a logger
+    assert @internal_gateway.config.logger.is_a?(Logger)
+  end
+
+  def test_configured_logger_has_a_default_log_level_defined_by_active_merchant
+    assert_equal Logger::WARN, @internal_gateway.config.logger.level
+  end
+
+  def test_default_logger_sets_warn_level_without_overwriting_global
+    with_braintree_configuration_restoration do
+      assert Braintree::Configuration.logger.level != Logger::DEBUG
+      Braintree::Configuration.logger.level = Logger::DEBUG
+
+      # Re-instantiate a gateway to show it doesn't touch the global
+      gateway = BraintreePinkGateway.new(
+        :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650'
+      )
+      internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
+
+      assert_equal Logger::WARN, internal_gateway.config.logger.level
+      assert_equal Logger::DEBUG, Braintree::Configuration.logger.level
+    end
+  end
+
+  def test_that_setting_a_wiredump_device_on_the_gateway_sets_the_braintree_logger_upon_instantiation
+    with_braintree_configuration_restoration do
+      logger = Logger.new(STDOUT)
+      ActiveMerchant::Billing::BraintreePinkGateway.wiredump_device = logger
+
+      assert_not_equal logger, Braintree::Configuration.logger
+
+      gateway = BraintreePinkGateway.new(
+        :access_token => 'access_token$sandbox$nb8654qnrrw3jwkn$3deb3954ecdc555eb2e6a35dc1c08650'
+      )
+      internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
+
+      assert_equal logger, internal_gateway.config.logger
+      assert_equal Logger::DEBUG, internal_gateway.config.logger.level
+    end
+  end
+
+  def test_successful_purchase_with_descriptor
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:descriptor][:name] == 'wow*productname') &&
+      (params[:descriptor][:phone] == '4443331112') &&
+      (params[:descriptor][:url] == 'wow.com')
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), descriptor_name: 'wow*productname', descriptor_phone: '4443331112', descriptor_url: 'wow.com')
+  end
+
+
+  def test_unsuccessful_transaction_returns_id_when_available
+    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_error_result(transaction: {id: 'transaction_id'}))
+    assert response = @gateway.purchase(100, credit_card("41111111111111111111"))
+    refute response.success?
+    assert response.authorization.present?
+  end
+
+  def test_unsuccessful_transaction_returns_message_when_available
+    Braintree::TransactionGateway.any_instance.
+      expects(:sale).
+      returns(braintree_error_result(message: 'Some error message'))
+    assert response = @gateway.purchase(100, credit_card("41111111111111111111"))
+    refute response.success?
+    assert_equal response.message, 'Some error message'
+  end
+
+  private
+
+  def braintree_result(options = {})
+    Braintree::SuccessfulResult.new(:transaction => Braintree::Transaction._new(nil, {:id => "transaction_id"}.merge(options)))
+  end
+
+  def braintree_error_result(options = {})
+    Braintree::ErrorResult.new(@internal_gateway, {errors: {}}.merge(options))
+  end
+
+  def with_braintree_configuration_restoration(&block)
+    # Remember the wiredump device since we may overwrite it
+    existing_wiredump_device = ActiveMerchant::Billing::BraintreePinkGateway.wiredump_device
+
+    yield
+
+    # Restore the wiredump device
+    ActiveMerchant::Billing::BraintreePinkGateway.wiredump_device = existing_wiredump_device
+
+    # Reset the Braintree logger
+    Braintree::Configuration.logger = nil
+  end
+end


### PR DESCRIPTION
This new gateway is to offer support for the "v.zero SDK" that Paypal/Braintree offers.  The main difference between how this works with regular braintree is the authentication, where one authenticates with an `access_token` instead of username/password.  Most of this is copypasta from the Braintree Blue gateway, with a few minor changes to options building and things of that nature.  Cheers! :shipit: 