### PR TITLE
Braintree Blue: Change :full_refund option to :force_full_refund_if_unsettled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Braintree Blue: Force refund of unsettled payments via void [bizla] #2398
 * Openpay: Support card points [shasum] #2401
 * Authorize.Net: Force refund of unsettled payments via void [bizla] #2399
+* Braintree Blue: Change :full_refund option to :force_full_refund_if_unsettled [bizla] #2403
 
 == Version 1.64.0 (March 6, 2017)
 * Authorize.net: Allow settings to be passed for CIM purchases [fwilkins] #2300

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
         commit do
           response = response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
           return response if response.success?
-          return response unless options[:full_refund]
+          return response unless options[:force_full_refund_if_unsettled]
 
           void(transaction_id) if response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
         end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -697,7 +697,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       expects(:void).
       returns(braintree_result)
 
-    response = @gateway.refund(1.00, 'transaction_id', full_refund: true)
+    response = @gateway.refund(1.00, 'transaction_id', force_full_refund_if_unsettled: true)
     assert response.success?
   end
 


### PR DESCRIPTION
From [a discussion in another PR](https://github.com/activemerchant/active_merchant/pull/2399#issuecomment-296225743), this clarifies the interface that I intended to add on refunds and makes it match with https://github.com/activemerchant/active_merchant/pull/2399. 
(See the original context in https://github.com/activemerchant/active_merchant/pull/2398).