### PR TITLE
Move changelog entries to the correct release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,16 +19,6 @@
 * Payeezy: Add client_email field for telecheck [davidsantoso] #2455
 * Payeezy: Add customer_id_type and customer_id_number fields [davidsantoso] #2454
 * Quickpay V10: Fix store and token use for recurring payments [wsmoak] #2180
-
-== Version 1.66.0 (May 4, 2017)
-* Support Rails 5.1 [jhawthorn] #2407
-* ProPay: Add Canada as supported country [davidsantoso]
-* ProPay: Add gateway support [davidsantoso] #2405
-* SafeCharge: Support credit transactions [shasum] #2404
-* WePay: Add scrub method [shasum] #2406
-* iVeri: Add gateway support [curiousepic] #2400
-* iVeri: Support 3DSecure data fields [davidsantoso] #2412
-* Opp: Fix transaction success criteria and clean up options [shasum] #2414
 * Elavon: Support custom fields [curiousepic] #2416
 * WePay: Support risk headers [shasum] #2419
 * WePay: Add Canada as supported country [shasum] #2419
@@ -40,6 +30,16 @@
 * SafeCharge: Map standard Active Merchant order_id field [davidsantoso] #2434
 * Payeezy: Default check number to 001 if not present [davidsantoso] #2439
 * Opp: Fix incorrect customParameter key to disable 3DS [davidsantoso]
+
+== Version 1.66.0 (May 4, 2017)
+* Support Rails 5.1 [jhawthorn] #2407
+* ProPay: Add Canada as supported country [davidsantoso]
+* ProPay: Add gateway support [davidsantoso] #2405
+* SafeCharge: Support credit transactions [shasum] #2404
+* WePay: Add scrub method [shasum] #2406
+* iVeri: Add gateway support [curiousepic] #2400
+* iVeri: Support 3DSecure data fields [davidsantoso] #2412
+* Opp: Fix transaction success criteria and clean up options [shasum] #2414
 
 == Version 1.65.0 (April 26, 2017)
 * Adyen: Add Adyen v18 gateway [adyenpayments] #2272


### PR DESCRIPTION
Some items were mistakenly added to the changelog for release 1.66.0 after the release was created. This just moves them into 1.67.0.

[1.66.0 release](https://github.com/activemerchant/active_merchant/releases/tag/v1.66.0)
[1.67.0 release](https://github.com/activemerchant/active_merchant/releases/tag/v1.67.0)