### PR TITLE
Litle: Update schema and certification tests to v9.12

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class LitleGateway < Gateway
-      SCHEMA_VERSION = '9.4'
+      SCHEMA_VERSION = '9.12'
 
       self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
       self.live_url = 'https://payments.litle.com/vap/communicator/online'
@@ -15,12 +15,6 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.litle.com/'
       self.display_name = 'Litle & Co.'
 
-      # Public: Create a new Litle gateway.
-      #
-      # options - A hash of options:
-      #           :login         - The user.
-      #           :password      - The password.
-      #           :merchant_id   - The merchant id.
       def initialize(options={})
         requires!(options, :login, :password, :merchant_id)
         super
@@ -261,6 +255,8 @@ module ActiveMerchant #:nodoc:
           doc.orderSource(options[:order_source])
         elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :apple_pay
           doc.orderSource('applepay')
+        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :android_pay
+          doc.orderSource('androidpay')
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.orderSource('retail')
         else

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -3,14 +3,15 @@ require 'test_helper'
 class RemoteLitleCertification < Test::Unit::TestCase
   def setup
     Base.mode = :test
-    @gateway = LitleGateway.new(fixtures(:litle).merge(:url => "https://cert.litle.com/vap/communicator/online"))
+    @gateway = LitleGateway.new(fixtures(:litle))
+    @gateway.test_url = "https://payments.vantivprelive.com/vap/communicator/online"
   end
 
   def test1
     credit_card = CreditCard.new(
       :number => '4457010000000009',
       :month => '01',
-      :year => '2014',
+      :year => '2021',
       :verification_value => '349',
       :brand => 'visa'
     )
@@ -18,7 +19,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     options = {
       :order_id => '1',
       :billing_address => {
-        :name => 'John Smith',
+        :name => 'John & Mary Smith',
         :address1 => '1 Main St.',
         :city => 'Burlington',
         :state => 'MA',
@@ -27,24 +28,24 @@ class RemoteLitleCertification < Test::Unit::TestCase
       }
     }
 
-    auth_assertions(10010, credit_card, options, :avs => "X", :cvv => "M")
+    auth_assertions(10100, credit_card, options, :avs => "X", :cvv => "M")
 
-    # 1: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "X", :cvv => "M")
 
-    sale_assertions(10010, credit_card, options, :avs => "X", :cvv => "M")
+    sale_assertions(10100, credit_card, options, :avs => "X", :cvv => "M")
   end
 
   def test2
     credit_card = CreditCard.new(:number => '5112010000000003', :month => '02',
-                                 :year => '2014', :brand => 'master',
-                                 :verification_value => '261')
+                                 :year => '2021', :brand => 'master',
+                                 :verification_value => '261',
+                                 :name => 'Mike J. Hammer')
 
     options = {
       :order_id => '2',
       :billing_address => {
-        :name => 'Mike J. Hammer',
         :address1 => '2 Main St.',
+        :address2 => 'Apt. 222',
         :city => 'Riverside',
         :state => 'RI',
         :zip => '02915',
@@ -52,19 +53,18 @@ class RemoteLitleCertification < Test::Unit::TestCase
       }
     }
 
-    auth_assertions(20020, credit_card, options, :avs => "Z", :cvv => "M")
+    auth_assertions(10100, credit_card, options, :avs => "Z", :cvv => "M")
 
-    # 2: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "Z", :cvv => "M")
 
-    sale_assertions(20020, credit_card, options, :avs => "Z", :cvv => "M")
+    sale_assertions(10100, credit_card, options, :avs => "Z", :cvv => "M")
   end
 
   def test3
     credit_card = CreditCard.new(
       :number => '6011010000000003',
       :month => '03',
-      :year => '2014',
+      :year => '2021',
       :verification_value => '758',
       :brand => 'discover'
     )
@@ -80,19 +80,18 @@ class RemoteLitleCertification < Test::Unit::TestCase
         :country => 'US'
       }
     }
-    auth_assertions(30030, credit_card, options, :avs => "Z", :cvv => "M")
+    auth_assertions(10100, credit_card, options, :avs => "Z", :cvv => "M")
 
-    # 3: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "Z", :cvv => "M")
 
-    sale_assertions(30030, credit_card, options, :avs => "Z", :cvv => "M")
+    sale_assertions(10100, credit_card, options, :avs => "Z", :cvv => "M")
   end
 
   def test4
     credit_card = CreditCard.new(
       :number => '375001000000005',
       :month => '04',
-      :year => '2014',
+      :year => '2021',
       :brand => 'american_express'
     )
 
@@ -108,17 +107,37 @@ class RemoteLitleCertification < Test::Unit::TestCase
       }
     }
 
-    auth_assertions(40040, credit_card, options, :avs => "A", :cvv => nil)
+    auth_assertions(10100, credit_card, options, :avs => "A", :cvv => nil)
 
-    # 4: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "A")
 
-    sale_assertions(40040, credit_card, options, :avs => "A", :cvv => nil)
+    sale_assertions(10100, credit_card, options, :avs => "A", :cvv => nil)
+  end
+
+  def test5
+    credit_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      :number => '4100200300011001',
+      :month => '05',
+      :year => '2021',
+      :verification_value => '463',
+      :brand => 'visa',
+      :payment_cryptogram => 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+    )
+
+    options = {
+      :order_id => '5'
+    }
+
+    auth_assertions(10100, credit_card, options, :avs => "U", :cvv => "M")
+
+    authorize_avs_assertions(credit_card, options, :avs => "U", :cvv => "M")
+
+    sale_assertions(10100, credit_card, options, :avs => "U", :cvv => "M")
   end
 
   def test6
     credit_card = CreditCard.new(:number => '4457010100000008', :month => '06',
-                                 :year => '2014', :brand => 'visa',
+                                 :year => '2021', :brand => 'visa',
                                  :verification_value => '992')
 
     options = {
@@ -134,30 +153,35 @@ class RemoteLitleCertification < Test::Unit::TestCase
     }
 
     # 6: authorize
-    assert response = @gateway.authorize(60060, credit_card, options)
+    assert response = @gateway.authorize(10100, credit_card, options)
     assert !response.success?
-    assert_equal '110', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '110', response.params['response']
     assert_equal 'Insufficient Funds', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 6. sale
-    assert response = @gateway.purchase(60060, credit_card, options)
+    assert response = @gateway.purchase(10100, credit_card, options)
     assert !response.success?
-    assert_equal '110', response.params['litleOnlineResponse']['saleResponse']['response']
+    assert_equal '110', response.params['response']
     assert_equal 'Insufficient Funds', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+
 
     # 6A. void
     assert response = @gateway.void(response.authorization, {:order_id => '6A'})
-    assert_equal '360', response.params['litleOnlineResponse']['voidResponse']['response']
-    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal '360', response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', response.message
+    puts "Test #{options[:order_id]}A: #{txn_id(response)}"
+
   end
 
   def test7
     credit_card = CreditCard.new(:number => '5112010100000002', :month => '07',
-                                 :year => '2014', :brand => 'master',
+                                 :year => '2021', :brand => 'master',
                                  :verification_value => '251')
 
     options = {
@@ -173,28 +197,30 @@ class RemoteLitleCertification < Test::Unit::TestCase
     }
 
     # 7: authorize
-    assert response = @gateway.authorize(70070, credit_card, options)
+    assert response = @gateway.authorize(10100, credit_card, options)
     assert !response.success?
-    assert_equal '301', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '301', response.params['response']
     assert_equal 'Invalid Account Number', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "N", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 7: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "I", :cvv => "N", :message => "Invalid Account Number", :success => false)
 
     # 7. sale
-    assert response = @gateway.purchase(70070, credit_card, options)
+    assert response = @gateway.purchase(10100, credit_card, options)
     assert !response.success?
-    assert_equal '301', response.params['litleOnlineResponse']['saleResponse']['response']
+    assert_equal '301', response.params['response']
     assert_equal 'Invalid Account Number', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "N", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
   end
 
   def test8
     credit_card = CreditCard.new(:number => '6011010100000002', :month => '08',
-                                 :year => '2014', :brand => 'discover',
+                                 :year => '2021', :brand => 'discover',
                                  :verification_value => '184')
 
     options = {
@@ -210,12 +236,13 @@ class RemoteLitleCertification < Test::Unit::TestCase
     }
 
     # 8: authorize
-    assert response = @gateway.authorize(80080, credit_card, options)
+    assert response = @gateway.authorize(10100, credit_card, options)
     assert !response.success?
-    assert_equal '123', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '123', response.params['response']
     assert_equal 'Call Discover', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 8: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "I", :cvv => "P", :message => "Call Discover", :success => false)
@@ -223,15 +250,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # 8: sale
     assert response = @gateway.purchase(80080, credit_card, options)
     assert !response.success?
-    assert_equal '123', response.params['litleOnlineResponse']['saleResponse']['response']
+    assert_equal '123', response.params['response']
     assert_equal 'Call Discover', response.message
     assert_equal "I", response.avs_result["code"]
     assert_equal "P", response.cvv_result["code"]
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
   end
 
   def test9
     credit_card = CreditCard.new(:number => '375001010000003', :month => '09',
-                                 :year => '2014', :brand => 'american_express',
+                                 :year => '2021', :brand => 'american_express',
                                  :verification_value => '0421')
 
     options = {
@@ -247,92 +275,187 @@ class RemoteLitleCertification < Test::Unit::TestCase
     }
 
     # 9: authorize
-    assert response = @gateway.authorize(90090, credit_card, options)
-
+    assert response = @gateway.authorize(10100, credit_card, options)
     assert !response.success?
-    assert_equal '303', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '303', response.params['response']
     assert_equal 'Pick Up Card', response.message
     assert_equal "I", response.avs_result["code"]
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 9: authorize avs
     authorize_avs_assertions(credit_card, options, :avs => "I", :message => "Pick Up Card", :success => false)
 
     # 9: sale
-    assert response = @gateway.purchase(90090, credit_card, options)
+    assert response = @gateway.purchase(10100, credit_card, options)
     assert !response.success?
-    assert_equal '303', response.params['litleOnlineResponse']['saleResponse']['response']
+    assert_equal '303', response.params['response']
     assert_equal 'Pick Up Card', response.message
     assert_equal "I", response.avs_result["code"]
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
   end
 
   # Authorization Reversal Tests
+  def test32
+    credit_card = CreditCard.new(:number => '4457010000000009', :month => '01',
+                                 :year => '2021', :brand => 'visa',
+                                 :verification_value => '349')
+
+    options = {
+      :order_id => '32',
+      :billing_address => {
+        :name => 'John Smith',
+        :address1 => '1 Main St.',
+        :city => 'Burlington',
+        :state => 'MA',
+        :zip => '01803-3747',
+        :country => 'US'
+      }
+    }
+
+    assert auth_response = @gateway.authorize(10010, credit_card, options)
+    assert_success auth_response
+    assert_equal '11111 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert capture_response = @gateway.capture(5050, auth_response.authorization, options)
+    assert_success capture_response
+    puts "Test #{options[:order_id]}A: #{txn_id(capture_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Authorization amount has already been depleted', reversal_response.message
+    puts "Test #{options[:order_id]}B: #{txn_id(reversal_response)}"
+  end
+
+  def test33
+    credit_card = CreditCard.new(:number => '5112010000000003', :month => '01',
+                                 :year => '2021', :brand => 'master',
+                                 :verification_value => '261')
+
+    options = {
+      :order_id => '33',
+      :billing_address => {
+        :name => 'Mike J. Hammer',
+        :address1 => '2 Main St.',
+        :address2 => 'Apt. 222',
+        :city => 'Riverside',
+        :state => 'RI',
+        :zip => '02915',
+        :country => 'US',
+        :payment_cryptogram => 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    }
+
+    assert auth_response = @gateway.authorize(20020, credit_card, options)
+    assert_success auth_response
+    assert_equal '22222 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_success reversal_response
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
+  end
+
   def test34
-    credit_card = CreditCard.new(:number => '6011010000000003', :month => '03',
-                                 :year => '2014', :brand => 'discover',
+    credit_card = CreditCard.new(:number => '6011010000000003', :month => '01',
+                                 :year => '2021', :brand => 'discover',
                                  :verification_value => '758')
 
     options = {
-        :order_id => '34',
-        :billing_address => {
-            :name => 'Eileen Jones',
-            :address1 => '3 Main St.',
-            :city => 'Bloomfield',
-            :state => 'CT',
-            :zip => '06002',
-            :country => 'US'
-        }
+      :order_id => '34',
+      :billing_address => {
+        :name => 'Eileen Jones',
+        :address1 => '3 Main St.',
+        :city => 'Bloomfield',
+        :state => 'CT',
+        :zip => '06002',
+        :country => 'US'
+      }
     }
 
     assert auth_response = @gateway.authorize(30030, credit_card, options)
     assert_success auth_response
+    assert '33333 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
 
-    credit_card = CreditCard.new(:number => '4024720001231239', :month => '12',
-                                 :year => '2014', :brand => 'visa')
-    assert auth_response2 = @gateway.authorize(18699, credit_card, :order_id => '29')
-
-    assert reversal_response = @gateway.void(auth_response2.authorization)
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
     assert_success reversal_response
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
+  end
+
+  def test35
+    credit_card = CreditCard.new(:number => '375001000000005', :month => '01',
+                                 :year => '2021', :brand => 'american_express')
+
+    options = {
+      :order_id => '35',
+      :billing_address => {
+        :name => 'Bob Black',
+        :address1 => '4 Main St.',
+        :city => 'Laurel',
+        :state => 'MD',
+        :zip => '20708',
+        :country => 'US'
+      }
+    }
+
+    assert auth_response = @gateway.authorize(10100, credit_card, options)
+    assert_success auth_response
+    assert_equal '44444 ', auth_response.params['authCode']
+    assert_equal 'A', auth_response.avs_result["code"]
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert capture_response = @gateway.capture(5050, auth_response.authorization, options)
+    assert_success capture_response
+    puts "Test #{options[:order_id]}A: #{txn_id(capture_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Reversal amount does not match Authorization amount', reversal_response.message
+    puts "Test #{options[:order_id]}B: #{txn_id(reversal_response)}"
   end
 
   def test36
-    options = {
-        :order_id => '36'
-    }
+    credit_card = CreditCard.new(:number => '375000026600004', :month => '01',
+                                 :year => '2021', :brand => 'american_express')
 
-    credit_card = CreditCard.new(:number => '375000026600004', :month => '05',
-                                 :year => '2014', :brand => 'american_express',
-                                 :verification_value => '261')
+    options = {
+      :order_id => '36'
+      }
 
     assert auth_response = @gateway.authorize(20500, credit_card, options)
     assert_success auth_response
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
 
-    assert reversal_response = @gateway.void(auth_response.authorization, amount: 10000)
-    assert !reversal_response.success?
-    assert_equal '336', reversal_response.params['litleOnlineResponse']['authReversalResponse']['response']
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Reversal amount does not match Authorization amount', reversal_response.message
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
   end
 
   # Explicit Token Registration Tests
   def test50
     credit_card = CreditCard.new(:number => '4457119922390123')
     options     = {
-        :order_id => '50'
+      :order_id => '50'
     }
 
     # store
     store_response = @gateway.store(credit_card, options)
 
     assert_success store_response
+    assert_equal '445711', store_response.params['bin']
+    assert_equal 'VI', store_response.params['type']
+    assert_equal '0123', store_response.params['litleToken'][-4,4]
+    assert_equal '801', store_response.params['response']
     assert_equal 'Account number was successfully registered', store_response.message
-    assert_equal '445711', store_response.params['litleOnlineResponse']['registerTokenResponse']['bin']
-    assert_equal 'VI', store_response.params['litleOnlineResponse']['registerTokenResponse']['type'] #type is on Object in 1.8.7 - later versions can use .registerTokenResponse.type
-    assert_equal '801', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
-    assert_equal '0123', store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken'][-4,4]
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
   end
 
   def test51
     credit_card = CreditCard.new(:number => '4457119999999999')
-    options     = {
-        :order_id => '51'
+    options = {
+      :order_id => '51'
     }
 
     # store
@@ -340,14 +463,14 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     assert_failure store_response
     assert_equal 'Credit card number was invalid', store_response.message
-    assert_equal '820', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
-    assert_equal nil, store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken']
+    assert_equal '820', store_response.params['response']
+    assert_equal nil, store_response.params['litleToken']
   end
 
   def test52
     credit_card = CreditCard.new(:number => '4457119922390123')
-    options     = {
-        :order_id => '52'
+    options = {
+      :order_id => '52'
     }
 
     # store
@@ -355,10 +478,11 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     assert_success store_response
     assert_equal 'Account number was previously registered', store_response.message
-    assert_equal '445711', store_response.params['litleOnlineResponse']['registerTokenResponse']['bin']
-    assert_equal 'VI', store_response.params['litleOnlineResponse']['registerTokenResponse']['type'] #type is on Object in 1.8.7 - later versions can use .registerTokenResponse.type
-    assert_equal '802', store_response.params['litleOnlineResponse']['registerTokenResponse']['response']
-    assert_equal '0123', store_response.params['litleOnlineResponse']['registerTokenResponse']['litleToken'][-4,4]
+    assert_equal '445711', store_response.params['bin']
+    assert_equal 'VI', store_response.params['type']
+    assert_equal '802', store_response.params['response']
+    assert_equal '0123', store_response.params['litleToken'][-4,4]
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
   end
 
   # Implicit Token Registration Tests
@@ -368,23 +492,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
                                  :year               => '2014',
                                  :brand              => 'master',
                                  :verification_value => '987')
-    options     = {
-        :order_id => '55'
+    options = {
+      :order_id => '55'
     }
 
     # authorize
     assert response = @gateway.authorize(15000, credit_card, options)
-    #"tokenResponse" => { "litleToken"        => "1712000118270196",
-    #                     "tokenResponseCode" => "802",
-    #                     "tokenMessage"      => "Account number was previously registered",
-    #                     "type"              => "MC",
-    #                     "bin"               => "543510" }
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal '0196', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['litleToken'][-4,4]
-    assert %w(801 802).include? response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['tokenResponseCode']
-    assert_equal 'MC', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['type']
-    assert_equal '543510', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['bin']
+    assert_equal '0196', response.params['tokenResponse_litleToken'][-4,4]
+    assert %w(801 802).include? response.params['tokenResponse_tokenResponseCode']
+    assert_equal 'MC', response.params['tokenResponse_type']
+    assert_equal '543510', response.params['tokenResponse_bin']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
   end
 
   def test56
@@ -393,15 +513,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
                                  :year               => '2014',
                                  :brand              => 'master',
                                  :verification_value => '987')
-    options     = {
-        :order_id => '56'
+    options = {
+      :order_id => '56'
     }
 
     # authorize
     assert response = @gateway.authorize(15000, credit_card, options)
 
     assert_failure response
-    assert_equal '301', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '301', response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
   end
 
   def test57_58
@@ -410,8 +531,8 @@ class RemoteLitleCertification < Test::Unit::TestCase
                                  :year               => '2014',
                                  :brand              => 'master',
                                  :verification_value => '987')
-    options     = {
-        :order_id => '57'
+    options = {
+      :order_id => '57'
     }
 
     # authorize card
@@ -419,19 +540,20 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal '0196', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['litleToken'][-4,4]
-    assert %w(801 802).include? response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['tokenResponseCode']
-    assert_equal 'MC', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['type']
-    assert_equal '543510', response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['bin']
+    assert_equal '0196', response.params['tokenResponse_litleToken'][-4,4]
+    assert %w(801 802).include? response.params['tokenResponse_tokenResponseCode']
+    assert_equal 'MC', response.params['tokenResponse_type']
+    assert_equal '543510', response.params['tokenResponse_bin']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
 
     # authorize token
-    token   = response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['litleToken']
+    token   = response.params['tokenResponse_litleToken']
     options = {
-        :order_id => '58',
-        :token    => {
-            :month => credit_card.month,
-            :year  => credit_card.year
-        }
+      :order_id => '58',
+      :token    => {
+        :month => credit_card.month,
+        :year  => credit_card.year
+      }
     }
 
     # authorize
@@ -439,55 +561,95 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'Approved', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
   end
 
   def test59
-    token   = '1712990000040196'
+    token   = '1111000100092332'
     options = {
-        :order_id => '59',
-        :token    => {
-            :month => '11',
-            :year  => '2014'
-        }
+      :order_id => '59',
+      :token    => {
+        :month => '11',
+        :year  => '2021'
+      }
     }
 
     # authorize
     assert response = @gateway.authorize(15000, token, options)
 
     assert_failure response
-    assert_equal '822', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '822', response.params['response']
     assert_equal 'Token was not found', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
   end
 
   def test60
     token   = '171299999999999'
     options = {
-        :order_id => '60',
-        :token    => {
-            :month => '11',
-            :year  => '2014'
-        }
+      :order_id => '60',
+      :token    => {
+        :month => '11',
+        :year  => '2014'
+      }
     }
 
     # authorize
     assert response = @gateway.authorize(15000, token, options)
 
     assert_failure response
-    assert_equal '823', response.params['litleOnlineResponse']['authorizationResponse']['response']
+    assert_equal '823', response.params['response']
     assert_equal 'Token was invalid', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test_apple_pay_purchase
+    options = {
+      :order_id => transaction_id,
+    }
+    decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        month: '01',
+        year: '2021',
+        brand: "visa",
+        number:  "4457000300000007",
+        payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+      })
+
+    assert response = @gateway.purchase(10010, decrypted_apple_pay, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_android_pay_purchase
+    options = {
+      :order_id => transaction_id,
+    }
+    decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2021',
+        brand: "visa",
+        number:  "4457000300000007",
+        payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+      })
+
+    assert response = @gateway.purchase(10010, decrypted_android_pay, options)
+    assert_success response
+    assert_equal 'Approved', response.message
   end
 
   def test_authorize_and_purchase_and_credit_with_token
     options = {
-        :order_id => transaction_id,
-        :billing_address => {
-            :name => 'John Smith',
-            :address1 => '1 Main St.',
-            :city => 'Burlington',
-            :state => 'MA',
-            :zip => '01803-3747',
-            :country => 'US'
-        }
+      :order_id => transaction_id,
+      :billing_address => {
+        :name => 'John Smith',
+        :address1 => '1 Main St.',
+        :city => 'Burlington',
+        :state => 'MA',
+        :zip => '01803-3747',
+        :country => 'US'
+      }
     }
 
     credit_card = CreditCard.new(:number             => '5435101234510196',
@@ -536,63 +698,109 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   private
 
-  def auth_assertions(amount, card, options, assertions)
+  def auth_assertions(amount, card, options, assertions={})
     # 1: authorize
     assert response = @gateway.authorize(amount, card, options)
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal assertions[:avs], response.avs_result["code"]
+    assert_equal assertions[:avs], response.avs_result["code"] if assertions[:avs]
     assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
-    assert_equal options[:order_id], response.params['litleOnlineResponse']['authorizationResponse']['id']
+    assert_equal auth_code(options[:order_id]), response.params['authCode']
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 1A: capture
-    id = transaction_id
-    assert response = @gateway.capture(amount, response.authorization, {:id => id})
+    assert response = @gateway.capture(amount, response.authorization, {:id => transaction_id})
     assert_equal 'Approved', response.message
-    assert_equal id, response.params['litleOnlineResponse']['captureResponse']['id']
+    puts "Test #{options[:order_id]}A: #{txn_id(response)}"
 
     # 1B: credit
-    id = transaction_id
-    assert response = @gateway.credit(amount, response.authorization, {:id => id})
+    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
     assert_equal 'Approved', response.message
-    assert_equal id, response.params['litleOnlineResponse']['creditResponse']['id']
+    puts "Test #{options[:order_id]}B: #{txn_id(response)}"
 
     # 1C: void
-    id = transaction_id
-    assert response = @gateway.void(response.authorization, {:id => id})
+    assert response = @gateway.void(response.authorization, {:id => transaction_id})
     assert_equal 'Approved', response.message
-    assert_equal id, response.params['litleOnlineResponse']['voidResponse']['id']
+    puts "Test #{options[:order_id]}C: #{txn_id(response)}"
   end
 
   def authorize_avs_assertions(credit_card, options, assertions={})
-    assert response = @gateway.authorize(0, credit_card, options)
+    assert response = @gateway.authorize(000, credit_card, options)
     assert_equal assertions.key?(:success) ? assertions[:success] : true, response.success?
     assert_equal assertions[:message] || 'Approved', response.message
     assert_equal assertions[:avs], response.avs_result["code"], caller.inspect
     assert_equal assertions[:cvv], response.cvv_result["code"], caller.inspect if assertions[:cvv]
-    assert_equal options[:order_id], response.params['litleOnlineResponse']['authorizationResponse']['id']
+    puts "Test #{options[:order_id]} AVS Only: #{txn_id(response)}"
   end
 
-  def sale_assertions(amount, card, options, assertions)
+  def sale_assertions(amount, card, options, assertions={})
     # 1: sale
     assert response = @gateway.purchase(amount, card, options)
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal assertions[:avs], response.avs_result["code"]
+    assert_equal assertions[:avs], response.avs_result["code"] if assertions[:avs]
     assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
-    assert_equal options[:order_id], response.params['litleOnlineResponse']['saleResponse']['id']
+    assert_equal auth_code(options[:order_id]), response.params['authCode']
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+
 
     # 1B: credit
-    id = transaction_id
-    assert response = @gateway.credit(amount, response.authorization, {:id => id})
+    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
     assert_equal 'Approved', response.message
-    assert_equal id, response.params['litleOnlineResponse']['creditResponse']['id']
+    puts "Test #{options[:order_id]}B Sale: #{txn_id(response)}"
 
     # 1C: void
-    id = transaction_id
-    assert response = @gateway.void(response.authorization, {:id => id})
+    assert response = @gateway.void(response.authorization, {:id => transaction_id})
     assert_equal 'Approved', response.message
-    assert_equal id, response.params['litleOnlineResponse']['voidResponse']['id']
+    puts "Test #{options[:order_id]}C Sale: #{txn_id(response)}"
+  end
+
+  def auth_assertions(amount, card, options, assertions={})
+    # 1: authorize
+    assert response = @gateway.authorize(amount, card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result["code"] if assertions[:avs]
+    assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
+    assert_equal auth_code(options[:order_id]), response.params['authCode']
+
+    # 1A: capture
+    assert response = @gateway.capture(amount, response.authorization, {:id => transaction_id})
+    assert_equal 'Approved', response.message
+
+    # 1B: credit
+    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
+    assert_equal 'Approved', response.message
+
+    # 1C: void
+    assert response = @gateway.void(response.authorization, {:id => transaction_id})
+    assert_equal 'Approved', response.message
+  end
+
+  def authorize_avs_assertions(credit_card, options, assertions={})
+    assert response = @gateway.authorize(000, credit_card, options)
+    assert_equal assertions.key?(:success) ? assertions[:success] : true, response.success?
+    assert_equal assertions[:message] || 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result["code"], caller.inspect
+    assert_equal assertions[:cvv], response.cvv_result["code"], caller.inspect if assertions[:cvv]
+  end
+
+  def sale_assertions(amount, card, options, assertions={})
+    # 1: sale
+    assert response = @gateway.purchase(amount, card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result["code"] if assertions[:avs]
+    assert_equal assertions[:cvv], response.cvv_result["code"] if assertions[:cvv]
+    # assert_equal auth_code(options[:order_id]), response.params['authCode']
+
+    # 1B: credit
+    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
+    assert_equal 'Approved', response.message
+
+    # 1C: void
+    assert response = @gateway.void(response.authorization, {:id => transaction_id})
+    assert_equal 'Approved', response.message
   end
 
   def transaction_id
@@ -603,5 +811,13 @@ class RemoteLitleCertification < Test::Unit::TestCase
     #
     # minLength = N/A   maxLength = 25
     generate_unique_id[0, 24]
+  end
+
+  def auth_code(order_id)
+    order_id * 5 + ' '
+  end
+
+  def txn_id(response)
+    response.authorization.split(";")[0]
   end
 end

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -54,6 +54,15 @@ class RemoteLitleTest < Test::Unit::TestCase
         number:  "44444444400009",
         payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
       })
+    @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2021',
+        brand: "visa",
+        number:  "4457000300000007",
+        payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+      })
   end
 
   def test_successful_authorization
@@ -111,6 +120,12 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay
     assert response = @gateway.purchase(10010, @decrypted_apple_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_android_pay
+    assert response = @gateway.purchase(10000, @decrypted_android_pay)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -21,6 +21,15 @@ class LitleTest < Test::Unit::TestCase
         number:  "44444444400009",
         payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
       })
+    @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2021',
+        brand: "visa",
+        number:  "4457000300000007",
+        payment_cryptogram: "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+      })
     @amount = 100
     @options = {}
   end
@@ -114,6 +123,13 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_add_android_pay_order_source
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_android_pay)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<orderSource>androidpay</orderSource>", data
+    end.respond_with(successful_purchase_response)
+  end
 
   def test_successful_authorize_and_capture
     response = stub_comms do


### PR DESCRIPTION
Also updates Android Pay support to pass the ordersource correctly.

Unit:
32 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
28 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

I'm happy to consider an alternate method of passing the prelive url for the cert tests.