### PR TITLE
Adds support for Google Pay sourced cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * Payeezy: Surface gateway_message on failure [curiousepic] #2717
 * Payment Express: Scrub merchant password [curiousepic] #2723
 * Stripe: Fix Partial Application Fee Refunds [curiousepic] #2713
+* GooglePay: Support network tokenized cards [joshnuss] #2725
 
 == Version 1.76.0 (January 3, 2018)
 * PayU Latam: Change default text for description [nfarve] #2669

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       attr_accessor :payment_cryptogram, :eci, :transaction_id
       attr_writer :source
 
-      SOURCES = [:apple_pay, :android_pay]
+      SOURCES = %i(apple_pay android_pay google_pay)
 
       def source
         if defined?(@source) && SOURCES.include?(@source)

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -14,6 +14,9 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     @tokenized_android_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :android_pay
     })
+    @tokenized_google_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      source: :google_pay
+    })
     @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :bogus_pay
     })
@@ -27,6 +30,7 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     assert @tokenized_card.credit_card?
     assert @tokenized_apple_pay_card.credit_card?
     assert @tokenized_android_pay_card.credit_card?
+    assert @tokenized_google_pay_card.credit_card?
     assert @tokenized_bogus_pay_card.credit_card?
   end
 
@@ -38,6 +42,7 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     assert_equal @tokenized_card.source, :apple_pay
     assert_equal @tokenized_apple_pay_card.source, :apple_pay
     assert_equal @tokenized_android_pay_card.source, :android_pay
+    assert_equal @tokenized_google_pay_card.source, :google_pay
     assert_equal @tokenized_bogus_pay_card.source, :apple_pay
   end
 end


### PR DESCRIPTION
Adds Google Pay to list of allowed sources.

- Updated `NetworkTokenizedCard::SOURCES` to include `:google_pay`