### PR TITLE
Worldpay US: Allow requesting use of backup URL

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -3,11 +3,14 @@ require "nokogiri"
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class WorldpayUsGateway < Gateway
+      class_attribute :backup_url
+
       self.display_name = "Worldpay US"
       self.homepage_url = "http://www.worldpay.com/us"
 
       # No sandbox, just use test cards.
-      self.live_url = 'https://trans.worldpay.us/cgi-bin/process.cgi'
+      self.live_url   = 'https://trans.worldpay.us/cgi-bin/process.cgi'
+      self.backup_url = 'https://trans.gwtx01.com/cgi-bin/process.cgi'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
@@ -70,6 +73,10 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def url
+        @options[:use_backup_url] ? self.backup_url : self.live_url
+      end
 
       def add_customer_data(post, options)
         if(billing_address = (options[:billing_address] || options[:address]))
@@ -170,7 +177,7 @@ module ActiveMerchant #:nodoc:
 
         post[:authonly] = '1' if action == 'authorize'
 
-        raw = parse(ssl_post(live_url, post.to_query))
+        raw = parse(ssl_post(url, post.to_query))
 
         succeeded = success_from(raw['result'])
         Response.new(

--- a/test/remote/gateways/remote_worldpay_us_test.rb
+++ b/test/remote/gateways/remote_worldpay_us_test.rb
@@ -22,6 +22,13 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_on_backup_url
+    gateway = WorldpayUsGateway.new(fixtures(:worldpay_us).merge({ use_backup_url: true}))
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/worldpay_us_test.rb
+++ b/test/unit/gateways/worldpay_us_test.rb
@@ -175,6 +175,21 @@ class WorldpayUsTest < Test::Unit::TestCase
     assert_equal "Unable to read error message", response.message
   end
 
+  def test_backup_url
+    gateway = WorldpayUsGateway.new(
+      acctid: 'acctid',
+      subid: 'subid',
+      merchantpin: 'merchantpin',
+      use_backup_url: true
+    )
+    response = stub_comms(gateway) do
+      gateway.purchase(@amount, @credit_card, use_backup_url: true)
+    end.check_request do |endpoint, data, headers|
+      assert_equal WorldpayUsGateway.backup_url, endpoint
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
In the case a Worldpay US transaction fails, clients should reattempt on the backup URL. This change allows them to do so by instantiating a copy of the gateway with `use_backup_url` set to a truthy value.

Furthers ENRG-6747