### PR TITLE
make Bogus gateway authorize procecess work with credit card tokens

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
       def authorize_swipe(money, paysource, options = {})
         money = amount(money)
         case normalize(paysource)
-        when /1$/
+        when /1$/, AUTHORIZATION
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -28,6 +28,11 @@ class BogusTest < Test::Unit::TestCase
     assert_equal("Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error", e.message)
   end
 
+  def test_authorize_using_credit_card_token
+    token = @gateway.store(credit_card(CC_SUCCESS_PLACEHOLDER)).authorization
+    assert @gateway.authorize(1000, token).success?
+  end
+
   def test_purchase
     assert  @gateway.purchase(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     response = @gateway.purchase(1000, credit_card(CC_FAILURE_PLACEHOLDER))


### PR DESCRIPTION
Currently, Bogus gateway doesn't work with credit card tokens as far as payment authorization is concerned. This PR solves it. 