### PR TITLE
moved to name value pair (NVP) with payflow

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -187,7 +187,8 @@ module ActiveMerchant #:nodoc:
           "X-VPS-Client-Timeout" => timeout.to_s,
           "X-VPS-VIT-Integration-Product" => "ActiveMerchant",
           "X-VPS-VIT-Runtime-Version" => RUBY_VERSION,
-          "X-VPS-Request-ID" => SecureRandom.hex(16)
+          "X-VPS-Request-ID" => SecureRandom.hex(16),
+          "PAYPAL-NVP" => "Y"
         }
       end
 


### PR DESCRIPTION
A bug was happening with payflow pro when a lot of items were present in the cart (40+ items). Paypal would respond with `10413 error: The totals of the cart item amounts do not match order amounts.` After discussing with paypal, it was determined that we should use PAYPAL-NVP as it will fix the problem.

PAYPAL-NVP adds new exdata in the response (which we ignore at this moment) Here are the new fields:
  - TIMESTAMP
  - ACK
  - VERSION
  - BUILD 

Both paypal express and direct flow have been tested and this had no negative impact. Carts with 40+ items will not generate the error anymore. Since the line item fields are deprecated in paypal, we seem to lose the items description on the paypal checkout page. This is a small compromise to make in order to get payflow to work with any carts.