### PR TITLE
FirstPay: Add processor_id field

### DIFF
--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -67,6 +67,7 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         post[:owner_email] = options[:email] if options[:email]
         post[:remote_ip_address] = options[:ip] if options[:ip]
+        post[:processor_id] = options[:processor_id] if options[:processor_id]
       end
 
       def add_address(post, creditcard, options)


### PR DESCRIPTION
For context- this field is used to identify the processor to run the
transaction under. I should also note the lack of remote tests since
this field is on a per merchant account basis so unfortunately there
isn't really any test data to exercise a specific response.

Remote test suite run-
```
➜ ruby -Itest test/remote/gateways/remote_first_pay_test.rb
Loaded suite test/remote/gateways/remote_first_pay_test
Started
...........

Finished in 11.311564 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
11 tests, 25 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.97 tests/s, 2.21 assertions/s
```