### PR TITLE
Litle: Update live endpoint url

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -6,14 +6,14 @@ module ActiveMerchant #:nodoc:
       SCHEMA_VERSION = '9.12'
 
       self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
-      self.live_url = 'https://payments.litle.com/vap/communicator/online'
+      self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
 
-      self.homepage_url = 'http://www.litle.com/'
-      self.display_name = 'Litle & Co.'
+      self.homepage_url = 'http://www.vantiv.com/'
+      self.display_name = 'Vantiv eCommerce'
 
       def initialize(options={})
         requires!(options, :login, :password, :merchant_id)


### PR DESCRIPTION
Vantiv, which now owns Litle is rebranding the Litle API. This
includes changing the urls for the live endpoint. This new endpoint url
is already active. Replacement for the Sandbox test environment url is
forthcoming. The deadline for the change is August 31 2017.

Unit:
32 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
28 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed