### PR TITLE
Beanstream: Pass email fields without address

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -221,11 +221,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
+        post[:ordEmailAddress]  = options[:email] if options[:email]
+        post[:shipEmailAddress] = options[:shipping_email] || options[:email] if options[:email]
+
         prepare_address_for_non_american_countries(options)
 
         if billing_address = options[:billing_address] || options[:address]
           post[:ordName]          = billing_address[:name]
-          post[:ordEmailAddress]  = options[:email]
           post[:ordPhoneNumber]   = billing_address[:phone]
           post[:ordAddress1]      = billing_address[:address1]
           post[:ordAddress2]      = billing_address[:address2]
@@ -234,9 +236,9 @@ module ActiveMerchant #:nodoc:
           post[:ordPostalCode]    = billing_address[:zip]
           post[:ordCountry]       = billing_address[:country]
         end
+
         if shipping_address = options[:shipping_address]
           post[:shipName]         = shipping_address[:name]
-          post[:shipEmailAddress] = options[:email]
           post[:shipPhoneNumber]  = shipping_address[:phone]
           post[:shipAddress1]     = shipping_address[:address1]
           post[:shipAddress2]     = shipping_address[:address2]
@@ -465,4 +467,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -18,7 +18,7 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     @declined_mastercard = credit_card('5100000020002000')
 
     @amex                = credit_card('371100001000131', {:verification_value => 1234})
-    @declined_amex       = credit_card('342400001000180')
+    @declined_amex       = credit_card('342400001000180', {:verification_value => 1234})
 
     # Canadian EFT
     @check               = check(
@@ -104,6 +104,19 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_state_in_iso_format
     assert response = @gateway.purchase(@amount, @visa, @options.merge(billing_address: address, shipping_address: address))
+    assert_success response
+    assert_false response.authorization.blank?
+    assert_equal "Approved", response.message
+  end
+
+  def test_successful_purchase_with_only_email
+    options = {
+      :order_id => generate_unique_id,
+      :email => 'xiaobozzz@example.com',
+      :shipping_email => 'ship@mail.com'
+    }
+
+    assert response = @gateway.purchase(@amount, @visa, options)
     assert_success response
     assert_false response.authorization.blank?
     assert_equal "Approved", response.message

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -264,6 +264,20 @@ class BeanstreamTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_sends_email_without_addresses
+    @options[:billing_address] = nil
+    @options[:shipping_address] = nil
+    @options[:shipping_email] = "ship@mail.com"
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @decrypted_credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/ordEmailAddress=xiaobozzz%40example.com/, data)
+      assert_match(/shipEmailAddress=ship%40mail.com/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
Passes email fields even if a billing or shipping address is not
present. Also supports a shipping_email option.

2 remote test failures are occuring for echeck transactions, for which
we are not currently concerned.

Remote:
35 tests, 158 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.2857% passed

Unit:
21 tests, 100 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed