### PR TITLE
Worldpay: Support Credit on CFT-enabled merchant IDs

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1223,8 +1223,12 @@ world_net:
   secret: 'sandboxEUR'
 
 world_pay_gateway:
-  login: LOGIN
-  password: PASSWORD
+  login: 'SPREEDLY'
+  password: 'KZ#P2aR+'
+
+world_pay_gateway_cft:
+  login: 'SPREEDLYCFT'
+  password: 'Xbf+6#pD'
 
 worldpay_online_payments:
   client_key: "T_C_b9f629e7-cea7-4edb-8206-24bbe351d699"

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -164,6 +164,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<paymentDetails action="REFUND">/, data)
+    end.respond_with(successful_credit_response)
+    assert_success response
+    assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
+  end
+
   def test_description
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -702,6 +712,23 @@ class WorldpayTest < Test::Unit::TestCase
         </reply>
       </paymentService>
     REQUEST
+  end
+
+  def successful_credit_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLYCFT">
+        <reply>
+          <ok>
+            <refundReceived orderCode="3d4187536044bd39ad6a289c4339c41c">
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+            </refundReceived>
+          </ok>
+        </reply>
+      </paymentService>
+    RESPONSE
   end
 
   def sample_authorization_request


### PR DESCRIPTION
Worldpay only supports Credits (aka Payouts) by sending a transaction
with the same structure as an Authorization, but with its action flagged
as REFUND and a Merchant ID (login credential) that has been flagged by
Worldpay to treat these transactions as a Credit (they call it a Credit
Fund Transfer or CFT). Purchases, normal Refunds, and other transactions
should only be performed with the separate Merchant ID flagged as eCom.

Unit:
37 tests, 205 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed