### PR TITLE
Safe Charge: Adds 3DS flag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * PayU Latam: Require payment_country on initialize [curiousepic] #2663
 * Adyen: Remove CVV as Required Field and Determines shopperInteraction [nfarve] #2665
 * SafeCharge: add support for VendorID, WebsiteID, and IP logging [bpollack] #2667
+* Safe Charge: Adds 3DS flag [deedeelavinder] #2668
 
 == Version 1.75.0 (November 9, 2017)
 * Barclaycard Smartpay: Clean up test options hashes [bpollack] #2632

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -22,8 +22,9 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options={})
         post = {}
-        post[:sg_APIType] = 1
-        add_transaction_data("Sale3D", post, money, options)
+        post[:sg_APIType] = 1 if options[:three_d_secure]
+        trans_type = options[:three_d_secure] ? "Sale3D" : "Sale"
+        add_transaction_data(trans_type, post, money, options)
         add_payment(post, payment)
         add_customer_details(post, payment, options)
 

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -14,6 +14,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       currency: "EUR"
     }
 
+    @three_ds_options = @options.merge(three_d_secure: true)
     @three_ds_gateway = SafeChargeGateway.new(fixtures(:safe_charge_three_ds))
     @three_ds_enrolled_card = credit_card('4012 0010 3749 0014')
     @three_ds_non_enrolled_card = credit_card('5333 3062 3122 6927')
@@ -21,7 +22,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
   end
 
   def test_successful_3ds_purchase
-    response = @three_ds_gateway.purchase(@amount, @three_ds_enrolled_card, @options)
+    response = @three_ds_gateway.purchase(@amount, @three_ds_enrolled_card, @three_ds_options)
     assert_success response
     assert !response.params["acsurl"].blank?
     assert !response.params["pareq"].blank?
@@ -30,7 +31,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
   end
 
   def test_successful_regular_purchase_through_3ds_flow_with_non_enrolled_card
-    response = @three_ds_gateway.purchase(@amount, @three_ds_non_enrolled_card, @options)
+    response = @three_ds_gateway.purchase(@amount, @three_ds_non_enrolled_card, @three_ds_options)
     assert_success response
     assert response.params["acsurl"].blank?
     assert response.params["pareq"].blank?
@@ -40,7 +41,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
   end
 
   def test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res
-    response = @three_ds_gateway.purchase(@amount, @three_ds_invalid_pa_res_card, @options)
+    response = @three_ds_gateway.purchase(@amount, @three_ds_invalid_pa_res_card, @three_ds_options)
     assert_success response
     assert !response.params["acsurl"].blank?
     assert !response.params["pareq"].blank?

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -14,6 +14,7 @@ class SafeChargeTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+    @three_ds_options = @options.merge(three_d_secure: true)
   end
 
   def test_successful_purchase
@@ -163,7 +164,7 @@ class SafeChargeTest < Test::Unit::TestCase
 
   def test_3ds_response
     purchase = stub_comms do
-      @gateway.purchase(@amount, @three_ds_enrolled_card, @options)
+      @gateway.purchase(@amount, @three_ds_enrolled_card, @three_ds_options)
     end.check_request do |endpoint, data, headers|
       assert_match(/Sale3D/, data)
       assert_match(/sg_APIType/, data)


### PR DESCRIPTION
The documentation and sandbox indicate that Safe Charge has an internal
method for determining 3DS status/flow. This adds an explicit 3DS flag
when/if there are issues with that internal mechanism.

Unit Tests:
17 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote Tests:
21 tests, 62 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed