### PR TITLE
Worldpay US: Scrub sensitive data

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -72,6 +72,18 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((&?merchantpin=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?ccnum=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?ckno=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?cvv2=)[^&]*)i, '\1[FILTERED]')
+      end
+
       private
 
       def url(options)

--- a/test/remote/gateways/remote_worldpay_us_test.rb
+++ b/test/remote/gateways/remote_worldpay_us_test.rb
@@ -5,9 +5,9 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
     @gateway = WorldpayUsGateway.new(fixtures(:worldpay_us))
 
     @amount = 100
-    @credit_card = credit_card('4446661234567892')
+    @credit_card = credit_card('4446661234567892', :verification_value => '987')
     @declined_card = credit_card('4000300011112220')
-    @check = check
+    @check = check(:number => '12345654321')
 
     @options = {
       order_id: generate_unique_id,
@@ -116,4 +116,22 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
     assert response.message =~ /DECLINED/
   end
 
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:merchantpin], transcript)
+
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.number, transcript)
+    assert_scrubbed(@gateway.options[:merchantpin], transcript)
+  end
 end


### PR DESCRIPTION
One remote test failing before and after changes, unrelated.

Remote:
15 tests, 45 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed

Unit:
16 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed