### PR TITLE
Worldpay: Force refund of unsettled payments via void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * Openpay: Support card points [shasum] #2401
 * Authorize.Net: Force refund of unsettled payments via void [bizla] #2399
 * Braintree Blue: Change :full_refund option to :force_full_refund_if_unsettled [bizla] #2403
+* Worldpay: Force refund of unsettled payments via void [bizla] #2402
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300


### PR DESCRIPTION
**What: This is the same situation as https://github.com/activemerchant/active_merchant/pull/2398 and https://github.com/activemerchant/active_merchant/pull/2399**

Allows refunds of unsettled payments by voiding them instead. 

**How:** Issues a void call if (and only if) the refund is unsettled. If the "last event" for the payment is `AUTHORISED` (and not `CAPTURED`, `SETTLED`, or `SETTLED_BY_MERCHANT`), and the `full_refund` option is passed in, we perform a void.

**Why:** Consider the scenario: 
1. A purchase payment is submitted.
1. ActiveMerchant responds with a successful response. 
1. A refund for the purchase is submitted.
1. ActiveMerchant responds with a failure response, because the purchase payment has not settled. 

This violates the expectation that successful ActiveMerchant purchases can be fully refunded. 