### PR TITLE
Borgun: Include currency code from split authorization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Update list of supported countries [dtykocki] #2600
 * Credorax: Update response codes [curiousepic] #2595
 * Borgun: Add support for USD transactions [dtykocki] #2602
+* Borgun: Include currency code from split authorization for voids [dtykocki] #2605
 
 == Version 1.73.0 (September 28, 2017)
 * Adyen: Use original authorization pspReference on Refunds [lyverovski] #2589

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -55,9 +55,10 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options={})
         post = {}
-        # TransType and TrAmount must match original values from auth or purchase.
-        _, _, _, _, _, transtype, tramount = split_authorization(authorization)
+        # TransType, TrAmount, and currency must match original values from auth or purchase.
+        _, _, _, _, _, transtype, tramount, currency = split_authorization(authorization)
         post[:TransType] = transtype
+        options[:currency] = options[:currency] || CURRENCY_CODES.key(currency)
         add_invoice(post, tramount.to_i, options)
         add_reference(post, authorization)
         commit('void', post)
@@ -94,7 +95,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_reference(post, authorization)
-        dateandtime, batch, transaction, rrn, authcode, _, _ = split_authorization(authorization)
+        dateandtime, batch, transaction, rrn, authcode, _, _, _ = split_authorization(authorization)
         post[:DateAndTime] = dateandtime
         post[:Batch] = batch
         post[:Transaction] = transaction
@@ -165,13 +166,14 @@ module ActiveMerchant #:nodoc:
           response[:rrn],
           response[:authcode],
           response[:transtype],
-          response[:tramount]
+          response[:tramount],
+          response[:trcurrency]
         ].join("|")
       end
 
       def split_authorization(authorization)
-        dateandtime, batch, transaction, rrn, authcode, transtype, tramount = authorization.split("|")
-        [dateandtime, batch, transaction, rrn, authcode, transtype, tramount]
+        dateandtime, batch, transaction, rrn, authcode, transtype, tramount, currency = authorization.split("|")
+        [dateandtime, batch, transaction, rrn, authcode, transtype, tramount, currency]
       end
 
       def headers

--- a/test/remote/gateways/remote_borgun_test.rb
+++ b/test/remote/gateways/remote_borgun_test.rb
@@ -117,11 +117,28 @@ class RemoteBorgunTest < Test::Unit::TestCase
     assert_success void
   end
 
+  def test_successful_void_with_no_currency_in_authorization
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    *new_auth, _ = auth.authorization.split("|")
+    assert void = @gateway.void(new_auth.join("|"))
+    assert_success void
+  end
+
   def test_successful_void_usd
     auth = @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'USD'))
     assert_success auth
 
-    assert void = @gateway.void(auth.authorization, currency: 'USD')
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_void_usd_with_options
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'USD'))
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization, @options.merge(currency: 'USD'))
     assert_success void
   end
 

--- a/test/unit/gateways/borgun_test.rb
+++ b/test/unit/gateways/borgun_test.rb
@@ -27,7 +27,7 @@ class BorgunTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300", response.authorization
+    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300|978", response.authorization
     assert response.test?
   end
 
@@ -44,7 +44,7 @@ class BorgunTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
 
     assert_success response
-    assert_equal "140601083732|11|18|WC0000000001|123456|5|000000012300", response.authorization
+    assert_equal "140601083732|11|18|WC0000000001|123456|5|000000012300|978", response.authorization
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
@@ -61,7 +61,7 @@ class BorgunTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300", response.authorization
+    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300|978", response.authorization
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
@@ -78,7 +78,7 @@ class BorgunTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300", response.authorization
+    assert_equal "140216103700|11|15|WC0000000001|123456|1|000000012300|978", response.authorization
 
     refund = stub_comms do
       @gateway.void(response.authorization)


### PR DESCRIPTION
When performing a void transaction on Borgun, the currency code must
match the original currency code used on the authorization. Because of
this, the adapter will now store the original currency code in the
authorization and include it when void is called.