### PR TITLE
Cyber Source: Correctly handle voiding a purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -307,7 +307,7 @@ module ActiveMerchant #:nodoc:
         options[:order_id] = order_id
 
         xml = Builder::XmlMarkup.new :indent => 2
-        if action == "capture"
+        if action == "capture" || action == "purchase"
           add_void_service(xml, request_id, request_token)
         else
           add_purchase_data(xml, money, true, options.merge(:currency => currency || default_currency))

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -116,6 +116,15 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert void.test?
   end
 
+  def test_purchase_and_void
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert void = @gateway.void(purchase.authorization, @options)
+    assert_equal 'Successful transaction', void.message
+    assert_success void
+    assert void.test?
+  end
+
   def test_successful_tax_calculation
     assert response = @gateway.calculate_tax(@credit_card, @options)
     assert_equal 'Successful transaction', response.message


### PR DESCRIPTION
treat voiding a purchase as voiding a capture instead of voiding an
auth