### PR TITLE
PayU Latam: Correctly condition buyer element fields

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
         add_credentials(post, 'SUBMIT_TRANSACTION')
         add_transaction_elements(post, transaction_type, options)
         add_order(post, options)
-        add_buyer(post, options)
+        add_buyer(post, payment_method, options)
         add_invoice(post, amount, options)
         add_signature(post)
         add_payment_method(post, payment_method, options)
@@ -183,15 +183,25 @@ module ActiveMerchant #:nodoc:
         billing_address
       end
 
-      def add_buyer(post, options)
+      def add_buyer(post, payment_method, options)
         buyer = {}
-        buyer[:fullName] = options[:buyer_name] if options[:buyer_name]
-        buyer[:dniNumber] = options[:buyer_dni_number] if options[:buyer_dni_number]
-        buyer[:dniType] = options[:buyer_dni_type] if options[:buyer_dni_type]
-        buyer[:cnpj] = options[:buyer_cnpj] if options[:buyer_cnpj] && options[:payment_country] == 'BR'
-        buyer[:emailAddress] = options[:buyer_email] if options[:buyer_email]
-        buyer[:contactPhone] = options[:shipping_address][:phone] if options[:shipping_address]
-        buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
+        if buyer_hash = options[:buyer]
+          buyer[:fullName] = buyer_hash[:name]
+          buyer[:dniNumber] = buyer_hash[:dni_number]
+          buyer[:dniType] = buyer_hash[:dni_type]
+          buyer[:cnpj] = buyer_hash[:cnpj] if options[:payment_country] == 'BR'
+          buyer[:emailAddress] = buyer_hash[:email]
+          buyer[:contactPhone] = options[:shipping_address][:phone] if options[:shipping_address]
+          buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
+        else
+          buyer[:fullName] = payment_method.name.strip
+          buyer[:dniNumber] = options[:dni_number]
+          buyer[:dniType] = options[:dni_type]
+          buyer[:cnpj] = options[:cnpj] if options[:payment_country] == 'BR'
+          buyer[:emailAddress] = options[:email]
+          buyer[:contactPhone] = (options[:shipping_address][:phone] if options[:shipping_address]) || (options[:billing_address][:phone] if options[:billing_address])
+          buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
+        end
         post[:transaction][:order][:buyer] = buyer
       end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -72,11 +72,13 @@ class RemotePayuLatamTest < Test::Unit::TestCase
         zip: "01019-030",
         phone: "(11)756312633"
       ),
-      buyer_name: 'Jorge Borges',
-      buyer_dni_number: '5415668464123',
-      buyer_dni_type: 'TI',
-      buyer_cnpj: '32593371000110',
-      buyer_email: 'axaxaxas@mlo.org'
+      buyer: {
+        name: 'Jorge Borges',
+        dni_number: '5415668464123',
+        dni_type: 'TI',
+        cnpj: '32593371000110',
+        email: 'axaxaxas@mlo.org'
+      }
     }
 
     response = gateway.purchase(@amount, @credit_card, @options.update(options_buyer))
@@ -109,7 +111,9 @@ class RemotePayuLatamTest < Test::Unit::TestCase
         zip: "01019-030",
         phone: "(11)756312633"
       ),
-      buyer_cnpj: "32593371000110"
+      buyer:{
+        cnpj: "32593371000110"
+      }
     }
 
     response = gateway.purchase(@amount, @credit_card, @options.update(options_brazil))


### PR DESCRIPTION
According to PayU, the Buyer element is required, and if no buyer info
is provided, the Payer's info should be sent in its place, and if only
partial Buyer info is provided, the missing fields should instead be
sent empty.

This change ensures these conditions are fulfilled. It also gathers the
buyer fields under one buyer hash option instead of multiple top-level
buyer_* fields, and exposes a top-level cnpj field for the payer.

Remote tests continue to fail unrelated capture and void.

Remote:
18 tests, 47 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.8889% passed

23 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed