### PR TITLE
stripe emv transactions send statement_addess parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Stripe: Add support for statement_address parameters for EMV transactions [malcolm-mergulhao] #2524
 * Vantiv (Litle): Pass 3DS fields [curiousepic] #2536
 * Checkout V2: Add localized_amount support to add_invoice function [nicolas-maalouf-cko] #2452
 * Checkout V2: Fix success response code validation [nicolas-maalouf-cko] #2452

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -303,7 +303,9 @@ module ActiveMerchant #:nodoc:
           add_creditcard(post, payment, options)
         end
 
-        unless emv_payment?(payment)
+        if emv_payment?(payment)
+          add_statement_address(post, options)
+        else
           add_amount(post, money, options, true)
           add_customer_data(post, options)
           post[:description] = options[:description]
@@ -363,6 +365,18 @@ module ActiveMerchant #:nodoc:
           post[:card][:address_state] = address[:state] if address[:state]
           post[:card][:address_city] = address[:city] if address[:city]
         end
+      end
+
+      def add_statement_address(post, options)
+        return unless statement_address = options[:statement_address]
+        return unless [:address1, :city, :zip, :state].all? { |key| statement_address[key].present? } 
+
+        post[:statement_address] = {}
+        post[:statement_address][:line1] = statement_address[:address1]
+        post[:statement_address][:line2] = statement_address[:address2] if statement_address[:address2].present?
+        post[:statement_address][:city] = statement_address[:city]
+        post[:statement_address][:postal_code] = statement_address[:zip]
+        post[:statement_address][:state] = statement_address[:state]
       end
 
       def add_creditcard(post, creditcard, options)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -234,6 +234,16 @@ module ActiveMerchant
       }.update(options)
     end
 
+    def statement_address(options = {})
+      {
+        address1: '456 My Street',
+        address2: 'Apt 1',
+        city:     'Ottawa',
+        state:    'ON',
+        zip:      'K1C2N6'
+      }.update(options)
+    end
+
     def generate_unique_id
       SecureRandom.hex(16)
     end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -12,6 +12,7 @@ class StripeTest < Test::Unit::TestCase
 
     @options = {
       :billing_address => address(),
+      :statement_address => statement_address(),
       :description => 'Test Purchase'
     }
 
@@ -896,6 +897,32 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @options[:billing_address][:address2], post[:card][:address_line2]
     assert_equal @options[:billing_address][:country], post[:card][:address_country]
     assert_equal @options[:billing_address][:city], post[:card][:address_city]
+  end
+
+  def test_add_statement_address
+    post = {}
+
+    @gateway.send(:add_statement_address, post, @options)
+
+    assert_equal @options[:statement_address][:zip], post[:statement_address][:postal_code]
+    assert_equal @options[:statement_address][:state], post[:statement_address][:state]
+    assert_equal @options[:statement_address][:address1], post[:statement_address][:line1]
+    assert_equal @options[:statement_address][:address2], post[:statement_address][:line2]
+    assert_equal @options[:statement_address][:country], post[:statement_address][:country]
+    assert_equal @options[:statement_address][:city], post[:statement_address][:city]
+  end
+
+  def test_add_statement_address_returns_nil_if_required_fields_missing
+    post = {}
+    [:address1, :city, :zip, :state].each do |required_key|
+      missing_required = @options.tap do |options|
+        options[:statement_address].delete_if { |k| k == required_key }
+      end
+
+      @gateway.send(:add_statement_address, post, missing_required)
+
+      assert_equal nil, post[:statement_address]
+    end
   end
 
   def test_ensure_does_not_respond_to_credit


### PR DESCRIPTION
related to: https://gist.github.com/bct/53ffdf4dd4dab2540f7b#including-a-custom-address-on-an-emv-transaction
This will allow us to pass `statement_address` in through options and have them added to emv authorize and purchase requests. This is accomplished by adding these parameters to the post in `create_post_for_auth_or_purchase` if the transaction is an EMV payment.