### PR TITLE
Braintree Blue: allow passing skip_cvv parameter

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -568,6 +568,7 @@ module ActiveMerchant #:nodoc:
         if options[:recurring]
           parameters[:recurring] = true
         end
+        parameters[:skip_cvv] = true if options[:skip_cvv]
 
         if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
           if options[:payment_method_token]

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -534,6 +534,22 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"))
   end
 
+  def test_passes_skip_cvv_flag
+    Braintree::TransactionGateway
+      .any_instance
+      .expects(:sale)
+      .with(has_entries(skip_cvv: true))
+      .returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), skip_cvv: true)
+
+    Braintree::TransactionGateway
+      .any_instance
+      .expects(:sale)
+      .with(Not(has_entries(skip_cvv: true)))
+      .returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"))
+  end
+
   def test_configured_logger_has_a_default
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not


### PR DESCRIPTION
Supported by the braintree gem: https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#options.skip_cvv