### PR TITLE
Barclaycard must populate a billing address house number

### DIFF
--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -225,12 +225,12 @@ module ActiveMerchant #:nodoc:
       def address_hash(address)
         full_address = "#{address[:address1]} #{address[:address2]}" if address
         street = address[:street] if address[:street]
-        house = address[:houseNumberOrName] if address[:houseNumberOrName]
-
+        house = address[:houseNumberOrName] ? address[:houseNumberOrName] : full_address.split(/\s+/).keep_if { |x| x =~ /\d/ }.join(' ')
+        
         hash = {}
         hash[:city]              = address[:city] if address[:city]
         hash[:street]            = street || full_address.split(/\s+/).keep_if { |x| x !~ /\d/ }.join(' ')
-        hash[:houseNumberOrName] = house || full_address.split(/\s+/).keep_if { |x| x =~ /\d/ }.join(' ')
+        hash[:houseNumberOrName] = house.empty? ? "Not Provided" : house
         hash[:postalCode]        = address[:zip] if address[:zip]
         hash[:stateOrProvince]   = address[:state] if address[:state]
         hash[:country]           = address[:country] if address[:country]

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -166,6 +166,13 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal 'N', response.avs_result['code']
   end
 
+  def test_avs_nohousenumber_result
+    avs_nohousenumber = @avs_address
+    avs_nohousenumber[:billing_address].delete(:houseNumberOrName)
+    response = @gateway.authorize(@amount, @avs_credit_card, avs_nohousenumber)
+    assert_equal 'Z', response.avs_result['code']
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
One half of the fix for "Unprocessable Entity" error raised when no
houseNumberOrName is used for AVS transcation. Default value is set as
"Not Provided"

Closes ENRG-6583

Successful remote BarclaySmartCard Test Run at 2017-07-31 14:55:02