### PR TITLE
Auth.Net: Use two character default for billing state

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -555,6 +555,7 @@ module ActiveMerchant
 
         xml.billTo do
           first_name, last_name = names_from(payment_source, address, options)
+          state = state_from(address, options)
           full_address = "#{address[:address1]} #{address[:address2]}".strip
 
           xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
@@ -562,7 +563,7 @@ module ActiveMerchant
           xml.company(truncate(address[:company], 50)) unless empty?(address[:company])
           xml.address(truncate(full_address, 60))
           xml.city(truncate(address[:city], 40))
-          xml.state(empty?(address[:state]) ? 'n/a' : truncate(address[:state], 40))
+          xml.state(truncate(state, 40))
           xml.zip(truncate((address[:zip] || options[:zip]), 20))
           xml.country(truncate(address[:country], 60))
           xml.phoneNumber(truncate(address[:phone], 25)) unless empty?(address[:phone])
@@ -711,6 +712,14 @@ module ActiveMerchant
           [(payment_source.first_name || first_name), (payment_source.last_name || last_name)]
         else
           [options[:first_name], options[:last_name]]
+        end
+      end
+
+      def state_from(address, options)
+        if ["US", "CA"].include?(address[:country])
+          address[:state] || 'NC'
+        else
+          address[:state]
         end
       end
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -398,6 +398,26 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_match %r{The amount requested for settlement cannot be greater}, capture.message
   end
 
+  def test_faux_successful_refund_with_billing_address
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    refund = @gateway.refund(@amount, purchase.authorization, @options.merge(first_name: 'Jim', last_name: 'Smith'))
+    assert_failure refund
+    assert_match %r{does not meet the criteria for issuing a credit}, refund.message, "Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise."
+  end
+
+  def test_faux_successful_refund_without_billing_address
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    @options[:billing_address] = nil
+
+    refund = @gateway.refund(@amount, purchase.authorization, @options.merge(first_name: 'Jim', last_name: 'Smith'))
+    assert_failure refund
+    assert_match %r{does not meet the criteria for issuing a credit}, refund.message, "Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise."
+  end
+
   def test_faux_successful_refund_using_stored_card
     store = @gateway.store(@credit_card, @options)
     assert_success store


### PR DESCRIPTION
For addresses in North America, billing state is a required field, should
not contain any symbols, and must be a valid two-character state code.
Instead of defaulting to "N/A", now default to "NC".

Remote tests:
```
ruby -Itest test/remote/gateways/remote_authorize_net_test.rb
Loaded suite test/remote/gateways/remote_authorize_net_test
Started
.............................................................

Finished in 44.356651 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
61 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
1.38 tests/s, 4.73 assertions/s
```