### PR TITLE
JetPay: Pass down authorization payment method token to refund a capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * GlobalCollect: Set REJECTED refunds as unsuccessful transactions [davidsantoso] #2365
 * WePay: Support unique_id for idempotent transactions [shasum] #2367
 * Orbital: Don't send CVV indicator if CVV is not present [curiousepic] #2368
+* JetPay: Pass down authorization payment method token to refund a capture [davidsantoso]
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -165,12 +165,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, reference, options = {})
-        commit(money, build_capture_request(reference.split(";").first, money, options))
+        split_authorization = reference.split(";")
+        transaction_id = split_authorization[0]
+        token = split_authorization[3]
+        commit(money, build_capture_request(transaction_id, money, options), token)
       end
 
       def void(reference, options = {})
         transaction_id, approval, amount, token = reference.split(";")
-        commit(amount.to_i, build_void_request(amount.to_i, transaction_id, approval, token, options))
+        commit(amount.to_i, build_void_request(amount.to_i, transaction_id, approval, token, options), token)
       end
 
       def credit(money, transaction_id_or_card, options = {})
@@ -183,9 +186,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, reference, options = {})
-        params = reference.split(";")
-        transaction_id = params[0]
-        token = params[3]
+        split_authorization = reference.split(";")
+        transaction_id = split_authorization[0]
+        token = split_authorization[3]
         credit_card = options[:credit_card]
         commit(money, build_credit_request('CREDIT', money, transaction_id, credit_card, token, options))
       end
@@ -279,7 +282,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def commit(money, request)
+      def commit(money, request, token = nil)
         response = parse(ssl_post(url, request))
 
         success = success?(response)
@@ -287,7 +290,7 @@ module ActiveMerchant #:nodoc:
           success ? 'APPROVED' : message_from(response),
           response,
           :test => test?,
-          :authorization => authorization_from(response, money),
+          :authorization => authorization_from(response, money, token),
           :avs_result => { :code => response[:avs] },
           :cvv_result => response[:cvv2]
         )
@@ -330,9 +333,9 @@ module ActiveMerchant #:nodoc:
         ACTION_CODE_MESSAGES[response[:action_code]]
       end
 
-      def authorization_from(response, money)
+      def authorization_from(response, money, previous_token)
         original_amount = amount(money) if money
-        [ response[:transaction_id], response[:approval], original_amount, response[:token]].join(";")
+        [ response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(";")
       end
 
       def add_credit_card(xml, credit_card)


### PR DESCRIPTION
Capture responses do not return the token used during the authorize and
without a token, it's not possible to refund the capture without sending
in the original credit card number. This passes down the payment method
token returned in the authorization response to the capture's concatenated
authorization. This allows the token to be passed when refunding a
capture which negates the need to send in a credit card number.

Previously, this discrepency bubbled up as a failed refund with the
error message being that the credit card number is missing.