### PR TITLE
PayU Latam: Change default text for description

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
         order[:accountId] = @options[:account_id]
         order[:partnerId] = options[:partner_id] if options[:partner_id]
         order[:referenceCode] = options[:order_id] || generate_unique_id
-        order[:description] = options[:description] || 'unspecified'
+        order[:description] = options[:description] || 'Compra en ' + @options[:merchant_id]
         order[:language] = 'en'
         order[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
         post[:transaction][:order] = order

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -146,11 +146,11 @@ class RemotePayuLatamTest < Test::Unit::TestCase
         zip: "01019-030",
         phone: "(11)756312633"
       ),
-      tx_tax: '3193',
-      tx_tax_return_base: '16806'
+      tax: "3193",
+      tax_return_base: "16806"
     }
 
-    response = gateway.purchase(@amount, @credit_card, @options.update(options_colombia))
+    response = gateway.purchase(2000000, @credit_card, @options.update(options_colombia))
     assert_success response
     assert_equal "APPROVED", response.message
     assert response.test?
@@ -184,6 +184,15 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     }
 
     response = gateway.purchase(@amount, @credit_card, @options.update(options_mexico))
+    assert_success response
+    assert_equal "APPROVED", response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_no_description
+    options = @options
+    options.delete(:description)
+    response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal "APPROVED", response.message
     assert response.test?


### PR DESCRIPTION
Updates description to include merchant_id if there is no description.
Updates the tests for purchases in Colombia to properly use tax
information and to  match the test example
provided in docs.

3 tests are failing that are not related to these changes

Remote Tests:
Finished in 49.482971 seconds.
19 tests, 50 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
84.2105% passed

Unit Tests:
Finished in 0.015186 seconds.
22 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed