### PR TITLE
WePay: Don't default API version header

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -10,8 +10,6 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'USD'
       self.display_name = 'WePay'
 
-      API_VERSION = "2017-02-01"
-
       def initialize(options = {})
         requires!(options, :client_id, :account_id, :access_token)
         super(options)
@@ -229,18 +227,13 @@ module ActiveMerchant #:nodoc:
         headers = {
           "Content-Type"      => "application/json",
           "User-Agent"        => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
-          "Authorization"     => "Bearer #{@options[:access_token]}",
-          "Api-Version"       => api_version(options)
+          "Authorization"     => "Bearer #{@options[:access_token]}"
         }
-
+        headers["Api-Version"] = options[:version] if options[:version]
         headers["Client-IP"] = options[:ip] if options[:ip]
         headers["WePay-Risk-Token"] = options[:risk_token] if options[:risk_token]
 
         headers
-      end
-
-      def api_version(options)
-        options[:version] || API_VERSION
       end
     end
   end

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -143,6 +143,13 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_success void
   end
 
+  # Version sent here will need to match or be one ahead of the version set in the test account's dashboard
+  def test_successful_purchase_with_version
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(version: '2017-05-31'))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_invalid_login
     gateway = WepayGateway.new(
       client_id: 12515,


### PR DESCRIPTION
WePay has restricted compatibility for the version specified in the
request header, to equal to or one ahead of the version set in WePay's
Dashboard for that merchant account.

This means that letting the adapter default the version header to a
certain version (likely one or more version behind current) has greater
potential to break integration than allowing WePay's API to assume the
version set in the dashboard for that account, which occurs if the
header is absent.

api_version can still be sent in options and will override the dashboard
setting, but be advised that this will only work for one version ahead
of what is set in the dashboard.

I have updated the version in the dashboard for the test account in
Fixtures to the current version, so these tests are run against that
version.

Remote:
22 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
18 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@nfarve 