### PR TITLE
Add XSD schema validation to CyberSource tests

### DIFF
--- a/test/schema/cyber_source/CyberSourceTransaction_1.121.xsd
+++ b/test/schema/cyber_source/CyberSourceTransaction_1.121.xsd
@@ -1,0 +1,3627 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="urn:schemas-cybersource-com:transaction-data-1.121" targetNamespace="urn:schemas-cybersource-com:transaction-data-1.121" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xsd:simpleType name="amount">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="boolean">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="dateTime">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:complexType name="Item">
+        <xsd:sequence>
+            <xsd:element name="unitPrice" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="quantity" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="productCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productSKU" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productRisk" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cityOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cityOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countyOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countyOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="districtOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="districtOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="stateOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="stateOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countryOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countryOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptancePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="export" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="noExport" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nationalTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="sellerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration6" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration7" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration8" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration9" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buyerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middlemanRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfTitleTransfer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftCategory" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="timeCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="hostHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="timeHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="velocityHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nonsensicalHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="obscenitiesHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="unitOfMeasure" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="commodityCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grossNetIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxTypeApplied" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxTypeApplied" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="localTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="zeroCostToCustomerIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="taxStatusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountManagementIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="typeOfSupply" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sign" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCAuthService">
+        <xsd:sequence>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvAlgorithm" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnAuthRecord" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verbalAuthCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authenticationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="traceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="splitTenderIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="captureDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstRecurringPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mobileRemotePaymentType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+	<xsd:complexType name="OCTService">
+        <xsd:sequence>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+   <xsd:complexType name="CCSaleService">
+        <xsd:sequence>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+</xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>    
+    
+    <xsd:complexType name="CCSaleCreditService">
+        <xsd:sequence>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>    
+
+    <xsd:complexType name="CCSaleReversalService">
+        <xsd:sequence>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>  
+
+  <xsd:complexType name="CCIncrementalAuthService">
+    <xsd:sequence>
+      <xsd:element name="authRequestID" type="xsd:string" minOccurs="0" />
+      <xsd:element name="duration" type="xsd:integer" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="run" type="tns:boolean" use="required" />
+  </xsd:complexType>	
+    <xsd:complexType name="CCCaptureService">
+        <xsd:sequence>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verbalAuthCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchasingLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReceiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="posData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="gratuityAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="dpdeBillingMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="sequence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCount" type="xsd:string" minOccurs="0"/>
+	   		<xsd:element name="reconciliationIDAlternate" type="xsd:string" minOccurs="0"/>
+	   		<xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCCreditService">
+        <xsd:sequence>
+            <xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchasingLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="occurrenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="captureRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReceiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="dpdeBillingMonth" type="xsd:integer" minOccurs="0"/>
+	    <xsd:element name="reconciliationIDAlternate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reversalReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCAutoAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="authPaymentServiceData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="dateAdded" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCDCCService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ServiceFeeCalculateService">
+            <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECDebitService">
+        <xsd:sequence>
+            <xsd:element name="paymentMode" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationLevel" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="effectiveDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECCreditService">
+        <xsd:sequence>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="effectiveDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECAuthenticateService">
+        <xsd:sequence>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthEnrollService">
+        <xsd:sequence>
+            <xsd:element name="httpAccept" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpUserAgent" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acquirerBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="loginID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="password" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mobilePhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="MCC" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productCode" type="xsd:string" minOccurs="0"/>
+       </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthValidateService">
+        <xsd:sequence>
+            <xsd:element name="signedPARes" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="TaxService">
+        <xsd:sequence>
+            <xsd:element name="nexus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="noNexus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptancePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration6" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration7" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration8" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration9" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buyerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middlemanRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfTitleTransfer" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- DME -->
+  <xsd:complexType name="DMEService">
+    <xsd:sequence>
+      <xsd:element name="eventType" type="xsd:string" minOccurs="0" />
+      <xsd:element name="eventPolicy" type="xsd:string" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="run" type="tns:boolean" use="required" />
+  </xsd:complexType>
+    <xsd:complexType name="AFSService">
+        <xsd:sequence>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="disableAVSScoring" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customRiskModel" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DAVService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ExportService">
+        <xsd:sequence>
+            <xsd:element name="addressOperator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressWeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyWeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nameWeight" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="FXRatesService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRefundService">
+        <xsd:sequence>
+            <xsd:element name="bankTransferRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeReconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRealTimeService">
+        <xsd:sequence>
+            <xsd:element name="bankTransferRealTimeType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitMandateService">
+        <xsd:sequence>
+            <xsd:element name="mandateDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstDebitDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitService">
+        <xsd:sequence>
+            <xsd:element name="dateCollect" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitText" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="validateRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="validateRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitRefundService">
+        <xsd:sequence>
+            <xsd:element name="directDebitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitValidateService">
+        <xsd:sequence>
+            <xsd:element name="directDebitValidateText" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionCreateService">
+        <xsd:sequence>
+            <xsd:element name="paymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="disableAutoAuth" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionUpdateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionEventUpdateService">
+        <xsd:sequence>
+            <xsd:element name="action" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionRetrieveService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionDeleteService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPaymentService">
+        <xsd:sequence>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalCreditService">
+        <xsd:sequence>
+            <xsd:element name="payPalPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payPalPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcSet-->
+    <xsd:complexType name="PayPalEcSetService">
+        <xsd:sequence>
+            <xsd:element name="paypalReturn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCancelReturn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalMaxamt" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReqconfirmshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNoshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAddressOverride" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalLc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPagestyle" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrimg" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrbordercolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrbackcolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayflowcolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestBillingAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalLogoimg" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcGetDetails-->
+    <xsd:complexType name="PayPalEcGetDetailsService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcDoPayment-->
+    <xsd:complexType name="PayPalEcDoPaymentService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalDoCapture-->
+    <xsd:complexType name="PayPalDoCaptureService">
+        <xsd:sequence>
+            <xsd:element name="paypalAuthorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="completeType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalAuthReversal-->
+    <xsd:complexType name="PayPalAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="paypalAuthorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalRefund-->
+    <xsd:complexType name="PayPalRefundService">
+        <xsd:sequence>
+            <xsd:element name="paypalDoCaptureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoCaptureRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCaptureId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNote" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcOrderSetup-->
+    <xsd:complexType name="PayPalEcOrderSetupService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalAuthorization-->
+    <xsd:complexType name="PayPalAuthorizationService">
+        <xsd:sequence>
+            <xsd:element name="paypalOrderId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoRefTransactionRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoRefTransactionRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalUpdateAgreement-->
+    <xsd:complexType name="PayPalUpdateAgreementService">
+        <xsd:sequence>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalCreateAgreement-->
+    <xsd:complexType name="PayPalCreateAgreementService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalDoRefTransaction-->
+    <xsd:complexType name="PayPalDoRefTransactionService">
+        <xsd:sequence>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReqconfirmshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReturnFmfDetails" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalSoftDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalShippingdiscount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcNotifyUrl" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="VoidService">
+        <xsd:sequence>
+            <xsd:element name="voidRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="voidRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitValidateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitReversalService">
+        <xsd:sequence>
+            <xsd:element name="pinlessDebitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pinlessDebitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <!--PinDebitPurchaseService-->
+    <xsd:complexType name="PinDebitPurchaseService">
+        <xsd:sequence>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtVoucherSerialNumber" type="xsd:string" minOccurs="0"/>			
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>			
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitPurchaseService-->
+    <!--PinDebitCreditService-->
+    <xsd:complexType name="PinDebitCreditService">
+        <xsd:sequence>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitCreditService-->
+    <!--PinDebitReversalService-->
+    <xsd:complexType name="PinDebitReversalService">
+        <xsd:sequence>
+            <xsd:element name="pinDebitRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitReversalService-->
+
+    <!--PayPal upgrade services -->
+    <xsd:complexType name="PayPalButtonCreateService">
+        <xsd:sequence>
+            <xsd:element name="buttonType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedPaymentService">
+        <xsd:sequence>
+            <xsd:element name="mpID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedUpdateService">
+        <xsd:sequence>
+            <xsd:element name="mpID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- China Payment -->
+    <xsd:complexType name="ChinaPaymentService">
+        <xsd:sequence>
+            <xsd:element name="paymentMode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- China Refund -->
+    <xsd:complexType name="ChinaRefundService">
+        <xsd:sequence>
+            <xsd:element name="chinaPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="chinaPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--Boleto Payment -->
+    <xsd:complexType name="BoletoPaymentService">
+        <xsd:sequence>
+            <xsd:element name="instruction" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="Address">
+        <xsd:sequence>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="APInitiateService">
+        <xsd:sequence>
+            <xsd:element name="returnURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="escrowAgreement" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="languageInterface" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="APCheckStatusService">
+        <xsd:sequence>
+            <xsd:element name="apInitiateRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="RiskUpdateService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recordID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recordName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="negativeAddress" type="tns:Address" minOccurs="0"/>
+            <xsd:element name="markingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingNotes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="FraudUpdateService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markedData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingNotes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CaseManagementActionService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="comments" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="EncryptPaymentDataService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="InvoiceHeader">
+        <xsd:sequence>
+            <xsd:element name="merchantDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorContact" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorAlternate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorStreet" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="isGift" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="returnsAccepted" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="tenderType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantVATRegistrationNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaserOrderDate" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="purchaserVATRegistrationNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="vatInvoiceReferenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="summaryCommodityCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supplierOrderReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="userPO" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="costCenter" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaserCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxable" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="amexDataTAA1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalTaxTypeCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAcceptorRefNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizedContactName" type="xsd:string" minOccurs="0"/>			
+            <xsd:element name="businessApplicationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="salesOrganizationID" type="xsd:integer" minOccurs="0"/>
+			<xsd:element name="submerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantName" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantStreet" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantCity" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantPostalCode" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantState" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantCountry" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantEmail" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="submerchantTelephoneNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BusinessRules">
+        <xsd:sequence>
+            <xsd:element name="ignoreAVSResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreCVResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreDAVResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreExportResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreValidateResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="declineAVSFlags" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoreThreshold" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BillTo">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buildingNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="district" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerUserName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerPassword" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipNetworkAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="hostname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="domainName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="driversLicenseNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="driversLicenseState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ssn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserCookiesAccepted" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="nif" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="personalID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="language" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ShipTo">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shippingMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="id" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressVerificationStatus" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ShipFrom">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Card">
+        <xsd:sequence>
+            <xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="expirationYear" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="cvIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="issueNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="startMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="startYear" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="pin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountEncoderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encryptedData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prefix" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Check">
+        <xsd:sequence>
+            <xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransitNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="secCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountEncoderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="imageReferenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalState" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BML">
+        <xsd:sequence>
+            <xsd:element name="customerBillingAddressChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerEmailChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerHasCheckingAccount" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerHasSavingsAccount" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerPasswordChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerPhoneChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerRegistrationDate" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="customerTypeFlag" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grossHouseholdIncome" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="householdIncomeCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="itemCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantPromotionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="preapprovalNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDeliveryTypeIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="residenceStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tcVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="yearsAtCurrentResidence" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="yearsWithCurrentEmployer" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="employerStreet1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerStreet2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCompanyName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="methodOfPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAuthenticatedByMerchant" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="backOfficeIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToEqualsBillToNameIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToEqualsBillToAddressIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateIPAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessLegalName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dbaName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessMainPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="userID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminFax" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminTitle" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessDAndBNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNAICSCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessYearsInBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNumberOfEmployees" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessPONumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessLoanType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessApplicationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessProductCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgSSN" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgDateOfBirth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgAnnualIncome" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgIncomeCurrencyType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgResidenceStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgCheckingAccountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgSavingsAccountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgYearsAtEmployer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgYearsAtResidence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomePhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgTitle" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="OtherTax">
+        <xsd:sequence>
+            <xsd:element name="vatTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatTaxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatTaxAmountSign" type="xsd:string" minOccurs="0"/>			
+            <xsd:element name="alternateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="localTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="localTaxIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="nationalTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nationalTaxIndicator" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+     <xsd:complexType name="Aft">
+        <xsd:sequence>
+            <xsd:element name="indicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="serviceFee" type="xsd:string" minOccurs="0" />
+            <xsd:element name="foreignExchangeFee" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>  
+    
+    <xsd:complexType name="Wallet">
+        <xsd:sequence>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>	
+    <xsd:complexType name="PurchaseTotals">
+        <xsd:sequence>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountManagementIndicator" type="xsd:string" minOccurs="0"/>			
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dutyAmount" type="tns:amount" minOccurs="0"/>
+			<xsd:element name="dutyAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="freightAmount" type="tns:amount" minOccurs="0"/>
+			<xsd:element name="freightAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="foreignAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="foreignCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="originalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="originalCurrency" type="xsd:string" minOccurs="0"/>              
+            <xsd:element name="exchangeRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="exchangeRateTimeStamp" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="serviceFeeAmount" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FundingTotals">
+        <xsd:sequence>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="GECC">
+        <xsd:sequence>
+            <xsd:element name="saleType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="planNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sequenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionEndDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionPlan" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="line" type="xsd:string" minOccurs="0" maxOccurs="7"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="UCAF">
+        <xsd:sequence>
+            <xsd:element name="authenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="collectionIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FundTransfer">
+        <xsd:sequence>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankCheckDigit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BankInfo">
+        <xsd:sequence>
+            <xsd:element name="bankCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="address" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="branchCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="swiftCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sortCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="issuerID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="RecurringSubscriptionInfo">
+        <xsd:sequence>
+            <xsd:element name="subscriptionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="numberOfPayments" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="numberOfPaymentsToAdd" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="automaticRenew" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="approvalRequired" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="event" type="tns:PaySubscriptionEvent" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionEvent">
+        <xsd:sequence>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="approvedBy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="number" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Subscription">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaymentNetworkToken">
+        <xsd:sequence>
+        	<xsd:element name="requestorID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>        	
+					<xsd:element name="assuranceLevel" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="originalCardCategory" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionManager">
+			<xsd:sequence>
+					<xsd:element name="enabled" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="profile" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="travelData" type="tns:DecisionManagerTravelData" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionManagerTravelData">
+			<xsd:sequence>
+					<xsd:element name="leg" type="tns:DecisionManagerTravelLeg" minOccurs="0" maxOccurs="100"/>
+					<xsd:element name="departureDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="completeRoute" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="journeyType" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionManagerTravelLeg">
+			<xsd:sequence>
+					<xsd:element name="origin" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="destination" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="Batch">
+			<xsd:sequence>
+					<xsd:element name="batchID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="recordID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayPal">
+			<xsd:sequence>
+					<xsd:any processContents="skip" minOccurs="0" maxOccurs="999"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="JPO">
+			<xsd:sequence>
+					<xsd:element name="paymentMethod" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="bonusAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="bonuses" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="installments" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="firstBillingMonth" type="xsd:integer" minOccurs="0"/>
+			<xsd:element name="jccaTerminalID" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="issuerMessage" type="xsd:integer" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- Vme Reseller Service-->
+	<xsd:complexType name="AP">
+			<xsd:sequence>
+					<xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerRepresentativeID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="productDescription" type="xsd:string" minOccurs="0" />
+					<xsd:element name="settlementCurrency" type="xsd:string" minOccurs="0" />
+					<xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="shippingAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="handlingAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="additionalAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="taxAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="discountAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="purchaseID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="productID" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+	<!--  apAuthService -->
+	<xsd:complexType name="APAuthService">
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of apAuthService -->
+	<!--  apAuthReversalService -->
+	<xsd:complexType name="APAuthReversalService">
+			<xsd:sequence>
+					<xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of apAuthReversalService -->
+	<!--  apCaptureService -->
+	<xsd:complexType name="APCaptureService">
+			<xsd:sequence>
+					<xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of apCaptureService -->
+	<!--  apRefundService -->
+	<xsd:complexType name="APRefundService">
+			<xsd:sequence>
+					<xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="note" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="apInitiateRequestID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="returnRef" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of apRefundService -->
+	<xsd:complexType name="APCheckOutDetailsService">
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of apCheckoutDetailsService -->
+	<xsd:complexType name="APTransactionDetailsService">
+			<xsd:sequence>
+					<xsd:element name="transactionDetailsRequestID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!--  APConfirmPurchaseService -->
+	<xsd:complexType name="APConfirmPurchaseService">
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of APConfirmPurchaseService -->
+	<!--PayPalGetTxnDetails-->
+	<xsd:complexType name="PayPalGetTxnDetailsService">
+			<xsd:sequence>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of PayPalGetTxnDetails -->
+	<!--PayPalTransactionSearch-->
+	<xsd:complexType name="PayPalTransactionSearchService">
+			<xsd:sequence>
+					<xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- End of PayPalTransactionSearch -->
+	<!-- Credit card recipient data -->
+	<xsd:complexType name="Recipient">
+<xsd:sequence>
+					<xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="name" type="xsd:string" minOccurs="0"/>
+</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of Credit card recipient data -->
+	<xsd:complexType name="Sender">
+		<xsd:sequence>
+			<xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="sourceOfFunds" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="name" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="address" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="city" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="state" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="country" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="RequestMessage">
+			<xsd:sequence>
+					<xsd:element name="merchantID" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="merchantReferenceCode" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="debtIndicator" type="tns:boolean"
+											 minOccurs="0" />
+					<xsd:element name="clientLibrary" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="clientLibraryVersion" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="clientEnvironment" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="clientSecurityLibraryVersion"
+											 type="xsd:string" minOccurs="0" />
+					<xsd:element name="clientApplication" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="clientApplicationVersion"
+											 type="xsd:string" minOccurs="0" />
+					<xsd:element name="clientApplicationUser" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="routingCode" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="comments" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="returnURL" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="invoiceHeader" type="tns:InvoiceHeader"
+											 minOccurs="0" />
+					<xsd:element name="aggregatorMerchantIdentifier" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerFirstName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerLastName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billTo" type="tns:BillTo" minOccurs="0" />
+					<xsd:element name="shipTo" type="tns:ShipTo" minOccurs="0" />
+					<xsd:element name="shipFrom" type="tns:ShipFrom"
+											 minOccurs="0" />
+					<xsd:element name="item" type="tns:Item" minOccurs="0"
+											 maxOccurs="1000" />
+					<xsd:element name="purchaseTotals" type="tns:PurchaseTotals"
+											 minOccurs="0" />
+					<xsd:element name="fundingTotals" type="tns:FundingTotals"
+											 minOccurs="0" />
+					<xsd:element name="dcc" type="tns:DCC" minOccurs="0" />
+					<xsd:element name="pos" type="tns:Pos" minOccurs="0" />
+					<xsd:element name="encryptedPayment" type="tns:EncryptedPayment" minOccurs="0" />					
+					<xsd:element name="installment" type="tns:Installment"
+											 minOccurs="0" />
+					<xsd:element name="card" type="tns:Card" minOccurs="0" />
+					<xsd:element name="check" type="tns:Check" minOccurs="0" />
+					<xsd:element name="bml" type="tns:BML" minOccurs="0" />
+					<xsd:element name="gecc" type="tns:GECC" minOccurs="0" />
+					<xsd:element name="ucaf" type="tns:UCAF" minOccurs="0" />
+					<xsd:element name="fundTransfer" type="tns:FundTransfer"
+											 minOccurs="0" />
+					<xsd:element name="bankInfo" type="tns:BankInfo"
+											 minOccurs="0" />
+					<xsd:element name="subscription" type="tns:Subscription"
+											 minOccurs="0" />
+					<xsd:element name="recurringSubscriptionInfo"
+											 type="tns:RecurringSubscriptionInfo" minOccurs="0" />
+					<xsd:element name="decisionManager"
+											 type="tns:DecisionManager" minOccurs="0" />
+					<xsd:element name="otherTax" type="tns:OtherTax"
+											 minOccurs="0" />
+					<xsd:element name="paypal" type="tns:PayPal" minOccurs="0" />
+					<xsd:element name="merchantDefinedData"
+											 type="tns:MerchantDefinedData" minOccurs="0" />
+					<xsd:element name="merchantSecureData"
+											 type="tns:MerchantSecureData" minOccurs="0" />
+					<xsd:element name="jpo" type="tns:JPO" minOccurs="0" />
+					<xsd:element name="orderRequestToken" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="linkToRequest" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="serviceFee" type="tns:ServiceFee" minOccurs="0" />
+					<xsd:element name="ccAuthService" type="tns:CCAuthService"
+											 minOccurs="0" />
+					<xsd:element name="octService" type="tns:OCTService"
+											 minOccurs="0" />
+					<xsd:element name="ccSaleService" type="tns:CCSaleService" minOccurs="0" />						 
+
+					<xsd:element name="ccSaleCreditService" type="tns:CCSaleCreditService" minOccurs="0" />						 
+
+					<xsd:element name="ccSaleReversalService" type="tns:CCSaleReversalService" minOccurs="0" />						 
+					<xsd:element name="ccIncrementalAuthService" type="tns:CCIncrementalAuthService" minOccurs="0" />						 
+					<xsd:element name="ccCaptureService"
+											 type="tns:CCCaptureService" minOccurs="0" />
+					<xsd:element name="ccCreditService"
+											 type="tns:CCCreditService" minOccurs="0" />
+					<xsd:element name="ccAuthReversalService"
+											 type="tns:CCAuthReversalService" minOccurs="0" />
+					<xsd:element name="ccAutoAuthReversalService"
+											 type="tns:CCAutoAuthReversalService" minOccurs="0" />
+					<xsd:element name="ccDCCService" type="tns:CCDCCService"
+											 minOccurs="0" />
+					<xsd:element name="serviceFeeCalculateService" type="tns:ServiceFeeCalculateService"
+											 minOccurs="0" />
+					<xsd:element name="ecDebitService" type="tns:ECDebitService"
+											 minOccurs="0" />
+					<xsd:element name="ecCreditService"
+											 type="tns:ECCreditService" minOccurs="0" />
+					<xsd:element name="ecAuthenticateService"
+											 type="tns:ECAuthenticateService" minOccurs="0" />
+					<xsd:element name="payerAuthEnrollService"
+											 type="tns:PayerAuthEnrollService" minOccurs="0" />
+					<xsd:element name="payerAuthValidateService"
+											 type="tns:PayerAuthValidateService" minOccurs="0" />
+					<xsd:element name="taxService" type="tns:TaxService"
+											 minOccurs="0" />
+          <xsd:element name="dmeService" type="tns:DMEService"
+                       minOccurs="0" />
+					<xsd:element name="afsService" type="tns:AFSService"
+											 minOccurs="0" />
+					<xsd:element name="davService" type="tns:DAVService"
+											 minOccurs="0" />
+					<xsd:element name="exportService" type="tns:ExportService"
+											 minOccurs="0" />
+					<xsd:element name="fxRatesService" type="tns:FXRatesService"
+											 minOccurs="0" />
+					<xsd:element name="bankTransferService"
+											 type="tns:BankTransferService" minOccurs="0" />
+					<xsd:element name="bankTransferRefundService"
+											 type="tns:BankTransferRefundService" minOccurs="0" />
+					<xsd:element name="bankTransferRealTimeService"
+											 type="tns:BankTransferRealTimeService" minOccurs="0" />
+					<xsd:element name="directDebitMandateService"
+											 type="tns:DirectDebitMandateService" minOccurs="0" />
+					<xsd:element name="directDebitService"
+											 type="tns:DirectDebitService" minOccurs="0" />
+					<xsd:element name="directDebitRefundService"
+											 type="tns:DirectDebitRefundService" minOccurs="0" />
+					<xsd:element name="directDebitValidateService"
+											 type="tns:DirectDebitValidateService" minOccurs="0" />
+					<xsd:element name="paySubscriptionCreateService"
+											 type="tns:PaySubscriptionCreateService" minOccurs="0" />
+					<xsd:element name="paySubscriptionUpdateService"
+											 type="tns:PaySubscriptionUpdateService" minOccurs="0" />
+					<xsd:element name="paySubscriptionEventUpdateService"
+											 type="tns:PaySubscriptionEventUpdateService" minOccurs="0" />
+					<xsd:element name="paySubscriptionRetrieveService"
+											 type="tns:PaySubscriptionRetrieveService" minOccurs="0" />
+					<xsd:element name="paySubscriptionDeleteService"
+											 type="tns:PaySubscriptionDeleteService" minOccurs="0" />
+					<xsd:element name="payPalPaymentService"
+											 type="tns:PayPalPaymentService" minOccurs="0" />
+					<xsd:element name="payPalCreditService"
+											 type="tns:PayPalCreditService" minOccurs="0" />
+					<xsd:element name="voidService" type="tns:VoidService"
+											 minOccurs="0" />
+					<xsd:element name="businessRules" type="tns:BusinessRules"
+											 minOccurs="0" />
+					<xsd:element name="pinlessDebitService"
+											 type="tns:PinlessDebitService" minOccurs="0" />
+					<xsd:element name="pinlessDebitValidateService"
+											 type="tns:PinlessDebitValidateService" minOccurs="0" />
+					<xsd:element name="pinlessDebitReversalService"
+											 type="tns:PinlessDebitReversalService" minOccurs="0" />
+					<xsd:element name="batch" type="tns:Batch" minOccurs="0" />
+					<xsd:element name="airlineData" type="tns:AirlineData"
+											 minOccurs="0" />
+					<xsd:element name="ancillaryData" type="tns:AncillaryData"
+											 minOccurs="0" />
+					<xsd:element name="lodgingData" type="tns:LodgingData" minOccurs="0" />						 
+					<xsd:element name="payPalButtonCreateService"
+											 type="tns:PayPalButtonCreateService" minOccurs="0" />
+					<xsd:element name="payPalPreapprovedPaymentService"
+											 type="tns:PayPalPreapprovedPaymentService" minOccurs="0" />
+					<xsd:element name="payPalPreapprovedUpdateService"
+											 type="tns:PayPalPreapprovedUpdateService" minOccurs="0" />
+					<xsd:element name="riskUpdateService"
+											 type="tns:RiskUpdateService" minOccurs="0" />
+					<xsd:element name="fraudUpdateService"
+											 type="tns:FraudUpdateService" minOccurs="0" />
+					<xsd:element name="caseManagementActionService"
+											 type="tns:CaseManagementActionService" minOccurs="0" />
+					<xsd:element name="reserved" type="tns:RequestReserved"
+											 minOccurs="0" maxOccurs="999" />
+					<xsd:element name="deviceFingerprintID" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="deviceFingerprintRaw" type="tns:boolean"
+											 minOccurs="0" />
+					<xsd:element name="deviceFingerprintHash" type="xsd:string"
+											 minOccurs="0" />                         
+					<xsd:element name="payPalRefundService"
+											 type="tns:PayPalRefundService" minOccurs="0" />
+					<xsd:element name="payPalAuthReversalService"
+											 type="tns:PayPalAuthReversalService" minOccurs="0" />
+					<xsd:element name="payPalDoCaptureService"
+											 type="tns:PayPalDoCaptureService" minOccurs="0" />
+					<xsd:element name="payPalEcDoPaymentService"
+											 type="tns:PayPalEcDoPaymentService" minOccurs="0" />
+					<xsd:element name="payPalEcGetDetailsService"
+											 type="tns:PayPalEcGetDetailsService" minOccurs="0" />
+					<xsd:element name="payPalEcSetService"
+											 type="tns:PayPalEcSetService" minOccurs="0" />
+					<xsd:element name="payPalEcOrderSetupService"
+											 type="tns:PayPalEcOrderSetupService" minOccurs="0" />
+					<xsd:element name="payPalAuthorizationService"
+											 type="tns:PayPalAuthorizationService" minOccurs="0" />
+					<xsd:element name="payPalUpdateAgreementService"
+											 type="tns:PayPalUpdateAgreementService" minOccurs="0" />
+					<xsd:element name="payPalCreateAgreementService"
+											 type="tns:PayPalCreateAgreementService" minOccurs="0" />
+					<xsd:element name="payPalDoRefTransactionService"
+											 type="tns:PayPalDoRefTransactionService" minOccurs="0" />
+					<xsd:element name="chinaPaymentService"
+											 type="tns:ChinaPaymentService" minOccurs="0" />
+					<xsd:element name="chinaRefundService"
+											 type="tns:ChinaRefundService" minOccurs="0" />
+					<xsd:element name="boletoPaymentService"
+											 type="tns:BoletoPaymentService" minOccurs="0" />
+					<xsd:element name="apPaymentType" type="xsd:string"
+											 minOccurs="0"/>
+					<xsd:element name="apInitiateService"
+											 type="tns:APInitiateService" minOccurs="0" />
+					<xsd:element name="apCheckStatusService"
+											 type="tns:APCheckStatusService" minOccurs="0" />
+					<xsd:element name="ignoreCardExpiration" type="tns:boolean"
+											 minOccurs="0" />
+					<xsd:element name="reportGroup" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="processorID" type="xsd:string"
+											 minOccurs="0" />
+					<xsd:element name="thirdPartyCertificationNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionLocalDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="solutionProviderTransactionID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="surchargeAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="surchargeSign" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="pinDataEncryptedPIN" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="pinDataKeySerialNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cashbackAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="pinDebitPurchaseService" type="tns:PinDebitPurchaseService" minOccurs="0"/>
+					<xsd:element name="pinDebitCreditService" type="tns:PinDebitCreditService" minOccurs="0"/>
+					<xsd:element name="pinDebitReversalService" type="tns:PinDebitReversalService" minOccurs="0"/>
+					<xsd:element name="ap" type="tns:AP" minOccurs="0" />
+					<xsd:element name="apAuthService" type="tns:APAuthService" minOccurs="0" />
+					<xsd:element name="apAuthReversalService" type="tns:APAuthReversalService" minOccurs="0" />
+					<xsd:element name="apCaptureService" type="tns:APCaptureService" minOccurs="0" />
+					<xsd:element name="apRefundService" type="tns:APRefundService" minOccurs="0" />
+					<xsd:element name="apCheckoutDetailsService" type="tns:APCheckOutDetailsService" minOccurs="0" />
+					<xsd:element name="apTransactionDetailsService" type="tns:APTransactionDetailsService" minOccurs="0" />
+					<xsd:element name="apConfirmPurchaseService" type="tns:APConfirmPurchaseService" minOccurs="0" />
+					<xsd:element name="payPalGetTxnDetailsService" type="tns:PayPalGetTxnDetailsService" minOccurs="0" />
+					<xsd:element name="payPalTransactionSearchService" type="tns:PayPalTransactionSearchService" minOccurs="0" />
+					<xsd:element name="ccDCCUpdateService" type="tns:CCDCCUpdateService" minOccurs="0"/>
+					<xsd:element name="emvRequest" type="tns:EmvRequest" minOccurs="0" />
+					<xsd:element name="merchantTransactionIdentifier" type="xsd:string" minOccurs="0" />
+					<xsd:element name="hostedDataCreateService" type="tns:HostedDataCreateService" minOccurs="0"/>
+					<xsd:element name="hostedDataRetrieveService" type="tns:HostedDataRetrieveService" minOccurs="0"/>
+					<xsd:element name="merchantCategoryCode" type="xsd:string" minOccurs="0" />
+				<xsd:element name="salesSlipNumber" type="xsd:string" minOccurs="0" />
+				<xsd:element name="merchandiseCode" type="xsd:string" minOccurs="0" />
+				<xsd:element name="paymentInitiationChannel" type="xsd:string" minOccurs="0" />
+				<xsd:element name="extendedCreditTotalCount" type="xsd:string" minOccurs="0" />
+				<xsd:element name="authIndicator" type="xsd:string" minOccurs="0"/>
+				<xsd:element name="paymentNetworkToken" type="tns:PaymentNetworkToken" minOccurs="0"/>
+				<xsd:element name="recipient" type="tns:Recipient" minOccurs="0"/>
+				<xsd:element name="sender" type="tns:Sender" minOccurs="0"/>
+				<xsd:element name="autoRentalData" type="tns:AutoRentalData" minOccurs="0" />
+					<xsd:element name="paymentSolution" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vc" type="tns:VC" minOccurs="0" />
+					<xsd:element name="decryptVisaCheckoutDataService" type="tns:DecryptVisaCheckoutDataService" minOccurs="0" />
+				<xsd:element name="taxManagementIndicator" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="promotionGroup" type="tns:PromotionGroup" minOccurs="0" maxOccurs="100"/>
+				<xsd:element name="wallet" type="tns:Wallet" minOccurs="0" />
+				<xsd:element name="aft" type="tns:Aft" minOccurs="0" />
+				<xsd:element name="balanceInquiry" type="tns:boolean" minOccurs="0" />
+				<xsd:element name="prenoteTransaction" type="tns:boolean" minOccurs="0"/>
+                <xsd:element name="encryptPaymentDataService" type="tns:EncryptPaymentDataService" minOccurs="0"/>
+				<xsd:element name="nationalNetDomesticData" type="xsd:string" minOccurs="0"/>
+				<xsd:element name="subsequentAuth" type="xsd:string" minOccurs="0"/> 
+				<xsd:element name="binLookupService" type="tns:BinLookupService" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<!-- added for Visa Checkout -->
+	<xsd:complexType name="VC">
+			<xsd:sequence>
+					<xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecryptVisaCheckoutDataService">
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="DCC">
+			<xsd:sequence>
+					<xsd:element name="dccIndicator" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>           
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="Promotion">
+			<xsd:sequence>
+					<xsd:element name="discountedAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="code" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="receiptData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="discountApplied" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+   <xsd:complexType name="PromotionGroup">
+        <xsd:sequence>
+            <xsd:element name="subtotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="taxRate" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="PromotionGroupReply">
+        <xsd:sequence>
+            <xsd:element name="discountApplied" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+	
+	<xsd:complexType name="CCAuthReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cvCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="personalIDCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+					<!-- dateTime -->
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bmlAccountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authFactorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fundingTotals" type="tns:FundingTotals" minOccurs="0"/>
+					<xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fxQuoteRate" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="fxQuoteType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fxQuoteExpirationDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="authRecord" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantAdviceCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantAdviceCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavvResponseCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavvResponseCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authenticationXID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorCardType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalance" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="referralResponseNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="subResponseCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="approvedAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="creditLine" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="approvedTerms" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardCategory" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="affluenceIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evEmail" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evPhoneNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evPostalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evStreet" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evEmailRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evPhoneNumberRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evPostalCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evNameRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evStreetRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="posData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardIssuerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardRegulated" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardCommercial" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardPrepaid" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardPayroll" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardHealthcare" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardSignatureDebit" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardPINlessDebit" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardLevel3Eligible" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerReasonCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerReasonDescription" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerPassThroughData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerCVNResponseCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerAVSResponseCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerAcquirerBankCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="OCTReply">
+		<xsd:sequence>
+			<xsd:element name="reasonCode" type="xsd:integer"/>
+			<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+			<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="approvalCode" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="CCSaleReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cvCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavvResponseCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavvResponseCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardCategory" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalance" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	
+	<xsd:complexType name="CCSaleCreditReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+                    <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="CCSaleReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+ <xsd:complexType name="CCIncrementalAuthReply">
+    <xsd:sequence>
+      <xsd:element name="reasonCode" type="xsd:integer"/>
+      <xsd:element name="amount" type="tns:amount" minOccurs="0" />
+      <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0" />
+      <xsd:element name="processorResponse" type="xsd:string" minOccurs="0" />
+      <xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0" />
+      <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0" />
+      <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0" />
+      <xsd:element name="cardCategory" type="xsd:string" minOccurs="0" />
+    </xsd:sequence>
+  </xsd:complexType>
+  
+	<xsd:complexType name="CCCaptureReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fundingTotals" type="tns:FundingTotals" minOccurs="0"/>
+					<xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fxQuoteRate" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="fxQuoteType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fxQuoteExpirationDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="purchasingLevel3Enabled" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	 <xsd:complexType name="ServiceFeeCalculateReply">
+	 <xsd:sequence>
+			<xsd:element name="reasonCode" type="xsd:integer" /> 
+			<xsd:element name="amount" type="tns:amount" minOccurs="0" />
+			<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0" />
+	 </xsd:sequence>
+	 </xsd:complexType>
+	<xsd:complexType name="CCCreditReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="purchasingLevel3Enabled" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinDebitPurchaseReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="networkCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalance" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinDebitCreditReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="networkCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinDebitReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CCAuthReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CCAutoAuthReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="result" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ECDebitReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="verificationLevel" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verificationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verificationCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correctedAccountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correctedRoutingNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ECCreditReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verificationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verificationCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correctedAccountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correctedRoutingNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ECAuthenticateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkpointSummary" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fraudShieldIndicators" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayerAuthEnrollReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="acsURL" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="eci" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paReq" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="proxyPAN" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="proofXML" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ucafCollectionIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authenticationPath" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayerAuthValidateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="authenticationResult" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="authenticationStatusMessage" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cavvAlgorithm" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="eci" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ucafAuthenticationData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ucafCollectionIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TaxReplyItem">
+			<xsd:sequence>
+					<xsd:element name="cityTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="countyTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="districtTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="stateTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="totalTaxAmount" type="tns:amount"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="TaxReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="totalCityTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="city" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalCountyTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="county" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalDistrictTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="totalStateTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="state" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalTaxAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="geocode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="item" type="tns:TaxReplyItem" minOccurs="0" maxOccurs="1000"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DeviceFingerprint">
+			<xsd:sequence>
+					<xsd:element name="cookiesEnabled" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="flashEnabled" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="hash" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="imagesEnabled" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="javascriptEnabled" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="proxyIPAddress" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="proxyIPAddressActivities" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="proxyIPAddressAttributes" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="proxyServerType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trueIPAddress" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trueIPAddressActivities" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trueIPAddressAttributes" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trueIPAddressCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trueIPAddressCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="smartID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="smartIDConfidenceLevel" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="screenResolution" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="browserLanguage" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="agentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="profileDuration" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="profiledURL" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="timeOnPage" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="deviceMatch" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="firstEncounter" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="flashOS" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="flashVersion" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="deviceLatitude" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="deviceLongitude" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="gpsAccuracy" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="jbRoot" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="jbRootReason" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AFSReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="afsResult" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="hostSeverity" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="consumerLocalTime" type="xsd:string" minOccurs="0"/>
+					<!-- xsd:time -->
+					<xsd:element name="afsFactorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="hotlistInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="internetInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="phoneInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="suspiciousInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="velocityInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="identityInfoCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ipCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ipState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ipCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ipRoutingMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ipAnonymizerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="scoreModelUsed" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardBin" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="binCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardAccountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardScheme" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardIssuer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="deviceFingerprint" type="tns:DeviceFingerprint" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DAVReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="addressType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="apartmentInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="barCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="barCodeCheckDigit" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="careOf" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cityInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="countryInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="directionalInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="lvrInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="matchScore" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="standardizedAddress1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedAddress2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedAddress3" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedAddress4" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedAddressNoApt" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedCounty" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedCSP" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedPostalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="standardizedISOCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="stateInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="streetInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="suffixInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="postalCodeInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="overallInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="usInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="caInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="intlInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="usErrorInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="caErrorInfo" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="intlErrorInfo" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DeniedPartiesMatch">
+			<xsd:sequence>
+					<xsd:element name="list" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="name" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+					<xsd:element name="address" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+					<xsd:element name="program" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ExportReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="ipCountryConfidence" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="infoCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FXQuote">
+			<xsd:sequence>
+					<xsd:element name="id" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="rate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="expirationDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fundingCurrency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="receivedDateTime" type="tns:dateTime" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FXRatesReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="quote" type="tns:FXQuote" minOccurs="0" maxOccurs="999"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BankTransferReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="accountHolder" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="bankName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentReference" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankSwiftCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankSpecialID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="branchCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BankTransferRealTimeReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="formMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="formAction" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentReference" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DirectDebitMandateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mandateMaturationDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BankTransferRefundReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DirectDebitReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DirectDebitValidateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bankSwiftCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DirectDebitRefundReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PaySubscriptionCreateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="subscriptionID" type="xsd:string"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PaySubscriptionUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="subscriptionID" type="xsd:string"/>
+					<xsd:element name="subscriptionIDNew" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PaySubscriptionEventUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PaySubscriptionRetrieveReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="approvalRequired" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="automaticRenew" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardAccountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardIssueNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardStartMonth" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardStartYear" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkAccountNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkAccountType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkBankTransitNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkSecCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkAuthenticateID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="city" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="comments" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="companyName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="country" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerAccountID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="email" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantReferenceCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentsRemaining" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="recurringAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="setupAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="state" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="subscriptionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="subscriptionIDNew" type="xsd:string"/>
+					<xsd:element name="title" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalPayments" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToFirstName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToLastName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToStreet1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToStreet2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToPostalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCompany" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billPayment" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantDefinedDataField1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantDefinedDataField2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantDefinedDataField3" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantDefinedDataField4" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantSecureDataField1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantSecureDataField2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantSecureDataField3" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantSecureDataField4" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="companyTaxID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="driversLicenseNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="driversLicenseState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PaySubscriptionDeleteReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="subscriptionID" type="xsd:string"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayPalPaymentReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="secureData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayPalCreditReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="VoidReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinlessDebitReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<!-- dateTime -->
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="receiptNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinlessDebitValidateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<!-- dateTime -->
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PinlessDebitReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- payPal Upgrade Services -->
+	<xsd:complexType name="PayPalButtonCreateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="encryptedFormData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="unencryptedFormData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="buttonType" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayPalPreapprovedPaymentReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="feeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="pendingReason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mpStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="desc" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mpMax" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentGrossAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="settleAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="taxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="exchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentSourceID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PayPalPreapprovedUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mpStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="desc" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mpMax" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentSourceID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- PayPalEcSet -->
+	<xsd:complexType name="PayPalEcSetReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalEcSet -->
+	<!-- PayPalEcGetDetails -->
+	<xsd:complexType name="PayPalEcGetDetailsReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToAddress1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToAddress2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToZip" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerPhone" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="city" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="state" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="countryName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalBillingAgreementAcceptedStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="item" type="tns:Item" minOccurs="0" maxOccurs="1000" />
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalEcGetDetails -->
+	<!-- PayPalEcDoPayment -->
+	<xsd:complexType name="PayPalEcDoPaymentReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="orderId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalEcDoPayment -->
+	<!-- PayPalDoCapture -->
+	<xsd:complexType name="PayPalDoCaptureReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="authorizationId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="parentTransactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentGrossAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalDoCapture -->
+	<!-- PayPalAuthReversal -->
+	<xsd:complexType name="PayPalAuthReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="authorizationId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalAuthReversal -->
+	<!-- PayPalRefund -->
+	<xsd:complexType name="PayPalRefundReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalNetRefundAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeRefundAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalGrossRefundAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalRefund -->
+	<!-- PayPalEcOrderSetup -->
+	<xsd:complexType name="PayPalEcOrderSetupReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalEcOrderSetup -->
+	<!-- PayPalAuthorization-->
+	<xsd:complexType name="PayPalAuthorizationReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="protectionEligibility" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="protectionEligibilityType" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalAuthorization -->
+	<!-- PayPalUpdateAgreement-->
+	<xsd:complexType name="PayPalUpdateAgreementReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalBillingAgreementStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalUpdateAgreement-->
+	<!-- PayPalCreateAgreement-->
+	<xsd:complexType name="PayPalCreateAgreementReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalCreateAgreement-->
+	<!-- PayPalDoRefTransaction-->
+	<xsd:complexType name="PayPalDoRefTransactionReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTransactionType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- end of PayPalDoRefTransaction-->
+	<xsd:complexType name="RiskUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FraudUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CaseManagementActionReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="RuleResultItem">
+			<xsd:sequence>
+					<xsd:element name="name" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="decision" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="evaluation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ruleID" type="xsd:integer" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="RuleResultItems">
+			<xsd:sequence>
+					<xsd:element name="ruleResultItem" type="tns:RuleResultItem" minOccurs="0" maxOccurs="1000"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionReply">
+			<xsd:sequence>
+					<xsd:element name="casePriority" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="activeProfileReply" type="tns:ProfileReply" minOccurs="0"/>
+					<xsd:element name="velocityInfoCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+  <!-- DME -->
+  <xsd:complexType name="AdditionalFields">
+    <xsd:sequence>
+      <xsd:element name="field" type="tns:Field" minOccurs="0" maxOccurs="3000"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Field">
+    <xsd:sequence>
+      <xsd:element name="provider" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="DMEReply">
+    <xsd:sequence>
+      <xsd:element name="eventType" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="eventInfo" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="eventHotlistInfo" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="eventPolicy" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="additionalFields" type="tns:AdditionalFields" minOccurs="0" maxOccurs="1" />
+    </xsd:sequence>
+  </xsd:complexType>
+	<xsd:complexType name="ProfileReply">
+			<xsd:sequence>
+					<xsd:element name="selectedBy" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="name" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="destinationQueue" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="profileScore" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="rulesTriggered" type="tns:RuleResultItems" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CCDCCReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="dccSupported" type="tns:boolean" minOccurs="0"/>
+					<xsd:element name="validHours" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="marginRatePercentage" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CCDCCUpdateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChinaPaymentReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="formData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verifyFailure" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verifyInProcess" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="verifySuccess" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChinaRefundReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BoletoPaymentReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="boletoNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="expirationDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="url" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="APInitiateReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="signature" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="publicKey" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="APCheckStatusReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="reconciliationID" type="xsd:string"/>
+					<xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTradeNo" type="xsd:string"/>
+					<xsd:element name="processorTransactionID" type="xsd:string"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- Vme Reseller Reply-->
+	<xsd:complexType name="APReply">
+			<xsd:sequence>
+					<xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardNumberSuffix" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="purchaseID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="productID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shippingAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="handlingAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="additionalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="taxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalPurchaseAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="discountAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardNumberPrefix" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="riskIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantUUID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="merchantSiteID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- AP Auth Service -->
+	<xsd:complexType name="APAuthReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP Auth Service -->
+	<!-- AP Auth Reversal Service -->
+	<xsd:complexType name="APAuthReversalReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP Auth Reversal Service -->
+	<!-- AP Capture Service -->
+	<xsd:complexType name="APCaptureReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP Capture Service -->
+	<!-- AP Refund Service -->
+	<xsd:complexType name="APRefundReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="returnRef" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP Refund Service -->
+	<!-- AP CheckOutDetailsReply Service -->
+	<xsd:complexType name="APCheckOutDetailsReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP CheckOutDetailsReply Service -->
+	<xsd:complexType name="APTransactionDetailsReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- AP ConfirmPurchase Service -->
+	<xsd:complexType name="APConfirmPurchaseReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="status" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- End of AP ConfirmPurchase Service -->
+	<xsd:complexType name="ReplyMessage">
+			<xsd:sequence>
+					<xsd:element name="merchantReferenceCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="requestID" type="xsd:string"/>
+					<xsd:element name="decision" type="xsd:string"/>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="missingField" type="xsd:string" minOccurs="0" maxOccurs="1000"/>
+					<xsd:element name="invalidField" type="xsd:string" minOccurs="0" maxOccurs="1000"/>
+					<xsd:element name="requestToken" type="xsd:string"/>
+					<xsd:element name="purchaseTotals" type="tns:PurchaseTotals" minOccurs="0"/>
+					<xsd:element name="deniedPartiesMatch" type="tns:DeniedPartiesMatch" minOccurs="0" maxOccurs="100"/>
+					<xsd:element name="ccAuthReply" type="tns:CCAuthReply" minOccurs="0"/>
+					<xsd:element name="octReply" type="tns:OCTReply" minOccurs="0"/>
+					<xsd:element name="ccSaleReply" type="tns:CCSaleReply" minOccurs="0"/>
+					<xsd:element name="ccSaleCreditReply" type="tns:CCSaleCreditReply" minOccurs="0"/>
+					<xsd:element name="ccSaleReversalReply" type="tns:CCSaleReversalReply" minOccurs="0"/>
+					<xsd:element name="ccIncrementalAuthReply" type="tns:CCIncrementalAuthReply" minOccurs="0"/>
+					<xsd:element name="serviceFeeCalculateReply" type="tns:ServiceFeeCalculateReply" minOccurs="0"/>
+					<xsd:element name="ccCaptureReply" type="tns:CCCaptureReply" minOccurs="0"/>
+					<xsd:element name="ccCreditReply" type="tns:CCCreditReply" minOccurs="0"/>
+					<xsd:element name="ccAuthReversalReply" type="tns:CCAuthReversalReply" minOccurs="0"/>
+					<xsd:element name="ccAutoAuthReversalReply" type="tns:CCAutoAuthReversalReply" minOccurs="0"/>
+					<xsd:element name="ccDCCReply" type="tns:CCDCCReply" minOccurs="0"/>
+					<xsd:element name="ccDCCUpdateReply" type="tns:CCDCCUpdateReply" minOccurs="0"/>
+					<xsd:element name="ecDebitReply" type="tns:ECDebitReply" minOccurs="0"/>
+					<xsd:element name="ecCreditReply" type="tns:ECCreditReply" minOccurs="0"/>
+					<xsd:element name="ecAuthenticateReply" type="tns:ECAuthenticateReply" minOccurs="0"/>
+					<xsd:element name="payerAuthEnrollReply" type="tns:PayerAuthEnrollReply" minOccurs="0"/>
+					<xsd:element name="payerAuthValidateReply" type="tns:PayerAuthValidateReply" minOccurs="0"/>
+					<xsd:element name="taxReply" type="tns:TaxReply" minOccurs="0"/>
+                    <xsd:element name="encryptedPayment" type="tns:EncryptedPayment" minOccurs="0" />
+                    <xsd:element name="encryptPaymentDataReply" type="tns:EncryptPaymentDataReply" minOccurs="0"/>
+          <xsd:element name="dmeReply" type="tns:DMEReply" minOccurs="0"/>
+					<xsd:element name="afsReply" type="tns:AFSReply" minOccurs="0"/>
+					<xsd:element name="davReply" type="tns:DAVReply" minOccurs="0"/>
+					<xsd:element name="exportReply" type="tns:ExportReply" minOccurs="0"/>
+					<xsd:element name="fxRatesReply" type="tns:FXRatesReply" minOccurs="0"/>
+					<xsd:element name="bankTransferReply" type="tns:BankTransferReply" minOccurs="0"/>
+					<xsd:element name="bankTransferRefundReply" type="tns:BankTransferRefundReply" minOccurs="0"/>
+					<xsd:element name="bankTransferRealTimeReply" type="tns:BankTransferRealTimeReply" minOccurs="0"/>
+					<xsd:element name="directDebitMandateReply" type="tns:DirectDebitMandateReply" minOccurs="0"/>
+					<xsd:element name="directDebitReply" type="tns:DirectDebitReply" minOccurs="0"/>
+					<xsd:element name="directDebitValidateReply" type="tns:DirectDebitValidateReply" minOccurs="0"/>
+					<xsd:element name="directDebitRefundReply" type="tns:DirectDebitRefundReply" minOccurs="0"/>
+					<xsd:element name="paySubscriptionCreateReply" type="tns:PaySubscriptionCreateReply" minOccurs="0"/>
+					<xsd:element name="paySubscriptionUpdateReply" type="tns:PaySubscriptionUpdateReply" minOccurs="0"/>
+					<xsd:element name="paySubscriptionEventUpdateReply" type="tns:PaySubscriptionEventUpdateReply" minOccurs="0"/>
+					<xsd:element name="paySubscriptionRetrieveReply" type="tns:PaySubscriptionRetrieveReply" minOccurs="0"/>
+					<xsd:element name="paySubscriptionDeleteReply" type="tns:PaySubscriptionDeleteReply" minOccurs="0"/>
+					<xsd:element name="payPalPaymentReply" type="tns:PayPalPaymentReply" minOccurs="0"/>
+					<xsd:element name="payPalCreditReply" type="tns:PayPalCreditReply" minOccurs="0"/>
+					<xsd:element name="voidReply" type="tns:VoidReply" minOccurs="0"/>
+					<xsd:element name="pinlessDebitReply" type="tns:PinlessDebitReply" minOccurs="0"/>
+					<xsd:element name="pinlessDebitValidateReply" type="tns:PinlessDebitValidateReply" minOccurs="0"/>
+					<xsd:element name="pinlessDebitReversalReply" type="tns:PinlessDebitReversalReply" minOccurs="0"/>
+					<xsd:element name="payPalButtonCreateReply" type="tns:PayPalButtonCreateReply" minOccurs="0"/>
+					<xsd:element name="payPalPreapprovedPaymentReply" type="tns:PayPalPreapprovedPaymentReply" minOccurs="0"/>
+					<xsd:element name="payPalPreapprovedUpdateReply" type="tns:PayPalPreapprovedUpdateReply" minOccurs="0"/>
+					<xsd:element name="riskUpdateReply" type="tns:RiskUpdateReply" minOccurs="0"/>
+					<xsd:element name="fraudUpdateReply" type="tns:FraudUpdateReply" minOccurs="0"/>
+					<xsd:element name="caseManagementActionReply" type="tns:CaseManagementActionReply" minOccurs="0"/>
+					<xsd:element name="decisionReply" type="tns:DecisionReply" minOccurs="0"/>
+					<xsd:element name="payPalRefundReply" type="tns:PayPalRefundReply" minOccurs="0"/>
+					<xsd:element name="payPalAuthReversalReply" type="tns:PayPalAuthReversalReply" minOccurs="0"/>
+					<xsd:element name="payPalDoCaptureReply" type="tns:PayPalDoCaptureReply" minOccurs="0"/>
+					<xsd:element name="payPalEcDoPaymentReply" type="tns:PayPalEcDoPaymentReply" minOccurs="0"/>
+					<xsd:element name="payPalEcGetDetailsReply" type="tns:PayPalEcGetDetailsReply" minOccurs="0"/>
+					<xsd:element name="payPalEcSetReply" type="tns:PayPalEcSetReply" minOccurs="0"/>
+					<xsd:element name="payPalAuthorizationReply" type="tns:PayPalAuthorizationReply" minOccurs="0"/>
+					<xsd:element name="payPalEcOrderSetupReply" type="tns:PayPalEcOrderSetupReply" minOccurs="0"/>
+					<xsd:element name="payPalUpdateAgreementReply" type="tns:PayPalUpdateAgreementReply" minOccurs="0"/>
+					<xsd:element name="payPalCreateAgreementReply" type="tns:PayPalCreateAgreementReply" minOccurs="0"/>
+					<xsd:element name="payPalDoRefTransactionReply" type="tns:PayPalDoRefTransactionReply" minOccurs="0"/>
+					<xsd:element name="chinaPaymentReply" type="tns:ChinaPaymentReply" minOccurs="0"/>
+					<xsd:element name="chinaRefundReply" type="tns:ChinaRefundReply" minOccurs="0"/>
+					<xsd:element name="boletoPaymentReply" type="tns:BoletoPaymentReply" minOccurs="0"/>
+					<xsd:element name="pinDebitPurchaseReply" type="tns:PinDebitPurchaseReply" minOccurs="0"/>
+					<xsd:element name="pinDebitCreditReply" type="tns:PinDebitCreditReply" minOccurs="0"/>
+					<xsd:element name="pinDebitReversalReply" type="tns:PinDebitReversalReply" minOccurs="0"/>
+					<xsd:element name="apInitiateReply" type="tns:APInitiateReply" minOccurs="0"/>
+					<xsd:element name="apCheckStatusReply" type="tns:APCheckStatusReply" minOccurs="0"/>
+					<xsd:element name="receiptNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="additionalData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="solutionProviderTransactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="apReply" type="tns:APReply" minOccurs="0"/>
+					<xsd:element name="shipTo" type="tns:ShipTo" minOccurs="0" />
+					<xsd:element name="billTo" type="tns:BillTo" minOccurs="0" />
+					<xsd:element name="apAuthReply" type="tns:APAuthReply" minOccurs="0"/>
+					<xsd:element name="apAuthReversalReply" type="tns:APAuthReversalReply" minOccurs="0"/>
+					<xsd:element name="apCaptureReply" type="tns:APCaptureReply" minOccurs="0"/>
+					<xsd:element name="apRefundReply" type="tns:APRefundReply" minOccurs="0"/>
+					<xsd:element name="apCheckoutDetailsReply" type="tns:APCheckOutDetailsReply" minOccurs="0"/>
+					<xsd:element name="apTransactionDetailsReply" type="tns:APTransactionDetailsReply" minOccurs="0"/>
+					<xsd:element name="apConfirmPurchaseReply" type="tns:APConfirmPurchaseReply" minOccurs="0"/>
+					<xsd:element name="promotion" type="tns:Promotion" minOccurs="0"/>
+					<xsd:element name="promotionGroup" type="tns:PromotionGroupReply" minOccurs="0" maxOccurs="100"/>
+					<xsd:element name="payPalGetTxnDetailsReply" type="tns:PayPalGetTxnDetailsReply" minOccurs="0"/>
+					<xsd:element name="payPalTransactionSearchReply" type="tns:PayPalTransactionSearchReply" minOccurs="0"/>
+					<xsd:element name="emvReply" type="tns:EmvReply" minOccurs="0" />
+					<xsd:element name="originalTransaction" type="tns:OriginalTransaction" minOccurs="0" />
+					<xsd:element name="hostedDataCreateReply" type="tns:HostedDataCreateReply" minOccurs="0" />
+					<xsd:element name="hostedDataRetrieveReply" type="tns:HostedDataRetrieveReply" minOccurs="0" />
+					<xsd:element name="salesSlipNumber" type="xsd:string" minOccurs="0" />
+					<xsd:element name="additionalProcessorResponse" type="xsd:string" minOccurs="0" />
+					<xsd:element name="jpo" type="tns:JPO" minOccurs="0" />            
+					<xsd:element name="card" type="tns:Card" minOccurs="0" />
+					<xsd:element name="paymentNetworkToken" type="tns:PaymentNetworkToken" minOccurs="0"/>
+					<xsd:element name="vcReply" type="tns:VCReply" minOccurs="0" />
+					<xsd:element name="decryptVisaCheckoutDataReply" type="tns:DecryptVisaCheckoutDataReply" minOccurs="0"/>
+					<xsd:element name="binLookupReply" type="tns:BinLookupReply" minOccurs="0"/>
+					<xsd:element name="issuerMessage" type="xsd:string" minOccurs="0" />
+					<xsd:element name="reserved" type="tns:ReplyReserved" minOccurs="0"/>			
+					<!--ReplyReserved should always be the last element in the xsd, new elements should be added before this-->
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="requestMessage" type="tns:RequestMessage">
+			<xsd:unique name="unique-item-id">
+					<xsd:selector xpath="tns:item"/>
+					<xsd:field xpath="@id"/>
+			</xsd:unique>
+	</xsd:element>
+	<xsd:element name="replyMessage" type="tns:ReplyMessage">
+			<xsd:unique name="unique-tax-item-id">
+					<xsd:selector xpath="tns:taxReplyItem"/>
+					<xsd:field xpath="@id"/>
+			</xsd:unique>
+	</xsd:element>
+	<xsd:element name="nvpRequest" type="xsd:string"/>
+	<xsd:element name="nvpReply" type="xsd:string"/>
+	<!-- used in SOAP faults -->
+	<xsd:complexType name="FaultDetails">
+			<xsd:sequence>
+					<xsd:element name="requestID" type="xsd:string"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="faultDetails" type="tns:FaultDetails"/>
+	<xsd:complexType name="AirlineData">
+			<xsd:sequence>
+					<xsd:element name="agentCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="agentName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerPostalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerAddress" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssuerName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="checkDigit" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="restrictedTicketIndicator" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="extendedPaymentCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="carrierName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="passengerName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="documentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="documentNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="documentNumberOfParts" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="invoiceDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="chargeDetails" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="bookingReference" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalFee" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="clearingSequence" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="clearingCount" type="xsd:integer" minOccurs="0"/>
+					<xsd:element name="totalClearingAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="leg" type="tns:Leg" minOccurs="0" maxOccurs="1000"/>
+					<xsd:element name="numberOfPassengers" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="reservationSystem" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="processIdentifier" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="iataNumericCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketIssueDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="electronicTicket" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="originalTicketNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="purchaseType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="creditReasonIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketUpdateIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="planNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="arrivalDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="ticketRestrictionText" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="exchangeTicketAmount" type="tns:amount" minOccurs="0"/>
+					<xsd:element name="exchangeTicketFee" type="tns:amount" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="Leg">
+			<xsd:sequence>
+					<xsd:element name="carrierCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="flightNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="originatingAirportCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="class" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="stopoverCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="departureDate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="destination" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fareBasis" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="departTax" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="conjunctionTicket" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="exchangeTicket" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="couponNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="departureTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="departureTimeSegment" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="arrivalTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="arrivalTimeSegment" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="endorsementsRestrictions" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fare" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fee" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="tax" type="xsd:string" minOccurs="0"/>                    
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="AncillaryData">
+			<xsd:sequence>
+					<xsd:element name="ticketNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="passengerName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="connectedTicketNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="creditReasonIndicator" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="service" type="tns:Service" minOccurs="0" maxOccurs="1000"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="Service">
+			<xsd:sequence>
+					<xsd:element name="categoryCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="subcategoryCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="required"/>
+	</xsd:complexType>
+    <xsd:complexType name="LodgingData">
+        <xsd:sequence>
+            <xsd:element name="checkInDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkOutDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate1" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate2" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate3" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomNights1" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomNights2" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomNights3" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="guestSmokingPreference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="numberOfRoomsBooked" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="numberOfGuests" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomBedType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomTaxElements" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomRateType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="guestName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerServicePhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="corporateClientCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalCoupon" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomLocation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="specialProgramCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="prepaidCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="foodAndBeverageCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="adjustmentAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="phoneCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="restaurantCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomServiceCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="miniBarCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="laundryCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="miscellaneousCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="giftShopCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="movieCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="healthClubCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="valetParkingCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cashDisbursementCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nonRoomCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="businessCenterCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="loungeBarCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="transportationCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="gratuityCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="conferenceRoomCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="audioVisualCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="banquetCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="internetAccessCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="earlyCheckOutCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nonRoomTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="travelAgencyCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="travelAgencyName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>	
+	<xsd:complexType name="Pos">
+			<xsd:sequence>
+					<xsd:element name="entryMode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardPresent" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="terminalCapability" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="trackData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="terminalID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="terminalType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="terminalLocation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionSecurity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="catLevel" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="conditionCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="environment" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="deviceReaderData" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="encryptionAlgorithm" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="encodingMethod" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="deviceID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="serviceCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="terminalIDAlternate" type="xsd:string" minOccurs="0" />
+					<xsd:element name="terminalCompliance" type="xsd:integer" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="EncryptedPayment">
+			<xsd:sequence>
+					<xsd:element name="descriptor" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="data" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="encoding" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="wrappedKey" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="Installment">
+			<xsd:sequence>
+					<xsd:element name="sequence" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalCount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="totalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="planType" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MDDField">
+			<xsd:simpleContent>
+					<xsd:extension base="xsd:string">
+							<xsd:attribute name="id" type="xsd:integer" use="required"/>
+					</xsd:extension>
+			</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="MerchantDefinedData">
+			<xsd:sequence>
+					<xsd:element name="field1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field3" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field4" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field5" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field6" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field7" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field8" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field9" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field10" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field11" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field12" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field13" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field14" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field15" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field16" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field17" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field18" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field19" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field20" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="mddField" type="tns:MDDField" minOccurs="0" maxOccurs="100"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MerchantSecureData">
+			<xsd:sequence>
+					<xsd:element name="field1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field3" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="field4" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReplyReserved">
+			<xsd:sequence>
+					<xsd:any processContents="skip" minOccurs="0" maxOccurs="999"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="RequestReserved">
+			<xsd:sequence>
+					<xsd:element name="name" type="xsd:string"/>
+					<xsd:element name="value" type="xsd:string"/>
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- PayPalGetTxnDetails -->
+	<xsd:complexType name="PayPalGetTxnDetailsReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToAddress1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToAddress2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="shipToZip" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="payerPhone" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="parentTransactionId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentGrossAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalSettleAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="protectionEligibility" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="protectionEligibilityType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalNote" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="item" type="tns:Item" minOccurs="0" maxOccurs="1000" />
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<!-- end of PayPalGetTxnDetails -->
+
+	<!-- PayPalTransactionSearchReply -->
+	<xsd:complexType name="PayPalTransactionSearchReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="transaction" type="tns:PaypalTransaction" minOccurs="0" maxOccurs="999" />
+					<xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="PaypalTransaction">
+			<xsd:sequence>
+					<xsd:element name="transactionTime" type="tns:dateTime" minOccurs="0"/>
+					<xsd:element name="transactionTimeZone" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPayerOrPayeeEmail" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="customerDisplayName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="grandTotalAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paypalNetAmount" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="optional"/>
+	</xsd:complexType>
+	<!-- end of PayPalTransactionSearchReply -->
+
+	 <xsd:complexType name="CCDCCUpdateService">
+			<xsd:sequence>
+					<xsd:element name="reason" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="action" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="dccRequestID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="creditRequestID" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<!-- Merchant Descriptor fields for Service Fee. goes into RequestMessage-->
+	<xsd:complexType name="ServiceFee">
+					<xsd:sequence>
+							<xsd:element name="merchantDescriptor" type="xsd:string" minOccurs="0"/>
+							<xsd:element name="merchantDescriptorContact" type="xsd:string" minOccurs="0"/>
+							<xsd:element name="merchantDescriptorState" type="xsd:string" minOccurs="0"/>    
+					</xsd:sequence>
+			</xsd:complexType>
+	<!-- EMV transaction data request/reply start -->
+	<xsd:complexType name="EmvRequest">
+			<xsd:sequence>
+					<xsd:element name="combinedTags" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardSequenceNumber" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="aidAndDFname" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="fallback" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="EmvReply">
+			<xsd:sequence>
+					<xsd:element name="combinedTags" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="chipValidationResults" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="chipValidationType" type="xsd:string" minOccurs="0"/>					
+			</xsd:sequence>
+	</xsd:complexType>
+	<!-- EMV transaction data request/reply end -->
+	<!-- Auth Reversal time out merchant intitated -->
+	<xsd:complexType name="OriginalTransaction">
+			<xsd:sequence>
+					<xsd:element name="amount" type="tns:amount" minOccurs="0" />
+					<xsd:element name="reasonCode" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="HostedDataCreateService">
+			<xsd:sequence>
+					<xsd:element name="profileID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="HostedDataRetrieveService">
+			<xsd:sequence>
+					<xsd:element name="profileID" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="tokenValue" type="xsd:string" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attribute name="run" type="tns:boolean" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="HostedDataCreateReply">
+			<xsd:sequence>
+					<xsd:element name="responseMessage" type="xsd:string" minOccurs="0" />
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="cardAccountNumberToken" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="HostedDataRetrieveReply">
+			<xsd:sequence>
+					<xsd:element name="responseMessage" type="xsd:string" minOccurs="0" />
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+					<xsd:element name="aggregatorMerchantIdentifier" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customerFirstName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customerLastName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="paymentMethod" type="xsd:string" minOccurs="0" />
+					<xsd:element name="billToStreet1" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToStreet2" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToEmail" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToState" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToFirstName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToLastName" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToCity" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToCountry" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="billToPostalCode" type="xsd:string" minOccurs="0"/>
+					<xsd:element name="cardAccountNumber" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardType" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardIssueNumber" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardStartMonth" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardStartYear" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="AutoRentalData">
+			<xsd:sequence>
+					<xsd:element name="adjustmentCost" type="tns:amount" minOccurs="0" />      
+					<xsd:element name="adjustmentCode" type="xsd:string" minOccurs="0" />
+					<xsd:element name="agreementNumber" type="xsd:string" minOccurs="0" />     
+					<xsd:element name="classCode" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customerServicePhoneNumber" type="xsd:string" minOccurs="0" />     
+					<xsd:element name="dailyRate" type="tns:amount" minOccurs="0" />    
+					<xsd:element name="mileageCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="gasCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="insuranceCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="lateReturnCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="maximumFreeMiles" type="xsd:integer" minOccurs="0" />                  
+					<xsd:element name="milesTraveled" type="xsd:integer" minOccurs="0" />
+					<xsd:element name="oneWayCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="parkingViolationCost" type="tns:amount" minOccurs="0" />
+					<xsd:element name="pickUpCity" type="xsd:string" minOccurs="0" />
+					<xsd:element name="pickUpCountry" type="xsd:string" minOccurs="0" />
+					<xsd:element name="pickUpDate" type="xsd:string" minOccurs="0" />
+					<xsd:element name="pickUpState" type="xsd:string" minOccurs="0" />
+					<xsd:element name="pickUpTime" type="xsd:integer" minOccurs="0" />
+					<xsd:element name="ratePerMile" type="tns:amount" minOccurs="0" />
+					<xsd:element name="renterName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnCity" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnCountry" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnDate" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnLocationID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnState" type="xsd:string" minOccurs="0" />
+					<xsd:element name="returnTime" type="xsd:integer" minOccurs="0" />
+					<xsd:element name="specialProgramCode" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="VCReply">
+			<xsd:sequence>
+					<xsd:element name="creationTimeStamp" type="xsd:string" minOccurs="0" />
+					<xsd:element name="alternateShippingAddressCountryCode" type="xsd:string" minOccurs="0" />
+					<xsd:element name="alternateShippingAddressPostalCode" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountLoginName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountFirstName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountLastName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountEncryptedID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountEmail" type="xsd:string" minOccurs="0" />
+					<xsd:element name="vcAccountMobilePhoneNumber" type="xsd:string" minOccurs="0" />
+					<xsd:element name="merchantReferenceID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="taxAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="discountAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="uncategorizedAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="totalPurchaseAmount" type="xsd:string" minOccurs="0" />
+					<xsd:element name="walletReferenceID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="promotionCode" type="xsd:string" minOccurs="0" />
+					<xsd:element name="paymentInstrumentID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardVerificationStatus" type="xsd:string" minOccurs="0" />
+					<xsd:element name="issuerID" type="xsd:string" minOccurs="0" />
+					<xsd:element name="paymentInstrumentNickName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="nameOnCard" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardType" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardGroup" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardArt" type="tns:VCCardArt" minOccurs="0" />
+					<xsd:element name="riskAdvice" type="xsd:string" minOccurs="0" />
+					<xsd:element name="riskScore" type="xsd:string" minOccurs="0" />
+					<xsd:element name="riskAdditionalData" type="xsd:string" minOccurs="0" />
+					<xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cvnCodeRaw" type="xsd:string" minOccurs="0" />
+					<xsd:element name="eciRaw" type="xsd:string" minOccurs="0" />
+					<xsd:element name="eci" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cavv" type="xsd:string" minOccurs="0" />
+					<xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0" />
+					<xsd:element name="veresTimeStamp" type="xsd:string" minOccurs="0" />
+					<xsd:element name="paresStatus" type="xsd:string" minOccurs="0" />
+					<xsd:element name="paresTimeStamp" type="xsd:string" minOccurs="0" />
+					<xsd:element name="xid" type="xsd:string" minOccurs="0" />
+					<xsd:element name="customData" type="tns:VCCustomData" minOccurs="0" />
+			</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="VCCardArt">
+			<xsd:sequence>
+					<xsd:element name="fileName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="height" type="xsd:string" minOccurs="0" />
+					<xsd:element name="width" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="optional"/>
+	</xsd:complexType>
+	
+	<xsd:complexType name="VCCustomData">
+			<xsd:sequence>
+					<xsd:element name="name" type="xsd:string" minOccurs="0" />
+					<xsd:element name="value" type="xsd:string" minOccurs="0" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:integer" use="optional"/>
+	</xsd:complexType>
+	
+	<xsd:complexType name="DecryptVisaCheckoutDataReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>
+			</xsd:sequence>
+	</xsd:complexType>	
+    <xsd:complexType name="EncryptPaymentDataReply">
+            <xsd:sequence>
+                    <xsd:element name="reasonCode" type="xsd:integer"/>
+                    <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BinLookupService">
+            <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BinLookupReply">
+			<xsd:sequence>
+					<xsd:element name="reasonCode" type="xsd:integer"/>	
+					<xsd:element name="cardType" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardGroup" type="xsd:string" minOccurs="0" />
+					<xsd:element name="issuerName" type="xsd:string" minOccurs="0" />
+					<xsd:element name="issuerCountry" type="xsd:string" minOccurs="0" />
+					<xsd:element name="issuedCurrency" type="xsd:string" minOccurs="0" />
+					<xsd:element name="level2Eligibility" type="xsd:string" minOccurs="0" />
+					<xsd:element name="level3Eligibility" type="xsd:string" minOccurs="0" />
+					<xsd:element name="cardCategory" type="xsd:string" minOccurs="0" />
+					<xsd:element name="crossBorderIndicator" type="xsd:string" minOccurs="0" />
+					<xsd:element name="issuerPhoneNumber" type="xsd:string" minOccurs="0" />
+					<xsd:element name="billingCurrency" type="xsd:string" minOccurs="0" />
+					<xsd:element name="billingCurrencyMinorDigits" type="xsd:string" minOccurs="0" />
+					<xsd:element name="fastFundsIndicator" type="xsd:string" minOccurs="0" />
+					<xsd:element name="octBlockIndicator" type="xsd:string" minOccurs="0" />
+					<xsd:element name="onlineGamblingBlockIndicator" type="xsd:string" minOccurs="0" />
+					<xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+			</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>
+

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'nokogiri'
 
 class CyberSourceTest < Test::Unit::TestCase
   include CommStub
@@ -354,11 +355,6 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_for_visa
-    @gateway.expects(:ssl_post).with do |host, request_body|
-      assert_match %r'<ccAuthService run=\"true\">\n  <cavv>111111111100cryptogram</cavv>\n  <commerceIndicator>vbv</commerceIndicator>\n  <xid>111111111100cryptogram</xid>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
-      true
-    end.returns(successful_purchase_response)
-
     credit_card = network_tokenization_credit_card('4111111111111111',
       :brand              => 'visa',
       :transaction_id     => "123",
@@ -366,12 +362,37 @@ class CyberSourceTest < Test::Unit::TestCase
       :payment_cryptogram => "111111111100cryptogram"
     )
 
-    assert response = @gateway.authorize(@amount, credit_card, @options)
+    response = stub_comms do
+      @gateway.authorize(@amount, credit_card, @options)
+    end.check_request do |_endpoint, body, _headers|
+      assert_xml_valid_to_xsd(body)
+      assert_match %r'<ccAuthService run=\"true\">\n  <cavv>111111111100cryptogram</cavv>\n  <commerceIndicator>vbv</commerceIndicator>\n  <xid>111111111100cryptogram</xid>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', body
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_network_tokenization_for_visa
+    credit_card = network_tokenization_credit_card('4111111111111111',
+      :brand              => 'visa',
+      :transaction_id     => "123",
+      :eci                => "05",
+      :payment_cryptogram => "111111111100cryptogram"
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_endpoint, body, _headers|
+      assert_xml_valid_to_xsd(body)
+      assert_match %r'<ccAuthService run="true">.+?<ccCaptureService run="true"/>'m, body
+    end.respond_with(successful_purchase_response)
+
     assert_success response
   end
 
   def test_successful_auth_with_network_tokenization_for_mastercard
     @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_xml_valid_to_xsd(request_body)
       assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
       true
     end.returns(successful_purchase_response)
@@ -389,6 +410,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_auth_with_network_tokenization_for_amex
     @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_xml_valid_to_xsd(request_body)
       assert_match %r'<ccAuthService run=\"true\">\n  <cavv>MTExMTExMTExMTAwY3J5cHRvZ3I=\n</cavv>\n  <commerceIndicator>aesk</commerceIndicator>\n  <xid>YW0=\n</xid>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
       true
     end.returns(successful_purchase_response)
@@ -668,5 +690,14 @@ class CyberSourceTest < Test::Unit::TestCase
 <soap:Header>
 <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690"><wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26"><c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode><c:requestID>2004333231260008401927</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>123456</c:authorizationCode><c:avsCode>Y</c:avsCode><c:avsCodeRaw>Y</c:avsCodeRaw><c:cvCode>M</c:cvCode><c:cvCodeRaw>M</c:cvCodeRaw><c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime><c:processorResponse>00</c:processorResponse><c:authFactorCode>U</c:authFactorCode><p></c:ccAuthReply></c:replyMessage></soap:Body></soap:Envelope>
     XML
+  end
+
+  def assert_xml_valid_to_xsd(data, root_element = '//s:Body/*')
+    schema_file = File.open("#{File.dirname(__FILE__)}/../../schema/cyber_source/CyberSourceTransaction_#{CyberSourceGateway::XSD_VERSION}.xsd")
+    doc = Nokogiri::XML(data)
+    root = Nokogiri::XML(doc.xpath(root_element).to_s)
+    xsd = Nokogiri::XML::Schema(schema_file)
+    errors = xsd.validate(root)
+    assert_empty errors, "XSD validation errors in the following XML:\n#{root}"
   end
 end


### PR DESCRIPTION
The CyberSource Simple (heh) Order API has some strict element ordering
requirements around auths, captures and network tokenization fields.
This adds a schema validator to ensure that we're always compliant.

As per an email exchange we had with CyberSource support, the
`paymentNetworkToken` element must always come after the
`ccCaptureService` element. This was not the case for us for purchase
transactions, as we set it in the `add_auth_service` method, which means
it was sandwiched between `ccAuthService` and `ccCaptureService`.

This also cleans up a few other XSD validation violations, none of which
should be significant--just some empty tags here and there.

Also, I renamed `add_network_tokenization` to
`add_auth_network_tokenization`, since that's actually what it was
doing--it was only used for authorization transactions (as it was
responsible to for adding the `ccAuthService` commands to the request).

Originally by @bdewater in https://github.com/activemerchant/active_merchant/pull/2481