### PR TITLE
Missing cardnumber params in xml_signed_fields

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -508,8 +508,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def xml_signed_fields(data)
-        data[:ds_amount] + data[:ds_order] + data[:ds_merchantcode] + data[:ds_currency] +
-          data[:ds_response] + data[:ds_transactiontype] + data[:ds_securepayment]
+        xml_signed_fields = data[:ds_amount] + data[:ds_order] + data[:ds_merchantcode] +
+          data[:ds_currency] + data[:ds_response]
+
+        if data[:ds_cardnumber]
+          xml_signed_fields += data[:ds_cardnumber]
+        end
+
+        xml_signed_fields += data[:ds_transactiontype] + data[:ds_securepayment]
       end
 
       def get_key(order_id)


### PR DESCRIPTION
Hi,
I was trying to use the Redsys gateway and I noticed that succesful transactions returned "false" when
response.success? was checked.

I looked into the code and inside "xml_signed_fields" method is missing the ds_cardnumber.
According to the manual, this parameter must to be passed when we are in a transacction types that requires send the card number.

After this change, the response of success? turned true as shloud be.

Redsys manual (page 11):
https://canales.redsys.es/canales/ayuda/documentacion/Manual%20integracion%20para%20conexion%20por%20Web%20Service.pdf

Greetings

