### PR TITLE
GlobalCollect: Truncate firstName field to 15 characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * JetPay: Adjust refund and void transaction types [davidsantoso] #2356
+* GlobalCollect: Truncate firstName field to 15 characters [davidsantoso]
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -131,8 +131,8 @@ module ActiveMerchant #:nodoc:
         if payment
           post["order"]["customer"]["personalInformation"] = {
             "name" => {
-              "firstName" => payment.first_name,
-              "surname" => payment.last_name
+              "firstName" => payment.first_name[0..14],
+              "surname" => payment.last_name[0..69]
             }
           }
         end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -337,9 +337,9 @@ garanti:
   password: "123qweASD"
 
 global_collect:
-  merchant_id: 1428
-  api_key_id: 96f16a41890565d0
-  secret_api_key: g/VQ432G02bFpwg/6EY7uiPRSZxKMbQ87Kal716XORA=
+  merchant_id: 2196
+  api_key_id: c91d6752cbbf9cf1
+  secret_api_key: xHjQr5gL9Wcihkqoj4w/UQugdSCNXM2oUQHG5C82jy4=
 
 global_transport:
   global_user_name: "USERNAME"

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -33,6 +33,14 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_very_long_name
+    credit_card = credit_card('4567350000427977', { first_name: "thisisaverylongfirstname"})
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@rejected_amount, @declined_card, @options)
     assert_failure response
@@ -65,7 +73,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '123', @options)
     assert_failure response
-    assert_equal 'UNKNOWN_PAYMENT_ID', response.message
+    assert_match %r{The given paymentId is not correct}, response.message
   end
 
   # Because payments are not fully authorized immediately, refunds can only be
@@ -89,7 +97,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_refund
     response = @gateway.refund(@amount, '123')
     assert_failure response
-    assert_equal 'UNKNOWN_PAYMENT_ID', response.message
+    assert_match %r{The given paymentId is not correct}, response.message
   end
 
   def test_successful_void
@@ -104,7 +112,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('123')
     assert_failure response
-    assert_equal 'UNKNOWN_PAYMENT_ID', response.message
+    assert_match %r{The given paymentId is not correct}, response.message
   end
 
   def test_successful_verify
@@ -124,7 +132,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_match %r{MISSING_OR_INVALID_AUTHORIZATION}, response.message
+    assert_match %r{The authorization was missing or invalid}, response.message
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -45,6 +45,19 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_equal 1, response.responses.size
   end
 
+  def test_trucates_first_name_to_15_chars
+    credit_card = credit_card('4567350000427977', { first_name: "thisisaverylongfirstname" })
+
+    response = stub_comms do
+      @gateway.authorize(@accepted_amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/thisisaverylong/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal "000000142800000000920000100001", response.authorization
+  end
+
   def test_failed_authorize
     response = stub_comms do
       @gateway.authorize(@rejected_amount, @declined_card, @options)


### PR DESCRIPTION
GlobalCollect has fairly flexible field lengths for most of their request fields, however the `firstName` field is maxed at 15 characters which is just short enough that it could be an issue. There aren't that many first names more than 15 characters, but some are and formatting of a first name could also play a role. This truncates it to 15 characters so requests for ease of use sake.

`lastName` is also truncated at 70 characters but that's less because of it being an issue and more for consistency truncating name fields than need.

Additionally, while running the remote tests to verify the change it appears as though some of the error response formats have change so this updates those tests as well.

Here is the full remote test output to validate it passes-

```
➜ ruby -Itest test/remote/gateways/remote_global_collect_test.rb
Loaded suite test/remote/gateways/remote_global_collect_test
Started
...............

Finished in 23.088724 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.65 tests/s, 1.52 assertions/s
```