### PR TITLE
Remove all TLS 1.0 version pins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Payflow: Support scrub [curiousepic] #2768
 * SecureNet: Support scrub [curiousepic] #2769
 * Payeezy: Update transaction method when using stored cards [dtykocki] #2770
+* Citrus Pay, DIBS, 1stPayGateway, Global Transport, NETbilling, Ogone, TNS: remove TLS 1.0 requirement [bdewater] #2774
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/citrus_pay.rb
+++ b/lib/active_merchant/billing/gateways/citrus_pay.rb
@@ -16,7 +16,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :laser]
-      self.ssl_version = :TLSv1
 
     end
   end

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -9,7 +9,6 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ["US", "FI", "NO", "SE", "GB"]
       self.default_currency = "USD"
       self.money_format = :cents
-      self.ssl_version = :TLSv1
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -12,7 +12,6 @@ module ActiveMerchant #:nodoc:
 
       self.homepage_url = 'http://1stpaygateway.net/'
       self.display_name = '1stPayGateway.Net'
-      self.ssl_version = :TLSv1
 
       def initialize(options={})
         requires!(options, :transaction_center_id, :gateway_id)

--- a/lib/active_merchant/billing/gateways/global_transport.rb
+++ b/lib/active_merchant/billing/gateways/global_transport.rb
@@ -9,7 +9,6 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(CA PR US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
-      self.ssl_version = :TLSv1
 
       self.homepage_url = 'https://www.globalpaymentsinc.com'
       self.display_name = 'Global Transport'

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -31,7 +31,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'NETbilling'
       self.homepage_url = 'http://www.netbilling.com'
       self.supported_countries = ['US']
-      self.ssl_version = :TLSv1
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
 
       def initialize(options = {})

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -141,7 +141,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Ogone'
       self.default_currency = 'EUR'
       self.money_format = :cents
-      self.ssl_version = :TLSv1
 
       def initialize(options = {})
         requires!(options, :login, :user, :password)

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -16,7 +16,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :laser]
-      self.ssl_version = :TLSv1
 
     end
   end


### PR DESCRIPTION
Most of these were added years ago as workarounds. They were never revisited to see if gateways had fixed their SSL setup. By removing the pinned version requirement, the highest supported version will be negotiated between the client and the server.

TLS 1.0 is old with [known vulnerabilities that require server mitigations](https://en.wikipedia.org/wiki/Transport_Layer_Security#cite_note-rfc5746-37) to be properly configured. Version 1.2 was released in 2008 and is considered secure with most cipher configurations.

The PCI DSS v3.2 disallows TLS 1.0 unless existing implementations have applied for an exception. However, this exception is [not valid after June 30, 2018](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls). I have verified (with `curl -v`) that all live and test URLs of the affected gateways support TLS 1.2.