### PR TITLE
Braintree: Add boolean for skip_advanced_fraud_checking

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Braintree: Remove decimal for non-fractional currencies [nfarve] #2806
 * Realex: Add documented country support for US and CA [a-salty-strudel] #2810
 * Paymentez: Add `tax_percentage` optional parameter [deedeelavinder] #2814
+* Braintree: Add `skip_advanced_fraud_checking` optional parameter [deedeelavinder] #2811
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -555,9 +555,14 @@ module ActiveMerchant #:nodoc:
           :options => {
             :store_in_vault => options[:store] ? true : false,
             :submit_for_settlement => options[:submit_for_settlement],
-            :hold_in_escrow => options[:hold_in_escrow]
+            :hold_in_escrow => options[:hold_in_escrow],
           }
         }
+        
+        if options[:skip_advanced_fraud_checking]
+          parameters[:options].merge!({ :skip_advanced_fraud_checking => options[:skip_advanced_fraud_checking] })
+        end
+
         parameters[:custom_fields] = options[:custom_fields]
         parameters[:device_data] = options[:device_data] if options[:device_data]
         parameters[:service_fee_amount] = options[:service_fee_amount] if options[:service_fee_amount]

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -279,6 +279,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '(555)555-5555', transaction["customer_details"]["phone"]
   end
 
+  def test_successful_purchase_with_skip_advanced_fraud_checking_option
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(skip_advanced_fraud_checking: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params["braintree_transaction"]["status"]
+  end
+
   def test_purchase_with_store_using_random_customer_id
     assert response = @gateway.purchase(
       @amount, credit_card('5105105105105100'), @options.merge(:store => true)


### PR DESCRIPTION
Remote tests:
61 tests, 353 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit tests:
6 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed