### PR TITLE
Add payment context to Quickbooks charges and refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -78,6 +78,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         capture_uri = "#{ENDPOINT}/#{CGI.escape(authorization)}/capture"
         post[:amount] = localized_amount(money, currency(money))
+        add_context(post, options)
 
         commit(capture_uri, post)
       end
@@ -85,6 +86,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         post = {}
         post[:amount] = localized_amount(money, currency(money))
+        add_context(post, options)
 
         commit(refund_uri(authorization), post)
       end
@@ -137,6 +139,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(post, payment, options = {})
         add_creditcard(post, payment, options)
+        add_context(post, options)
       end
 
       def add_creditcard(post, creditcard, options = {})
@@ -149,6 +152,13 @@ module ActiveMerchant #:nodoc:
         card[:commercialCardCode] = options[:card_code] if options[:card_code]
 
         post[:card] = card
+      end
+
+      def add_context(post, options = {})
+        post[:context] = {
+          mobile: options.fetch(:mobile, false),
+          isEcommerce: options.fetch(:ecommerce, true)
+        }
       end
 
       def parse(body)

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -112,6 +112,16 @@ class QuickBooksTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed_small_json), post_scrubbed_small_json
   end
 
+  def test_default_context
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      json = JSON.parse(data)
+      refute json.fetch('context').fetch('mobile')
+      assert json.fetch('context').fetch('isEcommerce')
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def pre_scrubbed_small_json


### PR DESCRIPTION
The mobile and isEcommerce flags are mandatory on the sandbox env now and will be in production starting February 1st. Without the context errors like "PMT-4000: context is invalid." are returned.

References:
- https://developer.intuit.com/hub/blog/2017/08/01/updates-payment-apis-quickbooks-online
- https://developer.intuit.com/docs/api/payments/charges