### PR TITLE
Stripe: Support custom application in X-Stripe-Client-User-Agent header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * GlobalCollect: Make message and error reporting more robust [curiousepic] #2370
 * Cybersource: Rescue XML parse exception [shasum] #2380
 * Payeezy: Support dynamic soft descriptors [shasum] #2384
+* Stripe: Support custom application in X-Stripe-Client-User-Agent header [davidsantoso]
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -475,12 +475,17 @@ module ActiveMerchant #:nodoc:
           "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
           "User-Agent" => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           "Stripe-Version" => api_version(options),
-          "X-Stripe-Client-User-Agent" => user_agent,
+          "X-Stripe-Client-User-Agent" => stripe_client_user_agent(options),
           "X-Stripe-Client-User-Metadata" => {:ip => options[:ip]}.to_json
         }
         headers.merge!("Idempotency-Key" => idempotency_key) if idempotency_key
         headers.merge!("Stripe-Account" => options[:stripe_account]) if options[:stripe_account]
         headers
+      end
+
+      def stripe_client_user_agent(options)
+        return user_agent unless options[:application]
+        JSON.dump(JSON.parse(user_agent).merge!({application: options[:application]}))
       end
 
       def api_version(options)


### PR DESCRIPTION
Stripe will soon roll out blocks to prevent anyone from sending them raw PANs directly via their API. However, if you are PCI compliant they will allow you to continue sending raw PAN directly but you'll need to be in touch with them to get whitelisted.

Being whitelisted means sending in a `X-Stripe-Client-User-Agent` header with an `application` key that properly identifies your requests. The format is-

```json
"application": {
  "name":"app",
  "version":"1.0",
  "url":"https://example.com"
}
```
This update allows that `application` hash to be injected into the `X-Stripe-Client-User-Agent` header via the options hash should Stripe allow/whitelist your account to do so.

Full test runs for proof:

```
/Users/david/dev/active_merchant stripe-user-agent ✔
➜ ruby -Itest test/unit/gateways/stripe_test.rb
Loaded suite test/unit/gateways/stripe_test
Started
....................................................................................................................

Finished in 0.074984 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
116 tests, 615 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1547.00 tests/s, 8201.75 assertions/s

/Users/david/dev/active_merchant stripe-user-agent ✔
➜ ruby -Itest test/remote/gateways/remote_stripe_test.rb
Loaded suite test/remote/gateways/remote_stripe_test
Started
...........................................................

Finished in 80.015562 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
59 tests, 258 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.74 tests/s, 3.22 assertions/s
```