### PR TITLE
Send customer email and name in authorize and purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -130,8 +130,20 @@ module ActiveMerchant #:nodoc:
             holder_name: creditcard.name
           }
           add_address(card, options)
+          add_customer_data(post, creditcard, options)
           post[:card] = card
         end
+      end
+
+      def add_customer_data(post, creditcard, options)
+        if options[:email]
+          customer = {
+            name: creditcard.name || options[:name],
+            email: options[:email]
+          }
+          post[:customer] = customer
+        end
+        post
       end
 
       def add_address(card, options)

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -21,6 +21,13 @@ class RemoteOpenpayTest < Test::Unit::TestCase
     assert_nil response.message
   end
 
+  def test_successful_purchase_with_email
+    @options[:email] = '%d@example.org' % Time.now
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_nil response.message
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
@@ -47,6 +54,13 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_nil response.message
+  end
+
+  def test_successful_authorize_with_email
+    @options[:email] = '%d@example.org' % Time.now
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_nil response.message


### PR DESCRIPTION
Previously only name and email were sent to Openpay when storing a card.
This adds support for sending the customer's name and email when performing
authorize or purchase transactions.

Unit:
```
ruby -Itest test/unit/gateways/openpay_test.rb
19 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100%
```

Remote:
```
ruby -Itest test/remote/gateways/remote_openpay_test.rb
23 tests, 78 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.6522% passed
```

Closes #2661

The remote test failure above currently fails on master. The details about the failure have been captured in https://github.com/activemerchant/active_merchant/issues/2465

@davidsantoso / @curiousepic 