### PR TITLE
TransFirst Express: Fix Optional Fields Being Passed Blank

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -537,15 +537,17 @@ module ActiveMerchant #:nodoc:
           doc["v1"].title options[:title] if options[:title]
 
           if (billing_address = options[:billing_address])
-            doc["v1"].phone do
-              doc["v1"].type (options[:phone_number_type] || "4")
-              doc["v1"].nr billing_address[:phone].gsub(/\D/, '') if billing_address[:phone]
+            if billing_address[:phone]
+              doc["v1"].phone do
+                doc["v1"].type (options[:phone_number_type] || "4")
+                doc["v1"].nr billing_address[:phone].gsub(/\D/, '')
+              end
             end
-            doc["v1"].addrLn1 billing_address[:address1]
+            doc["v1"].addrLn1 billing_address[:address1] if billing_address[:address1]
             doc["v1"].addrLn2 billing_address[:address2] if billing_address[:address2]
-            doc["v1"].city billing_address[:city]
-            doc["v1"].state billing_address[:state]
-            doc["v1"].zipCode billing_address[:zip]
+            doc["v1"].city billing_address[:city] if billing_address[:city]
+            doc["v1"].state billing_address[:state] if billing_address[:state]
+            doc["v1"].zipCode billing_address[:zip] if billing_address[:zip]
             doc["v1"].ctry "US"
           end
 
@@ -556,11 +558,11 @@ module ActiveMerchant #:nodoc:
           if (shipping_address = options[:shipping_address])
             doc["v1"].ship do
               doc["v1"].fullName fullname
-              doc["v1"].addrLn1 shipping_address[:address1]
+              doc["v1"].addrLn1 shipping_address[:address1] if shipping_address[:address1]
               doc["v1"].addrLn2 shipping_address[:address2] if shipping_address[:address2]
-              doc["v1"].city shipping_address[:city]
-              doc["v1"].state shipping_address[:state]
-              doc["v1"].zipCode shipping_address[:zip]
+              doc["v1"].city shipping_address[:city] if shipping_address[:city]
+              doc["v1"].state shipping_address[:state] if shipping_address[:state]
+              doc["v1"].zipCode shipping_address[:zip] if shipping_address[:zip]
               doc["v1"].phone shipping_address[:phone].gsub(/\D/, '') if shipping_address[:phone]
               doc["v1"].email shipping_address[:email] if shipping_address[:email]
             end

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -46,10 +46,27 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal "CVV matches", response.cvv_result["message"]
   end
  
-  def test_successful_purchase_with_no_address2
+  def test_successful_purchase_no_avs
     options = @options.dup
-    options[:shipping_address][:address2] = nil
-    options[:billing_address][:address2] = nil
+    options[:shipping_address] = nil
+    options[:billing_address] = nil
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_only_required
+    # Test the purchase with only the required billing and shipping information
+    options = @options.dup
+    options[:shipping_address] = {
+      address1: "450 Main",
+      zip: "85284",
+    }
+
+    options[:billing_address] = {
+      address1: "450 Main",
+      zip: "85284",
+    }
+
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal "Succeeded", response.message


### PR DESCRIPTION
Continuation of issue where address2 field being passed as an empty
string caused an error. Currently, only address1 and zip are required
for AVS. Previous fix to only pass address2 if is present doesn't fix
the larger issue that none of the optional fields should be passed
blank.

Updated previous remote test to not only remove address2 but everything in
shipping and billing that is not required.

Loaded suite
test/remote/gateways/remote_trans_first_transaction_express_test
Started

Finished in 25.935593 seconds.
30 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
1.16 tests/s, 4.05 assertions/s

Loaded suite test/unit/gateways/trans_first_transaction_express_test
Started

Finished in 0.104014 seconds.
21 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
201.90 tests/s, 990.25 assertions/s