### PR TITLE
PayU Latam: Pass payment_country option

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -249,7 +249,7 @@ module ActiveMerchant #:nodoc:
       def add_payer(post, options)
         if address = options[:billing_address]
           payer = {}
-          post[:transaction][:paymentCountry] = address[:country]
+          post[:transaction][:paymentCountry] = options[:payment_country] if options[:payment_country]
           payer[:fullName] = address[:name]
           payer[:contactPhone] = address[:phone]
           payer[:dniNumber] = options[:dni_number] if options[:dni_number]

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -10,6 +10,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     @pending_card = credit_card("4097440000000004", verification_value: "444", first_name: "PENDING", last_name: "")
 
     @options = {
+      payment_country: 'AR',
       dni_number: '5415668464654',
       dni_type: 'TI',
       currency: "ARS",
@@ -55,6 +56,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327"))
 
     options_brazil = {
+      payment_country: "BR",
       currency: "BRL",
       billing_address: address(
         address1: "Calle 100",

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -14,6 +14,7 @@ class PayuLatamTest < Test::Unit::TestCase
     @no_cvv_amex_card = credit_card("4097440000000004", verification_value: " ", brand: "american_express")
 
     @options = {
+      payment_country: 'AR',
       dni_number: '5415668464654',
       dni_type: 'TI',
       currency: "ARS",


### PR DESCRIPTION
payment_country must be the country of the merchant, rather than the
buyer/payer. This opens an option field for the merchant to pass this
value.

Two tests unrelated to this change still fail as "Internal payment
provider error. "

Remote:
15 tests, 39 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.6667% passed

Unit:
17 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@nfarve 