### PR TITLE
Prevent frozen objects being assigned as wiredump device

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -25,7 +25,7 @@ module ActiveMerchant
     attr_accessor :ca_path
     attr_accessor :pem
     attr_accessor :pem_password
-    attr_accessor :wiredump_device
+    attr_reader :wiredump_device
     attr_accessor :logger
     attr_accessor :tag
     attr_accessor :ignore_http_status
@@ -46,6 +46,11 @@ module ActiveMerchant
       @ssl_version = nil
       @proxy_address = nil
       @proxy_port = nil
+    end
+
+    def wiredump_device=(device)
+      raise ArgumentError, "can't wiredump to frozen #{device.class}" if device && device.frozen?
+      @wiredump_device = device
     end
 
     def request(method, body, headers = {})

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -178,4 +178,11 @@ class ConnectionTest < Test::Unit::TestCase
     end
   end
 
+  def test_wiredump_service_raises_on_frozen_object
+    transcript = ''.freeze
+    assert_raise ArgumentError, "can't wiredump to frozen object" do
+      @connection.wiredump_device = transcript
+    end
+  end
+
 end


### PR DESCRIPTION
The wiredump_device setter takes an object that quacks like an IO stream (e.g. File or String) and passes it along to Net:HTTP#set_debug_output where it is used by the private `D` method for appending log messages, as seen here: https://github.com/ruby/ruby/blob/c91cb76f8d84b2963f6ede2ef445ad46a6104216/lib/net/http.rb#L1567

If the device is set to an empty string literal (i.e. "") and the frozen string literal magic comment is added to the file, this causes `RuntimeError: can't modify frozen String` exceptions. The stacktrace can be confusing since setting up the gateway object and using it usually happens in different places in the application code.

This PR aims to fail early if such a situation occurs and provide a stacktrace that clearly points to the cause of the error.