### PR TITLE
PayU Latam: Pass DNI Number

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -155,6 +155,7 @@ module ActiveMerchant #:nodoc:
         if address = options[:shipping_address]
           buyer = {}
           buyer[:fullName] = address[:name]
+          buyer[:dniNumber] = options[:dni_number]
           shipping_address = {}
           shipping_address[:street1] = address[:address1]
           shipping_address[:street2] = address[:address2]
@@ -234,6 +235,7 @@ module ActiveMerchant #:nodoc:
           post[:transaction][:paymentCountry] = address[:country]
           payer[:fullName] = address[:name]
           payer[:contactPhone] = address[:phone]
+          payer[:dniNumber] = options[:dni_number]
           billing_address = {}
           billing_address[:street1] = address[:address1]
           billing_address[:street2] = address[:address2]

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -10,6 +10,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     @pending_card = credit_card("4097440000000004", verification_value: "222", first_name: "PENDING", last_name: "")
 
     @options = {
+      dni_number: '5415668464654',
       currency: "ARS",
       order_id: generate_unique_id,
       description: "Active Merchant Transaction",


### PR DESCRIPTION
The 2 Remote failures are unrelated to this change.

Remote:
15 tests, 39 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.6667% passed

Unit:
17 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed