### PR TITLE
Support Colombia with EBANX

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * FirstData E4 (Payeezy): Ensure numeric ECI values are zero padded [jasonwebster] #2630
+* EBANX: Support Colombian transactions [bpollack] #2636
 
 == Version 1.74.0 (October 24, 2017)
 * Adyen: Update list of supported countries [dtykocki] #2600

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://sandbox.ebanx.com/ws/'
       self.live_url = 'https://api.ebanx.com/ws/'
 
-      self.supported_countries = ['BR', 'MX']
+      self.supported_countries = ['BR', 'MX', 'CO']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club]
 

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -47,6 +47,27 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Accepted', response.message
   end
 
+  def test_successful_purchase_as_colombian
+    options = @options.merge({
+      order_id: generate_unique_id,
+      ip: "127.0.0.1",
+      email: "jose@example.com.co",
+      birth_date: "10/11/1980",
+      billing_address: address({
+        address1: '1040 Rua E',
+        city: 'Medellín',
+        state: 'AN',
+        zip: '29269',
+        country: 'CO',
+        phone_number: '8522847035'
+      })
+    })
+
+    response = @gateway.purchase(500, @credit_card, options)
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
This required no implementation changes to support, but, since EBANX allows only one country per email address, and since each country is slightly different, I did go ahead and add an explicit test just for Colombia--which does now pass.

Note that the four tests identified as failing in #2635 still fail, for the same reason, but the new test succeeds.

ENRG-7030