### PR TITLE
Stop making remote requests for payeezy store unit tests

### DIFF
--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -58,7 +58,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_successful_store
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(successful_store_response)
 
@@ -68,7 +68,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_successful_store_and_purchase
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(successful_store_response)
 
@@ -82,7 +82,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_failed_store
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@bad_credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(failed_store_response)
 


### PR DESCRIPTION
Payeezy uses the :ssl_request method to store CCs.

https://github.com/activemerchant/active_merchant/blob/23c38dd7f5758360fca02b6099254b31211d7573/lib/active_merchant/billing/gateways/payeezy.rb#L276-L285

The problem is, the `stub_comms` method defaults to stubbing the `ssl_post` method.

https://github.com/activemerchant/active_merchant/blob/23c38dd7f5758360fca02b6099254b31211d7573/test/comm_stub.rb#L43-L46

This means that these tests were making remote requests every single time they run, causing flakyness in CI runs.

![screen shot 2017-11-07 at 5 12 40 pm](https://user-images.githubusercontent.com/3300109/32520698-edcc8336-c3de-11e7-9791-c00926eee761.png)
