### PR TITLE
Authorize.net: Allow Transaction Id to be passed for refuds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,10 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698
 * Forte: ensure unit tests are local-only [bpollack] #2696
 * Moneris US: ensure unit tests are local-only [bpollack] #2696
+* Payflow: Change Verify Method for Amex Cards [nfarve] #2693
 
 == Version 1.76.0 (January 3, 2018)
 * PayU Latam: Change default text for description [nfarve] #2669

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -168,6 +168,7 @@ module ActiveMerchant
             xml.amount(amount(amount))
 
             add_payment_source(xml, payment)
+            xml.refTransId(transaction_id_from(options[:transaction_id])) if options[:transaction_id] 
             add_invoice(xml, 'refundTransaction', options)
             add_customer_data(xml, payment, options)
             add_settings(xml, payment, options)
@@ -421,6 +422,12 @@ module ActiveMerchant
             xml.setting do
               xml.settingName("headerEmailReceipt")
               xml.settingValue(options[:header_email_receipt])
+            end
+          end
+          if options[:test_request]
+            xml.setting do
+              xml.settingName("testRequest")
+              xml.settingValue("1")
             end
           end
         end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -168,7 +168,7 @@ module ActiveMerchant
             xml.amount(amount(amount))
 
             add_payment_source(xml, payment)
-            xml.refTransId(transaction_id_from(options[:transaction_id])) if options[:transaction_id] 
+            xml.refTransId(transaction_id_from(options[:transaction_id])) if options[:transaction_id]
             add_invoice(xml, 'refundTransaction', options)
             add_customer_data(xml, payment, options)
             add_settings(xml, payment, options)

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -569,6 +569,16 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_echeck_refund
+    purchase = @gateway.purchase(@amount, @check, @options)
+    assert_success purchase
+
+    @options.update(transaction_id:  purchase.params['transaction_id'], test_request: true)
+    refund = @gateway.credit(@amount, @check, @options)
+    assert_failure refund
+    assert_match %r{The transaction cannot be found}, refund.message, "Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise."
+  end
+
   def test_failed_credit
     response = @gateway.credit(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
Authorize.net requires transaction id and payment info to refund a
transaction. This allows for the transaction_id to be passed directly

Loaded suite test/remote/gateways/remote_authorize_net_test
63 tests, 215 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/authorize_net_test
Finished in 0.306942 seconds.
90 tests, 511 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed