### PR TITLE
Barclaycard Smartpay: Allows purchase with no address

### DIFF
--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -33,7 +33,7 @@ module ActiveMerchant #:nodoc:
         post = payment_request(money, options)
         post[:amount] = amount_hash(money, options[:currency])
         post[:card] = credit_card_hash(creditcard)
-        post[:billingAddress] = billing_address_hash(options)
+        post[:billingAddress] = billing_address_hash(options) if options[:billing_address]
         post[:deliveryAddress] = shipping_address_hash(options) if options[:shipping_address]
         commit('authorise', post)
       end

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -63,6 +63,13 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
         description: 'Store Purchase'
     }
 
+    @options_with_no_address = {
+        order_id: '1',
+        email: 'long@bob.com',
+        customer: 'Longbob Longsen',
+        description: 'Store Purchase'
+    }
+
     @avs_credit_card = credit_card('4400000000000008',
                                     :month => 8,
                                     :year => 2018,
@@ -108,6 +115,14 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount,
                                  @credit_card,
                                  @options.merge(street: 'Top Level Drive', house_number: '100'))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_purchase_with_no_address
+    response = @gateway.purchase(@amount,
+                                 @credit_card,
+                                 @options_with_no_address)
     assert_success response
     assert_equal '[capture-received]', response.message
   end


### PR DESCRIPTION
Unit tests:
22 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote tests:
26 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed