### PR TITLE
Make library files individually `require`-able

### DIFF
--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -51,16 +51,6 @@ require 'active_merchant/posts_data'
 require 'active_merchant/billing'
 require 'active_merchant/version'
 require 'active_merchant/country'
-
-module ActiveMerchant
-  def self.deprecated(message, caller=Kernel.caller[1])
-    warning = caller + ": " + message
-    if(respond_to?(:logger) && logger.present?)
-      logger.warn(warning)
-    else
-      warn(warning)
-    end
-  end
-end
+require 'active_merchant/deprecated'
 
 I18n.enforce_available_locales = false

--- a/lib/active_merchant/billing.rb
+++ b/lib/active_merchant/billing.rb
@@ -1,7 +1,5 @@
 require 'active_merchant/errors'
 
-require 'active_merchant/billing/avs_result'
-require 'active_merchant/billing/cvv_result'
 require 'active_merchant/billing/credit_card_methods'
 require 'active_merchant/billing/credit_card_formatting'
 require 'active_merchant/billing/credit_card'

--- a/lib/active_merchant/billing.rb
+++ b/lib/active_merchant/billing.rb
@@ -1,7 +1,5 @@
 require 'active_merchant/errors'
 
-require 'active_merchant/billing/credit_card_methods'
-require 'active_merchant/billing/credit_card_formatting'
 require 'active_merchant/billing/credit_card'
 require 'active_merchant/billing/network_tokenization_credit_card'
 require 'active_merchant/billing/base'

--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/deprecated'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     module Base

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/deprecated'
+
 module ActiveMerchant
   module Billing
     module Compatibility
@@ -117,4 +119,3 @@ module ActiveMerchant
     Compatibility::Model.send(:include, Rails::Model)
   end
 end
-

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -1,6 +1,8 @@
 require 'time'
 require 'date'
 require "active_merchant/billing/model"
+require 'active_merchant/billing/credit_card_formatting'
+require 'active_merchant/billing/credit_card_methods'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -1,5 +1,12 @@
 require 'net/http'
 require 'net/https'
+require 'securerandom'
+require 'json'
+require 'active_merchant/country'
+require 'active_merchant/posts_data'
+require 'active_merchant/deprecated'
+require 'active_merchant/version'
+require 'active_merchant/billing/credit_card_formatting'
 require 'active_merchant/billing/response'
 
 module ActiveMerchant #:nodoc:

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/credit_card'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class NetworkTokenizationCreditCard < CreditCard

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -1,3 +1,7 @@
+require 'active_merchant/billing/avs_result'
+require 'active_merchant/billing/cvv_result'
+require 'active_merchant/errors'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class Error < ActiveMerchantError #:nodoc:

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -2,6 +2,8 @@ require 'uri'
 require 'net/http'
 require 'net/https'
 require 'benchmark'
+require 'active_merchant/errors'
+require 'active_merchant/network_connection_retries'
 
 module ActiveMerchant
   class Connection

--- a/lib/active_merchant/deprecated.rb
+++ b/lib/active_merchant/deprecated.rb
@@ -1,0 +1,10 @@
+module ActiveMerchant
+  def self.deprecated(message, caller=Kernel.caller[1])
+    warning = caller + ": " + message
+    if(respond_to?(:logger) && logger.present?)
+      logger.warn(warning)
+    else
+      warn(warning)
+    end
+  end
+end

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -1,3 +1,8 @@
+require 'timeout'
+require 'socket'
+require 'openssl'
+require 'active_merchant/errors'
+
 module ActiveMerchant
   module NetworkConnectionRetries
     DEFAULT_RETRIES = 3

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -1,3 +1,6 @@
+require 'active_merchant/connection'
+require 'active_merchant/errors'
+
 module ActiveMerchant #:nodoc:
   module PostsData  #:nodoc:
 


### PR DESCRIPTION
We would like to be able to use parts of ActiveMerchant without having to load hundreds of Gateways and their dependencies. 

This is a first step towards individually require-able library files. 

I have not checked whether `ActiveSupport` dependencies are in those files. They probably are, but for all the Rails users, `ActiveSupport` will be already loaded. 

