### PR TITLE
[Merchant Warrior] Adds default for empty state field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Paymentez: Add support for purchasing and authorizatin with tokens [bpollack] #2753
 * Ingenico: Remove Trinidad and Tobego from supported country list [bpollack] #2754
 * Barclaycard Smartpay: Remove Georgia from supported country list [bpollack] #2755
+* Merchant Warrior: Remove requirement for state field [joshnuss] #2638
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -79,13 +79,13 @@ module ActiveMerchant #:nodoc:
 
         post['customerName'] = scrub_name(address[:name])
         post['customerCountry'] = address[:country]
-        post['customerState'] = address[:state]
+        post['customerState'] = address[:state] || 'N/A'
         post['customerCity'] = address[:city]
         post['customerAddress'] = address[:address1]
         post['customerPostCode'] = address[:zip]
-		post['customerIP'] = address[:ip]
-		post['customerPhone'] = address[:phone]
-		post['customerEmail'] = address[:email]
+        post['customerIP'] = address[:ip]
+        post['customerPhone'] = address[:phone]
+        post['customerEmail'] = address[:email]
       end
 
       def add_order_id(post, options)

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -90,6 +90,47 @@ class MerchantWarriorTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_address
+    @options[:address] = {
+      name: 'Bat Man',
+      address1: '123 Main',
+      city: 'Brooklyn',
+      state: 'NY',
+      country: 'US',
+      zip: '11111',
+      phone: '555-1212',
+      email: 'user@aol.com',
+      ip: '1.2.3.4'
+    }
+
+    stub_comms do
+      @gateway.purchase(@success_amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/customerName=Bat\+Man/, data)
+      assert_match(/customerCountry=US/, data)
+      assert_match(/customerState=NY/, data)
+      assert_match(/customerCity=Brooklyn/, data)
+      assert_match(/customerAddress=123\+Main/, data)
+      assert_match(/customerPostCode=11111/, data)
+      assert_match(/customerIP=1.2.3.4/, data)
+      assert_match(/customerPhone=555-1212/, data)
+      assert_match(/customerEmail=user%40aol.com/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_address_without_state
+    @options[:address] = {
+      name: 'Bat Man',
+      state: nil
+    }
+
+    stub_comms do
+      @gateway.purchase(@success_amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/customerState=N%2FA/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_orderid_truncated
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, order_id: "ThisIsQuiteALongDescriptionWithLotsOfChars")


### PR DESCRIPTION
Makes the Province/State field optional for Merchant Warrior.

When no province/state is provided, the value "N/A" will be used instead.