### PR TITLE
Stub Authorize.Net unit test to fix Travis build failure

### DIFF
--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -660,7 +660,9 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_duplicate_window_class_attribute_deprecated
     @gateway.class.duplicate_window = 0
     assert_deprecation_warning("Using the duplicate_window class_attribute is deprecated. Use the transaction options hash instead.") do
-      @gateway.purchase(@amount, @credit_card)
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card)
+      end.respond_with(successful_purchase_response)
     end
   ensure
     @gateway.class.duplicate_window = nil


### PR DESCRIPTION
Travis is failing on a particular build and it looks like the test is actually trying to make an HTTP request. Since it's a unit test, it should be stubbed out like all of the other tests around it.

```
Started
...............................................................................
......../home/travis/.rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/net/http.rb:895: warning: instance variable @npn_protocols not initialized
/home/travis/.rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/net/http.rb:895: warning: instance variable @npn_select_cb not initialized
E
===============================================================================
Error: test_duplicate_window_class_attribute_deprecated(AuthorizeNetTest): ActiveMerchant::ConnectionError: The remote server reset the connection
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/network_connection_retries.rb:32:in `rescue in block in retry_exceptions'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/network_connection_retries.rb:22:in `block in retry_exceptions'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/network_connection_retries.rb:46:in `retry_network_exceptions'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/network_connection_retries.rb:21:in `retry_exceptions'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/connection.rb:54:in `request'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/posts_data.rb:65:in `raw_ssl_request'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/posts_data.rb:39:in `ssl_request'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/posts_data.rb:35:in `ssl_post'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/billing/gateways/authorize_net.rb:664:in `commit'
/home/travis/build/activemerchant/active_merchant/lib/active_merchant/billing/gateways/authorize_net.rb:108:in `purchase'
/home/travis/build/activemerchant/active_merchant/test/unit/gateways/authorize_net_test.rb:663:in `block in test_duplicate_window_class_attribute_deprecated'
     660:   def test_duplicate_window_class_attribute_deprecated
     661:     @gateway.class.duplicate_window = 0
     662:     assert_deprecation_warning("Using the duplicate_window class_attribute is deprecated. Use the transaction options hash instead.") do
  => 663:       @gateway.purchase(@amount, @credit_card)
     664:     end
     665:   ensure
     666:     @gateway.class.duplicate_window = nil
/home/travis/build/activemerchant/active_merchant/test/test_helper.rb:107:in `assert_deprecation_warning'
/home/travis/build/activemerchant/active_merchant/test/unit/gateways/authorize_net_test.rb:662:in `test_duplicate_window_class_attribute_deprecated'
===============================================================================
```