### PR TITLE
Adyen: Support store action

### DIFF
--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -33,7 +33,7 @@ class AdyenTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
 
-    assert_equal '7914775043909934', response.authorization
+    assert_equal '7914775043909934|', response.authorization
     assert response.test?
   end
 
@@ -48,15 +48,15 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934')
-    assert_equal '7914775043909934#8814775564188305', response.authorization
+    assert_equal '8814775564188305|', response.authorization
     assert_success response
     assert response.test?
   end
 
   def test_successful_capture_with_compount_psp_reference
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    response = @gateway.capture(@amount, '7914775043909934#8514775559000000')
-    assert_equal '7914775043909934#8814775564188305', response.authorization
+    response = @gateway.capture(@amount, '8514775559000000')
+    assert_equal '8814775564188305|', response.authorization
     assert_success response
     assert response.test?
   end
@@ -74,7 +74,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
-    assert_equal '7914775043909934#8814775564188305', response.authorization
+    assert_equal '8814775564188305|', response.authorization
     assert response.test?
   end
 
@@ -90,15 +90,15 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_refund
     @gateway.expects(:ssl_post).returns(successful_refund_response)
     response = @gateway.refund(@amount, '7914775043909934')
-    assert_equal '7914775043909934#8514775559925128', response.authorization
+    assert_equal '8514775559925128|', response.authorization
     assert_equal '[refund-received]', response.message
     assert response.test?
   end
 
   def test_successful_refund_with_compound_psp_reference
     @gateway.expects(:ssl_post).returns(successful_refund_response)
-    response = @gateway.refund(@amount, '7914775043909934#8514775559000000')
-    assert_equal '7914775043909934#8514775559925128', response.authorization
+    response = @gateway.refund(@amount, '7914775043909934')
+    assert_equal '8514775559925128|', response.authorization
     assert_equal '[refund-received]', response.message
     assert response.test?
   end
@@ -114,7 +114,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
     response = @gateway.void('7914775043909934')
-    assert_equal '7914775043909934#8614775821628806', response.authorization
+    assert_equal '8614775821628806|', response.authorization
     assert_equal '[cancel-received]', response.message
     assert response.test?
   end
@@ -126,12 +126,28 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal "8835205392522157|8315202663743702", response.authorization
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+
+    response = @gateway.store(@credit_card, @options)
+    assert_failure response
+    assert_equal 'Refused', response.message
+  end
+
   def test_successful_verify
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_verify_response)
     assert_success response
-    assert_equal '7914776426645103', response.authorization
+    assert_equal '7914776426645103|', response.authorization
     assert_equal 'Authorised', response.message
     assert response.test?
   end
@@ -141,7 +157,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_verify_response)
     assert_failure response
-    assert_equal '7914776433387947', response.authorization
+    assert_equal '7914776433387947|', response.authorization
     assert_equal 'Refused', response.message
     assert response.test?
   end
@@ -353,6 +369,18 @@ class AdyenTest < Test::Unit::TestCase
   def failed_authorize_avs_response
     <<-RESPONSE
     {\"additionalData\":{\"cvcResult\":\"0 Unknown\",\"fraudResultType\":\"GREEN\",\"avsResult\":\"3 AVS unavailable\",\"fraudManualReview\":\"false\",\"avsResultRaw\":\"U\",\"refusalReasonRaw\":\"05 : Do not honor\",\"authorisationMid\":\"494619000001174\",\"acquirerCode\":\"AdyenVisa_BR_494619\",\"acquirerReference\":\"802320302458\",\"acquirerAccountCode\":\"AdyenVisa_BR_Cabify\"},\"fraudResult\":{\"accountScore\":0,\"results\":[{\"FraudCheckResult\":{\"accountScore\":0,\"checkId\":46,\"name\":\"DistinctCountryUsageByShopper\"}}]},\"pspReference\":\"1715167376763498\",\"refusalReason\":\"Refused\",\"resultCode\":\"Refused\"}
+    RESPONSE
+  end
+
+  def successful_store_response
+    <<-RESPONSE
+    {"additionalData":{"recurring.recurringDetailReference":"8315202663743702","recurring.shopperReference":"John Smith"},"pspReference":"8835205392522157","resultCode":"Authorised","authCode":"94571"}
+    RESPONSE
+  end
+
+  def failed_store_response
+    <<-RESPONSE
+    {"pspReference":"8835205393394754","refusalReason":"Refused","resultCode":"Refused"}
     RESPONSE
   end
 end


### PR DESCRIPTION
As part of implementation, the previous usage of the authorization_from
method and passing an unnecessary pspReference around was found to be
unnecessary, so was replaced with the split authorization pattern used
for store in other adapters. Also switches Verify to a 0 amount since it
is supported.

Remote:
32 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
19 tests, 91 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed