### PR TITLE
Authorize.net: Restore default state value for non-US addresses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Qvalent: Support general credit [curiousepic] #2558
 * DataCash: Enable refunding recurring transactions [davidsantoso] #2560
 * Ebanx: Adds Brazil Specific Parameters [nfarve] #2559
+* Authorize.net: Restore default state value for non-US addresses [jasonwebster] #2563
 
 == Version 1.71.0 (August 22, 2017)
 * Bambora formerly Beanstream: Change casing on customerIp variable [aengusbates] #2551

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -719,7 +719,7 @@ module ActiveMerchant
         if ["US", "CA"].include?(address[:country])
           address[:state] || 'NC'
         else
-          address[:state]
+          address[:state] || 'n/a'
         end
       end
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -653,7 +653,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       parse(data) do |doc|
         assert_equal "", doc.at_xpath("//billTo/address").content, data
         assert_equal "", doc.at_xpath("//billTo/city").content, data
-        assert_equal "", doc.at_xpath("//billTo/state").content, data
+        assert_equal "n/a", doc.at_xpath("//billTo/state").content, data
         assert_equal "", doc.at_xpath("//billTo/zip").content, data
         assert_equal "", doc.at_xpath("//billTo/country").content, data
       end
@@ -691,7 +691,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'DE'})
     end.check_request do |endpoint, data, headers|
       parse(data) do |doc|
-        assert_equal "", doc.at_xpath("//billTo/state").content, data
+        assert_equal "n/a", doc.at_xpath("//billTo/state").content, data
         assert_equal "164 Waverley Street", doc.at_xpath("//billTo/address").content, data
         assert_equal "DE", doc.at_xpath("//billTo/country").content, data
       end
@@ -703,7 +703,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', address2: 'Apt 1234', country: 'DE'})
     end.check_request do |endpoint, data, headers|
       parse(data) do |doc|
-        assert_equal "", doc.at_xpath("//billTo/state").content, data
+        assert_equal "n/a", doc.at_xpath("//billTo/state").content, data
         assert_equal "164 Waverley Street Apt 1234", doc.at_xpath("//billTo/address").content, data
         assert_equal "DE", doc.at_xpath("//billTo/country").content, data
       end


### PR DESCRIPTION
Removed in https://github.com/activemerchant/active_merchant/pull/2496

Turns out (surprise!) Authorize.net docs have some contradictory advice.

http://developer.authorize.net/api/reference/#payment-transactions-charge-a-credit-card
For `billTo.state` says:

> State of customer’s billing address. Required only when using a European Payment Processor.