### PR TITLE
Explicitly require braintree-ruby gem version 2.78.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Braintree Blue: Explicitely require braintree-ruby version 2.78 [anotherjosmith]
+* Braintree Blue: Explicitly require braintree-ruby version 2.78 [anotherjosmith]
 * Wirecard: Format non-fractional currency amounts correctly [bdewater] #2594
 
 == Version 1.72.0 (September 20, 2017)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Braintree Blue: Explicitely require braintree-ruby version 2.78 [anotherjosmith]
 
 == Version 1.72.0 (September 20, 2017)
 * Adyen: Fix failing remote tests [dtykocki] #2584

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -6,8 +6,8 @@ rescue LoadError
   raise "Could not load the braintree gem.  Use `gem install braintree` to install it."
 end
 
-unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 4
-  raise "Need braintree gem >= 2.4.0. Run `gem install braintree --version '~>2.4'` to get the correct version."
+unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 78
+  raise "Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version."
 end
 
 module ActiveMerchant #:nodoc:


### PR DESCRIPTION
#2565 introduced a requirement on braintree-ruby gem version 2.78.0. While the Gemfile was updated with the correct version for tests, the version check at the top of the gateway class was not updated, meaning apple pay transactions will fail if you're not running version 2.78.0.

This PR explicitly requires version 2.78.0 of braintree-ruby to be able to load the class.