### PR TITLE
Fix Changelog entry listed in the wrong version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * FirstData E4 (Payeezy): Ensure numeric ECI values are zero padded [jasonwebster] #2630
+* PayU Latam: Adds `partnerID`, adjusts phone preferences, allows empty `ip_address`, and adjusts for no `cvv` [deedeelavinder] #2634
 
 == Version 1.74.0 (October 24, 2017)
 * Adyen: Update list of supported countries [dtykocki] #2600
@@ -23,8 +24,6 @@
 * PayU Latam: Set payment_country gateway attribute [curiousepic] #2611
 * Redsys: Support the DKK currency type [bpollack] #2618
 * WePay: Only send ip and device for non-recurring transactions [dtykocki] #2597
-* PayU Latam: Adds `partnerID`, adjusts phone preferences, allows empty `ip_address`, and adjusts for no `cvv`
-*   [deedeelavinder] #2634
 
 == Version 1.73.0 (September 28, 2017)
 * Adyen: Use original authorization pspReference on Refunds [lyverovski] #2589


### PR DESCRIPTION
PayU changes are in the not-yet-released 1.75 branch, not 1.74.