### PR TITLE
Remove HUF from default non-fractional currencies

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = []
 
       class_attribute :currencies_without_fractions, :currencies_with_three_decimal_places
-      self.currencies_without_fractions = %w(BIF BYR CLP CVE DJF GNF HUF ISK JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
+      self.currencies_without_fractions = %w(BIF BYR CLP CVE DJF GNF ISK JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
       self.currencies_with_three_decimal_places = %w()
 
       class_attribute :homepage_url

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -83,11 +83,11 @@ class GatewayTest < Test::Unit::TestCase
   def test_localized_amount_should_ignore_money_format_for_non_fractional_currencies
     Gateway.money_format = :dollars
     assert_equal '1', @gateway.send(:localized_amount, 100, 'JPY')
-    assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
+    assert_equal '12', @gateway.send(:localized_amount, 1234, 'ISK')
 
     Gateway.money_format = :cents
     assert_equal '1', @gateway.send(:localized_amount, 100, 'JPY')
-    assert_equal '12', @gateway.send(:localized_amount, 1234, 'HUF')
+    assert_equal '12', @gateway.send(:localized_amount, 1234, 'ISK')
   end
 
   def test_localized_amount_returns_three_decimal_places_for_three_decimal_currencies


### PR DESCRIPTION
HUF is not a true non-fractional currency, but was included in the
default list of non-fractional currencies in the Gateway class. After
changing Barclaycard Smartpay to use localized_amount, this was causing
it to send incorrect amounts for HUF.

This removes it from the Gateway class's default list of non-fractional
currencies. Paypal Express and Worldpay seem to be the only gateways
that consider HUF to be non-fractional, and those already override the
default list. It's possible other gateways consider HUF to be non-
fractional, in which case those gateways should have their own over-
riding list.

Full Unit:
3648 tests, 66870 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed