### PR TITLE
Fix for Bambora (North America) gateway, formerly Beanstream. Issue #2544. Changing casing on customerIp variable.

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_ip(post, options)
-        post[:customerIP] = options[:ip] if options[:ip]
+        post[:customerIp] = options[:ip] if options[:ip]
       end
 
       def void_action(original_transaction_type)

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -213,7 +213,7 @@ class BeanstreamTest < Test::Unit::TestCase
 
   def test_ip_is_being_sent
     @gateway.expects(:ssl_post).with do |url, data|
-      data =~ /customerIP=123\.123\.123\.123/
+      data =~ /customerIp=123\.123\.123\.123/
     end.returns(successful_purchase_response)
 
     @options[:ip] = "123.123.123.123"


### PR DESCRIPTION
Fix for issue #2544. Changing casing of customerIP variable.

Changing variable from "customerIP" to "customerIp".

https://support.na.bambora.com/bic/w/index.html#docs/about-risk-thresholds.htm