### PR TITLE
Adyen: Remove CVV as Required Field and Determines shopperInteraction

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -45,6 +45,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment)
         add_extra_data(post, options)
+        add_shopper_interaction(post,payment,options)
         add_address(post, options)
         commit('authorise', post)
       end
@@ -97,7 +98,11 @@ module ActiveMerchant #:nodoc:
         post[:selectedBrand] = options[:selected_brand] if options[:selected_brand]
         post[:deliveryDate] = options[:delivery_date] if options[:delivery_date]
         post[:merchantOrderReference] = options[:merchant_order_reference] if options[:merchant_order_reference]
-        post[:shopperInteraction] = options[:shopper_interaction] if options[:shopper_interaction]
+      end
+
+      def add_shopper_interaction(post, payment, options={})
+        shopper_interaction = payment.verification_value ?  "Ecommerce" : "ContAuth"
+        post[:shopperInteraction] = options[:shopper_interaction] || shopper_interaction
       end
 
       def add_address(post, options)
@@ -138,8 +143,9 @@ module ActiveMerchant #:nodoc:
           number: payment.number,
           cvc: payment.verification_value
         }
+
         card.delete_if{|k,v| v.blank? }
-        requires!(card, :expiryMonth, :expiryYear, :holderName, :number, :cvc)
+        requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:card] = card
       end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -45,6 +45,14 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_no_cvv
+    credit_card = @credit_card
+    credit_card.verification_value = nil
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_purchase_with_more_options
     options = @options.merge!(fraudOffset: '1')
     response = @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
Adyen gateway does not require that cvv is passed, it shouldn't be used
in recurring transactions. Updates shopperInteraction to be determined
using based on if the cvv is passed. This can be  overridden by
passing the value directly.

Loaded suite test/remote/gateways/remote_adyen_test
28 tests, 68 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/adyen_test
17 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed