### PR TITLE
WorldPay: Support three-decimal currencies

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -9,6 +9,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(HK GB AU AD BE CH CY CZ DE DK ES FI FR GI GR HU IE IL IT LI LU MC MT NL NO NZ PL PT SE SG SI SM TR UM VA)
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :laser, :switch]
       self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
+      self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.homepage_url = 'http://www.worldpay.com/'
       self.display_name = 'Worldpay Global'
 
@@ -194,7 +195,7 @@ module ActiveMerchant #:nodoc:
         amount_hash = {
           :value => localized_amount(money, currency),
           'currencyCode' => currency,
-          'exponent' => non_fractional_currency?(currency) ? 0 : 2
+          'exponent' => currency_exponent(currency)
         }
 
         if options[:debit_credit_indicator]
@@ -368,6 +369,12 @@ module ActiveMerchant #:nodoc:
       def encoded_credentials
         credentials = "#{@options[:login]}:#{@options[:password]}"
         "Basic #{[credentials].pack('m').strip}"
+      end
+
+      def currency_exponent(currency)
+        return 0 if non_fractional_currency?(currency)
+        return 3 if three_decimal_currency?(currency)
+        return 2
       end
     end
   end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -123,6 +123,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal "0", result.params['amount_exponent']
   end
 
+  def test_authorize_three_decimal_currency
+    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'OMR')))
+    assert_equal "OMR", result.params['amount_currency_code']
+    assert_equal "1234", result.params['amount_value']
+    assert_equal "3", result.params['amount_exponent']
+  end
+
   def test_reference_transaction
     assert_success(original = @gateway.authorize(100, @credit_card, @options))
     assert_success(@gateway.authorize(200, original.authorization, :order_id => generate_unique_id))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -223,6 +223,14 @@ class WorldpayTest < Test::Unit::TestCase
           {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
         data
     end.respond_with(successful_authorize_response)
+
+    stub_comms do
+      @gateway.authorize(10000, @credit_card, @options.merge(currency: :OMR))
+    end.check_request do |endpoint, data, headers|
+      assert_tag_with_attributes 'amount',
+          {'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR'},
+        data
+    end.respond_with(successful_authorize_response)
   end
 
   def test_address_handling


### PR DESCRIPTION
Unit:
36 tests, 205 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed