### PR TITLE
PayFlow: Add optional email field

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -152,6 +152,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'FreightAmt', options[:freightamt] unless options[:freightamt].blank?
               xml.tag! 'DutyAmt', options[:dutyamt] unless options[:dutyamt].blank?
               xml.tag! 'DiscountAmt', options[:discountamt] unless options[:discountamt].blank?
+              xml.tag! 'EMail', options[:email] unless options[:email].nil?
 
               billing_address = options[:billing_address] || options[:address]
               add_address(xml, 'BillTo', billing_address, options) if billing_address

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -651,9 +651,9 @@ payex:
 
 # Working credentials, no need to replace
 payflow:
-  login: spreedly
-  password: 'ibB4Z8=d;G'
-  partner: PayPal
+  login: 'spreedlyIntegrations'
+  password: 'y9q)(j7H'
+  partner: 'PayPal'
 
 payflow_uk:
   login: LOGIN


### PR DESCRIPTION
Payflow includes an optional email field outside of the address block.
This allows the email address to still be sent with authorize and
purchase transactions even if a billing address isn't included.

---

I should note that the test account wasn't setup for recurring transactions so a couple of the remote tests fail with a recurring billing failure. However, here are the relevant remote tests:

```
/Users/david/dev/active_merchant payflow-email ✔
➜ ruby -Itest test/remote/gateways/remote_payflow_test.rb -n test_successful_purchase
Loaded suite test/remote/gateways/remote_payflow_test
Started
.

Finished in 1.605358 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.62 tests/s, 3.74 assertions/s

/Users/david/dev/active_merchant payflow-email ✔
➜ ruby -Itest test/remote/gateways/remote_payflow_test.rb -n test_successful_authorization
Loaded suite test/remote/gateways/remote_payflow_test
Started
.

Finished in 1.873113 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.53 tests/s, 2.67 assertions/s

/Users/david/dev/active_merchant payflow-email ✔
➜ ruby -Itest test/remote/gateways/remote_payflow_test.rb -n test_authorize_and_capture
Loaded suite test/remote/gateways/remote_payflow_test
Started
.

Finished in 2.558284 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.39 tests/s, 2.35 assertions/s
```