### PR TITLE
Fix ENV based configuration of Net::Http for proxies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Spreedly: Support verify and find transactions [abarrak] #2798
 * Adyen: Support merchant-specific subdomains [curiousepic] #2799
+* Fix ENV based configuration of Net::Http for proxies [bbergstrom] #2800
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -44,7 +44,7 @@ module ActiveMerchant
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
-      @proxy_address = nil
+      @proxy_address = :ENV
       @proxy_port = nil
     end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -26,6 +26,25 @@ class ConnectionTest < Test::Unit::TestCase
     end
   end
 
+  def test_connection_passes_env_proxy_by_default
+    @connection.logger.expects(:info).twice
+
+    spy = Net::HTTP.new('example.com', 443)
+    Net::HTTP.expects(:new).with('example.com', 443, :ENV, nil).returns(spy)
+    spy.expects(:get).with('/tx.php', {}).returns(@ok)
+    response = @connection.request(:get, nil, {})
+  end
+
+  def test_connection_does_pass_requested_proxy
+    @connection.logger.expects(:info).twice
+    @connection.proxy_address = "proxy.example.com"
+    @connection.proxy_port = 8080
+    spy = Net::HTTP.new('example.com', 443)
+    Net::HTTP.expects(:new).with('example.com', 443, "proxy.example.com", 8080).returns(spy)
+    spy.expects(:get).with('/tx.php', {}).returns(@ok)
+    response = @connection.request(:get, nil, {})
+  end
+
   def test_successful_get_request
     @connection.logger.expects(:info).twice
     Net::HTTP.any_instance.expects(:get).with('/tx.php', {}).returns(@ok)

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -27,22 +27,19 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_connection_passes_env_proxy_by_default
-    @connection.logger.expects(:info).twice
-
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, :ENV, nil).returns(spy)
     spy.expects(:get).with('/tx.php', {}).returns(@ok)
-    response = @connection.request(:get, nil, {})
+    @connection.request(:get, nil, {})
   end
 
   def test_connection_does_pass_requested_proxy
-    @connection.logger.expects(:info).twice
     @connection.proxy_address = "proxy.example.com"
     @connection.proxy_port = 8080
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, "proxy.example.com", 8080).returns(spy)
     spy.expects(:get).with('/tx.php', {}).returns(@ok)
-    response = @connection.request(:get, nil, {})
+    @connection.request(:get, nil, {})
   end
 
   def test_successful_get_request


### PR DESCRIPTION
Net::Http has a slightly odd constructor semantics that aren't
immediately obvious. If no proxy parameters are sent then, by default, it
looks up the proxy from the standard HTTP_PROXY/http+proxy environment
variables. To set no proxy at all, ignoring the environment variable, you can pass nil
as the p_address parameter.

ActiveMerchant::Connection was always passing proxy parameters
to Net::Http.new even when a proxy had not been set, meaning that
the default environment variable configuration behaviour was never respected.

This commit ensures that if you do not explicitly set proxy parameters
on your Gateway the default behaviour of Net::Http to retrieve proxy
settings from the environment applies. Proxy parameters can still explicitly
set to nil to avoid environment variable configuration or to desired proxy values.

Ref: https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new
Fixes: https://github.com/activemerchant/active_merchant/issues/2372
Revision of dormant PR: https://github.com/activemerchant/active_merchant/pull/2371