### PR TITLE
Allow `device_data` to be provided when storing card

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -230,6 +230,7 @@ module ActiveMerchant #:nodoc:
             :email => scrub_email(options[:email]),
             :id => options[:customer],
           }.merge credit_card_params
+          parameters[:device_data] = options[:device_data] if options[:device_data]
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           Response.new(result.success?, message_from_result(result),
             {

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -218,6 +218,24 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal response.params["customer_vault_id"], response.authorization
   end
 
+  def test_store_with_device_data
+    customer = stub(
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith'
+    )
+    expected_device_data = '{\"device_session_id\":\"fake89a16027c85bfbe0896d86d7d785\",\"fraud_merchant_id\":\"000000\"}'
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_equal expected_device_data, params[:device_data]
+      params
+    end.returns(result)
+
+    @gateway.store(credit_card("41111111111111111111"), :device_data => expected_device_data)
+  end
+
   def test_passes_email
     customer = stub(
       :credit_cards => [stub_everything],


### PR DESCRIPTION
This parameter is documented in [Braintree's API](https://developers.braintreepayments.com/reference/request/customer/create/ruby#device_data) but not available to be used in ActiveMerchant. This commit makes the parameters available.

You can consider this a follow-up to 8dba9d3c which added the `device_data` option when creating a transaction. This is the same only it is for when vaulting a card.

NOTE: When creating a card on an existing customer, [Braintree's API](https://developers.braintreepayments.com/reference/request/credit-card/create/ruby) doesn't seem to have the `device_data` param so this only affects cases where we are creating a customer and card together via `store`.

NOTE: When updating an existing customer there is [the option](https://developers.braintreepayments.com/reference/request/customer/update/ruby) to
provide `device_data`. I left that out of this commit as my app is not using `update` and I'm hesitant to add code I am not also testing within the context of an app. Leaving the scope of this commit to just what I am using.