### PR TITLE
Beanstream: Fix recurring flag in order to bypass CVV requirement

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -267,7 +267,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_recurring_payment(post, options)
-        post[:recurringPayment] = true if options[:recurring].to_s == 'true'
+        post[:recurringPayment] = 1 if options[:recurring].to_s == 'true'
       end
 
       def add_invoice(post, options)

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -78,8 +78,8 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert_equal "Approved", response.message
   end
 
-  def test_successful_visa_purchase_no_cvv
-    assert response = @gateway.purchase(@amount, @visa_no_cvv, @options)
+  def test_successful_visa_purchase_no_cvv_with_recurring
+    assert response = @gateway.purchase(@amount, @visa_no_cvv, @options.merge(recurring: true))
     assert_success response
     assert_false response.authorization.blank?
     assert_equal "Approved", response.message

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -60,7 +60,7 @@ class BeanstreamTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      refute_match(/recurringPayment=true/, data)
+      refute_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -71,7 +71,7 @@ class BeanstreamTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/recurringPayment=true/, data)
+      assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -81,7 +81,7 @@ class BeanstreamTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/recurringPayment=true/, data)
+      assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response


### PR DESCRIPTION
I upgraded ActiveMerchant this week to pull in the enhancement in #2617 but was still getting declines. After some back-and-forth with their support team, we found that `recurringPayment=true` was not getting picked up, and that it should be `recurringPayment=1`.

I can't get API authentication nor `check_purchase` to work consistently so I've commented out some of the remote tests, but otherwise, running tests against my own test merchant account, before the change:

```
% ruby -Itest test/remote/gateways/remote_beanstream_test.rb
Loaded suite test/remote/gateways/remote_beanstream_test
Started
..........test/remote/gateways/remote_beanstream_test.rb:285:in `test_successful_cancel_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
test/remote/gateways/remote_beanstream_test.rb:290:in `test_successful_cancel_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
.........test/remote/gateways/remote_beanstream_test.rb:268:in `test_successful_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
.test/remote/gateways/remote_beanstream_test.rb:275:in `test_successful_update_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
test/remote/gateways/remote_beanstream_test.rb:280:in `test_successful_update_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
...F
========================================================================================================================================================
test/remote/gateways/remote_beanstream_test.rb:83:in `test_successful_visa_purchase_no_cvv_with_recurring'
     80:
     81:   def test_successful_visa_purchase_no_cvv_with_recurring
     82:     assert response = @gateway.purchase(@amount, @visa_no_cvv, @options.merge(recurring: true))
  => 83:     assert_success response
     84:     assert_false response.authorization.blank?
     85:     assert_equal "Approved", response.message
     86:   end
Failure: test_successful_visa_purchase_no_cvv_with_recurring(RemoteBeanstreamTest):
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x00007f97ac1335a8
   @authorization="0;15.00;P",
   @avs_result=
    {"code"=>"R",
     "message"=>"System unavailable.",
     "street_match"=>nil,
     "postal_match"=>nil},
   @cvv_result={"code"=>nil, "message"=>nil},
   @emv_authorization=nil,
   @error_code=nil,
   @fraud_review=nil,
   @message="Card CVD is invalid.",
   @params=
    {"trnApproved"=>"0",
     "trnId"=>"0",
     "messageId"=>"0",
     "messageText"=>"Card CVD is invalid.",
     "trnOrderNumber"=>nil,
     "authCode"=>nil,
     "errorType"=>"U",
     "errorFields"=>"trnCardCvd",
     "responseType"=>"T",
     "trnAmount"=>"15.00",
     "trnDate"=>"1/10/2018 12:01:01 PM",
     "avsProcessed"=>"0",
     "avsId"=>"0",
     "avsResult"=>"0",
     "avsAddrMatch"=>"0",
     "avsPostalMatch"=>"0",
     "avsMessage"=>"Address Verification not performed for this transaction.",
     "cardType"=>"VI",
     "trnType"=>"P",
     "paymentMethod"=>"CC",
     "ref1"=>"reference one",
     "ref2"=>nil,
     "ref3"=>nil,
     "ref4"=>nil,
     "ref5"=>nil,
     "hashValue"=>"5d58975bf16d26511fde0ac798e62e7590a2e13c"},
   @success=false,
   @test=true>>
========================================================================================================================================================
....
Finished in 17.736585 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------
28 tests, 111 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4286% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------
1.58 tests/s, 6.26 assertions/s

```

And after:

```
% b ruby -Itest test/remote/gateways/remote_beanstream_test.rb
Loaded suite test/remote/gateways/remote_beanstream_test
Started
..........test/remote/gateways/remote_beanstream_test.rb:285:in `test_successful_cancel_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
test/remote/gateways/remote_beanstream_test.rb:290:in `test_successful_cancel_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
.........test/remote/gateways/remote_beanstream_test.rb:268:in `test_successful_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
.test/remote/gateways/remote_beanstream_test.rb:275:in `test_successful_update_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
test/remote/gateways/remote_beanstream_test.rb:280:in `test_successful_update_recurring': Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.
........
Finished in 17.824632 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------
28 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------
1.57 tests/s, 6.34 assertions/s

% ruby -Itest test/unit/gateways/beanstream_test.rb
Loaded suite test/unit/gateways/beanstream_test
Started
.......................
Finished in 0.027793 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------
827.55 tests/s, 3885.87 assertions/s

```
