### PR TITLE
Authorize.Net: Get customer profile with merchant_customer_id or email

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -216,9 +216,13 @@ module ActiveMerchant #:nodoc:
       #
       # ==== Options
       #
-      # * <tt>:customer_profile_id</tt> -- The Customer Profile ID of the customer to retrieve. (REQUIRED)
+      # * <tt>:customer_profile_id</tt> -- The Customer Profile ID of the customer to retrieve. (CONDITIONAL)
+      # * <tt>:email</tt> -- The Email address associated with the customer to retrieve. (CONDITIONAL)
+      # * <tt>:merchant_customer_id</tt> -- The Merchant assigned ID of the customer to retrieve. (CONDITIONAL)
       def get_customer_profile(options)
-        requires!(options, :customer_profile_id)
+        requires!(options, :customer_profile_id) unless options[:email] || options[:merchant_customer_id]
+        requires!(options, :email) unless options[:customer_profile_id] || options[:merchant_customer_id]
+        requires!(options, :merchant_customer_id) unless options[:customer_profile_id] || options[:email]
 
         request = build_request(:get_customer_profile, options)
         commit(:get_customer_profile, request)
@@ -563,7 +567,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_get_customer_profile_request(xml, options)
-        xml.tag!('customerProfileId', options[:customer_profile_id])
+        xml.tag!('customerProfileId', options[:customer_profile_id]) if options[:customer_profile_id]
+        xml.tag!('merchantCustomerId', options[:merchant_customer_id]) if options[:merchant_customer_id]
+        xml.tag!('email', options[:email]) if options[:email]
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -220,9 +220,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:email</tt> -- The Email address associated with the customer to retrieve. (CONDITIONAL)
       # * <tt>:merchant_customer_id</tt> -- The Merchant assigned ID of the customer to retrieve. (CONDITIONAL)
       def get_customer_profile(options)
-        requires!(options, :customer_profile_id) unless options[:email] || options[:merchant_customer_id]
-        requires!(options, :email) unless options[:customer_profile_id] || options[:merchant_customer_id]
-        requires!(options, :merchant_customer_id) unless options[:customer_profile_id] || options[:email]
+        raise ArgumentError, "Requires one of customer_profile_id, email, or merchant_customer_id" unless options[:customer_profile_id] || options[:email] || options[:merchant_customer_id]
 
         request = build_request(:get_customer_profile, options)
         commit(:get_customer_profile, request)

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -81,10 +81,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response.test?
     assert_success response
     assert_nil response.authorization
-    assert response = @gateway.get_customer_profile(:email => 'johndoe@test.com')
-    assert_nil response.params['profile']['merchant_customer_id']
-    assert_equal 'Up to 255 Characters', response.params['profile']['description']
-    #assert_equal 'new email address', response.params['profile']['email']
+    assert profile = @gateway.get_customer_profile(:email => 'johndoe@test.com')
+    assert_nil profile.params['profile']['merchant_customer_id']
+    assert_equal 'Up to 255 Characters', profile.params['profile']['description']
   end
 
   # NOTE - prior_auth_capture should be used to complete an auth_only request

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -74,8 +74,17 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_nil response.authorization
     assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
     assert_nil response.params['profile']['merchant_customer_id']
-    assert_nil response.params['profile']['description']
+    assert_equal 'Up to 255 Characters', response.params['profile']['description']
     assert_equal 'new email address', response.params['profile']['email']
+
+    assert response = @gateway.update_customer_profile(:profile => {:customer_profile_id => @customer_profile_id, :email => 'johndoe@test.com'})
+    assert response.test?
+    assert_success response
+    assert_nil response.authorization
+    assert response = @gateway.get_customer_profile(:email => 'johndoe@test.com')
+    assert_nil response.params['profile']['merchant_customer_id']
+    assert_equal 'Up to 255 Characters', response.params['profile']['description']
+    #assert_equal 'new email address', response.params['profile']['email']
   end
 
   # NOTE - prior_auth_capture should be used to complete an auth_only request

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -12,17 +12,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @credit_card = credit_card
     @address = address
     @customer_profile_id = '3187'
-    @email = 'johndoe@test.com'
-    @merchant_customer_id = '1000'
     @customer_payment_profile_id = '7813'
     @customer_address_id = '4321'
     @payment = {
       :credit_card => @credit_card
     }
     @profile = {
-      :merchant_customer_id => @merchant_customer_id, # Optional
+      :merchant_customer_id => 'Up to 20 chars', # Optional
       :description => 'Up to 255 Characters', # Optional
-      :email => @email, # Optional
+      :email => 'Up to 255 Characters', # Optional
       :payment_profiles => { # Optional
         :customer_type => 'individual or business', # Optional
         :bill_to => @address,
@@ -338,6 +336,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   end
 
   def test_should_get_customer_profile_request
+    @profile[:email] = "johndoe@test.com"
+    @profile[:merchant_customer_id] = "1000"
+
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
 
     assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
@@ -347,17 +348,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
 
-    assert response = @gateway.get_customer_profile(:email => @email)
-    assert_instance_of Response, response
+    assert response = @gateway.get_customer_profile(:email => @profile[:email])
     assert_success response
-    assert_equal @email, response.params['email']
+    assert_equal @profile[:email], response.params['email']
 
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
 
-    assert response = @gateway.get_customer_profile(:merchant_customer_id => @merchant_customer_id)
-    assert_instance_of Response, response
+    assert response = @gateway.get_customer_profile(:merchant_customer_id => @profile[:merchant_customer_id])
     assert_success response
-    assert_equal @merchant_customer_id, response.params['merchant_customer_id']
+    assert_equal @profile[:merchant_customer_id], response.params['merchant_customer_id']
   end
 
   def test_should_get_customer_profile_ids_request
@@ -831,8 +830,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
             <text>Successful.</text>
           </message>
         </messages>
-        <merchantCustomerId>#{@merchant_customer_id}</merchantCustomerId>
-        <email>#{@email}</email>
+        <merchantCustomerId>#{@profile[:merchant_customer_id]}</merchantCustomerId>
+        <email>#{@profile[:email]}</email>
         <customerProfileId>#{@customer_profile_id}</customerProfileId>
         <profile>
           <paymentProfiles>
@@ -882,9 +881,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           </message>
         </messages>
         <profile>
-          <merchantCustomerId>#{@merchant_customer_id}</merchantCustomerId>
           <description>Up to 255 Characters</description>
-          <email>#{@email}</email>
           <customerProfileId>#{@customer_profile_id}</customerProfileId>
           <paymentProfiles>
             <customerPaymentProfileId>1000</customerPaymentProfileId>

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -12,15 +12,17 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @credit_card = credit_card
     @address = address
     @customer_profile_id = '3187'
+    @email = 'johndoe@test.com'
+    @merchant_customer_id = '1000'
     @customer_payment_profile_id = '7813'
     @customer_address_id = '4321'
     @payment = {
       :credit_card => @credit_card
     }
     @profile = {
-      :merchant_customer_id => 'Up to 20 chars', # Optional
+      :merchant_customer_id => @merchant_customer_id, # Optional
       :description => 'Up to 255 Characters', # Optional
-      :email => 'Up to 255 Characters', # Optional
+      :email => @email, # Optional
       :payment_profiles => { # Optional
         :customer_type => 'individual or business', # Optional
         :bill_to => @address,
@@ -342,6 +344,20 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
     assert_equal @customer_profile_id, response.authorization
+
+    @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
+
+    assert response = @gateway.get_customer_profile(:email => @email)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal @email, response.params['email']
+
+    @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
+
+    assert response = @gateway.get_customer_profile(:merchant_customer_id => @merchant_customer_id)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal @merchant_customer_id, response.params['merchant_customer_id']
   end
 
   def test_should_get_customer_profile_ids_request
@@ -815,6 +831,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
             <text>Successful.</text>
           </message>
         </messages>
+        <merchantCustomerId>#{@merchant_customer_id}</merchantCustomerId>
+        <email>#{@email}</email>
         <customerProfileId>#{@customer_profile_id}</customerProfileId>
         <profile>
           <paymentProfiles>
@@ -864,9 +882,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           </message>
         </messages>
         <profile>
-          <merchantCustomerId>Up to 20 chars</merchantCustomerId>
+          <merchantCustomerId>#{@merchant_customer_id}</merchantCustomerId>
           <description>Up to 255 Characters</description>
-          <email>Up to 255 Characters</email>
+          <email>#{@email}</email>
           <customerProfileId>#{@customer_profile_id}</customerProfileId>
           <paymentProfiles>
             <customerPaymentProfileId>1000</customerPaymentProfileId>


### PR DESCRIPTION
I wanted to use the `AuthorizeNetCim#get_customer_profile` method in a project and noticed the API [supports getting a profile with the `merchantCustomerId` or `email`](https://developer.authorize.net/api/reference/index.html#customer-profiles-get-customer-profile) in addition to the `customerProfileId`, so I added support for that.