### PR TITLE
GlobalCollect: Make message and error reporting more robust

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -271,8 +271,10 @@ EOS
         else
           if errors = response["errors"]
             errors.first.try(:[], "message")
+          elsif status = response["status"]
+            "Status: " + status
           else
-            "Unable to read error message"
+            "No message available"
           end
         end
       end
@@ -289,8 +291,10 @@ EOS
         unless succeeded
           if errors = response["errors"]
             errors.first.try(:[], "code")
+          elsif status = response.try(:[], "statusOutput").try(:[], "statusCode")
+            status.to_s
           else
-            "Unable to read error code"
+            "No error code available"
           end
         end
       end

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -73,7 +73,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '123', @options)
     assert_failure response
-    assert_match %r{The given paymentId is not correct}, response.message
+    assert_match %r{UNKNOWN_PAYMENT_ID}, response.message
   end
 
   # Because payments are not fully authorized immediately, refunds can only be
@@ -97,7 +97,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_refund
     response = @gateway.refund(@amount, '123')
     assert_failure response
-    assert_match %r{The given paymentId is not correct}, response.message
+    assert_match %r{UNKNOWN_PAYMENT_ID}, response.message
   end
 
   def test_successful_void
@@ -112,7 +112,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('123')
     assert_failure response
-    assert_match %r{The given paymentId is not correct}, response.message
+    assert_match %r{UNKNOWN_PAYMENT_ID}, response.message
   end
 
   def test_successful_verify
@@ -132,7 +132,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_match %r{The authorization was missing or invalid}, response.message
+    assert_match %r{MISSING_OR_INVALID_AUTHORIZATION}, response.message
   end
 
   def test_transcript_scrubbing

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -87,7 +87,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    response = @gateway.purchase(@rejected_amount, @declined_card, @options)
     assert_failure response
     assert_equal "Not sufficient funds", response.message
     assert_equal "51", response.params["rspCode"]

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -162,6 +162,8 @@ class GlobalCollectTest < Test::Unit::TestCase
     end.respond_with(rejected_refund_response)
 
     assert_failure response
+    assert_equal "1850", response.error_code
+    assert_equal "Status: REJECTED", response.message
   end
 
   def test_scrub


### PR DESCRIPTION
For some transactions, particularly refunds when rejected,
the transaction was unsusscessful but no error code or
useful message was being mapped in the response. This change
maps statusCode to error_code when errors are absent, and
status to message when an error message is absent.

It also updates some remote test message expectations, so
they are all passing now.

15 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@davidsantoso to review and merge.