### PR TITLE
Worldpay US: Allowing switching to backup gateway per-transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method)
         add_customer_data(post, options)
 
-        commit('purchase', post)
+        commit('purchase', options, post)
       end
 
       def authorize(money, payment, options={})
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         add_credit_card(post, payment)
         add_customer_data(post, options)
 
-        commit('authorize', post)
+        commit('authorize', options, post)
       end
 
       def capture(amount, authorization, options={})
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization)
         add_customer_data(post, options)
 
-        commit('capture', post)
+        commit('capture', options, post)
       end
 
       def refund(amount, authorization, options={})
@@ -55,14 +55,14 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization)
         add_customer_data(post, options)
 
-        commit("refund", post)
+        commit("refund", options, post)
       end
 
       def void(authorization, options={})
         post = {}
         add_reference(post, authorization)
 
-        commit('void', post)
+        commit('void', options, post)
       end
 
       def verify(credit_card, options={})
@@ -74,8 +74,8 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def url
-        @options[:use_backup_url] ? self.backup_url : self.live_url
+      def url(options)
+        options[:use_backup_url] ? self.backup_url : self.live_url
       end
 
       def add_customer_data(post, options)
@@ -169,7 +169,7 @@ module ActiveMerchant #:nodoc:
         "void" => "ns_void",
       }
 
-      def commit(action, post)
+      def commit(action, options, post)
         post[:action] = ACTIONS[action] unless post[:action]
         post[:acctid] = @options[:acctid]
         post[:subid] = @options[:subid]
@@ -177,7 +177,7 @@ module ActiveMerchant #:nodoc:
 
         post[:authonly] = '1' if action == 'authorize'
 
-        raw = parse(ssl_post(url, post.to_query))
+        raw = parse(ssl_post(url(options), post.to_query))
 
         succeeded = success_from(raw['result'])
         Response.new(

--- a/test/unit/gateways/worldpay_us_test.rb
+++ b/test/unit/gateways/worldpay_us_test.rb
@@ -176,14 +176,8 @@ class WorldpayUsTest < Test::Unit::TestCase
   end
 
   def test_backup_url
-    gateway = WorldpayUsGateway.new(
-      acctid: 'acctid',
-      subid: 'subid',
-      merchantpin: 'merchantpin',
-      use_backup_url: true
-    )
-    response = stub_comms(gateway) do
-      gateway.purchase(@amount, @credit_card, use_backup_url: true)
+    response = stub_comms(@gateway) do
+      @gateway.purchase(@amount, @credit_card, use_backup_url: true)
     end.check_request do |endpoint, data, headers|
       assert_equal WorldpayUsGateway.backup_url, endpoint
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
Previously, in 42e69f44390d, we allowed creating a Worldpay US gateway that targeted the backup URL. This commit changes that to instead allow specifying the URL per-transaction.

Note that one remote test fails, but it does prior to this commit (and to this entire chain of commits) as well.

Furthers ENRG-6747

Unit tests:
16 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
14 tests, 40 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.8571% passed