### PR TITLE
Revert "Fixes basic auth for netbanx by sending the account_number and api_key"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Cyber Source: Correctly passes subscriptionID for store [deedeelavinder] #2633
 * Worldbank US: Allow using the backup URL per-request [bpollack] #2645
 * Netbanx: Only send currency and billing_details for auths and sales [anotherjosmith] #2643
+* Netbanx: Revert "Fixes basic auth for netbanx by sending the account_number and api_key" [anotherjosmith] #2644
 
 == Version 1.74.0 (October 24, 2017)
 * Adyen: Update list of supported countries [dtykocki] #2600

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -238,13 +238,9 @@ module ActiveMerchant #:nodoc:
         {
           'Accept'        => 'application/json',
           'Content-type'  => 'application/json',
-          'Authorization' => "Basic #{basic_auth}",
+          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}",
           'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
         }
-      end
-
-      def basic_auth
-        Base64.strict_encode64("#{@options[:account_number]}:#{@options[:api_key]}")
       end
 
       def error_code_from(response)


### PR DESCRIPTION
This reverts commit a838219a497144abc2bd72f16729e9d9b07a495c. The
previous change needed to be reverted because I had misunderstood that
the account number and username are different values. By reverting the
last PR, the api_key needs to be in the basic auth format already
(`<username>:<password>`).