### PR TITLE
Remove param[:order_number] from captures in Forte Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -46,7 +46,6 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options={})
         post = {}
-        add_invoice(post, options)
         post[:transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization) || ""
         post[:action] = "capture"

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -21,8 +21,10 @@ class RemoteForteTest < Test::Unit::TestCase
 
     @options = {
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      order_id: '1'
     }
+
   end
 
   def test_invalid_login
@@ -76,7 +78,7 @@ class RemoteForteTest < Test::Unit::TestCase
 
     wait_for_authorization_to_clear
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'APPROVED', capture.message
   end
@@ -94,12 +96,12 @@ class RemoteForteTest < Test::Unit::TestCase
 
     wait_for_authorization_to_clear
 
-    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert capture = @gateway.capture(@amount-1, auth.authorization, @options)
     assert_success capture
   end
 
   def test_failed_capture
-    response = @gateway.capture(@amount, '')
+    response = @gateway.capture(@amount, '', @options)
     assert_failure response
     assert_match 'field transaction_id', response.message
   end


### PR DESCRIPTION
When processing captures in the forte gateway only admin messages are
allowed. Adding the param[:order_number] produces an F03 invalid field name
error.

Loaded suite test/remote/gateways/remote_forte_test
Started

Finished in 40.85056 seconds.
18 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,

0 notifications
100% passed