### PR TITLE
Stripe: Add `exchange_rate` parameter

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -128,6 +128,7 @@ module ActiveMerchant #:nodoc:
         else
           add_application_fee(post, options)
           add_amount(post, money, options)
+          add_exchange_rate(post, options)
           commit(:post, "charges/#{CGI.escape(authorization)}/capture", post, options)
         end
       end
@@ -320,6 +321,7 @@ module ActiveMerchant #:nodoc:
 
         add_metadata(post, options)
         add_application_fee(post, options)
+        add_exchange_rate(post, options)
         add_destination(post, options)
         post
       end
@@ -332,6 +334,10 @@ module ActiveMerchant #:nodoc:
 
       def add_application_fee(post, options)
         post[:application_fee] = options[:application_fee] if options[:application_fee]
+      end
+
+      def add_exchange_rate(post, options)
+        post[:exchange_rate] = options[:exchange_rate] if options[:exchange_rate]
       end
 
       def add_destination(post, options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -853,6 +853,22 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_exchange_rate_is_submitted_for_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({:exchange_rate => 0.96251}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/exchange_rate=0.96251/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_exchange_rate_is_submitted_for_capture
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.capture(@amount, "ch_test_charge", @options.merge({:exchange_rate => 0.96251}))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/exchange_rate=0.96251/, data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_destination_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid'}))


### PR DESCRIPTION
This adds support for the optional `exchange_rate` parameter during
capture and purchase. This specifies an exchange rate to be used during
a transaction, and if incorrect or stale, Stripe will return a 400
`invalid_request_error` with an `invalid_exchange_rate` code. The
response also contains the updated rate in the event of a failure in the
`new_rate` parameter.

This is currently a preview feature.

Ref: https://stripe.com/docs/api#capture_charge

Unit:
126 tests, 667 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed

Remote:
64 tests, 291 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed