### PR TITLE
Add razorpay gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/razorpay.rb
+++ b/lib/active_merchant/billing/gateways/razorpay.rb
@@ -1,0 +1,165 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class RazorpayGateway < Gateway
+      self.test_url = 'https://api.razorpay.com/v1'
+      self.live_url = 'https://api.razorpay.com/v1'
+      self.supported_countries = ['IN']
+      self.default_currency = 'INR'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://razorpay/'
+      self.display_name = 'Razorpay'
+      self.money_format = :cents
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      def initialize(options={})
+        requires!(options, :key_id, :key_secret)
+        super
+      end
+
+      def purchase(money, payment_id, options={})
+        capture(money, payment_id, options)
+      end
+
+      def authorize(money, payment_id, options={})
+        commit(:get, "/payments/#{payment_id}", {})
+      end
+
+      def capture(money, payment_id, options={})
+        post = {}
+        add_amount(post, money)
+        commit(:post, "/payments/#{payment_id}/capture", post)
+      end
+
+      def refund(money, payment_id, options={})
+        commit(:post,"/payments/#{payment_id}/refund", {})
+      end
+
+      def void(authorization, options={})
+        Response.new(true, 'Razorpay does not support void api')
+      end
+
+      def verify(credit_card, options={})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+      end
+
+      private
+
+      def add_customer_data(post, options)
+      end
+
+      def add_address(post, creditcard, options)
+      end
+
+      def add_invoice(post, money, options)
+        post[:currency] = (options[:currency] || currency(money))
+        post[:method] = 'card'
+        post[:contact] = options[:phone]
+        post[:email] = options[:email]
+      end
+
+      def add_amount(post, money)
+        post[:amount] = amount(money)
+      end
+
+
+      def add_credit_card(post, payment)
+        post[:card] = {
+          number: payment.number,
+          cvv: payment.verification_value,
+          name: "#{payment.first_name} #{payment.last_name}",
+          expiry_month: payment.month,
+          expiry_year: payment.year,
+        }
+      end
+
+      def add_payment(post, payment)
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def api_request(method, endpoint, parameters = nil, body = nil)
+        raw_response = ssl_request(method, "#{endpoint}?#{post_data(parameters)}", body, headers)
+        parse(raw_response)
+      end
+
+      def headers
+        {
+          'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
+          'Authorization' => 'Basic ' + Base64.strict_encode64("#{@options[:key_id]}:#{@options[:key_secret]}").strip
+        }
+      end
+
+      def commit(method, path, parameters)
+
+        url = (test? ? test_url : live_url)
+        response = api_request(method, "#{url}#{path}", parameters)
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: {conde: 'Y'},
+          cvv_result: 'M',
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def success_from(response)
+        response['error_code'].nil?
+      end
+
+      def message_from(response)
+        if success_from(response)
+          'OK'
+        end
+      end
+
+      def authorization_from(response)
+        response['id']
+      end
+
+      def post_data(params)
+        return nil unless params
+
+        params.map do |key, value|
+          next if value != false && value.blank?
+          if value.is_a?(Hash)
+            h = {}
+            value.each do |k, v|
+              h["#{key}[#{k}]"] = v unless v.blank?
+            end
+            post_data(h)
+          elsif value.is_a?(Array)
+            value.map { |v| "#{key}[]=#{CGI.escape(v.to_s)}" }.join("&")
+          else
+            "#{key}=#{CGI.escape(value.to_s)}"
+          end
+        end.compact.join("&")
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          # TODO: lookup error code for this response
+          response['error_description']
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -950,8 +950,8 @@ raven_pac_net:
 
 # Working credentials, no need to replace
 razorpay:
-  key_id: 'rzp_test_4CnzOFbRfs13NK'
-  key_secret: '3369hUThUVzKnr03V7jQjZDx'
+  key_id:
+  key_secret:
 
 realex:
   login: X

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -948,6 +948,11 @@ raven_pac_net:
   secret: "all good men die young"
   prn: 987743
 
+# Working credentials, no need to replace
+razorpay:
+  key_id: 'rzp_test_4CnzOFbRfs13NK'
+  key_secret: '3369hUThUVzKnr03V7jQjZDx'
+
 realex:
   login: X
   password: Y

--- a/test/remote/gateways/remote_razorpay_test.rb
+++ b/test/remote/gateways/remote_razorpay_test.rb
@@ -1,0 +1,151 @@
+require 'test_helper'
+
+class RemoteRazorpayTest < Test::Unit::TestCase
+  def setup
+    @gateway = RazorpayGateway.new(fixtures(:razorpay))
+
+    @amount = 1000
+    @credit_card = 'pay_7zxGQpLbSCKvS0'
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      currency: 'INR',
+      phone: '917912341123',
+      email: 'user@example.com'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'OK', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com"
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'REPLACE WITH SUCCESS MESSAGE', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED PURCHASE MESSAGE', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    Net::HTTP.new("api.razorpay.com", 443, nil, nil)
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    #assert capture = @gateway.capture(@amount, auth.authorization)
+    #assert_success capture
+    #assert_equal 'REPLACE WITH SUCCESS MESSAGE', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+  end
+
+  def test_invalid_login
+    gateway = RazorpayGateway.new(login: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{REPLACE WITH FAILED LOGIN MESSAGE}, response.message
+  end
+
+  def test_dump_transcript
+    # This test will run a purchase transaction on your gateway
+    # and dump a transcript of the HTTP conversation so that
+    # you can use that transcript as a reference while
+    # implementing your scrubbing logic.  You can delete
+    # this helper after completing your scrub implementation.
+    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end

--- a/test/unit/gateways/razorpay_test.rb
+++ b/test/unit/gateways/razorpay_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class RazorpayTest < Test::Unit::TestCase
+  def setup
+    @gateway = RazorpayGateway.new(some_credential: 'login', another_credential: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'REPLACE', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_authorize
+  end
+
+  def test_failed_authorize
+  end
+
+  def test_successful_capture
+  end
+
+  def test_failed_capture
+  end
+
+  def test_successful_refund
+  end
+
+  def test_failed_refund
+  end
+
+  def test_successful_void
+  end
+
+  def test_failed_void
+  end
+
+  def test_successful_verify
+  end
+
+  def test_successful_verify_with_failed_void
+  end
+
+  def test_failed_verify
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      Run the remote tests for this gateway, and then put the contents of transcript.log here.
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
+      Things to scrub:
+        - Credit card number
+        - CVV
+        - Sensitive authentication details
+    )
+  end
+
+  def successful_purchase_response
+    %(
+      Easy to capture by setting the DEBUG_ACTIVE_MERCHANT environment variable
+      to "true" when running remote tests:
+
+      $ DEBUG_ACTIVE_MERCHANT=true ruby -Itest \
+        test/remote/gateways/remote_razorpay_test.rb \
+        -n test_successful_purchase
+    )
+  end
+
+  def failed_purchase_response
+  end
+
+  def successful_authorize_response
+  end
+
+  def failed_authorize_response
+  end
+
+  def successful_capture_response
+  end
+
+  def failed_capture_response
+  end
+
+  def successful_refund_response
+  end
+
+  def failed_refund_response
+  end
+
+  def successful_void_response
+  end
+
+  def failed_void_response
+  end
+end


### PR DESCRIPTION
HI! This is not final version of gateway. Currently stuck with remote tests.
Gateway do not allow to create/authorize payment via api, only via JavaScript library. That means I have to create manually payment and copy payment id to test each example. Because if I run test with one payment_id i can't run it again or other one with the same payment_id.

The only way I see - add a payment_id for each test to 'test/fixtures.yml' and change it each time i want to run a test. Or may be use capybara gem to create payments via js and use payment_ids in tests. But the contribution guide said that ' - No new gem dependencies will be accepted.' Is this a good reason to propose capybara with Poltergeist?