### PR TITLE
Ebanx: Support Store and person_type option

### DIFF
--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -6,7 +6,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
-    @declined_card = credit_card('4716909774636285')
+    @declined_card = credit_card('5102026827345142')
     @options = {
       billing_address: address({
         address1: '1040 Rua E',
@@ -24,7 +24,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'Sandbox - Test credit card, transaction captured', response.message
+    assert_equal 'Accepted', response.message
   end
 
   def test_successful_purchase_with_more_options
@@ -37,7 +37,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
-    assert_equal 'Sandbox - Test credit card, transaction captured', response.message
+    assert_equal 'Accepted', response.message
   end
 
   def test_failed_purchase
@@ -50,11 +50,11 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
-    assert_equal 'Sandbox - Test credit card, transaction will be approved', auth.message
+    assert_equal 'Accepted', auth.message
 
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-    assert_equal 'Sandbox - Test credit card, transaction captured', capture.message
+    assert_equal 'Accepted', capture.message
   end
 
   def test_failed_authorize
@@ -85,7 +85,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
     refund_options = @options.merge({description: "full refund"})
     assert refund = @gateway.refund(@amount, purchase.authorization, refund_options)
     assert_success refund
-    assert_equal 'Sandbox - Test credit card, transaction captured', refund.message
+    assert_equal 'Accepted', refund.message
   end
 
   def test_partial_refund
@@ -109,7 +109,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
-    assert_equal 'Sandbox - Test credit card, transaction cancelled', void.message
+    assert_equal 'Accepted', void.message
   end
 
   def test_failed_void
@@ -118,16 +118,33 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Parameter hash not informed', response.message
   end
 
+  def test_successful_store_and_purchase
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success purchase
+    assert_equal 'Accepted', purchase.message
+  end
+
+  def test_failed_purchase_with_stored_card
+    store = @gateway.store(@declined_card, @options)
+    assert_success store
+
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options)
+    assert_failure purchase
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
-    assert_match %r{Sandbox - Test credit card, transaction will be approved}, response.message
+    assert_match %r{Accepted}, response.message
   end
 
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{Sandbox - Test credit card, transaction declined reason insufficientFunds}, response.message
+    assert_match %r{Accepted}, response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Adds Store support. The "responsible" element is now only added when it
is required, for transactions in Brazil with a person_type of
"business". Store also passes "country" from options, as it is required.

Four negative test cases are failing due to changes to test card numbers
we have yet to receive an update for.

Remote:
18 tests, 46 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
77.7778% passed

Unit:
15 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed