### PR TITLE
Correct calculation for three-exponent currencies

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -280,9 +280,9 @@ module ActiveMerchant #:nodoc:
           end
         elsif three_decimal_currency?(currency)
           if self.money_format == :cents
-            (amount.to_i * 10).to_s
+            amount.to_s
           else
-            sprintf("%.3f", amount.to_f)
+            sprintf("%.3f", (amount.to_f / 10))
           end
         end
       end

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -94,12 +94,12 @@ class GatewayTest < Test::Unit::TestCase
     @gateway.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
 
     Gateway.money_format = :dollars
-    assert_equal '1.000', @gateway.send(:localized_amount, 100, 'OMR')
-    assert_equal '12.340', @gateway.send(:localized_amount, 1234, 'BHD')
+    assert_equal '0.100', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '1.234', @gateway.send(:localized_amount, 1234, 'BHD')
 
     Gateway.money_format = :cents
-    assert_equal '1000', @gateway.send(:localized_amount, 100, 'OMR')
-    assert_equal '12340', @gateway.send(:localized_amount, 1234, 'BHD')
+    assert_equal '100', @gateway.send(:localized_amount, 100, 'OMR')
+    assert_equal '1234', @gateway.send(:localized_amount, 1234, 'BHD')
   end
 
   def test_split_names


### PR DESCRIPTION
The first implementation of support for three-exponent currencies used
both incorrect calculations and incorrect tests. These have been
corrected.
