### PR TITLE
SafeCharge: Map billing address fields

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -24,6 +24,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_transaction_data("Sale", post, money, options)
         add_payment(post, payment)
+        add_customer_details(post, payment, options)
 
         commit(post)
       end
@@ -32,6 +33,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_transaction_data("Auth", post, money, options)
         add_payment(post, payment)
+        add_customer_details(post, payment, options)
 
         commit(post)
       end
@@ -123,6 +125,21 @@ module ActiveMerchant #:nodoc:
         post[:sg_ExpMonth] = format(payment.month, :two_digits)
         post[:sg_ExpYear] = format(payment.year, :two_digits)
         post[:sg_CVV2] = payment.verification_value
+      end
+
+      def add_customer_details(post, payment, options)
+        if address = options[:billing_address] || options[:address]
+          post[:sg_FirstName] = payment.first_name
+          post[:sg_LastName] = payment.last_name
+          post[:sg_Address] = address[:address1] if address[:address1]
+          post[:sg_City] = address[:city] if address[:city]
+          post[:sg_State] = address[:state]  if address[:state]
+          post[:sg_Zip] = address[:zip]  if address[:zip]
+          post[:sg_Country] = address[:country]  if address[:country]
+          post[:sg_Phone] = address[:phone]  if address[:phone]
+        end
+
+        post[:sg_Email] = options[:email]
       end
 
       def parse(xml)


### PR DESCRIPTION
Pretty quick add to include billing address (if passed in the `options`) to SafeCharge transactions. Two things to note:

1. There aren't any additional remote tests since we were [actually already passing in an address](https://github.com/activemerchant/active_merchant/blob/master/test/remote/gateways/remote_safe_charge_test.rb#L12) but not adding them to the request. So, passing tests means 👍 
2. There's one test failure on`credit`. Seems like SafeCharge is requiring a specific card number for a `credit` request which isn't uncommon. I'm ok with the failure since it's just stale test data.

Remote test run output:

```ruby
➜ ruby -Itest test/remote/gateways/remote_safe_charge_test.rb
Loaded suite test/remote/gateways/remote_safe_charge_test
Started
...........F
==============================================================================================================================================================================================================================================
Failure:
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x007feb1186f278
   ...
   @message="This card is not supported in the CFT Program",
   @params=
    {"version"=>"4.0.4",
     "client_login_id"=>"SpreedlyTestTRX",
     "client_unique_id"=>"15f072404caf251dc12f31982f220a5f",
     "transaction_id"=>"101508737153",
     "status"=>"ERROR",
     "auth_code"=>"",
     "avs_code"=>"",
     "cvv2_reply"=>"",
     "reason_codes"=>"This card is not supported in the CFT Program",
     "err_code"=>"-1100",
     "ex_err_code"=>"1139",
    ...>
test_successful_credit(RemoteSafeChargeTest)
test/remote/gateways/remote_safe_charge_test.rb:95:in `test_successful_credit'
     92:
     93:   def test_successful_credit
     94:     response = @gateway.credit(@amount, @credit_card, @options)
  => 95:     assert_success response
     96:     assert_equal 'Success', response.message
     97:   end
     98:
==============================================================================================================================================================================================================================================
......

Finished in 21.967072 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
18 tests, 44 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.4444% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.82 tests/s, 2.00 assertions/s
```