### PR TITLE
NMI: Add first and lastname to echeck transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -146,6 +146,8 @@ module ActiveMerchant #:nodoc:
           post[:token_cryptogram] = payment_method.payment_cryptogram
         elsif(card_brand(payment_method) == 'check')
           post[:payment] = 'check'
+          post[:firstname] = payment_method.first_name
+          post[:lastname] = payment_method.last_name
           post[:checkname] = payment_method.name
           post[:checkaba] = payment_method.routing_number
           post[:checkaccount] = payment_method.account_number

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -70,6 +70,8 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/type=sale/, data)
       assert_match(/amount=1.00/, data)
       assert_match(/payment=check/, data)
+      assert_match(/firstname=#{@check.first_name}/, data)
+      assert_match(/lastname=#{@check.last_name}/, data)
       assert_match(/checkname=#{@check.name}/, CGI.unescape(data))
       assert_match(/checkaba=#{@check.routing_number}/, data)
       assert_match(/checkaccount=#{@check.account_number}/, data)


### PR DESCRIPTION
Unit:
```
27 tests, 194 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Remote:
```
33 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```