### PR TITLE
Barclaycard Smartpay: Correct repsonse for fraud rejects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * MiGS: Update hash format to SHA256 and restore remote tests [bpollack] #2676
 * MiGS: Support verify calls [bpollack] #2664
 * iATS: Fix Messages with Failure on iATS Server [nfarve] #2680
+* Barclaycard Smartpay: Correct repsonse for fraud rejects #2683
 
 == Version 1.75.0 (November 9, 2017)
 * Barclaycard Smartpay: Clean up test options hashes [bpollack] #2632

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -211,8 +211,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response)
-        return true if response.has_key?('authCode')
         return true if response['result'] == 'Success'
+        return true if response['resultCode'] == 'Authorised'
         return true if response['resultCode'] == 'Received'
         successful_responses = %w([capture-received] [cancel-received] [refund-received])
         successful_responses.include?(response['response'])

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -313,6 +313,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_avs_response)
 
     response = @gateway.authorize(@amount, @credit_card, @avs_address)
+    assert_failure response
     assert_equal "N", response.avs_result['code']
     assert response.test?
   end


### PR DESCRIPTION
The docs say that an authCode is only returned for successful
transactions, but it is also passed for fraud rejects.

Loaded suite test/unit/gateways/barclaycard_smartpay_test

23 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_barclaycard_smartpay_test

27 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed