### PR TITLE
PayU Latam: Provide a mechanism to override the amount in verify

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(credit_card, options={})
         minimum = MINIMUMS[options[:currency].upcase] if options[:currency]
-        amount = minimum || 100
+        amount = options[:verify_amount] || minimum || 100
 
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(amount, credit_card, options) }


### PR DESCRIPTION
On PayU Latam, transaction minimums are variable per customer, country,
and payment method. Because of this, the default set of minimums may
result in failed transactions. This provides the ability to override the
amount used in the verify call via the `verify_amount` option.

Unit:
```
22 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Remote:
```
22 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% pa