### PR TITLE
Barclaycard Smartpay: Use authorization pspReference for refunds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* WePay: Only send ip and device for non-recurring transactions [dtykocki] #2597
+* Barclaycard Smartpay: Use authorization pspReference for refunds [davidsantoso] #2599
 
 == Version 1.73.0 (September 28, 2017)
 * Adyen: Use original authorization pspReference on Refunds [lyverovski] #2589
@@ -8,7 +10,6 @@
 * FirstData E4: Scrub 3DS cryptogram [jasonwebster] #2596
 * PayHub: Replace single quotes with double quotes in error message [matthewheath] #2572
 * Wirecard: Format non-fractional currency amounts correctly [bdewater] #2594
-* WePay: Only send ip and device for non-recurring transactions [dtykocki] #2597
 
 == Version 1.72.0 (September 20, 2017)
 * Adyen: Fix failing remote tests [dtykocki] #2584

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
   def setup
     @gateway = BarclaycardSmartpayGateway.new(fixtures(:barclaycard_smartpay))
+    BarclaycardSmartpayGateway.ssl_strict = false
 
     @amount = 100
     @credit_card = credit_card('4111111111111111', :month => 8, :year => 2018, :verification_value => 737)
@@ -40,6 +41,10 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
         zip:      '95014',
         country:  'US'
         })
+  end
+
+  def teardown
+    BarclaycardSmartpayGateway.ssl_strict = true
   end
 
   def test_successful_purchase


### PR DESCRIPTION
Barclaycard Smartpay requires a `pspReference` from a previous
authorization to be sent, not the `pspReference` from a subsequent
capture. This updates the authorization field to be a concat of the
authorization and capture `pspReference` values which will then be later
split, and the first (authorization) `pspReference` will be used in the
refund request.

I should note that this fix is backwards compatible with the previous
setup- non concated authorizations will still send the capture
`pspReference`- however those transactions will still ultimately fail
when refund settlements are attempted.

---

Unit:
```
➜ ruby -Itest test/unit/gateways/barclaycard_smartpay_test.rb
Loaded suite test/unit/gateways/barclaycard_smartpay_test
Started
...................

Finished in 0.011974 seconds.
----------------------------------------------------------------------------------------------------------------------
19 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
1586.77 tests/s, 6013.03 assertions/s
```

Remote:
```
➜ ruby -Itest test/remote/gateways/remote_barclaycard_smartpay_test.rb
Loaded suite test/remote/gateways/remote_barclaycard_smartpay_test
Started
.......................

Finished in 39.42143 seconds.
----------------------------------------------------------------------------------------------------------------------
23 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
0.58 tests/s, 1.17 assertions/s
```