### PR TITLE
Payeezy: Update transaction method when using stored cards

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -131,7 +131,7 @@ module ActiveMerchant
         transaction_id, transaction_tag, method, _ = authorization.split('|')
         params[:transaction_id] = transaction_id
         params[:transaction_tag] = transaction_tag
-        params[:method] = method
+        params[:method] = (method == 'token') ? 'credit_card' : method
       end
 
       def add_creditcard_for_tokenization(params, payment_method, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -28,16 +28,14 @@ class RemotePayeezyTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card,
-                                     @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
+    assert response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_equal 'Token successfully created.', response.message
     assert response.authorization
   end
 
   def test_successful_store_and_purchase
-    assert response = @gateway.store(@credit_card,
-                                     @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
+    assert response = @gateway.store(@credit_card, @options)
     assert_success response
     assert !response.authorization.blank?
     assert purchase = @gateway.purchase(@amount, response.authorization, @options)
@@ -45,8 +43,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_store
-    assert response = @gateway.store(@bad_credit_card,
-                                     @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
+    assert response = @gateway.store(@bad_credit_card, @options)
     assert_failure response
     assert_equal 'The credit card number check failed', response.message
   end
@@ -81,6 +78,18 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_successful_store_and_auth_and_capture
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    assert auth = @gateway.authorize(@amount, response.authorization, @options)
+    assert_success auth
+    assert auth.authorization
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
   end
@@ -127,6 +136,20 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_refund_with_stored_card
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    assert purchase = @gateway.purchase(@amount, response.authorization, @options)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+
+    assert response = @gateway.refund(50, purchase.authorization)
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+  end
+
   def test_partial_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -148,6 +171,18 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'Transaction Normal - Approved', void.message
+  end
+
+  def test_successful_void_with_stored_card
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    auth = @gateway.authorize(@amount, response.authorization, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
@@ -204,7 +239,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing_store
     transcript = capture_transcript(@gateway) do
-      @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
+      @gateway.store(@credit_card, @options)
     end
 
     transcript = @gateway.scrub(transcript)
@@ -217,7 +252,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
   def test_transcript_scrubbing_store_with_missing_ta_token
     transcript = capture_transcript(@gateway) do
       @options.delete(:ta_token)
-      @gateway.store(@credit_card, @options.merge(js_security_key: 'js-f4c4b54f08d6c44c8cad3ea80bbf92c4f4c4b54f08d6c44c'))
+      @gateway.store(@credit_card, @options)
     end
 
     transcript = @gateway.scrub(transcript)


### PR DESCRIPTION
For reference based transactions that accept stored cards, we'll now
pass `credit_card` instead of `token` in the `method` option. It's
not entirely clear from Payeezy's documentation that this is the
correct value to use, but with `credit_card` we no longer see the "Token
information is missing" error message on `capture`, `void`, and `refund`
calls.

Unit:
32 tests, 153 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 118 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed