### PR TITLE
Payeezy: Changes assessment of store endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Orbital: Correct level 2 tax handling [deedeelavinder] #2729
+* Payeezy: Change determination method of endpoint for store request [deedeelavinder] #2731
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -74,7 +74,7 @@ module ActiveMerchant
       end
 
       def store(payment_method, options = {})
-        params = {}
+        params = {transaction_type: 'store'}
 
         add_creditcard_for_tokenization(params, payment_method, options)
 
@@ -149,7 +149,7 @@ module ActiveMerchant
       end
 
       def is_store_action?(params)
-        params[:ta_token].present?
+        params[:transaction_type] == 'store'
       end
 
       def add_payment_method(params, payment_method, options)


### PR DESCRIPTION
Although 'store' does not officially require a 'transaction_type', it is
used here to determine the correct endpoint for a 'store' request.

Unit Tests:
32 tests, 153 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote Tests:
27 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed