### PR TITLE
JetPay V2: Add new gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * NMI: Add Network Tokenization support [shasum] #2431
+* JetPay V2: Add new gateway [shasum] #2442
 
 == Version 1.66.0 (May 4, 2017)
 * Support Rails 5.1 [jhawthorn] #2407

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -1,0 +1,406 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class JetpayV2Gateway < Gateway
+      self.test_url = 'https://test1.jetpay.com/jetpay'
+      self.live_url = 'https://gateway20.jetpay.com/jetpay'
+
+      self.money_format = :cents
+      self.default_currency = 'USD'
+      self.supported_countries = ['US', 'CA']
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://www.jetpay.com'
+      self.display_name = 'JetPay'
+
+      API_VERSION = '2.2'
+
+      ACTION_CODE_MESSAGES = {
+        "000" =>  "Approved.",
+        "001" =>  "Refer to card issuer.",
+        "002" =>  "Refer to card issuer, special condition.",
+        "003" =>  "Invalid merchant or service provider.",
+        "004" =>  "Pick up card.",
+        "005" =>  "Do not honor.",
+        "006" =>  "Error.",
+        "007" =>  "Pick up card, special condition.",
+        "008" =>  "Honor with ID (Show ID).",
+        "010" =>  "Partial approval.",
+        "011" =>  "VIP approval.",
+        "012" =>  "Invalid transaction.",
+        "013" =>  "Invalid amount or exceeds maximum for card program.",
+        "014" =>  "Invalid account number (no such number).",
+        "015" =>  "No such issuer.",
+        "019" =>  "Re-enter Transaction.",
+        "021" =>  "No action taken (unable to back out prior transaction).",
+        "025" =>  "Transaction Not Found.",
+        "027" =>  "File update field edit error.",
+        "028" =>  "File is temporarily unavailable.",
+        "030" =>  "Format error.",
+        "039" =>  "No credit account.",
+        "041" =>  "Pick up card (lost card).",
+        "043" =>  "Pick up card (stolen card).",
+        "051" =>  "Insufficient funds.",
+        "052" =>  "No checking account.",
+        "053" =>  "Mp savomgs accpimt.",
+        "054" =>  "Expired Card.",
+        "055" =>  "Incorrect PIN.",
+        "057" =>  "Transaction not permitted to cardholder.",
+        "058" =>  "Transaction not allowed at terminal.",
+        "061" =>  "Exceeds withdrawal limit.",
+        "062" =>  "Restricted card (eg, Country Exclusion).",
+        "063" =>  "Security violation.",
+        "065" =>  "Activity count limit exceeded.",
+        "068" =>  "Response late.",
+        "070" =>  "Contact card issuer.",
+        "071" =>  "PIN not changed.",
+        "075" =>  "Allowable number of PIN-entry tries exceeded.",
+        "076" =>  "Unable to locate previous message (no matching retrieval reference number).",
+        "077" =>  "Repeat or reversal data are inconsistent with original message.",
+        "078" =>  "Blocked (first use), or non-existent account.",
+        "079" =>  "Key exchange validation failed.",
+        "080" =>  "Credit issuer unavailable or invalid date.",
+        "081" =>  "PIN cryptographic error found.",
+        "082" =>  "Negative online CVV results.",
+        "084" =>  "Invalid auth life cycle.",
+        "085" =>  "No reason to decline - CVV or AVS approved.",
+        "086" =>  "Cannot verify PIN.",
+        "087" =>  "Cashback not allowed.",
+        "089" =>  "Issuer Down.",
+        "091" =>  "Issuer Down.",
+        "092" =>  "Unable to route transaction.",
+        "093" =>  "Transaction cannot be completed - violation of law.",
+        "094" =>  "Duplicate transmission.",
+        "096" =>  "System error.",
+        "100" =>  "Deny.",
+        "101" =>  "Expired Card.",
+        "103" =>  "Deny - Invalid manual Entry 4DBC.",
+        "104" =>  "Deny - New card issued.",
+        "105" =>  "Deny - Account Cancelled.",
+        "106" =>  "Exceeded PIN Attempts.",
+        "107" =>  "Please Call Issuer.",
+        "109" =>  "Invalid merchant.",
+        "110" =>  "Invalid amount.",
+        "111" =>  "Invalid account.",
+        "115" =>  "Service not permitted.",
+        "117" =>  "Invalid PIN.",
+        "119" =>  "Card member not enrolled.",
+        "122" =>  "Invalid card (CID) security code.",
+        "125" =>  "Invalid effective date.",
+        "181" =>  "Format error.",
+        "182" =>  "Please wait.",
+        "183" =>  "Invalid currency code.",
+        "187" =>  "Deny - new card issued.",
+        "188" =>  "Deny - Expiration date required.",
+        "189" =>  "Deny - Cancelled or Closed Merchant/SE.",
+        "200" =>  "Deny - Pick up card.",
+        "400" =>  "Reversal accepted.",
+        "601" =>  "Reject - EMV Chip Declined Transaction.",
+        "602" =>  "Reject - Suspected Fraud.",
+        "603" =>  "Reject - Communications Error.",
+        "604" =>  "Reject - Insufficient Approval.",
+        "750" =>  "Velocity Check Fail.",
+        "899" =>  "Misc Decline.",
+        "900" =>  "Invalid Message Type.",
+        "901" =>  "Invalid Merchant ID.",
+        "903" =>  "Debit not supported.",
+        "904" =>  "Private label not supported.",
+        "905" =>  "Invalid card type.",
+        "906" =>  "Unit not active.",
+        "908" =>  "Manual card entry invalid.",
+        "909" =>  "Invalid track information.",
+        "911" =>  "Master merchant not found.",
+        "912" =>  "Invalid card format.",
+        "913" =>  "Invalid card type.",
+        "914" =>  "Invalid card length.",
+        "917" =>  "Expired card.",
+        "919" =>  "Invalid entry type.",
+        "920" =>  "Invalid amount.",
+        "921" =>  "Invalid messge format.",
+        "923" =>  "Invalid ABA.",
+        "924" =>  "Invalid DDA.",
+        "925" =>  "Invalid TID.",
+        "926" =>  "Invalid Password.",
+        "930" =>  "Invalid zipcode.",
+        "931" =>  "Invalid Address.",
+        "932" =>  "Invalid ZIP and Address.",
+        "933" =>  "Invalid CVV2.",
+        "934" =>  "Program Not Allowed.",
+        "935" =>  "Invalid Device/App.",
+        "940" =>  "Record Not Found.",
+        "941" =>  "Merchant ID error.",
+        "942" =>  "Refund Not Allowed.",
+        "943" =>  "Refund denied.",
+        "955" =>  "Invalid PIN block.",
+        "956" =>  "Invalid KSN.",
+        "958" =>  "Bad Status.",
+        "959" =>  "Seek Record limit exceeded.",
+        "960" =>  "Internal Key Database Error.",
+        "961" =>  "TRANS not Supported. Cash Disbursement required a specific MCC.",
+        "962" =>  "Invalid PIN key (Unknown KSN).",
+        "981" =>  "Invalid AVS.",
+        "987" =>  "Issuer Unavailable.",
+        "988" =>  "System error SD.",
+        "989" =>  "Database Error.",
+        "992" =>  "Transaction Timeout.",
+        "996" =>  "Bad Terminal ID.",
+        "997" =>  "Message rejected by association.",
+        "999" =>  "Communication failure",
+        nil   =>  "No response returned (missing credentials?)."
+      }
+
+      def initialize(options = {})
+        requires!(options, :login)
+        super
+      end
+
+      def purchase(money, credit_card, options = {})
+        commit(money, build_sale_request(money, credit_card, options))
+      end
+
+      def authorize(money, credit_card, options = {})
+        commit(money, build_authonly_request(money, credit_card, options))
+      end
+
+      def capture(money, reference, options = {})
+        split_authorization = reference.split(";")
+        transaction_id = split_authorization[0]
+        token = split_authorization[3]
+        commit(money, build_capture_request(transaction_id, money, options), token)
+      end
+
+      def void(reference, options = {})
+        transaction_id, approval, amount, token = reference.split(";")
+        commit(amount.to_i, build_void_request(amount.to_i, transaction_id, approval, token, options), token)
+      end
+
+      def credit(money, credit_card, options = {})
+        commit(money, build_credit_request(money, nil, credit_card, nil, options))
+      end
+
+      def refund(money, reference, options = {})
+        split_authorization = reference.split(";")
+        transaction_id = split_authorization[0]
+        token = split_authorization[3]
+        commit(money, build_credit_request(money, transaction_id, nil, token, options))
+      end
+
+      def verify(credit_card, options={})
+        authorize(0, credit_card, options)
+      end
+
+      def supports_scrubbing
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((>)\d+(</CardNum>)), '\1[FILTERED]\2').
+          gsub(%r((<CVV2>)\d+(</CVV2>)), '\1[FILTERED]\2')
+      end
+
+      private
+
+      def build_xml_request(transaction_type, options = {}, transaction_id = nil, &block)
+        xml = Builder::XmlMarkup.new
+        xml.tag! 'JetPay', 'Version' => API_VERSION do
+          # Basic values needed for any request
+          xml.tag! 'TerminalID', @options[:login]
+          xml.tag! 'TransactionType', transaction_type
+          xml.tag! 'TransactionID', transaction_id.nil? ? generate_unique_id.slice(0, 18) : transaction_id
+          xml.tag! 'Origin', options[:origin] || 'INTERNET'
+          xml.tag! 'IndustryInfo', 'Type' => options[:industry_info] || 'ECOMMERCE'
+          xml.tag! 'Application', (options[:application] || 'n/a'), {'Version' => options[:application_version] || '1.0'}
+          xml.tag! 'Device', (options[:device] || 'n/a'), {'Version' => options[:device_version] || '1.0'}
+          xml.tag! 'Library', 'VirtPOS SDK', 'Version' => '1.5'
+          xml.tag! 'Gateway', 'JetPay'
+          xml.tag! 'DeveloperID', options[:developer_id] || 'n/a'
+
+          if block_given?
+            yield xml
+          else
+            xml.target!
+          end
+        end
+      end
+
+      def build_sale_request(money, credit_card, options)
+        build_xml_request('SALE', options) do |xml|
+          add_credit_card(xml, credit_card)
+          add_addresses(xml, options)
+          add_customer_data(xml, options)
+          add_invoice_data(xml, options)
+          add_user_defined_fields(xml, options)
+          xml.tag! 'TotalAmount', amount(money)
+
+          xml.target!
+        end
+      end
+
+      def build_authonly_request(money, credit_card, options)
+        build_xml_request('AUTHONLY', options) do |xml|
+          add_credit_card(xml, credit_card)
+          add_addresses(xml, options)
+          add_customer_data(xml, options)
+          add_invoice_data(xml, options)
+          add_user_defined_fields(xml, options)
+          xml.tag! 'TotalAmount', amount(money)
+
+          xml.target!
+        end
+      end
+
+      def build_capture_request(transaction_id, money, options)
+        build_xml_request('CAPT', options, transaction_id) do |xml|
+          xml.tag! 'TotalAmount', amount(money)
+          add_user_defined_fields(xml, options)
+        end
+      end
+
+      def build_void_request(money, transaction_id, approval, token, options)
+        build_xml_request('VOID', options, transaction_id) do |xml|
+          xml.tag! 'Approval', approval
+          xml.tag! 'TotalAmount', amount(money)
+          xml.tag! 'Token', token if token
+          xml.target!
+        end
+      end
+
+      def build_credit_request(money, transaction_id, card, token, options)
+        build_xml_request('CREDIT', options, transaction_id) do |xml|
+          add_credit_card(xml, card) if card
+          add_invoice_data(xml, options)
+          add_addresses(xml, options)
+          add_customer_data(xml, options)
+          add_user_defined_fields(xml, options)
+          xml.tag! 'TotalAmount', amount(money)
+          xml.tag! 'Token', token if token
+
+          xml.target!
+        end
+      end
+
+      def commit(money, request, token = nil)
+        response = parse(ssl_post(url, request))
+
+        success = success?(response)
+        Response.new(success,
+          success ? 'APPROVED' : message_from(response),
+          response,
+          :test => test?,
+          :authorization => authorization_from(response, money, token),
+          :avs_result => AVSResult.new(:code => response[:avs]),
+          :cvv_result => CVVResult.new(response[:cvv2]),
+          :error_code => success ? nil : error_code_from(response)
+        )
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def parse(body)
+        return {} if body.blank?
+
+        xml = REXML::Document.new(body)
+
+        response = {}
+        xml.root.elements.to_a.each do |node|
+          parse_element(response, node)
+        end
+        response
+      end
+
+      def parse_element(response, node)
+        if node.has_elements?
+          node.elements.each{|element| parse_element(response, element) }
+        else
+          response[node.name.underscore.to_sym] = node.text
+        end
+      end
+
+      def format_exp(value)
+        format(value, :two_digits)
+      end
+
+      def success?(response)
+        response[:action_code] == "000"
+      end
+
+      def message_from(response)
+        ACTION_CODE_MESSAGES[response[:action_code]]
+      end
+
+      def authorization_from(response, money, previous_token)
+        original_amount = amount(money) if money
+        [ response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(";")
+      end
+
+      def error_code_from(response)
+        response[:action_code]
+      end
+
+      def add_credit_card(xml, credit_card)
+        xml.tag! 'CardNum', credit_card.number, "CardPresent" => false, "Tokenize" => true
+        xml.tag! 'CardExpMonth', format_exp(credit_card.month)
+        xml.tag! 'CardExpYear', format_exp(credit_card.year)
+
+        if credit_card.first_name || credit_card.last_name
+          xml.tag! 'CardName', [credit_card.first_name,credit_card.last_name].compact.join(' ')
+        end
+
+        unless credit_card.verification_value.nil? || (credit_card.verification_value.length == 0)
+          xml.tag! 'CVV2', credit_card.verification_value
+        end
+      end
+
+      def add_addresses(xml, options)
+        if billing_address = options[:billing_address] || options[:address]
+          xml.tag! 'Billing' do
+            xml.tag! 'Address', [billing_address[:address1], billing_address[:address2]].compact.join(" ")
+            xml.tag! 'City', billing_address[:city]
+            xml.tag! 'StateProv', billing_address[:state]
+            xml.tag! 'PostalCode', billing_address[:zip]
+            xml.tag! 'Country', lookup_country_code(billing_address[:country])
+            xml.tag! 'Phone', billing_address[:phone]
+            xml.tag! 'Email', options[:email] if options[:email]
+          end
+        end
+
+        if shipping_address = options[:shipping_address]
+          xml.tag! 'Shipping' do
+            xml.tag! 'Name', shipping_address[:name]
+            xml.tag! 'Address', [shipping_address[:address1], shipping_address[:address2]].compact.join(" ")
+            xml.tag! 'City', shipping_address[:city]
+            xml.tag! 'StateProv', shipping_address[:state]
+            xml.tag! 'PostalCode', shipping_address[:zip]
+            xml.tag! 'Country', lookup_country_code(shipping_address[:country])
+            xml.tag! 'Phone', shipping_address[:phone]
+          end
+        end
+      end
+
+      def add_customer_data(xml, options)
+        xml.tag! 'UserIPAddress', options[:ip] if options[:ip]
+      end
+
+      def add_invoice_data(xml, options)
+        xml.tag! 'OrderNumber', options[:order_id] if options[:order_id]
+        if tax = options[:tax]
+          xml.tag! 'TaxAmount', tax, {'ExemptInd' => options[:tax_exemption] || "false"}
+        end
+      end
+
+      def add_user_defined_fields(xml, options)
+        xml.tag! 'UDField1', options[:ud_field_1] if options[:ud_field_1]
+        xml.tag! 'UDField2', options[:ud_field_2] if options[:ud_field_2]
+        xml.tag! 'UDField3', options[:ud_field_3] if options[:ud_field_3]
+      end
+
+      def lookup_country_code(code)
+        country = Country.find(code) rescue nil
+        country && country.code(:alpha3)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -398,6 +398,9 @@ iveri:
 jetpay:
   login: TESTTERMINAL
 
+jetpay_v2:
+  login: TESTMCC3136X
+
 komoju:
   login: sk_f1dd75ce3d5cad477eac0c827c1cac8eaa51ede3
 

--- a/test/remote/gateways/remote_jetpay_v2_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_test.rb
@@ -1,0 +1,196 @@
+require 'test_helper'
+
+class RemoteJetpayV2Test < Test::Unit::TestCase
+
+  def setup
+    @gateway = JetpayV2Gateway.new(fixtures(:jetpay_v2))
+
+    @credit_card = credit_card('4000300020001000')
+
+    @amount_approved = 9900
+    @amount_declined = 5205
+
+    @options = {
+      :device => 'spreedly',
+      :application => 'spreedly',
+      :developer_id => 'GenkID',
+      :billing_address => address(:city => 'Durham', :state => 'NC', :country => 'US', :zip => '27701'),
+      :shipping_address => address(:city => 'Durham', :state => 'NC', :country => 'US', :zip => '27701'),
+      :email => 'test@test.com',
+      :ip => '127.0.0.1',
+      :order_id => '12345'
+    }
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount_approved, @credit_card, @options)
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert_not_nil response.authorization
+    assert_not_nil response.params["approval"]
+  end
+
+  def test_failed_purchase
+    assert response = @gateway.purchase(@amount_declined, @credit_card, @options)
+    assert_failure response
+    assert_equal "Do not honor.", response.message
+  end
+
+  def test_successful_purchase_with_minimal_options
+    assert response = @gateway.purchase(@amount_approved, @credit_card, {:device => 'spreedly', :application => 'spreedly'})
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert_not_nil response.authorization
+    assert_not_nil response.params["approval"]
+  end
+
+  def test_successful_purchase_with_additional_options
+    options = @options.merge(
+      ud_field_1: "Value1",
+      ud_field_2: "Value2",
+      ud_field_3: "Value3",
+      tax: '777'
+      )
+    assert response = @gateway.purchase(@amount_approved, @credit_card, options)
+    assert_success response
+  end
+
+  def test_authorize_and_capture
+    assert auth = @gateway.authorize(@amount_approved, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVED', auth.message
+    assert_not_nil auth.authorization
+    assert_not_nil auth.params["approval"]
+
+    assert capture = @gateway.capture(@amount_approved, auth.authorization, @options)
+    assert_success capture
+  end
+
+  def test_partial_capture
+    assert auth = @gateway.authorize(9900, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVED', auth.message
+    assert_not_nil auth.authorization
+    assert_not_nil auth.params["approval"]
+
+    assert capture = @gateway.capture(4400, auth.authorization, @options)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    assert response = @gateway.capture(@amount_approved, '7605f7c5d6e8f74deb', @options)
+    assert_failure response
+    assert_equal 'Transaction Not Found.', response.message
+  end
+
+  def test_successful_void
+    assert auth = @gateway.authorize(@amount_approved, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVED', auth.message
+    assert_not_nil auth.authorization
+    assert_not_nil auth.params["approval"]
+
+
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_success void
+  end
+
+  def test_failed_void
+    assert void = @gateway.void('bogus', @options)
+    assert_failure void
+  end
+
+  def test_purchase_refund
+    assert response = @gateway.purchase(@amount_approved, @credit_card, @options)
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert_not_nil response.authorization
+    assert_not_nil response.params["approval"]
+
+    assert refund = @gateway.refund(@amount_approved, response.authorization, @options)
+    assert_success refund
+    assert_not_nil(refund.authorization)
+    assert_not_nil(response.params["approval"])
+    assert_equal [response.params['transaction_id'], response.params["approval"], @amount_approved, response.params["token"]].join(";"), response.authorization
+  end
+
+  def test_capture_refund
+    assert auth = @gateway.authorize(@amount_approved, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVED', auth.message
+    assert_not_nil auth.authorization
+    assert_not_nil auth.params["approval"]
+    assert_equal [auth.params['transaction_id'], auth.params["approval"], @amount_approved, auth.params["token"]].join(";"), auth.authorization
+
+    assert capture = @gateway.capture(@amount_approved, auth.authorization, @options)
+    assert_success capture
+    assert_equal [capture.params['transaction_id'], capture.params["approval"], @amount_approved, auth.params["token"]].join(";"), capture.authorization
+
+    assert refund = @gateway.refund(@amount_approved, capture.authorization, @options)
+    assert_success refund
+    assert_not_nil(refund.authorization)
+    assert_not_nil(refund.params["approval"])
+  end
+
+  def test_failed_refund
+    assert refund = @gateway.refund(@amount_approved, 'bogus', @options)
+    assert_failure refund
+  end
+
+  def test_successful_credit
+    card = credit_card('4242424242424242', :verification_value => nil)
+
+    assert credit = @gateway.credit(@amount_approved, card, @options)
+    assert_success credit
+    assert_not_nil(credit.authorization)
+    assert_not_nil(credit.params["approval"])
+  end
+
+  def test_failed_credit
+    card = credit_card('2424242424242424', :verification_value => nil)
+
+    assert credit = @gateway.credit(@amount_approved, card, @options)
+    assert_failure credit
+    assert_match %r{Invalid card format}, credit.message
+  end
+
+  def test_successful_verify
+    assert verify = @gateway.verify(@credit_card, @options)
+    assert_success verify
+  end
+
+  def test_failed_verify
+    card = credit_card('2424242424242424', :verification_value => nil)
+
+    assert verify = @gateway.verify(card, @options)
+    assert_failure verify
+    assert_match %r{Invalid card format}, verify.message
+  end
+
+  def test_invalid_login
+    gateway = JetpayV2Gateway.new(:login => 'bogus')
+    assert response = gateway.purchase(@amount_approved, @credit_card, @options)
+    assert_failure response
+
+    assert_equal 'Bad Terminal ID.', response.message
+  end
+
+  def test_missing_login
+    gateway = JetpayV2Gateway.new(:login => '')
+    assert response = gateway.purchase(@amount_approved, @credit_card, @options)
+    assert_failure response
+
+    assert_equal 'No response returned (missing credentials?).', response.message
+  end
+
+  def test_transcript_scrubbing
+    @credit_card.verification_value = "421"
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+end

--- a/test/unit/gateways/jetpay_v2_test.rb
+++ b/test/unit/gateways/jetpay_v2_test.rb
@@ -1,0 +1,308 @@
+require 'test_helper'
+
+class JetpayV2Test < Test::Unit::TestCase
+
+  def setup
+    @gateway = JetpayV2Gateway.new(:login => 'login')
+
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      :device => 'spreedly',
+      :application => 'spreedly',
+      :developer_id => 'GenkID',
+      :billing_address => address(:country => 'US'),
+      :shipping_address => address(:country => 'US'),
+      :email => 'test@test.com',
+      :ip => '127.0.0.1',
+      :order_id => '12345'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '8afa688fd002821362;TEST97;100;KKLIHOJKKNKKHJKONJHOLHOL', response.authorization
+    assert_equal('TEST97', response.params["approval"])
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal('7605f7c5d6e8f74deb;;100;', response.authorization)
+    assert response.test?
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal('cbf902091334a0b1aa;TEST01;100;KKLIHOJKKNKKHJKONOHCLOIO', response.authorization)
+    assert_equal('TEST01', response.params["approval"])
+    assert response.test?
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+
+    assert response = @gateway.capture(1111, "010327153017T10018;502F7B;1111", @options)
+    assert_success response
+
+    assert_equal('010327153017T10018;502F6B;1111;', response.authorization)
+    assert_equal('502F6B', response.params["approval"])
+    assert response.test?
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_post).returns(failed_capture_response)
+
+    assert response = @gateway.capture(@amount, '7605f7c5d6e8f74deb', @options)
+    assert_failure response
+    assert_equal 'Transaction Not Found.', response.message
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    assert response = @gateway.void('010327153x17T10418;502F7B;500', @options)
+    assert_success response
+
+    assert_equal('010327153x17T10418;502F7B;500;', response.authorization)
+    assert_equal('502F7B', response.params["approval"])
+    assert response.test?
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    assert void = @gateway.void('bogus', @options)
+    assert_failure void
+  end
+
+  def test_successful_credit
+    card = credit_card('4242424242424242', :verification_value => nil)
+
+    @gateway.expects(:ssl_post).returns(successful_credit_response)
+
+    assert response = @gateway.credit(@amount, card, @options)
+    assert_success response
+  end
+
+  def test_failed_credit
+    card = credit_card('2424242424242424', :verification_value => nil)
+
+    @gateway.expects(:ssl_post).returns(failed_credit_response)
+
+    assert credit = @gateway.credit(@amount, card, @options)
+    assert_failure credit
+    assert_match %r{Invalid card format}, credit.message
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_credit_response)
+
+    assert response = @gateway.refund(9900, '010327153017T10017', @options)
+    assert_success response
+
+    assert_equal('010327153017T10017;002F6B;9900;', response.authorization)
+    assert_equal('002F6B', response.params['approval'])
+    assert response.test?
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    assert refund = @gateway.refund(@amount_approved, 'bogus', @options)
+    assert_failure refund
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    assert verify = @gateway.verify(@credit_card, @options)
+    assert_success verify
+  end
+
+  def test_failed_verify
+    card = credit_card('2424242424242424', :verification_value => nil)
+
+    @gateway.expects(:ssl_post).returns(failed_credit_response)
+
+    assert verify = @gateway.verify(card, @options)
+    assert_failure verify
+    assert_match %r{Invalid card format}, verify.message
+  end
+
+  def test_avs_result
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'D', response.avs_result['code']
+  end
+
+  def test_cvv_result
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'P', response.cvv_result['code']
+  end
+
+  def test_transcript_scrubbing
+    assert @gateway.supports_scrubbing
+    assert_equal scrubbed_transcript, @gateway.scrub(transcript)
+  end
+
+  def test_purchase_sends_additional_options
+    @gateway.expects(:ssl_post).
+    with(anything, regexp_matches(/<TaxAmount ExemptInd=\"false\">777<\/TaxAmount>/)).
+    with(anything, regexp_matches(/<UDField1>Value1<\/UDField1>/)).
+    with(anything, regexp_matches(/<UDField2>Value2<\/UDField2>/)).
+    with(anything, regexp_matches(/<UDField3>Value3<\/UDField3>/)).
+    returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, {:tax => '777', :ud_field_1 => 'Value1', :ud_field_2 => 'Value2', :ud_field_3 => 'Value3'})
+  end
+
+  private
+
+  def successful_purchase_response
+    <<-EOF
+    <JetPayResponse Version="2.2">
+      <TransactionID>8afa688fd002821362</TransactionID>
+      <ActionCode>000</ActionCode>
+      <Approval>TEST97</Approval>
+      <CVV2>P</CVV2>
+      <ResponseText>APPROVED</ResponseText>
+      <Token>KKLIHOJKKNKKHJKONJHOLHOL</Token>
+      <AddressMatch>Y</AddressMatch>
+      <ZipMatch>Y</ZipMatch>
+      <AVS>D</AVS>
+    </JetPayResponse>
+    EOF
+  end
+
+  def failed_purchase_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>7605f7c5d6e8f74deb</TransactionID>
+        <ActionCode>005</ActionCode>
+        <ResponseText>DECLINED</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def successful_authorize_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>cbf902091334a0b1aa</TransactionID>
+        <ActionCode>000</ActionCode>
+        <Approval>TEST01</Approval>
+        <CVV2>P</CVV2>
+        <ResponseText>APPROVED</ResponseText>
+        <Token>KKLIHOJKKNKKHJKONOHCLOIO</Token>
+        <AddressMatch>Y</AddressMatch>
+        <ZipMatch>Y</ZipMatch>
+        <AVS>D</AVS>
+      </JetPayResponse>
+    EOF
+  end
+
+  def successful_capture_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153017T10018</TransactionID>
+        <ActionCode>000</ActionCode>
+        <Approval>502F6B</Approval>
+        <ResponseText>APPROVED</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def failed_capture_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153017T10018</TransactionID>
+        <ActionCode>025</ActionCode>
+        <Approval>REJECT</Approval>
+        <ResponseText>ED</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def successful_void_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153x17T10418</TransactionID>
+        <ActionCode>000</ActionCode>
+        <Approval>502F7B</Approval>
+        <ResponseText>VOID PROCESSED</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def failed_void_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153x17T10418</TransactionID>
+        <ActionCode>900</ActionCode>
+        <ResponseText>INVALID MESSAGE TYPE</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def successful_credit_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153017T10017</TransactionID>
+        <ActionCode>000</ActionCode>
+        <Approval>002F6B</Approval>
+        <ResponseText>APPROVED</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def failed_credit_response
+    <<-EOF
+      <JetPayResponse Version="2.2">
+        <TransactionID>010327153017T10017</TransactionID>
+        <ActionCode>912</ActionCode>
+        <ResponseText>INVALID CARD NUMBER</ResponseText>
+      </JetPayResponse>
+    EOF
+  end
+
+  def transcript
+    <<-EOF
+    <TerminalID>TESTMCC3136X</TerminalID>
+    <TransactionType>SALE</TransactionType>
+    <TransactionID>e23c963a1247fd7aad</TransactionID>
+    <CardNum>4000300020001000</CardNum>
+    <CardExpMonth>09</CardExpMonth>
+    <CardExpYear>16</CardExpYear>
+    <CardName>Longbob Longsen</CardName>
+    <CVV2>123</CVV2>
+    EOF
+  end
+
+  def scrubbed_transcript
+    <<-EOF
+    <TerminalID>TESTMCC3136X</TerminalID>
+    <TransactionType>SALE</TransactionType>
+    <TransactionID>e23c963a1247fd7aad</TransactionID>
+    <CardNum>[FILTERED]</CardNum>
+    <CardExpMonth>09</CardExpMonth>
+    <CardExpYear>16</CardExpYear>
+    <CardName>Longbob Longsen</CardName>
+    <CVV2>[FILTERED]</CVV2>
+    EOF
+  end
+end


### PR DESCRIPTION
New adapter that talks to [JetPay Host XML Specification V2.03.01.pdf](https://github.com/activemerchant/active_merchant/files/1030427/JetPay.Host.XML.Specification.V2.03.01.pdf)

---

```
$ RUBYOPT=W0 be rake test:remote TEST=test/remote/gateways/remote_jetpay_v2_test.rb 
19 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

```
$ RUBYOPT=W0 be rake test:units TEST=test/unit/gateways/jetpay_v2_test.rb 
17 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```