### PR TITLE
MercadoPago: Small tweaks to building requests

### DIFF
--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -9,6 +9,7 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
     @options = {
       billing_address: address,
+      shipping_address: address,
       email: "user+br@example.com",
       description: 'Store Purchase'
     }


### PR DESCRIPTION
After working with MercadoPago engineering for a bit there were a
couple tweaks that needed to be made in order for the integration
to process smoothly:

- use "binary_mode" to avoid a notification URL for transaction states
- send American Express cards as "amex" instead of "american_express"
- send shipping address if available

I should note that I also noticed that the `additional_info` field was
getting overwritten each time a new field was getting added so that
needed to be fixed to be merged instead.

tagging @nfarve too 👋 