### PR TITLE
Mercado Pago: Support X-Device-Session-ID

### DIFF
--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -194,6 +194,15 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal '4141491|1.0', response.authorization
   end
 
+  def test_includes_deviceid_header
+    @options[:device_id] = '1a2b3c'
+    @gateway.expects(:ssl_post).with(anything, anything, headers = {'Content-Type' => 'application/json'}).returns(successful_purchase_response)
+    @gateway.expects(:ssl_post).with(anything, anything, headers = {'Content-Type' => 'application/json', 'X-Device-Session-ID' => '1a2b3c'}).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
This is one of two components to decrease erroneously rejected Mercado
Pago transactions.

Remote:
`16 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed`

Unit:
`18 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed`