### PR TITLE
Fixing issue where partial refund actually voids the whole transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -1,4 +1,5 @@
 module ActiveMerchant #:nodoc:
+
   module Billing #:nodoc:
     class TransFirstGateway < Gateway
       self.test_url = 'https://ws.cert.transfirst.com'
@@ -16,7 +17,7 @@ module ActiveMerchant #:nodoc:
       ACTIONS = {
         purchase: "CCSale",
         purchase_echeck: "ACHDebit",
-        refund: "CreditCardAutoRefundorVoid",
+        refund: "CreditCardCredit",
         refund_echeck: "ACHVoidTransaction",
         void: "CreditCardAutoRefundorVoid",
       }
@@ -52,6 +53,7 @@ module ActiveMerchant #:nodoc:
         transaction_id, payment_type = split_authorization(authorization)
         add_amount(post, money)
         add_pair(post, :TransID, transaction_id)
+        add_pair(post, :RefID, options[:order_id], required: true)
 
         commit((payment_type == "check" ? :refund_echeck : :refund), post)
       end
@@ -169,7 +171,6 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, params)
         response = parse(ssl_post(url(action), post_data(action, params)))
-
         Response.new(
           success_from(response),
           message_from(response),

--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -70,13 +70,32 @@ class RemoteTransFirstTest < Test::Unit::TestCase
     assert_equal 'Insufficient funds', response.message
   end
 
-  def test_successful_refund
+  def test_successful_void
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount, purchase.authorization)
-    assert_success refund
+    assert void = @gateway.void(purchase.authorization)
+    assert_success void
   end
+
+  # Refunds can only be successfully run on settled transactions which take 24 hours 
+  # def test_successful_refund
+  #   assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+  #   assert_success purchase
+
+  #   assert refund = @gateway.refund(@amount, purchase.authorization)
+  #   assert_equal @amount, refund.params["amount"].to_i*100
+  #   assert_success refund
+  # end
+
+  # def test_successful_partial_refund
+  #   assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+  #   assert_success purchase
+
+  #   assert refund = @gateway.refund(@amount-1, purchase.authorization)
+  #   assert_equal @amount-1, refund.params["amount"].to_i*100
+  #   assert_success refund
+  # end
 
   def test_successful_refund_with_echeck
     assert purchase = @gateway.purchase(@amount, @check, @options)

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -68,12 +68,27 @@ class TransFirstTest < Test::Unit::TestCase
     response = @gateway.refund(@amount, "TransID")
     assert_success response
     assert_equal '207686608|creditcard', response.authorization
+    assert_equal @amount, response.params["amount"].to_i*100
   end
 
   def test_failed_refund
     @gateway.stubs(:ssl_post).returns(failed_refund_response)
 
     response = @gateway.refund(@amount, "TransID")
+    assert_failure response
+  end
+ 
+  def test_successful_void
+    @gateway.stubs(:ssl_post).returns(successful_void_response)
+
+    response = @gateway.void("TransID")
+    assert_success response
+  end
+
+  def test_failed_void
+    @gateway.stubs(:ssl_post).returns(failed_void_response)
+
+    response = @gateway.void("TransID")
     assert_failure response
   end
 
@@ -320,4 +335,36 @@ class TransFirstTest < Test::Unit::TestCase
       </BankCardRefundStatus>
     XML
   end
+
+  def successful_void_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <BankCardRefundStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.paymentresources.com/webservices/">
+        <TransID>0</TransID>
+      <TransID>207616632</TransID>
+      <CreditID>0</CreditID>
+      <RefID>123</RefID>
+      <PostedDate>2010-08-09T12:25:00</PostedDate> <SettledDate>0001-01-01T00:00:00</SettledDate>
+      <Amount>1.3100</Amount>
+      <AuthCode>012921</AuthCode>
+      <Status>Voided</Status>
+      <AVSCode>N</AVSCode>
+      <CVV2Code />
+      </BankCardRefundStatus>
+   XML
+  end
+
+  def failed_void_response
+    <<-XML
+      <?xml version="1.0" encoding="utf-8" ?>
+      <BankCardRefundStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.paymentresources.com/webservices/">
+      <TransID>0</TransID>
+      <CreditID>0</CreditID>
+      <PostedDate>0001-01-01T00:00:00</PostedDate> <SettledDate>0001-01-01T00:00:00</SettledDate>
+      <Amount>0</Amount>
+      <Status>Canceled</Status>
+      <Message>Transaction Is Not Allowed To Void or Refund</Message>
+      </BankCardRefundStatus>
+     XML
+   end
 end


### PR DESCRIPTION
The incorrect endpoint was being used for refunds. This updates the
refund method so that a partial refund can be done.

Remote tests are not possible since refunds can only be done on settled
transctions. A unit test was updated to check the amount returned.

Closes ENRG-6905

Remote tests:
Finished in 0.016094 seconds.
11 tests, 25 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
683.48 tests/s, 1553.37 assertions/s

Remote tests:
Finished in 8.146803 seconds.
12 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
1.47 tests/s, 5.03 assertions/s