### PR TITLE
Stripe: Support destination amount

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -335,7 +335,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_destination(post, options)
-        post[:destination] = options[:destination] if options[:destination]
+        if options[:destination]
+          post[:destination] = {}
+          post[:destination][:account] = options[:destination]
+          post[:destination][:amount] = options[:destination_amount] if options[:destination_amount]
+        end
       end
 
       def add_expand_parameters(post, options)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -66,12 +66,44 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "wow@example.com", response.params["metadata"]["email"]
   end
 
+  def test_successful_purchase_with_destination
+    destination = fixtures(:stripe_destination)[:stripe_user_id]
+    custom_options = @options.merge(:destination => destination)
+    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert_equal destination, response.params["destination"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+  end
+
+  def test_successful_purchase_with_destination_and_amount
+    destination = fixtures(:stripe_destination)[:stripe_user_id]
+    custom_options = @options.merge(:destination => destination, :destination_amount => @amount - 20)
+    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert_equal destination, response.params["destination"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_match %r{Your card was declined}, response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
     assert_match /ch_[a-zA-Z\d]+/, response.authorization
+  end
+
+  def test_unsuccessful_purchase_with_destination_and_amount
+    destination = fixtures(:stripe_destination)[:stripe_user_id]
+    custom_options = @options.merge(:destination => destination, :destination_amount => @amount + 20)
+    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
+    assert_failure response
+    assert_match %r{must be less than or equal to the charge amount}, response.message
   end
 
   def test_successful_echeck_purchase_with_verified_account
@@ -96,6 +128,36 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
     refute authorization.params["captured"]
+    assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
+    assert_equal "wow@example.com", authorization.params["metadata"]["email"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+  end
+
+  def test_authorization_and_capture_with_destination
+    destination = fixtures(:stripe_destination)[:stripe_user_id]
+    custom_options = @options.merge(:destination => destination)
+
+    assert authorization = @gateway.authorize(@amount, @credit_card, custom_options)
+    assert_success authorization
+    refute authorization.params["captured"]
+    assert_equal destination, authorization.params["destination"]
+    assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
+    assert_equal "wow@example.com", authorization.params["metadata"]["email"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+  end
+
+  def test_authorization_and_capture_with_destination_and_amount
+    destination = fixtures(:stripe_destination)[:stripe_user_id]
+    custom_options = @options.merge(:destination => destination, :destination_amount => @amount - 20)
+
+    assert authorization = @gateway.authorize(@amount, @credit_card, custom_options)
+    assert_success authorization
+    refute authorization.params["captured"]
+    assert_equal destination, authorization.params["destination"]
     assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
     assert_equal "wow@example.com", authorization.params["metadata"]["email"]
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -857,7 +857,15 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid'}))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/destination=subaccountid/, data)
+      assert_match(/destination\[account\]=subaccountid/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_destination_amount_is_submitted_for_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid', :destination_amount => @amount - 20}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/destination\[amount\]=#{@amount - 20}/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
By default, when no destination amount is present, Stripe applies the
full amount of the transction to the account when creating destination
charges. With this, we'll now be able to specify a destination
amount when both `destination` and `destination_amount` are present.

Ref: https://stripe.com/docs/connect/destination-charges

Remote:
64 tests, 291 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
124 tests, 661 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed