### PR TITLE
Fix some very tiny test issues

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -491,7 +491,7 @@ module ActiveMerchant #:nodoc:
 
       def encrypt(key, order_id)
         block_length = 8
-        cipher = OpenSSL::Cipher::Cipher.new('DES3')
+        cipher = OpenSSL::Cipher.new('DES3')
         cipher.encrypt
 
         cipher.key = Base64.strict_decode64(key)

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -9,6 +9,7 @@ class RemoteRedsysTest < Test::Unit::TestCase
       order_id: generate_order_id,
       description: 'Test Description'
     }
+    @amount = 100
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -53,7 +53,7 @@ class AdyenTest < Test::Unit::TestCase
     assert response.test?
   end
 
-def test_successful_capture_with_compount_psp_reference
+  def test_successful_capture_with_compount_psp_reference
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934#8514775559000000')
     assert_equal '7914775043909934#8814775564188305', response.authorization

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -77,7 +77,7 @@ class TransFirstTest < Test::Unit::TestCase
     response = @gateway.refund(@amount, "TransID")
     assert_failure response
   end
- 
+
   def test_successful_void
     @gateway.stubs(:ssl_post).returns(successful_void_response)
 
@@ -365,6 +365,6 @@ class TransFirstTest < Test::Unit::TestCase
       <Status>Canceled</Status>
       <Message>Transaction Is Not Allowed To Void or Refund</Message>
       </BankCardRefundStatus>
-     XML
-   end
+    XML
+  end
 end


### PR DESCRIPTION
I noticed when looking at Travis that we have some warnings printed during unit test runs. These patches silence them, without meaningfully changing any code. (I did fix one minor issue in Redsys' remote tests in the process, too, which I can break out into its own patch if we'd like, but it seemed small enough to lump in here).