### PR TITLE
EBANX: Pass person_type and name for stored cards

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -139,18 +139,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, payment, options)
-        post[:payment][:name] = payment.is_a?(String) ? "Not Provided" : payment.name
+        post[:payment][:name] = customer_name(payment, options)
         post[:payment][:email] = options[:email] || "unspecified@example.com"
         post[:payment][:document] = options[:document]
         post[:payment][:birth_date] = options[:birth_date] if options[:birth_date]
       end
 
       def add_customer_responsible_person(post, payment, options)
-        return unless (options[:person_type] && options[:person_type].downcase == 'business') && customer_country(options) == 'br'
-        post[:payment][:responsible] = {}
-        post[:payment][:responsible][:name] = payment.name
-        post[:payment][:responsible][:document] = options[:document]
-        post[:payment][:responsible][:birth_date] = options[:birth_date] if options[:birth_date]
+        post[:payment][:person_type] = options[:person_type] if options[:person_type]
+        if options[:person_type] && options[:person_type].downcase == 'business'
+          post[:payment][:responsible] = {}
+          post[:payment][:responsible][:name] = customer_name(payment, options)
+          post[:payment][:responsible][:document] = options[:document] if options[:document]
+          post[:payment][:responsible][:birth_date] = options[:birth_date] if options[:birth_date]
+        end
       end
 
       def add_address(post, options)
@@ -278,6 +280,15 @@ module ActiveMerchant #:nodoc:
       def customer_country(options)
         if country = options[:country] || (options[:billing_address][:country] if options[:billing_address])
           country.downcase
+        end
+      end
+
+      def customer_name(payment, options)
+        address_name = options[:billing_address][:name] if options[:billing_address] && options[:billing_address][:name]
+        if payment.is_a?(String)
+          address_name || "Not Provided"
+        else
+          payment.name
         end
       end
     end

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -32,10 +32,17 @@ class RemoteEbanxTest < Test::Unit::TestCase
       order_id: generate_unique_id,
       ip: "127.0.0.1",
       email: "joe@example.com",
-      birth_date: "10/11/1980"
+      birth_date: "10/11/1980",
+      person_type: 'personal'
     })
 
     response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
+  def test_successful_purchase_as_brazil_business_with_cnpj
+    response = @gateway.purchase(@amount, @credit_card, @options.update(person_type: 'business', document: '32593371000110'))
     assert_success response
     assert_equal 'Accepted', response.message
   end
@@ -123,6 +130,15 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_success store
 
     assert purchase = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success purchase
+    assert_equal 'Accepted', purchase.message
+  end
+
+  def test_successful_store_and_purchase_as_brazil_business
+    store = @gateway.store(@credit_card, @options.update(person_type: 'business', document: '32593371000110'))
+    assert_success store
+
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.update(person_type: 'business', document: '32593371000110'))
     assert_success purchase
     assert_equal 'Accepted', purchase.message
   end


### PR DESCRIPTION
Also conditions person_responsible element more correctly, and allows
the customer name passed to use the name associated with the billing
address when it is not available from the payment method, such as when
the payment method is a string for a stored card.

Four negative test cases are failing due to changes to test card numbers
we have yet to receive an update for.

Unit:
15 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
20 tests, 52 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
80% passed