### PR TITLE
Litle: Add Support for Echeck

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Litle: Add Support for Echeck [nfarve] #2776
 * Orbital: Correct level 2 tax handling [deedeelavinder] #2729
 * Payeezy: Change determination method of endpoint for store request [deedeelavinder] #2731
 * Adyen: Return refusal_reason_raw when present [curiousepic] #2728

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -23,23 +23,33 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_method, options={})
         request = build_xml_request do |doc|
           add_authentication(doc)
-          doc.sale(transaction_attributes(options)) do
-            add_auth_purchase_params(doc, money, payment_method, options)
+          if check?(payment_method)
+            doc.echeckSale(transaction_attributes(options)) do
+              add_echeck_purchase_params(doc, money, payment_method, options)
+            end
+          else
+            doc.sale(transaction_attributes(options)) do
+              add_auth_purchase_params(doc, money, payment_method, options)
+            end
           end
         end
-
-        commit(:sale, request, money)
+       check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
       end
 
       def authorize(money, payment_method, options={})
         request = build_xml_request do |doc|
           add_authentication(doc)
-          doc.authorization(transaction_attributes(options)) do
-            add_auth_purchase_params(doc, money, payment_method, options)
+          if check?(payment_method)
+            doc.echeckVerification(transaction_attributes(options)) do
+              add_echeck_purchase_params(doc, money, payment_method, options)
+            end
+          else
+            doc.authorization(transaction_attributes(options)) do
+              add_auth_purchase_params(doc, money, payment_method, options)
+            end
           end
         end
-
-        commit(:authorization, request, money)
+        check?(payment_method) ? commit(:echeckVerification, request, money) : commit(:authorization, request, money)
       end
 
       def capture(money, authorization, options={})
@@ -62,19 +72,24 @@ module ActiveMerchant #:nodoc:
         refund(money, authorization, options)
       end
 
-      def refund(money, authorization, options={})
-        transaction_id, _, _ = split_authorization(authorization)
-
+      def refund(money, payment, options={})
         request = build_xml_request do |doc|
           add_authentication(doc)
           add_descriptor(doc, options)
-          doc.credit(transaction_attributes(options)) do
-            doc.litleTxnId(transaction_id)
-            doc.amount(money) if money
+          doc.send(refund_type(payment), transaction_attributes(options)) do
+            if payment.is_a?(String)
+              transaction_id, kind, _ = split_authorization(payment)
+              doc.litleTxnId(transaction_id)
+              doc.amount(money) if money
+            elsif check?(payment)
+              add_echeck_purchase_params(doc, money, payment, options)
+            else
+              add_auth_purchase_params(doc, money, payment, options)
+            end
           end
         end
 
-        commit(:credit, request)
+        commit(refund_type(payment), request)
       end
 
       def verify(creditcard, options = {})
@@ -124,6 +139,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r((<user>).+(</user>)), '\1[FILTERED]\2').
           gsub(%r((<password>).+(</password>)), '\1[FILTERED]\2').
           gsub(%r((<number>).+(</number>)), '\1[FILTERED]\2').
+          gsub(%r((<accNum>).+(</accNum>)), '\1[FILTERED]\2').
+          gsub(%r((<routingNum>).+(</routingNum>)), '\1[FILTERED]\2').
           gsub(%r((<cardValidationNum>).+(</cardValidationNum>)), '\1[FILTERED]\2').
           gsub(%r((<accountNumber>).+(</accountNumber>)), '\1[FILTERED]\2').
           gsub(%r((<paypageRegistrationId>).+(</paypageRegistrationId>)), '\1[FILTERED]\2').
@@ -160,7 +177,27 @@ module ActiveMerchant #:nodoc:
       }
 
       def void_type(kind)
-        (kind == 'authorization') ? :authReversal : :void
+        if kind == 'authorization'
+          :authReversal
+        elsif kind == 'echeckSales'
+          :echeckVoid
+        else
+          :void
+        end
+      end
+
+      def refund_type(payment)
+        transaction_id, kind, _ = split_authorization(payment)
+        if check?(payment) || kind  == 'echeckSales'
+          :echeckCredit
+        else
+          :credit
+        end
+      end
+
+      def check?(payment_method)
+        return false if payment_method.is_a?(String)
+        card_brand(payment_method) == 'check'
       end
 
       def add_authentication(doc)
@@ -193,6 +230,15 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def add_echeck_purchase_params(doc, money, payment_method, options)
+        doc.orderId(truncate(options[:order_id], 24))
+        doc.amount(money)
+        add_order_source(doc, payment_method, options)
+        add_billing_address(doc, payment_method, options)
+        add_payment_method(doc, payment_method, options)
+        add_descriptor(doc, options)
+      end
+
       def add_descriptor(doc, options)
         if options[:descriptor_name] || options[:descriptor_phone]
           doc.customBilling do
@@ -214,6 +260,13 @@ module ActiveMerchant #:nodoc:
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
             doc.track(payment_method.track_data)
+          end
+        elsif check?(payment_method)
+          doc.echeck do
+            doc.accType(payment_method.account_type)
+            doc.accNum(payment_method.account_number)
+            doc.routingNum(payment_method.routing_number)
+            doc.checkNum(payment_method.number)
           end
         else
           doc.card do
@@ -239,7 +292,13 @@ module ActiveMerchant #:nodoc:
         return if payment_method.is_a?(String)
 
         doc.billToAddress do
-          doc.name(payment_method.name)
+          if check?(payment_method)
+            doc.name(payment_method.name)
+            doc.firstName(payment_method.first_name)
+            doc.lastName(payment_method.last_name)
+          else
+            doc.name(payment_method.name)
+          end
           doc.email(options[:email]) if options[:email]
 
           add_address(doc, options[:billing_address])

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -433,6 +433,416 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
   end
 
+  # Echeck
+  def test37
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '37',
+      :billing_address => {
+        :name => 'Tom Black',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3001, check, options)
+    assert_failure auth_response
+    assert_equal 'Invalid Account Number', auth_response.message
+    assert_equal '301', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test38
+    check = check(
+      name: 'John Smith',
+      routing_number:  '011075150',
+      account_number: '1099999999',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '38',
+      :billing_address => {
+        :name => 'John Smith',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3002, check, options)
+    assert_success auth_response
+    assert_equal 'Approved', auth_response.message
+    assert_equal '000', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test39
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '053100300',
+      account_number: '3099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '39',
+      :billing_address => {
+        :name => 'John Smith',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Good Goods Inc',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3003, check, options)
+    assert_failure auth_response
+    assert_equal 'Decline - Negative Information on File', auth_response.message
+    assert_equal '950', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test40
+    declined_authorize_check = check(
+      name: 'Peter Green',
+      routing_number: '011075150',
+      account_number: '8099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '40',
+      :billing_address => {
+        :name => 'Peter Green',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Green Co',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3004, declined_authorize_check, options)
+    assert_failure auth_response
+    assert_equal 'Absolute Decline', auth_response.message
+    assert_equal '951', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test41
+    check = check(
+      name: 'Mike Hammer',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '41',
+      :billing_address => {
+        :name => 'Mike Hammer',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2008, check, options)
+    assert_failure purchase_response
+    assert_equal 'Invalid Account Number', purchase_response.message
+    assert_equal '301', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test42
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '42',
+      :billing_address => {
+        :name => 'Tom Black',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2004, check, options)
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+    assert_equal '000', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test43
+    check = check(
+      name: 'Peter Green',
+      routing_number:  '011075150',
+      account_number: '6099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '43',
+      :billing_address => {
+        :name => 'Peter Green',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Green Co',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2007, check, options)
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+    assert_equal '000', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test44
+    check = check(
+      name: 'Peter Green',
+      routing_number: '053133052',
+      account_number: '9099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '44',
+      :billing_address => {
+        :name => 'Peter Green',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Green Co',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2009, check, options)
+    assert_failure purchase_response
+    assert_equal 'Invalid Bank Routing Number', purchase_response.message
+    assert_equal '900', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test45
+    check = check(
+      name: 'John Smith',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '45',
+      :billing_address => {
+        :name => 'John Smith',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert refund_response = @gateway.refund(1001, check, options)
+    assert_failure refund_response
+    assert_equal 'Invalid Account Number', refund_response.message
+    assert_equal '301', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test46
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '011075150',
+      account_number: '3099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '46',
+      :order_source => 'telephone',
+      :billing_address => {
+        :name => 'Robert Jones',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444',
+        :company => 'Widget Inc'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1003, check, options)
+    sleep(10)
+    assert refund_response = @gateway.refund(1003, purchase_response.authorization, options)
+    assert_success refund_response
+    assert_equal 'Approved', refund_response.message
+    assert_equal '000', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test47
+    check = check(
+      name: 'Peter Green',
+      routing_number:  '211370545',
+      account_number: '6099999993',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '47',
+      :billing_address => {
+        :name => 'Peter Green',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Green Co',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1007, check, options)
+    assert refund_response = @gateway.refund(1007, purchase_response.authorization, options)
+    assert_success refund_response
+    assert_equal 'Approved', refund_response.message
+    assert_equal '000', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test48
+    check = check(
+      name: 'Peter Green',
+      routing_number: '011075150',
+      account_number: '6099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      :order_id => '43',
+      :billing_address => {
+        :name => 'Peter Green',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :company => 'Green Co',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2007, check, options)
+    assert_success purchase_response
+    assert refund_response = @gateway.refund(2007, purchase_response.authorization, options)
+    assert_equal '000', refund_response.params['response']
+    puts "Test 48: #{txn_id(refund_response)}"
+  end
+
+  def test49
+    assert refund_response = @gateway.refund(2007, 2)
+    assert_failure refund_response
+    assert_equal '360', refund_response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', refund_response.message
+    puts "Test 49: #{txn_id(refund_response)}"
+  end
+
+  def test_echeck_void1
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '42',
+      :id => '236222',
+      :billing_address => {
+        :name => 'Tom Black',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2004, check, options)
+    assert_success purchase_response
+    sleep(10)
+    assert void_response = @gateway.void(purchase_response.authorization)
+    assert_equal '000', void_response.params['response']
+    puts "Test void1: #{txn_id(void_response)}"
+  end
+
+  def test_echeck_void2
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '011075150',
+      account_number: '3099999999',
+      account_type: 'Checking'
+    )
+    options = {
+      :order_id => '46',
+      :id => '232222',
+      :billing_address => {
+        :name => 'Robert Jones',
+        :address1 => '8 Main St.',
+        :city => 'Manchester',
+        :state => 'NH',
+        :zip => '03101',
+        :country => 'US',
+        :email => 'test@test.com',
+        :phone => '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1003, check, options)
+    assert_success purchase_response
+    sleep(20)
+    assert void_response = @gateway.void(purchase_response.authorization)
+    assert_equal '000', void_response.params['response']
+    puts "Test void2: #{txn_id(void_response)}"
+  end
+
+  def test_echeck_void3
+    assert void_response = @gateway.void(2)
+    assert_failure void_response
+    assert_equal '360', void_response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', void_response.message
+    puts "Test void3: #{txn_id(void_response)}"
+  end
+
   # Explicit Token Registration Tests
   def test50
     credit_card = CreditCard.new(:number => '4457119922390123')

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -32,6 +32,18 @@ class LitleTest < Test::Unit::TestCase
       })
     @amount = 100
     @options = {}
+    @check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'Checking'
+    )
+    @authorize_check = check(
+      name: 'John Smith',
+      routing_number: '011075150',
+      account_number: '1099999999',
+      account_type: 'Checking'
+    )
   end
 
   def test_successful_purchase
@@ -42,6 +54,17 @@ class LitleTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal "100000000000000006;sale;100", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_echeck
+    response = stub_comms do
+      @gateway.purchase(2004, @check)
+    end.respond_with(successful_purchase_with_echeck_response)
+
+    assert_success response
+
+    assert_equal "621100411297330000;echeckSales;2004", response.authorization
     assert response.test?
   end
 
@@ -264,6 +287,15 @@ class LitleTest < Test::Unit::TestCase
     assert_equal "360", response.params["response"]
   end
 
+  def test_successful_void_of_echeck
+    response = stub_comms do
+      @gateway.void("945032206979933000;echeckSales;2004")
+    end.respond_with(successful_void_of_echeck_response)
+
+    assert_success response
+    assert_equal "986272331806746000;echeckVoid;", response.authorization
+  end
+
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card)
@@ -382,6 +414,20 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_purchase_with_echeck_response
+    %(
+      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <echeckSalesResponse id='42' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>621100411297330000</litleTxnId>
+          <orderId>42</orderId>
+          <response>000</response>
+          <responseTime>2018-01-09T14:02:20</responseTime>
+          <message>Approved</message>
+        </echeckSalesResponse>
       </litleOnlineResponse>
     )
   end
@@ -516,6 +562,20 @@ class LitleTest < Test::Unit::TestCase
           <responseTime>2014-03-31T12:44:52</responseTime>
           <message>Approved</message>
         </voidResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_void_of_echeck_response
+    %(
+      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <echeckVoidResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>986272331806746000</litleTxnId>
+          <response>000</response>
+          <responseTime>2018-01-09T14:20:00</responseTime>
+          <message>Approved</message>
+          <postDate>2018-01-09</postDate>
+        </echeckVoidResponse>
       </litleOnlineResponse>
     )
   end


### PR DESCRIPTION
Adds support for Echeck and tests for certification.

Loaded suite test/remote/gateways/remote_litle_test
...................................

35 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Loaded suite test/unit/gateways/litle_test
Started
...................................

35 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------