### PR TITLE
PayU Latam: Require payment_country on initialize

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -29,9 +29,8 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options={})
-        requires!(options, :merchant_id, :account_id, :api_login, :api_key)
+        requires!(options, :merchant_id, :account_id, :api_login, :api_key, :payment_country)
         super
-        @options[:payment_country] ||= options[:payment_country] if options[:payment_country]
       end
 
       def purchase(amount, payment_method, options={})
@@ -139,7 +138,7 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction_elements(post, type, options)
         transaction = {}
-        transaction[:paymentCountry] = @options[:payment_country] || (options[:billing_address][:country] if options[:billing_address])
+        transaction[:paymentCountry] = @options[:payment_country]
         transaction[:type] = type
         transaction[:ipAddress] = options[:ip] || ''
         transaction[:userAgent] = options[:user_agent] if options[:user_agent]
@@ -167,7 +166,7 @@ module ActiveMerchant #:nodoc:
         payer[:dniNumber] = options[:dni_number] if options[:dni_number]
         payer[:dniType] = options[:dni_type] if options[:dni_type]
         payer[:emailAddress] = options[:email] if options[:email]
-        payer[:birthdate] = options[:birth_date] if options[:birth_date] && options[:payment_country] == 'MX'
+        payer[:birthdate] = options[:birth_date] if options[:birth_date] && @options[:payment_country] == 'MX'
         payer[:billingAddress] = billing_address_fields(options)
         post[:transaction][:payer] = payer
       end
@@ -180,7 +179,7 @@ module ActiveMerchant #:nodoc:
         billing_address[:city] = address[:city]
         billing_address[:state] = address[:state]
         billing_address[:country] = address[:country]
-        billing_address[:postalCode] = address[:zip] if options[:payment_country] == 'MX'
+        billing_address[:postalCode] = address[:zip] if @options[:payment_country] == 'MX'
         billing_address[:phone] = address[:phone]
         billing_address
       end
@@ -191,7 +190,7 @@ module ActiveMerchant #:nodoc:
           buyer[:fullName] = buyer_hash[:name]
           buyer[:dniNumber] = buyer_hash[:dni_number]
           buyer[:dniType] = buyer_hash[:dni_type]
-          buyer[:cnpj] = buyer_hash[:cnpj] if options[:payment_country] == 'BR'
+          buyer[:cnpj] = buyer_hash[:cnpj] if @options[:payment_country] == 'BR'
           buyer[:emailAddress] = buyer_hash[:email]
           buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone] if options[:shipping_address]) || ''
           buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
@@ -199,7 +198,7 @@ module ActiveMerchant #:nodoc:
           buyer[:fullName] = payment_method.name.strip
           buyer[:dniNumber] = options[:dni_number]
           buyer[:dniType] = options[:dni_type]
-          buyer[:cnpj] = options[:cnpj] if options[:payment_country] == 'BR'
+          buyer[:cnpj] = options[:cnpj] if @options[:payment_country] == 'BR'
           buyer[:emailAddress] = options[:email]
           buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone] if options[:shipping_address]) || ''
           buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
@@ -235,8 +234,8 @@ module ActiveMerchant #:nodoc:
 
         additional_values = {}
         additional_values[:TX_VALUE] = tx_value
-        additional_values[:TX_TAX] = tx_tax if options[:payment_country] == 'CO'
-        additional_values[:TX_TAX_RETURN_BASE] = tx_tax_return_base if options[:payment_country] == 'CO'
+        additional_values[:TX_TAX] = tx_tax if @options[:payment_country] == 'CO'
+        additional_values[:TX_TAX_RETURN_BASE] = tx_tax_return_base if @options[:payment_country] == 'CO'
 
         post[:transaction][:order][:additionalValues] = additional_values
       end

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -37,7 +37,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   # supports auth and purchase transactions only
 
   def test_invalid_login
-    gateway = PayuLatamGateway.new(merchant_id: "", account_id: "", api_login: "U", api_key: "U")
+    gateway = PayuLatamGateway.new(merchant_id: "", account_id: "", api_login: "U", api_key: "U", payment_country: "AR")
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end
@@ -50,7 +50,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successul_purchase_with_buyer
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327"))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327", payment_country: "BR"))
 
     options_buyer = {
       currency: "BRL",
@@ -88,7 +88,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_brazil
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327"))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512327", payment_country: "BR"))
 
     options_brazil = {
       payment_country: "BR",
@@ -123,7 +123,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_colombia
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512321"))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512321", payment_country: "CO"))
 
     options_colombia = {
       payment_country: "CO",
@@ -157,7 +157,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_mexico
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512324"))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => "512324", payment_country: "MX"))
 
     options_mexico = {
       payment_country: "MX",
@@ -230,13 +230,14 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_match (/property: parentTransactionId, message: must not be null/), response.message
   end
 
-  def test_successful_void
+  # If this test fails, support for void may have been added to the sandbox
+  def test_unsupported_test_void_fails_as_expected
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
-    assert_success void
-    assert_equal "APPROVED", void.message
+    assert_failure void
+    assert_equal "Internal payment provider error. ", void.message
   end
 
   def test_failed_void
@@ -245,13 +246,14 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_match (/property: parentTransactionId, message: must not be null/), response.message
   end
 
-  def test_successful_authorize_and_capture
+  # If this test fails, support for captures may have been added to the sandbox
+  def test_unsupported_test_capture_fails_as_expected
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount, auth.authorization)
-    assert_success capture
-    assert_equal 'APPROVED', response.message
+    assert_failure capture
+    assert_equal 'Internal payment provider error. ', capture.message
   end
 
   def test_failed_capture
@@ -263,7 +265,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   def test_verify_credentials
     assert @gateway.verify_credentials
 
-    gateway = PayuLatamGateway.new(merchant_id: "X", account_id: "512322", api_login: "X", api_key: "X")
+    gateway = PayuLatamGateway.new(merchant_id: "X", account_id: "512322", api_login: "X", api_key: "X", payment_country: "AR")
     assert !gateway.verify_credentials
   end
 


### PR DESCRIPTION
Also cleans up tests, though declined and pending test cards are now
throwing a new unexpected error, unrelated to this change.

Remote:
18 tests, 47 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
83.3333% passed

Unit:
22 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed