### PR TITLE
Use monotonic clock to measure elapsed time

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -49,7 +49,7 @@ module ActiveMerchant
     end
 
     def request(method, body, headers = {})
-      request_start = Time.now.to_f
+      request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do
         begin
@@ -89,7 +89,7 @@ module ActiveMerchant
       end
 
     ensure
-      info "connection_request_total_time=%.4fs" % [Time.now.to_f - request_start], tag
+      info "connection_request_total_time=%.4fs" % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start], tag
     end
 
     private

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -42,19 +42,19 @@ module ActiveMerchant
       request_start = nil
 
       begin
-        request_start = Time.now.to_f
+        request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         result = yield
-        log_with_retry_details(options[:logger], initial_retries-retries + 1, Time.now.to_f - request_start, "success", options[:tag])
+        log_with_retry_details(options[:logger], initial_retries-retries + 1, Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start, "success", options[:tag])
         result
       rescue ActiveMerchant::RetriableConnectionError => e
         retries -= 1
 
-        log_with_retry_details(options[:logger], initial_retries-retries, Time.now.to_f - request_start, e.message, options[:tag])
+        log_with_retry_details(options[:logger], initial_retries-retries, Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start, e.message, options[:tag])
         retry unless retries.zero?
         raise ActiveMerchant::ConnectionError.new(e.message, e)
       rescue ActiveMerchant::ConnectionError, ActiveMerchant::InvalidResponseError => e
         retries -= 1
-        log_with_retry_details(options[:logger], initial_retries-retries, Time.now.to_f - request_start, e.message, options[:tag])
+        log_with_retry_details(options[:logger], initial_retries-retries, Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start, e.message, options[:tag])
         retry if (options[:retry_safe] || retry_safe) && !retries.zero?
         raise
       end


### PR DESCRIPTION
The monotonic clock can only move forward and is not subject to changes of the system clock, e.g. corrections due to NTP or VM adjustments.

This is what `Benchmark.realtime` uses too and it's a bit faster than using `Time`: https://bugs.ruby-lang.org/issues/10165