### PR TITLE
Fix basic auth for netbanx by sending the account_number and api_key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Netbanx: Fix basic auth by sending the account_number and api_key [anotherjosmith] #2616
 * WePay: Only send ip and device for non-recurring transactions [dtykocki] #2597
 * Barclaycard Smartpay: Use authorization pspReference for refunds [davidsantoso] #2599
 * Adyen: Update list of supported countries [dtykocki] #2600

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -241,9 +241,13 @@ module ActiveMerchant #:nodoc:
         {
           'Accept'        => 'application/json',
           'Content-type'  => 'application/json',
-          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s).strip}",
+          'Authorization' => "Basic #{basic_auth}",
           'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
         }
+      end
+
+      def basic_auth
+        Base64.strict_encode64("#{@options[:account_number]}:#{@options[:api_key]}")
       end
 
       def error_code_from(response)


### PR DESCRIPTION
The previous implementation for basic auth was only using the api_key. According to https://developer.paysafe.com/en/cards/api/#/introduction/authentication,
we should be sending the account_number followed by the api_key.