### PR TITLE
CardStream: Default IP and customer country

### DIFF
--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -155,6 +155,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, credit_card_or_reference, money, options)
         add_credit_card_or_reference(post, credit_card_or_reference)
         add_customer_data(post, options)
+        add_remote_address(post, options)
         commit('SALE', post)
       end
 
@@ -165,6 +166,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, credit_card_or_reference, money, options)
         add_credit_card_or_reference(post, credit_card_or_reference)
         add_customer_data(post, options)
+        add_remote_address(post, options)
         commit('SALE', post)
       end
 
@@ -172,6 +174,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_pair(post, :xref, authorization)
         add_pair(post, :amount, amount(money), :required => true)
+        add_remote_address(post, options)
 
         commit('CAPTURE', post)
       end
@@ -180,12 +183,14 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_pair(post, :xref, authorization)
         add_amount(post, money, options)
+        add_remote_address(post, options)
         commit('REFUND', post)
       end
 
       def void(authorization, options = {})
         post = {}
         add_pair(post, :xref, authorization)
+        add_remote_address(post, options)
         commit('CANCEL', post)
       end
 
@@ -220,6 +225,9 @@ module ActiveMerchant #:nodoc:
           add_pair(post, :customerAddress, "#{address[:address1]} #{address[:address2]}".strip)
           add_pair(post, :customerPostCode, address[:zip])
           add_pair(post, :customerPhone, options[:phone])
+          add_pair(post, :customerCountryCode, address[:country] || 'GB')
+        else
+          add_pair(post, :customerCountryCode, 'GB')
         end
       end
 
@@ -271,6 +279,10 @@ module ActiveMerchant #:nodoc:
 
       def add_threeds_required(post, options)
         add_pair(post, :threeDSRequired, (options[:threeds_required] || @threeds_required) ? 'Y' : 'N')
+      end
+
+      def add_remote_address(post, options={})
+        add_pair(post, :remoteAddress, options[:ip] || '1.1.1.1')
       end
 
       def normalize_line_endings(str)


### PR DESCRIPTION
Per a request from CardStream, when no IP address is specified, the
default of 1.1.1.1 should used. Additionally, when no customer country
code is specified, GB should be used as a default.

Remote:
26 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
22 tests, 114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed