### PR TITLE
FirstData E4: Override ECI value for Apple Pay transactions with Discover

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Adyen: Remove CVV as Required Field and Determines shopperInteraction [nfarve] #2665
 * SafeCharge: add support for VendorID, WebsiteID, and IP logging [bpollack] #2667
 * Safe Charge: Adds 3DS flag [deedeelavinder] #2668
+* FirstData E4: Override ECI value for Apple Pay transactions with Discover [jasonwebster] #2671
 
 == Version 1.75.0 (November 9, 2017)
 * Barclaycard Smartpay: Clean up test options hashes [bpollack] #2632

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -237,6 +237,25 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_network_tokenization_requests_with_discover
+    stub_comms do
+      credit_card = network_tokenization_credit_card(
+        "6011111111111117",
+        brand: "discover",
+        transaction_id: "123",
+        eci: "05",
+        payment_cryptogram: "whatever_the_cryptogram_is",
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_, data, _|
+      assert_match "<Ecommerce_Flag>04</Ecommerce_Flag>", data
+      assert_match "<XID>123</XID>", data
+      assert_match "<CAVV>whatever_the_cryptogram_is</CAVV>", data
+      assert_xml_valid_to_wsdl(data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_network_tokenization_requests_with_other_brands
     %w(visa mastercard other).each do |brand|
       stub_comms do


### PR DESCRIPTION
Discover has a hard requirement that the ECI value for all Apple Pay
transactions be set to exactly 4, regardless of what is or is not
provided in the Apple PKPaymentToken. This is under subject of merchant
fees and penalties if not, according to people I've talked to at
Discover.

The Discover specification reads:

https://www.dropbox.com/s/fnmofdfnsc37wuj/Screenshot%202017-11-21%2017.43.16.png?dl=0

Yes, that's mostly meaningless, but "field 61 position 9" is what
gateways map the incoming ECI value to. I've confirmed this information
with contacts at FirstData, which said basically "yeah, this is a
Discover requirement, and you must send it in differently, we won't do
it for you."

This is, technically, a problem that needs to be solved for every gateway.
However, we do not have a place to handle that in Active Merchant. I had 
considered changing the `NetworkTokenizedCreditCard` object to do it,
but it felt _really_ wrong.