### PR TITLE
Orbital: Don't send CVV indicator if CVV is not present

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -417,10 +417,12 @@ module ActiveMerchant #:nodoc:
         #   Do not submit the attribute at all.
         # - http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf
         unless creditcard.nil?
-          if %w( visa discover ).include?(creditcard.brand)
-            xml.tag! :CardSecValInd, (creditcard.verification_value? ? '1' : '9')
+          if creditcard.verification_value?
+            if %w( visa discover ).include?(creditcard.brand)
+              xml.tag! :CardSecValInd, '1'
+            end
+            xml.tag! :CardSecVal,  creditcard.verification_value
           end
-          xml.tag! :CardSecVal,  creditcard.verification_value if creditcard.verification_value?
         end
       end
 


### PR DESCRIPTION
Previously, the CardSecValInd field was being passed with a value of
9 ("Cardholder states data not available") when no CVV was present
and the card brand was Visa or Discover. Chase has indicated that the
field should not be passed at all when no CVV is provided with the
request. This may have been causing declines.

Unfortunately remote tests cannot be run as we do not currently have
credentials for an active test account.

@davidsantoso to confirm and merge.