### PR TITLE
Payu Latam: Changes partnerID to partner_id in options

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
       def add_order(post, options)
         order = {}
         order[:accountId] = @options[:account_id]
-        order[:partnerId] = options[:partnerId] if options[:partnerId]
+        order[:partnerId] = options[:partner_id] if options[:partner_id]
         order[:referenceCode] = options[:order_id] || generate_unique_id
         order[:description] = options[:description] || 'unspecified'
         order[:language] = 'en'


### PR DESCRIPTION
Remote Tests:
(Includes 5 failing tests on master: 2 'INTERNAL_PAYMENT_PROVIDER_ERROR'
and 3 'DECLINED_TEST_MODE_NOT_ALLOWED'.)

18 tests, 45 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
72.2222% passed

Unit Tests:
24 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed