### PR TITLE
Braintree Blue: Refund unsettled payments via void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Checkout V2: Fix success_from not properly checking two possible success codes [davidsantoso]
 * SagePay: Support Repeat transactions [curiousepic] #2395
 * PayU LATAM: Fix incorrect capture method definition [davidsantoso]
+* Braintree Blue: Force refund of unsettled payments via void [bizla]
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -42,6 +42,10 @@ module ActiveMerchant #:nodoc:
 
       self.display_name = 'Braintree (Blue Platform)'
 
+      ERROR_CODES = {
+        cannot_refund_if_unsettled: 91506
+      }
+
       def initialize(options = {})
         requires!(options, :merchant_id, :public_key, :private_key)
         @merchant_account_id = options[:merchant_account_id]
@@ -90,11 +94,15 @@ module ActiveMerchant #:nodoc:
       def refund(*args)
         # legacy signature: #refund(transaction_id, options = {})
         # new signature: #refund(money, transaction_id, options = {})
-        money, transaction_id, _ = extract_refund_args(args)
+        money, transaction_id, options = extract_refund_args(args)
         money = amount(money).to_s if money
 
         commit do
-          response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
+          response = response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
+          return response if response.success?
+          return response unless options[:full_refund]
+
+          void(transaction_id) if response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
         end
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -675,6 +675,32 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal response.message, 'Some error message'
   end
 
+  def test_refund_unsettled_payment
+    Braintree::TransactionGateway.any_instance.
+      expects(:refund).
+      returns(braintree_error_result(message: "Cannot refund a transaction unless it is settled. (91506)"))
+
+    Braintree::TransactionGateway.any_instance.
+      expects(:void).
+      never
+
+    response = @gateway.refund(1.00, 'transaction_id')
+    refute response.success?
+  end
+
+  def test_refund_unsettled_payment_forces_void_on_full_refund
+    Braintree::TransactionGateway.any_instance.
+      expects(:refund).
+      returns(braintree_error_result(message: "Cannot refund a transaction unless it is settled. (91506)"))
+
+    Braintree::TransactionGateway.any_instance.
+      expects(:void).
+      returns(braintree_result)
+
+    response = @gateway.refund(1.00, 'transaction_id', full_refund: true)
+    assert response.success?
+  end
+
   private
 
   def braintree_result(options = {})


### PR DESCRIPTION
**What:** Allows refunds of unsettled payments by voiding them instead. 

**How:** Issues a void call if (and only if) the refund fails specifically with [error code 91506](https://developers.braintreepayments.com/reference/general/validation-errors/all/ruby).

**Why:** Consider the scenario: 
1. A purchase payment is submitted.
1. ActiveMerchant responds with a successful response. 
1. A refund for the purchase is submitted.
1. ActiveMerchant responds with a failure response, because the purchase payment has not settled. 

This violates the expectation that successful ActiveMerchant purchases can be fully refunded. 
The gateway-specific details of what's required to make that happen are properly abstracted away with this patch. 

Note that since there's no such thing a partial void, this only applies to full refunds via a `full_refund` option passed into`#refund`.