### PR TITLE
Stripe: Support pickup_card decline code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Optimal Payments: Fix scrub for double escaping [curiousepic] #2763
 * Orbital: Scrub profile transactions [curiousepic] #2762
 * BlueSnap: Fix currency passing [curiousepic] #2765
+* Stripe: Support pickup_card decline code [dtykocki] #2764
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -43,7 +43,8 @@ module ActiveMerchant #:nodoc:
         'call_issuer' => STANDARD_ERROR_CODE[:call_issuer],
         'processing_error' => STANDARD_ERROR_CODE[:processing_error],
         'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin],
-        'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card]
+        'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card],
+        'pickup_card' => STANDARD_ERROR_CODE[:pickup_card]
       }
 
       BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -426,7 +426,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   # These "track data present" tests fail with invalid expiration dates. The
   # test track data probably needs to be updated.
   def test_card_present_purchase
-    @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
+    @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^2205101130504392?'
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal "charge", response.params["object"]
@@ -434,7 +434,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_card_present_authorize_and_capture
-    @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
+    @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^2205101130504392?'
     assert authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
     refute authorization.params["captured"]

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -713,6 +713,17 @@ class StripeTest < Test::Unit::TestCase
     assert_equal 'ch_test_charge', response.authorization
   end
 
+  def test_declined_request_advanced_pickup_card_code
+    @gateway.expects(:ssl_request).returns(declined_pickup_card_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal Gateway::STANDARD_ERROR_CODE[:pickup_card], response.error_code
+    refute response.test? # unsuccessful request defaults to live
+    assert_equal 'ch_test_charge', response.authorization
+  end
+
   def test_declined_request_advanced_decline_code_not_in_standard_mapping
     @gateway.expects(:ssl_request).returns(declined_generic_decline_purchase_response)
 
@@ -2027,6 +2038,20 @@ class StripeTest < Test::Unit::TestCase
         "type": "card_error",
         "code": "card_declined",
         "decline_code": "call_issuer",
+        "charge": "ch_test_charge"
+      }
+    }
+    RESPONSE
+  end
+
+  def declined_pickup_card_purchase_response
+    <<-RESPONSE
+    {
+      "error": {
+        "message": "Your card was declined.",
+        "type": "card_error",
+        "code": "card_declined",
+        "decline_code": "pickup_card",
         "charge": "ch_test_charge"
       }
     }


### PR DESCRIPTION
Adds the `pickup_card` decline code to the `STANDARD_ERROR_CODE_MAPPING`
hash. This also fixes two failing remote tests by updating the
expiration dates on card track data.

Remote:
59 tests, 258 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
123 tests, 658 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed