### PR TITLE
Adds new Punto Pagos gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/punto_pagos.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos.rb
@@ -1,0 +1,176 @@
+require 'active_merchant/billing/gateways/punto_pagos/authorization.rb'
+require 'active_merchant/billing/gateways/punto_pagos/request.rb'
+require 'active_merchant/billing/gateways/punto_pagos/purchase_request.rb'
+require 'active_merchant/billing/gateways/punto_pagos/status_request.rb'
+require 'active_merchant/billing/gateways/punto_pagos/response.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PuntoPagosGateway < Gateway
+      self.test_url = 'http://sandbox.puntopagos.com'
+      self.live_url = 'https://www.puntopagos.com'
+
+      self.supported_countries = %w(CL)
+      self.default_currency = 'CLP'
+      self.currencies_without_fractions = %w(CLP)
+      self.money_format = :cents
+
+      self.homepage_url = 'https://www.puntopagos.com'
+      self.display_name = 'Punto Pagos'
+
+      SUCCESS_CODE = '00'
+      ERROR_CODE = '99'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        ERROR_CODE => STANDARD_ERROR_CODE[:processing_error],
+        '1' => STANDARD_ERROR_CODE[:processing_error],
+        '2' => STANDARD_ERROR_CODE[:processing_error],
+        '6' => STANDARD_ERROR_CODE[:processing_error],
+        '7' => STANDARD_ERROR_CODE[:processing_error]
+      }
+
+      PAYMENT_METHOD_CODE_MAPPING = {
+        presto: 2,
+        webpay_transbank: 3,
+        banco_chile: 4,
+        bci: 5,
+        tbanc: 6,
+        banco_estado: 7,
+        bbva: 16,
+        ripley: 10,
+        paypal: 15
+      }
+
+      def initialize(options = {})
+        requires!(options, :key, :secret)
+        super
+      end
+
+      def setup_purchase(money, params = {})
+        requires!(params, :trx_id)
+
+        post = {}
+        add_invoice(post, money, params)
+        add_payment_method(post, params)
+        add_trx_id(post, params)
+        add_gateway_config(post)
+
+        request = PuntoPagos::PurchaseRequest.new(post)
+        response = parse(ssl_post(request.endpoint, request.data, request.headers))
+        build_response(response)
+      end
+
+      def details_for(params)
+        requires!(params, :token, :trx_id, :amount)
+        add_gateway_config(params)
+
+        request = PuntoPagos::StatusRequest.new(params)
+        response = parse(ssl_get(request.endpoint, request.headers))
+        build_response(response)
+      end
+
+      def redirect_url_for(token)
+        "#{url}/transaccion/procesar/#{token}"
+      end
+
+      def notificate(params = {})
+        validate_notification_params!(params)
+        response = details_for(params)
+
+        if response.success?
+          { respuesta: SUCCESS_CODE, token: response.token }
+        else
+          { respuesta: ERROR_CODE, error: response.message, token: response.token }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.gsub(/(Autorizacion: ).+[^\r\n]/, '\1[FILTERED]')
+      end
+
+      private
+
+      def validate_notification_params!(params)
+        requires!(params, :authorization, :timestamp, :token, :trx_id, :amount)
+
+        signature = PuntoPagos::Authorization.new(options).sign(
+          'transaccion/notificacion',
+          params[:token],
+          params[:trx_id],
+          "%0.2f" % params[:amount].to_s.to_i,
+          params[:timestamp]
+        )
+
+        raise StandardError, 'Invalid notification signature' if signature != params[:authorization]
+      end
+
+      def add_invoice(post, money, params)
+        post[:amount] = localized_amount(money, allowed_currency(params))
+      end
+
+      def add_payment_method(post, params)
+        return if params[:payment_method].blank?
+        code = PAYMENT_METHOD_CODE_MAPPING[params[:payment_method].to_sym]
+        raise ArgumentError.new("Invalid payment type: #{params[:payment_method]}") unless code
+        post[:payment_method] = code
+      end
+
+      def add_trx_id(post, params)
+        post[:trx_id] = params[:trx_id]
+      end
+
+      def add_gateway_config(post)
+        post[:url] = url
+        post[:key] = options[:key]
+        post[:secret] = options[:secret]
+      end
+
+      def allowed_currency(params)
+        provided_currency = params[:currency] || default_currency
+        return provided_currency if provided_currency == 'CLP'
+        raise ArgumentError.new("Unsupported currency: #{provided_currency}")
+      end
+
+      def parse(body)
+        return {} if body.blank?
+        JSON.parse(body)
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def build_response(raw_response)
+        PuntoPagos::Response.new(
+          success_from(raw_response),
+          message_from(raw_response),
+          raw_response,
+          test: test?,
+          error_code: error_code_from(raw_response),
+          authorization: authorization_from(raw_response)
+        )
+      end
+
+      def success_from(response)
+        response['respuesta'] == SUCCESS_CODE
+      end
+
+      def message_from(response)
+        return 'Success' if success_from(response)
+        response['error']
+      end
+
+      def error_code_from(response)
+        STANDARD_ERROR_CODE_MAPPING[response['respuesta']]
+      end
+
+      def authorization_from(response)
+        response['token']
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/punto_pagos/authorization.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos/authorization.rb
@@ -1,0 +1,20 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module PuntoPagos #:nodoc:
+      class Authorization
+        def initialize(params)
+          @key = params[:key]
+          @secret = params[:secret]
+          raise ArgumentError.new("Invalid key") if @key.blank?
+          raise ArgumentError.new("Invalid secret") if @secret.blank?
+        end
+
+        def sign(*message)
+          digest = OpenSSL::HMAC.digest('sha1', @secret, message.join("\n"))
+          encoded_string = Base64.encode64(digest).chomp
+          "PP " + @key + ":" + encoded_string
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/punto_pagos/purchase_request.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos/purchase_request.rb
@@ -1,0 +1,46 @@
+require 'active_merchant/billing/gateways/punto_pagos/request.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module PuntoPagos #:nodoc:
+      class PurchaseRequest < Request
+        def endpoint
+          [url, function].join('/')
+        end
+
+        def data
+          r = {
+            'trx_id' => trx_id_to_s,
+            'monto' => amount_to_s
+          }
+
+          r['medio_pago'] = payment_method if payment_method
+          r.to_json
+        end
+
+        private
+
+        def payment_method
+          params[:payment_method]
+        end
+
+        def message
+          [
+            function,
+            trx_id_to_s,
+            amount_to_s,
+            timestamp
+          ]
+        end
+
+        def function
+          [path, action].join('/')
+        end
+
+        def action
+          'crear'
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/punto_pagos/request.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos/request.rb
@@ -1,0 +1,68 @@
+require 'base64'
+require 'openssl'
+require 'active_merchant/billing/gateways/punto_pagos/authorization.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module PuntoPagos #:nodoc:
+      class Request
+        attr_reader :url, :params
+
+        def initialize(params)
+          @url = params[:url]
+          @key = params[:key]
+          @secret = params[:secret]
+          @params = params
+        end
+
+        def headers
+          {
+            'Accept' => 'application/json',
+            'Accept-Charset' => 'utf-8',
+            'Content-Type' => 'application/json; charset=utf-8',
+            'Fecha' => timestamp,
+            'Autorizacion' => signature
+          }
+        end
+
+        def endpoint
+          raise NotImplementedError
+        end
+
+        def message
+          raise NotImplementedError
+        end
+
+        private
+
+        def action
+          raise NotImplementedError
+        end
+
+        def trx_id_to_s
+          params[:trx_id].to_s
+        end
+
+        def amount_to_s
+          "%0.2f" % params[:amount].to_s.to_i
+        end
+
+        def function
+          [path, action].join('/')
+        end
+
+        def path
+          'transaccion'
+        end
+
+        def signature
+          @signature ||= Authorization.new(key: @key, secret: @secret).sign(*message)
+        end
+
+        def timestamp
+          @timestamp ||= Time.now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/punto_pagos/response.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos/response.rb
@@ -1,0 +1,67 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module PuntoPagos #:nodoc:
+      class Response < Response
+        def token
+          @params['token']
+        end
+
+        def trx_id
+          @params['trx_id']
+        end
+
+        def code
+          @params['respuesta']
+        end
+
+        def auth_code
+          @params['codigo_autorizacion']
+        end
+
+        def approved_at
+          @params['fecha_aprobacion']
+        end
+
+        def payment_method
+          @params['medio_pago']
+        end
+
+        def payment_method_description
+          @params['medio_pago_descripcion']
+        end
+
+        def amount
+          @params['monto']
+        end
+
+        def shares
+          @params['num_cuotas']
+        end
+
+        def share_value
+          @params['valor_cuota']
+        end
+
+        def share_type
+          @params['tipo_cuotas']
+        end
+
+        def card_number
+          @params['numero_tarjeta']
+        end
+
+        def operation_number
+          @params['numero_operacion']
+        end
+
+        def first_expiration
+          @params['primer_vencimiento']
+        end
+
+        def payment_type
+          @params['tipo_pago']
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/punto_pagos/status_request.rb
+++ b/lib/active_merchant/billing/gateways/punto_pagos/status_request.rb
@@ -1,0 +1,33 @@
+require 'active_merchant/billing/gateways/punto_pagos/request.rb'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    module PuntoPagos #:nodoc:
+      class StatusRequest < Request
+        def endpoint
+          [url, path, token].join('/')
+        end
+
+        private
+
+        def token
+          params[:token]
+        end
+
+        def message
+          [
+            function,
+            token,
+            trx_id_to_s,
+            amount_to_s,
+            timestamp
+          ]
+        end
+
+        def action
+          'traer'
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -832,6 +832,10 @@ psl_visa_debit_address:
   state:
   zip:
 
+punto_pagos:
+  key: KEY
+  secret: VALUE
+
 pxpay:
   login: LOGIN
   password: PASSWORD

--- a/test/remote/gateways/remote_punto_pagos_test.rb
+++ b/test/remote/gateways/remote_punto_pagos_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class RemotePuntoPagosTest < Test::Unit::TestCase
+  def setup
+    @now = Time.new(2018, 3, 1)
+    Time.stubs(:now).returns(@now)
+    @timestamp = Time.now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    @config = fixtures(:punto_pagos)
+    @gateway = PuntoPagosGateway.new(@config)
+    @amount = 9999
+    @str_amount = '100.00'
+    @trx_id = 10
+
+    @purchase_options = { trx_id: @trx_id }
+
+    @details_options = {
+      trx_id: @trx_id,
+      amount: 100
+    }
+
+    @notificate_options = {
+      trx_id: @trx_id,
+      amount: 100,
+      timestamp: @timestamp
+    }
+  end
+
+  def test_successful_purchase_setup
+    response = @gateway.setup_purchase(@amount, @purchase_options)
+    assert_purchase_setup_success(response)
+  end
+
+  def test_successful_purchase_setup_with_payment_method
+    @purchase_options[:payment_method] = :ripley
+
+    response = @gateway.setup_purchase(@amount, @purchase_options)
+    assert_purchase_setup_success(response)
+  end
+
+  def test_failed_purchase_setup_with_invalid_trx_id
+    @purchase_options[:trx_id] = ''
+
+    response = @gateway.setup_purchase(@amount, @purchase_options)
+    assert_request_failure(response, '99', 'Input string was not in a correct format.')
+  end
+
+  def test_failed_purchase_setup_with_invalid_credentials
+    @gateway = PuntoPagosGateway.new(key: 'X', secret: 'Y')
+
+    response = @gateway.setup_purchase(@amount, @purchase_options)
+    assert_request_failure(response, '99', 'La llave no existe')
+  end
+
+  def test_notification_with_incomplete_transaction
+    purchase_response = @gateway.setup_purchase(@amount, @purchase_options)
+    @notificate_options[:token] = purchase_response.token
+    @notificate_options[:authorization] = build_notification_signature(purchase_response.token)
+
+    response = @gateway.notificate(@notificate_options)
+    assert_equal purchase_response.token, response[:token]
+    assert_equal 'Transaccion incompleta', response[:error]
+    assert_equal '99', response[:respuesta]
+  end
+
+  def test_details_for_with_failed_transaction
+    purchase_response = @gateway.setup_purchase(@amount, @purchase_options)
+    @details_options[:token] = purchase_response.token
+
+    response = @gateway.details_for(@details_options)
+    assert_request_failure(response, '6', 'Transaccion incompleta')
+  end
+
+  private
+
+  def assert_purchase_setup_success(response)
+    assert response.success?
+    assert response.test?
+    assert_equal '00', response.code
+    assert_equal 'Success', response.message
+    assert_nil response.error_code
+    assert !response.authorization.blank?
+    assert !response.token.blank?
+    assert !response.trx_id.blank?
+  end
+
+  def assert_request_failure(response, code, message)
+    assert !response.success?
+    assert response.test?
+    assert_equal code, response.code
+    assert_equal message, response.message
+    assert_equal 'processing_error', response.error_code
+  end
+
+  def assert_purchase_failure(response, code, message)
+    assert_request_failure(response, code, message)
+    assert response.authorization.blank?
+    assert response.token.blank?
+    assert response.trx_id.blank?
+  end
+
+  def build_notification_signature(token)
+    ActiveMerchant::Billing::PuntoPagos::Authorization.new(@config).sign(
+      'transaccion/notificacion',
+      token,
+      @trx_id,
+      @str_amount,
+      @timestamp
+    )
+  end
+end

--- a/test/unit/gateways/punto_pagos/authorization_test.rb
+++ b/test/unit/gateways/punto_pagos/authorization_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../../../lib/active_merchant/billing/gateways/punto_pagos/authorization')
+
+class PuntoPagosAuthorizationTest < Test::Unit::TestCase
+  def setup
+    @auth_class = ActiveMerchant::Billing::PuntoPagos::Authorization
+    @authorization = @auth_class.new(key: 'k', secret: 's')
+  end
+
+  def test_failed_initialization_with_invalid_keys
+    assert_raise_message('Invalid key') do
+      @auth_class.new(key: '', secret: 's')
+    end
+
+    assert_raise_message('Invalid secret') do
+      @auth_class.new(key: 'k', secret: nil)
+    end
+  end
+
+  def test_successful_sign
+    assert_equal('PP k:foLweXBORVOYonstrW1kd3TLcMk=', @authorization.sign("a", "b", "c"))
+  end
+end

--- a/test/unit/gateways/punto_pagos/purchase_request_test.rb
+++ b/test/unit/gateways/punto_pagos/purchase_request_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../../../lib/active_merchant/billing/gateways/punto_pagos/purchase_request')
+
+class PuntoPagosPurchaseRequestTest < Test::Unit::TestCase
+  def setup
+    Time.stubs(:now).returns(Time.new(1984, 6, 4))
+    @request_class = ActiveMerchant::Billing::PuntoPagos::PurchaseRequest
+    @request = @request_class.new(
+      key: 'k',
+      secret: 's',
+      url: 'some-url',
+      trx_id: 123,
+      amount: 1000,
+      payment_method: 1
+    )
+  end
+
+  def test_headers
+    headers = @request.headers
+    assert_equal('application/json', headers['Accept'])
+    assert_equal('utf-8', headers['Accept-Charset'])
+    assert_equal('application/json; charset=utf-8', headers['Content-Type'])
+    assert_equal('PP k:wbDLfr22QQNDrYNv2ayJUhebljs=', headers['Autorizacion'])
+    assert_equal('Mon, 04 Jun 1984 00:00:00 GMT', headers['Fecha'])
+  end
+
+  def test_data
+    data = JSON.parse(@request.data)
+    assert_equal('123', data['trx_id'])
+    assert_equal('1000.00', data['monto'])
+    assert_equal(1, data['medio_pago'])
+  end
+
+  def test_endpoint
+    assert_equal('some-url/transaccion/crear', @request.endpoint)
+  end
+end

--- a/test/unit/gateways/punto_pagos/response_test.rb
+++ b/test/unit/gateways/punto_pagos/response_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../../../lib/active_merchant/billing/gateways/punto_pagos/response')
+
+class PuntoPagosResponseTest < Test::Unit::TestCase
+  def setup
+    @response_class = ActiveMerchant::Billing::PuntoPagos::Response
+
+    params = [
+      'token',
+      'trx_id',
+      'codigo_autorizacion',
+      'fecha_aprobacion',
+      'medio_pago',
+      'medio_pago_descripcion',
+      'monto',
+      'num_cuotas',
+      'valor_cuota',
+      'tipo_cuotas',
+      'numero_tarjeta',
+      'numero_operacion',
+      'primer_vencimiento',
+      'tipo_pago'
+    ].inject({}) do |result, attribute|
+      result[attribute] = attribute
+      result
+    end
+
+    @response = @response_class.new(nil, nil, params)
+  end
+
+  def test_attributes
+    assert_equal('token', @response.token)
+    assert_equal('trx_id', @response.trx_id)
+    assert_equal('codigo_autorizacion', @response.auth_code)
+    assert_equal('fecha_aprobacion', @response.approved_at)
+    assert_equal('medio_pago', @response.payment_method)
+    assert_equal('medio_pago_descripcion', @response.payment_method_description)
+    assert_equal('monto', @response.amount)
+    assert_equal('num_cuotas', @response.shares)
+    assert_equal('valor_cuota', @response.share_value)
+    assert_equal('tipo_cuotas', @response.share_type)
+    assert_equal('numero_tarjeta', @response.card_number)
+    assert_equal('numero_operacion', @response.operation_number)
+    assert_equal('primer_vencimiento', @response.first_expiration)
+    assert_equal('tipo_pago', @response.payment_type)
+  end
+end

--- a/test/unit/gateways/punto_pagos/status_request_test.rb
+++ b/test/unit/gateways/punto_pagos/status_request_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../../../lib/active_merchant/billing/gateways/punto_pagos/status_request')
+
+class PuntoPagosStatusRequestTest < Test::Unit::TestCase
+  def setup
+    Time.stubs(:now).returns(Time.new(1984, 6, 4))
+    @request_class = ActiveMerchant::Billing::PuntoPagos::StatusRequest
+    @request = @request_class.new(
+      key: 'k',
+      secret: 's',
+      url: 'some-url',
+      token: 'xxx'
+    )
+  end
+
+  def test_headers
+    headers = @request.headers
+    assert_equal('application/json', headers['Accept'])
+    assert_equal('utf-8', headers['Accept-Charset'])
+    assert_equal('application/json; charset=utf-8', headers['Content-Type'])
+    assert_equal('PP k:bFpoEFFCtzgHrFwyxoHcSgpeR6o=', headers['Autorizacion'])
+    assert_equal('Mon, 04 Jun 1984 00:00:00 GMT', headers['Fecha'])
+  end
+
+  def test_endpoint
+    assert_equal('some-url/transaccion/xxx', @request.endpoint)
+  end
+end

--- a/test/unit/gateways/punto_pagos_test.rb
+++ b/test/unit/gateways/punto_pagos_test.rb
@@ -1,0 +1,439 @@
+require 'test_helper'
+
+class PuntoPagosTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @url = PuntoPagosGateway.test_url
+    Time.stubs(:now).returns(Time.new(1984, 6, 4))
+    @timestamp = 'Mon, 04 Jun 1984 00:00:00 GMT'
+    @gateway = PuntoPagosGateway.new(key: "KEY", secret: "SECRET")
+    @amount = 9999
+    @trx_id = 10
+    @token = 'P54L1SGNVJHE6VV1'
+    @authorization = 'PP KEY:Q2AsxwHWW3Bfe9bO56KVixzJDig='
+
+    @purchase_options = { trx_id: @trx_id }
+
+    @details_options = {
+      trx_id: @trx_id,
+      amount: @amount,
+      token: @token
+    }
+
+    @notification_options = {
+      trx_id: @trx_id,
+      amount: @amount,
+      token: @token,
+      authorization: @authorization,
+      timestamp: @timestamp
+    }
+  end
+
+  def test_urls
+    assert_equal 'http://sandbox.puntopagos.com', PuntoPagosGateway.test_url
+    assert_equal 'https://www.puntopagos.com', PuntoPagosGateway.live_url
+  end
+
+  def test_default_currency
+    assert_equal 'CLP', PuntoPagosGateway.default_currency
+  end
+
+  def test_currencies_without_fractions
+    assert_equal %w(CLP), PuntoPagosGateway.currencies_without_fractions
+  end
+
+  def test_supported_countries
+    assert_equal %w(CL), PuntoPagosGateway.supported_countries
+  end
+
+  def test_money_format
+    assert_equal :cents, PuntoPagosGateway.money_format
+  end
+
+  def test_homepage_url
+    assert_equal 'https://www.puntopagos.com', PuntoPagosGateway.homepage_url
+  end
+
+  def test_display_name
+    assert_equal 'Punto Pagos', PuntoPagosGateway.display_name
+  end
+
+  def test_initialize_with_missing_secret_credential
+    assert_raise_message("Missing required parameter: secret") do
+      PuntoPagosGateway.new(key: "KEY")
+    end
+  end
+
+  def test_initialize_with_missing_key_credential
+    assert_raise_message("Missing required parameter: key") do
+      PuntoPagosGateway.new(secret: "SECRET")
+    end
+  end
+
+  def test_successful_purchase_setup
+    response = stub_comms do
+      @gateway.setup_purchase(@amount, @purchase_options)
+    end.check_request do |endpoint, data, headers|
+      expected_data = { 'trx_id' => '10', 'monto' => '100.00' }
+      check_punto_pagos_request(endpoint, data, headers, expected_data, 'transaccion/crear')
+    end.respond_with(successful_purchase_setup_response)
+
+    assert_purchase_setup_success(response)
+  end
+
+  def test_successful_purchase_setup_with_payment_method
+    @purchase_options[:payment_method] = :ripley
+
+    response = stub_comms do
+      @gateway.setup_purchase(@amount, @purchase_options)
+    end.check_request do |endpoint, data, headers|
+      expected_data = { 'medio_pago' => 10, 'trx_id' => '10', 'monto' => '100.00' }
+      check_punto_pagos_request(endpoint, data, headers, expected_data, 'transaccion/crear')
+    end.respond_with(successful_purchase_setup_response)
+
+    assert_purchase_setup_success(response)
+  end
+
+  def test_failed_purchase_setup_with_invalid_trx_id
+    @purchase_options = { trx_id: "" }
+
+    response = stub_comms do
+      @gateway.setup_purchase(@amount, @purchase_options)
+    end.check_request do |endpoint, data, headers|
+      expected_data = { 'trx_id' => '', 'monto' => '100.00' }
+      check_punto_pagos_request(endpoint, data, headers, expected_data, 'transaccion/crear')
+    end.respond_with(failed_purchase_setup_response)
+
+    assert_purchase_setup_failure(response)
+  end
+
+  def test_failed_purchase_setup_with_missing_trx_id
+    assert_raise_message("Missing required parameter: trx_id") do
+      @gateway.setup_purchase(@amount, {})
+    end
+  end
+
+  def test_failed_purchase_setup_with_invalid_payment_method
+    @purchase_options[:payment_method] = 'invalid'
+
+    assert_raise_message("Invalid payment type: invalid") do
+      @gateway.setup_purchase(@amount, @purchase_options)
+    end
+  end
+
+  def test_failed_purchase_setup_with_unsupported_currency
+    @purchase_options[:currency] = 'USD'
+
+    assert_raise_message("Unsupported currency: USD") do
+      @gateway.setup_purchase(@amount, @purchase_options)
+    end
+  end
+
+  def test_redirect_url_for
+    assert_equal("#{@url}/transaccion/procesar/#{@token}", @gateway.redirect_url_for(@token))
+  end
+
+  def test_successful_details
+    response = stub_comms(@gateway, :ssl_get) do
+      @gateway.details_for(@details_options)
+    end.check_request do |endpoint, headers|
+      check_punto_pagos_request(endpoint, nil, headers, nil, "transaccion/#{@token}")
+    end.respond_with(successful_details_response)
+
+    assert_details_success(response)
+  end
+
+  def test_failed_details
+    response = stub_comms(@gateway, :ssl_get) do
+      @gateway.details_for(@details_options)
+    end.check_request do |endpoint, headers|
+      check_punto_pagos_request(endpoint, nil, headers, nil, "transaccion/#{@token}")
+    end.respond_with(failed_details_response)
+
+    assert_details_failure(response, '6', 'Transaccion incompleta')
+  end
+
+  def test_failed_details_with_missing_token
+    @details_options.delete(:token)
+
+    assert_raise_message("Missing required parameter: token") do
+      @gateway.details_for(@details_options)
+    end
+  end
+
+  def test_failed_details_with_missing_trx_id
+    @details_options.delete(:trx_id)
+
+    assert_raise_message("Missing required parameter: trx_id") do
+      @gateway.details_for(@details_options)
+    end
+  end
+
+  def test_failed_details_with_missing_amount
+    @details_options.delete(:amount)
+
+    assert_raise_message("Missing required parameter: amount") do
+      @gateway.details_for(@details_options)
+    end
+  end
+
+  def test_successful_notification
+    response = stub_comms(@gateway, :ssl_get) do
+      @gateway.notificate(@notification_options)
+    end.check_request do |endpoint, headers|
+      check_punto_pagos_request(endpoint, nil, headers, nil, "transaccion/#{@token}")
+    end.respond_with(successful_details_response)
+
+    assert_notification_success(response)
+  end
+
+  def test_notification_with_incomplete_transaction
+    @notification_options[:error] = 'error'
+
+    response = stub_comms(@gateway, :ssl_get) do
+      @gateway.notificate(@notification_options)
+    end.check_request do |endpoint, headers|
+      check_punto_pagos_request(endpoint, nil, headers, nil, "transaccion/#{@token}")
+    end.respond_with(failed_details_response)
+
+    assert_notification_failure(response, 'Transaccion incompleta')
+  end
+
+  def test_failed_notification_with_missing_token
+    @notification_options.delete(:token)
+
+    assert_raise_message("Missing required parameter: token") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_missing_trx_id
+    @notification_options.delete(:trx_id)
+
+    assert_raise_message("Missing required parameter: trx_id") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_missing_amount
+    @notification_options.delete(:amount)
+
+    assert_raise_message("Missing required parameter: amount") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_missing_timestamp
+    @notification_options.delete(:timestamp)
+
+    assert_raise_message("Missing required parameter: timestamp") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_missing_authorization
+    @notification_options.delete(:authorization)
+
+    assert_raise_message("Missing required parameter: authorization") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_invalid_timestamp
+    @notification_options[:timestamp] = "invalid"
+
+    assert_raise_message("Invalid notification signature") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_failed_notification_with_invalid_authorization
+    @notification_options[:authorization] = "invalid"
+
+    assert_raise_message("Invalid notification signature") do
+      @gateway.notificate(@notification_options)
+    end
+  end
+
+  def test_scrub
+    assert_equal(post_scrubbed, @gateway.scrub(pre_scrubbed))
+  end
+
+  private
+
+  def check_punto_pagos_request(endpoint, data, headers, expected_data, action)
+    assert_equal("#{@url}/#{action}", endpoint)
+    assert_equal(expected_data, JSON.parse(data)) if data && expected_data
+    assert_equal(@timestamp, headers["Fecha"])
+    assert_match(/\APP\sKEY:.+=\z/, headers["Autorizacion"])
+  end
+
+  def assert_details_success(response)
+    assert_success(response)
+    assert(response.test?)
+    assert_equal(@token, response.token)
+    assert_equal(@trx_id.to_s, response.trx_id)
+    assert_equal('Success', response.message)
+    assert_equal('00', response.code)
+    assert_equal('codigo_autorizacion', response.auth_code)
+    assert_equal('fecha_aprobacion', response.approved_at)
+    assert_equal('medio_pago', response.payment_method)
+    assert_equal('medio_pago_descripcion', response.payment_method_description)
+    assert_equal('monto', response.amount)
+    assert_equal('num_cuotas', response.shares)
+    assert_equal('valor_cuota', response.share_value)
+    assert_equal('tipo_cuotas', response.share_type)
+    assert_equal('numero_tarjeta', response.card_number)
+    assert_equal('numero_operacion', response.operation_number)
+    assert_equal('primer_vencimiento', response.first_expiration)
+    assert_equal('tipo_pago', response.payment_type)
+  end
+
+  def assert_purchase_setup_success(response)
+    assert_success(response)
+    assert_equal(@token, response.authorization)
+    assert_equal('Success', response.message)
+    assert(response.test?)
+  end
+
+  def assert_notification_success(response)
+    assert_equal('00', response[:respuesta])
+    assert_equal(@token, response[:token])
+  end
+
+  def assert_purchase_setup_failure(response)
+    assert_failure(response)
+    assert_nil(response.authorization)
+    assert(response.test?)
+  end
+
+  def assert_details_failure(response, code, message)
+    assert_failure(response)
+    assert(response.test?)
+    assert_equal(message, response.message)
+    assert_equal(code, response.code)
+    assert_equal(@token, response.token)
+    assert_equal(@token, response.authorization)
+  end
+
+  def assert_notification_failure(response, error)
+    assert_equal('99', response[:respuesta])
+    assert_equal(@token, response[:token])
+    assert_equal(error, response[:error])
+  end
+
+  def successful_purchase_setup_response
+    <<-RESPONSE
+    {
+      "error": null,
+      "monto": "100.00",
+      "respuesta": "00",
+      "token": "#{@token}",
+      "trx_id": "10"
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_setup_response
+    <<-RESPONSE
+    {
+      "error": "Input string was not in a correct format.",
+      "monto": "0",
+      "respuesta": "99",
+      "token": null,
+      "trx_id": null
+    }
+    RESPONSE
+  end
+
+  def successful_details_response
+    <<-RESPONSE
+    {
+      "codigo_autorizacion": "codigo_autorizacion",
+      "error": null,
+      "fecha_aprobacion": "fecha_aprobacion",
+      "medio_pago": "medio_pago",
+      "medio_pago_descripcion": "medio_pago_descripcion",
+      "monto": "monto",
+      "num_cuotas": "num_cuotas",
+      "numero_operacion": "numero_operacion",
+      "numero_tarjeta": "numero_tarjeta",
+      "primer_vencimiento": "primer_vencimiento",
+      "respuesta": "00",
+      "tipo_cuotas": "tipo_cuotas",
+      "tipo_pago": "tipo_pago",
+      "token": "#{@token}",
+      "trx_id": "#{@trx_id}",
+      "valor_cuota": "valor_cuota"
+    }
+    RESPONSE
+  end
+
+  def failed_details_response
+    <<-RESPONSE
+    {
+      "codigo_autorizacion": null,
+      "error": "Transaccion incompleta",
+      "fecha_aprobacion": null,
+      "medio_pago": null,
+      "medio_pago_descripcion": null,
+      "monto": 0,
+      "num_cuotas": 0,
+      "numero_operacion": 0,
+      "numero_tarjeta": null,
+      "primer_vencimiento": null,
+      "respuesta": "6",
+      "tipo_cuotas": null,
+      "tipo_pago": null,
+      "token": "#{@token}",
+      "trx_id": null,
+      "valor_cuota": 0
+    }
+    RESPONSE
+  end
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to sandbox.puntopagos.com:80...
+      opened
+      <- "POST /transaccion/crear HTTP/1.1\r\nContent-Type: application/json; charset=utf-8\r\nAccept: application/json\r\nAccept-Charset: utf-8\r\nFecha: Thu, 01 Mar 2018 00:00:00 GMT\r\nAutorizacion: PP Qxp1tuu5410mIEKKS1cx:j3ke5PzhZSH6X+5/iXeKtiNkmwQ=\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.puntopagos.com\r\nContent-Length: 48\r\n\r\n"
+      <- "{\"trx_id\":\"10\",\"monto\":\"100.00\",\"medio_pago\":10}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: private\r\n"
+      -> "Content-Length: 87\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Server: Microsoft-IIS/7.0\r\n"
+      -> "X-AspNet-Version: 4.0.30319\r\n"
+      -> "Date: Fri, 09 Mar 2018 17:02:39 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "\r\n"
+      reading 87 bytes...
+      -> "{\"error\":null,\"monto\":100.00,\"respuesta\":\"00\",\"token\":\"P5C20F7EACAHQM5E\",\"trx_id\":\"10\"}"
+      read 87 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to sandbox.puntopagos.com:80...
+      opened
+      <- "POST /transaccion/crear HTTP/1.1\r\nContent-Type: application/json; charset=utf-8\r\nAccept: application/json\r\nAccept-Charset: utf-8\r\nFecha: Thu, 01 Mar 2018 00:00:00 GMT\r\nAutorizacion: [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.puntopagos.com\r\nContent-Length: 48\r\n\r\n"
+      <- "{\"trx_id\":\"10\",\"monto\":\"100.00\",\"medio_pago\":10}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: private\r\n"
+      -> "Content-Length: 87\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Server: Microsoft-IIS/7.0\r\n"
+      -> "X-AspNet-Version: 4.0.30319\r\n"
+      -> "Date: Fri, 09 Mar 2018 17:02:39 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "\r\n"
+      reading 87 bytes...
+      -> "{\"error\":null,\"monto\":100.00,\"respuesta\":\"00\",\"token\":\"P5C20F7EACAHQM5E\",\"trx_id\":\"10\"}"
+      read 87 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+end


### PR DESCRIPTION
I made a gateway to integrate https://www.puntopagos.com (a Chilean service for payments)
https://www.puntopagos.com/Home/Integracion
https://github.com/PuntoPagos/documentacion

Form the [contributing](https://github.com/activemerchant/active_merchant/wiki/contributing) section:

 > Include `test/fixtures.yml` if the gateway’s test credentials are shareable (recommended)

 the key and secret are not shareable. You need to contact with puntopagos to get sandbox access.

> Must have unit tests and functional remote tests

* Unit

<img width="690" alt="unit" src="https://user-images.githubusercontent.com/3026413/37232871-9a6dd7a2-23cf-11e8-95f2-2ab0bba3dc9f.png">

* Remote

<img width="622" alt="remote" src="https://user-images.githubusercontent.com/3026413/37232881-a7ab4ed6-23cf-11e8-97b0-306ace9356f1.png">

> Remote tests for a gateway should cover all supported transaction methods (auth, purchase, capture, refund, void, verify, store and scrub) and validate critical response formats such as charge amounts

Punto Pagos works like `PaypalExpressGateway`. Because of this, the generated template did not fit. So, I improvised a bit and copied from that gateway.

> Your code should support all the Ruby versions and ActiveSupport versions we have enabled on Travis CI

Done.

> No new gem dependencies will be accepted

No new dependencies added.

----

Finally, a working example:

![punto-pagosexample-success](https://user-images.githubusercontent.com/3026413/37313136-a72b9e70-262c-11e8-93ba-565706e2f8c7.gif)
