### PR TITLE
Ebank: Adds Brazil Specific Parameters

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, payment, options)
         add_payment(post, payment)
         add_address(post, options)
-
+        add_customer_responsible_person(post, payment, options) if post[:payment][:country] == 'BR'
         commit(:purchase, post)
       end
 
@@ -60,6 +60,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, payment, options)
         add_payment(post, payment)
         add_address(post, options)
+        add_customer_responsible_person(post, payment, options) if post[:payment][:country] == 'BR'
         post[:payment][:creditcard][:auto_capture] = false
 
         commit(:authorize, post)
@@ -129,6 +130,14 @@ module ActiveMerchant #:nodoc:
         post[:payment][:name] = payment.name
         post[:payment][:email] = options[:email] || "unspecified@example.com"
         post[:payment][:document] = options[:document]
+        post[:payment][:birth_date] = options[:birth_date] if options[:birth_date]
+      end
+
+      def add_customer_responsible_person(post, payment,  options)
+        post[:payment][:responsible] = {}
+        post[:payment][:responsible][:name] = payment.name
+        post[:payment][:responsible][:document] = options[:document]
+        post[:payment][:responsible][:birth_date] = options[:birth_date] if options[:birth_date]
       end
 
       def add_address(post, options)
@@ -147,6 +156,7 @@ module ActiveMerchant #:nodoc:
         post[:payment][:amount_total] = amount(money)
         post[:payment][:currency_code] = (options[:currency] || currency(money))
         post[:payment][:merchant_payment_code] = options[:order_id]
+        post[:payment][:instalments] = options[:instalments] || 1
       end
 
       def add_payment(post, payment)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -31,7 +31,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
     options = @options.merge({
       order_id: generate_unique_id,
       ip: "127.0.0.1",
-      email: "joe@example.com"
+      email: "joe@example.com",
+      birth_date: "10/11/1980"
     })
 
     response = @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
Birth_date and payment.responsible parameters are required for customers in
Brazil. Adding these fields to the gateway.

Loaded suite test/remote/gateways/remote_ebanx_test

16 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Loaded suite test/unit/gateways/ebanx_test

14 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed