### PR TITLE
Adyen: Use Active Merchant standard order_id option for reference

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize(money, payment, options={})
-        requires!(options, :reference)
+        requires!(options, :order_id)
         post = init_post(options)
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
           value: amount(money),
           currency: options[:currency] || currency(money)
         }
-        post[:reference] = options[:reference]
+        post[:reference] = options[:order_id]
         post[:amount] = amount
       end
 
@@ -145,7 +145,7 @@ module ActiveMerchant #:nodoc:
 
       def add_references(post, authorization, options = {})
         post[:originalReference] = authorization
-        post[:reference] = options[:reference]
+        post[:reference] = options[:order_id]
       end
 
       def parse(body)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -22,8 +22,8 @@ class AdyenTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :billing_address => address(),
-      reference: '345123'
+      billing_address: address(),
+      order_id: '345123'
     }
   end
 


### PR DESCRIPTION
From https://docs.adyen.com/developers/api-reference/payments-api#paymentrequest

> A reference to uniquely identify the payment. This reference is used
> in all communication with you about the payment status. We recommend
> using a unique value per payment; however, it is not a requirement.

The `order_id` option is what is used for this throughout Active
Merchant. Let's do that for the Adyen gateway too instead of requiring a
gateway specific option.