### PR TITLE
Openpay: Support card points

### DIFF
--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -113,6 +113,7 @@ module ActiveMerchant #:nodoc:
         post[:order_id] = options[:order_id]
         post[:device_session_id] = options[:device_session_id]
         post[:currency] = (options[:currency] || currency(money)).upcase
+        post[:use_card_points] = options[:use_card_points] if options[:use_card_points]
         add_creditcard(post, creditcard, options)
         post
       end

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -106,6 +106,17 @@ class RemoteOpenpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_card_points
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(use_card_points: 'NONE'))
+    assert_success response
+  end
+
+  def test_failed_purchase_with_card_points
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(use_card_points: 'MIXED'))
+    assert_failure response
+    assert_match %r{cardNumber not allowed for Card points}, response.message
+  end
+
   def test_successful_store
     new_email_address = '%d@example.org' % Time.now
     assert response = @gateway.store(@credit_card, name: 'Test User', email: new_email_address)


### PR DESCRIPTION
Adding support for Openpay's `use_card_points` field. The API accepts points based charges as long as the supplied credit card is a points card. Unlike what below reference doc implies it is not necessary to set `points_card` property if the card is passed along in the transaction as is done for AM transactions.

**ref:** http://www.openpay.mx/en/docs/api/#with-a-card-id-or-token

```
--------------------------------------------------------------------------------------------------------------------------------------------------
21 tests, 72 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.2381% passed
--------------------------------------------------------------------------------------------------------------------------------------------------

```