### PR TITLE
Beanstream: Do not default state and zip with empty country

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -1,6 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module BeanstreamCore
+      include Empty
+
       RECURRING_URL = 'https://www.beanstream.com/scripts/recurring_billing.asp'
       SECURE_PROFILE_URL = 'https://www.beanstream.com/scripts/payment_profile.asp'
 
@@ -177,6 +179,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def purchase_action(source)
         if source.is_a?(Check)
           :check_purchase
@@ -227,7 +230,7 @@ module ActiveMerchant #:nodoc:
           post[:ordAddress1]      = billing_address[:address1]
           post[:ordAddress2]      = billing_address[:address2]
           post[:ordCity]          = billing_address[:city]
-          post[:ordProvince]      = STATES[billing_address[:state].upcase] || billing_address[:state] if billing_address[:state]
+          post[:ordProvince]      = state_for(billing_address)
           post[:ordPostalCode]    = billing_address[:zip]
           post[:ordCountry]       = billing_address[:country]
         end
@@ -238,7 +241,7 @@ module ActiveMerchant #:nodoc:
           post[:shipAddress1]     = shipping_address[:address1]
           post[:shipAddress2]     = shipping_address[:address2]
           post[:shipCity]         = shipping_address[:city]
-          post[:shipProvince]     = STATES[shipping_address[:state].upcase] || shipping_address[:state] if shipping_address[:state]
+          post[:shipProvince]     = state_for(shipping_address)
           post[:shipPostalCode]   = shipping_address[:zip]
           post[:shipCountry]      = shipping_address[:country]
           post[:shippingMethod]   = shipping_address[:shipping_method]
@@ -246,8 +249,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def state_for(address)
+        STATES[address[:state].upcase] || address[:state] if address[:state]
+      end
+
       def prepare_address_for_non_american_countries(options)
         [ options[:billing_address], options[:shipping_address] ].compact.each do |address|
+          next if empty?(address[:country])
           unless ['US', 'CA'].include?(address[:country])
             address[:state] = '--'
             address[:zip]   = '000000' unless address[:zip]


### PR DESCRIPTION
We've see transaction failures on Beanstream when `ordProvince` and
`shipProvince` are provided without a country. According to Beanstream,
these values may be optional, but they are codependent and if one is
included, then both must be present.

```
ruby -Itest test/remote/gateways/remote_beanstream_test.rb
Loaded suite test/remote/gateways/remote_beanstream_test
Started

Finished in 38.504746 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
34 tests, 154 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.1176% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.88 tests/s, 4.00 assertions/s

ruby -Itest test/unit/gateways/beanstream_test.rb
Loaded suite test/unit/gateways/beanstream_test
Started
....................

Finished in 0.02935 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
20 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
681.43 tests/s, 3236.80 assertions/s
```

Note: two unrelated remote tests are failing. These failing tests seem related to processing e-checks and currently fail on master. I did fix a failed authenticate test, but fixing the other two failures seem more involved.