### PR TITLE
Safe Charge: Provisions adapter for 3DS purchases

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1053,6 +1053,10 @@ safe_charge:
   client_login_id: 'SpreedlyTestTRX'
   client_password: '5Jp5xKmgqY'
 
+safe_charge_three_ds:
+  client_login_id: 'SpreedlyManTestTRX'
+  client_password: 'iGx9DQQHQG'
+
 sage:
   login: 214282982451
   password: 'Z5W2S8J7X8T5'

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -13,6 +13,40 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       description: 'Store Purchase',
       currency: "EUR"
     }
+
+    @three_ds_gateway = SafeChargeGateway.new(fixtures(:safe_charge_three_ds))
+    @three_ds_enrolled_card = credit_card('4012 0010 3749 0014')
+    @three_ds_non_enrolled_card = credit_card('5333 3062 3122 6927')
+    @three_ds_invalid_pa_res_card = credit_card('4012 0010 3749 0006')
+  end
+
+  def test_successful_3ds_purchase
+    response = @three_ds_gateway.purchase(@amount, @three_ds_enrolled_card, @options)
+    assert_success response
+    assert !response.params["acsurl"].blank?
+    assert !response.params["pareq"].blank?
+    assert !response.params["xid"].blank?
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_regular_purchase_through_3ds_flow_with_non_enrolled_card
+    response = @three_ds_gateway.purchase(@amount, @three_ds_non_enrolled_card, @options)
+    assert_success response
+    assert response.params["acsurl"].blank?
+    assert response.params["pareq"].blank?
+    assert response.params["xid"].blank?
+    assert response.params["threedflow"] = 1
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res
+    response = @three_ds_gateway.purchase(@amount, @three_ds_invalid_pa_res_card, @options)
+    assert_success response
+    assert !response.params["acsurl"].blank?
+    assert !response.params["pareq"].blank?
+    assert !response.params["xid"].blank?
+    assert response.params["threedflow"] = 1
+    assert_equal 'Success', response.message
   end
 
   def test_successful_purchase


### PR DESCRIPTION
Safe Charge has implemented a system by which they determine whether
purchases should be routed through the 3DS flow or not. If the merchant
is not approved for 3DS, transactions will occur as before, outside of
the 3DS flow. If a merchant is approved for 3DS, Sage Charge will
evaluate the card for enrollment status. If the card is not enrolled, it
will be processed as a 'regular' transaction. If the card is enrolled,
the Safe Charge response will include the 'xid', 'ascurl', and the
'pareq'.

Remote Tests:
21 tests, 62 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit Tests:
17 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed