### PR TITLE
Orbital: Complete scrub test coverage

### DIFF
--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -12,6 +12,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     @options = {
       :order_id => generate_unique_id,
       :address => address,
+      :merchant_id => 'merchant1234'
     }
 
     @cards = {
@@ -293,5 +294,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:login], transcript)
+    assert_scrubbed(@gateway.options[:merchant_id], transcript)
   end
 end


### PR DESCRIPTION
Two fields scrubbed by the adapter were not asserted in the remote scrub
test.

Remote:
22 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
69 tests, 418 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed