### PR TITLE
Shallow copy the options hash for Barclays tests

### DIFF
--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -100,7 +100,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
                                     :year => 2018,
                                     :verification_value => 737)
 
-    @avs_address = @options
+    @avs_address = @options.clone
     @avs_address.update(billing_address: {
         name:     'Jim Smith',
         street:   'Test AVS result',

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -89,7 +89,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       }
     }
 
-    @avs_address = @options
+    @avs_address = @options.clone
     @avs_address.update(billing_address: {
         name:     'Jim Smith',
         street:   'Test AVS result',


### PR DESCRIPTION
The intent in the tests was clearly to create a *distinct* options array, but what actually happened is that the original options array was modified. This patch causes the code to do the intended behavior. (Interestingly, this doesn't alter any test passes or failures, because having extra data doesn't upset either the unit tests or remote tests.)