### PR TITLE
Braintree Blue: Add ECI indicator to Android Pay transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -592,7 +592,8 @@ module ActiveMerchant #:nodoc:
                 :expiration_year => credit_card_or_vault_id.year.to_s,
                 :google_transaction_id => credit_card_or_vault_id.transaction_id,
                 :source_card_type => credit_card_or_vault_id.brand,
-                :source_card_last_four => credit_card_or_vault_id.last_digits
+                :source_card_last_four => credit_card_or_vault_id.last_digits,
+                :eci_indicator => credit_card_or_vault_id.eci
               }
             end
           else

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -390,7 +390,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       :month              => "01",
       :year               => "2024",
       :source             => :android_pay,
-      :transaction_id     => "123456789"
+      :transaction_id     => "123456789",
+      :eci                => "05"
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
@@ -441,7 +442,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'voided', void.params["braintree_transaction"]["status"]
     assert failed_void = @gateway.void(auth.authorization)
     assert_failure failed_void
-    assert_equal 'Transaction can only be voided if status is authorized or submitted_for_settlement. (91504)', failed_void.message
+    assert_match('Transaction can only be voided if status is authorized', failed_void.message)
     assert_equal({"processor_response_code"=>"91504"}, failed_void.params["braintree_transaction"])
   end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -637,14 +637,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
           :cryptogram => '111111111100cryptogram',
           :google_transaction_id => '1234567890',
           :source_card_type => "visa",
-          :source_card_last_four => "1111"
+          :source_card_last_four => "1111",
+          :eci_indicator => '05'
         }
       ).
       returns(braintree_result(:id => "transaction_id"))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
       :brand              => 'visa',
-      :transaction_id     => "123",
       :eci                => "05",
       :payment_cryptogram => "111111111100cryptogram",
       :source             => :android_pay,


### PR DESCRIPTION
Currently the ECI indicator field is not passed with any Android Pay transactions despite being part of the Android Pay token data. In some cases, this can cause the Android Pay transaction to fail. 

Note this PR also includes a small fix for a failing `void` test where the returned response has been updated. I've relaxed the assert to match on part of the error message instead of the whole.

Remote test run suite:
```
➜ ruby -Itest test/remote/gateways/remote_braintree_blue_test.rb
Loaded suite test/remote/gateways/remote_braintree_blue_test
Started
..........................................................

Finished in 104.994639 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
58 tests, 341 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.55 tests/s, 3.25 assertions/s
```

Unit test run:

```
➜ bundle exec rake
Finished in 19.823915 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3615 tests, 66645 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
182.36 tests/s, 3361.85 assertions/s
```