### PR TITLE
NMI: Add Network Tokenization support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* NMI: Add Network Tokenization support [shasum] #2431
 
 == Version 1.66.0 (May 4, 2017)
 * Support Rails 5.1 [jhawthorn] #2407

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -116,7 +116,12 @@ module ActiveMerchant #:nodoc:
           gsub(%r((ccnumber=)\d+), '\1[FILTERED]').
           gsub(%r((cvv=)\d+), '\1[FILTERED]').
           gsub(%r((checkaba=)\d+), '\1[FILTERED]').
-          gsub(%r((checkaccount=)\d+), '\1[FILTERED]')
+          gsub(%r((checkaccount=)\d+), '\1[FILTERED]').
+          gsub(%r((cryptogram=)[^&]+(&?)), '\1[FILTERED]\2')
+      end
+
+      def supports_network_tokenization?
+        true
       end
 
       private
@@ -135,6 +140,10 @@ module ActiveMerchant #:nodoc:
       def add_payment_method(post, payment_method, options)
         if(payment_method.is_a?(String))
           post[:customer_vault_id] = payment_method
+        elsif (payment_method.is_a?(NetworkTokenizationCreditCard))
+          post[:ccnumber] = payment_method.number
+          post[:ccexp] = exp_date(payment_method)
+          post[:token_cryptogram] = payment_method.payment_cryptogram
         elsif(card_brand(payment_method) == 'check')
           post[:payment] = 'check'
           post[:checkname] = payment_method.name

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -9,6 +9,14 @@ class RemoteNmiTest < Test::Unit::TestCase
       :routing_number => '123123123',
       :account_number => '123123123'
     )
+    @apple_pay_card = network_tokenization_credit_card('4111111111111111',
+      :payment_cryptogram => "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      :month              => "01",
+      :year               => "2024",
+      :source             => :apple_pay,
+      :eci                => "5",
+      :transaction_id     => "123456789"
+    )
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,
@@ -60,6 +68,22 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert_failure response
     assert response.test?
     assert_equal 'FAILED', response.message
+  end
+
+  def test_successful_purchase_with_apple_pay_card
+    assert @gateway.supports_network_tokenization?
+    assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
+  def test_failed_purchase_with_apple_pay_card
+    assert response = @gateway.purchase(99, @apple_pay_card, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'DECLINE', response.message
   end
 
   def test_successful_authorization
@@ -239,6 +263,19 @@ class RemoteNmiTest < Test::Unit::TestCase
 
     assert_scrubbed(@check.account_number, clean_transcript)
     assert_scrubbed(@check.routing_number, clean_transcript)
+
+    # "password=password is filtered, but can't be tested b/c of key match"
+    # assert_scrubbed(@gateway.options[:password], clean_transcript)
+  end
+
+  def test_network_tokenization_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @apple_pay_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@apple_pay_card.number, clean_transcript)
+    assert_scrubbed(@apple_pay_card.payment_cryptogram, clean_transcript)
 
     # "password=password is filtered, but can't be tested b/c of key match"
     # assert_scrubbed(@gateway.options[:password], clean_transcript)


### PR DESCRIPTION
**UPDATED**
```
$ RUBYOPT=W0 be rake test:remote TEST=test/remote/gateways/remote_nmi_test.rb 
33 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```
---
```
$ RUBYOPT=W0 be rake test:units TEST=test/unit/gateways/nmi_test.rb 
27 tests, 192 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```