### PR TITLE
NMI: Compact before joining authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response, payment_type)
-        [ response[:transactionid], payment_type ].join("#")
+        [ response[:transactionid], payment_type ].compact.join("#")
       end
 
       def split_authorization(authorization)


### PR DESCRIPTION
## Description
When generating the authorization in `authorization_from`, it is possible for `params[:payment]` to be `nil`, which appends a "#" to the end of the `transaction_id`. This PR adds `compact` when calling `authorization_from` to handle this case.

**Ref:** A similar pattern exists here:
https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/efsnet.rb#L163

### Tests
```
# Remote Tests
33 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

# Unit Tests
27 tests, 194 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```