### PR TITLE
PayU Latam: Add additional mandatory fields.

### DIFF
--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -6,15 +6,23 @@ class RemotePayuLatamTest < Test::Unit::TestCase
 
     @amount = 4000
     @credit_card = credit_card("4097440000000004", verification_value: "444", first_name: "APPROVED", last_name: "")
-    @declined_card = credit_card("4097440000000004", verification_value: "333", first_name: "REJECTED", last_name: "")
-    @pending_card = credit_card("4097440000000004", verification_value: "222", first_name: "PENDING", last_name: "")
+    @declined_card = credit_card("4097440000000004", verification_value: "444", first_name: "REJECTED", last_name: "")
+    @pending_card = credit_card("4097440000000004", verification_value: "444", first_name: "PENDING", last_name: "")
 
     @options = {
       dni_number: '5415668464654',
+      dni_type: 'TI',
       currency: "ARS",
       order_id: generate_unique_id,
       description: "Active Merchant Transaction",
       installments_number: 1,
+      tax: 0,
+      tax_return_base: 0,
+      email: "username@domain.com",
+      ip: "127.0.0.1",
+      device_session_id: 'vghs6tvkcle931686k1900o6e1',
+      cookie: 'pt1t38347bs6jc9ruv2ecpv7o2',
+      user_agent: 'Mozilla/5.0 (Windows NT 5.1; rv:18.0) Gecko/20100101 Firefox/18.0',
       billing_address: address(
         address1: "Viamonte",
         address2: "1366",

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -15,10 +15,18 @@ class PayuLatamTest < Test::Unit::TestCase
 
     @options = {
       dni_number: '5415668464654',
+      dni_type: 'TI',
       currency: "ARS",
       order_id: generate_unique_id,
       description: "Active Merchant Transaction",
       installments_number: 1,
+      tax: 0,
+      tax_return_base: 0,
+      email: "username@domain.com",
+      ip: "127.0.0.1",
+      device_session_id: 'vghs6tvkcle931686k1900o6e1',
+      cookie: 'pt1t38347bs6jc9ruv2ecpv7o2',
+      user_agent: 'Mozilla/5.0 (Windows NT 5.1; rv:18.0) Gecko/20100101 Firefox/18.0',
       billing_address: address(
         address1: "Viamonte",
         address2: "1366",


### PR DESCRIPTION
Remote:
15 tests, 39 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.6667% passed
(These two failures both have a responseCode of 'INTERNAL_PAYMENT_PROVIDER_ERROR' and pre-date these changes.)

Unit:
17 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed