### PR TITLE
Credorax: Pass Transaction Type field

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -129,6 +129,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        add_transaction_type(post, options)
 
         commit(:purchase, post)
       end
@@ -141,6 +142,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        add_transaction_type(post, options)
 
         commit(:authorize, post)
       end
@@ -182,7 +184,8 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_email(post, options)
         add_echo(post, options)
-
+        add_transaction_type(post, options)
+        
         commit(:credit, post)
       end
 
@@ -262,6 +265,10 @@ module ActiveMerchant #:nodoc:
         # The d2 parameter is used during the certification process
         # See remote tests for full certification test suite
         post[:d2] = options[:echo] unless options[:echo].blank?
+      end
+
+      def add_transaction_type(post, options)
+        post[:a9] = options[:transaction_type] if options[:transaction_type]
       end
 
       ACTIONS = {

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -28,6 +28,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal "Succeeded", response.message
   end
 
+  def test_successful_purchase_with_extra_options
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(transaction_type: '8'))
+    assert_success response
+    assert_equal "1", response.params["H9"]
+    assert_equal "Succeeded", response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -204,6 +204,16 @@ class CredoraxTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_adds_a9_field
+    options_with_3ds = @options.merge({transaction_type: '8'})
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/a9=8/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
The a9 ("Transaction Type") field is required to be sent with a value of
8 for visa and mastercard if the card data is stored (anywhere) as
tokenized data. This commit allows passing the a9 value as an option.