### PR TITLE
Adyen: Support merchant-specific subdomains

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -202,8 +202,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters)
-        url = (test? ? test_url : live_url)
-
         begin
           raw_response = ssl_post("#{url}/#{action.to_s}", post_data(action, parameters), request_headers)
           response = parse(raw_response)
@@ -222,6 +220,16 @@ module ActiveMerchant #:nodoc:
           error_code: success ? nil : error_code_from(response)
         )
 
+      end
+
+      def url
+        if test?
+          test_url
+        elsif @options[:subdomain]
+          "https://#{@options[:subdomain]}-pal-live.adyenpayments.com/pal/servlet/Payment/v18"
+        else
+          live_url
+        end
       end
 
       def basic_auth

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -28,6 +28,25 @@ class AdyenTest < Test::Unit::TestCase
     }
   end
 
+  # Subdomains are only valid for production gateways, so the test_url check must be manually bypassed this test to pass.
+  # def test_subdomain_specification
+  #   gateway = AdyenGateway.new(
+  #     username: 'ws@adyenmerchant.com',
+  #     password: 'password',
+  #     merchant_account: 'merchantAccount',
+  #     subdomain: '123-subdomain'
+  #   )
+  #
+  #   response = stub_comms(gateway) do
+  #     gateway.authorize(@amount, @credit_card, @options)
+  #   end.check_request do |endpoint, data, headers|
+  #     assert_match("https://123-subdomain-pal-live.adyenpayments.com/pal/servlet/Payment/v18/authorise", endpoint)
+  #   end.respond_with(successful_authorize_response)
+  #
+  #   assert response
+  #   assert_success response
+  # end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 


### PR DESCRIPTION
Adyen's sandbox doesn't support testing of these subdomains, so the only
way I found to test the functionality was by subverting the check for a
test url in the adapter itself, and checking the request in a unit test,
hence the 1 unit failure.

Happy to take suggestions on more robust methods to test this.

Remote:
32 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
19 tests, 89 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.7368% passed