### PR TITLE
Vantiv: Add support for merchantData elements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * USA Epay Transaction: Scrub sensitive data [curiousepic] #2745
 * MIGS: Add unit test for scrub [curiousepic] #2747
 * Worldpay US: Fix bank account scrub [curiousepic] #2748
+* Litle: Add support for merchantData elements [dtykocki] #2751
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -131,6 +131,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       CARD_TYPE = {
         'visa'             => 'VI',
         'master'           => 'MC',
@@ -178,7 +179,18 @@ module ActiveMerchant #:nodoc:
         add_payment_method(doc, payment_method, options)
         add_pos(doc, payment_method)
         add_descriptor(doc, options)
+        add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
+      end
+
+      def add_merchant_data(doc, options={})
+        if options[:affiliate] || options[:campaign] || options[:merchant_grouping_id]
+          doc.merchantData do
+            doc.affiliate(options[:affiliate]) if options[:affiliate]
+            doc.campaign(options[:campaign]) if options[:campaign]
+            doc.merchantGroupingId(options[:merchant_grouping_id]) if options[:merchant_grouping_id]
+          end
+        end
       end
 
       def add_descriptor(doc, options)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -71,6 +71,17 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_authorization_with_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    assert response = @gateway.authorize(10010, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_avs_and_cvv_result
     assert response = @gateway.authorize(10010, @credit_card1, @options)
     assert_equal "X", response.avs_result["code"]
@@ -137,6 +148,17 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_android_pay
     assert response = @gateway.purchase(10000, @decrypted_android_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    assert response = @gateway.purchase(10010, @credit_card1, options)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -56,6 +56,21 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_passing_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<affiliate>some-affiliate</affiliate>), data)
+      assert_match(%r(<campaign>super-awesome-campaign</campaign>), data)
+      assert_match(%r(<merchantGroupingId>brilliant-group</merchantGroupingId>), data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_passing_name_on_card
     stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
Adds the optional `affiliate`, `campaign` and `merchantGroupingId`
elements as children of the `merchantData` element.

Unit:
33 tests, 142 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 126 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed