### PR TITLE
Update Vantiv eCommerce URLs

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       SCHEMA_VERSION = '9.4'
 
       self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
-      self.live_url = 'https://payments.litle.com/vap/communicator/online'
+      self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RemoteLitleCertification < Test::Unit::TestCase
   def setup
     Base.mode = :test
-    @gateway = LitleGateway.new(fixtures(:litle).merge(:url => "https://cert.litle.com/vap/communicator/online"))
+    @gateway = LitleGateway.new(fixtures(:litle).merge(:url => 'https://payments.vantivprelive.com/vap/communicator/online'))
   end
 
   def test1


### PR DESCRIPTION
Vantiv eCommerce is updating URLs to reflect new domain names, updating the prod and cert URLs to be current.