### PR TITLE
Realex: Map AVS and CVV response codes

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -103,11 +103,8 @@ module ActiveMerchant
           response,
           :test => (response[:message] =~ %r{\[ test system \]}),
           :authorization => authorization_from(response),
-          :cvv_result => response[:cvnresult],
-          :avs_result => {
-            :street_match => response[:avspostcoderesponse],
-            :postal_match => response[:avspostcoderesponse]
-          }
+          avs_result: AVSResult.new(code: response[:avspostcoderesponse]),
+          cvv_result: CVVResult.new(response[:cvnresult]),
         )
       end
 

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -57,7 +57,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '506', response.params['result']
+    assert_equal '504', response.params['result']
     assert_match %r{no such}i, response.message
   end
 
@@ -75,7 +75,6 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_declined
-
     [ @visa_declined, @mastercard_declined ].each do |card|
 
       response = @gateway.purchase(@amount, card,
@@ -122,7 +121,6 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_coms_error
-
     [ @visa_coms_error, @mastercard_coms_error ].each do |card|
 
       response = @gateway.purchase(@amount, card,
@@ -178,8 +176,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '502', response.params['result']
-    assert_match(/missing/i, response.message)
+    assert_equal '506', response.params['result']
+    assert_match(/does not conform/i, response.message)
   end
 
   def test_cvn
@@ -287,6 +285,24 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert rebate_response.test?
     assert rebate_response.authorization.length > 0
     assert_equal 'Successful', rebate_response.message
+  end
+
+  def test_maps_avs_and_cvv_response_codes
+    [ @visa, @mastercard ].each do |card|
+
+      response = @gateway.purchase(@amount, card,
+        :order_id => generate_unique_id,
+        :description => 'Test Realex Purchase',
+        :billing_address => {
+          :zip => '90210',
+          :country => 'US'
+        }
+      )
+      assert_not_nil response
+      assert_success response
+      assert_equal "M", response.avs_result["code"]
+      assert_equal "M", response.cvv_result["code"]
+    end
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
Maps the AVS and CVV codes from a Realex response. Note to reviewers- seems like we have some stale test data. I'm not sure what the rebate password should be for a refund! However, the failure below is not related to mapping the AVS and CVV response codes so I'm ok accepting it as just stale data and merging even with this remote failure.

```
➜ ruby -Itest test/remote/gateways/remote_realex_test.rb

Loaded suite test/remote/gateways/remote_realex_test
Started
.............F
=======================================================================================================================
Failure:
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x007fc184fa1f20
   @authorization="_rebate_ad25b5c48df31c270ad9334647fc3474;;",
   @avs_result=
    {"code"=>nil, "message"=>nil, "street_match"=>nil, "postal_match"=>nil},
   @cvv_result={"code"=>nil, "message"=>nil},
   @emv_authorization=nil,
   @error_code=nil,
   @fraud_review=nil,
   @message="The refund password you entered was incorrect.",
   @params=
    {"result"=>"505",
     "message"=>"The refund password you entered was incorrect.",
     "orderid"=>"_rebate_ad25b5c48df31c270ad9334647fc3474"},
   @success=false,
   @test=false>>
test_realex_purchase_then_refund(RemoteRealexTest)
test/remote/gateways/remote_realex_test.rb:290:in `test_realex_purchase_then_refund'
     287:     rebate_response = gateway_with_refund_password.refund(@amount, purchase_response.authorization)
     288:
     289:     assert_not_nil rebate_response
  => 290:     assert_success rebate_response
     291:     assert rebate_response.test?
     292:     assert rebate_response.authorization.length > 0
     293:     assert_equal 'Successful', rebate_response.message
=======================================================================================================================
....

Finished in 15.138506 seconds.
-----------------------------------------------------------------------------------------------------------------------
18 tests, 73 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.4444% passed
-----------------------------------------------------------------------------------------------------------------------
1.19 tests/s, 4.82 assertions/s
```