### PR TITLE
Borgun: add TerminalID support

### DIFF
--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -84,6 +84,7 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, money, options)
         post[:TrAmount] = amount(money)
         post[:TrCurrency] = CURRENCY_CODES[options[:currency] || currency(money)]
+        post[:TerminalID] = options[:terminal_id] || '1'
       end
 
       def add_payment_method(post, payment_method)
@@ -129,7 +130,6 @@ module ActiveMerchant #:nodoc:
         post[:Version] = '1000'
         post[:Processor] = @options[:processor]
         post[:MerchantID] = @options[:merchant_id]
-        post[:TerminalID] = 1
 
         url = (test? ? test_url : live_url)
         request = build_request(action, post)

--- a/test/unit/gateways/borgun_test.rb
+++ b/test/unit/gateways/borgun_test.rb
@@ -17,7 +17,8 @@ class BorgunTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      terminal_id: '3'
     }
   end
 
@@ -94,6 +95,14 @@ class BorgunTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card)
     end.check_request do |endpoint, data, headers|
       assert_match(/#{@credit_card.verification_value}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_terminal_id
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, { terminal_id: '3' })
+    end.check_request do |endpoint, data, headers|
+      assert_match(/TerminalID&gt;3/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
TerminalID is required to handle recurring transactions (ID 3).

One remote test (`test_invalid_login`) fails, but this is expected (see
comment in the test), and at any rate wasn't altered by this commit.

Unit:
8 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
20 tests, 45 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95% passed