### PR TITLE
Braintree Blue: Add eci_indicator field for Apple Pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Ebanx: Adds Brazil Specific Parameters [nfarve] #2559
 * Authorize.net: Restore default state value for non-US addresses [jasonwebster] #2563
 * MercadoPago: Additional tweaks for transaction requests [davidsantoso]
+* Braintree Blue: Add eci_indicator field for Apple Pay [davidsantoso]
 
 == Version 1.71.0 (August 22, 2017)
 * Bambora formerly Beanstream: Change casing on customerIp variable [aengusbates] #2551

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
+  gem 'braintree', '>= 2.78.0'
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -582,7 +582,8 @@ module ActiveMerchant #:nodoc:
                 :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, "0"),
                 :expiration_year => credit_card_or_vault_id.year.to_s,
                 :cardholder_name => credit_card_or_vault_id.name,
-                :cryptogram => credit_card_or_vault_id.payment_cryptogram
+                :cryptogram => credit_card_or_vault_id.payment_cryptogram,
+                :eci_indicator => credit_card_or_vault_id.eci
               }
           elsif credit_card_or_vault_id.source == :android_pay
               parameters[:android_pay_card] = {

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -606,7 +606,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
           :expiration_month => '09',
           :expiration_year => (Time.now.year + 1).to_s,
           :cardholder_name => 'Longbob Longsen',
-          :cryptogram => '111111111100cryptogram'
+          :cryptogram => '111111111100cryptogram',
+          :eci_indicator => '05'
         }
       ).
       returns(braintree_result(:id => "transaction_id"))


### PR DESCRIPTION
The eci_indicator field was previously only supported for Android Pay,
however it has recently been added to Apple Pay as well.

https://github.com/braintree/braintree_ruby/commit/fb4032d004ea8ad51e521796b01adf1895af6bf5