### PR TITLE
Add partial capture support for Litle gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -44,6 +44,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options={})
         transaction_id, _, _ = split_authorization(authorization)
+        options[:partial] = true if money
 
         request = build_xml_request do |doc|
           add_authentication(doc)
@@ -198,6 +199,9 @@ module ActiveMerchant #:nodoc:
         if payment_method.is_a?(String)
           doc.token do
             doc.litleToken(payment_method)
+            doc.expDate(options[:expiration_date]) if options[:expiration_date].present?
+            doc.cardValidationNum(options[:card_validation_num]) if options[:card_validation_num].present?
+            doc.type(options[:type]) if options[:type].present?
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
@@ -339,6 +343,7 @@ module ActiveMerchant #:nodoc:
         attributes[:id] = truncate(options[:id] || options[:order_id], 24)
         attributes[:reportGroup] = options[:merchant] || 'Default Report Group'
         attributes[:customerId] = options[:customer]
+        attributes[:partial] = options[:partial]
         attributes.delete_if { |key, value| value == nil }
         attributes
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -150,6 +150,26 @@ class LitleTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_partial_capture
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+
+    assert_equal "100000000000000001;authorization;100", response.authorization
+    assert response.test?
+
+    capture = stub_comms do
+      @gateway.capture(@amount - 1, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/100000000000000001/, data)
+      assert_match(/partial/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
   def test_failed_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)


### PR DESCRIPTION
@davidsantoso @dtykocki - Hi David, Doug - I noticed you approved some of the more recent pull requests. Can you review my pull request at your earliest convenience? I rely on this gem to do partial captures. Thanks!

Added support for partial capture of an authorization for a Litle Capture Transaction. According to the Litle documentation:

> 1.12.3 Capture Transaction
> 
> You can submit a Capture transaction for the full amount of the Authorization, or for a lesser amount by setting the partial attribute to true.


Litle requires additional options to be sent with purchase request using a token.

> Does the expiration date need to be sent with a token?
> 
> The expiration date must be sent in with a token. We only tokenize the card number. The token does not include the expiration date or card validation number. When the card expires you can simply send in the new expiration date without replacing the token.

Cross referencing: #2273