### PR TITLE
Auth.Net: Remove numeric restriction on customer ID

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -535,7 +535,7 @@ module ActiveMerchant
 
       def add_customer_data(xml, payment_source, options)
         xml.customer do
-          xml.id(options[:customer]) unless empty?(options[:customer]) || options[:customer] !~ /^\d+$/
+          xml.id(options[:customer]) unless empty?(options[:customer]) || options[:customer] !~ /^\w+$/
           xml.email(options[:email]) unless empty?(options[:email])
         end
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -103,6 +103,12 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', response.message
   end
 
+  def test_successful_purchase_with_customer
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(customer: "abcd_123"))
+    assert_success response
+    assert_equal 'This transaction has been approved', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -908,9 +908,31 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
-  def test_dont_include_cust_id_for_non_numeric_values
+  def test_include_cust_id_for_word_character_values
+   stub_comms do
+      @gateway.purchase(@amount, @credit_card, customer: "4840_TT")
+    end.check_request do |endpoint, data, headers|
+      parse(data) do |doc|
+        assert_not_nil doc.at_xpath("//customer/id"), data
+        assert_equal "4840_TT", doc.at_xpath("//customer/id").content, data
+        assert_equal "1.00", doc.at_xpath("//transactionRequest/amount").content
+      end
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_dont_include_cust_id_for_email_addresses
    stub_comms do
       @gateway.purchase(@amount, @credit_card, customer: "bob@test.com")
+    end.check_request do |endpoint, data, headers|
+      doc = parse(data)
+      assert !doc.at_xpath("//customer/id"), data
+      assert_equal "1.00", doc.at_xpath("//transactionRequest/amount").content
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_dont_include_cust_id_for_phone_numbers
+   stub_comms do
+      @gateway.purchase(@amount, @credit_card, customer: "111-123-1231")
     end.check_request do |endpoint, data, headers|
       doc = parse(data)
       assert !doc.at_xpath("//customer/id"), data


### PR DESCRIPTION
Instead of restricting the customer ID to numbers only, allow for any
letter, number, or underscore characters. This will allow for a wider
range of values while still preventing email addresses and phone
numbers.

Related https://github.com/activemerchant/active_merchant/pull/704