### PR TITLE
PayULatam: Support language parameter

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
       def capture(amount, authorization, options={})
         post = {}
 
-        add_credentials(post, 'SUBMIT_TRANSACTION')
+        add_credentials(post, 'SUBMIT_TRANSACTION', options)
         add_transaction_elements(post, 'CAPTURE', options)
         add_reference(post, authorization)
 
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options={})
         post = {}
 
-        add_credentials(post, 'SUBMIT_TRANSACTION')
+        add_credentials(post, 'SUBMIT_TRANSACTION', options)
         add_transaction_elements(post, 'VOID', options)
         add_reference(post, authorization)
 
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
       def refund(amount, authorization, options={})
         post = {}
 
-        add_credentials(post, 'SUBMIT_TRANSACTION')
+        add_credentials(post, 'SUBMIT_TRANSACTION', options)
         add_transaction_elements(post, 'REFUND', options)
         add_reference(post, authorization)
 
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def auth_or_sale(post, transaction_type, amount, payment_method, options)
-        add_credentials(post, 'SUBMIT_TRANSACTION')
+        add_credentials(post, 'SUBMIT_TRANSACTION', options)
         add_transaction_elements(post, transaction_type, options)
         add_order(post, options)
         add_buyer(post, payment_method, options)
@@ -126,9 +126,9 @@ module ActiveMerchant #:nodoc:
         add_extra_parameters(post, options)
       end
 
-      def add_credentials(post, command)
+      def add_credentials(post, command, options={})
         post[:test] = test? unless command == 'CREATE_TOKEN'
-        post[:language] = 'en'
+        post[:language] = options[:language] || 'en'
         post[:command] = command
         merchant = {}
         merchant[:apiLogin] = @options[:api_login]
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
         order[:partnerId] = options[:partner_id] if options[:partner_id]
         order[:referenceCode] = options[:order_id] || generate_unique_id
         order[:description] = options[:description] || 'Compra en ' + @options[:merchant_id]
-        order[:language] = 'en'
+        order[:language] = options[:language] || 'en'
         order[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
         post[:transaction][:order] = order
       end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -48,6 +48,14 @@ class PayuLatamTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_specified_language
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(language: 'es'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"language":"es"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 
@@ -64,6 +72,14 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_success response
     assert_equal "APPROVED", response.message
     assert_match %r(^\d+\|(\w|-)+$), response.authorization
+  end
+
+  def test_successful_authorize_with_specified_language
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(language: 'es'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"language":"es"/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_failed_authorize
@@ -83,6 +99,14 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal "PENDING", response.params["transactionResponse"]["state"]
   end
 
+  def test_pending_refund_with_specified_language
+    stub_comms do
+      @gateway.refund(@amount, "7edbaf68-8f3a-4ae7-b9c7-d1e27e314999", @options.merge(language: 'es'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"language":"es"/, data)
+    end.respond_with(pending_refund_response)
+  end
+
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 
@@ -97,6 +121,14 @@ class PayuLatamTest < Test::Unit::TestCase
     response = @gateway.void("7edbaf68-8f3a-4ae7-b9c7-d1e27e314999", @options)
     assert_success response
     assert_equal "PENDING_REVIEW", response.message
+  end
+
+  def test_successful_void_with_specified_language
+    stub_comms do
+      @gateway.void("7edbaf68-8f3a-4ae7-b9c7-d1e27e314999", @options.merge(language: 'es'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"language":"es"/, data)
+    end.respond_with(successful_void_response)
   end
 
   def test_failed_void
@@ -165,6 +197,14 @@ class PayuLatamTest < Test::Unit::TestCase
     response = @gateway.capture(@amount, "4000|authorization", @options)
     assert_success response
     assert_equal "APPROVED", response.message
+  end
+
+  def test_successful_capture_with_specified_language
+    stub_comms do
+      @gateway.capture(@amount, "4000|authorization", @options.merge(language: 'es'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"language":"es"/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_failed_capture


### PR DESCRIPTION
The `language` option can be used to specify the language used in
error messages and emails. Instead of hardcoding to `en`, we'll now
default to `en` when no `language` option is present.

Remote:
30 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
27 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed