### PR TITLE
Barclaycard Smartpay: Update URLs

### DIFF
--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -1,8 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BarclaycardSmartpayGateway < Gateway
-      self.test_url = 'https://pal-test.barclaycardsmartpay.com/pal/servlet'
-      self.live_url = 'https://pal-live.barclaycardsmartpay.com/pal/servlet'
+      self.test_url = 'https://pal-test.adyen.com/pal/servlet'
+      self.live_url = 'https://pal-live.adyen.com/pal/servlet'
 
       self.supported_countries = ['AL', 'AD', 'AM', 'AT', 'AZ', 'BY', 'BE', 'BA', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'GE', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'KZ', 'LV', 'LI', 'LT', 'LU', 'MK', 'MT', 'MD', 'MC', 'ME', 'NL', 'NO', 'PL', 'PT', 'RO', 'RU', 'SM', 'RS', 'SK', 'SI', 'ES', 'SE', 'CH', 'TR', 'UA', 'GB', 'VA']
       self.default_currency = 'EUR'


### PR DESCRIPTION
URLs updated per Smartpay: 'adyen' replaces 'barclaycardsmartpay'.

https://docs.adyen.com/developers/api-reference/live-endpoints

Remote tests:
23 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit tests:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed