### PR TITLE
Payflow: Change Verify Method for Amex Cards

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -45,7 +45,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(payment, options={})
-        authorize(0, payment, options)
+        if credit_card_type(payment) == 'Amex'
+          MultiResponse.run(:use_first_response) do |r|
+            r.process { authorize(100, payment, options) }
+            r.process(:ignore_result) { void(r.authorization, options) }
+          end
+        else
+          authorize(0, payment, options)
+        end
       end
 
       def verify_credentials

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -663,7 +663,7 @@ payex:
 # Working credentials, no need to replace
 payflow:
   login: 'spreedlyIntegrations'
-  password: 'y9q)(j7H'
+  password: 'L9DjqEKjXCkU'
   partner: 'PayPal'
 
 payflow_uk:

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -129,6 +129,16 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_equal "Verified", response.message
   end
 
+  def test_successful_verify_amex
+    @amex_credit_card = credit_card(
+      '378282246310005',
+      :brand => 'american_express'
+    )
+    assert response = @gateway.verify(@amex_credit_card, @options)
+    assert_success response
+    assert_equal "Approved", response.message
+  end
+
   def test_failed_verify
     assert response = @gateway.verify(credit_card("4000056655665556"), @options)
     assert_failure response


### PR DESCRIPTION
Currently $0 authorization is only supported for AVS. This changes the
verify method for amex cards to be a $1 auth and void.

Tests failures are unrelated to these changes.

Loaded suite test/remote/gateways/remote_payflow_test
27 tests, 99 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
62.963% passed
----------------------------------------------------------------------------------------
0.60 tests/s, 2.18 assertions/s
Loaded suite test/unit/gateways/payflow_test
44 tests, 192 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed