### PR TITLE
PayU Latam: Set payment_country gateway attribute

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
       def initialize(options={})
         requires!(options, :merchant_id, :account_id, :api_login, :api_key)
         super
+        @options[:payment_country] ||= options[:payment_country] if options[:payment_country]
       end
 
       def purchase(amount, payment_method, options={})
@@ -138,7 +139,7 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction_elements(post, type, options)
         transaction = {}
-        transaction[:paymentCountry] = options[:payment_country] || (options[:billing_address][:country] if options[:billing_address])
+        transaction[:paymentCountry] = @options[:payment_country] || (options[:billing_address][:country] if options[:billing_address])
         transaction[:type] = type
         transaction[:ipAddress] = options[:ip] if options[:ip]
         transaction[:userAgent] = options[:user_agent] if options[:user_agent]

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RemotePayuLatamTest < Test::Unit::TestCase
   def setup
-    @gateway = PayuLatamGateway.new(fixtures(:payu_latam))
+    @gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(payment_country: 'AR'))
 
     @amount = 4000
     @credit_card = credit_card("4097440000000004", verification_value: "444", first_name: "APPROVED", last_name: "")

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -307,6 +307,26 @@ class PayuLatamTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_payment_country_set_from_credential_or_options
+    gateway = PayuLatamGateway.new(merchant_id: 'merchant_id', account_id: 'account_id', api_login: 'api_login', api_key: 'api_key', payment_country: 'payment_country')
+    assert_match gateway.options[:payment_country], "payment_country"
+
+    stub_comms do
+      gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"paymentCountry\":\"payment_country\"/, data)
+    end.respond_with(successful_purchase_response)
+
+    gateway = PayuLatamGateway.new(merchant_id: 'merchant_id', account_id: 'account_id', api_login: 'api_login', api_key: 'api_key')
+    assert_nil gateway.options[:payment_country]
+
+    stub_comms do
+      gateway.purchase(@amount, @credit_card, @options.merge(payment_country: 'payment_country'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/\"paymentCountry\":\"payment_country\"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_payment_country_defaults_to_billing_address
     options_mexico = {
       currency: "MXN",


### PR DESCRIPTION
Checks both gateway parameters and options for payment_country and sets
it as an attribute on initialize.

2 remote tests continue to fail unrelated capture and void.

Remote:
18 tests, 47 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.8889% passed

Unit:
24 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed