### PR TITLE
Barclaycard Smartpay: Refactors address parsing.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Authorize.net CIM: Handle multiple error messages [amandapuff] #2537
 * Beanstream: Pass email fields without address [curiousepic] #2615
 * Beanstream: Support recurringPayment for auth, capture, and purchase transactions [dtykocki] #2617
+* Barclaycard Smartpay: Pass street and house_number fields, in addition to standard address [deedeelavinder] #2603
 
 == Version 1.73.0 (September 28, 2017)
 * Adyen: Use original authorization pspReference on Refunds [lyverovski] #2589
@@ -1790,7 +1791,7 @@ value [jduff]
 * Support default Return class for all Integrations that don't use returns [Soleone]
 * Add support for passing additional options when creating a Notification to all Integrations [Soleone]
 * Update BraintreeBlue#refund to have consistent method signature [Jonathan Rudenberg]
-* Add rails/init.rb for gem campatability in Rails [Rūdolfs Ošiņš]
+* Add rails/init.rb for gem campatability in Rails [R?dolfs O?i??]
 * Fix Paypal Express response parser [Jonathan Rudenberg]
 * Braintree/Transax: Add tax field [wisq]
 
@@ -2106,7 +2107,7 @@ value [jduff]
 * Update Secure Pay Au to meet specs for MessageInfo elements [cody]
 * Add support for the Australian Secure Pay payment gateway [cody]
 * Allow LinkPoint cancellations for recurring billing. [yanagimoto.shin]
-* Add support for Åland Islands to the country list [cody]
+* Add support for ?land Islands to the country list [cody]
 
 == Version 1.3.1 (January 28, 2008)
 

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -26,6 +26,43 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
       description: 'Store Purchase'
     }
 
+    @options_with_alternate_address = {
+        order_id: '1',
+        billing_address: {
+            name:     'PU JOI SO',
+            address1: '新北市店溪路3579號139樓',
+            company:  'Widgets Inc',
+            city:     '新北市',
+            zip:      '231509',
+            country:  'TW',
+            phone:    '(555)555-5555',
+            fax:      '(555)555-6666'
+        },
+        email: 'pujoi@so.com',
+        customer: 'PU JOI SO',
+        description: 'Store Purchase'
+    }
+
+    @options_with_house_number_and_street = {
+        order_id: '1',
+        house_number: '100',
+        street: 'Top Level Drive',
+        billing_address:       {
+            name:     'Jim Smith',
+            address1: '100 Top Level Dr',
+            company:  'Widgets Inc',
+            city:     'Ottawa',
+            state:    'ON',
+            zip:      'K1C2N6',
+            country:  'CA',
+            phone:    '(555)555-5555',
+            fax:      '(555)555-6666'
+        },
+        email: 'long@deb.com',
+        customer: 'Longdeb Longsen',
+        description: 'Store Purchase'
+    }
+
     @avs_credit_card = credit_card('4400000000000008',
                                     :month => 8,
                                     :year => 2018,
@@ -57,6 +94,22 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'Refused', response.message
+  end
+
+  def test_successful_purchase_with_unusual_address
+    response = @gateway.purchase(@amount,
+                                 @credit_card,
+                                 @options_with_alternate_address)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_purchase_with_house_number_and_street
+    response = @gateway.purchase(@amount,
+                                 @credit_card,
+                                 @options.merge(street: 'Top Level Drive', house_number: '100'))
+    assert_success response
+    assert_equal '[capture-received]', response.message
   end
 
   def test_successful_authorize_and_capture


### PR DESCRIPTION
Although using a regex has worked for *most* of the needed address
parsing, there are still a few exceptions. Due to the unusual address
structure, this allows some require fields to
come through in the options hash: `:street`, `:shipping_street`,
`:house_number`, and `:shipping_house_number`.

Unit Tests:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote Tests:
24 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed