### PR TITLE
WePay: Adds tests to verify store options.

### DIFF
--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -6,6 +6,8 @@ class RemoteWepayTest < Test::Unit::TestCase
 
     @amount = 2000
     @credit_card = credit_card('5496198584584769', verification_value: '321')
+    @credit_card_without_cvv = credit_card('5496198584584769', verification_value: nil)
+
     @declined_card = credit_card('')
 
     @options = {
@@ -97,10 +99,33 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_successful_store
+  def test_successful_store_via_create_with_cvv
+    # POST /credit_card/create
     response = @gateway.store(@credit_card, @options)
     assert_success response
   end
+
+  def test_successful_store_via_transfer_without_cvv
+    # special permission required
+    # POST /credit_card/transfer
+    response = @gateway.store(@credit_card_without_cvv, @options.merge(recurring: true))
+    assert_success response
+  end
+
+  def test_unsuccessful_store_via_create_with_cvv
+    response = @gateway.store(@credit_card_without_cvv, @options)
+
+    assert_failure response
+    assert_equal('This app does not have permissions to create credit cards without a cvv', response.message)
+  end
+
+  # # Requires commenting out `unless options[:recurring]` when building post hash in `store` method.
+  # def test_unsuccessful_store_via_transfer_with_cvv
+  #   response = @gateway.store(@credit_card, @options.merge(recurring: true))
+  #
+  #   assert_failure response
+  #   assert_equal('cvv parameter is unexpected', response.message)
+  # end
 
   def test_successful_store_with_defaulted_email
     response = @gateway.store(@credit_card, {billing_address: address})

--- a/test/unit/gateways/wepay_test.rb
+++ b/test/unit/gateways/wepay_test.rb
@@ -125,10 +125,18 @@ class WepayTest < Test::Unit::TestCase
     assert_equal "this checkout has already been cancelled", response.message
   end
 
-  def test_successful_store
+  def test_successful_store_via_create
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
     response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal "3322208138", response.authorization
+  end
+
+  def test_successful_store_via_transfer
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    response = @gateway.store(@credit_card, @options.merge(recurring: true))
     assert_success response
     assert_equal "3322208138", response.authorization
   end


### PR DESCRIPTION
The `store` action uses one of two possible endpoints depending on other
parameters. Only `/create` was being tested.

This adds tests to verify success and failure for both endpoints.

Remote Tests:
27 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit Tests:
21 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed