### PR TITLE
Payflow: Move PAYPAL-NVP header option to a class attribute on the payment gateway

### DIFF
--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -376,7 +376,7 @@ class PayflowTest < Test::Unit::TestCase
   def test_timeout_is_same_in_header_and_xml
     timeout = PayflowGateway.timeout.to_s
 
-    headers = @gateway.send(:build_headers, 1, {})
+    headers = @gateway.send(:build_headers, 1)
     assert_equal timeout, headers['X-VPS-Client-Timeout']
 
     xml = @gateway.send(:build_request, 'dummy body')
@@ -399,6 +399,15 @@ class PayflowTest < Test::Unit::TestCase
     response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
     assert_equal '2014-06-25 09:33:41', response.params['transaction_time']
+  end
+
+  def test_paypal_nvp_option_sends_header
+    headers = @gateway.send(:build_headers, 1)
+    assert_not_include headers, 'PAYPAL-NVP'
+
+    PayflowGateway.use_paypal_nvp = true
+    headers = @gateway.send(:build_headers, 1)
+    assert_equal 'Y', headers['PAYPAL-NVP']
   end
 
   private


### PR DESCRIPTION
Change the way the PAYPAL-NVP header is made optional. Adding it as an option on the `commit` method creates a special case that makes the Payflow gateway handling not to be agnostic anymore. Moving that option to the class allows integrators to set that option once during the initialization of the payment gateway.

See https://github.com/activemerchant/active_merchant/pull/2462 and https://github.com/activemerchant/active_merchant/pull/2480.