### PR TITLE
Checkout V2: Expose AVS and CVV results for purchases

### DIFF
--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -33,6 +33,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_includes_avs_result
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'S', response.avs_result["code"]
+    assert_equal 'U.S.-issuing bank does not support AVS.', response.avs_result["message"]
+  end
+
+  def test_successful_purchase_includes_cvv_result
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'Y', response.cvv_result["code"]
+  end
+
   def test_successful_purchase_with_descriptors
     options = @options.merge(descriptor_name: "shop", descriptor_city: "london")
     response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -18,9 +18,27 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
-
     assert_equal 'charge_test_941CA9CE174U76BD29C8', response.authorization
     assert response.test?
+  end
+
+  def test_successful_purchase_includes_avs_result
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_equal 'S', response.avs_result["code"]
+    assert_equal 'U.S.-issuing bank does not support AVS.', response.avs_result["message"]
+    assert_equal 'X', response.avs_result["postal_match"]
+    assert_equal 'X', response.avs_result["street_match"]
+  end
+
+  def test_successful_purchase_includes_cvv_result
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_equal 'Y', response.cvv_result["code"]
   end
 
   def test_purchase_with_additional_fields


### PR DESCRIPTION
This adds AVS and CVV result details to `purchase`. Since the gateway
only returns AVS and CVV information when performing the initial
authorization, the responses from both `authorize` and `capture` are
now merged in `purchase`.

Also, this fixes a failing test by correcting how the adapter sends
address1 and address2.

Unit:
```
ruby -Itest test/unit/gateways/checkout_v2_test.rb
Loaded suite test/unit/gateways/checkout_v2_test
Started
.................

Finished in 0.010582 seconds.
-------------------------------------------------------------------------------------------------
17 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------
1606.50 tests/s, 6709.51 assertions/s
```

Remote:
```
ruby -Itest test/remote/gateways/remote_checkout_v2_test.rb
Loaded suite test/remote/gateways/remote_checkout_v2_test
Started
.....................

Finished in 21.856911 seconds.
-------------------------------------------------------------------------------------------------
21 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------
0.96 tests/s, 2.20 assertions/s
```