### PR TITLE
Global Collect: Add Creator Info Fields

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -33,6 +33,7 @@ module ActiveMerchant #:nodoc:
         add_payment(post, payment, options)
         add_customer_data(post, options, payment)
         add_address(post, payment, options)
+        add_creator_info(post, options)
 
         commit(:authorize, post)
       end
@@ -41,6 +42,7 @@ module ActiveMerchant #:nodoc:
         post = nestable_hash
         add_order(post, money, options)
         add_customer_data(post, options)
+        add_creator_info(post, options)
         commit(:capture, post, authorization)
       end
 
@@ -48,11 +50,13 @@ module ActiveMerchant #:nodoc:
         post = nestable_hash
         add_amount(post, money, options)
         add_refund_customer_data(post, options)
+        add_creator_info(post, options)
         commit(:refund, post, authorization)
       end
 
       def void(authorization, options={})
         post = nestable_hash
+        add_creator_info(post, options)
         commit(:void, post, authorization)
       end
 
@@ -97,6 +101,17 @@ module ActiveMerchant #:nodoc:
         post["order"]["references"]["invoiceData"] = {
           "invoiceNumber" => options[:invoice]
         }
+      end
+
+      def add_creator_info(post, options)
+        post['sdkIdentifier'] = options[:sdk_identifier] if options[:sdk_identifier]
+        post['sdkCreator'] = options[:sdk_creator] if options[:sdk_creator]
+        post['integrator'] = options[:integrator] if options[:integrator]
+        post['shoppingCartExtension'] = {}
+        post['shoppingCartExtension']['creator'] = options[:creator] if options[:creator]
+        post['shoppingCartExtension']['name'] = options[:name] if options[:name]
+        post['shoppingCartExtension']['version'] = options[:version] if options[:version]
+        post['shoppingCartExtension']['extensionID'] = options[:extension_ID] if options[:extension_ID]
       end
 
       def add_amount(post, money, options={})

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -25,7 +25,14 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     options = @options.merge(
       order_id: '1',
       ip: "127.0.0.1",
-      email: "joe@example.com"
+      email: "joe@example.com",
+      sdk_identifier: 'Channel',
+      sdk_creator: 'Bob',
+      integrator: 'Bill',
+      creator: 'Super',
+      name: 'Cala',
+      version: '1.0',
+      extension_ID: '5555555'
     )
 
     response = @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
Adds creator fields to all transactions if present.

Loaded suite test/remote/gateways/remote_global_collect_test
...............

15 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/global_collect_test
................

16 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed