### PR TITLE
Include DKK as supported currency

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -59,6 +59,7 @@ module ActiveMerchant #:nodoc:
         "COP" => '170',
         "CRC" => '188',
         "CZK" => '203',
+        "DKK" => '208',
         "DOP" => '214',
         "EUR" => '978',
         "GBP" => '826',


### PR DESCRIPTION
Message from Redsys regarding DKK currency - Moneda del Terminal  (Ds_Merchant_Currency): 208 ("208")