### PR TITLE
WePay: Support `unique_id` for idempotent transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -126,6 +126,7 @@ module ActiveMerchant #:nodoc:
         post[:payer_email_message] = options[:payer_email_message] if options[:payer_email_message]
         post[:payee_email_message] = options[:payee_email_message] if options[:payee_email_message]
         post[:reference_id] = options[:order_id] if options[:order_id]
+        post[:unique_id] = options[:unique_id] if options[:unique_id]
         post[:redirect_uri] = options[:redirect_uri] if options[:redirect_uri]
         post[:callback_uri] = options[:callback_uri] if options[:callback_uri]
         post[:fallback_uri] = options[:fallback_uri] if options[:fallback_uri]

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -66,6 +66,12 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_unique_id
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(unique_id: generate_unique_id))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_authorize
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
@davidsantoso 

Customer generated `unique_id` to prevent duplicates. Reference: [WePay Docs](https://developer.wepay.com/api-calls/checkout#create)

**Remote test**
```
$ RUBYOPT=W0 be rake test:remote TEST=test/remote/gateways/remote_wepay_test.rb 
Started
....................

Finished in 190.130509 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
20 tests, 32 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.11 tests/s, 0.17 assertions/s
```