### PR TITLE
BlueSnap: Fix currency passing

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -86,7 +86,7 @@ module ActiveMerchant
       def refund(money, authorization, options={})
         commit(:refund, :put) do |doc|
           add_authorization(doc, authorization)
-          add_amount(doc, money)
+          add_amount(doc, money, options)
           add_order(doc, options)
         end
       end
@@ -140,7 +140,7 @@ module ActiveMerchant
       def add_auth_purchase(doc, money, payment_method, options)
         doc.send("recurring-transaction", options[:recurring] ? "RECURRING" : "ECOMMERCE")
         add_order(doc, options)
-        add_amount(doc, money)
+        add_amount(doc, money, options)
         doc.send("transaction-fraud-info") do
           doc.send("shopper-ip-address", options[:ip]) if options[:ip]
         end
@@ -155,7 +155,7 @@ module ActiveMerchant
         end
       end
 
-      def add_amount(doc, money)
+      def add_amount(doc, money, options)
         doc.amount(amount(money))
         doc.currency(options[:currency] || currency(money))
       end
@@ -201,11 +201,6 @@ module ActiveMerchant
         doc.address(address[:address]) if address[:address]
         doc.city(address[:city]) if address[:city]
         doc.zip(address[:zip]) if address[:zip]
-      end
-
-      def add_invoice(post, money, options)
-        post[:amount] = amount(money)
-        post[:currency] = (options[:currency] || currency(money))
       end
 
       def add_authorization(doc, authorization)

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -6,7 +6,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4263982640269299')
-    @declined_card = credit_card('4917484589897107', month: 1, year: 2018)
+    @declined_card = credit_card('4917484589897107', month: 1, year: 2023)
     @options = { billing_address: address }
   end
 
@@ -34,6 +34,14 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, more_options)
     assert_success response
     assert_equal "Success", response.message
+  end
+
+  def test_successful_purchase_with_currency
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
+    assert_success response
+
+    assert_equal 'Success', response.message
+    assert_equal 'CAD', response.params["currency"]
   end
 
   def test_failed_purchase
@@ -100,8 +108,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_success purchase
 
     assert refund = @gateway.refund(@amount-1, purchase.authorization)
-    assert_failure refund
-    assert_match /failed because the financial transaction was created less than 24 hours ago/, refund.message
+    assert_success refund
   end
 
   def test_failed_refund

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class BlueSnapTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = BlueSnapGateway.new(api_username: 'login', api_password: 'password')
     @credit_card = credit_card
@@ -118,6 +120,14 @@ class BlueSnapTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_failure response
     assert_equal "14002", response.error_code
+  end
+
+  def test_currency_added_correctly
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<currency>CAD<\/currency>/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_verify_good_credentials


### PR DESCRIPTION
Options was not being passed to add_amount, so a currency sent in
options was never getting added.

Also removes an add_invoice method that was not being used, and updates
the declined test card to fix some remote tests. One unrelated failing
remote test, a store call with a declined card expecting a failure now
succeeds for some reason.

Remote:
25 tests, 72 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96% passed

Unit:
18 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed