### PR TITLE
Ogone: Add field ORIG

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -334,6 +334,7 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, options)
         add_pair post, 'orderID', options[:order_id] || generate_unique_id[0...30]
         add_pair post, 'COM',     options[:description]
+        add_pair post, 'ORIG',    options[:origin] if options[:origin]
       end
 
       def add_creditcard(post, creditcard)

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -14,7 +14,8 @@ class RemoteOgoneTest < Test::Unit::TestCase
       :order_id => generate_unique_id[0...30],
       :billing_address => address,
       :description => 'Store Purchase',
-      :currency => fixtures(:ogone)[:currency] || 'EUR'
+      :currency => fixtures(:ogone)[:currency] || 'EUR',
+      :origin => 'STORE'
     }
   end
 


### PR DESCRIPTION
Add the field ORIG if sent

Two failing tests unrelated to this change

Loaded suite test/remote/gateways/remote_ogone_test
Failure:
test_successful_credit(RemoteOgoneTest)
      "Refunds are not allowed for your PSPID. Please contact helpdesk."},
Error: test_successful_store_generated_alias(RemoteOgoneTest): NoMethodError: undefined method `name' for nil:NilClass
27 tests, 99 assertions, 1 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications

Loaded suite test/unit/gateways/ogone_test

48 tests, 206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed