### PR TITLE
Ensure TLS version 1.2 for Authorize.Net gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -5,6 +5,8 @@ module ActiveMerchant
     class AuthorizeNetGateway < Gateway
       include Empty
 
+      self.ssl_version = :TLSv1_2
+
       self.test_url = 'https://apitest.authorize.net/xml/v1/request.api'
       self.live_url = 'https://api2.authorize.net/xml/v1/request.api'
 


### PR DESCRIPTION
Authorize.Net is removing support for TLS versions 1.0 and 1.1 beginning February 28, 2018. This PR applies a supported version to prevent new installs from encountering issues. I didn't add a spec, as it seemed to be covered in the following:

``` ruby
def test_override_ssl_version
  refute_equal :SSLv3, @connection.ssl_version
  @connection.ssl_version = :SSLv3
  assert_equal :SSLv3, @connection.ssl_version
end
```

Source: https://support.authorize.net/authkb/index?page=content&id=A1623&pmv=print&impressions=false&actp=LIST