### PR TITLE
AVS on TransFirst Express are failing when no address2

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -542,7 +542,7 @@ module ActiveMerchant #:nodoc:
               doc["v1"].nr billing_address[:phone].gsub(/\D/, '') if billing_address[:phone]
             end
             doc["v1"].addrLn1 billing_address[:address1]
-            doc["v1"].addrLn2 billing_address[:address2]
+            doc["v1"].addrLn2 billing_address[:address2] if billing_address[:address2]
             doc["v1"].city billing_address[:city]
             doc["v1"].state billing_address[:state]
             doc["v1"].zipCode billing_address[:zip]

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -45,6 +45,20 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "Street address does not match, but 5-digit postal code matches.", response.avs_result["message"]
     assert_equal "CVV matches", response.cvv_result["message"]
   end
+ 
+  def test_successful_purchase_with_no_address2
+    options = @options.dup
+    options[:shipping_address][:address2] = nil
+    options[:billing_address][:address2] = nil
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal "Succeeded", response.message
+    assert_not_nil response.avs_result
+    assert_not_nil response.cvv_result
+    assert_equal "Street address does not match, but 5-digit postal code matches.", response.avs_result["message"]
+    assert_equal "CVV matches", response.cvv_result["message"]
+  end
+
 
   def test_successful_purchase_without_cvv
     credit_card_opts = {


### PR DESCRIPTION
Removed the address2 field unless a value is given.

Loaded suite
test/remote/gateways/remote_trans_first_transaction_express_test
Started

Finished in 23.362846 seconds.
30 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
1.28 tests/s, 4.49 assertions/s

Loaded suite test/unit/gateways/trans_first_transaction_express_test
Started

Finished in 0.068235 seconds.
21 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
307.76 tests/s, 1509.49 assertions/s