### PR TITLE
FirstData E4: Override ECI value to `04` for tokenized Discover cards

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -236,11 +236,19 @@ module ActiveMerchant #:nodoc:
           xml.tag! "CardHoldersName", credit_card.name
           xml.tag! "CardType", card_type(credit_card.brand)
 
-          eci = (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
-          xml.tag! "Ecommerce_Flag", eci
-
+          add_eci(xml, credit_card, options)
           add_credit_card_verification_strings(xml, credit_card, options)
         end
+      end
+
+      def add_eci(xml, credit_card, options)
+        eci = if credit_card.is_a?(NetworkTokenizationCreditCard) && credit_card.brand == "discover"
+          "04"
+        else
+          (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
+        end
+
+        xml.tag! "Ecommerce_Flag", eci
       end
 
       def add_credit_card_verification_strings(xml, credit_card, options)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
 
         xml.instruct!
-        xml.tag! "Transaction" do
+        xml.tag! "Transaction", xmlns: "http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes" do
           add_credentials(xml)
           add_transaction_type(xml, action)
           xml << body

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -171,14 +171,13 @@ module ActiveMerchant #:nodoc:
         add_amount(xml, money, options)
 
         if credit_card_or_store_authorization.is_a? String
-          add_credit_card_token(xml, credit_card_or_store_authorization)
+          add_credit_card_token(xml, credit_card_or_store_authorization, options)
         else
           add_credit_card(xml, credit_card_or_store_authorization, options)
         end
 
         add_customer_data(xml, options)
         add_invoice(xml, options)
-        add_card_authentication_data(xml, options)
         add_tax_fields(xml, options)
         add_level_3(xml, options)
 
@@ -254,9 +253,13 @@ module ActiveMerchant #:nodoc:
 
         if credit_card.is_a?(NetworkTokenizationCreditCard)
           add_network_tokenization_credit_card(xml, credit_card)
-        elsif credit_card.verification_value?
-          xml.tag! "CVD_Presence_Ind", "1"
-          xml.tag! "VerificationStr2", credit_card.verification_value
+        else
+          if credit_card.verification_value?
+            xml.tag! "CVD_Presence_Ind", "1"
+            xml.tag! "VerificationStr2", credit_card.verification_value
+          end
+
+          add_card_authentication_data(xml, options)
         end
       end
 
@@ -277,7 +280,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! "XID", options[:xid]
       end
 
-      def add_credit_card_token(xml, store_authorization)
+      def add_credit_card_token(xml, store_authorization, options)
         params = store_authorization.split(";")
         credit_card = CreditCard.new(
           :brand      => params[1],
@@ -290,6 +293,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! "Expiry_Date", expdate(credit_card)
         xml.tag! "CardHoldersName", credit_card.name
         xml.tag! "CardType", card_type(credit_card.brand)
+        add_card_authentication_data(xml, options)
       end
 
       def add_customer_data(xml, options)

--- a/test/schema/firstdata_e4/v11.xsd
+++ b/test/schema/firstdata_e4/v11.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:schema
+   elementFormDefault="qualified"
+   xmlns:s="http://www.w3.org/2001/XMLSchema"
+   xmlns:s0="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes"
+   xmlns="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes"
+   targetNamespace="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes">
+  <s:complexType name="SoftDescriptor_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="DBAName" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Street" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Region" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="PostalCode" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CountryCode" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="MID" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="MCC" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="MerchantContactInfo" type="s:string" />
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_ShipToAddress_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="Address1" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Country" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CustomerNumber" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Phone" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Name" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Zip" type="s:string" />
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_LineItem_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="CommodityCode" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="Description" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountIndicator" type="s:boolean" />
+      <s:element minOccurs="0" maxOccurs="1" name="GrossNetIndicator" type="s:boolean" />
+      <s:element minOccurs="1" maxOccurs="1" name="LineItemTotal" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="ProductCode" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="Quantity" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="TaxAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="TaxRate" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="TaxType" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="UnitCost" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="UnitOfMeasure" type="s:string" />
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="TaxRate" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="AltTaxAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="AltTaxId" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="DutyAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="FreightAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="ShipFromZip" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="ShipToAddress" type="Level3_ShipToAddress_Type" />
+      <s:element minOccurs="1" maxOccurs="98" name="LineItem" type="Level3_LineItem_Type" />
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="PaypalTransactionDetails">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="PayerID" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="GrossAmountCurrencyID" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+      <s:element minOccurs="0" maxOccurs="1" name="Authorization" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CorrelationID" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Timestamp" type="s:string" />
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Transaction">
+    <s:all>
+      <s:element minOccurs="1" maxOccurs="1" name="ExactID" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="Password" type="s:string" />
+      <s:element minOccurs="1" maxOccurs="1" name="Transaction_Type" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="DollarAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="SurchargeAmount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Card_Number" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Transaction_Tag" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Track1" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Track2" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="PAN" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Authorization_Num" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Expiry_Date" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CardHoldersName" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="VerificationStr1" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="VerificationStr2" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CVD_Presence_Ind" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="ZipCode" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Tax1Amount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Tax1Number" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Tax2Amount" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Tax2Number" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Secure_AuthRequired" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Secure_AuthResult" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Ecommerce_Flag" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="XID" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CAVV" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CAVV_Algorithm" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Reference_No" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Customer_Ref" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Reference_3" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Language" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Client_IP" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Client_Email" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="User_Name" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="Currency" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="PartialRedemption" type="s:boolean" />
+      <s:element minOccurs="0" maxOccurs="1" name="Level3" type="Level3_Type" />
+      <s:element minOccurs="0" maxOccurs="1" name="TransarmorToken" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="CardType" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="EAN" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="VirtualCard" type="s:boolean" />
+      <s:element minOccurs="0" maxOccurs="1" name="CardCost" type="s:string" />
+      <s:element minOccurs="0" maxOccurs="1" name="PaypalResponse" type="PaypalTransactionDetails" />
+      <s:element minOccurs="0" maxOccurs="1" name="SoftDescriptor" type="SoftDescriptor_Type" />
+    </s:all>
+  </s:complexType>
+
+  <s:element name="Transaction" type="Transaction" />
+</s:schema>

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'nokogiri'
 require 'yaml'
 
 class FirstdataE4Test < Test::Unit::TestCase
@@ -212,6 +213,7 @@ class FirstdataE4Test < Test::Unit::TestCase
       assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
       assert_match "<XID>mrLdtHIWq2nLXq7IrA==\n</XID>", data
       assert_match "<CAVV>whateverthecryptogramofatlc=\n</CAVV>", data
+      assert_xml_valid_to_wsdl(data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -231,6 +233,7 @@ class FirstdataE4Test < Test::Unit::TestCase
         assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
         assert_match "<XID>123</XID>", data
         assert_match "<CAVV>whatever_the_cryptogram_is</CAVV>", data
+        assert_xml_valid_to_wsdl(data)
       end.respond_with(successful_purchase_response)
     end
   end
@@ -249,6 +252,7 @@ class FirstdataE4Test < Test::Unit::TestCase
       assert_match "<Ecommerce_Flag>06</Ecommerce_Flag>", data
       assert_match "<CAVV>SAMPLECAVV</CAVV>", data
       assert_match "<XID>SAMPLEXID</XID>", data
+      assert_xml_valid_to_wsdl(data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -285,6 +289,13 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   private
+
+  def assert_xml_valid_to_wsdl(data)
+    xsd = Nokogiri::XML::Schema(File.open("#{File.dirname(__FILE__)}/../../schema/firstdata_e4/v11.xsd"))
+    doc = Nokogiri::XML(data)
+    errors = xsd.validate(doc)
+    assert_empty errors, "XSD validation errors in the following XML:\n#{doc}"
+  end
 
   def pre_scrubbed
     <<-PRE_SCRUBBED

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -217,6 +217,25 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_network_tokenization_requests_with_discover_override_eci
+    stub_comms do
+      credit_card = network_tokenization_credit_card(
+        "378282246310005",
+        brand: "discover",
+        transaction_id: "123",
+        eci: "05",
+        payment_cryptogram: "whatever_the_cryptogram_is",
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_, data, _|
+      assert_match "<Ecommerce_Flag>04</Ecommerce_Flag>", data
+      assert_match "<XID>123</XID>", data
+      assert_match "<CAVV>whatever_the_cryptogram_is</CAVV>", data
+      assert_xml_valid_to_wsdl(data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_network_tokenization_requests_with_other_brands
     %w(visa mastercard other).each do |brand|
       stub_comms do


### PR DESCRIPTION
We've been in contact with Bank of America and FirstData, and they've
informed us that Discover is **requiring** all Apple Pay transactions to
use the "in-app" indicator of `04`. I chose to do so for all tokenized cards,
because I have to imagine the same requirements would be true for
all digital wallets--not just Apple Pay.

In addition, I've added a loose XSD validation for the request payloads.
I've extracted this from the official WSDL for the version we use, which
you can find here:
https://api.globalgatewaye4.firstdata.com/transaction/v11/wsdl

I've made some changes to the `Transaction` object to _not_ define a
sequence. We do not send the elements in the order that the schema defines,
but that doesn't appear to have ever been a problem. Now, This isn't great,
but it avoids a significant refactor of the code to get elements in the
correct sequence.

The above led me to fix duplicate XID and CAVV values when processing tokenized cards.
These were being added twice, once with the correct values and again empty.