### PR TITLE
Beanstream: Add recurring flag in order to bypass CVV requirement

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -75,6 +75,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, options)
         add_transaction_type(post, :authorization)
         add_customer_ip(post, options)
+        add_recurring_payment(post, options)
         commit(post)
       end
 
@@ -86,6 +87,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, options)
         add_transaction_type(post, purchase_action(source))
         add_customer_ip(post, options)
+        add_recurring_payment(post, options)
         commit(post)
       end
 

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
 
         # The homepage URL of the gateway
         base.homepage_url = 'http://www.beanstream.com/'
-        base.live_url = 'https://www.beanstream.com/scripts/process_transaction.asp'
+        base.live_url = 'https://api.na.bambora.com/scripts/process_transaction.asp'
 
         # The name of the gateway
         base.display_name = 'Beanstream.com'
@@ -161,6 +161,7 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money)
         add_reference(post, reference)
         add_transaction_type(post, :capture)
+        add_recurring_payment(post, options)
         commit(post)
       end
 
@@ -263,6 +264,10 @@ module ActiveMerchant #:nodoc:
             address[:zip]   = '000000' unless address[:zip]
           end
         end
+      end
+
+      def add_recurring_payment(post, options)
+        post[:recurringPayment] = true if options[:recurring].to_s == 'true'
       end
 
       def add_invoice(post, options)


### PR DESCRIPTION
Per Beanstream, as of Oct 14th, 2017 new merchants will be required
to pass in the CVV on transactions. By supplying the `recurringPayment`
flag on `authorize`, `capture`, or `purchase` the CVV requirement will
be bypassed.

```
ruby -Itest test/remote/gateways/remote_beanstream_test.rb
Loaded suite test/remote/gateways/remote_beanstream_test
Started

Finished in 37.815344 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
39 tests, 181 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
1.03 tests/s, 4.79 assertions/s

ruby -Itest test/unit/gateways/beanstream_test.rb
Loaded suite test/unit/gateways/beanstream_test
Started

Finished in 0.025634 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------
897.25 tests/s, 4213.15 assertions/s
```