### PR TITLE
Opp: Clean up options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * WePay: Add scrub method [shasum] #2406
 * iVeri: Add gateway support [curiousepic] #2400
 * iVeri: Support 3DSecure data fields [davidsantoso] #2412
+* Opp: Fix transaction success criteria and clean up options [shasum] #2414
 
 == Version 1.65.0 (April 26, 2017)
 * Adyen: Add Adyen v18 gateway [adyenpayments] #2272

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -3,19 +3,19 @@ module ActiveMerchant #:nodoc:
     class OppGateway < Gateway
 # = Open Payment Platform
     #
-    #  The Open Payment Platform includes a powerful omni-channel transaction processing API, 
-    #   enabling you to quickly and flexibly build new applications and services on the platform. 
-    #   
-    #   This plugin enables connectivity to the Open Payment Platform for activemerchant. 
+    #  The Open Payment Platform includes a powerful omni-channel transaction processing API,
+    #   enabling you to quickly and flexibly build new applications and services on the platform.
+    #
+    #   This plugin enables connectivity to the Open Payment Platform for activemerchant.
     #
     # For any questions or comments please contact support@payon.com
     #
     # == Usage
     #
     #   gateway = ActiveMerchant::Billing::OppGateway.new(
-    #      user_id: 'merchant user id', 
+    #      user_id: 'merchant user id',
     #      password: 'password',
-    #      entity_id: 'entity id', 
+    #      entity_id: 'entity id',
     #   )
     #
     #   # set up credit card object as in main ActiveMerchant example
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
     #
     #   # Request: complete example, including address, billing address, shipping address
     #    complete_request_options = {
-    #      order_id: "your merchant/shop order id", # alternative is to set merchantInvoiceId 
+    #      order_id: "your merchant/shop order id", # alternative is to set merchantInvoiceId
     #      merchant_transaction_id: "your merchant/shop transaction id",
     #      address: address,
     #      description: 'Store Purchase - Books',
@@ -67,34 +67,34 @@ module ActiveMerchant #:nodoc:
     #        ip:  101.102.103.104,
     #      },
     #    }
-    #    
+    #
     #    # Request: minimal example
     #    minimal_request_options = {
-    #      order_id: "your merchant/shop order id", # alternative is to set merchantInvoiceId 
+    #      order_id: "your merchant/shop order id", # alternative is to set merchantInvoiceId
     #      description: 'Store Purchase - Books',
     #    }
     #
-    #   options = 
+    #   options =
     #   # run request
     #   response = gateway.purchase(754, creditcard, options) # charge 7,54 EUR
     #
     #   response.success?                   # Check whether the transaction was successful
-    #   response.error_code                 # Retrieve the error message - it's mapped to Gateway::STANDARD_ERROR_CODE 
+    #   response.error_code                 # Retrieve the error message - it's mapped to Gateway::STANDARD_ERROR_CODE
     #   response.message                    # Retrieve the message returned by opp
     #   response.authorization              # Retrieve the unique transaction ID returned by opp
     #   response.params['result']['code']   # Retrieve original return code returned by opp server
     #
     # == Errors
-    #   If transaction is not successful, response.error_code contains mapped to Gateway::STANDARD_ERROR_CODE error message. 
-    #   Complete list of opp error codes can be viewed on https://docs.oppwa.com/ 
-    #   Because this list is much bigger than Gateway::STANDARD_ERROR_CODE, only fraction is mapped to Gateway::STANDARD_ERROR_CODE. 
-    #   All other codes are mapped as Gateway::STANDARD_ERROR_CODE[:processing_error], so if this is the case, 
+    #   If transaction is not successful, response.error_code contains mapped to Gateway::STANDARD_ERROR_CODE error message.
+    #   Complete list of opp error codes can be viewed on https://docs.oppwa.com/
+    #   Because this list is much bigger than Gateway::STANDARD_ERROR_CODE, only fraction is mapped to Gateway::STANDARD_ERROR_CODE.
+    #   All other codes are mapped as Gateway::STANDARD_ERROR_CODE[:processing_error], so if this is the case,
     #   you may check the original result code from OPP that can be found in response.params['result']['code']
-    #       
+    #
     # == Special features
-    #   For purchase method risk check can be forced when options[:risk_workflow] = true 
-    #   This will split (on OPP server side) the transaction into two separate transactions: authorize and capture, 
-    #   but capture will be executed only if risk checks are successful.   
+    #   For purchase method risk check can be forced when options[:risk_workflow] = true
+    #   This will split (on OPP server side) the transaction into two separate transactions: authorize and capture,
+    #   but capture will be executed only if risk checks are successful.
     #
     #   For testing you may use the test account details listed fixtures.yml under opp. It is important to note that there are two test modes available:
     #     options[:test_mode]='EXTERNAL' causes test transactions to be forwarded to the processor's test system for 'end-to-end' testing
@@ -102,10 +102,10 @@ module ActiveMerchant #:nodoc:
     #   If no test_mode parameter is sent, test_mode=INTERNAL is the default behaviour.
     #
     #   Billing Address, Shipping Address, Custom Parameters are supported as described under https://docs.oppwa.com/parameters
-    #   See complete example above for details. 
+    #   See complete example above for details.
     #
     #   == Tokenization
-    #  When create_registration is set to true, the payment details will be stored and a token will be returned in registrationId response field, 
+    #  When create_registration is set to true, the payment details will be stored and a token will be returned in registrationId response field,
     #  which can subsequently be used to reference the stored payment.
 
       self.test_url = 'https://test.oppwa.com/v1/payments'
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w(AD AI AG AR AU AT BS BB BE BZ BM BR BN BG CA HR CY CZ DK DM EE FI FR DE GR GD GY HK HU IS IN IL IT JP LV LI LT LU MY MT MX MC MS NL PA PL PT KN LC MF VC SM SG SK SI ZA ES SR SE CH TR GB US UY)
       self.default_currency = 'EUR'
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro, :dankort] 
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro, :dankort]
 
       self.homepage_url = 'https://docs.oppwa.com'
       self.display_name = 'Open Payment Platform'
@@ -125,7 +125,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options={})
         # debit
-        execute_dbpa(options[:risk_workflow] ? 'PA.CP': 'DB', 
+        execute_dbpa(options[:risk_workflow] ? 'PA.CP': 'DB',
           money, payment, options)
       end
 
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         # preauthorization PA
         execute_dbpa('PA', money, payment, options)
       end
-      
+
       def capture(money, authorization, options={})
         # capture CP
         execute_referencing('CP', money, authorization, options)
@@ -163,8 +163,6 @@ module ActiveMerchant #:nodoc:
       def scrub(transcript)
         transcript.
           gsub(%r((authentication\.password=)\w+), '\1[FILTERED]').
-          gsub(%r((authentication\.userId=)\w+), '\1[FILTERED]').
-          gsub(%r((authentication\.entityId=)\w+), '\1[FILTERED]').
           gsub(%r((card\.number=)\d+), '\1[FILTERED]').
           gsub(%r((card\.cvv=)\d+), '\1[FILTERED]')
       end
@@ -173,11 +171,11 @@ module ActiveMerchant #:nodoc:
 
       def execute_dbpa(txtype, money, payment, options)
         post = {}
-        post[:paymentType] = txtype 
+        post[:paymentType] = txtype
         add_invoice(post, money, options)
         add_payment_method(post, payment, options)
         add_address(post, options)
-        add_customer_data(post, options)
+        add_customer_data(post, payment, options)
         add_options(post, options)
         commit(post, nil, options)
       end
@@ -189,38 +187,38 @@ module ActiveMerchant #:nodoc:
         commit(post, authorization, options)
       end
 
-      def add_authentication(post) 
-          post[:authentication] = { entityId: @options[:entity_id], password: @options[:password], userId: @options[:user_id]} 
+      def add_authentication(post)
+          post[:authentication] = { entityId: @options[:entity_id], password: @options[:password], userId: @options[:user_id]}
       end
 
-      def add_customer_data(post, options)
+      def add_customer_data(post, payment, options)
         if options[:customer]
           post[:customer] = {
             merchantCustomerId:  options[:customer][:merchant_customer_id],
-            givenName:  options[:customer][:givenname],
-            surname:  options[:customer][:surname],
+            givenName:  options[:customer][:givenname] || payment.first_name,
+            surname:  options[:customer][:surname] || payment.last_name,
             birthDate:  options[:customer][:birth_date],
             phone:  options[:customer][:phone],
             mobile:  options[:customer][:mobile],
-            email:  options[:customer][:email],
+            email:  options[:customer][:email] || options[:email],
             companyName:  options[:customer][:company_name],
             identificationDocType:  options[:customer][:identification_doctype],
             identificationDocId:  options[:customer][:identification_docid],
-            ip:  options[:customer][:ip],
+            ip:  options[:customer][:ip] || options[:ip]
           }
         end
       end
 
       def add_address(post, options)
-        if billing_address = options[:billing_address]
+        if billing_address = options[:billing_address] || options[:address]
           address(post, billing_address, 'billing')
         end
         if shipping_address = options[:shipping_address]
-          address(post, billing_address, 'shipping')
+          address(post, shipping_address, 'shipping')
           if shipping_address[:name]
-            firstname, lastname = shipping_address[:name].split(' ') 
-            post[:shipping] = { givenName: firstname, surname: lastname }          
-          end 
+            firstname, lastname = shipping_address[:name].split(' ')
+            post[:shipping] = { givenName: firstname, surname: lastname }
+          end
         end
       end
 
@@ -232,15 +230,15 @@ module ActiveMerchant #:nodoc:
             state: address[:state],
             postcode: address[:zip],
             country: address[:country],
-          } 
+          }
       end
 
       def add_invoice(post, money, options)
           post[:amount] = amount(money)
-          post[:currency] = (currency(money) || @options[:currency]) if 'RV'!=(post[:paymentType])
-          post[:descriptor] = options[:description] || options[:descriptor]  
-          post[:merchantInvoiceId] = options[:merchantInvoiceId] || options[:order_id] 
-          post[:merchantTransactionId] = options[:merchant_transaction_id]  
+          post[:currency] = options[:currency] || currency(money) unless post[:paymentType] == 'RV'
+          post[:descriptor] = options[:description] || options[:descriptor]
+          post[:merchantInvoiceId] = options[:merchantInvoiceId] || options[:order_id]
+          post[:merchantTransactionId] = options[:merchant_transaction_id] || generate_unique_id
       end
 
       def add_payment_method(post, payment, options)
@@ -271,30 +269,31 @@ module ActiveMerchant #:nodoc:
       def build_url(url, authorization, options)
         if options[:registrationId]
           "#{url.gsub(/payments/, 'registrations')}/#{options[:registrationId]}/payments"
-        elsif authorization  
+        elsif authorization
           "#{url}/#{authorization}"
         else
           url
         end
       end
-      
+
       def commit(post, authorization, options)
-        url = (test? ? test_url : live_url)
+        url = build_url(test? ? test_url : live_url, authorization, options)
         add_authentication(post)
         post = flatten_hash(post)
 
-        url = build_url(url, authorization, options)
-        raw_response = raw_ssl_request(:post, url, 
-            post.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&"), 
-            "Content-Type" => "application/x-www-form-urlencoded;charset=UTF-8")
-            
-        success = success_from(raw_response)
-        response = raw_response.body
-        begin 
-          response = JSON.parse(response)          
-        rescue JSON::ParserError
-          response = json_error(response)
+        response = begin
+          parse(
+            ssl_post(
+              url,
+              post.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join("&"),
+              "Content-Type" => "application/x-www-form-urlencoded;charset=UTF-8"
+            )
+          )
+        rescue ResponseError => e
+          parse(e.response.body)
         end
+
+        success = success_from(response)
 
         Response.new(
           success,
@@ -306,11 +305,34 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def success_from(raw_response)
-        raw_response.code.to_i.between?(200,299)  
+      def parse(body)
+        begin
+          JSON.parse(body)
+        rescue JSON::ParserError
+          json_error(body)
+        end
+      end
+
+      def json_error(body)
+        message = "Invalid response received #{body.inspect}"
+        { 'result' => {'description' => message, 'code' => 'unknown' } }
+      end
+
+      def success_from(response)
+        return false unless response['result']
+
+        success_regex = /^(000\.000\.|000\.100\.1|000\.[36])/
+
+        if success_regex =~ response['result']['code']
+          true
+        else
+          false
+        end
       end
 
       def message_from(response)
+        return 'Failed' unless response['result']
+
         response['result']['description']
       end
 
@@ -319,44 +341,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
-          case response['result']['code']
-          when '100.100.101' 
-              Gateway::STANDARD_ERROR_CODE[:incorrect_number]
-          when '100.400.317' 
-              Gateway::STANDARD_ERROR_CODE[:invalid_number]
-          when '100.100.600', '100.100.601', '800.100.153', '800.100.192' 
-              Gateway::STANDARD_ERROR_CODE[:invalid_cvc]
-          when '100.100.303' 
-              Gateway::STANDARD_ERROR_CODE[:expired_card]
-          when '100.800.200', '100.800.201', '100.800.202', '800.800.202' 
-              Gateway::STANDARD_ERROR_CODE[:incorrect_zip]
-          when '100.400.000', '100.400.086', '100.400.305', '800.400.150' 
-              Gateway::STANDARD_ERROR_CODE[:incorrect_address]
-          when '800.100.159' 
-              Gateway::STANDARD_ERROR_CODE[:pickup_card]
-          when '800.100.151', '800.100.158', '800.100.160' 
-              Gateway::STANDARD_ERROR_CODE[:card_declined]
-            else
-              Gateway::STANDARD_ERROR_CODE[:processing_error]
-          end
+        response['result']['code']
       end
-      
-      def json_error(raw_response)
-        message = "Invalid response received #{raw_response.inspect}"
-        { 'result' => {'description' => message, 'code' => 'unknown' } }
-      end
-      
+
       def flatten_hash(hash)
         hash.each_with_object({}) do |(k, v), h|
           if v.is_a? Hash
             flatten_hash(v).map do |h_k, h_v|
               h["#{k}.#{h_k}".to_sym] = h_v
             end
-          else 
+          else
             h[k] = v
           end
          end
-      end      
+      end
     end
   end
 end

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -8,7 +8,7 @@ class OppTest < Test::Unit::TestCase
     @valid_card = credit_card("4200000000000000", month: 05, year: 2018, verification_value: '123')
     @invalid_card = credit_card("4444444444444444", month: 05, year: 2018, verification_value: '123')
 
-    request_type = 'complete' # 'minimal' || 'complete'  
+    request_type = 'complete' # 'minimal' || 'complete'
     time = Time.now.to_i
     ip = '101.102.103.104'
     @complete_request_options = {
@@ -49,23 +49,23 @@ class OppTest < Test::Unit::TestCase
         ip:  ip,
       },
     }
-    
+
     @minimal_request_options = {
       order_id: "Order #{time}",
       description: 'Store Purchase - Books',
     }
 
-    @complete_request_options['customParameters[SHOPPER_test124TestName009]'] = 'customParameters_test'     
-    @complete_request_options['customParameters[SHOPPER_otherCustomerParameter]'] = 'otherCustomerParameter_test'     
+    @complete_request_options['customParameters[SHOPPER_test124TestName009]'] = 'customParameters_test'
+    @complete_request_options['customParameters[SHOPPER_otherCustomerParameter]'] = 'otherCustomerParameter_test'
 
     @test_success_id = "8a82944a4e008ca9014e1273e0696122"
     @test_failure_id = "8a8294494e0078a6014e12b371fb6a8e"
-    
+
     @options = @minimal_request_options if request_type == 'minimal'
     @options = @complete_request_options if request_type == 'complete'
   end
-  
-# ****************************************** SUCCESSFUL TESTS ****************************************** 
+
+# ****************************************** SUCCESSFUL TESTS ******************************************
   def test_successful_purchase
     @gateway.expects(:raw_ssl_request).returns(successful_response('DB', @test_success_id))
     response = @gateway.purchase(@amount, @valid_card, @options)
@@ -77,7 +77,7 @@ class OppTest < Test::Unit::TestCase
   def test_successful_authorize
     @gateway.expects(:raw_ssl_request).returns(successful_response('PA', @test_success_id))
     response = @gateway.authorize(@amount, @valid_card, @options)
-    assert_success response, "Authorization Failed" 
+    assert_success response, "Authorization Failed"
     assert_equal @test_success_id, response.authorization
     assert response.test?
   end
@@ -98,7 +98,7 @@ class OppTest < Test::Unit::TestCase
   def test_successful_refund
     @gateway.expects(:raw_ssl_request).returns(successful_response('DB', @test_success_id))
     purchase = @gateway.purchase(@amount, @valid_card, @options)
-    assert_success purchase, "Purchase failed" 
+    assert_success purchase, "Purchase failed"
     assert purchase.test?
     @gateway.expects(:raw_ssl_request).returns(successful_response('RF', @test_success_id))
     refund = @gateway.refund(@amount, purchase.authorization, @options)
@@ -110,7 +110,7 @@ class OppTest < Test::Unit::TestCase
   def test_successful_void
     @gateway.expects(:raw_ssl_request).returns(successful_response('DB', @test_success_id))
     purchase = @gateway.purchase(@amount, @valid_card, @options)
-    assert_success purchase, "Purchase failed" 
+    assert_success purchase, "Purchase failed"
     assert purchase.test?
     @gateway.expects(:raw_ssl_request).returns(successful_response('RV', @test_success_id))
     void = @gateway.void(purchase.authorization, @options)
@@ -119,40 +119,40 @@ class OppTest < Test::Unit::TestCase
     assert void.test?
   end
 
-# ****************************************** FAILURE TESTS ****************************************** 
+# ****************************************** FAILURE TESTS ******************************************
   def test_failed_purchase
     @gateway.expects(:raw_ssl_request).returns(failed_response('DB', @test_failure_id))
     response = @gateway.purchase(@amount, @invalid_card, @options)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+    assert_equal '100.100.101', response.error_code
   end
 
   def test_failed_authorize
     @gateway.expects(:raw_ssl_request).returns(failed_response('PA', @test_failure_id))
     response = @gateway.authorize(@amount, @invalid_card, @options)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+    assert_equal '100.100.101', response.error_code
   end
 
   def test_failed_capture
     @gateway.expects(:raw_ssl_request).returns(failed_response('CP', @test_failure_id))
     response = @gateway.capture(@amount, @invalid_card)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+    assert_equal '100.100.101', response.error_code
   end
 
   def test_failed_refund
     @gateway.expects(:raw_ssl_request).returns(failed_response('PF', @test_failure_id))
     response = @gateway.refund(@amount, @test_success_id)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+    assert_equal '100.100.101', response.error_code
   end
 
   def test_failed_void
     @gateway.expects(:raw_ssl_request).returns(failed_response('RV', @test_failure_id))
     response = @gateway.void(@test_success_id, @options)
     assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+    assert_equal '100.100.101', response.error_code
   end
 
   def test_scrub
@@ -167,11 +167,11 @@ class OppTest < Test::Unit::TestCase
   end
 
   def post_scrubbed
-      "paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=[FILTERED]&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=[FILTERED]&authentication.password=[FILTERED]&authentication.userId=[FILTERED]"
+      "paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=[FILTERED]&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=[FILTERED]&authentication.userId=8a8294174b7ecb28014b9699220015cc"
   end
 
   def successful_response(type, id)
-    OppMockResponse.new(200, 
+    OppMockResponse.new(200,
         JSON.generate({"id" => id,"paymentType" => type,"paymentBrand" => "VISA","amount" => "1.00","currency" => "EUR","des
         criptor" => "5410.9959.0306 OPP_Channel ","result" => {"code" => "000.100.110","description" => "Request successfully processed in 'Merchant in Integrator Test Mode'"},"card" => {"bin
         " => "420000","last4Digits" => "0000","holder" => "Longbob Longsen","expiryMonth" => "05","expiryYear" => "2018"},"buildNumber" => "20150618-111601.r185004.opp-tags-20150618_stage","time
@@ -180,7 +180,7 @@ class OppTest < Test::Unit::TestCase
   end
 
   def failed_response(type, id, code='100.100.101')
-    OppMockResponse.new(400, 
+    OppMockResponse.new(400,
       JSON.generate({"id" => id,"paymentType" => type,"paymentBrand" => "VISA","result" => {"code" => code,"des
         cription" => "invalid creditcard, bank account number or bank name"},"card" => {"bin" => "444444","last4Digits" => "4444","holder" => "Longbob Longsen","expiryMonth" => "05","expiryYear" => "2018"},
         "buildNumber" => "20150618-111601.r185004.opp-tags-20150618_stage","timestamp" => "2015-06-20 20:40:26+0000","ndc" => "8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d"})
@@ -192,14 +192,14 @@ class OppTest < Test::Unit::TestCase
         @code = code
         @body = body
       end
-  
-      def code 
+
+      def code
         @code
-      end      
-  
-      def body 
+      end
+
+      def body
         @body
-      end      
+      end
   end
 
 end


### PR DESCRIPTION
Lotsa automatically trimmed trailing spaces showing up in the diff. Sorry about that. Minor changes to keep options in-line with other AM adapters.

Some portions of the implementation is different from typical adapters. The way stored tokens are handled needs some change. I guess that can happen when there's a need for `store` to be added. Right now focus is on minimal changes.

In addition to the diffs, please review transaction success criteria as defined in
`def success_from(raw_response)` 
It's deciding based on http response code. Should it actually be looking at `result.code` within the response. I can make that change once reviewer confirms.

ref: https://docs.acaptureservices.com/