### PR TITLE
GlobalTransport: Support partial authorizations

### DIFF
--- a/lib/active_merchant/billing/gateways/global_transport.rb
+++ b/lib/active_merchant/billing/gateways/global_transport.rb
@@ -109,6 +109,10 @@ module ActiveMerchant #:nodoc:
           response[node.name.downcase.to_sym] = node.text
         end
 
+        ext_data = Nokogiri::HTML.parse(response[:extdata])
+        response[:approved_amount] = ext_data.xpath("//approvedamount").text
+        response[:balance_due] = ext_data.xpath("//balancedue").text
+
         response
       end
 
@@ -140,7 +144,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response)
-        (response[:result] == "0")
+        response[:result] == "0" || response[:result] == "200"
       end
 
       def message_from(response)

--- a/test/remote/gateways/remote_global_transport_test.rb
+++ b/test/remote/gateways/remote_global_transport_test.rb
@@ -19,6 +19,13 @@ class RemoteGlobalTransportTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_partial_purchase
+    @credit_card = credit_card('4111111111111111')
+    response = @gateway.purchase(2354, @credit_card, @options)
+    assert_success response
+    assert_equal 'Partial Approval', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(2304, @credit_card, @options)
     assert_failure response
@@ -40,11 +47,13 @@ class RemoteGlobalTransportTest < Test::Unit::TestCase
     assert_equal "Declined", response.message
   end
 
-  def test_partial_capture
-    auth = @gateway.authorize(500, @credit_card, @options)
+  def test_successful_partial_authorize_and_capture
+    @credit_card = credit_card('4111111111111111')
+    auth = @gateway.authorize(2354, @credit_card, @options)
     assert_success auth
+    assert_equal "Partial Approval", auth.message
 
-    assert capture = @gateway.capture(499, auth.authorization)
+    assert capture = @gateway.capture(2000, auth.authorization)
     assert_success capture
   end
 


### PR DESCRIPTION
This adds support for partial authorizations when using a pre-paid credit
card. Additional, this exposes `ApprovedAmount` and `BalanceDue` in order to
provide more information when using a pre-paid credit card.

```
ruby -Itest test/unit/gateways/global_transport_test.rb
Loaded suite test/unit/gateways/global_transport_test
Started
..............

Finished in 0.340767 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
41.08 tests/s, 205.42 assertions/s
```

```
ruby -Itest test/remote/gateways/remote_global_transport_test.rb
Loaded suite test/remote/gateways/remote_global_transport_test
Started
...............

Finished in 10.131058 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
1.48 tests/s, 4.44 assertions/s
```