### PR TITLE
CreditCall: Only allow AVS when specified

### DIFF
--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -126,17 +126,22 @@ module ActiveMerchant #:nodoc:
 
       def add_card_details(xml, payment_method, options={})
         xml.CardDetails do
-          xml.Manual(type: "ecommerce") do
+          xml.Manual(type: manual_type(options)) do
             xml.PAN payment_method.number
             xml.ExpiryDate exp_date(payment_method)
             xml.CSC payment_method.verification_value unless empty?(payment_method.verification_value)
           end
 
-          if address = options[:billing_address]
-            xml.AdditionalVerification do
-              xml.Address address[:address1]
-              xml.Zip address[:zip]
-            end
+          add_additional_verification(xml, options)
+        end
+      end
+
+      def add_additional_verification(xml, options)
+        return unless (options[:verify_zip].to_s == 'true') || (options[:verify_address].to_s == 'true')
+        if address = options[:billing_address]
+          xml.AdditionalVerification do
+            xml.Zip address[:zip] if options[:verify_zip].to_s  == 'true'
+            xml.Address address[:address1] if options[:verify_address].to_s  == 'true'
           end
         end
       end
@@ -221,6 +226,9 @@ module ActiveMerchant #:nodoc:
         response["CardEaseReference"]
       end
 
+      def manual_type(options)
+        options[:manual_type] ? options[:manual_type] : "ecommerce"
+      end
     end
   end
 end

--- a/test/remote/gateways/remote_creditcall_test.rb
+++ b/test/remote/gateways/remote_creditcall_test.rb
@@ -22,6 +22,8 @@ class RemoteCreditcallTest < Test::Unit::TestCase
   def test_successful_purchase_sans_options
     response = @gateway.purchase(@amount, @credit_card)
     assert_success response
+    assert_equal response.params['Zip'], 'notchecked'
+    assert_equal response.params['Address'], 'notchecked'
     assert_equal 'Succeeded', response.message
   end
 
@@ -29,7 +31,8 @@ class RemoteCreditcallTest < Test::Unit::TestCase
     options = {
       order_id: '1',
       ip: "127.0.0.1",
-      email: "joe@example.com"
+      email: "joe@example.com",
+      manual_type: "cnp"
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)
@@ -48,6 +51,22 @@ class RemoteCreditcallTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'Succeeded', auth.message
+  end
+
+  def test_successful_authorize_with_zip_verification
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(verify_zip: 'true'))
+    assert_success response
+    assert_equal response.params['Zip'], 'matched'
+    assert_equal response.params['Address'], 'notchecked'
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_authorize_with_address_verification
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(verify_address: 'true'))
+    assert_success response
+    assert_equal response.params['Zip'], 'notchecked'
+    assert_equal response.params['Address'], 'matched'
+    assert_equal 'Succeeded', response.message
   end
 
   def test_successful_authorize_and_capture


### PR DESCRIPTION
CreditCall: Only allow AVS when specified
    
    This disables AVS checking by default, and only sends the
    AdditionalVerification element if either verify_zip or verify_address
    flags are sent in options. It also exposes `manual_type` to an option
    field. These options can help with decline rates.
    
    Remote:
    20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    
    Unit:
    17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

Tagging @nfarve too.