### PR TITLE
PayU Latam: Count pending Voids as successful

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -357,7 +357,7 @@ module ActiveMerchant #:nodoc:
           response["code"] == "SUCCESS" && response["creditCardToken"] && response["creditCardToken"]["creditCardTokenId"].present?
         when 'verify_credentials'
           response["code"] == "SUCCESS"
-        when 'refund'
+        when 'refund', 'void'
         response["code"] == "SUCCESS" && response["transactionResponse"] && (response["transactionResponse"]["state"] == "PENDING" || response["transactionResponse"]["state"] == "APPROVED")
         else
           response["code"] == "SUCCESS" && response["transactionResponse"] && (response["transactionResponse"]["state"] == "APPROVED")
@@ -374,8 +374,10 @@ module ActiveMerchant #:nodoc:
           return "VERIFIED" if success
           "FAILED"
         else
-          response_message = response["transactionResponse"]["responseMessage"] if response["transactionResponse"]
-          response_code = response["transactionResponse"]["responseCode"] if response["transactionResponse"]
+          if response["transactionResponse"]
+            response_message = response["transactionResponse"]["responseMessage"]
+            response_code = response["transactionResponse"]["responseCode"] || response["transactionResponse"]["pendingReason"]
+          end
           return response_code if success
           response["error"] || response_message || response_code || "FAILED"
         end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -96,7 +96,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     response = @gateway.void("7edbaf68-8f3a-4ae7-b9c7-d1e27e314999", @options)
     assert_success response
-    assert_equal "APPROVED", response.message
+    assert_equal "PENDING_REVIEW", response.message
   end
 
   def test_failed_void
@@ -530,15 +530,15 @@ class PayuLatamTest < Test::Unit::TestCase
       "transactionResponse": {
         "orderId": 840434914,
         "transactionId": "e66fd9aa-f485-4f10-b1d6-be8e9e354b63",
-        "state": "APPROVED",
+        "state": "PENDING",
         "paymentNetworkResponseCode": "0",
         "paymentNetworkResponseErrorMessage": null,
         "trazabilityCode": "49263990",
         "authorizationCode": "NPS-011111",
-        "pendingReason": null,
-        "responseCode": "APPROVED",
+        "pendingReason": "PENDING_REVIEW",
+        "responseCode": null,
         "errorCode": null,
-        "responseMessage": "APROBADA - Autorizada",
+        "responseMessage": null,
         "transactionDate": null,
         "transactionTime": null,
         "operationDate": 1486655230074,


### PR DESCRIPTION
Previously, voids with a state of pending were not counted as succeeded.
This accounts for that, passes a meaningful value for the message, and
updates a test response to be more accurate.

Three unrelated failing remote tests.

Remote:
19 tests, 50 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
84.2105% passed

Unit:
22 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed