### PR TITLE
TransFirst Transaction Express: Support ACH

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -175,6 +175,10 @@ module ActiveMerchant #:nodoc:
 
         verify: 9,
 
+        purchase_echeck: 11,
+        refund_echeck: 16,
+        void_echeck: 16,
+
         wallet_sale: 14,
       }
 
@@ -187,7 +191,15 @@ module ActiveMerchant #:nodoc:
         if credit_card?(payment_method)
           action = :purchase
           request = build_xml_transaction_request do |doc|
-            add_payment_method(doc, payment_method)
+            add_credit_card(doc, payment_method)
+            add_contact(doc, payment_method.name, options)
+            add_amount(doc, amount)
+            add_order_number(doc, options)
+          end
+        elsif echeck?(payment_method)
+          action = :purchase_echeck
+          request = build_xml_transaction_request do |doc|
+            add_echeck(doc, payment_method)
             add_contact(doc, payment_method.name, options)
             add_amount(doc, amount)
             add_order_number(doc, options)
@@ -207,7 +219,7 @@ module ActiveMerchant #:nodoc:
       def authorize(amount, payment_method, options={})
         if credit_card?(payment_method)
           request = build_xml_transaction_request do |doc|
-            add_payment_method(doc, payment_method)
+            add_credit_card(doc, payment_method)
             add_contact(doc, payment_method.name, options)
             add_amount(doc, amount)
           end
@@ -243,28 +255,37 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(amount, authorization, options={})
-        transaction_id = split_authorization(authorization)[1]
+        action, transaction_id = split_authorization(authorization)
 
         request = build_xml_transaction_request do |doc|
-          add_amount(doc, amount)
+          add_amount(doc, amount) unless action == 'purchase_echeck'
           add_original_transaction_data(doc, transaction_id)
         end
 
-        commit(:refund, request)
+        commit(refund_type(action), request)
       end
 
       def credit(amount, payment_method, options={})
-        request = build_xml_transaction_request do |doc|
-          add_pan(doc, payment_method)
-          add_amount(doc, amount)
+        if echeck?(payment_method)
+          action = :credit_echeck
+          request = build_xml_transaction_request do |doc|
+            add_name(doc, payment_method)
+            add_echeck(doc, payment_method)
+            add_amount(doc, amount)
+          end
+        else
+          action = :credit
+          request = build_xml_transaction_request do |doc|
+            add_pan(doc, payment_method)
+            add_amount(doc, amount)
+          end
         end
-
-        commit(:credit, request)
+        commit(action, request)
       end
 
       def verify(credit_card, options={})
         request = build_xml_transaction_request do |doc|
-          add_payment_method(doc, credit_card)
+          add_credit_card(doc, credit_card)
           add_contact(doc, credit_card.name, options)
         end
 
@@ -286,7 +307,7 @@ module ActiveMerchant #:nodoc:
               add_customer_id(doc, customer_id)
               doc["v1"].pmt do
                 doc["v1"].type 0 # add
-                add_payment_method(doc, payment_method)
+                add_credit_card(doc, payment_method)
               end
             end
           end
@@ -383,8 +404,9 @@ module ActiveMerchant #:nodoc:
 
           message = RESPONSE_MESSAGES[code]
           extended = EXTENDED_RESPONSE_MESSAGES[extended_code]
+          ach_response = response["achResponse"]
 
-          [message, extended].compact.join('. ')
+          [message, extended, ach_response].compact.join('. ')
         else
           response["faultstring"]
         end
@@ -401,7 +423,11 @@ module ActiveMerchant #:nodoc:
 
       # -- helper methods ----------------------------------------------------
       def credit_card?(payment_method)
-        payment_method.respond_to?(:number)
+        payment_method.respond_to?(:verification_value)
+      end
+
+      def echeck?(payment_method)
+        payment_method.respond_to?(:routing_number)
       end
 
       def split_authorization(authorization)
@@ -409,7 +435,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def void_type(action)
-        :"void_#{action}"
+        action == 'purchase_echeck' ? :void_echeck : :"void_#{action}"
+      end
+
+      def refund_type(action)
+        action == 'purchase_echeck' ? :refund_echeck : :refund
       end
 
       # -- request methods ---------------------------------------------------
@@ -482,11 +512,18 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def add_payment_method(doc, payment_method)
+      def add_credit_card(doc, payment_method)
         doc["v1"].card {
           doc["v1"].pan payment_method.number
           doc["v1"].sec payment_method.verification_value if payment_method.verification_value?
           doc["v1"].xprDt expiration_date(payment_method)
+        }
+      end
+
+      def add_echeck(doc, payment_method)
+        doc["v1"].achEcheck {
+          doc["v1"].bankRtNr payment_method.routing_number
+          doc["v1"].acctNr payment_method.account_number
         }
       end
 
@@ -537,6 +574,12 @@ module ActiveMerchant #:nodoc:
               doc["v1"].email shipping_address[:email] if shipping_address[:email]
             end
           end
+        end
+      end
+
+      def add_name(doc, payment_method)
+        doc["v1"].contact do
+          doc["v1"].fullName payment_method.name
         end
       end
 

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -10,9 +10,9 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card
+    @check = check
     @amount = 100
     @declined_amount = 21
-    @partial_amount = 1110
   end
 
   def test_successful_purchase
@@ -26,16 +26,6 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_partial_purchase
-    response = stub_comms do
-      @gateway.purchase(@partial_amount, @credit_card)
-    end.respond_with(partial_purchase_response)
-
-    assert_success response
-    assert_equal "000000000555", response.params["amt"]
-    assert response.test?
-  end
-
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@declined_amount, @credit_card)
@@ -45,6 +35,22 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "Not sufficient funds", response.message
     assert_equal "51", response.error_code
     assert response.test?
+  end
+
+  def test_successful_purchase_with_echeck
+    @gateway.stubs(:ssl_post).returns(successful_purchase_echeck_response)
+    response = @gateway.purchase(@amount, @check)
+
+    assert_success response
+    assert_equal "purchase_echeck|000028705491", response.authorization
+  end
+
+  def test_failed_purchase_with_echeck
+    @gateway.stubs(:ssl_post).returns(failed_purchase_echeck_response)
+    response = @gateway.purchase(@amount, @check)
+
+    assert_failure response
+    assert_equal "Error. Bank routing number validation negative (ABA).", response.message
   end
 
   def test_successful_authorize_and_capture
@@ -137,6 +143,32 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "50011", response.error_code
   end
 
+  def test_successful_refund_with_echeck
+    response = stub_comms do
+      @gateway.purchase(@amount, @check)
+    end.respond_with(successful_purchase_echeck_response)
+
+    assert_success response
+    assert_equal "purchase_echeck|000028705491", response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/000028705491/, data)
+    end.respond_with(successful_refund_echeck_response)
+
+    assert_success refund
+  end
+
+  def test_failed_refund_with_echeck
+    response = stub_comms do
+      @gateway.refund(@amount, 'purchase_echeck|000028706091')
+    end.respond_with(failed_refund_response)
+
+    assert_failure response
+    assert_equal "50011", response.error_code
+  end
+
   def test_successful_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card)
@@ -216,10 +248,6 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A1009331525B2A2DBFAF771E2E62B</ns2:swchKey><ns2:tranNr>000015212561</ns2:tranNr><ns2:dtTm>2016-01-19T10:33:57.000-08:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>305156</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
   end
 
-  def partial_purchase_response
-    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:SendTranResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:rspCode>10</ns2:rspCode><ns2:authRsp><ns2:secRslt>M</ns2:secRslt><ns2:avsRslt>Z</ns2:avsRslt><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A10092D15279AD062097039A74A15</ns2:swchKey><ns2:tranNr>000015526161</ns2:tranNr><ns2:dtTm>2016-01-25T08:45:28.000-08:00</ns2:dtTm><ns2:amt>000000000555</ns2:amt><ns2:stan>332604</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid><ns2:additionalAmount><ns2:accountType>00</ns2:accountType><ns2:amountType>57</ns2:amountType><ns2:currencyCode>840</ns2:currencyCode><ns2:amountSign>C</ns2:amountSign><ns2:amount>000000001110</ns2:amount></ns2:additionalAmount></ns2:SendTranResponse></S:Body></S:Envelope>)
-  end
-
   def failed_purchase_response
     %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>51</ns2:rspCode><ns2:authRsp><ns2:aci>Y</ns2:aci></ns2:authRsp><ns2:tranData><ns2:swchKey>0A1009331525BA8F333FC15F59AB32</ns2:swchKey><ns2:tranNr>000015220671</ns2:tranNr><ns2:dtTm>2016-01-19T12:52:25.000-08:00</ns2:dtTm><ns2:amt>000000000021</ns2:amt><ns2:stan>305918</ns2:stan><ns2:auth>Lexc05</ns2:auth></ns2:tranData><ns2:cardType>0</ns2:cardType><ns2:mapCaid>300979940268000</ns2:mapCaid></ns2:SendTranResponse></S:Body></S:Envelope>)
   end
@@ -270,6 +298,22 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def failed_store_response
     %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Server</faultcode><faultstring>Validation Failure</faultstring><detail><SystemFault:SystemFault xmlns:SystemFault=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><name>Validation Fault</name><message>cvc-type.3.1.3: The value '123' of element 'v1:pan' is not valid.</message><errorCode>50011</errorCode></SystemFault:SystemFault></detail></S:Fault></S:Body></S:Envelope>)
+  end
+
+  def successful_purchase_echeck_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp><ns2:gwyTranId>43550871</ns2:gwyTranId></ns2:authRsp><ns2:tranData><ns2:swchKey>0A09071615AD2403F804EFDA26EA76</ns2:swchKey><ns2:tranNr>000028705491</ns2:tranNr><ns2:dtTm>2017-03-15T06:55:10-07:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>386950</ns2:stan></ns2:tranData><ns2:achResponse><ns2:Message>Transaction processed.</ns2:Message><ns2:Note>PrevPay: nil +0</ns2:Note><ns2:Note>Score: 100/100</ns2:Note></ns2:achResponse></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_purchase_echeck_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>06</ns2:rspCode><ns2:authRsp/><ns2:tranData><ns2:swchKey>0A09071715AD2654A6814EE9ADC0EF</ns2:swchKey><ns2:tranNr>000028705711</ns2:tranNr><ns2:dtTm>2017-03-15T07:35:38-07:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>386972</ns2:stan></ns2:tranData><ns2:achResponse><ns2:Message>Bank routing number validation negative (ABA).</ns2:Message></ns2:achResponse></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def successful_refund_echeck_response
+    %( <?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>00</ns2:rspCode><ns2:authRsp><ns2:gwyTranId>43550889</ns2:gwyTranId></ns2:authRsp><ns2:tranData><ns2:swchKey>0A09071715AD2786821E2F357D7E52</ns2:swchKey><ns2:tranNr>000028706091</ns2:tranNr><ns2:dtTm>2017-03-15T07:56:31-07:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt><ns2:stan>387010</ns2:stan></ns2:tranData><ns2:achResponse><ns2:Message>Transaction Cancelled.</ns2:Message><ns2:Note>PrevPay: nil +0</ns2:Note><ns2:Note>Score: 100/100</ns2:Note><ns2:Note>Cancellation Notes: RefNumber:28706091</ns2:Note></ns2:achResponse></ns2:SendTranResponse></S:Body></S:Envelope>)
+  end
+
+  def failed_refund_echeck_response
+    %(<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:SendTranResponse xmlns="http://postilion/realtime/portal/soa/xsd/Faults/2009/01" xmlns:ns2="http://postilion/realtime/merchantframework/xsd/v1/"><ns2:rspCode>12</ns2:rspCode><ns2:extRspCode>B40F</ns2:extRspCode><ns2:authRsp><ns2:gwyTranId>43550889</ns2:gwyTranId></ns2:authRsp><ns2:tranData><ns2:swchKey>0A09071615AD285C3E4E0AE3A42CF3</ns2:swchKey><ns2:tranNr>000028706091</ns2:tranNr><ns2:dtTm>2017-03-15T08:11:06-07:00</ns2:dtTm><ns2:amt>000000000100</ns2:amt></ns2:tranData></ns2:SendTranResponse></S:Body></S:Envelope>)
   end
 
   def empty_purchase_response


### PR DESCRIPTION
This adds support for purchase, refund, and void of eChecks.
eCheck general credit transactions ("blind credit") are
strictly controlled by TransFirst and are not included in
this implementation. It also cleans up some remote tests and
removed tests for "partial purchases", which aren't actually
a thing.

29 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@davidsantoso to review and merge