### PR TITLE
[wip] Adding a method to generate avs code from postal & street matches

### DIFF
--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -70,12 +70,17 @@ module ActiveMerchant
       def initialize(attrs)
         attrs ||= {}
         
-        @code = attrs[:code].upcase unless attrs[:code].blank?
+        if attrs[:code].blank?
+          @code = generate_avs_code(street_match: attrs[:street_match], postal_match: attrs[:postal_match])
+        else
+          @code = attrs[:code].upcase
+        end
+
         @message = self.class.messages[code]
-        
+
         if attrs[:street_match].blank?
           @street_match = STREET_MATCH_CODE[code]
-        else  
+        else
           @street_match = attrs[:street_match].upcase
         end
           
@@ -92,6 +97,22 @@ module ActiveMerchant
           'street_match' => street_match,
           'postal_match' => postal_match
         }
+      end
+
+      def generate_avs_code(street_match:, postal_match:)
+        return if street_match.blank? && postal_match.blank?
+
+        if street_match == 'Y' && postal_match == 'Y'
+          'Y'
+        elsif street_match == 'Y'
+          'A'
+        elsif postal_match == 'Y'
+          'P'
+        elsif street_match == 'N' && postal_match == 'N'
+          'N'
+        else
+          'U'
+        end
       end
     end
   end

--- a/test/unit/avs_result_test.rb
+++ b/test/unit/avs_result_test.rb
@@ -56,4 +56,15 @@ class AVSResultTest < Test::Unit::TestCase
     avs_data = AVSResult.new(:postal_match => 'Y')
     assert_equal 'Y', avs_data.postal_match
   end
+
+  def test_generate_avs_code
+    assert_equal 'Y', AVSResult.new(:postal_match => 'Y', :street_match => 'Y').code
+    assert_equal 'N', AVSResult.new(:postal_match => 'N', :street_match => 'N').code
+    assert_equal 'P', AVSResult.new(:postal_match => 'Y', :street_match => 'N').code
+    assert_equal 'P', AVSResult.new(:postal_match => 'Y').code
+    assert_equal 'A', AVSResult.new(:postal_match => 'N', :street_match => 'Y').code
+    assert_equal 'A', AVSResult.new(:street_match => 'Y').code
+    assert_equal 'U', AVSResult.new(:postal_match => 'X', :street_match => 'X').code
+    assert_nil AVSResult.new(:postal_match => '', :street_match => '').code
+  end
 end


### PR DESCRIPTION
A few gateways provide AVS postal and street checks, but do not provide any value avs `code`. Through this PR, I am attempting to add a rudimentary method that would allow us to fill in this missing `code`.

cc @jasonwebster