### PR TITLE
Authorize.net: Concatenate address1 and address2

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -555,11 +555,12 @@ module ActiveMerchant
 
         xml.billTo do
           first_name, last_name = names_from(payment_source, address, options)
+          full_address = "#{address[:address1]} #{address[:address2]}".strip
+
           xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
           xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
-
           xml.company(truncate(address[:company], 50)) unless empty?(address[:company])
-          xml.address(truncate(address[:address1], 60))
+          xml.address(truncate(full_address, 60))
           xml.city(truncate(address[:city], 40))
           xml.state(empty?(address[:state]) ? 'n/a' : truncate(address[:state], 40))
           xml.zip(truncate((address[:zip] || options[:zip]), 20))
@@ -579,12 +580,12 @@ module ActiveMerchant
           else
             [address[:first_name], address[:last_name]]
           end
+          full_address = "#{address[:address1]} #{address[:address2]}".strip
 
           xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
           xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
-
           xml.company(truncate(address[:company], 50)) unless empty?(address[:company])
-          xml.address(truncate(address[:address1], 60))
+          xml.address(truncate(full_address, 60))
           xml.city(truncate(address[:city], 40))
           xml.state(truncate(address[:state], 40))
           xml.zip(truncate(address[:zip], 20))


### PR DESCRIPTION
Authorize.net does not provide a field for just address2. This combines
address1 and address2 for both the `billTo` and `shipTo` elements.

Remote:
```
ruby -Itest test/remote/gateways/remote_authorize_net_test.rb
Loaded suite test/remote/gateways/remote_authorize_net_test
Started
...........................................................

Finished in 63.003082 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------
59 tests, 204 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------
0.94 tests/s, 3.24 assertions/s
```

Unit:
```
ruby -Itest test/unit/gateways/authorize_net_test.rb
Loaded suite test/unit/gateways/authorize_net_test
Started
......................................................................................

Finished in 0.337633 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------
86 tests, 490 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------
254.71 tests/s, 1451.28 assertions/s
```

@davidsantoso / @curiousepic 