### PR TITLE
Stripe: Accept strings for refund_fee_amount

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -149,10 +149,10 @@ module ActiveMerchant #:nodoc:
         MultiResponse.run(:first) do |r|
           r.process { commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options) }
 
-          return r unless options[:refund_fee_amount]
-
-          r.process { fetch_application_fee(identification, options) }
-          r.process { refund_application_fee(options[:refund_fee_amount], application_fee_from_response(r.responses.last), options) }
+          if options[:refund_fee_amount] && options[:refund_fee_amount].to_s != '0'
+            r.process { fetch_application_fee(identification, options) }
+            r.process { refund_application_fee(options[:refund_fee_amount].to_i, application_fee_from_response(r.responses.last), options) }
+          end
         end
       end
 

--- a/test/remote/gateways/remote_stripe_connect_test.rb
+++ b/test/remote/gateways/remote_stripe_connect_test.rb
@@ -36,7 +36,7 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
 
   def test_refund_partial_application_fee
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => 10))
+    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => "10"))
     assert_success refund
 
     # Verify the application fee is partially refunded
@@ -46,4 +46,15 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
     assert_equal "Application fee could not be refunded: Refund amount ($0.10) is greater than unrefunded amount on fee ($0.02)", refund_check.message
   end
 
+  def test_refund_application_fee_amount_zero
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
+    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => "0"))
+    assert_success refund
+
+    # Verify the application fee is not refunded
+    fetch_fee_id = @gateway.send(:fetch_application_fee, response.authorization, @options)
+    fee_id = @gateway.send(:application_fee_from_response, fetch_fee_id)
+    refund_check = @gateway.send(:refund_application_fee, 14, fee_id, @options)
+    assert_equal "Application fee could not be refunded: Refund amount ($0.14) is greater than fee amount ($0.12)", refund_check.message
+  end
 end


### PR DESCRIPTION
This now accounts for a string value for the refund_fee_amount or a
value of 0 when requesting refunds through Stripe Connect.

Remote (2 failing for stale test card data):
59 tests, 253 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6102% passed

Connect Remote:
3 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
3 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed