### PR TITLE
Mercado Pago: add arbitrary additional_info parameters

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -117,7 +117,8 @@ module ActiveMerchant #:nodoc:
         post[:device_id] = options[:device_id] if options[:device_id]
         post[:additional_info] = {
           ip_address: options[:ip_address]
-        }
+        }.merge(options[:additional_info] || {})
+
 
         add_address(post, options)
         add_shipping_address(post, options)

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -203,6 +203,20 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_includes_additional_data
+    @options[:additional_info] = {'foo' => 'bar', 'baz' => 'quux'}
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if data =~ /payment_method_id/
+        assert_match(/"foo":"bar"/, data)
+        assert_match(/"baz":"quux"/, data)
+      end
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Remote:
`16 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed`

Unit:
`19 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed`