### PR TITLE
Fix 'posting to plaintext endpoint, which is insecure' warning

### DIFF
--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
 
     def raw_ssl_request(method, endpoint, data, headers = {})
       logger.warn "#{self.class} using ssl_strict=false, which is insecure" if logger unless ssl_strict
-      logger.warn "#{self.class} posting to plaintext endpoint, which is insecure" if logger unless endpoint =~ /^https:/
+      logger.warn "#{self.class} posting to plaintext endpoint, which is insecure" if logger unless endpoint.to_s =~ /^https:/
 
       connection = new_connection(endpoint)
       connection.open_timeout = open_timeout


### PR DESCRIPTION
Saw a bunch of these warnings that did not make sense because it was connecting to a https endpoint. An URI object is valid to pass in for `Connection#initialize`.

```ruby
URI('https://foo.com') =~ /^https:/
=> nil # would trigger warning
```