### PR TITLE
Improve scrub testing for five gateways

### DIFF
--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -154,6 +154,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
   end
 
   def test_incorrect_number_for_purchase

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -184,8 +184,17 @@ class RemoteCardConnectTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end
     transcript = @gateway.scrub(transcript)
+
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
 end

--- a/test/remote/gateways/remote_cardprocess_test.rb
+++ b/test/remote/gateways/remote_cardprocess_test.rb
@@ -144,5 +144,6 @@ class RemoteCardprocessTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:entity_id], transcript)
   end
 end

--- a/test/remote/gateways/remote_dibs_test.rb
+++ b/test/remote/gateways/remote_dibs_test.rb
@@ -172,7 +172,9 @@ class RemoteDibsTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
+
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+    assert_scrubbed(@gateway.options[:secret_key], clean_transcript)
   end
 end

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -129,5 +129,6 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:app_key], transcript)
   end
 end


### PR DESCRIPTION
Adds missing remote test scrubbing assertions for sensitive data to the
Paymentez, Adyen, Dibs, CardConnect and CardProcess gateways.

Paymentez Remote:
15 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Paymentez Unit:
15 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Adyen Remote:
28 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Adyen Unit:
17 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Dibs Remote (most failing with a test card issue, scrub test succeeds):
19 tests, 28 assertions, 14 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
26.3158% passed

Dibs Unit:
17 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CardConnect Remote:
19 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CardConnect Unit:
17 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CardProcess Remote (4 unrelated failures):
17 tests, 42 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
76.4706% passed

CardProcess Unit:
16 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed