### PR TITLE
Mercado Pago: Allow binary_mode to be changed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Return refusal_reason_raw when present [curiousepic] #2728
 * Payeezy: Update Store method [nfarve] #2733
 * CenPOS: Remove gzip encoding header [curiousepic] #2735
+* Mercado Pago: Allow binary_mode to be changed [nfarve] #2736
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
         add_additional_data(post, options)
         add_customer_data(post, payment, options)
         add_address(post, options)
-        post[:binary_mode] = true
+        post[:binary_mode] = (options[:binary_mode].nil? ? true : options[:binary_mode])
         post
       end
 

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -21,6 +21,13 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_equal 'accredited', response.message
   end
 
+  def test_successful_purchase_with_binary_false
+    @options.update(binary_mode: false)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
   def test_successful_purchase_with_american_express
     amex_card = credit_card('375365153556885', brand: 'american_express', verification_value: '1234')
 


### PR DESCRIPTION
Allows binary_mode to be set to a value rather than the current default
of true.

Loaded suite test/unit/gateways/mercado_pago_test
Started
...................

19 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_mercado_pago_test
Started
.................

17 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed