### PR TITLE
Always override ECI value for Apple Pay transactions with Discover

### DIFF
--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -14,8 +14,8 @@ module ActiveMerchant #:nodoc:
       self.require_verification_value = false
       self.require_name = false
 
-      attr_accessor :payment_cryptogram, :eci, :transaction_id
-      attr_writer :source
+      attr_accessor :payment_cryptogram, :transaction_id
+      attr_writer :source, :eci
 
       SOURCES = [:apple_pay, :android_pay]
 
@@ -24,6 +24,14 @@ module ActiveMerchant #:nodoc:
           @source
         else
           :apple_pay
+        end
+      end
+
+      def eci
+        if brand == "discover" && source == :apple_pay
+          "04"
+        else
+          @eci
         end
       end
 

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -17,6 +17,15 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :bogus_pay
     })
+    @tokenized_apple_pay_discover_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      number: "6011111111111117",
+      brand: "discover",
+      month: default_expiration_date.month,
+      year: default_expiration_date.year,
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      eci: "05",
+      source: :apple_pay
+    })
   end
 
   def test_type
@@ -39,5 +48,13 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     assert_equal @tokenized_apple_pay_card.source, :apple_pay
     assert_equal @tokenized_android_pay_card.source, :android_pay
     assert_equal @tokenized_bogus_pay_card.source, :apple_pay
+  end
+
+  def test_eci
+    assert_equal "05", @tokenized_card.eci
+  end
+
+  def test_discover_eci_override
+    assert_equal "04", @tokenized_apple_pay_discover_card.eci
   end
 end


### PR DESCRIPTION
I am so sorry.

Discover has a hard requirement that the ECI value for all Apple Pay
transactions be set to exactly 4, regardless of what is or is not
provided in the Apple PKPaymentToken. This is under subject of merchant
fees and penalties if not, according to people I've talked to at
Discover.

The Discover specification reads:

https://www.dropbox.com/s/fnmofdfnsc37wuj/Screenshot%202017-11-21%2017.43.16.png?dl=0

Yes, that's mostly meaningless, but "field 61 position 9" is what
gateways map the incoming ECI value to. I've confirmed this information
with contacts at FirstData, which said basically "yeah, this is a
Discover requirement, and you must send it in differently, we won't do
it for you."

This was the only way that I could think of that would fix this issue
for all gateways supported by Active Merchant.