### PR TITLE
SagePay: Use VPSTxId from authorization for refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -359,9 +359,9 @@ module ActiveMerchant #:nodoc:
           response['Token']
         else
          [ params[:VendorTxCode],
-           response["VPSTxId"],
+           response["VPSTxId"] || params[:VPSTxId],
            response["TxAuthNo"],
-           response["SecurityKey"],
+           response["SecurityKey"] || params[:SecurityKey],
            action ].join(";")
         end
       end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1047,7 +1047,7 @@ sage:
   password: 'Z5W2S8J7X8T5'
 
 sage_pay:
-  login: LOGIN
+  login: spreedly
 
 sallie_mae:
   login: TEST0

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -124,6 +124,20 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorization_and_capture_and_refund
+    assert auth = @gateway.authorize(@amount, @mastercard, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+
+    assert refund = @gateway.refund(@amount, capture.authorization,
+      :description => 'Crediting trx',
+      :order_id => generate_unique_id
+    )
+    assert_success refund
+  end
+
   def test_successful_authorization_and_void
     assert auth = @gateway.authorize(@amount, @mastercard, @options)
     assert_success auth
@@ -158,14 +172,6 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert response.test?
     assert !response.authorization.blank?
   end
-
-  # Maestro is not available for GBP
-  # def test_successful_maestro_purchase
-  #   assert response = @gateway.purchase(@amount, @maestro, @options)
-  #   assert_success response
-  #   assert response.test?
-  #   assert !response.authorization.blank?
-  # end
 
   def test_successful_amex_purchase
     assert response = @gateway.purchase(@amount, @amex, @options)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -285,6 +285,26 @@ class SagePayTest < Test::Unit::TestCase
     assert_equal "Joikam Lomström", @gateway.send(:truncate, "Joikam Lomström Rate", 20)
   end
 
+  def test_successful_authorization_and_capture_and_refund
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+
+    capture = stub_comms do
+      @gateway.capture(@amount, auth.authorization)
+    end.respond_with(successful_capture_response)
+    assert_success capture
+
+    refund = stub_comms do
+      @gateway.refund(@amount, capture.authorization,
+        order_id: generate_unique_id,
+        description: "Refund txn"
+       )
+    end.respond_with(successful_refund_response)
+    assert_success refund
+  end
+
   private
 
   def purchase_with_options(optional)
@@ -336,6 +356,25 @@ PostCodeResult=MATCHED
 CV2Result=NOTMATCHED
 3DSecureStatus=NOTCHECKED
 Token=1
+    RESP
+  end
+
+  def successful_refund_response
+    <<-RESP
+VPSProtocol=3.00
+Status=OK
+StatusDetail=0000 : The Authorisation was Successful.
+SecurityKey=KUMJBP02HM
+TxAuthNo=15282432
+VPSTxId={08C870A9-1E53-3852-BA44-CBC91612CBCA}
+    RESP
+  end
+
+  def successful_capture_response
+    <<-RESP
+VPSProtocol=3.00
+Status=OK
+StatusDetail=2004 : The Release was Successful.
     RESP
   end
 


### PR DESCRIPTION
SagePay does not return the `VPSTxId` field in the response of
successful capture transactions. For refunds, the `VPSTxId` field from
authorization transactions must be used instead.