### PR TITLE
Add support for new cashnet test url

### DIFF
--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -4,6 +4,7 @@ module ActiveMerchant #:nodoc:
       include Empty
 
       self.live_url      = "https://commerce.cashnet.com/"
+      self.test_url      = "https://train.cashnet.com/"
 
       self.supported_countries = ["US"]
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
@@ -25,6 +26,7 @@ module ActiveMerchant #:nodoc:
       #   "ActiveMerchant/#{ActiveMerchant::VERSION}")
       # * <tt>:default_item_code</tt> -- Default item code (defaults to "FEE",
       #   can be overridden on a per-transaction basis with options[:item_code])
+      # * <tt>:test</tt> -- Run the gateway against the test url (defaults to false)
       def initialize(options = {})
         requires!(
           options,
@@ -58,7 +60,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, money, fields)
         fields[:amount] = amount(money)
-        url = live_url + CGI.escape(@options[:merchant_gateway_name])
+        url = gateway_url + CGI.escape(@options[:merchant_gateway_name])
         raw_response = ssl_post(url, post_data(action, fields))
         parsed_response = parse(raw_response)
 
@@ -140,6 +142,10 @@ module ActiveMerchant #:nodoc:
         message = "Unparsable response received from Cashnet. Please contact Cashnet if you continue to receive this message."
         message += " (The raw response returned by the API was #{raw_response.inspect})"
         return Response.new(false, message)
+      end
+
+      def gateway_url
+        test? ? test_url : live_url
       end
 
       CASHNET_CODES = {

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -141,6 +141,16 @@ class Cashnet < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_allows_test_gateway
+    gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', test: true)
+    assert gateway.test?
+    gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = gateway.purchase(@amount, @credit_card)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '1234', response.authorization
+  end
+
   private
   def expected_expiration_date
     '%02d%02d' % [@credit_card.month, @credit_card.year.to_s[2..4]]


### PR DESCRIPTION
Went to post a test transaction and got the following message: "Are you trying to reach the Cashnet Training environment? The URL is now https://train.cashnet.com"

Added support for gateway test mode