### PR TITLE
Orbital: Add support for level 2 data

### DIFF
--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -22,6 +22,22 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       :diners => "36438999960016",
       :jcb => "3566002020140006"}
 
+    @level_2_options = {
+      tax_indicator: 1,
+      tax: 10,
+      advice_addendum_1: 'taa1 - test',
+      advice_addendum_2: 'taa2 - test',
+      advice_addendum_3: 'taa3 - test',
+      advice_addendum_4: 'taa4 - test',
+      purchase_order: '123abc',
+      name: address[:name],
+      address1: address[:address1],
+      address2: address[:address2],
+      city: address[:city],
+      state: address[:state],
+      zip: address[:zip],
+    }
+
     @test_suite = [
       {:card => :visa, :AVSzip => 11111, :CVD =>	111,  :amount => 3000},
       {:card => :visa, :AVSzip => 33333, :CVD =>	nil,  :amount => 3801},
@@ -54,6 +70,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_level_2_data
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   # Amounts of x.01 will fail
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(101, @declined_card, @options)
@@ -68,6 +91,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
     assert auth.authorization
     assert capture = @gateway.capture(amount, auth.authorization, :order_id => '2')
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_level_2_data
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+    assert_success auth
+    assert_equal "Approved", auth.message
+
+    capture = @gateway.capture(@amount, auth.authorization, @options.merge(level_2_data: @level_2_options))
     assert_success capture
   end
 
@@ -86,6 +118,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
     assert refund = @gateway.refund(amount, response.authorization, @options)
+    assert_success refund
+  end
+
+  def test_successful_refund_with_level_2_data
+    amount = @amount
+    assert response = @gateway.purchase(amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+    assert_success response
+    assert response.authorization
+    assert refund = @gateway.refund(amount, response.authorization, @options.merge(level_2_data: @level_2_options))
     assert_success refund
   end
 

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -14,6 +14,22 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     )
     @customer_ref_num = "ABC"
 
+    @level_2 = {
+      tax_indicator: 1,
+      tax: 10,
+      advice_addendum_1: 'taa1 - test',
+      advice_addendum_2: 'taa2 - test',
+      advice_addendum_3: 'taa3 - test',
+      advice_addendum_4: 'taa4 - test',
+      purchase_order: '123abc',
+      name: address[:name],
+      address1: address[:address1],
+      address2: address[:address2],
+      city: address[:city],
+      state: address[:state],
+      zip: address[:zip],
+    }
+
     @options = { :order_id => '1'}
   end
 
@@ -24,6 +40,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
     assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+  end
+
+  def test_level_2_data
+    stub_comms do
+      @gateway.purchase(50, credit_card, @options.merge(level_2_data: @level_2))
+    end.check_request do |endpoint, data, headers|
+      assert_match %{<TaxInd>#{@level_2[:tax_indicator]}</TaxInd>}, data
+      assert_match %{<Tax>#{@level_2[:tax]}</Tax>}, data
+      assert_match %{<AMEXTranAdvAddn1>#{@level_2[:advice_addendum_1]}</AMEXTranAdvAddn1>}, data
+      assert_match %{<AMEXTranAdvAddn2>#{@level_2[:advice_addendum_2]}</AMEXTranAdvAddn2>}, data
+      assert_match %{<AMEXTranAdvAddn3>#{@level_2[:advice_addendum_3]}</AMEXTranAdvAddn3>}, data
+      assert_match %{<AMEXTranAdvAddn4>#{@level_2[:advice_addendum_4]}</AMEXTranAdvAddn4>}, data
+      assert_match %{<PCOrderNum>#{@level_2[:purchase_order]}</PCOrderNum>}, data
+      assert_match %{<PCDestZip>#{@level_2[:zip]}</PCDestZip>}, data
+      assert_match %{<PCDestName>#{@level_2[:name]}</PCDestName>}, data
+      assert_match %{<PCDestAddress1>#{@level_2[:address1]}</PCDestAddress1>}, data
+      assert_match %{<PCDestAddress2>#{@level_2[:address2]}</PCDestAddress2>}, data
+      assert_match %{<PCDestCity>#{@level_2[:city]}</PCDestCity>}, data
+      assert_match %{<PCDestState>#{@level_2[:state]}</PCDestState>}, data
+    end.respond_with(successful_purchase_response)
   end
 
   def test_currency_exponents


### PR DESCRIPTION
This adds support for all level 2 data fields on authorize, capture,
purchase, and refund transactions. Since Orbital enforces strict
ordering of XML elements (see test/schema/orbital/Request_PTI54.xsd),
there are three methods used to add the fields in their entirety.

Remote tests:
```
ruby -Itest test/remote/gateways/remote_orbital_test.rb
Loaded suite test/remote/gateways/remote_orbital_test
Started
..................

Finished in 23.538797 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
18 tests, 121 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
0.76 tests/s, 5.14 assertions/s
```

Unit tests:
```
ruby -Itest test/unit/gateways/orbital_test.rb
Loaded suite test/unit/gateways/orbital_test
Started
....................................................................

Finished in 0.441849 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
68 tests, 412 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
153.90 tests/s, 932.45 assertions/s
```