### PR TITLE
Only send currency and billing_details for auths and sales for Netbanx

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Worldbank US: Allow using the backup URL [bpollack] #2641
 * Cyber Source: Correctly passes subscriptionID for store [deedeelavinder] #2633
 * Worldbank US: Allow using the backup URL per-request [bpollack] #2645
+* Netbanx: Only send currency and billing_details for auths and sales [anotherjosmith] #2643
 
 == Version 1.74.0 (October 24, 2017)
 * Adyen: Update list of supported countries [dtykocki] #2600

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, money, options)
         add_settle_with_auth(post)
-        add_payment(post, payment)
+        add_payment(post, payment, options)
 
         commit(:post, 'auths', post)
       end
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment, options={})
         post = {}
         add_invoice(post, money, options)
-        add_payment(post, payment)
+        add_payment(post, payment, options)
 
         commit(:post, 'auths', post)
       end
@@ -132,13 +132,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:amount] = amount(money)
-        post[:currencyCode] = options[:currency] if options[:currency]
         add_order_id(post, options)
-
-        if options[:billing_address]
-          post[:billingDetails]  = map_address(options[:billing_address])
-        end
-
       end
 
       def add_payment(post, credit_card_or_reference, options = {})
@@ -150,6 +144,9 @@ module ActiveMerchant #:nodoc:
           post[:card][:cvv]        = credit_card_or_reference.verification_value
           post[:card][:cardExpiry] = expdate(credit_card_or_reference)
         end
+
+        post[:currencyCode] = options[:currency] if options[:currency]
+        post[:billingDetails]  = map_address(options[:billing_address]) if options[:billing_address]
       end
 
       def expdate(credit_card)

--- a/test/remote/gateways/remote_netbanx_test.rb
+++ b/test/remote/gateways/remote_netbanx_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class RemoteNetbanxTest < Test::Unit::TestCase
   def setup
     @gateway = NetbanxGateway.new(fixtures(:netbanx))
-
     @amount = 100
     @credit_card = credit_card('4530910000012345')
     @declined_amount = 11
     @options = {
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      currency: 'CAD'
     }
   end
 
@@ -54,7 +54,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'OK', capture.message
   end
@@ -63,7 +63,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(@amount-1, auth.authorization)
+    assert capture = @gateway.capture(@amount-1, auth.authorization, @options)
     assert_success capture
   end
 
@@ -127,7 +127,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
 
     # the following shall fail if you run it immediately after the capture
@@ -141,7 +141,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
-    assert void = @gateway.void(auth.authorization)
+    assert void = @gateway.void(auth.authorization, @options)
     assert_success void
     assert_equal 'OK', void.message
   end

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -9,7 +9,8 @@ class NetbanxTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      currency: 'CAD'
     }
   end
 


### PR DESCRIPTION
Paysafe does not allow you to send this information for captures and
purchases. Therefore we shouldn't include them even if they're passed in
the options. The remote tests would previously fail if you included the
options field for captures or refunds, but they now pass.