### PR TITLE
DataCash: Add new xml element to refund configuration.

### DIFF
--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -168,6 +168,7 @@ module ActiveMerchant
             unless money.nil?
               xml.tag! :TxnDetails do
                 xml.tag! :amount, amount(money)
+                xml.tag! :capturemethod, 'ecomm'
               end
             end
           end
@@ -188,6 +189,7 @@ module ActiveMerchant
             xml.tag! :TxnDetails do
               xml.tag! :merchantreference, format_reference_number(options[:order_id])
               xml.tag! :amount, amount(money)
+              xml.tag! :capturemethod, 'ecomm'
             end
           end
         end

--- a/test/remote/gateways/remote_data_cash_test.rb
+++ b/test/remote/gateways/remote_data_cash_test.rb
@@ -45,7 +45,6 @@ class RemoteDataCashTest < Test::Unit::TestCase
       :issue_number => 5,
       :start_month => 12,
       :start_year => 2006,
-      :verification_value => 444
     )
 
     @address = {


### PR DESCRIPTION
Adds a new XML element `capturemethod` with value `ecomm` to refund
and credit transactions.

Also corrects failing remote tests for `test_successful_refund` and
`test_successful_purchase_with_solo_card`.

Remote:
27 tests, 82 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit:
14 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed