### PR TITLE
Beanstream: Map iso province codes for US and CA

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -59,6 +59,72 @@ module ActiveMerchant #:nodoc:
         :cancel => 'C'
       }
 
+      STATES = {
+        "ALBERTA" => "AB",
+        "BRITISH COLUMBIA" => "BC",
+        "MANITOBA" => "MB",
+        "NEW BRUNSWICK" => "NB",
+        "NEWFOUNDLAND AND LABRADOR" => "NL",
+        "NOVA SCOTIA" => "NS",
+        "ONTARIO" => "ON",
+        "PRINCE EDWARD ISLAND" => "PE",
+        "QUEBEC" => "QC",
+        "SASKATCHEWAN" => "SK",
+        "NORTHWEST TERRITORIES" => "NT",
+        "NUNAVUT" => "NU",
+        "YUKON" => "YT",
+        "ALABAMA" => "AL",
+        "ALASKA" => "AK",
+        "ARIZONA" => "AZ",
+        "ARKANSAS" => "AR",
+        "CALIFORNIA" => "CA",
+        "COLORADO" => "CO",
+        "CONNECTICUT" => "CT",
+        "DELAWARE" => "DE",
+        "FLORIDA" => "FL",
+        "GEORGIA" => "GA",
+        "HAWAII" => "HI",
+        "IDAHO" => "ID",
+        "ILLINOIS" => "IL",
+        "INDIANA" => "IN",
+        "IOWA" => "IA",
+        "KANSAS" => "KS",
+        "KENTUCKY" => "KY",
+        "LOUISIANA" => "LA",
+        "MAINE" => "ME",
+        "MARYLAND" => "MD",
+        "MASSACHUSETTS" => "MA",
+        "MICHIGAN" => "MI",
+        "MINNESOTA" => "MN",
+        "MISSISSIPPI" => "MS",
+        "MISSOURI" => "MO",
+        "MONTANA" => "MT",
+        "NEBRASKA" => "NE",
+        "NEVADA" => "NV",
+        "NEW HAMPSHIRE" => "NH",
+        "NEW JERSEY" => "NJ",
+        "NEW MEXICO" => "NM",
+        "NEW YORK" => "NY",
+        "NORTH CAROLINA" => "NC",
+        "NORTH DAKOTA" => "ND",
+        "OHIO" => "OH",
+        "OKLAHOMA" => "OK",
+        "OREGON" => "OR",
+        "PENNSYLVANIA" => "PA",
+        "RHODE ISLAND" => "RI",
+        "SOUTH CAROLINA" => "SC",
+        "SOUTH DAKOTA" => "SD",
+        "TENNESSEE" => "TN",
+        "TEXAS" => "TX",
+        "UTAH" => "UT",
+        "VERMONT" => "VT",
+        "VIRGINIA" => "VA",
+        "WASHINGTON" => "WA",
+        "WEST VIRGINIA" => "WV",
+        "WISCONSIN" => "WI",
+        "WYOMING" => "WY"
+      }
+
       def self.included(base)
         base.default_currency = 'CAD'
 
@@ -161,7 +227,7 @@ module ActiveMerchant #:nodoc:
           post[:ordAddress1]      = billing_address[:address1]
           post[:ordAddress2]      = billing_address[:address2]
           post[:ordCity]          = billing_address[:city]
-          post[:ordProvince]      = billing_address[:state]
+          post[:ordProvince]      = STATES[billing_address[:state].upcase] || billing_address[:state] if billing_address[:state]
           post[:ordPostalCode]    = billing_address[:zip]
           post[:ordCountry]       = billing_address[:country]
         end
@@ -172,7 +238,7 @@ module ActiveMerchant #:nodoc:
           post[:shipAddress1]     = shipping_address[:address1]
           post[:shipAddress2]     = shipping_address[:address2]
           post[:shipCity]         = shipping_address[:city]
-          post[:shipProvince]     = shipping_address[:state]
+          post[:shipProvince]     = STATES[shipping_address[:state].upcase] || shipping_address[:state] if shipping_address[:state]
           post[:shipPostalCode]   = shipping_address[:zip]
           post[:shipCountry]      = shipping_address[:country]
           post[:shippingMethod]   = shipping_address[:shipping_method]

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -36,9 +36,19 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
         :address1 => '4444 Levesque St.',
         :address2 => 'Apt B',
         :city => 'Montreal',
-        :state => 'QC',
+        :state => 'Quebec',
         :country => 'CA',
         :zip => 'H2C1X8'
+      },
+      :shipping_address => {
+        :name => 'shippy',
+        :phone => '888-888-8888',
+        :address1 => '777 Foster Street',
+        :address2 => 'Ste #100',
+        :city => 'Durham',
+        :state => 'North Carolina',
+        :country => 'US',
+        :zip => '27701'
       },
       :email => 'xiaobozzz@example.com',
       :subtotal => 800,
@@ -90,6 +100,27 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @declined_amex, @options)
     assert_failure response
     assert_equal 'DECLINE', response.message
+  end
+
+  def test_successful_purchase_with_state_in_iso_format
+    assert response = @gateway.purchase(@amount, @visa, @options.merge(billing_address: address, shipping_address: address))
+    assert_success response
+    assert_false response.authorization.blank?
+    assert_equal "Approved", response.message
+  end
+
+  def test_failed_purchase_due_to_invalid_billing_state
+    @options[:billing_address][:state] = "Quebecistan"
+    assert response = @gateway.purchase(@amount, @visa, @options)
+    assert_failure response
+    assert_match %r{province does not match country}, response.message
+  end
+
+  def test_failed_purchase_due_to_invalid_shipping_state
+    @options[:shipping_address][:state] = "North"
+    assert response = @gateway.purchase(@amount, @visa, @options)
+    assert_failure response
+    assert_match %r{Invalid shipping province}, response.message
   end
 
   def test_authorize_and_capture


### PR DESCRIPTION
Beanstream expects char(2) iso codes for province

![image](https://cloud.githubusercontent.com/assets/4900443/25138320/dab18ab4-2477-11e7-80a3-981c03fb32b2.png)

ref: https://developer.beanstream.com/docs/references/merchant_API/v1-0-2/
ref: https://en.wikipedia.org/wiki/ISO_3166-2:CA
ref: https://en.wikipedia.org/wiki/ISO_3166-2:US

---

A few remote tests fail with available credentials. Hence, pasting a `purchase` run which is most relevant in this case.
```
$ bundle exec rake test:remote TEST=test/remote/gateways/remote_beanstream_test.rb TESTOPTS="--name=test_successful_visa_purchase"
Started
.

Finished in 1.927778 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.52 tests/s, 2.07 assertions/s
```