### PR TITLE
Mercado Pago: Add gateway support

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -1,0 +1,229 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class MercadoPagoGateway < Gateway
+      self.live_url = self.test_url = 'https://api.mercadopago.com/v1'
+
+      self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY']
+      self.supported_cardtypes = [:visa, :master, :american_express]
+
+      self.homepage_url = 'https://www.mercadopago.com/'
+      self.display_name = 'Mercado Pago'
+      self.money_format = :dollars
+
+      def initialize(options={})
+        requires!(options, :access_token)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        MultiResponse.run do |r|
+          r.process { commit("tokenize", "card_tokens", card_token_request(money, payment, options)) }
+          options.merge!(card_brand: payment.brand)
+          options.merge!(card_token: r.authorization.split("|").first)
+          r.process { commit("purchase", "payments", purchase_request(money, payment, options) ) }
+        end
+      end
+
+      def authorize(money, payment, options={})
+        MultiResponse.run do |r|
+          r.process { commit("tokenize", "card_tokens", card_token_request(money, payment, options)) }
+          options.merge!(card_brand: payment.brand)
+          options.merge!(card_token: r.authorization.split("|").first)
+          r.process { commit("authorize", "payments", authorize_request(money, payment, options) ) }
+        end
+      end
+
+      def capture(money, authorization, options={})
+        post = {}
+        authorization, _ = authorization.split("|")
+        post[:capture] = true
+        post[:transaction_amount] = amount(money).to_f
+        commit("capture", "payments/#{authorization}", post)
+      end
+
+      def refund(money, authorization, options={})
+        post = {}
+        authorization, original_amount = authorization.split("|")
+        post[:amount] = amount(money).to_f if original_amount && original_amount.to_f > amount(money).to_f
+        commit("refund", "payments/#{authorization}/refunds", post)
+      end
+
+      def void(authorization, options={})
+        authorization, _ = authorization.split("|")
+        post = { status: "cancelled" }
+        commit("void", "payments/#{authorization}", post)
+      end
+
+      def verify(credit_card, options={})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((access_token=).*?([^\s]+)), '\1[FILTERED]').
+          gsub(%r((\"card_number\\\":\\\")\d+), '\1[FILTERED]').
+          gsub(%r((\"security_code\\\":\\\")\d+), '\1[FILTERED]')
+      end
+
+      private
+
+      def card_token_request(money, payment, options = {})
+        post = {}
+        post[:card_number] = payment.number
+        post[:security_code] = payment.verification_value
+        post[:expiration_month] = payment.month
+        post[:expiration_year] = payment.year
+        post[:cardholder] = { name: payment.name }
+        post
+      end
+
+      def purchase_request(money, payment, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, options)
+        add_additional_data(post, options)
+        add_customer_data(post, payment, options)
+        add_address(post, options)
+        post
+      end
+
+      def authorize_request(money, payment, options = {})
+        post = purchase_request(money, payment, options)
+        post.merge!(capture: false)
+        post
+      end
+
+      def add_additional_data(post, options)
+        post[:sponsor_id] = options["sponsor_id"]
+        post[:additional_info] = {
+          ip_address: options[:ip_address]
+        }
+
+        add_address(post, options)
+      end
+
+      def add_customer_data(post, payment, options)
+        post[:payer] = {
+          email: options[:email],
+          first_name: payment.first_name,
+          last_name: payment.last_name
+        }
+      end
+
+      def add_address(post, options)
+        if address = (options[:billing_address] || options[:address])
+          street_number = address[:address1].split(" ").first
+          street_name = address[:address1].split(" ")[1..-1].join(" ")
+
+          post[:additional_info] = {
+            payer: {
+              address: {
+                zip_code: address[:zip],
+                street_number: street_number,
+                street_name: street_name,
+              }
+            }
+          }
+        end
+      end
+
+      def add_invoice(post, money, options)
+        post[:transaction_amount] = amount(money).to_f
+        post[:description] = options[:description]
+        post[:installments] = options[:installments] ? options[:installments].to_i : 1
+        post[:statement_descriptor] = options[:statement_descriptor] if options[:statement_descriptor]
+        post[:order] = {
+          type: options[:order_type] || "mercadopago",
+          id: options[:order_id] || generate_integer_only_order_id
+        }
+      end
+
+      def add_payment(post, options)
+        post[:token] = options[:card_token]
+        post[:payment_method_id] = options[:card_brand]
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(action, path, parameters)
+        if ["capture", "void"].include?(action)
+          response = parse(ssl_request(:put, url(path), post_data(parameters), headers))
+        else
+          response = parse(ssl_post(url(path), post_data(parameters), headers))
+        end
+
+        Response.new(
+          success_from(action, response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response, parameters),
+          test: test?,
+          error_code: error_code_from(action, response)
+        )
+      end
+
+      def success_from(action, response)
+        if action == "refund"
+          response["error"].nil?
+        else
+          ["active", "approved", "authorized", "cancelled"].include?(response["status"])
+        end
+      end
+
+      def message_from(response)
+        (response["status_detail"]) || (response["message"])
+      end
+
+      def authorization_from(response, params)
+        [response["id"], params[:transaction_amount]].join("|")
+      end
+
+      def post_data(parameters = {})
+        parameters.to_json
+      end
+
+      def error_code_from(action, response)
+        unless success_from(action, response)
+          if cause = response["cause"]
+            cause.empty? ? nil : cause.first["code"]
+          else
+            response["status"]
+          end
+        end
+      end
+
+      def url(action)
+        full_url = (test? ? test_url : live_url)
+        full_url + "/#{action}?access_token=#{@options[:access_token]}"
+      end
+
+      def headers
+        {
+          "Content-Type" => "application/json"
+        }
+      end
+
+      def handle_response(response)
+        case response.code.to_i
+        when 200..499
+          response.body
+        else
+          raise ResponseError.new(response)
+        end
+      end
+
+      def generate_integer_only_order_id
+        Time.now.to_i + rand(0..1000)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -432,6 +432,10 @@ maxipago:
   login: "100"
   password: "21g8u6gh6szw1gywfs165vui"
 
+# Working credentials, no need to replace
+mercado_pago:
+  access_token: "TEST-8527269031909288-071213-0fc96cb7cd3633189bfbe29f63722700__LB_LA__-263489584"
+
 # Working test credentials, no need to replace
 merchant_esolutions:
   login: "94100008043900000004"

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -1,0 +1,130 @@
+require 'test_helper'
+
+class RemoteMercadoPagoTest < Test::Unit::TestCase
+  def setup
+    @gateway = MercadoPagoGateway.new(fixtures(:mercado_pago))
+
+    @amount = 500
+    @credit_card = credit_card('4509953566233704')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      email: "user+br@example.com",
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal "rejected", response.error_code
+    assert_equal 'cc_rejected_other_reason', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'pending_capture', auth.message
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'accredited', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'cc_rejected_other_reason', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert_success capture
+    assert_equal 'accredited', capture.message
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'Method not allowed', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal nil, refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'Resource /payments/refunds not found.', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'by_collector', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'Method not allowed', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{pending_capture}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{cc_rejected_other_reason}, response.message
+  end
+
+  def test_invalid_login
+    gateway = MercadoPagoGateway.new(access_token: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid access parameters}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:access_token], transcript)
+  end
+
+end

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -1,0 +1,321 @@
+require 'test_helper'
+
+class MercadoPagoTest < Test::Unit::TestCase
+  def setup
+    @gateway = MercadoPagoGateway.new(access_token: 'access_token')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).at_most(2).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal "4141491|1.0", response.authorization
+    assert_equal "accredited", response.message
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).at_most(2).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "rejected", response.error_code
+    assert_equal "cc_rejected_other_reason", response.message
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).at_most(2).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal "4261941|1.0", response.authorization
+    assert_equal "pending_capture", response.message
+    assert response.test?
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).at_most(2).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal "rejected", response.error_code
+    assert_equal "cc_rejected_other_reason", response.message
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+
+    response = @gateway.capture(@amount, "authorization|amount")
+    assert_success response
+
+    assert_equal "4261941|1.0", response.authorization
+    assert_equal "accredited", response.message
+    assert response.test?
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, "")
+    assert_failure response
+
+    assert_equal "|1.0", response.authorization
+    assert_equal "Method not allowed", response.message
+    assert response.test?
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    response = @gateway.refund(@amount, 'authorization|1.0', @options)
+    assert_success response
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.refund(@amount, '', @options)
+    assert_failure response
+    assert_equal nil, response.error_code
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_request).returns(successful_void_response)
+
+    response = @gateway.void("authorization|amount")
+    assert_success response
+
+    assert_equal "4261966|", response.authorization
+    assert_equal "by_collector", response.message
+    assert response.test?
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_request).returns(failed_void_response)
+
+    response = @gateway.void("")
+    assert_failure response
+
+    assert_equal "|", response.authorization
+    assert_equal "Method not allowed", response.message
+    assert response.test?
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_request).at_most(3).returns(successful_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal "by_collector", response.message
+    assert response.test?
+  end
+
+  def test_successful_verify_with_failed_void
+    @gateway.expects(:ssl_request).at_most(3).returns(failed_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+
+    assert_equal "Method not allowed", response.message
+    assert response.test?
+  end
+
+  def test_failed_verify
+    @gateway.expects(:ssl_request).at_most(2).returns(failed_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+
+    assert_equal "cc_rejected_other_reason", response.message
+    assert response.test?
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      opening connection to api.mercadopago.com:443...
+      opened
+      starting SSL for api.mercadopago.com:443...
+      SSL established
+      <- "POST /v1/card_tokens?access_token=TEST-8527269031909288-071213-0fc96cb7cd3633189bfbe29f63722700__LB_LA__-263489584 HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.mercadopago.com\r\nContent-Length: 140\r\n\r\n"
+      <- "{\"card_number\":\"4509953566233704\",\"security_code\":\"123\",\"expiration_month\":9,\"expiration_year\":2018,\"cardholder\":{\"name\":\"Longbob Longsen\"}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "X-Request-Id: eb7a95a0-dccb-4580-9a69-534f6faf0bd6\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Date: Thu, 13 Jul 2017 17:37:58 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Strict-Transport-Security: max-age=16070400\r\n"
+      -> "Set-Cookie: TS016da221=0119b547a2244bba3789910575ac019d7d44d644026217ca433918a8c8fd9ff83de9d4b3c095adc76ee58870b56cd33041797db9e2; Path=/; Secure; HTTPOnly\r\n"
+      -> "Vary: Accept-Encoding, User-Agent\r\n"
+      -> "Content-Encoding: gzip\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      Conn close
+      opening connection to api.mercadopago.com:443...
+      opened
+      starting SSL for api.mercadopago.com:443...
+      SSL established
+      <- "POST /v1/payments?access_token=TEST-8527269031909288-071213-0fc96cb7cd3633189bfbe29f63722700__LB_LA__-263489584 HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.mercadopago.com\r\nContent-Length: 395\r\n\r\n"
+      <- "{\"transaction_amount\":5.0,\"description\":\"Store Purchase\",\"installments\":1,\"order\":{\"type\":\"mercadopago\",\"id\":2554731505684667137},\"token\":\"02ed9760103508d54361da8741a22a9e\",\"payment_method_id\":\"visa\",\"additional_info\":{\"payer\":{\"address\":{\"zip_code\":\"K1C2N6\",\"street_number\":\"456\",\"street_name\":\"My Street\"}}},\"payer\":{\"email\":\"user+br@example.com\",\"first_name\":\"Longbob\",\"last_name\":\"Longsen\"}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Thu, 13 Jul 2017 17:37:59 GMT\r\n"
+      -> "Content-Type: application/json;charset=UTF-8\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Response-Status: approved/accredited\r\n"
+      -> "X-Caller-Id: 263489584\r\n"
+      -> "Vary: Accept,Accept-Encoding, User-Agent\r\n"
+      -> "Cache-Control: max-age=0\r\n"
+      -> "ETag: 1deee4b03ae344416c5863ac0d92c13e\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: DENY\r\n"
+      -> "X-Request-Id: ccb324d1-8365-42dd-8e9a-734488220777\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Strict-Transport-Security: max-age=15724800\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Headers: Content-Type\r\n"
+      -> "Access-Control-Allow-Methods: PUT, GET, POST, DELETE, OPTIONS\r\n"
+      -> "Access-Control-Max-Age: 86400\r\n"
+      -> "Set-Cookie: TS016da221=0119b547a287375accd901052e4871cecbc881599be32e9bcb508701e62cabee4424801a25969778d1c93e2c57c2fd0a8a934c9817; Path=/; Secure; HTTPOnly\r\n"
+      -> "Content-Encoding: gzip\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      Conn close
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      opening connection to api.mercadopago.com:443...
+      opened
+      starting SSL for api.mercadopago.com:443...
+      SSL established
+      <- "POST /v1/card_tokens?access_token=[FILTERED] HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.mercadopago.com\r\nContent-Length: 140\r\n\r\n"
+      <- "{\"card_number\":\"[FILTERED]\",\"security_code\":\"[FILTERED]\",\"expiration_month\":9,\"expiration_year\":2018,\"cardholder\":{\"name\":\"Longbob Longsen\"}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "X-Request-Id: eb7a95a0-dccb-4580-9a69-534f6faf0bd6\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Date: Thu, 13 Jul 2017 17:37:58 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Strict-Transport-Security: max-age=16070400\r\n"
+      -> "Set-Cookie: TS016da221=0119b547a2244bba3789910575ac019d7d44d644026217ca433918a8c8fd9ff83de9d4b3c095adc76ee58870b56cd33041797db9e2; Path=/; Secure; HTTPOnly\r\n"
+      -> "Vary: Accept-Encoding, User-Agent\r\n"
+      -> "Content-Encoding: gzip\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      Conn close
+      opening connection to api.mercadopago.com:443...
+      opened
+      starting SSL for api.mercadopago.com:443...
+      SSL established
+      <- "POST /v1/payments?access_token=[FILTERED] HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.mercadopago.com\r\nContent-Length: 395\r\n\r\n"
+      <- "{\"transaction_amount\":5.0,\"description\":\"Store Purchase\",\"installments\":1,\"order\":{\"type\":\"mercadopago\",\"id\":2554731505684667137},\"token\":\"02ed9760103508d54361da8741a22a9e\",\"payment_method_id\":\"visa\",\"additional_info\":{\"payer\":{\"address\":{\"zip_code\":\"K1C2N6\",\"street_number\":\"456\",\"street_name\":\"My Street\"}}},\"payer\":{\"email\":\"user+br@example.com\",\"first_name\":\"Longbob\",\"last_name\":\"Longsen\"}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Thu, 13 Jul 2017 17:37:59 GMT\r\n"
+      -> "Content-Type: application/json;charset=UTF-8\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Response-Status: approved/accredited\r\n"
+      -> "X-Caller-Id: 263489584\r\n"
+      -> "Vary: Accept,Accept-Encoding, User-Agent\r\n"
+      -> "Cache-Control: max-age=0\r\n"
+      -> "ETag: 1deee4b03ae344416c5863ac0d92c13e\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: DENY\r\n"
+      -> "X-Request-Id: ccb324d1-8365-42dd-8e9a-734488220777\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Strict-Transport-Security: max-age=15724800\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Headers: Content-Type\r\n"
+      -> "Access-Control-Allow-Methods: PUT, GET, POST, DELETE, OPTIONS\r\n"
+      -> "Access-Control-Max-Age: 86400\r\n"
+      -> "Set-Cookie: TS016da221=0119b547a287375accd901052e4871cecbc881599be32e9bcb508701e62cabee4424801a25969778d1c93e2c57c2fd0a8a934c9817; Path=/; Secure; HTTPOnly\r\n"
+      -> "Content-Encoding: gzip\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      Conn close
+    )
+  end
+
+  def successful_purchase_response
+    %(
+      {"id":4141491,"date_created":"2017-07-06T09:49:35.000-04:00","date_approved":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","date_of_expiration":null,"money_release_date":"2017-07-18T09:49:35.000-04:00","operation_type":"regular_payment","issuer_id":"166","payment_method_id":"visa","payment_type_id":"credit_card","status":"approved","status_detail":"accredited","currency_id":"MXN","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":261735089,"payer":{"type":"guest","id":null,"email":"user@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":""},"first_name":"First User","last_name":"User","entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"2326513804447055222"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0.14,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[{"type":"mercadopago_fee","amount":4.86,"fee_payer":"collector"}],"captured":true,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":null,"merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      {"id":4142297,"date_created":"2017-07-06T10:13:32.000-04:00","date_approved":null,"date_last_updated":"2017-07-06T10:13:32.000-04:00","date_of_expiration":null,"money_release_date":null,"operation_type":"regular_payment","issuer_id":"166","payment_method_id":"visa","payment_type_id":"credit_card","status":"rejected","status_detail":"cc_rejected_other_reason","currency_id":"MXN","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":261735089,"payer":{"type":"guest","id":null,"email":"user@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":""},"first_name":"First User","last_name":"User","entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"830943860538524456"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[],"captured":true,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"400030","last_four_digits":"2220","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-06T10:13:32.000-04:00","date_last_updated":"2017-07-06T10:13:32.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":null,"merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def successful_authorize_response
+    %(
+      {"id":4261941,"date_created":"2017-07-13T14:24:46.000-04:00","date_approved":null,"date_last_updated":"2017-07-13T14:24:46.000-04:00","date_of_expiration":null,"money_release_date":null,"operation_type":"regular_payment","issuer_id":"25","payment_method_id":"visa","payment_type_id":"credit_card","status":"authorized","status_detail":"pending_capture","currency_id":"BRL","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":263489584,"payer":{"type":"guest","id":null,"email":"user+br@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":null},"first_name":null,"last_name":null,"entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"2294029672081601730"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[],"captured":false,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-13T14:24:46.000-04:00","date_last_updated":"2017-07-13T14:24:46.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":"aggregator","merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def failed_authorize_response
+    %(
+      {"id":4261953,"date_created":"2017-07-13T14:25:33.000-04:00","date_approved":null,"date_last_updated":"2017-07-13T14:25:33.000-04:00","date_of_expiration":null,"money_release_date":null,"operation_type":"regular_payment","issuer_id":"25","payment_method_id":"visa","payment_type_id":"credit_card","status":"rejected","status_detail":"cc_rejected_other_reason","currency_id":"BRL","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":263489584,"payer":{"type":"guest","id":null,"email":"user+br@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":null},"first_name":null,"last_name":null,"entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"7528376941458928221"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[],"captured":false,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"400030","last_four_digits":"2220","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-13T14:25:33.000-04:00","date_last_updated":"2017-07-13T14:25:33.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":"aggregator","merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def successful_capture_response
+    %(
+      {"id":4261941,"date_created":"2017-07-13T14:24:46.000-04:00","date_approved":"2017-07-13T14:24:47.000-04:00","date_last_updated":"2017-07-13T14:24:47.000-04:00","date_of_expiration":null,"money_release_date":"2017-07-27T14:24:47.000-04:00","operation_type":"regular_payment","issuer_id":"25","payment_method_id":"visa","payment_type_id":"credit_card","status":"approved","status_detail":"accredited","currency_id":"BRL","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":263489584,"payer":{"type":"guest","id":null,"email":"user+br@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":null},"first_name":null,"last_name":null,"entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"2294029672081601730"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":4.75,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[{"type":"mercadopago_fee","amount":0.25,"fee_payer":"collector"}],"captured":true,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-13T14:24:46.000-04:00","date_last_updated":"2017-07-13T14:24:46.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":"aggregator","merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def failed_capture_response
+    %(
+      {"message":"Method not allowed","error":"method_not_allowed","status":405,"cause":[{"code":"Method not allowed","description":"Method not allowed","data":null}]}
+    )
+  end
+
+  def successful_refund_response
+    %(
+      {"id":4247757,"payment_id":4247751,"amount":5,"metadata":{},"source":{"id":"261735089","name":"Spreedly Integrations","type":"collector"},"date_created":"2017-07-12T14:45:08.752-04:00","unique_sequence_number":null}
+    )
+  end
+
+  def failed_refund_response
+    %(
+      {"message":"Resource /payments/refunds/ not found.","error":"not_found","status":404,"cause":[]}
+    )
+  end
+
+  def successful_void_response
+    %(
+      {"id":4261966,"date_created":"2017-07-13T14:26:56.000-04:00","date_approved":null,"date_last_updated":"2017-07-13T14:26:57.000-04:00","date_of_expiration":null,"money_release_date":null,"operation_type":"regular_payment","issuer_id":"25","payment_method_id":"visa","payment_type_id":"credit_card","status":"cancelled","status_detail":"by_collector","currency_id":"BRL","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":263489584,"payer":{"type":"guest","id":null,"email":"user+br@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":null},"first_name":null,"last_name":null,"entity_type":null},"metadata":{},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"6688620487994029432"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[],"captured":false,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-13T14:26:56.000-04:00","date_last_updated":"2017-07-13T14:26:56.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":"aggregator","merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def failed_void_response
+    %(
+      {"message":"Method not allowed","error":"method_not_allowed","status":405,"cause":[{"code":"Method not allowed","description":"Method not allowed","data":null}]}
+    )
+  end
+end


### PR DESCRIPTION
Just want to note a couple little quirks with this gateway since I imagine it could come up 😸 

1. The transaction amount must be a numeric decimal. However, the `amount()` function returns the correctly formatted amount as a string so I'm calling `to_f` to convert it back to a float.
2. The `order_id` must be numeric. Hopefully the method I'm using to generate a numeric only `order_id` prevents collisions. Up for suggestions!
3. Sending a currency isn't supported. Each set of credentials is tied to only one currency so it's not even defaulted.
4. Refund is funky because you can't send the `transaction_amount` field if it's a refund for the full amount. So, I have to check the new amount against the original amount.

Test suite runs:
```
/Users/david/dev/active_merchant mercado-pago ✔
➜ ruby -Itest test/unit/gateways/mercado_pago_test.rb
Loaded suite test/unit/gateways/mercado_pago_test
Started
..............

Finished in 0.007458 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1877.18 tests/s, 7642.80 assertions/s

/Users/david/dev/active_merchant mercado-pago ✔
➜ ruby -Itest test/remote/gateways/remote_mercado_pago_test.rb
Loaded suite test/remote/gateways/remote_mercado_pago_test
Started
...............

Finished in 22.51241 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.67 tests/s, 1.87 assertions/s
```