### PR TITLE
Orbital: Handles level 2 tax data correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Orbital: Correct level 2 tax handling [deedeelavinder] #2729
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -356,8 +356,8 @@ module ActiveMerchant #:nodoc:
 
       def add_level_2_tax(xml, options={})
         if (level_2 = options[:level_2_data])
-          xml.tag! :TaxInd, level_2[:tax_indicator] if [TAX_NOT_PROVIDED, TAX_INCLUDED, NON_TAXABLE_TRANSACTION].include?(level_2[:tax_indicator])
-          xml.tag! :Tax, amount(level_2[:tax]) if level_2[:tax]
+          xml.tag! :TaxInd, level_2[:tax_indicator] if [TAX_NOT_PROVIDED, TAX_INCLUDED, NON_TAXABLE_TRANSACTION].include?(level_2[:tax_indicator].to_i)
+          xml.tag! :Tax, level_2[:tax].to_i if level_2[:tax]
         end
       end
 

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -23,8 +23,8 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       :jcb => "3566002020140006"}
 
     @level_2_options = {
-      tax_indicator: 1,
-      tax: 10,
+      tax_indicator: "1",
+      tax: "75",
       advice_addendum_1: 'taa1 - test',
       advice_addendum_2: 'taa2 - test',
       advice_addendum_3: 'taa3 - test',

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -15,8 +15,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @customer_ref_num = "ABC"
 
     @level_2 = {
-      tax_indicator: 1,
-      tax: 10,
+      tax_indicator: "1",
+      tax: "10",
       advice_addendum_1: 'taa1 - test',
       advice_addendum_2: 'taa2 - test',
       advice_addendum_3: 'taa3 - test',
@@ -46,8 +46,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(level_2_data: @level_2))
     end.check_request do |endpoint, data, headers|
-      assert_match %{<TaxInd>#{@level_2[:tax_indicator]}</TaxInd>}, data
-      assert_match %{<Tax>#{@level_2[:tax]}</Tax>}, data
+      assert_match %{<TaxInd>#{@level_2[:tax_indicator].to_i}</TaxInd>}, data
+      assert_match %{<Tax>#{@level_2[:tax].to_i}</Tax>}, data
       assert_match %{<AMEXTranAdvAddn1>#{@level_2[:advice_addendum_1]}</AMEXTranAdvAddn1>}, data
       assert_match %{<AMEXTranAdvAddn2>#{@level_2[:advice_addendum_2]}</AMEXTranAdvAddn2>}, data
       assert_match %{<AMEXTranAdvAddn3>#{@level_2[:advice_addendum_3]}</AMEXTranAdvAddn3>}, data


### PR DESCRIPTION
Level 2 tax amount may be passed in as a string, which was throwing an
error. This will now convert tax data to an integer format.

Remote Tests:
22 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit Tests:
69 tests, 418 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed