### PR TITLE
SafeCharge: Track currency from original transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -40,8 +40,8 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options={})
         post = {}
-        add_transaction_data("Settle", post, money, options)
-        auth, transaction_id, token, exp_month, exp_year, _ = authorization.split("|")
+        auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split("|")
+        add_transaction_data("Settle", post, money, (options.merge!({currency: original_currency})))
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id
         post[:sg_CCToken] = token
@@ -53,8 +53,8 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options={})
         post = {}
-        add_transaction_data("Credit", post, money, options)
-        auth, transaction_id, token, exp_month, exp_year, _ = authorization.split("|")
+        auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split("|")
+        add_transaction_data("Credit", post, money, (options.merge!({currency: original_currency})))
         post[:sg_CreditType] = 2
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id
@@ -76,8 +76,8 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options={})
         post = {}
-        auth, transaction_id, token, exp_month, exp_year, original_amount = authorization.split("|")
-        add_transaction_data("Void", post, (original_amount.to_f * 100), options)
+        auth, transaction_id, token, exp_month, exp_year, original_amount, original_currency = authorization.split("|")
+        add_transaction_data("Void", post, (original_amount.to_f * 100), (options.merge!({currency: original_currency})))
         post[:sg_CreditType] = 2
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id
@@ -194,7 +194,8 @@ module ActiveMerchant #:nodoc:
           response[:token],
           parameters[:sg_ExpMonth],
           parameters[:sg_ExpYear],
-          parameters[:sg_Amount]
+          parameters[:sg_Amount],
+          parameters[:sg_Currency]
         ].join("|")
       end
 

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -10,7 +10,8 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     @options = {
       order_id: generate_unique_id,
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      currency: "EUR"
     }
   end
 

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -21,7 +21,7 @@ class SafeChargeTest < Test::Unit::TestCase
 
     assert_equal '111951|101508189567|ZQBpAFAASABGAHAAVgBPAFUAMABiADMAewBtAGsAd' \
                  'AAvAFIAQQBrAGoAYwBxACoAXABHAEEAOgA3ACsAMgA4AD0AOABDAG4AbQAzAF' \
-                 'UAbQBYAFIAMwA=|09|18|1.00', response.authorization
+                 'UAbQBYAFIAMwA=|09|18|1.00|USD', response.authorization
     assert response.test?
   end
 
@@ -41,7 +41,7 @@ class SafeChargeTest < Test::Unit::TestCase
 
     assert_equal '111534|101508189855|MQBVAG4ASABkAEgAagB3AEsAbgAtACoAWgAzAFwAW' \
                  'wBNAF8ATQBUAD0AegBQAGwAQAAtAD0AXAB5AFkALwBtAFAALABaAHoAOgBFAE' \
-                 'wAUAA1AFUAMwA=|09|18|1.00', response.authorization
+                 'wAUAA1AFUAMwA=|09|18|1.00|USD', response.authorization
     assert response.test?
   end
 
@@ -56,12 +56,12 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
 
-    response = @gateway.capture(@amount, "auth|transaction_id|token|month|year")
+    response = @gateway.capture(@amount, "auth|transaction_id|token|month|year|amount|currency")
     assert_success response
 
     assert_equal '111301|101508190200|RwA1AGQAMgAwAEkAWABKADkAcABjAHYAQQA4AC8AZ' \
                  'AAlAHMAfABoADEALAA8ADQAewB8ADsAewBiADsANQBoACwAeAA/AGQAXQAjAF' \
-                 'EAYgBVAHIAMwA=|month|year|1.00', response.authorization
+                 'EAYgBVAHIAMwA=|month|year|1.00|currency', response.authorization
     assert response.test?
   end
 
@@ -108,12 +108,12 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
 
-    response = @gateway.void("auth|transaction_id|token|month|year")
+    response = @gateway.void("auth|transaction_id|token|month|year|amount|currency")
     assert_success response
 
     assert_equal '111171|101508208625|ZQBpAFAAZgBuAHEATgBUAHcASAAwADUAcwBHAHQAV' \
                  'QBLAHAAbgB6AGwAJAA1AEMAfAB2AGYASwBrAHEAeQBOAEwAOwBZAGIAewB4AG' \
-                 'wAYwBUAE0AMwA=|month|year|0.00', response.authorization
+                 'wAYwBUAE0AMwA=|month|year|0.00|currency', response.authorization
     assert response.test?
   end
 
@@ -134,7 +134,7 @@ class SafeChargeTest < Test::Unit::TestCase
 
     assert_equal '111534|101508189855|MQBVAG4ASABkAEgAagB3AEsAbgAtACoAWgAzAFwAW' \
                  'wBNAF8ATQBUAD0AegBQAGwAQAAtAD0AXAB5AFkALwBtAFAALABaAHoAOgBFAE' \
-                 'wAUAA1AFUAMwA=|09|18|1.00', response.authorization
+                 'wAUAA1AFUAMwA=|09|18|1.00|USD', response.authorization
     assert response.test?
   end
 
@@ -144,8 +144,6 @@ class SafeChargeTest < Test::Unit::TestCase
     response = @gateway.verify(@credit_card, @options)
     assert_success response
   end
-
-
 
   def test_failed_verify
     @gateway.expects(:ssl_post).returns(failed_authorize_response)


### PR DESCRIPTION
Sending in a currency is required for all SafeCharge transaction types.
Moreover, SafeCharge does not keep track of the original currency used
for an authorize or purchase so if an authorize is done using EUR and
 then a subsequent capture is run on that authorization, the capture
 will be done in USD instead of EUR since the adapter defaults to USD.

Of course this could be mitigated by sending in a currency code into
the options hash for a void/refund/capture, but it's a bit silly to need
to remember that and pass that in when you'll most likely want to run
subsequent transaction requests (e.g. refund, void, and capture) on the
same currency.

This add the currency code used in the original transaction to the
authorization response field so running a void/refund/capture will
always do so in the original currency used vs defaulting to USD.

Remote test run: again, there's a single failure for stale test card data 
on a `credit` request which requires a specific card number to properly 
exercise the transaction.

```
➜ ruby -Itest test/remote/gateways/remote_safe_charge_test.rb
Loaded suite test/remote/gateways/remote_safe_charge_test
Started
...........F
==============================================================================================================================================================================================================================================
Failure:
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x007fe19d0295f0
   @authorization="|101508748226|bwBpAFAAcABGAE0ANAAzAEwAZQA0AE0ANAA6AD4ASgBbADsAUwB6AHQAewAsAG4AJgBCACUAUgBDAFoAKgA+AD0ANQBUACoAQwBiAG4AdgA+AFgAMwA=|09|18|1.00|EUR",
   ...
   @message="This card is not supported in the CFT Program",
   @params={...},
   @success=false,
   @test=true>>
test_successful_credit(RemoteSafeChargeTest)
test/remote/gateways/remote_safe_charge_test.rb:96:in `test_successful_credit'
     93:
     94:   def test_successful_credit
     95:     response = @gateway.credit(@amount, @credit_card, @options)
  => 96:     assert_success response
     97:     assert_equal 'Success', response.message
     98:   end
     99:
==============================================================================================================================================================================================================================================
......

Finished in 24.59002 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
18 tests, 44 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.4444% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.73 tests/s, 1.79 assertions/s
```