### PR TITLE
DataCash: Enable refunding recurring transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -168,6 +168,7 @@ module ActiveMerchant
             unless money.nil?
               xml.tag! :TxnDetails do
                 xml.tag! :amount, amount(money)
+                xml.tag! :capturemethod, 'ecomm'
               end
             end
           end
@@ -188,6 +189,7 @@ module ActiveMerchant
             xml.tag! :TxnDetails do
               xml.tag! :merchantreference, format_reference_number(options[:order_id])
               xml.tag! :amount, amount(money)
+              xml.tag! :capturemethod, 'ecomm'
             end
           end
         end


### PR DESCRIPTION
In order to refund a recurring/continuous authority transaction, the
`capturemethod` field must but submitted with the value of "ecomm" or
"cnp". See DataCash docs for more details.

https://datacash.custhelp.com/app/answers/detail/a_id/792/~/refunding-recurring-transactions

Note that this commit also fixes stale card details for transactions
using a Solo card. Sending any value for the CV2 results in a rejected
response with an invalid CV2 message so we're not longer going to send
it.

also tagging @nfarve 

---

Test suite runs:

```
/Users/david/dev/active_merchant data-cash-refund-repeat ✔
➜ ruby -Itest test/remote/gateways/remote_data_cash_test.rb

Loaded suite test/remote/gateways/remote_data_cash_test
Started
............................

Finished in 51.045349 seconds.
----------------------------------------------------------------------------------------------------------------------
28 tests, 87 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
0.55 tests/s, 1.70 assertions/s

/Users/david/dev/active_merchant data-cash-refund-repeat ✔
➜ bundle exec ruby -Itest test/unit/gateways/data_cash_test.rb
Loaded suite test/unit/gateways/data_cash_test
Started
..............

Finished in 0.034191 seconds.
----------------------------------------------------------------------------------------------------------------------
14 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
409.46 tests/s, 994.41 assertions/s
```