### PR TITLE
Authorize.Net: Force refund of unsettled payments via void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,9 @@
 * SagePay: Support Repeat transactions [curiousepic] #2395
 * PayU LATAM: Fix incorrect capture method definition [davidsantoso]
 * Beanstream: Map ISO province codes for US and CA [shasum] #2396
+* Braintree Blue: Force refund of unsettled payments via void [bizla] #2398
 * Openpay: Support card points [shasum] #2401
+* Authorize.Net: Force refund of unsettled payments via void [bizla] #2399
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -549,6 +549,20 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal "The record cannot be found", refund.message
   end
 
+  def test_failed_refund_due_to_unsettled_payment
+    @gateway.expects(:ssl_post).returns(failed_refund_for_unsettled_payment_response)
+    @gateway.expects(:void).never
+
+    @gateway.refund(36.40, '2214269051#XXXX1234')
+  end
+
+  def test_failed_full_refund_due_to_unsettled_payment_forces_void
+    @gateway.expects(:ssl_post).returns(failed_refund_for_unsettled_payment_response)
+    @gateway.expects(:void).once
+
+    @gateway.refund(36.40, '2214269051#XXXX1234', force_full_refund_if_unsettled: true)
+  end
+
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
@@ -2180,6 +2194,42 @@ class AuthorizeNetTest < Test::Unit::TestCase
           </message>
         </messages>
       </authenticateTestResponse>
+    eos
+  end
+
+  def failed_refund_for_unsettled_payment_response
+    <<-eos
+    <?xml version="1.0" encoding="utf-8"?>
+      <createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+        <messages>
+          <resultCode>Error</resultCode>
+          <message>
+            <code>E00027</code>
+            <text>The transaction was unsuccessful.</text>
+          </message>
+        </messages>
+        <transactionResponse>
+          <responseCode>3</responseCode>
+          <authCode/>
+          <avsResultCode>P</avsResultCode>
+          <cvvResultCode/>
+          <cavvResultCode/>
+          <transId>0</transId>
+          <refTransID/>
+          <transHash/>
+          <testRequest>0</testRequest>
+          <accountNumber>XXXX0001</accountNumber>
+          <accountType>Visa</accountType>
+          <errors>
+            <error>
+              <errorCode>54</errorCode>
+              <errorText>The referenced transaction does not meet the criteria for issuing a credit.</errorText>
+            </error>
+          </errors>
+          <userFields/>
+          <transHashSha2/>
+        </transactionResponse>
+      </createTransactionResponse>
     eos
   end
 end


### PR DESCRIPTION
**What: This is the same situation as https://github.com/activemerchant/active_merchant/pull/2398.** 
Allows refunds of unsettled payments by voiding them instead. 

**How:** Issues a void call if (and only if) the refund fails specifically with [error code 54](http://developer.authorize.net/api/reference/dist/json/responseCodes.json) and the `full_refund` option is included.

**Why:** Consider the scenario: 
1. A purchase payment is submitted.
1. ActiveMerchant responds with a successful response. 
1. A refund for the purchase is submitted.
1. ActiveMerchant responds with a failure response, because the purchase payment has not settled. 

This violates the expectation that successful ActiveMerchant purchases can be fully refunded. 