### PR TITLE
WePay - Only send ip and device for non-recurring transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -84,8 +84,6 @@ module ActiveMerchant #:nodoc:
         post[:cvv] = creditcard.verification_value unless options[:recurring]
         post[:expiration_month] = creditcard.month
         post[:expiration_year] = creditcard.year
-        post[:original_ip] = options[:ip] if options[:ip]
-        post[:original_device] = options[:device_fingerprint] if options[:device_fingerprint]
 
         if(billing_address = (options[:billing_address] || options[:address]))
           post[:address] = {}
@@ -100,6 +98,8 @@ module ActiveMerchant #:nodoc:
           post[:client_secret] = @options[:client_secret]
           commit('/credit_card/transfer', post, options)
         else
+          post[:original_device] = options[:device_fingerprint] if options[:device_fingerprint]
+          post[:original_ip] = options[:ip] if options[:ip]
           commit('/credit_card/create', post, options)
         end
       end

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -5,7 +5,7 @@ class RemoteWepayTest < Test::Unit::TestCase
     @gateway = WepayGateway.new(fixtures(:wepay))
 
     @amount = 2000
-    @credit_card = credit_card('5496198584584769')
+    @credit_card = credit_card('5496198584584769', verification_value: '321')
     @declined_card = credit_card('')
 
     @options = {
@@ -27,6 +27,14 @@ class RemoteWepayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_token
     store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    response = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_recurring_and_ip
+    store = @gateway.store(@credit_card, @options.merge(recurring: true, ip: '127.0.0.1'))
     assert_success store
 
     response = @gateway.purchase(@amount, store.authorization, @options)


### PR DESCRIPTION
Per WePay's documentation, both `original_ip` and `original_device`
are not valid arguments when calling `/credit_card/transfer`. These two
params will now only be sent to `/credit_card/create` when storing a
credit card.

Also, the `verification_value` has been changed in remote tests to
prevent a false positive failure in `test_transcript_scrubbing`.

Unit:
```
ruby -Itest test/unit/gateways/wepay_test.rb
Loaded suite test/unit/gateways/wepay_test
Started
....................

Finished in 0.014264 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
20 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
1402.13 tests/s, 5187.89 assertions/s
```

Remote:
```
ruby -Itest test/remote/gateways/remote_wepay_test.rb
Loaded suite test/remote/gateways/remote_wepay_test
Started
.........................

Finished in 151.078767 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
25 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
0.17 tests/s, 0.28 assertions/s
```