### PR TITLE
Psigate: Update Test URL and Card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Stripe: Support destination amount [dtykocki] #2777
 * GlobalCollect: Update supported country list [dtykocki] #2783
 * Adyen: Support store action [curiousepic] #2784
+* Psigate: Update Test URL and Card [nfarve] #2785
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
     #   :email => 'jack@yahoo.com'
     # )
     class PsigateGateway < Gateway
-      self.test_url  = 'https://dev.psigate.com:7989/Messenger/XMLMessenger'
+      self.test_url  = 'https://staging.psigate.com:17989/Messenger/XMLMessenger'
       self.live_url  = 'https://secure.psigate.com:17934/Messenger/XMLMessenger'
 
       self.supported_cardtypes = [:visa, :master, :american_express]

--- a/test/remote/gateways/remote_psigate_test.rb
+++ b/test/remote/gateways/remote_psigate_test.rb
@@ -5,9 +5,10 @@ class PsigateRemoteTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
     @gateway = PsigateGateway.new(fixtures(:psigate))
+    PsigateGateway.ssl_strict = false
 
     @amount = 2400
-    @creditcard = credit_card('4242424242424242')
+    @creditcard = credit_card('4111111111111111')
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,


### PR DESCRIPTION
Update the test url and the test card number for Psigate.

Loaded suite test/remote/gateways/remote_psigate_test
......

6 tests, 20 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Loaded suite test/unit/gateways/psigate_test
...........

11 tests, 28 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------