### PR TITLE
iATS: Fix Messages with Failure on iATS Server

### DIFF
--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -225,7 +225,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def successful_result_message?(response)
-        response[:authorization_result].start_with?('OK')
+        response[:authorization_result] ? response[:authorization_result].start_with?('OK') : false
       end
 
       def success_from(response)
@@ -233,7 +233,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        if(!successful_result_message?(response))
+        if !successful_result_message?(response) && response[:authorization_result]
           return response[:authorization_result].strip
         elsif(response[:status] == 'Failure')
           return response[:errors]

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -243,6 +243,16 @@ class IatsPaymentsTest < Test::Unit::TestCase
     end
   end
 
+  def test_failed_connection
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(failed_connection_response)
+
+    assert response
+    assert_failure response
+    assert_match(/Server Error/, response.message)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrub), post_scrub
   end
@@ -508,6 +518,26 @@ class IatsPaymentsTest < Test::Unit::TestCase
               </IATSRESPONSE>
             </DeleteCustomerCodeV1Result>
           </DeleteCustomerCodeV1Response>
+        </soap:Body>
+      </soap:Envelope>
+    XML
+  end
+
+  def failed_connection_response
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <soap:Body>
+          <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+            <ProcessCreditCardV1Result>
+              <IATSRESPONSE xmlns="">
+                <STATUS>Failure</STATUS>
+                <ERRORS>Server Error</ERRORS>
+                <PROCESSRESULT>
+                </PROCESSRESULT>
+              </IATSRESPONSE>
+            </ProcessCreditCardV1Result>
+          </ProcessCreditCardV1Response>
         </soap:Body>
       </soap:Envelope>
     XML


### PR DESCRIPTION
Authorization Result is not returned if there is a status failure. Can't
depending on having this result passed

Loaded suite test/unit/gateways/iats_payments_test

17 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_iats_payments_test

12 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications