### PR TITLE
Adding a default network tokenization strategy for FirstData E4

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -262,16 +262,13 @@ module ActiveMerchant #:nodoc:
 
       def add_network_tokenization_credit_card(xml, credit_card)
         case card_brand(credit_card).to_sym
-        when :visa
-          xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
-          xml.tag!("CAVV", credit_card.payment_cryptogram)
-        when :mastercard
-          xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
-          xml.tag!("CAVV", credit_card.payment_cryptogram)
         when :american_express
           cryptogram = Base64.decode64(credit_card.payment_cryptogram)
           xml.tag!("XID", Base64.encode64(cryptogram[20...40]))
           xml.tag!("CAVV", Base64.encode64(cryptogram[0...20]))
+        else
+          xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
+          xml.tag!("CAVV", credit_card.payment_cryptogram)
         end
       end
 


### PR DESCRIPTION
Adding a default network tokenization strategy for FirstData E4

Right now, if you'd pass in any credit card type other than visa, mastercard or amex, the gateway would set the ECI value, without the cryptogram.

 This is actually causing a problem in the case where you'd be passing in a Discover card as:
- Discover now supports network tokenization
- FirstData E4 supports Discover

So rather than passing in no XID or CAVV values, we'll revert on the default strategy which is to pass in the `transaction_id` and `payment_cryptogram` as the `XID` and `CAVV` parameters respectively, amex being the exception.

TBD: Is this the actual behaviour First Data is expecting in their API (there is no proper documentation for this).