### PR TITLE
PayU Latam: Four small updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,8 @@
 * PayU Latam: Set payment_country gateway attribute [curiousepic] #2611
 * Redsys: Support the DKK currency type [bpollack] #2618
 * WePay: Only send ip and device for non-recurring transactions [dtykocki] #2597
+* PayU Latam: Adds `partnerID`, adjusts phone preferences, allows empty `ip_address`, and adjusts for no `cvv`
+*   [deedeelavinder] #2634
 
 == Version 1.73.0 (September 28, 2017)
 * Adyen: Use original authorization pspReference on Refunds [lyverovski] #2589

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -196,7 +196,7 @@ class PayuLatamTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.update(options_buyer))
     end.check_request do |endpoint, data, headers|
-      assert_match(/\"buyer\":{\"fullName\":\"Jorge Borges\",\"dniNumber\":\"5415668464456\",\"dniType\":null,\"emailAddress\":\"axaxaxas@mlo.org\",\"contactPhone\":\"\(11\)756312345\",\"shippingAddress\":{\"street1\":\"Calle 200\",\"street2\":\"N107\",\"city\":\"Sao Paulo\",\"state\":\"SP\",\"country\":\"BR\",\"postalCode\":\"01019-030\",\"phone\":\"\(11\)756312345\"}}/, data)
+      assert_match(/\"buyer\":{\"fullName\":\"Jorge Borges\",\"dniNumber\":\"5415668464456\",\"dniType\":null,\"emailAddress\":\"axaxaxas@mlo.org\",\"contactPhone\":\"7563126\",\"shippingAddress\":{\"street1\":\"Calle 200\",\"street2\":\"N107\",\"city\":\"Sao Paulo\",\"state\":\"SP\",\"country\":\"BR\",\"postalCode\":\"01019-030\",\"phone\":\"\(11\)756312345\"}}/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
1) Adds `partnerId`.
2) Ensures phone_number is passed to 'buyer.contactPhone' and prefers
billing phone over shipping phone.
3) Sends empty field for 'ip_address' when none supplied.
4) Ensures 'creditCard.secutiryCode' node is not included when there is
no 'cvv'.

Remote Tests:
(Includes 5 failing tests on master: 2 'INTERNAL_PAYMENT_PROVIDER_ERROR'
and 3 'DECLINED_TEST_MODE_NOT_ALLOWED'.)

18 tests, 45 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
72.2222% passed

Unit Tests:
24 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed