### PR TITLE
GlobalCollect: Set REJECTED refunds as unsuccessful transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Qvalent: Add soft descriptor fields. Add authorize, capture, and void [davidsantoso]
 * Adyen: Add Adyen v18 gateway [adyenpayments] #2272
 * Pin: Add metadata optional field [shasum] #2363
+* GlobalCollect: Set REJECTED refunds as unsuccessful transactions [davidsantoso] #2365
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -262,14 +262,18 @@ EOS
       end
 
       def success_from(response)
-        !response["errorId"]
+        !response["errorId"] && response["status"] != "REJECTED"
       end
 
       def message_from(succeeded, response)
         if succeeded
           "Succeeded"
         else
-          response["errors"][0]["message"] || "Unable to read error message"
+          if errors = response["errors"]
+            errors.first.try(:[], "message")
+          else
+            "Unable to read error message"
+          end
         end
       end
 
@@ -283,7 +287,11 @@ EOS
 
       def error_code_from(succeeded, response)
         unless succeeded
-          response["errors"][0]["code"] || "Unable to read error code"
+          if errors = response["errors"]
+            errors.first.try(:[], "code")
+          else
+            "Unable to read error code"
+          end
         end
       end
 

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -156,6 +156,14 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_rejected_refund
+    response = stub_comms do
+      @gateway.refund(@accepted_amount, '000000142800000000920000100001')
+    end.respond_with(rejected_refund_response)
+
+    assert_failure response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -297,6 +305,10 @@ class GlobalCollectTest < Test::Unit::TestCase
 
   def failed_refund_response
     %({\n   \"errorId\" : \"1bd31e6a-39dd-4214-941a-088a320e0286\",\n   \"errors\" : [ {\n      \"code\" : \"1002\",\n      \"propertyName\" : \"paymentId\",\n      \"message\" : \"INVALID_PAYMENT_ID\"\n   } ]\n})
+  end
+
+  def rejected_refund_response
+    %({\n   \"id\" : \"00000022184000047564000-100001\",\n   \"refundOutput\" : {\n      \"amountOfMoney\" : {\n         \"amount\" : 627000,\n         \"currencyCode\" : \"COP\"\n      },\n      \"references\" : {\n         \"merchantReference\" : \"17091GTgZmcC\",\n         \"paymentReference\" : \"0\"\n      },\n      \"paymentMethod\" : \"card\",\n      \"cardRefundMethodSpecificOutput\" : {\n      }\n   },\n   \"status\" : \"REJECTED\",\n   \"statusOutput\" : {\n      \"isCancellable\" : false,\n      \"statusCategory\" : \"UNSUCCESSFUL\",\n      \"statusCode\" : 1850,\n      \"statusCodeChangeDateTime\" : \"20170313230631\"\n   }\n})
   end
 
   def successful_void_response


### PR DESCRIPTION
It should be noted that Global Collect requires 24 hours for purchase to
settle before attempting a refund so remote tests for refunds are not
easily reproducible. Furthermore, forcing a REJECTED response in a
refund is not covered in the docs which is why this is lacking a remote
tests. However the unit test does take into account the response as shown
in the docs.

Closes #2365