### PR TITLE
Payeezy: Default check number to 001 if not present

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -143,7 +143,7 @@ module ActiveMerchant
       def add_echeck(params, echeck)
         tele_check = {}
 
-        tele_check[:check_number] = echeck.number
+        tele_check[:check_number] = echeck.number || "001"
         tele_check[:check_type] = "P"
         tele_check[:routing_number] = echeck.routing_number
         tele_check[:account_number] = echeck.account_number

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -68,6 +68,21 @@ class PayeezyGateway < Test::Unit::TestCase
     assert_equal 'Transaction Normal - Approved', response.message
   end
 
+  def test_successful_purchase_defaulting_check_number
+    check_without_number = check(number: nil)
+
+    response = stub_comms do
+      @gateway.purchase(@amount, check_without_number, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/001/, data)
+    end.respond_with(successful_purchase_echeck_response)
+
+    assert_success response
+    assert_equal 'ET133078|69864362|tele_check|100', response.authorization
+    assert response.test?
+    assert_equal 'Transaction Normal - Approved', response.message
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).raises(failed_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Payeezy requires a check number when paying via echeck. This defaults
the check number to 001, providing the ability to also pay with a bank
account which uses the same fields, but does not have a "check number"
attribute.

Remote test run:

```
➜ ruby -Itest test/remote/gateways/remote_payeezy_test.rb
Loaded suite test/remote/gateways/remote_payeezy_test
Started
......................

Finished in 19.208321 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
22 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.15 tests/s, 4.06 assertions/s
```