### PR TITLE
Authorize.Net: Bug fix: Return failed response if forced refund settlement fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * SafeCharge: Track currency from original transaction [davidsantoso] #2470
 * Braintree Blue: Braintree Blue: Add ECI indicator to Android Pay transactions [davidsantoso] #2474
 * JetPay V2: Support store transactions and token based payments [shasum] #2475
+* Authorize.Net: Return failed response if forced refund settlement fails [bizla] #2476
 
 == Version 1.67.0 (June 8, 2017)
 * Acapture: Pass 3D Secure fields [davidsantoso] #2451

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -143,6 +143,8 @@ module ActiveMerchant
 
         if response.params["response_reason_code"] == INELIGIBLE_FOR_ISSUING_CREDIT_ERROR
           void(authorization, options)
+        else
+          response
         end
       end
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -563,6 +563,15 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @gateway.refund(36.40, '2214269051#XXXX1234', force_full_refund_if_unsettled: true)
   end
 
+  def test_failed_full_refund_returns_failed_response_if_reason_code_is_not_unsettled_error
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    @gateway.expects(:void).never
+
+    response = @gateway.refund(36.40, '2214269051#XXXX1234', force_full_refund_if_unsettled: true)
+    assert response.present?
+    assert_failure response
+  end
+
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 


### PR DESCRIPTION
Fixes: If the `force_full_refund_if_unsettled` option to `#refund` is `true`, we return `nil` instead of the failed response. 
This is due to falling through if the response code isn't explicitly `INELIGIBLE_FOR_ISSUING_CREDIT_ERROR`, so now we return the response by default.