### PR TITLE
Credorax: Flag for tokenized card data

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -129,6 +129,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        post[:a9] = '8' if options[:tokenized_card_data]
 
         commit(:purchase, post)
       end
@@ -141,6 +142,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        post[:a9] = '8' if options[:tokenized_card_data]
 
         commit(:authorize, post)
       end
@@ -182,6 +184,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_email(post, options)
         add_echo(post, options)
+        post[:a9] = '8' if options[:tokenized_card_data]
 
         commit(:credit, post)
       end

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -28,6 +28,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal "Succeeded", response.message
   end
 
+  def test_successful_purchase_with_extra_options
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(tokenized_card_data: true))
+    assert_success response
+    assert_equal "1", response.params["H9"]
+    assert_equal "Succeeded", response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -204,6 +204,16 @@ class CredoraxTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_adds_a9_field_for_tokenized_card_data
+    options_with_3ds = @options.merge({tokenized_card_data: true})
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/a9=8/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
The a9 field should be sent with a value of 8 for visa and mastercard if
the card data is stored (anywhere) as tokenized data. This will send it
if tokenized_card_data is flagged in options.