### PR TITLE
Add refund to Kushki

### DIFF
--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -51,6 +51,24 @@ class RemoteKushkiTest < Test::Unit::TestCase
     assert_equal 'Monto de la transacción es diferente al monto de la venta inicial', response.message
   end
 
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'Succeeded', refund.message
+  end
+
+  def test_failed_refund
+    purchase = @gateway.purchase(@amount, @credit_card)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, nil)
+    assert_failure refund
+    assert_equal 'Missing Authentication Token', refund.message
+  end
+
   def test_successful_void
     purchase = @gateway.purchase(@amount, @credit_card)
     assert_success purchase
@@ -63,7 +81,7 @@ class RemoteKushkiTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void("000")
     assert_failure response
-    assert_equal 'Tipo de moneda no válida', response.message
+    assert_equal 'El monto de la transacción es requerido', response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Adds support for performing refund transactions on Kushki. The refund
endpoint is a bit quirky in that the response body only returns
a message and status code, not a unique transaction identifier like
other endpoints. Additionally, the amount param is ignored since the
call to perform a refund only accepts a reference identifier.

```
ruby -Itest test/remote/gateways/remote_kushki_test.rb
Loaded suite test/remote/gateways/remote_kushki_test
Started
........

Finished in 11.867091 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
8 tests, 24 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.67 tests/s, 2.02 assertions/s

ruby -Itest test/unit/gateways/kushki_test.rb
Loaded suite test/unit/gateways/kushki_test
Started
........

Finished in 0.009668 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
8 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
827.47 tests/s, 4654.53 assertions/s
```