### PR TITLE
WePay: update headers, add Canada

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://stage.wepayapi.com/v2'
       self.live_url = 'https://wepayapi.com/v2'
 
-      self.supported_countries = ['US']
+      self.supported_countries = ['US', 'CA']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
       self.homepage_url = 'https://www.wepay.com/'
       self.default_currency = 'USD'

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -224,12 +224,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers(options)
-        {
-          "Content-Type"  => "application/json",
-          "User-Agent"    => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
-          "Authorization" => "Bearer #{@options[:access_token]}",
-          "Api-Version"   => api_version(options)
+        headers = {
+          "Content-Type"      => "application/json",
+          "User-Agent"        => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          "Authorization"     => "Bearer #{@options[:access_token]}",
+          "Api-Version"       => api_version(options)
         }
+
+        headers["Client-IP"] = options[:ip] if options[:ip]
+        headers["WePay-Risk-Token"] = options[:risk_token] if options[:risk_token]
+
+        headers
       end
 
       def api_version(options)

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -72,6 +72,12 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_ip_and_risk_token
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(ip: "100.166.99.123", risk_token: "123e4567-e89b-12d3-a456-426655440000"))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_authorize
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
```
$ RUBYOPT=W0 be rake test:remote TEST=test/remote/gateways/remote_wepay_test.rb 

Finished in 191.515339 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
22 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.11 tests/s, 0.19 assertions/s
```