### PR TITLE
Cybersource: update supported card types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Cybersource: update supported card types [bdewater] #2477
 * Moneris: Add 3DS fields for decrypted Apple and Android Pay data [davidsantoso] #2457
 * Trexle: Add gateway support [hossamhossny] #2351
 * QuickPay V10: Return last response for purchase and authorize [curiousepic] #2461

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
 
       XSD_VERSION = "1.121"
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :switch, :dankort, :maestro]
       self.supported_countries = %w(US BR CA CN DK FI FR DE JP MX NO SE GB SG LB)
 
       self.default_currency = 'USD'
@@ -39,7 +39,12 @@ module ActiveMerchant #:nodoc:
         :visa  => '001',
         :master => '002',
         :american_express => '003',
-        :discover => '004'
+        :discover => '004',
+        :diners_club => '005',
+        :jcb => '007',
+        :switch => '024',
+        :dankort => '034',
+        :maestro => '042'
       }
 
       @@response_codes = {


### PR DESCRIPTION
Docs: http://apps.cybersource.com/library/documentation/dev_guides/CC_Svcs_SO_API/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=app_card_types.html