### PR TITLE
Payeezy: Add client_email field for telecheck

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -150,6 +150,7 @@ module ActiveMerchant
         tele_check[:accountholder_name] = "#{echeck.first_name} #{echeck.last_name}"
         tele_check[:customer_id_type] = options[:customer_id_type] if options[:customer_id_type]
         tele_check[:customer_id_number] = options[:customer_id_number] if options[:customer_id_number]
+        tele_check[:client_email] = options[:client_email] if options[:client_email]
 
         params[:method] = 'tele_check'
         params[:tele_check] = tele_check

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -33,7 +33,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_echeck
-    options = @options.merge({customer_id_type: "1", customer_id_number: "1"})
+    options = @options.merge({customer_id_type: "1", customer_id_number: "1", client_email: "test@example.com"})
     assert response = @gateway.purchase(@amount, @check, options)
     assert_match(/Transaction Normal/, response.message)
     assert_success response


### PR DESCRIPTION
Missed adding a field in the previous commit. Unfortunately a proper check/telecheck transaction requires `client_email` as well.

Full remote test suite run:
```
➜ ruby -Itest test/remote/gateways/remote_payeezy_test.rb

Loaded suite test/remote/gateways/remote_payeezy_test
Started
......................

Finished in 15.340049 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
22 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.43 tests/s, 5.08 assertions/s
```