### PR TITLE
MercadoPago: Send diners_club cards as diners

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Beanstream: Do not default state and zip with empty country [dtykocki] #2582
 * Kushki: Add support for refunds [dtykocki] #2575
 * Adyen: Fix failing remote tests [dtykocki] #2584
+* MercadoPago: Send diners_club cards as diners [davidsantoso]
 
 == Version 1.71.0 (August 22, 2017)
 * Bambora formerly Beanstream: Change casing on customerIp variable [aengusbates] #2551

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -21,6 +21,14 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_equal 'accredited', response.message
   end
 
+  def test_successful_purchase_with_american_express
+    amex_card = credit_card('375365153556885', brand: 'american_express', verification_value: '1234')
+
+    response = @gateway.purchase(@amount, amex_card, @options)
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -164,6 +164,36 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal '4141491|1.0', response.authorization
   end
 
+  def test_sends_diners_club_as_diners
+    credit_card = credit_card('30569309025904', brand: 'diners_club')
+
+    response = stub_comms do
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if data =~ /"payment_method_id"/
+        assert_match(%r(diners), data)
+      end
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal '4141491|1.0', response.authorization
+  end
+
+  def test_sends_mastercard_as_master
+    credit_card = credit_card('5555555555554444', brand: 'master')
+
+    response = stub_comms do
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if data =~ /"payment_method_id"/
+        assert_match(%r(master), data)
+      end
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal '4141491|1.0', response.authorization
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
MercadoPago seems to use the same card type formatting as Active
Merchant except in the case of American Express and Diners Club. Amex
was updated previously but Diners Club was left out. This formats the
diners_club type as just diners.

Test suite run:

```
/Users/david/dev/active_merchant mercadopago-diners-club ✗
➜ ruby -Itest test/remote/gateways/remote_mercado_pago_test.rb
Loaded suite test/remote/gateways/remote_mercado_pago_test
Started
...............

Finished in 23.537752 seconds.
----------------------------------------------------------------------------------------------------------------------
15 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
0.64 tests/s, 1.78 assertions/s

/Users/david/dev/active_merchant mercadopago-diners-club ✗
➜ ruby -Itest test/unit/gateways/mercado_pago_test.rb
Loaded suite test/unit/gateways/mercado_pago_test
Started
.................

Finished in 0.008815 seconds.
----------------------------------------------------------------------------------------------------------------------
17 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
1928.53 tests/s, 9756.10 assertions/s
```