### PR TITLE
Fat Zebra: tweak transcript scrubbing regex

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -78,8 +78,8 @@ module ActiveMerchant #:nodoc:
       def scrub(transcript)
         transcript.
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
-          gsub(%r(("card_number\\":\\")[^"\\]*)i, '\1[FILTERED]').
-          gsub(%r(("cvv\\":\\")\d+), '\1[FILTERED]')
+          gsub(%r(("card_number\\?":\\?")[^"\\]*)i, '\1[FILTERED]').
+          gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
       end
 
       private


### PR DESCRIPTION
While the scrubbing as-written in ac0d721 works, it doesn't quite handle all types of transcripts Spreedly throws at it. This commit makes the regex slightly more flexible, without damaging its existing behavior (i.e., no tests had to be changed to handle this regex).

Unit:
17 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
19 tests, 68 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.7368% passed