### PR TITLE
CenPos: Switch to new endpoint URL

### DIFF
--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = "CenPOS"
       self.homepage_url = "https://www.cenpos.com/"
 
-      self.live_url = "https://ww3.cenpos.net/6/transact.asmx"
+      self.live_url = "https://ww2.payment1.cenpos.net/6/transact.asmx"
 
       self.supported_countries = %w(AD AI AG AR AU AT BS BB BE BZ BM BR BN BG CA HR CY CZ DK DM EE FI FR DE GR GD GY HK HU IS IN IL IT JP LV LI LT LU MY MT MX MC MS NL PA PL PT KN LC MF VC SM SG SK SI ZA ES SR SE CH TR GB US UY)
       self.default_currency = "USD"
@@ -180,7 +180,6 @@ module ActiveMerchant #:nodoc:
 
       def headers
         {
-          "Accept-Encoding" => "gzip,deflate",
           "Content-Type"  => "text/xml;charset=UTF-8",
           "SOAPAction"  => "http://tempuri.org/Transactional/ProcessCreditCard"
         }

--- a/test/remote/gateways/remote_cenpos_test.rb
+++ b/test/remote/gateways/remote_cenpos_test.rb
@@ -107,7 +107,7 @@ class RemoteCenposTest < Test::Unit::TestCase
     capture = @gateway.capture(@amount, response.authorization)
     capture = @gateway.capture(@amount, response.authorization)
     assert_failure capture
-    assert_equal "Duplicated transaction", capture.message
+    assert_equal "Duplicated force transaction.", capture.message
   end
 
   def test_successful_void


### PR DESCRIPTION
In addition to changing the endpoint, something in Active Merchant
or this adapter isn't dealing well with Gzip'd responses, so I've
removed that header for now. (Requests at the old endpoint weren't ever
Gzip'd, so the old path was effectively untested.) I also patched one
remote test that was trivial to fix while I was in here.

The six remote test failures are identical with or without this patch.
(Well, you'll get seven without it due to the above-mentioned trivial
fix.)

Unit:
23 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
23 tests, 51 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
73.913% passed