### PR TITLE
Forte and Moneris: ensure all unit tests do not call remote servers

### DIFF
--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class ForteTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = ForteGateway.new(location_id: 'location_id', account_id: 'account_id', api_key: 'api_key', secret: 'secret')
     @credit_card = credit_card
@@ -15,9 +17,9 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    @gateway.expects(:handle_resp).returns(successful_purchase_response)
-
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_purchase_response))
     assert_success response
 
     assert_equal 'trn_bb7687a7-3d3a-40c2-8fa9-90727a814249#123456', response.authorization
@@ -26,24 +28,25 @@ class ForteTest < Test::Unit::TestCase
 
   def test_purchase_passes_options
     options = { order_id: '1' }
-
     @gateway.expects(:commit).with(anything, has_entries(:order_number => '1'))
 
-    @gateway.purchase(@amount, @credit_card, options)
+    stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.respond_with(MockedResponse.new(successful_purchase_response))
   end
 
   def test_failed_purchase
-    @gateway.expects(:handle_resp).returns(failed_purchase_response)
-
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(failed_purchase_response))
     assert_failure response
     assert_equal "INVALID TRN", response.message
   end
 
   def test_successful_purchase_with_echeck
-    @gateway.expects(:handle_resp).returns(successful_echeck_purchase_response)
-
-    response = @gateway.purchase(@amount, @check, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @check, @options)
+    end.respond_with(MockedResponse.new(successful_echeck_purchase_response))
     assert_success response
 
     assert_equal 'trn_bb7687a7-3d3a-40c2-8fa9-90727a814249#123456', response.authorization
@@ -51,88 +54,88 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_echeck
-    @gateway.expects(:handle_resp).returns(failed_echeck_purchase_response)
-
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(failed_echeck_purchase_response))
     assert_failure response
     assert_equal "INVALID CREDIT CARD NUMBER", response.message
   end
 
   def test_successful_authorize
-    @gateway.expects(:handle_resp).returns(successful_authorize_response)
-
-    response = @gateway.authorize(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_authorize_response))
     assert_success response
   end
 
   def test_failed_authorize
-    @gateway.expects(:handle_resp).returns(failed_authorize_response)
-
-    response = @gateway.authorize(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(failed_authorize_response))
     assert_failure response
     assert_equal "INVALID CREDIT CARD NUMBER", response.message
   end
 
   def test_successful_capture
-    @gateway.expects(:handle_resp).returns(successful_capture_response)
-
-    response = @gateway.capture(@amount, "authcode")
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.capture(@amount, "authcode")
+    end.respond_with(MockedResponse.new(successful_capture_response))
     assert_success response
   end
 
   def test_failed_capture
-    @gateway.expects(:handle_resp).returns(failed_capture_response)
-
-    response = @gateway.capture(@amount, "authcode")
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.capture(@amount, "authcode")
+    end.respond_with(MockedResponse.new(failed_capture_response))
     assert_failure response
   end
 
   def test_successful_credit
-    @gateway.expects(:handle_resp).returns(successful_credit_response)
-
-    response = @gateway.credit(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_credit_response))
     assert_success response
   end
 
   def test_failed_credit
-    @gateway.expects(:handle_resp).returns(failed_credit_response)
-
-    response = @gateway.credit(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(failed_credit_response))
     assert_failure response
   end
 
   def test_successful_void
-    @gateway.expects(:handle_resp).returns(successful_credit_response)
-
-    response = @gateway.void("authcode")
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.void("authcode")
+    end.respond_with(MockedResponse.new(successful_credit_response))
     assert_success response
   end
 
   def test_failed_void
-    @gateway.expects(:handle_resp).returns(failed_credit_response)
-
-    response = @gateway.void("authcode")
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.void("authcode")
+    end.respond_with(MockedResponse.new(failed_credit_response))
     assert_failure response
   end
 
   def test_successful_verify
-    @gateway.expects(:handle_resp).times(2).returns(successful_authorize_response, successful_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_authorize_response), MockedResponse.new(successful_void_response))
     assert_success response
   end
 
   def test_successful_verify_with_failed_void
-    @gateway.expects(:handle_resp).times(2).returns(successful_authorize_response, failed_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_authorize_response), MockedResponse.new(failed_void_response))
     assert_success response
   end
 
   def test_failed_verify
-    @gateway.expects(:handle_resp).returns(failed_authorize_response)
-
-    response = @gateway.verify(@credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(MockedResponse.new(failed_authorize_response))
     assert_failure response
   end
 
@@ -142,6 +145,14 @@ class ForteTest < Test::Unit::TestCase
   end
 
   private
+
+  class MockedResponse
+    attr :code, :body
+    def initialize(body, code = 200)
+      @code = code
+      @body = body
+    end
+  end
 
   def pre_scrubbed
     %q(

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -243,7 +243,7 @@ class MonerisUsTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
     billing_address = address(address1: "1234 Anystreet", address2: "")
-    stub_comms do
+    stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: "1")
     end.check_request do |endpoint, data, headers|
       assert_match(%r{avs_street_number>1234<}, data)
@@ -255,7 +255,7 @@ class MonerisUsTest < Test::Unit::TestCase
   def test_avs_enabled_but_not_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
-    stub_comms do
+    stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     end.check_request do |endpoint, data, headers|
       assert_no_match(%r{avs_street_number>}, data)


### PR DESCRIPTION
Our Travis runs are failing because Forte and Moneris (at least) have unit tests that are actually partially remote tests. These commits get them local again.