### PR TITLE
SafeCharge: Map standard Active Merchant order_id field

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -114,6 +114,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_ClientPassword] = @options[:client_password]
         post[:sg_ResponseFormat] = "4"
         post[:sg_Version] = VERSION
+        post[:sg_ClientUniqueID] = options[:order_id] if options[:order_id]
       end
 
       def add_payment(post, payment)

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -8,6 +8,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
     @options = {
+      order_id: generate_unique_id,
       billing_address: address,
       description: 'Store Purchase'
     }


### PR DESCRIPTION
Small update to SafeCharge to map the standard Active Merchant `order_id` field. Remote test run had one failed test for `credit`, but it appears to be stale test data. None of their test card number seems to work either so I'm not sure what changed in their sandbox since it was first integrated.

```
➜ ruby -Itest test/remote/gateways/remote_safe_charge_test.rb
Loaded suite test/remote/gateways/remote_safe_charge_test
Started
...........F
==============================================================================================================================================================================================================================================
Failure:
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x007fd490a0ef80
   @authorization=
    "|101508556962|RwBpAGQAcABGAFcANABTADYAbwBJAG4AYABkADcAPQB4ADQAWQAqAHcAegBrAC4AUAB4AFsAJQBiAGYAZABYAHEAYgBOAGIAKwB6AHIAYwBBAGAAMwA=|09|18|1.00",
   @avs_result=
    {"code"=>nil, "message"=>nil, "street_match"=>nil, "postal_match"=>nil},
   @cvv_result={"code"=>nil, "message"=>nil},
   @emv_authorization=nil,
   @error_code="1139",
   @fraud_review=nil,
   @message="This card is not supported in the CFT Program",
   @params=
    {"version"=>"4.0.4",
     "client_login_id"=>"SpreedlyTestTRX",
     "client_unique_id"=>"22acd5ec3f523f679da5a802b77d3db6",
     "transaction_id"=>"101508556962",
     "status"=>"ERROR",
     "auth_code"=>"",
     "avs_code"=>"",
     "cvv2_reply"=>"",
     "reason_codes"=>"This card is not supported in the CFT Program",
     "err_code"=>"-1100",
     "ex_err_code"=>"1139",
     "token"=>
      "RwBpAGQAcABGAFcANABTADYAbwBJAG4AYABkADcAPQB4ADQAWQAqAHcAegBrAC4AUAB4AFsAJQBiAGYAZABYAHEAYgBOAGIAKwB6AHIAYwBBAGAAMwA=",
     "custom_data"=>"",
     "acquirer_id"=>"19",
     "issuer_bank_name"=>"University First Federal Credit Union",
     "issuer_bank_country"=>"us",
     "reference"=>"",
     "agv_code"=>"",
     "agv_error"=>"",
     "unique_cc"=>"SuiMHP60FrDKfyaJs47hqqrR/JU=",
     "custom_data2"=>"",
     "credit_card_info"=>"0Credit"},
   @success=false,
   @test=true>>
test_successful_credit(RemoteSafeChargeTest)
test/remote/gateways/remote_safe_charge_test.rb:95:in `test_successful_credit'
     92:
     93:   def test_successful_credit
     94:     response = @gateway.credit(@amount, @credit_card, @options)
  => 95:     assert_success response
     96:     assert_equal 'Success', response.message
     97:   end
     98:
==============================================================================================================================================================================================================================================
......

Finished in 17.818236 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
18 tests, 44 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.4444% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.01 tests/s, 2.47 assertions/s
```