### PR TITLE
Allow setting min/max SSL version for a connection on Ruby 2.5

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -21,6 +21,8 @@ module ActiveMerchant
     attr_accessor :read_timeout
     attr_accessor :verify_peer
     attr_accessor :ssl_version
+    attr_accessor :min_version
+    attr_accessor :max_version
     attr_accessor :ca_file
     attr_accessor :ca_path
     attr_accessor :pem
@@ -44,6 +46,8 @@ module ActiveMerchant
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
+      @min_version = nil
+      @max_version = nil
       @proxy_address = nil
       @proxy_port = nil
     end
@@ -121,6 +125,10 @@ module ActiveMerchant
 
       http.use_ssl = true
       http.ssl_version = ssl_version if ssl_version
+      if http.respond_to?(:min_version=)
+        http.min_version = min_version if min_version
+        http.max_version = max_version if max_version
+      end
 
       if verify_peer
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module ActiveMerchant
   module NetworkConnectionRetries
     DEFAULT_RETRIES = 3

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -8,6 +8,12 @@ module ActiveMerchant #:nodoc:
       base.class_attribute :ssl_version
       base.ssl_version = nil
 
+      base.class_attribute :min_version
+      base.min_version = nil
+
+      base.class_attribute :max_version
+      base.min_version = nil
+
       base.class_attribute :retry_safe
       base.retry_safe = false
 
@@ -53,6 +59,10 @@ module ActiveMerchant #:nodoc:
       connection.max_retries  = max_retries
       connection.tag          = self.class.name
       connection.wiredump_device = wiredump_device
+      if connection.respond_to?(:min_version=)
+        connection.min_version = min_version
+        connection.max_version = max_version
+      end
 
       connection.pem          = @options[:pem] if @options
       connection.pem_password = @options[:pem_password] if @options

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -75,6 +75,22 @@ class ConnectionTest < Test::Unit::TestCase
     assert_equal :SSLv3, @connection.ssl_version
   end
 
+  def test_override_min_version
+    omit_if Net::HTTP.instance_methods.exclude?(:min_version=)
+
+    refute_equal :TLSv1_1, @connection.min_version
+    @connection.min_version = :TLSv1_1
+    assert_equal :TLSv1_1, @connection.min_version
+  end
+
+  def test_override_max_version
+    omit_if Net::HTTP.instance_methods.exclude?(:min_version=)
+
+    refute_equal :TLSv1_2, @connection.max_version
+    @connection.max_version = :TLSv1_2
+    assert_equal :TLSv1_2, @connection.max_version
+  end
+
   def test_default_read_timeout
     assert_equal ActiveMerchant::Connection::READ_TIMEOUT, @connection.read_timeout
   end


### PR DESCRIPTION
The configuration on the Net::HTTP object is passed through to OpenSSL::SSLContext. The functionality in the OpenSSL gem was introduced in https://github.com/ruby/openssl/pull/142