### PR TITLE
Barclaycard Smartpay: Support 0- and 3-exponent currencies

### DIFF
--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -6,6 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['AL', 'AD', 'AM', 'AT', 'AZ', 'BY', 'BE', 'BA', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'GE', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'KZ', 'LV', 'LI', 'LT', 'LU', 'MK', 'MT', 'MD', 'MC', 'ME', 'NL', 'NO', 'PL', 'PT', 'RO', 'RU', 'SM', 'RS', 'SK', 'SI', 'ES', 'SE', 'CH', 'TR', 'UA', 'GB', 'VA']
       self.default_currency = 'EUR'
+      self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.money_format = :cents
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :dankort, :maestro]
 
@@ -238,9 +239,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def amount_hash(money, currency)
+        currency = currency || currency(money)
         hash = {}
-        hash[:currency] = currency || currency(money)
-        hash[:value]    = amount(money) if money
+        hash[:currency] = currency
+        hash[:value]    = localized_amount(money, currency) if money
         hash
       end
 

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -166,6 +166,22 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal 'N', response.avs_result['code']
   end
 
+  def test_nonfractional_currency
+    response = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'JPY'))
+    assert_success response
+
+    response = @gateway.purchase(1234, @credit_card, @options.merge(:currency => 'JPY'))
+    assert_success response
+  end
+
+  def test_three_decimal_currency
+    response = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'OMR'))
+    assert_success response
+
+    response = @gateway.purchase(1234, @credit_card, @options.merge(:currency => 'OMR'))
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Unit:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed