### PR TITLE
Borgun: Remove batch from request parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Support merchant-specific subdomains [curiousepic] #2799
 * Fix ENV based configuration of Net::Http for proxies [bbergstrom] #2800
 * ANET: Withhold cryptogram for credit [curiousepic] #2804
+* Borgun: Remove batch from request parameters [deedeelavinder] #2805
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -98,7 +98,6 @@ module ActiveMerchant #:nodoc:
       def add_reference(post, authorization)
         dateandtime, batch, transaction, rrn, authcode, _, _, _ = split_authorization(authorization)
         post[:DateAndTime] = dateandtime
-        post[:Batch] = batch
         post[:Transaction] = transaction
         post[:RRN] = rrn
         post[:AuthCode] = authcode


### PR DESCRIPTION
Batch is part of Borgun's response but is not needed for the
request. This removes it from the `add_reference` method adding it to
the request but maintains its place in the response.

Unit tests:
8 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote tests:
20 tests, 47 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed