### PR TITLE
WePay: Add payer_rbits and transaction_rbits optional fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* WePay: Add payer_rbits and transaction_rbits optional fields [davidsantoso]
 
 == Version 1.68.0 (June 27, 2017)
 * Authorize.Net: Return failed response if forced refund settlement fails [bizla] #2476

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -148,6 +148,8 @@ module ActiveMerchant #:nodoc:
         post[:preapproval_id] = options[:preapproval_id] if options[:preapproval_id]
         post[:prefill_info] = options[:prefill_info] if options[:prefill_info]
         post[:funding_sources] = options[:funding_sources] if options[:funding_sources]
+        post[:payer_rbits] = options[:payer_rbits] if options[:payer_rbits]
+        post[:transaction_rbits] = options[:transaction_rbits] if options[:transaction_rbits]
         add_fee(post, options)
       end
 


### PR DESCRIPTION
In some cases, platforms using WePay will have their transactions declined unless they send risk related information in addition to their transactions. This adds those optional fields for the merchant accounts that have this additional risk functionality enabled with WePay.

See the [WePay /checkout/create docs](https://developer.wepay.com/api/api-calls/checkout#create) for more information.