### PR TITLE
litle: refund credit card token

### DIFF
--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -172,6 +172,23 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', refund.message
   end
 
+  def test_refund_credit_card_token
+    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '4100280190123000'))
+    assert store_response = @gateway.store(credit_card, :order_id => '50')
+    assert_success store_response
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(10010, token)
+    assert_success response
+    assert_equal 'Approved', response.message
+
+    assert refund = @gateway.refund(10010, response.authorization,
+      litle_token: token, order_id: '50')
+    assert_success refund
+  end
+
   def test_partial_capture
     assert auth = @gateway.authorize(10010, @credit_card1, @options)
     assert_success auth

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -27,7 +27,34 @@ class LitleTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
+      @gateway.purchase(@amount, "token")
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "100000000000000006;sale;100", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_token
+    response = stub_comms do
+      @gateway.purchase(@amount, "token0009")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<token>\s*<litleToken>token0009<), data)
+      assert_not_match(%r(<expDate>), data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "100000000000000006;sale;100", response.authorization
+    assert response.test?
+  end
+
+  def test_successfull_purchase_with_token_and_expdate
+    response = stub_comms do
+      @gateway.purchase(@amount, "token0009", { :exp_month => "01", exp_year: "2017"})
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<expDate>0117<), data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -165,6 +192,17 @@ class LitleTest < Test::Unit::TestCase
       @gateway.refund(@amount, response.authorization)
     end.check_request do |endpoint, data, headers|
       assert_match(/100000000000000006/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_successful_token_refund
+    refund = stub_comms do
+      @gateway.refund(@amount, nil, litle_token: '100000000000000007' )
+    end.check_request do |endpoint, data, headers|
+      assert_match(/100000000000000007/, data)
+      assert_match(/ecommerce/, data)
     end.respond_with(successful_refund_response)
 
     assert_success refund


### PR DESCRIPTION
This PR adds enhances the Little Gateway refund method by allowing refunding a tokenized credit card and passing an optional expiration date on purchase.

This PR is adding the purchase expiration date when using a credit card token, because even the docs saying it is optional some banks requires the expiration date in order to complete the purchase transaction.

See https://www.vantiv.com/content/dam/vantiv/developers/Vantiv_LitleXML_Reference_Guide_XML10.1_V1.1.pdf in 4.162 expDate:

Although the schema defines the expDate element as an optional child of
the card, token and paypage elements, you must submit a value for
card-not-present transactions.
