### PR TITLE
SagePay: Make Repeat purchase if payment is a past authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_optional_data(post, options)
 
-        commit((options[:repeat] ? :repeat : :purchase), post)
+        commit((past_purchase_reference?(payment_method) ? :repeat : :purchase), post)
       end
 
       def authorize(money, payment_method, options = {})
@@ -268,12 +268,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment_method, options)
-        if options[:repeat]
-          add_related_reference(post, payment_method)
-        elsif payment_method.respond_to?(:number)
-          add_credit_card(post, payment_method)
+        if payment_method.is_a?(String)
+          if past_purchase_reference?(payment_method)
+            add_related_reference(post, payment_method)
+          else
+            add_token_details(post, payment_method, options)
+          end
         else
-          add_token_details(post, payment_method, options)
+          add_credit_card(post, payment_method)
         end
       end
 
@@ -422,6 +424,10 @@ module ActiveMerchant #:nodoc:
         post[key] = value if !value.blank? || options[:required]
       end
 
+      def past_purchase_reference?(payment_method)
+        return false unless payment_method.is_a?(String)
+        payment_method.split(';').last == 'purchase'
+      end
     end
 
   end

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -323,8 +323,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
   def test_successful_repeat_purchase
     response = @gateway.purchase(@amount, @visa, @options)
     assert_success response
-
-    repeat = @gateway.purchase(@amount, response.authorization, @options.merge(repeat: true, order_id: generate_unique_id))
+    repeat = @gateway.purchase(@amount, response.authorization, @options.merge(order_id: generate_unique_id))
     assert_success repeat
   end
 

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -305,6 +305,15 @@ class SagePayTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_repeat_purchase_with_reference_token
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, "1455548a8d178beecd88fe6a285f50ff;{0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474};15353766;BS231FNE14;purchase", @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/RelatedVPSTxId=%7B0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474%/, data)
+      assert_match(/TxType=REPEAT/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def purchase_with_options(optional)


### PR DESCRIPTION
The previous implementation of Repeat purchases required a flag to be
passed in as an option. Now, the payment method is checked and if it is
a past purchase authorization string, the transaction will automatically
be sent as a Repeat purchase.

Unit:
35 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
36 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed