### PR TITLE
Paymentez: add support for explicitly using tokens

### DIFF
--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -32,6 +32,14 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_token
+    store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+    token = store_response.authorization
+    purchase_response = @gateway.purchase(@amount, token, @options)
+    assert_success purchase_response
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
@@ -61,6 +69,17 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_equal 'Operation Successful', capture.message
   end
 
+  def test_successful_authorize_and_capture_with_token
+    store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+    token = store_response.authorization
+    auth = @gateway.authorize(@amount, token, @options)
+    assert_success auth
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'Operation Successful', capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
@@ -77,7 +96,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_equal 'Carrier not supported', response.message
+    assert_equal 'The capture method is not supported by carrier', response.message
   end
 
   def test_store

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -25,6 +25,16 @@ class PaymentezTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_token
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, '123456789012345678901234567890', @options)
+    assert_success response
+
+    assert_equal 'PR-926', response.authorization
+    assert response.test?
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 
@@ -37,6 +47,15 @@ class PaymentezTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(successful_store_response, successful_authorize_response)
 
     response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'CI-635', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_authorize_with_token
+    @gateway.stubs(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, '123456789012345678901234567890', @options)
     assert_success response
     assert_equal 'CI-635', response.authorization
     assert response.test?


### PR DESCRIPTION
Also tweaks the exact error message phrasing expected from one remote test to allow for 100% remote tests passing.

Remote:
15 tests, 36 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
32 tests, 153 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed