### PR TITLE
Adyen: make parts of addresses optional

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -107,12 +107,12 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         return unless post[:card] && post[:card].kind_of?(Hash)
-        if address = options[:billing_address] || options[:address]
+        if (address = options[:billing_address] || options[:address]) && address[:country]
           post[:card][:billingAddress] = {}
-          post[:card][:billingAddress][:street] = address[:address1] if address[:address1]
-          post[:card][:billingAddress][:houseNumberOrName] = address[:address2] if address[:address2]
+          post[:card][:billingAddress][:street] = address[:address1] || 'N/A'
+          post[:card][:billingAddress][:houseNumberOrName] = address[:address2] || 'N/A'
           post[:card][:billingAddress][:postalCode] = address[:zip] if address[:zip]
-          post[:card][:billingAddress][:city] = address[:city] if address[:city]
+          post[:card][:billingAddress][:city] = address[:city] || 'N/A'
           post[:card][:billingAddress][:stateOrProvince] = address[:state] if address[:state]
           post[:card][:billingAddress][:country] = address[:country] if address[:country]
         end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -195,22 +195,19 @@ class RemoteAdyenTest < Test::Unit::TestCase
     @options[:billing_address].delete(:address1)
     @options[:billing_address].delete(:address2)
     response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_failure response
-    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_address], response.error_code
+    assert_success response
   end
 
   def test_missing_city_for_purchase
     @options[:billing_address].delete(:city)
     response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_failure response
-    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_address], response.error_code
+    assert_success response
   end
 
   def test_missing_house_number_or_name_for_purchase
     @options[:billing_address].delete(:address2)
     response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_failure response
-    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_address], response.error_code
+    assert_success response
   end
 
   def test_invalid_country_for_purchase

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -153,15 +153,16 @@ def test_successful_capture_with_compount_psp_reference
 
   def test_add_address
     post = {:card => {:billingAddress => {}}}
+    @options[:billing_address].delete(:address1)
+    @options[:billing_address].delete(:address2)
     @gateway.send(:add_address, post, @options)
-    assert_equal @options[:billing_address][:address1], post[:card][:billingAddress][:street]
-    assert_equal @options[:billing_address][:address2], post[:card][:billingAddress][:houseNumberOrName]
+    assert_equal 'N/A', post[:card][:billingAddress][:street]
+    assert_equal 'N/A', post[:card][:billingAddress][:houseNumberOrName]
     assert_equal @options[:billing_address][:zip], post[:card][:billingAddress][:postalCode]
     assert_equal @options[:billing_address][:city], post[:card][:billingAddress][:city]
     assert_equal @options[:billing_address][:state], post[:card][:billingAddress][:stateOrProvince]
     assert_equal @options[:billing_address][:country], post[:card][:billingAddress][:country]
   end
-
 
   private
 


### PR DESCRIPTION
As long as the country code is provided, then Adyen may, in certain situations, allow the submission of "N/A" for address fields, but nevertheless requires those fields to be present.