### PR TITLE
Set the `receipt_email` attribute of charges to `options[:email]`

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -310,7 +310,7 @@ module ActiveMerchant #:nodoc:
           add_customer_data(post, options)
           post[:description] = options[:description]
           post[:statement_descriptor] = options[:statement_description]
-          post[:receipt_email] = options[:receipt_email] if options[:receipt_email]
+          post[:receipt_email] = options[:receipt_email] || options[:email]
           add_customer(post, payment, options)
           add_flags(post, options)
         end


### PR DESCRIPTION
I feel like this is how this should have always worked. The `:email`
option is a core, standardize option across Active Merchant, and is the
"customer's email address", meanwhile, the `receipt_email` attribute on
a Stripe charge is the "address a customer's receipt was sent to."
Definitely sounds like the same thing to me.

I've left the existing, one-off option `receipt_email` be, and it will
take precedence over the `email` option, which should maintain
backwards compatibility.