### PR TITLE
Add Rails 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,20 @@ gemfile:
 - Gemfile.rails41
 - Gemfile.rails42
 - Gemfile.rails50
+- Gemfile.rails51
 
 matrix:
   exclude:
     - rvm: 2.1
       gemfile: Gemfile.rails50
+    - rvm: 2.1
+      gemfile: Gemfile.rails51
     - rvm: 2.4.1
       gemfile: Gemfile.rails32
     - rvm: 2.4.1
       gemfile: Gemfile.rails40
     - rvm: 2.4.1
       gemfile: Gemfile.rails41
-  include:
-    - rvm: 2.4.1
-      gemfile: Gemfile.rails51
-  allow_failures:
-    - gemfile: Gemfile.rails51
 
 notifications:
   email:

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'activesupport', '~> 5.1.0.rc1'
+gem 'activesupport', '~> 5.1.0'

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -8,4 +8,4 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.50.0'
 end
 
-gem 'activesupport', gem 'activesupport', '~> 5.1.0.rc1'
+gem 'activesupport', '~> 5.1.0.rc1'

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 5.2')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.2')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 6.x')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
[Rails 5.1 final is out](http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/)!

This fixes the CI setup for the Rails 5.1 final release and loosens the gemspec dependency to support it.