### PR TITLE
PayU Latam: Pass unique buyer fields and country requirements

### DIFF
--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -11,13 +11,11 @@ class RemotePayuLatamTest < Test::Unit::TestCase
 
     @options = {
       dni_number: '5415668464654',
-      dni_type: 'TI',
       currency: "ARS",
       order_id: generate_unique_id,
       description: "Active Merchant Transaction",
       installments_number: 1,
       tax: 0,
-      tax_return_base: 0,
       email: "username@domain.com",
       ip: "127.0.0.1",
       device_session_id: 'vghs6tvkcle931686k1900o6e1',
@@ -51,10 +49,10 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_purchase_brazil
+  def test_successul_purchase_with_buyer
     gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327"))
 
-    options_brazil = {
+    options_buyer = {
       currency: "BRL",
       billing_address: address(
         address1: "Calle 100",
@@ -73,7 +71,45 @@ class RemotePayuLatamTest < Test::Unit::TestCase
         country: "BR",
         zip: "01019-030",
         phone: "(11)756312633"
-      )
+      ),
+      buyer_name: 'Jorge Borges',
+      buyer_dni_number: '5415668464123',
+      buyer_dni_type: 'TI',
+      buyer_cnpj: '32593371000110',
+      buyer_email: 'axaxaxas@mlo.org'
+    }
+
+    response = gateway.purchase(@amount, @credit_card, @options.update(options_buyer))
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_brazil
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327"))
+
+    options_brazil = {
+      payment_country: "BR",
+      currency: "BRL",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Sao Paulo",
+        state: "SP",
+        country: "BR",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Sao Paulo",
+        state: "SP",
+        country: "BR",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      buyer_cnpj: "32593371000110"
     }
 
     response = gateway.purchase(@amount, @credit_card, @options.update(options_brazil))
@@ -82,8 +118,68 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_purchase_sans_options
-    response = @gateway.purchase(@amount, @credit_card)
+  def test_successful_purchase_colombia
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512321"))
+
+    options_colombia = {
+      payment_country: "CO",
+      currency: "COP",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Bogota",
+        state: "Bogota DC",
+        country: "CO",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Bogota",
+        state: "Bogota DC",
+        country: "CO",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      tx_tax: '3193',
+      tx_tax_return_base: '16806'
+    }
+
+    response = gateway.purchase(@amount, @credit_card, @options.update(options_colombia))
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_mexico
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512324"))
+
+    options_mexico = {
+      payment_country: "MX",
+      currency: "MXN",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Guadalajara",
+        state: "Jalisco",
+        country: "MX",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Guadalajara",
+        state: "Jalisco",
+        country: "MX",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      birth_date: '1985-05-25'
+    }
+
+    response = gateway.purchase(@amount, @credit_card, @options.update(options_mexico))
     assert_success response
     assert_equal "APPROVED", response.message
     assert response.test?
@@ -94,6 +190,12 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_failure response
     assert_equal "ANTIFRAUD_REJECTED", response.message
     assert_equal "DECLINED", response.params["transactionResponse"]["state"]
+  end
+
+  def test_failed_purchase_with_no_options
+    response = @gateway.purchase(@amount, @declined_card, {})
+    assert_failure response
+    assert_equal "ANTIFRAUD_REJECTED", response.message
   end
 
   def test_successful_authorize
@@ -121,7 +223,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   def test_failed_refund
     response = @gateway.refund(@amount, '')
     assert_failure response
-    assert_match /property: parentTransactionId, message: must not be null/, response.message
+    assert_match (/property: parentTransactionId, message: must not be null/), response.message
   end
 
   def test_successful_void
@@ -136,7 +238,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_match /property: parentTransactionId, message: must not be null/, response.message
+    assert_match (/property: parentTransactionId, message: must not be null/), response.message
   end
 
   def test_successful_authorize_and_capture
@@ -151,7 +253,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_match /must not be null/, response.message
+    assert_match (/must not be null/), response.message
   end
 
   def test_verify_credentials

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -175,6 +175,127 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal "property: order.id, message: must not be null property: parentTransactionId, message: must not be null", response.message
   end
 
+  def test_buyer_fields
+    options_buyer = {
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Sao Paulo",
+        state: "SP",
+        country: "BR",
+        zip: "01019-030",
+        phone: "(11)756312345"
+      ),
+      buyer_name: 'Jorge Borges',
+      buyer_dni_number: '5415668464456',
+      buyer_dni_type: 'IT',
+      buyer_email: 'axaxaxas@mlo.org'
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.update(options_buyer))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"buyer\":{\"fullName\":\"Jorge Borges\",\"dniNumber\":\"5415668464456\",\"dniType\":\"IT\",\"emailAddress\":\"axaxaxas@mlo.org\",\"contactPhone\":\"\(11\)756312345/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_brazil_required_fields
+    options_brazil = {
+      payment_country: 'BR',
+      currency: "BRL",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Sao Paulo",
+        state: "SP",
+        country: "BR",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Sao Paulo",
+        state: "SP",
+        country: "BR",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      buyer_cnpj: "32593371000110"
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.update(options_brazil))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"cnpj\":\"32593371000110\"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_colombia_required_fields
+    options_colombia = {
+      payment_country: "CO",
+      currency: "COP",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Bogota",
+        state: "Bogota DC",
+        country: "CO",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Bogota",
+        state: "Bogota DC",
+        country: "CO",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      tx_tax: '3193',
+      tx_tax_return_base: '16806'
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.update(options_colombia))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"additionalValues\":{\"TX_VALUE\":{\"value\":\"40.00\",\"currency\":\"COP\"},\"TX_TAX\":{\"value\":0,\"currency\":\"COP\"},\"TX_TAX_RETURN_BASE\":{\"value\":0,\"currency\":\"COP\"}}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_mexico_required_fields
+    options_mexico = {
+      payment_country: "MX",
+      currency: "MXN",
+      billing_address: address(
+        address1: "Calle 100",
+        address2: "BL4",
+        city: "Guadalajara",
+        state: "Jalisco",
+        country: "MX",
+        zip: "09210710",
+        phone: "(11)756312633"
+      ),
+      shipping_address: address(
+        address1: "Calle 200",
+        address2: "N107",
+        city: "Guadalajara",
+        state: "Jalisco",
+        country: "MX",
+        zip: "01019-030",
+        phone: "(11)756312633"
+      ),
+      birth_date: '1985-05-25'
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.update(options_mexico))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"birthdate\":\"1985-05-25\"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
Buyer data can be separate from the Payer's (tied to the payment
method). This change allows options to be passed for a unique buyer, and
adding the buyer element no longer conditions only on the presence of a
shipping address. Also adds fields that were missing but are required
for Brazil, Colombia, and Mexico, and allows passing paymentCountry as
an option.

Unrelated Capture and Void remote tests still failing

Remote:
17 tests, 45 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.2353% passed

Unit:
21 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@nfarve 