### PR TITLE
Pin: Add metadata optional field

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -29,6 +29,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, creditcard)
         add_address(post, creditcard, options)
         add_capture(post, options)
+        add_metadata(post, options)
 
         commit(:post, 'charges', post, options)
       end
@@ -139,6 +140,10 @@ module ActiveMerchant #:nodoc:
             post[:customer_token] = creditcard
           end
         end
+      end
+
+      def add_metadata(post, options)
+        post[:metadata] = options[:metadata] if options[:metadata]
       end
 
       def headers(params = {})

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -24,6 +24,20 @@ class RemotePinTest < Test::Unit::TestCase
     assert_equal true, response.params['response']['captured']
   end
 
+  def test_successful_purchase_with_metadata
+    options_with_metadata = {
+      metadata: {
+        order_id: generate_unique_id,
+        purchase_number: generate_unique_id
+      }
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options_with_metadata))
+    assert_success response
+    assert_equal true, response.params['response']['captured']
+    assert_equal options_with_metadata[:metadata][:order_id], response.params['response']['metadata']['order_id']
+    assert_equal options_with_metadata[:metadata][:purchase_number], response.params['response']['metadata']['purchase_number']
+  end
+
   def test_successful_authorize_and_capture
     authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
@@ -162,7 +176,7 @@ class RemotePinTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
-    
+
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end


### PR DESCRIPTION
@davidsantoso 

Pin API does not have an assigned field to map `order_id`. Metadata, a placeholder for user defined key value pairs can be used to pass in fields like `order_id` and others.

**Remote Test**
```
$ RUBYOPT=W0 bundle exec rake test:remote TEST=test/remote/gateways/remote_pin_test.rb 

Started
...............

Finished in 31.094433 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.48 tests/s, 1.45 assertions/s
```