### PR TITLE
Payflow: Pass OrderDesc field

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -133,6 +133,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'CustIP', options[:ip] unless options[:ip].blank?
               xml.tag! 'InvNum', options[:order_id].to_s.gsub(/[^\w.]/, '') unless options[:order_id].blank?
               xml.tag! 'Description', options[:description] unless options[:description].blank?
+              xml.tag! 'OrderDesc', options[:order_desc] unless options[:order_desc].blank?
               xml.tag! 'Comment', options[:comment] unless options[:comment].blank?
               xml.tag!('ExtData', 'Name'=> 'COMMENT2', 'Value'=> options[:comment2]) unless options[:comment2].blank?
               xml.tag! 'TaxAmt', options[:taxamt] unless options[:taxamt].blank?
@@ -164,6 +165,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'CustIP', options[:ip] unless options[:ip].blank?
               xml.tag! 'InvNum', options[:order_id].to_s.gsub(/[^\w.]/, '') unless options[:order_id].blank?
               xml.tag! 'Description', options[:description] unless options[:description].blank?
+              xml.tag! 'OrderDesc', options[:order_desc] unless options[:order_desc].blank?
               # Comment and Comment2 will show up in manager.paypal.com as Comment1 and Comment2
               xml.tag! 'Comment', options[:comment] unless options[:comment].blank?
               xml.tag!('ExtData', 'Name'=> 'COMMENT2', 'Value'=> options[:comment2]) unless options[:comment2].blank?
@@ -196,6 +198,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'CustIP', options[:ip] unless options[:ip].blank?
               xml.tag! 'InvNum', options[:order_id].to_s.gsub(/[^\w.]/, '') unless options[:order_id].blank?
               xml.tag! 'Description', options[:description] unless options[:description].blank?
+              xml.tag! 'OrderDesc', options[:order_desc] unless options[:order_desc].blank?
               xml.tag! 'BillTo' do
                 xml.tag! 'Name', check.name
               end

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -17,6 +17,14 @@ class RemotePayflowTest < Test::Unit::TestCase
       :customer => 'codyexample'
     }
 
+    @extra_options = {
+      :order_id => "123",
+      :description => "Description string",
+      :order_desc => "OrderDesc string",
+      :comment => "Comment string",
+      :comment2 => "Comment2 string"
+    }
+
     @check = check(
       :routing_number => '111111118',
       :account_number => '1234567801'
@@ -25,6 +33,15 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_successful_purchase
     assert response = @gateway.purchase(100000, @credit_card, @options)
+    assert_equal "Approved", response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
+    assert !response.fraud_review?
+  end
+
+  def test_successful_purchase_with_extra_options
+    assert response = @gateway.purchase(100000, @credit_card, @options.merge(@extra_options))
     assert_equal "Approved", response.message
     assert_success response
     assert response.test?


### PR DESCRIPTION
Also adds tests for similar fields.

Remote (10 failures for unrelated account-specific features):
28 tests, 104 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
64.2857% passed

Unit:
46 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed