### PR TITLE
Elavon: Support custom fields

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -275,14 +275,14 @@ module ActiveMerchant #:nodoc:
         if non_fractional_currency?(currency)
           if self.money_format == :cents
             sprintf("%.0f", amount.to_f / 100)
-          else
+          elsif self.money_format == :dollars
             amount.split('.').first
           end
         elsif three_decimal_currency?(currency)
           if self.money_format == :cents
-            (amount.to_i * 10).to_s
-          else
-            sprintf("%.3f", amount.to_f)
+            amount.to_s
+          elsif self.money_format == :dollars
+            sprintf("%.3f", (amount.to_f / 10))
           end
         end
       end

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -94,12 +94,12 @@ class GatewayTest < Test::Unit::TestCase
     @gateway.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
 
     Gateway.money_format = :dollars
-    assert_equal '1.000', @gateway.send(:localized_amount, 100, 'OMR')
-    assert_equal '12.340', @gateway.send(:localized_amount, 1234, 'BHD')
+    assert_equal '0.100', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '1.234', @gateway.send(:localized_amount, 1234, 'BHD')
 
     Gateway.money_format = :cents
-    assert_equal '1000', @gateway.send(:localized_amount, 100, 'OMR')
-    assert_equal '12340', @gateway.send(:localized_amount, 1234, 'BHD')
+    assert_equal '100', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '1234', @gateway.send(:localized_amount, 1234, 'BHD')
   end
 
   def test_split_names


### PR DESCRIPTION
Also updates test card number to work with changes on Elavon's end, and
cleans up reference comments.

Remote:
23 tests, 102 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
28 tests, 138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed