### PR TITLE
CardStream: Change `refund` to use `REFUND_SALE`

### DIFF
--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -184,7 +184,16 @@ module ActiveMerchant #:nodoc:
         add_pair(post, :xref, authorization)
         add_amount(post, money, options)
         add_remote_address(post, options)
-        commit('REFUND', post)
+        response = commit('REFUND_SALE', post)
+
+        return response if response.success?
+        return response unless options[:force_full_refund_if_unsettled]
+
+        if response.params["responseCode"] == "65541"
+          void(authorization, options)
+        else
+          response
+        end
       end
 
       def void(authorization, options = {})

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -144,15 +144,29 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert responseCapture.test?
   end
 
-  def test_successful_visacreditcard_purchase_and_refund
+  def test_successful_visacreditcard_purchase_and_refund_with_force_refund
     assert responsePurchase = @gateway.purchase(284, @visacreditcard, @visacredit_options)
     assert_equal 'APPROVED', responsePurchase.message
     assert_success responsePurchase
     assert responsePurchase.test?
     assert !responsePurchase.authorization.blank?
-    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visacredit_options)
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visacredit_options.merge(force_full_refund_if_unsettled: true))
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
+    assert responseRefund.test?
+  end
+
+  def test_failed_visacreditcard_purchase_and_refund
+    assert responsePurchase = @gateway.purchase(284, @visacreditcard, @visacredit_options)
+    assert_equal 'APPROVED', responsePurchase.message
+    assert_success responsePurchase
+    assert responsePurchase.test?
+    assert !responsePurchase.authorization.blank?
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visacredit_options)
+    assert_failure responseRefund
+    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
     assert responseRefund.test?
   end
 
@@ -188,15 +202,29 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert responseCapture.test?
   end
 
-  def test_successful_visadebitcard_purchase_and_refund
+  def test_successful_visadebitcard_purchase_and_refund_with_force_refund
     assert responsePurchase = @gateway.purchase(284, @visadebitcard, @visadebit_options)
     assert_equal 'APPROVED', responsePurchase.message
     assert_success responsePurchase
     assert responsePurchase.test?
     assert !responsePurchase.authorization.blank?
-    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visadebit_options)
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visadebit_options.merge(force_full_refund_if_unsettled: true))
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
+    assert responseRefund.test?
+  end
+
+  def test_failed_visadebitcard_purchase_and_refund
+    assert responsePurchase = @gateway.purchase(284, @visadebitcard, @visadebit_options)
+    assert_equal 'APPROVED', responsePurchase.message
+    assert_success responsePurchase
+    assert responsePurchase.test?
+    assert !responsePurchase.authorization.blank?
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visadebit_options)
+    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_failure responseRefund
     assert responseRefund.test?
   end
 
@@ -212,15 +240,29 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert responseCapture.test?
   end
 
-  def test_successful_amex_purchase_and_refund
+  def test_successful_amex_purchase_and_refund_with_force_refund
     assert responsePurchase = @gateway.purchase(284, @amex, @amex_options)
     assert_equal 'APPROVED', responsePurchase.message
     assert_success responsePurchase
     assert responsePurchase.test?
     assert !responsePurchase.authorization.blank?
-    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @amex_options)
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @amex_options.merge(force_full_refund_if_unsettled: true))
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
+    assert responseRefund.test?
+  end
+
+  def test_failed_amex_purchase_and_refund
+    assert responsePurchase = @gateway.purchase(284, @amex, @amex_options)
+    assert_equal 'APPROVED', responsePurchase.message
+    assert_success responsePurchase
+    assert responsePurchase.test?
+    assert !responsePurchase.authorization.blank?
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @amex_options)
+    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_failure responseRefund
     assert responseRefund.test?
   end
 
@@ -236,15 +278,29 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert responseCapture.test?
   end
 
-  def test_successful_mastercard_purchase_and_refund
+  def test_successful_mastercard_purchase_and_refund_with_force_refund
     assert responsePurchase = @gateway.purchase(284, @mastercard, @mastercard_options)
     assert_equal 'APPROVED', responsePurchase.message
     assert_success responsePurchase
     assert responsePurchase.test?
     assert !responsePurchase.authorization.blank?
-    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @mastercard_options)
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @mastercard_options.merge(force_full_refund_if_unsettled: true))
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
+    assert responseRefund.test?
+  end
+
+  def test_failed_mastercard_purchase_and_refund
+    assert responsePurchase = @gateway.purchase(284, @mastercard, @mastercard_options)
+    assert_equal 'APPROVED', responsePurchase.message
+    assert_success responsePurchase
+    assert responsePurchase.test?
+    assert !responsePurchase.authorization.blank?
+
+    assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @mastercard_options)
+    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_failure responseRefund
     assert responseRefund.test?
   end
 

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -80,13 +80,33 @@ class CardStreamTest < Test::Unit::TestCase
     assert responseCapture.test?
   end
 
-  def test_successful_visacreditcard_refund
+  def test_successful_refund
     @gateway.expects(:ssl_post).returns(successful_refund_response)
 
     assert responseRefund = @gateway.refund(142, "authorization", @visacredit_options)
     assert_equal 'APPROVED', responseRefund.message
     assert_success responseRefund
     assert responseRefund.test?
+  end
+
+  def test_successful_refund_due_to_unsettled_payment_forces_void
+    refund = stub_comms do
+      @gateway.refund(142, 'authorization', @visacredit_options.merge(force_full_refund_if_unsettled: true))
+    end.respond_with(failed_refund_for_unsettled_payment_response, successful_void_response)
+
+    assert refund
+    assert_success refund
+    assert_equal 'APPROVED', refund.message
+    assert refund.test?
+  end
+
+  def test_failed_refund_due_to_unsettled_payment
+    @gateway.expects(:ssl_post).returns(failed_refund_for_unsettled_payment_response)
+
+    assert refund = @gateway.refund(142, "authorization", @visacredit_options)
+    assert_equal 'Can not REFUND this SALE transaction', refund.message
+    assert_failure refund
+    assert refund.test?
   end
 
   def test_successful_visacreditcard_void
@@ -278,6 +298,10 @@ class CardStreamTest < Test::Unit::TestCase
 
   def successful_refund_response
     "merchantID=0000000&threeDSEnabled=Y&merchantDescription=General+test+account+with+AVS%2FCV2+checking&xref=13021914NT06BM21GJ15VJH&amount=142&currencyCode=826&action=REFUND&type=1&countryCode=826&merchantAlias=0000992&remoteAddress=80.229.33.63&responseCode=0&responseMessage=REFUNDACCEPTED&customerName=Longbob+Longsen&customerAddress=Flat+6%2C+Primrose+Rise+347+Lavender+Road&customerPostCode=NN17+8YG+&transactionUnique=c7981d78d217cf3cfda6559921e31c4a&orderRef=AM+test+purchase&amountReceived=142&avscv2ResponseCode=222100&avscv2ResponseMessage=ALL+MATCH&avscv2AuthEntity=merchant+host&cv2Check=matched&addressCheck=matched&postcodeCheck=matched&threeDSXID=00000000000004717488&threeDSEnrolled=U&threeDSErrorCode=-1&threeDSErrorDescription=Error+while+attempting+to+send+the+request+to%3A+https%3A%2F%2F3dstest.universalpaymentgateway.com%3A4343%2FAPI%0A%0DPlease+make+sure+that+ActiveMerchant+server+is+running+and+the+URL+is+valid.+ERROR_INTERNET_CANNOT_CONNECT%3A+The+attempt+to+connect+to+the+server+failed.&threeDSMerchantPref=PROCEED&threeDSVETimestamp=2013-02-19+14%3A05%3A58&cardTypeCode=VC&cardNumberMask=%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A0821&threeDSRequired=N&transactionID=4717490&transactionPreviousID=4717488&timestamp=2013-02-19+14%3A06%3A21&cardType=Visa+Credit&currencyExponent=2&responseStatus=0&merchantName=CARDSTREAM+TEST&merchantID2=100001"
+  end
+
+  def failed_refund_for_unsettled_payment_response
+    "responseCode=65541&responseMessage=Can+not+REFUND+this+SALE+transaction&responseStatus=2&xref=18032714RP14KM21FX11YHT&amount=142&currencyCode=826&remoteAddress=1.1.1.1&countryCode=GB&merchantID=103191&action=REFUND_SALE&requestID=5aba43ad1481e&state=finished&requestMerchantID=103191&processMerchantID=103191&transactionID=25814232&timestamp=2018-03-27+14%3A14%3A21&vcsResponseCode=0&vcsResponseMessage=Success+-+no+velocity+check+rules+applied&signature=b56640b215510a04ebfaa095b63705cda08cca318a7ccb2b2b48caec75adc187d9cae5082eb1dc71d258813ee9d879721e48af04966a489171f435bfa67b6d92"
   end
 
   def successful_void_response


### PR DESCRIPTION
Per CardStream, specifying `REFUND` as the action performs a general /
independent credit against the card which may result in chargebacks. Instead,
the `REFUND_SALE` action can be used refund a `SALE` transaction that has settled.
When a `SALE` transaction has not settled, a `CANCEL` request must be made that
will refund the original `SALE`.

Note: I initially found this behavior quite confusing but it turns out we perform this
pattern in the Authorize.net, WorldPay, and BraintreeBlue adapters. These changes follow
the same pattern.

Unit:
24 tests, 126 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 200 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed