### PR TITLE
Cyber Source: Correctly identifies 'subscriptionID' for store

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Ebanx: Support Colombian transactions [bpollack] #2636
 * Sage Payment Solutions: Scrub check info [curiousepic] #2639
 * Worldbank US: Allow using the backup URL [bpollack] #2641
+* Cyber Source: Correctly passes subscriptionID for store [deedeelavinder] #2633
 
 == Version 1.74.0 (October 24, 2017)
 * Adyen: Update list of supported countries [dtykocki] #2600

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -618,7 +618,7 @@ module ActiveMerchant #:nodoc:
 
         xml.tag! 'recurringSubscriptionInfo' do
           if reference
-            _, subscription_id, _ = reference.split(";")
+            subscription_id = reference.split(";")[6]
             xml.tag! 'subscriptionID',  subscription_id
           end
 
@@ -709,7 +709,7 @@ module ActiveMerchant #:nodoc:
         success = response[:decision] == "ACCEPT"
         message = response[:message]
 
-        authorization = success ? [ options[:order_id], response[:requestID], response[:requestToken], action, amount, options[:currency]].compact.join(";") : nil
+        authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
           :test => test?,
@@ -758,6 +758,11 @@ module ActiveMerchant #:nodoc:
       def reason_message(reason_code)
         return if reason_code.blank?
         @@response_codes[:"r#{reason_code}"]
+      end
+
+      def authorization_from(response, action, amount, options)
+        [options[:order_id], response[:requestID], response[:requestToken], action, amount,
+         options[:currency], response[:subscriptionID]].join(";")
       end
     end
   end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -319,7 +319,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def test_successful_create_subscription_with_monthly_options
     response = @gateway.store(@credit_card, @subscription_options.merge(:setup_fee => 99.0, :subscription => {:amount => 49.0, :automatic_renew => false, frequency: 'monthly'}))
     assert_equal 'Successful transaction', response.message
-    response = @gateway.retrieve(";#{response.params['subscriptionID']};", :order_id => @subscription_options[:order_id])
+    response = @gateway.retrieve(response.authorization, order_id: @subscription_options[:order_id])
     assert_equal "0.49", response.params['recurringAmount']
     assert_equal 'monthly', response.params['frequency']
   end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -59,7 +59,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
     assert response.test?
   end
 
@@ -95,7 +95,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @check, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
     assert response.test?
   end
 
@@ -105,7 +105,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:pinless_debit_card => true))
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
'subscriptionID' is required to authorize store. Previously 'requestID'
was used to populate the 'subscriptionID'. In the sandbox, they yield
identical values. In production, however, they are two different values.
This correctly captures the 'subscriptionID' separately from the
'requestID'.

Remote Tests:
(Includes 2 failing tests on master regarding pinless_debit_cards. The
code for pinless_debit_cards does not currently run.)

39 tests, 181 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
94.8718% passed

Unit Tests:
44 tests, 212 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed