### PR TITLE
JetPay V2: Add optional tax data to capture calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 * JetPay V2: Add new gateway [shasum] #2442
 * Orbital: Update test and production urls [jcowhigjr] #2436
 * Orbital: Pass soft descriptors from options hash [curiousepic]
+* JetPay V2: Add optional tax data to capture calls [shasum] #2445
+
 == Version 1.66.0 (May 4, 2017)
 * Support Rails 5.1 [jhawthorn] #2407
 * ProPay: Add Canada as supported country [davidsantoso]

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -252,8 +252,11 @@ module ActiveMerchant #:nodoc:
 
       def build_capture_request(transaction_id, money, options)
         build_xml_request('CAPT', options, transaction_id) do |xml|
-          xml.tag! 'TotalAmount', amount(money)
+          add_invoice_data(xml, options)
           add_user_defined_fields(xml, options)
+          xml.tag! 'TotalAmount', amount(money)
+
+          xml.target!
         end
       end
 
@@ -262,6 +265,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Approval', approval
           xml.tag! 'TotalAmount', amount(money)
           xml.tag! 'Token', token if token
+
           xml.target!
         end
       end
@@ -386,8 +390,8 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice_data(xml, options)
         xml.tag! 'OrderNumber', options[:order_id] if options[:order_id]
-        if tax = options[:tax]
-          xml.tag! 'TaxAmount', tax, {'ExemptInd' => options[:tax_exemption] || "false"}
+        if tax_amount = options[:tax_amount]
+          xml.tag! 'TaxAmount', tax_amount, {'ExemptInd' => options[:tax_exemption] || "false"}
         end
       end
 

--- a/test/unit/gateways/jetpay_v2_test.rb
+++ b/test/unit/gateways/jetpay_v2_test.rb
@@ -121,7 +121,7 @@ class JetpayV2Test < Test::Unit::TestCase
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_void_response)
 
-    assert refund = @gateway.refund(@amount_approved, 'bogus', @options)
+    assert refund = @gateway.refund(@amount, 'bogus', @options)
     assert_failure refund
   end
 


### PR DESCRIPTION
```
$ be rake test:units
--------------------------------------------------------------------------------------------------------------------------------------------------
3560 tests, 66457 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
```

```
$ be rake test:remote TEST=test/remote/gateways/remote_jetpay_v2_test.rb 
--------------------------------------------------------------------------------------------------------------------------------------------------
20 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
```