### PR TITLE
Payeezy: Support dynamic soft descriptors

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -37,6 +37,7 @@ module ActiveMerchant
         add_payment_method(params, payment_method)
         add_address(params, options)
         add_amount(params, amount, options)
+        add_soft_descriptors(params, options)
 
         commit(params, options)
       end
@@ -48,6 +49,7 @@ module ActiveMerchant
         add_payment_method(params, payment_method)
         add_address(params, options)
         add_amount(params, amount, options)
+        add_soft_descriptors(params, options)
 
         commit(params, options)
       end
@@ -57,6 +59,7 @@ module ActiveMerchant
 
         add_authorization_info(params, authorization)
         add_amount(params, amount, options)
+        add_soft_descriptors(params, options)
 
         commit(params, options)
       end
@@ -167,6 +170,10 @@ module ActiveMerchant
       def add_amount(params, money, options)
         params[:currency_code] = (options[:currency] || default_currency).upcase
         params[:amount] = amount(money)
+      end
+
+      def add_soft_descriptors(params, options)
+        params[:soft_descriptors] = options[:soft_descriptors] if options[:soft_descriptors]
       end
 
       def commit(params, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -11,6 +11,19 @@ class RemotePayeezyTest < Test::Unit::TestCase
       :billing_address => address,
       :merchant_ref => 'Store Purchase'
     }
+    @options_mdd = {
+      soft_descriptors: {
+        dba_name: "Caddyshack",
+        street: "1234 Any Street",
+        city: "Durham",
+        region: "North Carolina",
+        mid: "mid_1234",
+        mcc: "mcc_5678",
+        postal_code: "27701",
+        country_code: "US",
+        merchant_contact_info: "8885551212"
+      }
+    }
   end
 
   def test_successful_purchase
@@ -21,6 +34,12 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_echeck
     assert response = @gateway.purchase(@amount, @check, @options)
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_soft_descriptors
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_mdd))
     assert_match(/Transaction Normal/, response.message)
     assert_success response
   end


### PR DESCRIPTION
@davidsantoso 

Add support for merchant defined dynamic soft descriptors.

ref: https://support.payeezy.com/hc/en-us/articles/203730599-Dynamic-Soft-Descriptors
ref: https://developer.payeezy.com/payeezy-api/apis/post/transactions-3