### PR TITLE
Stripe: support reason for voiding

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -133,6 +133,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         post = {}
         post[:metadata] = options[:metadata] if options[:metadata]
+        post[:reason] = options[:reason] if options[:reason]
         post[:expand] = [:charge]
         commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options)
       end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -132,6 +132,17 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "123", void.params["metadata"]["test_metadata"]
   end
 
+  def test_successful_void_with_reason
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization
+
+    assert void = @gateway.void(response.authorization, reason: 'fraudulent')
+    assert void.test?
+    assert_success void
+    assert_equal "fraudulent", void.params["reason"]
+  end
+
   def test_unsuccessful_void
     assert void = @gateway.void("active_merchant_fake_charge")
     assert_failure void

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -517,6 +517,15 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_void_with_reason
+    @gateway.expects(:ssl_request).with do |_, _, post, _|
+      post.include?("reason=fraudulent")
+    end.returns(successful_purchase_response(true))
+
+    assert response = @gateway.void('ch_test_charge', {reason: 'fraudulent'})
+    assert_success response
+  end
+
   def test_successful_refund
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response)
 


### PR DESCRIPTION
Adding an optional reason for voiding a charge, as detailed in the api https://stripe.com/docs/api#refunds

Added a unit and remote test.