### PR TITLE
Stripe: Fix Partial Application Fee Refunds

### DIFF
--- a/test/remote/gateways/remote_stripe_connect_test.rb
+++ b/test/remote/gateways/remote_stripe_connect_test.rb
@@ -12,31 +12,38 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
     @options = {
       :currency => "USD",
       :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      :email => 'wow@example.com',
+      :stripe_account => fixtures(:stripe_destination)[:stripe_user_id]
     }
   end
 
   def test_application_fee_for_stripe_connect
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12 ))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert response.params['fee_details'].any? do |fee|
-      (fee['type'] == 'application_fee') && (fee['amount'] == 12)
-    end
+    assert_success response
   end
 
   def test_successful_refund_with_application_fee
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert refund = @gateway.refund(@amount, response.authorization, :refund_application_fee => true)
+    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(:refund_application_fee => true))
     assert_success refund
-    assert_equal 0, refund.params["fee"]
+
+    # Verify the application fee is refunded
+    fetch_fee_id = @gateway.send(:fetch_application_fee, response.authorization, @options)
+    fee_id = @gateway.send(:application_fee_from_response, fetch_fee_id)
+    refund_check = @gateway.send(:refund_application_fee, 10, fee_id, @options)
+    assert_equal "Application fee could not be refunded: Refund amount ($0.10) is greater than unrefunded amount on fee ($0.00)", refund_check.message
   end
 
   def test_refund_partial_application_fee
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert refund = @gateway.refund(@amount - 20, response.authorization, { :refund_fee_amount => 10 })
+    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => 10))
     assert_success refund
+
+    # Verify the application fee is partially refunded
+    fetch_fee_id = @gateway.send(:fetch_application_fee, response.authorization, @options)
+    fee_id = @gateway.send(:application_fee_from_response, fetch_fee_id)
+    refund_check = @gateway.send(:refund_application_fee, 10, fee_id, @options)
+    assert_equal "Application fee could not be refunded: Refund amount ($0.10) is greater than unrefunded amount on fee ($0.02)", refund_check.message
   end
 
 end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -423,6 +423,8 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_match "Invalid API Key provided", response.message
   end
 
+  # These "track data present" tests fail with invalid expiration dates. The
+  # test track data probably needs to be updated.
   def test_card_present_purchase
     @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Note to reviewers: This was more complicated than it seemed to have any right to be, so I'm not very confident about almost any aspect of it and I'd love to get more/deeper eyes than usual on this change and am open to suggestions on better patterns, etc.

Previously, when a partial application fee refund was requested, the connected stripe_account option was sent in the authentication header for both the fee retrieval call AND the application fee refund itself. Since the fee exists only on the main Platform account, sending the connected stripe_account for the refund meant it was looking in the wrong place, and failed. Now we remove the stripe_account field before the partial refund, so it is not sent in headers.

This also switches to a method of fetching the transaction to obtain the id of the application fee, rather than querying all application fees associated with the transaction, since it simplifies things, and the prior method did not seem to have any benefits over this (having multiple application fees doesn't seem possible currently). Error messaging around this has been updated as well.

This also involved updating the aging remote_stripe_connect_tests to use the stripe_destination in fixtures as the stripe_account option, and to remove assertions that are now invalid due to the changes to response structure in https://stripe.com/docs/upgrades#2013-08-13 Unit tests were likewise updated for the partial fee refund method changes.

Remote (two failing likely due to unrelated stale test data):
59 tests, 253 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6102% passed

Remote Connect:
3 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
122 tests, 651 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed