### PR TITLE
Litle: Add store for echecks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Litle: Add store for echecks [nfarve] #2779
 * Litle: Add Support for Echeck [nfarve] #2776
 * Orbital: Correct level 2 tax handling [deedeelavinder] #2729
 * Payeezy: Change determination method of endpoint for store request [deedeelavinder] #2731

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -120,6 +120,11 @@ module ActiveMerchant #:nodoc:
             doc.orderId(truncate(options[:order_id], 24))
             if payment_method.is_a?(String)
               doc.paypageRegistrationId(payment_method)
+            elsif check?(payment_method)
+              doc.echeckForToken do
+                doc.accNum(payment_method.account_number)
+                doc.routingNum(payment_method.routing_number)
+              end
             else
               doc.accountNumber(payment_method.number)
               doc.cardValidationNum(payment_method.verification_value) if payment_method.verification_value

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -895,6 +895,42 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
   end
 
+  def test53
+    check = check(
+      routing_number: '011100012',
+      account_number: '1099999998'
+    )
+    options     = {
+      :order_id => '53'
+    }
+
+    store_response = @gateway.store(check, options)
+
+    assert_success store_response
+    assert_equal '998', store_response.params['eCheckAccountSuffix']
+    assert_equal 'EC', store_response.params['type']
+    assert_equal '801', store_response.params['response']
+    assert_equal 'Account number was successfully registered', store_response.message
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
+  end
+
+  def test54
+    check = check(
+      routing_number: '1145_7895',
+      account_number: '1022222102'
+    )
+    options     = {
+      :order_id => '54'
+    }
+
+    store_response = @gateway.store(check, options)
+
+    assert_failure store_response
+    assert_equal '900', store_response.params['response']
+    assert_equal 'Invalid Bank Routing Number', store_response.message
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
+  end
+
   # Implicit Token Registration Tests
   def test55
     credit_card = CreditCard.new(:number             => '5435101234510196',

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -75,6 +75,10 @@ class RemoteLitleTest < Test::Unit::TestCase
       account_number: '1099999999',
       account_type: 'Checking'
     )
+    @store_check = check(
+      routing_number: '011100012',
+      account_number: '1099999998'
+    )
   end
 
   def test_successful_authorization
@@ -357,6 +361,19 @@ class RemoteLitleTest < Test::Unit::TestCase
     credit_card = CreditCard.new(@credit_card_hash.merge(:number => '4100280190123000'))
     assert store_response = @gateway.store(credit_card, :order_id => '50')
     assert_success store_response
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(10010, token)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_echeck_store_and_purchase
+    assert store_response = @gateway.store(@store_check)
+    assert_success store_response
+    assert_equal 'Account number was successfully registered', store_response.message
 
     token = store_response.authorization
     assert_equal store_response.params['litleToken'], token


### PR DESCRIPTION
Adds the ability to store ehecks if merchant has enabled the
tokenization feature.

Loaded suite test/remote/gateways/remote_litle_test
.....................................

37 tests, 145 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Loaded suite test/unit/gateways/litle_test
...................................

35 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------