### PR TITLE
Pagame: Allow more options in the metadata field

### DIFF
--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -106,14 +106,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_metadata(post, options={})
-        post[:metadata] = {}
-        post[:metadata][:order_id] = options[:order_id]
-        post[:metadata][:ip] = options[:ip]
-        post[:metadata][:customer] = options[:customer]
-        post[:metadata][:invoice] = options[:invoice]
-        post[:metadata][:merchant] = options[:merchant]
-        post[:metadata][:description] = options[:description]
-        post[:metadata][:email] = options[:email]
+        metadata = options.each { |key, value| "#{key}: #{value}" }
+        post[:metadata] = metadata
       end
 
       def parse(body)


### PR DESCRIPTION
The above options were fixed. With the launch of the new api options for metadata are now free