### PR TITLE
Update supported Netbanx countries and cardtypes

### DIFF
--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -5,9 +5,20 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://api.test.netbanx.com/'
       self.live_url = 'https://api.netbanx.com/'
 
-      self.supported_countries = ['CA', 'US', 'GB']
+      self.supported_countries = %w(AF AX AL DZ AS AD AO AI AQ AG AR AM AW AU AT AZ BS BH BD BB BY BE BZ BJ BM BT BO BQ BA BW BV BR IO BN BG BF BI KH CM CA CV KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CW CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM HN HK HU IS IN ID IR IQ IE IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NC NZ NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF VC WS SM ST SA SN RS SC SL SG SX SK SI SB SO ZA GS SS ES LK PM SD SR SJ SZ SE CH SY TW TJ TZ TH NL TL TG TK TO TT TN TR TM TC TV UG UA AE GB US UM UY UZ VU VA VE VN VG VI WF EH YE ZM ZW)
       self.default_currency = 'CAD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [
+        :american_express,
+        :diners_club,
+        :discover,
+        :jcb,
+        :master,
+        :maestro,
+        :swiff,
+        :visa,
+        :visa_debit,
+        :visa_electron
+      ]
       self.money_format = :cents
 
       self.homepage_url = 'https://processing.paysafe.com/'
@@ -110,9 +121,6 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         post[:merchantCustomerId] = (options[:merchant_customer_id] || SecureRandom.uuid)
         post[:locale] = options[:locale]
-        # if options[:billing_address]
-        #   post[:address]  = map_address(options[:billing_address])
-        # end
       end
 
       def add_credit_card(post, credit_card, options = {})

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -24,8 +24,6 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://processing.paysafe.com/'
       self.display_name = 'Netbanx by PaySafe'
 
-      STANDARD_ERROR_CODE_MAPPING = {}
-
       def initialize(options={})
         requires!(options, :account_number, :api_key)
         super

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -16,6 +16,7 @@ module ActiveMerchant #:nodoc:
         :maestro,
         :visa
       ]
+
       self.money_format = :cents
 
       self.homepage_url = 'https://processing.paysafe.com/'
@@ -195,6 +196,7 @@ module ActiveMerchant #:nodoc:
           message_from(success, response),
           response,
           :test => test?,
+          :error_code => error_code_from(response),
           :authorization => authorization_from(success, get_url(uri), method, response)
         )
       end
@@ -242,6 +244,47 @@ module ActiveMerchant #:nodoc:
           'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s).strip}",
           'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
         }
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          case response['errorCode']
+            when '3002' ; STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid card number or brand or combination of card number and brand with your request.
+            when '3004' ; STANDARD_ERROR_CODE[:incorrect_zip] # The zip/postal code must be provided for an AVS check request.
+            when '3005' ; STANDARD_ERROR_CODE[:incorrect_cvc] # You submitted an incorrect CVC value with your request.
+            when '3006' ; STANDARD_ERROR_CODE[:expired_card] # You submitted an expired credit card number with your request.
+            when '3009' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank.
+            when '3011' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the card used is a restricted card. Contact the cardholder's credit card company for further investigation.
+            when '3012' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the credit card expiry date submitted is invalid.
+            when '3013' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to problems with the credit card account.
+            when '3014' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined - the issuing bank has returned an unknown response. Contact the card holder's credit card company for further investigation.
+            when '3015' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you process the transaction manually by calling the cardholder's credit card company.
+            when '3016' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – it may be a lost or stolen card.
+            when '3017' ; STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid credit card number with your request.
+            when '3022' ; STANDARD_ERROR_CODE[:card_declined] # The card has been declined due to insufficient funds.
+            when '3023' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to its proprietary card activity regulations.
+            when '3024' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the issuing bank does not permit the transaction for this card.          when '3032' ;   STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank or external gateway because the card is probably in one of their negative databases.
+            when '3035' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to exceeded PIN attempts.
+            when '3036' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid issuer.
+            when '3037' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because it is invalid.
+            when '3038' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to customer cancellation.
+            when '3039' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid authentication value.
+            when '3040' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the request type is not permitted on the card.
+            when '3041' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a timeout.
+            when '3042' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a cryptographic error.
+            when '3045' ; STANDARD_ERROR_CODE[:invalid_expiry_date] # You submitted an invalid date format for this request.
+            when '3046' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount was set to zero.
+            when '3047' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount exceeds the floor limit.
+            when '3048' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount is less than the floor limit.
+            when '3049' ; STANDARD_ERROR_CODE[:card_declinedr] # The bank has requested that you retrieve the card from the cardholder – the credit card has expired.
+            when '3050' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – fraudulent activity is suspected.
+            when '3051' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – contact the acquirer for more information.
+            when '3052' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – the credit card is restricted.
+            when '3053' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – please call the acquirer.
+            when '3054' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined due to suspected fraud.
+            else STANDARD_ERROR_CODE[:processing_error]
+          end
+        end
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -14,10 +14,7 @@ module ActiveMerchant #:nodoc:
         :jcb,
         :master,
         :maestro,
-        :swiff,
-        :visa,
-        :visa_debit,
-        :visa_electron
+        :visa
       ]
       self.money_format = :cents
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -249,39 +249,40 @@ module ActiveMerchant #:nodoc:
       def error_code_from(response)
         unless success_from(response)
           case response['errorCode']
-            when '3002' ; STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid card number or brand or combination of card number and brand with your request.
-            when '3004' ; STANDARD_ERROR_CODE[:incorrect_zip] # The zip/postal code must be provided for an AVS check request.
-            when '3005' ; STANDARD_ERROR_CODE[:incorrect_cvc] # You submitted an incorrect CVC value with your request.
-            when '3006' ; STANDARD_ERROR_CODE[:expired_card] # You submitted an expired credit card number with your request.
-            when '3009' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank.
-            when '3011' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the card used is a restricted card. Contact the cardholder's credit card company for further investigation.
-            when '3012' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the credit card expiry date submitted is invalid.
-            when '3013' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to problems with the credit card account.
-            when '3014' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined - the issuing bank has returned an unknown response. Contact the card holder's credit card company for further investigation.
-            when '3015' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you process the transaction manually by calling the cardholder's credit card company.
-            when '3016' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – it may be a lost or stolen card.
-            when '3017' ; STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid credit card number with your request.
-            when '3022' ; STANDARD_ERROR_CODE[:card_declined] # The card has been declined due to insufficient funds.
-            when '3023' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to its proprietary card activity regulations.
-            when '3024' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the issuing bank does not permit the transaction for this card.          when '3032' ;   STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank or external gateway because the card is probably in one of their negative databases.
-            when '3035' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to exceeded PIN attempts.
-            when '3036' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid issuer.
-            when '3037' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because it is invalid.
-            when '3038' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to customer cancellation.
-            when '3039' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid authentication value.
-            when '3040' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the request type is not permitted on the card.
-            when '3041' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a timeout.
-            when '3042' ; STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a cryptographic error.
-            when '3045' ; STANDARD_ERROR_CODE[:invalid_expiry_date] # You submitted an invalid date format for this request.
-            when '3046' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount was set to zero.
-            when '3047' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount exceeds the floor limit.
-            when '3048' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount is less than the floor limit.
-            when '3049' ; STANDARD_ERROR_CODE[:card_declinedr] # The bank has requested that you retrieve the card from the cardholder – the credit card has expired.
-            when '3050' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – fraudulent activity is suspected.
-            when '3051' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – contact the acquirer for more information.
-            when '3052' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – the credit card is restricted.
-            when '3053' ; STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – please call the acquirer.
-            when '3054' ; STANDARD_ERROR_CODE[:card_declined] # The transaction was declined due to suspected fraud.
+            when '3002' then STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid card number or brand or combination of card number and brand with your request.
+            when '3004' then STANDARD_ERROR_CODE[:incorrect_zip] # The zip/postal code must be provided for an AVS check request.
+            when '3005' then STANDARD_ERROR_CODE[:incorrect_cvc] # You submitted an incorrect CVC value with your request.
+            when '3006' then STANDARD_ERROR_CODE[:expired_card] # You submitted an expired credit card number with your request.
+            when '3009' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank.
+            when '3011' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the card used is a restricted card. Contact the cardholder's credit card company for further investigation.
+            when '3012' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank because the credit card expiry date submitted is invalid.
+            when '3013' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to problems with the credit card account.
+            when '3014' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined - the issuing bank has returned an unknown response. Contact the card holder's credit card company for further investigation.
+            when '3015' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you process the transaction manually by calling the cardholder's credit card company.
+            when '3016' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – it may be a lost or stolen card.
+            when '3017' then STANDARD_ERROR_CODE[:invalid_number] # You submitted an invalid credit card number with your request.
+            when '3022' then STANDARD_ERROR_CODE[:card_declined] # The card has been declined due to insufficient funds.
+            when '3023' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank due to its proprietary card activity regulations.
+            when '3024' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the issuing bank does not permit the transaction for this card.
+            when '3032' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined by the issuing bank or external gateway because the card is probably in one of their negative databases.
+            when '3035' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to exceeded PIN attempts.
+            when '3036' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid issuer.
+            when '3037' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because it is invalid.
+            when '3038' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to customer cancellation.
+            when '3039' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to an invalid authentication value.
+            when '3040' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined because the request type is not permitted on the card.
+            when '3041' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a timeout.
+            when '3042' then STANDARD_ERROR_CODE[:card_declined] # Your request has been declined due to a cryptographic error.
+            when '3045' then STANDARD_ERROR_CODE[:invalid_expiry_date] # You submitted an invalid date format for this request.
+            when '3046' then STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount was set to zero.
+            when '3047' then STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount exceeds the floor limit.
+            when '3048' then STANDARD_ERROR_CODE[:card_declined] # The transaction was declined because the amount is less than the floor limit.
+            when '3049' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – the credit card has expired.
+            when '3050' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – fraudulent activity is suspected.
+            when '3051' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – contact the acquirer for more information.
+            when '3052' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – the credit card is restricted.
+            when '3053' then STANDARD_ERROR_CODE[:card_declined] # The bank has requested that you retrieve the card from the cardholder – please call the acquirer.
+            when '3054' then STANDARD_ERROR_CODE[:card_declined] # The transaction was declined due to suspected fraud.
             else STANDARD_ERROR_CODE[:processing_error]
           end
         end

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -138,18 +138,6 @@ class NetbanxTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_unstore
-    @gateway.expects(:ssl_request).twice.returns(successful_unstore_response)
-
-    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015|e4a3cd5a-56db-4d9b-97d3-fdd9ab3bd0f4')
-    assert_success response
-    assert response.test?
-
-    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
-    assert_success response
-    assert response.test?
-  end
-
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -602,9 +590,5 @@ class NetbanxTest < Test::Unit::TestCase
       ]
     }
     RESPONSE
-  end
-
-  # just returns a 200 when successful
-  def successful_unstore_response
   end
 end

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -138,6 +138,19 @@ class NetbanxTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_unstore
+     @gateway.expects(:ssl_request).twice.returns(successful_unstore_response)
+
+     response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015|e4a3cd5a-56db-4d9b-97d3-fdd9ab3bd0f4')
+     assert_success response
+     assert response.test?
+
+    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
+    assert_success response
+    assert response.test?
+  end
+
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -564,6 +577,35 @@ class NetbanxTest < Test::Unit::TestCase
   end
 
   def successful_store_response
+    <<-RESPONSE
+    {
+      "id": "2f840ab3-0e71-4387-bad3-4705e6f4b015",
+      "status": "ACTIVE",
+      "merchantCustomerId": "5e9d1ab0f847d147ffe872a9faf76d98",
+      "locale": "en_GB",
+      "paymentToken": "PJzuA8s6c6pSIs4",
+      "addresses": [],
+      "cards": [
+        {
+          "status": "ACTIVE",
+          "id": "e4a3cd5a-56db-4d9b-97d3-fdd9ab3bd0f4",
+          "cardBin": "453091",
+          "lastDigits": "2345",
+          "cardExpiry": {
+            "year": 2017,
+            "month": 9
+          },
+          "holderName": "Longbob Longsen",
+          "cardType": "VI",
+          "paymentToken": "C6gmdUA1xWT8RsC",
+          "defaultCardIndicator": true
+        }
+      ]
+    }
+    RESPONSE
+  end
+
+  def successful_unstore_response
     <<-RESPONSE
     {
       "id": "2f840ab3-0e71-4387-bad3-4705e6f4b015",


### PR DESCRIPTION
this is a continuation of a abandoned PR https://github.com/activemerchant/active_merchant/pull/2188 which implements a gateway to the Nextbanx (aka PaySafe aka Optimal Payments) REST based API which supports store (tokenisation), unlike the SOAP API, as pre the APIdocumentation https://developer.optimalpayments.com/en/documentation/ .

I addressed the comment issues raised in pull/2188 



