### PR TITLE
WePay: Don't require email for Store

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -76,8 +76,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def store(creditcard, options = {})
-        requires!(options, :email)
-
         post = {}
         post[:client_id] = @options[:client_id]
         post[:user_name] = "#{creditcard.first_name} #{creditcard.last_name}"

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -88,8 +88,14 @@ class RemoteWepayTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
   end
+
   def test_successful_store
     response = @gateway.store(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_store_with_defaulted_email
+    response = @gateway.store(@credit_card, {billing_address: address})
     assert_success response
   end
 


### PR DESCRIPTION
No longer requires email for Store actions and instead allows the method
to default the value if it's absent.

Remote:
24 tests, 40 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
20 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed