### PR TITLE
Adyen: Support store action

### DIFF
--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -127,6 +127,39 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Original pspReference required for this operation', response.message
   end
 
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert !response.authorization.split("#")[2].nil?
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_failed_store
+    assert response = @gateway.store(@declined_card, @options)
+
+    assert_failure response
+    assert_equal 'Refused', response.message
+  end
+
+  def test_successful_purchase_using_stored_card
+    assert store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+
+    response = @gateway.purchase(@amount, store_response.authorization, @options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_authorize_using_stored_card
+    assert store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+
+    response = @gateway.authorize(@amount, store_response.authorization, @options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response


### PR DESCRIPTION
As part of implementation, I preserved the behavior of retaining
original psp references for refunds, and account for backwards
compatability with pre-existing non-compound authorizations. Also
removes an irrelevant test case (a capture should never have a compound
authorization) and switches Verify to a 0 amount, since it is supported.

Remote:
32 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
18 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed