### PR TITLE
Support three-decimal currencies

### DIFF
--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -90,6 +90,18 @@ class GatewayTest < Test::Unit::TestCase
     assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
   end
 
+  def test_localized_amount_returns_three_decimal_places_for_three_decimal_currencies
+    @gateway.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
+
+    Gateway.money_format = :dollars
+    assert_equal '1.000', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '12.340', @gateway.send(:localized_amount, 1234, 'BHD')
+
+    Gateway.money_format = :cents
+    assert_equal '1000', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '12340', @gateway.send(:localized_amount, 1234, 'BHD')
+  end
+
   def test_split_names
     assert_equal ["Longbob", "Longsen"], @gateway.send(:split_names, "Longbob Longsen")
   end


### PR DESCRIPTION
Similar to non-fractional currency support, gateways can override which
currencies should be treated as three-decimal.

Unit tests:
3615 tests, 66645 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

I'm unsure about adding some nominally three-decimal currencies (BHD KWD OMR RSD TND) to `gateway` itself, so I left it blank.