### PR TITLE
Remove Inquiry requests in verify transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Fix ENV based configuration of Net::Http for proxies [bbergstrom] #2800
 * ANET: Withhold cryptogram for credit [curiousepic] #2804
 * Borgun: Remove batch from request parameters [deedeelavinder] #2805
+* WorldPay: Remove Inquiry requests in verify transactions
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -55,7 +55,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         MultiResponse.run do |r|
-          r.process{inquire_request(authorization, options, "AUTHORISED")}
+          r.process{inquire_request(authorization, options, "AUTHORISED")} unless options[:authorization_validated]
           r.process{cancel_request(authorization, options)}
         end
       end
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options={})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
+          r.process(:ignore_result) { void(r.authorization, options.merge(:authorization_validated => true)) }
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -43,6 +43,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'SUCCESS', auth.message
     assert auth.authorization
+    sleep(40)
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
   end
@@ -51,12 +52,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'SUCCESS', auth.message
+    sleep(40)
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
 
     assert reference = auth.authorization
     @options[:order_id] = generate_unique_id
     assert auth = @gateway.authorize(@amount, reference, @options)
+    sleep(40)
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
   end
@@ -65,6 +68,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'SUCCESS', auth.message
+    sleep(40)
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
 
@@ -72,6 +76,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @options[:order_id] = generate_unique_id
     assert auth = @gateway.authorize(@amount, reference, @options)
     @options[:order_id] = generate_unique_id
+    sleep(40)
     assert capture = @gateway.purchase(@amount, auth.authorization, @options)
     assert_success capture
   end
@@ -100,6 +105,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_void
     assert_success(response = @gateway.authorize(@amount, @credit_card, @options))
+    sleep(40)
     assert_success (void = @gateway.void(response.authorization))
     assert_equal "SUCCESS", void.message
     assert void.params["cancel_received_order_code"]

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -442,7 +442,7 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    @gateway.expects(:ssl_post).times(3).returns(successful_authorize_response, successful_void_response)
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, successful_void_response)
 
     response = @gateway.verify(@credit_card, @options)
     assert_success response


### PR DESCRIPTION
Inquiries need at least 5 minutes after initial transaction in order to
be reliable. This removes inquiries from verify requests.

Errors are also caused by timeouts. Successful tests can be achieved by
adding a sleep, but doesn not produce consistent results.

Loaded suite test/unit/gateways/worldpay_test

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
37 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Loaded suite test/remote/gateways/remote_worldpay_test
Finished in 231.664812 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 71 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
78.2609% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------