### PR TITLE
CenPOS: Remove gzip encoding header

### DIFF
--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
 
       def headers
         {
-          "Accept-Encoding" => "gzip,deflate",
+          "Accept-Encoding" => "identity",
           "Content-Type"  => "text/xml;charset=UTF-8",
           "SOAPAction"  => "http://tempuri.org/Transactional/ProcessCreditCard"
         }

--- a/test/remote/gateways/remote_cenpos_test.rb
+++ b/test/remote/gateways/remote_cenpos_test.rb
@@ -107,7 +107,7 @@ class RemoteCenposTest < Test::Unit::TestCase
     capture = @gateway.capture(@amount, response.authorization)
     capture = @gateway.capture(@amount, response.authorization)
     assert_failure capture
-    assert_equal "Duplicated transaction", capture.message
+    assert_equal "Duplicated force transaction.", capture.message
   end
 
   def test_successful_void


### PR DESCRIPTION
Production transactions are now failing due to the gzip encoding header;
this removes it. 6 remote tests are failing due to changes in response
values which shouldn't be a result of this change.

Remote:
23 tests, 51 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
73.913% passed

Unit:
23 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed