### PR TITLE
Conekta: Update Required Fields

### DIFF
--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -82,15 +82,14 @@ module ActiveMerchant #:nodoc:
 
       def add_details_data(post, options)
         details = {}
-        details[:name] = options[:customer] if options[:customer]
+        details[:name] = options[:customer] || options[:billing_address][:name]
         details[:email] = options[:email] if options[:email]
-        details[:phone] = options[:phone] if options[:phone]
+        details[:phone] = options[:phone] || options[:billing_address][:phone]
         post[:device_fingerprint] = options[:device_fingerprint] if options[:device_fingerprint]
         details[:ip] = options[:ip] if options[:ip]
         add_billing_address(details, options)
         add_line_items(details, options)
         add_shipment(details, options)
-
         post[:details] = details
       end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -196,7 +196,7 @@ commercegate:
   card_number: "XXXXXXXXXXXXXXXX"
 
 conekta:
-  key: key_eYvWV7gSDkNYXsmr
+  key: key_6FTbuwqhYs6zvyyeL3PySg
 
 # Working credentials, no need to replace
 creditcall:

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -36,10 +36,19 @@ class RemoteConektaTest < Test::Unit::TestCase
         name: "Mario Reyes",
         phone: "12345678",
       },
-      carrier: "Estafeta"
+      carrier: "Estafeta", 
+      email: "bob@something.com",
+      line_items: [{
+      name: "Box of Cohiba S1s",
+      description: "Imported From Mex.",
+      unit_price: 20000,
+      quantity: 1,
+      sku: "7500244909",
+      type: "food"
+     }]
     }
   end
-
+ 
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -132,7 +141,7 @@ class RemoteConektaTest < Test::Unit::TestCase
       },
       line_items: [
         {
-          rname: "Box of Cohiba S1s",
+          name: "Box of Cohiba S1s",
           description: "Imported From Mex.",
           unit_price: 20000,
           quantity: 1,

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -34,7 +34,7 @@ class ConektaTest < Test::Unit::TestCase
       :city => "Guerrero",
       :country => "Mexico",
       :zip => "5555",
-      :name => "Mario Reyes",
+      :customer => "Mario Reyes",
       :phone => "12345678",
       :carrier => "Estafeta"
     }


### PR DESCRIPTION
The key previously used was the default key for testing and not actually
tied to an account. Conekta requires that all fields in the details
parameter be passed for a successful purchase.

Loaded suite test/unit/gateways/conekta_test

11 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Loaded suite test/remote/gateways/remote_conekta_test

13 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed