### PR TITLE
[WIP] Disable remote requests for unit tests

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('mocha', '~> 1')
+  s.add_development_dependency('webmock')
   s.add_development_dependency('thor')
 end

--- a/test/comm_stub.rb
+++ b/test/comm_stub.rb
@@ -40,9 +40,9 @@ module CommStub
     @last_comm_stub ||= Stub::Complete.new
   end
 
-  def stub_comms(gateway=@gateway, method_to_stub=:ssl_post, &action)
+  def stub_comms(gateway: @gateway, method: :ssl_post, &action)
     assert last_comm_stub.complete?, "Tried to stub communications when there's a stub already in progress."
-    @last_comm_stub = Stub.new(gateway, method_to_stub, action)
+    @last_comm_stub = Stub.new(gateway, method, action)
   end
 
   def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'bundler/setup'
 
 require 'test/unit'
 require 'mocha/test_unit'
+require 'webmock/test_unit'
 
 require 'yaml'
 require 'json'
@@ -16,6 +17,9 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/time/acts_like'
 
 ActiveMerchant::Billing::Base.mode = :test
+unless ENV['ALLOW_REMOTE_REQUESTS'] == 'true'
+  WebMock.disable_net_connect!
+end
 
 if ENV['DEBUG_ACTIVE_MERCHANT'] == 'true'
   require 'logger'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/time/acts_like'
 
 ActiveMerchant::Billing::Base.mode = :test
+
 unless ENV['ALLOW_REMOTE_REQUESTS'] == 'true'
   WebMock.disable_net_connect!
 end

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -31,7 +31,7 @@ class BalancedTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_outside_token
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "/cards/CCVOX2d7Ar6Ze5TOxHsebeH", @options)
     end.check_request do |method, endpoint, data, headers|
       assert_equal("https://api.balancedpayments.com/cards/CCVOX2d7Ar6Ze5TOxHsebeH/debits", endpoint)
@@ -219,7 +219,7 @@ class BalancedTest < Test::Unit::TestCase
   def test_successful_purchase_with_legacy_outside_token
     legacy_outside_token = '/v1/marketplaces/MP6oR9hHNlu2BLVsRRoQL3Gg/cards/CC7m1Mtqk6rVJo5tcD1qitAC'
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, legacy_outside_token, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_equal("https://api.balancedpayments.com/cards/CC7m1Mtqk6rVJo5tcD1qitAC/debits", endpoint)
@@ -235,7 +235,7 @@ class BalancedTest < Test::Unit::TestCase
     v11_authorization = "/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5/debits||/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5"
 
     [v1_authorization, v11_authorization].each do |authorization|
-      stub_comms(@gateway, :ssl_request) do
+      stub_comms(method: :ssl_request) do
         @gateway.capture(@amount, authorization)
       end.check_request do |method, endpoint, data, headers|
         assert_equal("https://api.balancedpayments.com/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5/debits", endpoint)
@@ -248,7 +248,7 @@ class BalancedTest < Test::Unit::TestCase
     v11_authorization = "/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5/debits||/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5"
 
     [v1_authorization, v11_authorization].each do |authorization|
-      stub_comms(@gateway, :ssl_request) do
+      stub_comms(method: :ssl_request) do
         @gateway.void(authorization)
       end.check_request do |method, endpoint, data, headers|
         assert_equal :put, method
@@ -263,7 +263,7 @@ class BalancedTest < Test::Unit::TestCase
     v11_authorization = "|/debits/WD2x6vLS7RzHYEcdymqRyNAO/refunds|"
 
     [v1_authorization, v11_authorization].each do |authorization|
-      stub_comms(@gateway, :ssl_request) do
+      stub_comms(method: :ssl_request) do
         @gateway.refund(nil, authorization)
       end.check_request do |method, endpoint, data, headers|
         assert_equal("https://api.balancedpayments.com/debits/WD2x6vLS7RzHYEcdymqRyNAO/refunds", endpoint)
@@ -273,7 +273,7 @@ class BalancedTest < Test::Unit::TestCase
 
   def test_passing_address
     a = address
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: a)
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
@@ -290,7 +290,7 @@ class BalancedTest < Test::Unit::TestCase
   end
 
   def test_passing_address_without_zip
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: address(zip: nil))
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
@@ -301,7 +301,7 @@ class BalancedTest < Test::Unit::TestCase
   end
 
   def test_passing_address_with_blank_zip
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: address(zip: "   "))
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -57,7 +57,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       refute_match(/recurringPayment=true/, data)
@@ -68,7 +68,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_recurring
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/recurringPayment=true/, data)
@@ -78,7 +78,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_recurring
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/recurringPayment=true/, data)
@@ -244,7 +244,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_includes_network_tokenization_fields
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/3DSecureXID/, data)
@@ -259,7 +259,7 @@ class BeanstreamTest < Test::Unit::TestCase
     address = { country: "AF" }
     @options[:billing_address] = address
     @options[:shipping_address] = address
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ordProvince=--/, data)
@@ -275,7 +275,7 @@ class BeanstreamTest < Test::Unit::TestCase
     address = { }
     @options[:billing_address] = address
     @options[:shipping_address] = address
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_no_match(/ordProvince=--/, data)
@@ -291,7 +291,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @options[:billing_address] = nil
     @options[:shipping_address] = nil
     @options[:shipping_email] = "ship@mail.com"
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ordEmailAddress=xiaobozzz%40example.com/, data)

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -123,9 +123,9 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_currency_added_correctly
-    stub_comms do
+    stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |method, endpoint, data|
       assert_match(/<currency>CAD<\/currency>/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/card_connect_test.rb
+++ b/test/unit/gateways/card_connect_test.rb
@@ -152,7 +152,7 @@ class CardConnectTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -106,7 +106,7 @@ class Cashnet < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_fname_and_lname
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/fname=Longbob/, data)
@@ -115,7 +115,7 @@ class Cashnet < Test::Unit::TestCase
   end
 
   def test_invalid_response
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(invalid_response)
 
@@ -125,7 +125,7 @@ class Cashnet < Test::Unit::TestCase
 
   def test_passes_custcode_from_credentials
     gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', custcode: "TheCustCode")
-    stub_comms(gateway, :ssl_request) do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       gateway.purchase(@amount, @credit_card, {})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/custcode=TheCustCode/, data)
@@ -134,7 +134,7 @@ class Cashnet < Test::Unit::TestCase
 
   def test_allows_custcode_override
     gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', custcode: "TheCustCode")
-    stub_comms(gateway, :ssl_request) do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       gateway.purchase(@amount, @credit_card, custcode: "OveriddenCustCode")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/custcode=OveriddenCustCode/, data)

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -94,7 +94,7 @@ class CheckoutTest < Test::Unit::TestCase
 
   def test_successful_void
     @options['orderid'] = '9c38d0506da258e216fa072197faaf37'
-    void = stub_comms(@gateway, :ssl_request) do
+    void = stub_comms(method: :ssl_request) do
       @gateway.void('36919371|9c38d0506da258e216fa072197faaf37|1|CAD|100', @options)
     end.check_request do |method, endpoint, data, headers|
       # Should only be one pair of track id tags.
@@ -133,7 +133,7 @@ class CheckoutTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(credit_card, @options)
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
@@ -141,7 +141,7 @@ class CheckoutTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
@@ -149,7 +149,7 @@ class CheckoutTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(credit_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -29,7 +29,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(failed_purchase_response)
 
@@ -39,14 +39,14 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
     assert_success response
     assert_equal '91debbeb-d88f-42e9-a6ce-9b62c99d656b|f3d100a7-18d9-4609-aabc-8a710ad0e210', response.authorization
 
-    capture = stub_comms(@gateway, :ssl_request) do
+    capture = stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/f3d100a7-18d9-4609-aabc-8a710ad0e210/, data)
@@ -56,14 +56,14 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_refund
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_capture_response)
 
     assert_success response
     assert_equal '2a79d859-8b23-4dd0-b319-201fe2373c50|ce61e06e-8c92-4a0f-a491-6eb473d883dd', response.authorization
 
-    refund = stub_comms(@gateway, :ssl_request) do
+    refund = stub_comms(method: :ssl_request) do
       @gateway.refund(@amount, response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
@@ -73,14 +73,14 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_capture_response)
 
     assert_success response
     assert_equal '2a79d859-8b23-4dd0-b319-201fe2373c50|ce61e06e-8c92-4a0f-a491-6eb473d883dd', response.authorization
 
-    void = stub_comms(@gateway, :ssl_request) do
+    void = stub_comms(method: :ssl_request) do
       @gateway.void(response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
@@ -90,7 +90,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_passing_alpha3_country_code
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => {country: "US"})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/USA/, data)
@@ -98,7 +98,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_non_existent_country
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => {country: "Blah"})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/"country":null/, data)
@@ -106,7 +106,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_passing_cvv
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/#{@credit_card.verification_value}/, data)
@@ -114,7 +114,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
@@ -124,7 +124,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_passing_shipping_name
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :shipping_address => address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
@@ -134,7 +134,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
@@ -142,7 +142,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
@@ -150,7 +150,7 @@ class CitrusPayTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
@@ -164,7 +164,7 @@ class CitrusPayTest < Test::Unit::TestCase
       region: 'north_america'
     )
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/secure.na.tnspayments.com/, endpoint)
@@ -180,7 +180,7 @@ class CitrusPayTest < Test::Unit::TestCase
       region: 'asia_pacific'
     )
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/secure.ap.tnspayments.com/, endpoint)

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -216,7 +216,7 @@ class ClearhausTest < Test::Unit::TestCase
     card = credit_card('4111111111111111', month: '06', year: '2018', verification_value: '123')
     options = { currency: 'EUR', ip: '1.1.1.1' }
 
-    stub_comms gateway, :ssl_request do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       response = gateway.authorize(2050, card, options)
       assert_success response
 
@@ -235,7 +235,7 @@ class ClearhausTest < Test::Unit::TestCase
     card = credit_card('4111111111111111', month: '06', year: '2018', verification_value: '123')
     options = { currency: 'EUR', ip: '1.1.1.1' }
 
-    stub_comms gateway, :ssl_request do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       response = gateway.authorize(2050, card, options)
       assert_success response
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -340,14 +340,14 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorization_response)
     assert_success response
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(unsuccessful_authorization_response)
     assert_failure response

--- a/test/unit/gateways/ezic_test.rb
+++ b/test/unit/gateways/ezic_test.rb
@@ -91,7 +91,7 @@ class EzicTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_raw_response, failed_void_response)
     assert_success response

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -66,7 +66,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_recurring_flag
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
       assert_match(%r("extra":{"ecm":"32"}), data)

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -17,7 +17,7 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(successful_purchase_response))
     assert_success response
@@ -30,13 +30,13 @@ class ForteTest < Test::Unit::TestCase
     options = { order_id: '1' }
     @gateway.expects(:commit).with(anything, has_entries(:order_number => '1'))
 
-    stub_comms(@gateway, :raw_ssl_request) do
+    stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
     end.respond_with(MockedResponse.new(successful_purchase_response))
   end
 
   def test_failed_purchase
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(failed_purchase_response))
     assert_failure response
@@ -44,7 +44,7 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_echeck
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @check, @options)
     end.respond_with(MockedResponse.new(successful_echeck_purchase_response))
     assert_success response
@@ -54,7 +54,7 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_echeck
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(failed_echeck_purchase_response))
     assert_failure response
@@ -62,14 +62,14 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(successful_authorize_response))
     assert_success response
   end
 
   def test_failed_authorize
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(failed_authorize_response))
     assert_failure response
@@ -77,63 +77,63 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_successful_capture
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.capture(@amount, "authcode")
     end.respond_with(MockedResponse.new(successful_capture_response))
     assert_success response
   end
 
   def test_failed_capture
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.capture(@amount, "authcode")
     end.respond_with(MockedResponse.new(failed_capture_response))
     assert_failure response
   end
 
   def test_successful_credit
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.credit(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(successful_credit_response))
     assert_success response
   end
 
   def test_failed_credit
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.credit(@amount, @credit_card, @options)
     end.respond_with(MockedResponse.new(failed_credit_response))
     assert_failure response
   end
 
   def test_successful_void
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.void("authcode")
     end.respond_with(MockedResponse.new(successful_credit_response))
     assert_success response
   end
 
   def test_failed_void
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.void("authcode")
     end.respond_with(MockedResponse.new(failed_credit_response))
     assert_failure response
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(MockedResponse.new(successful_authorize_response), MockedResponse.new(successful_void_response))
     assert_success response
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(MockedResponse.new(successful_authorize_response), MockedResponse.new(failed_void_response))
     assert_success response
   end
 
   def test_failed_verify
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(MockedResponse.new(failed_authorize_response))
     assert_failure response

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -142,7 +142,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
   end
 
   def test_visa_3dsecure_params_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:xid => '1', :cavv => '2'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/xid=1/, data)
@@ -151,7 +151,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
   end
 
   def test_mastercard_3dsecure_params_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:ucaf_collection_ind => '1', :ucaf_auth_data => '2'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ucaf_collection_ind=1/, data)

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -201,7 +201,7 @@ class MonerisTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
     @credit_card.verification_value = "452"
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cvd_indicator>1<}, data)
@@ -213,7 +213,7 @@ class MonerisTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
     @credit_card.verification_value = ""
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cvd_indicator>0<}, data)
@@ -245,7 +245,7 @@ class MonerisTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
     billing_address = address(address1: "1234 Anystreet", address2: "")
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: "1")
     end.check_request do |endpoint, data, headers|
       assert_match(%r{avs_street_number>1234<}, data)
@@ -257,7 +257,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_avs_enabled_but_not_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     end.check_request do |endpoint, data, headers|
       assert_no_match(%r{avs_street_number>}, data)

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -199,7 +199,7 @@ class MonerisUsTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
     @credit_card.verification_value = "452"
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cvd_indicator>1<}, data)
@@ -211,7 +211,7 @@ class MonerisUsTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
     @credit_card.verification_value = ""
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cvd_indicator>0<}, data)
@@ -243,7 +243,7 @@ class MonerisUsTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
     billing_address = address(address1: "1234 Anystreet", address2: "")
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: "1")
     end.check_request do |endpoint, data, headers|
       assert_match(%r{avs_street_number>1234<}, data)
@@ -255,7 +255,7 @@ class MonerisUsTest < Test::Unit::TestCase
   def test_avs_enabled_but_not_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     end.check_request do |endpoint, data, headers|
       assert_no_match(%r{avs_street_number>}, data)

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -137,7 +137,7 @@ class NabTransactTest < Test::Unit::TestCase
   end
 
   def test_request_timeout_default
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/<timeoutValue>60/, data)
@@ -146,7 +146,7 @@ class NabTransactTest < Test::Unit::TestCase
 
   def test_override_request_timeout
     gateway = NabTransactGateway.new(login: 'login', password: 'password', request_timeout: 44)
-    stub_comms(gateway, :ssl_request) do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/<timeoutValue>44/, data)
@@ -220,7 +220,7 @@ Conn close
   end
 
   def assert_metadata(name, location, &block)
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       block.call
     end.check_request do |method, endpoint, data, headers|
       metadata_matcher = Regexp.escape(valid_metadata(name, location))

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -96,14 +96,14 @@ class OpenpayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card)
     end.respond_with(successful_authorization_response, successful_void_response)
     assert_success response
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
@@ -169,7 +169,7 @@ class OpenpayTest < Test::Unit::TestCase
   end
 
   def test_passing_device_session_id
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, device_session_id: 'TheDeviceSessionID')
     end.check_request do |method, endpoint, data, headers|
       assert_match(%r{"device_session_id":"TheDeviceSessionID"}, data)

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -160,7 +160,7 @@ class OppTest < Test::Unit::TestCase
   def test_passes_3d_secure_fields
     options = @complete_request_options.merge({eci: "eci", cavv: "cavv", xid: "xid"})
 
-    response = stub_comms(@gateway, :raw_ssl_request) do
+    response = stub_comms(method: :raw_ssl_request) do
       @gateway.purchase(@amount, @valid_card, options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/threeDSecure.eci=eci/, data)

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -58,7 +58,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_successful_store
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(successful_store_response)
 
@@ -68,7 +68,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_successful_store_and_purchase
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(successful_store_response)
 
@@ -82,7 +82,7 @@ class PayeezyGateway < Test::Unit::TestCase
   end
 
   def test_failed_store
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.store(@bad_credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
     end.respond_with(failed_store_response)
 

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -197,14 +197,14 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway) do
+    response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorization_response)
     assert_success response
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway) do
+    response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorization_response)
     assert_failure response

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -236,7 +236,7 @@ class PayuLatamTest < Test::Unit::TestCase
       }
     }
 
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_brazil))
     end.check_request do |endpoint, data, headers|
       assert_match(/\"cnpj\":\"32593371000110\"/, data)
@@ -270,7 +270,7 @@ class PayuLatamTest < Test::Unit::TestCase
       tx_tax_return_base: '16806'
     }
 
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_colombia))
     end.check_request do |endpoint, data, headers|
       assert_match(/\"additionalValues\":{\"TX_VALUE\":{\"value\":\"40.00\",\"currency\":\"COP\"},\"TX_TAX\":{\"value\":0,\"currency\":\"COP\"},\"TX_TAX_RETURN_BASE\":{\"value\":0,\"currency\":\"COP\"}}/, data)
@@ -303,7 +303,7 @@ class PayuLatamTest < Test::Unit::TestCase
       birth_date: '1985-05-25'
     }
 
-    stub_comms(gateway) do
+    stub_comms(gateway: gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_mexico))
     end.check_request do |endpoint, data, headers|
       assert_match(/\"birthdate\":\"1985-05-25\"/, data)

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -145,7 +145,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   end
 
   def test_finalize_is_disabled_by_default
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, "12345")
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /finalize=0/
@@ -153,7 +153,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   end
 
   def test_finalize_is_enabled
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, "12345", finalize: true)
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /finalize=1/

--- a/test/unit/gateways/qvalent_test.rb
+++ b/test/unit/gateways/qvalent_test.rb
@@ -175,7 +175,7 @@ class QvalentTest < Test::Unit::TestCase
   end
 
   def test_3d_secure_fields
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {xid: '123', cavv: '456', eci: '5'})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/xid=123/, data)

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -115,7 +115,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_bad_order_id_format
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(100, credit_card, order_id: "Una#cce-ptable44Format")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/MERCHANT_ORDER%3E\d\d\d\dUnaccept%3C/, data)
@@ -123,7 +123,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_order_id_numeric_start_but_too_long
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(100, credit_card, order_id: "1234ThisIs]FineButTooLong")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/MERCHANT_ORDER%3E1234ThisIsFi%3C/, data)

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -113,7 +113,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_bad_order_id_format
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(123, credit_card, order_id: "Una#cce-ptable44Format")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/MERCHANT_ORDER%3E\d\d\d\dUnaccept%3C/, data)
@@ -121,7 +121,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_order_id_numeric_start_but_too_long
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(123, credit_card, order_id: "1234ThisIs]FineButTooLong")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/MERCHANT_ORDER%3E1234ThisIsFi%3C/, data)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -109,7 +109,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_paypal_callback_url_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(paypal_callback_url: 'callback.com')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/PayPalCallbackURL=callback\.com/, data)
@@ -117,7 +117,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_basket_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(basket: 'A1.2 Basket section')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/Basket=A1\.2\+Basket\+section/, data)
@@ -125,7 +125,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_gift_aid_payment_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(gift_aid_payment: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/GiftAidPayment=1/, data)
@@ -133,7 +133,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_apply_avscv2_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(apply_avscv2: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ApplyAVSCV2=1/, data)
@@ -141,7 +141,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_disable_3d_security_flag_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(apply_3d_secure: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/Apply3DSecure=1/, data)
@@ -149,7 +149,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_account_type_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(account_type: 'M')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/AccountType=M/, data)
@@ -157,7 +157,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_billing_agreement_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(billing_agreement: 1)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/BillingAgreement=1/, data)
@@ -165,7 +165,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_store_token_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(store: true)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/CreateToken=1/, data)
@@ -173,7 +173,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_basket_xml_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(basket_xml: 'A1.3 BasketXML section')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/BasketXML=A1\.3\+BasketXML\+section/, data)
@@ -181,7 +181,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_customer_xml_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(customer_xml: 'A1.4 CustomerXML section')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/CustomerXML=A1\.4\+CustomerXML\+section/, data)
@@ -189,7 +189,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_surcharge_xml_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(surcharge_xml: 'A1.1 SurchargeXML section')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/SurchargeXML=A1\.1\+SurchargeXML\+section/, data)
@@ -197,7 +197,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_vendor_data_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(vendor_data: 'any data')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/VendorData=any\+data/, data)
@@ -205,7 +205,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_language_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(language: 'FR')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/Language=FR/, data)
@@ -213,7 +213,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_website_is_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(website: 'transaction-origin.com')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/Website=transaction-origin\.com/, data)
@@ -221,7 +221,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_FIxxxx_optional_fields_are_submitted
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(recipient_account_number: '1234567890',
         recipient_surname: 'Withnail', recipient_postcode: 'AB11AB',
         recipient_dob: '19701223')
@@ -235,7 +235,7 @@ class SagePayTest < Test::Unit::TestCase
 
   def test_description_is_truncated
     huge_description = "SagePay transactions fail if the déscription is more than 100 characters. Therefore, we truncate it to 100 characters." + " Lots more text " * 1000
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       purchase_with_options(description: huge_description)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/&Description=SagePay\+transactions\+fail\+if\+the\+d%C3%A9scription\+is\+more\+than\+100\+characters.\+Therefore%2C\+we\+trunc&/, data)
@@ -245,7 +245,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_protocol_version_is_honoured
     gateway = SagePayGateway.new(protocol_version: '2.23', login: "X")
 
-    stub_comms(gateway, :ssl_request) do
+    stub_comms(gateway: gateway, method: :ssl_request) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/VPSProtocol=2.23/, data)
@@ -254,7 +254,7 @@ class SagePayTest < Test::Unit::TestCase
 
   def test_referrer_id_is_added_to_post_data_parameters
     ActiveMerchant::Billing::SagePayGateway.application_id = '00000000-0000-0000-0000-000000000001'
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert data.include?("ReferrerID=00000000-0000-0000-0000-000000000001")
@@ -264,7 +264,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.store(@credit_card)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/TxType=TOKEN/, data)
@@ -325,7 +325,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_repeat_purchase_with_reference_token
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "1455548a8d178beecd88fe6a285f50ff;{0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474};15353766;BS231FNE14;purchase", @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/RelatedVPSTxId=%7B0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474%/, data)

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -64,7 +64,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "tok_xxx")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/card=tok_xxx/, data)
@@ -85,7 +85,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({ description: "test charge", ip: "127.127.127.127", user_agent: "browser XXX", referrer: "http://www.foobar.com", email: "foo@bar.com" })
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -98,7 +98,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_purchase_without_email_or_order
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({ description: "test charge", ip: "127.127.127.127", user_agent: "browser XXX", referrer: "http://www.foobar.com" })
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -137,7 +137,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_address_is_included_with_card_data
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /card\[addressLine1\]/
@@ -257,14 +257,14 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
@@ -272,7 +272,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@declined_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -278,7 +278,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_validate_false_on_store
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.store(@credit_card, validate: false)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/validate=false/, data)
@@ -288,7 +288,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_empty_values_not_sent
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, referrer: "")
     end.check_request do |method, endpoint, data, headers|
       refute_match(/referrer/, data)
@@ -447,7 +447,7 @@ class StripeTest < Test::Unit::TestCase
       url: "https://example.com"
     }
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "cus_xxx|card_xxx", @options.merge({application: application}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/\"application\"/, headers["X-Stripe-Client-User-Agent"])
@@ -460,7 +460,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token_including_customer
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "cus_xxx|card_xxx")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/customer=cus_xxx/, data)
@@ -471,7 +471,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "card_xxx")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/card=card_xxx/, data)
@@ -481,7 +481,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_statement_description
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, statement_description: '5K RACE TICKET')
     end.check_request do |method, endpoint, data, headers|
       assert_match(/statement_descriptor=5K\+RACE\+TICKET/, data)
@@ -601,7 +601,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_reverse_transfer
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.refund(@amount, "auth", reverse_transfer: true)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/reverse_transfer=true/, data)
@@ -651,14 +651,14 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorization_response, successful_void_response)
     assert_success response
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorization_response, failed_void_response)
     assert_success response
@@ -666,7 +666,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(declined_authorization_response, successful_void_response)
     assert_failure response
@@ -838,7 +838,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_application_fee_is_submitted_for_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:application_fee => 144}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/application_fee=144/, data)
@@ -846,7 +846,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_application_fee_is_submitted_for_capture
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, "ch_test_charge", @options.merge({:application_fee => 144}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/application_fee=144/, data)
@@ -854,7 +854,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_destination_is_submitted_for_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/destination=subaccountid/, data)
@@ -862,7 +862,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({:description => "a test customer",:ip => "127.127.127.127", :user_agent => "some browser", :order_id => "42", :email => "foo@wonderfullyfakedomain.com", :receipt_email => "receipt-receiver@wonderfullyfakedomain.com", :referrer =>"http://www.shopify.com"})
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -879,7 +879,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_purchase_without_email_or_order
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({:description => "a test customer",:ip => "127.127.127.127", :user_agent => "some browser", :referrer =>"http://www.shopify.com"})
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -893,7 +893,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_metadata_in_options
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -905,7 +905,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
       @gateway.purchase(@amount, @emv_credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -918,7 +918,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_authorize
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
       @gateway.authorize(@amount, @emv_credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
@@ -931,7 +931,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_quickchip_is_set_on_purchase
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @emv_credit_card.read_method = 'contact_quickchip'
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
@@ -940,7 +940,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_quickchip_is_not_set_on_authorize
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @emv_credit_card.read_method = 'contact_quickchip'
       @gateway.authorize(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
@@ -1052,14 +1052,14 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_track_data_and_traditional_should_be_mutually_exclusive
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /card\[name\]/
       assert data !~ /card\[swipe_data\]/
     end.respond_with(successful_purchase_response)
 
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
@@ -1069,15 +1069,15 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_address_is_included_with_card_data
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /card\[address_line1\]/
     end.respond_with(successful_purchase_response)
   end
 
-  def test_contactless_flag_is_included_with_emv_card_data
-    stub_comms(@gateway, :ssl_request) do
+  def test_contactless_emv_flag_is_included_with_emv_card_data
+    stub_comms(method: :ssl_request) do
       @emv_credit_card.read_method = 'contactless'
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
@@ -1086,7 +1086,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_contactless_magstripe_flag_is_included_with_emv_card_data
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @emv_credit_card.read_method = 'contactless_magstripe'
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
@@ -1095,7 +1095,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_contactless_flag_is_not_included_with_emv_card_data_by_default
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       data !~ /card\[read_method\]=contactless/ && data !~ /card\[read_method\]=contactless_magstripe_mode/
@@ -1103,7 +1103,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_encrypted_pin_is_included_with_emv_card_data
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @emv_credit_card.encrypted_pin_cryptogram = "8b68af72199529b8"
       @emv_credit_card.encrypted_pin_ksn = "ffff0102628d12000001"
       @gateway.purchase(@amount, @emv_credit_card, @options)
@@ -1186,7 +1186,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_new_attributes_are_included_in_update
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.send(:update, "cus_3sgheFxeBgTQ3M", "card_483etw4er9fg4vF3sQdrt3FG", { :name => "John Smith", :exp_year => 2021, :exp_month => 6 })
     end.check_request do |method, endpoint, data, headers|
       assert data == "name=John+Smith&exp_year=2021&exp_month=6"
@@ -1301,7 +1301,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_emv_capture_application_fee_ignored
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, "ch_test_charge", application_fee: 100, icc_data: @emv_credit_card.icc_data)
     end.check_request do |method, endpoint, data, headers|
       assert data !~ /application_fee/, "request should not include application_fee"
@@ -1311,7 +1311,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_authorization_with_emv_payment_application_fee_included
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, "ch_test_charge", application_fee: 100, icc_data: @emv_credit_card.icc_data)
     end.check_request do |method, endpoint, data, headers|
       assert data =~ /application_fee/, "request should include application_fee"

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -29,7 +29,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(failed_purchase_response)
 
@@ -39,14 +39,14 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
     assert_success response
     assert_equal '91debbeb-d88f-42e9-a6ce-9b62c99d656b|f3d100a7-18d9-4609-aabc-8a710ad0e210', response.authorization
 
-    capture = stub_comms(@gateway, :ssl_request) do
+    capture = stub_comms(method: :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/f3d100a7-18d9-4609-aabc-8a710ad0e210/, data)
@@ -56,14 +56,14 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_refund
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_capture_response)
 
     assert_success response
     assert_equal '2a79d859-8b23-4dd0-b319-201fe2373c50|ce61e06e-8c92-4a0f-a491-6eb473d883dd', response.authorization
 
-    refund = stub_comms(@gateway, :ssl_request) do
+    refund = stub_comms(method: :ssl_request) do
       @gateway.refund(@amount, response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
@@ -73,14 +73,14 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_capture_response)
 
     assert_success response
     assert_equal '2a79d859-8b23-4dd0-b319-201fe2373c50|ce61e06e-8c92-4a0f-a491-6eb473d883dd', response.authorization
 
-    void = stub_comms(@gateway, :ssl_request) do
+    void = stub_comms(method: :ssl_request) do
       @gateway.void(response.authorization)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
@@ -90,7 +90,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_passing_alpha3_country_code
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => {country: "US"})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/USA/, data)
@@ -98,7 +98,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_non_existent_country
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => {country: "Blah"})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/"country":null/, data)
@@ -106,7 +106,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_passing_cvv
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/#{@credit_card.verification_value}/, data)
@@ -114,7 +114,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :billing_address => address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
@@ -124,7 +124,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_passing_shipping_name
-    stub_comms(@gateway, :ssl_request) do
+    stub_comms(method: :ssl_request) do
       @gateway.authorize(@amount, @credit_card, :shipping_address => address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
@@ -134,7 +134,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
@@ -142,7 +142,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_failed_void
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
@@ -150,7 +150,7 @@ class TnsTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_verify
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
@@ -164,7 +164,7 @@ class TnsTest < Test::Unit::TestCase
       region: 'north_america'
     )
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/secure.na.tnspayments.com/, endpoint)
@@ -180,7 +180,7 @@ class TnsTest < Test::Unit::TestCase
       region: 'asia_pacific'
     )
 
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/secure.ap.tnspayments.com/, endpoint)

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -58,7 +58,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    response = stub_comms(@gateway, :ssl_request) do
+    response = stub_comms(method: :ssl_request) do
       @gateway.purchase(@amount, "cus_xxx|card_xxx")
     end.check_request do |method, endpoint, data, headers|
       assert_match(/customer=cus_xxx/, data)

--- a/test/unit/gateways/worldpay_us_test.rb
+++ b/test/unit/gateways/worldpay_us_test.rb
@@ -176,7 +176,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   end
 
   def test_backup_url
-    response = stub_comms(@gateway) do
+    response = stub_comms do
       @gateway.purchase(@amount, @credit_card, use_backup_url: true)
     end.check_request do |endpoint, data, headers|
       assert_equal WorldpayUsGateway.backup_url, endpoint


### PR DESCRIPTION
This PR disables remote requests on unit tests. There were 18 additional tests that we're making real API calls every time unit tests were run, due to the fact that the HTTP method calls were not properly stubbed.

This is the first step in reworking how we handle HTTP stubbing in ActiveMerchant.

@jasonwebster @bdewater