### PR TITLE
Optimal Payments: Pass CVD indicator accurately

### DIFF
--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -259,9 +259,11 @@ module ActiveMerchant #:nodoc:
           if brand = card_type(@credit_card.brand)
             xml.tag! 'cardType'     , brand
           end
-          if @credit_card.verification_value
+          if @credit_card.verification_value?
             xml.tag! 'cvdIndicator' , '1' # Value Provided
             xml.tag! 'cvd'          , @credit_card.verification_value
+          else
+            xml.tag! 'cvdIndicator' , '0'
           end
         end
       end

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -44,6 +44,13 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     assert_equal 'auth declined', response.message
   end
 
+  def test_purchase_with_no_cvv
+    @credit_card.verification_value = ''
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'no_error', response.message
+  end
+
   def test_authorize_and_capture
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
@@ -134,6 +141,6 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
               )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'invalid credentials', response.message
+    assert_equal 'invalid merchant account', response.message
   end
 end


### PR DESCRIPTION
Previously, CVD Indicator was sent as '1' along with a blank CVD field,
if a CVV was not present, causing a schema error failure. Now, CVD
Indicator is properly passed as '0' with no CVD field when CVV is not
present, which appears to allow CVV-less transactions to be accepted, at
least in the test environment.

Unit:
17 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
14 tests, 68 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@dtykocki 