### PR TITLE
Mercado Pago: protect against invalid access tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * CardProcess: Fix success? to always return true or false [bpollack] #2674
 * SagePay: Correct CVV, AVS codes for Sagepay [singhai0] #2670
 * PayU Latam: Count pending Voids as successful [curiousepic] #2677
+* Mercado Pago: Ensure acess tokens are URL escaped [bpollack] #2675
 
 == Version 1.75.0 (November 9, 2017)
 * Barclaycard Smartpay: Clean up test options hashes [bpollack] #2632

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -236,7 +236,7 @@ module ActiveMerchant #:nodoc:
 
       def url(action)
         full_url = (test? ? test_url : live_url)
-        full_url + "/#{action}?access_token=#{@options[:access_token]}"
+        full_url + "/#{action}?access_token=#{CGI.escape(@options[:access_token])}"
       end
 
       def headers


### PR DESCRIPTION
An access token provided that was not validly URL-encoded (e.g., had
spaces) could cause ActiveRecord to crash, since it could result in a
malformed URL. This ensures that even a malformed access token can be
passed through, avoiding a crash and allowing normal error handling
to take place.