### PR TITLE
Checkout V2: Return error codes in response

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -212,7 +212,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(succeeded, response)
-        succeeded ? nil : STANDARD_ERROR_CODE_MAPPING[response["responseCode"]]
+        return if succeeded
+        if response["errorCode"] && response["errorMessageCodes"]
+          "#{response["errorCode"]}: #{response["errorMessageCodes"].join(", ")}"
+        elsif response["errorCode"]
+          response["errorCode"]
+        else
+          STANDARD_ERROR_CODE_MAPPING[response["responseCode"]]
+        end
       end
     end
   end

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -6,6 +6,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
     @amount = 200
     @credit_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2018')
+    @expired_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2010')
     @declined_card = credit_card('4000300011112220')
 
     @options = {
@@ -177,5 +178,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_failure response
     assert_match %r{Invalid Card Number}, response.message
     assert_equal Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+  end
+
+  def test_expired_card_returns_error_code
+    response = @gateway.purchase(@amount, @expired_card, @options)
+    assert_failure response
+    assert_equal 'Validation error: Expired Card', response.message
+    assert_equal '70000: 70077', response.error_code
   end
 end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -186,6 +186,15 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_match %r{Invalid JSON response}, response.message
   end
 
+  def test_error_code_returned
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(error_code_response)
+
+    assert_failure response
+    assert_match /70000: 70077/, response.error_code
+  end
+
   def test_supported_countries
     assert_equal ['AD', 'AE', 'AT', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FO', 'FI', 'FR', 'GB', 'GI', 'GL', 'GR', 'HR', 'HU', 'IE', 'IS', 'IL', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SI', 'SM', 'SK', 'SJ', 'TR', 'VA'], @gateway.supported_countries
   end
@@ -440,5 +449,11 @@ class CheckoutV2Test < Test::Unit::TestCase
     )
   end
 
-
+  def error_code_response
+    %(
+      {
+        "eventId":"1b206f69-b4db-4259-9713-b72dfe0f19da","errorCode":"70000","message":"Validation error","errorMessageCodes":["70077"],"errors":["Expired Card"]
+      }
+    )
+  end
 end


### PR DESCRIPTION
Remote:
25 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
20 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed