### PR TITLE
QuickPay: Return last response for purchase and authorize

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -15,7 +15,7 @@ module ActiveMerchant
       end
 
       def purchase(money, credit_card_or_reference, options = {})
-        MultiResponse.run(true) do |r|
+        MultiResponse.run do |r|
           if credit_card_or_reference.is_a?(String)
             r.process { create_token(credit_card_or_reference, options) }
             credit_card_or_reference = r.authorization
@@ -34,7 +34,7 @@ module ActiveMerchant
       end
 
       def authorize(money, credit_card_or_reference, options = {})
-        MultiResponse.run(true) do |r|
+        MultiResponse.run do |r|
           if credit_card_or_reference.is_a?(String)
             r.process { create_token(credit_card_or_reference, options) }
             credit_card_or_reference = r.authorization
@@ -132,7 +132,6 @@ module ActiveMerchant
 
         def create_token(identification, options)
           post = {}
-          # post[:id] = options[:id]
           commit(synchronized_path("/cards/#{identification}/tokens"), post)
         end
 
@@ -196,7 +195,7 @@ module ActiveMerchant
             post[:shipping_address] = map_address(options[:shipping_address])
           end
 
-          [:metadata, :brading_id, :variables].each do |field|
+          [:metadata, :branding_id, :variables].each do |field|
             post[field] = options[field] if options[field]
           end
         end


### PR DESCRIPTION
Previously, the MultiResponse used for Authorize and Purchase were
"using first response", which meant that for stored cards, this was
returning the single-use token for its authorization, causing refunds
and voids of auths and purchases by stored cards to fail. Authorize and
Purchase now return the last response as their result, allowing the proper
id to be returned as the authorization.

Unit:
14 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

I'd appreciate some eyes on this from @davidsantoso - I want to make sure the method I'm using here is kosher because while simple, it seems a bit unorthodox, and I'm not sure if it would confuse any error reporting that we don't currently account for in any tests.

An alternative might be to use a split-auth system, but given that auth and purchase can consist of 3 or 4 individual requests, and only under certain circumstances would we need to record the token, I'm not sure it would be preferable.