### PR TITLE
FirstData Payeezy: Set default ECI value for auth/purchase transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -236,7 +236,9 @@ module ActiveMerchant #:nodoc:
           xml.tag! "Expiry_Date", expdate(credit_card)
           xml.tag! "CardHoldersName", credit_card.name
           xml.tag! "CardType", card_type(credit_card.brand)
-          xml.tag! "Ecommerce_Flag", (credit_card.try(:eci) || options[:eci] || DEFAULT_ECI)
+
+          eci = (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
+          xml.tag! "Ecommerce_Flag", eci
 
           add_credit_card_verification_strings(xml, credit_card, options)
         end

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -34,6 +34,8 @@ module ActiveMerchant #:nodoc:
 
       E4_BRANDS = BRANDS.merge({:mastercard => "Mastercard"})
 
+      DEFAULT_ECI = "07"
+
       self.supported_cardtypes = BRANDS.keys
       self.supported_countries = ["CA", "US"]
       self.default_currency = "USD"
@@ -234,6 +236,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! "Expiry_Date", expdate(credit_card)
           xml.tag! "CardHoldersName", credit_card.name
           xml.tag! "CardType", card_type(credit_card.brand)
+          xml.tag! "Ecommerce_Flag", (credit_card.try(:eci) || options[:eci] || DEFAULT_ECI)
 
           add_credit_card_verification_strings(xml, credit_card, options)
         end
@@ -256,8 +259,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_network_tokenization_credit_card(xml, credit_card)
-        xml.tag!("Ecommerce_Flag", credit_card.eci)
-
         case card_brand(credit_card).to_sym
         when :visa
           xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
@@ -275,7 +276,6 @@ module ActiveMerchant #:nodoc:
       def add_card_authentication_data(xml, options)
         xml.tag! "CAVV", options[:cavv]
         xml.tag! "XID", options[:xid]
-        xml.tag! "Ecommerce_Flag", options[:eci]
       end
 
       def add_credit_card_token(xml, store_authorization)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -181,6 +181,22 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_eci_default_value
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>07</Ecommerce_Flag>", data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_eci_option_value
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(eci: "05"))
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_network_tokenization_requests_with_visa
     stub_comms do
       credit_card = network_tokenization_credit_card('4111111111111111',


### PR DESCRIPTION
I've heard from a few users that this gateway (and/or their processors
behind it) are now soft-requiring the ECI indicator to always be set.
Typical of this gateway, [documentation is unclear at
best](https://support.payeezy.com/hc/en-us/articles/206601408-First-Data-Payeezy-Gateway-Web-Service-API-Reference-Guide).

I've done this in such a way that all previous cases were accounted for,
and a 3DS/network transaction's embedded value will always take
precedence.