### PR TITLE
Payflow: Set PAYPAL_NVP header as optional

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -180,21 +180,23 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def build_headers(content_length)
-        {
+      def build_headers(content_length, options = {})
+        headers = {
           "Content-Type" => "text/xml",
           "Content-Length" => content_length.to_s,
           "X-VPS-Client-Timeout" => timeout.to_s,
           "X-VPS-VIT-Integration-Product" => "ActiveMerchant",
           "X-VPS-VIT-Runtime-Version" => RUBY_VERSION,
-          "X-VPS-Request-ID" => SecureRandom.hex(16),
-          "PAYPAL-NVP" => "Y"
+          "X-VPS-Request-ID" => SecureRandom.hex(16)
         }
+
+        headers.merge!("PAYPAL-NVP" => options[:paypal_nvp]) if options[:paypal_nvp]
+        headers
       end
 
-      def commit(request_body, options  = {})
+      def commit(request_body, options = {})
         request = build_request(request_body, options)
-        headers = build_headers(request.size)
+        headers = build_headers(request.size, options)
 
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request, headers))
 

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -376,7 +376,7 @@ class PayflowTest < Test::Unit::TestCase
   def test_timeout_is_same_in_header_and_xml
     timeout = PayflowGateway.timeout.to_s
 
-    headers = @gateway.send(:build_headers, 1)
+    headers = @gateway.send(:build_headers, 1, {})
     assert_equal timeout, headers['X-VPS-Client-Timeout']
 
     xml = @gateway.send(:build_request, 'dummy body')


### PR DESCRIPTION
This header was originally added for requests across the board, but then we discussed making it optional instead since not all users of the adapter may want the functionality it provides. See #2462 for more details.

Unit test run:

```
Finished in 14.758576 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3615 tests, 66653 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
244.94 tests/s, 4516.22 assertions/s
```