### PR TITLE
Allow Response Code 4 to be returned as successful

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -898,7 +898,7 @@ module ActiveMerchant
         if cim?(action) || (action == :verify_credentials)
           response[:result_code] == "Ok"
         else
-          response[:response_code] == APPROVED && TRANSACTION_ALREADY_ACTIONED.exclude?(response[:response_reason_code])
+          [APPROVED, FRAUD_REVIEW].include?(response[:response_code]) && TRANSACTION_ALREADY_ACTIONED.exclude?(response[:response_reason_code])
         end
       end
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -826,7 +826,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(fraud_review_response)
 
     response = @gateway.purchase(@amount, @credit_card)
-    assert_failure response
+    assert_success response
     assert response.fraud_review?
     assert_equal "Thank you! For security reasons your order is currently being reviewed", response.message
   end


### PR DESCRIPTION
Currently only response code 1 is being recorded as a successful
transaction, however response_code 4 is also successful but held for
fraud review.

Loaded suite test/remote/gateways/remote_authorize_net_test
Started
.............................................................

Finished in 40.926721 seconds.
61 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
1.49 tests/s, 5.13 assertions/s