### PR TITLE
Include gateway specific fields in Spreedly refund

### DIFF
--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -79,6 +79,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options={})
         request = build_xml_request('transaction') do |doc|
           add_invoice(doc, money, options)
+          add_extra_options(:gateway_specific_fields, doc, options)
         end
 
         commit("transactions/#{authorization}/credit.xml", request)


### PR DESCRIPTION
Extends commit: b1436c893

Refunds via Spreedly Core were not including extra options. As a result
the description seen by the customer was incorrect.