### PR TITLE
Beanstream Gateway Improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -152,6 +152,7 @@
 * Spreedly: Scrub sensitive transaction data [abarrak] #2781
 * Stripe: Add `exchange_rate` parameter [WilsonChiang] #2796
 * Mundipagg: New Gateway Implementation [nfarve] #2791
+* Beanstream: Integrated the Bambora Pacifc gateway into Bambora North America gateway #2813
 
 == Version 1.77.0 (January 31, 2018)
 * Authorize.net: Allow Transaction Id to be passed for refuds [nfarve] #2698

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -1,4 +1,5 @@
-require 'active_merchant/billing/gateways/beanstream/beanstream_core'
+require 'active_merchant/billing/gateways/beanstream/beanstream_default'
+require 'active_merchant/billing/gateways/beanstream/beanstream_ipp'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -64,149 +65,20 @@ module ActiveMerchant #:nodoc:
     #     :tax2 => 100,
     #     :custom => 'reference one'
     #   )
+
     class BeanstreamGateway < Gateway
-      include BeanstreamCore
+      def self.new(options = {})
+        klass = 
+          case options[:region]
+          when nil, :america
+            BeanstreamDefautGateway
+          when :pacific
+            BeanstreamIppGateway
+          else
+            raise ArgumentError, "invalid region #{options[:region]}"
+          end
 
-      def authorize(money, source, options = {})
-        post = {}
-        add_amount(post, money)
-        add_invoice(post, options)
-        add_source(post, source)
-        add_address(post, options)
-        add_transaction_type(post, :authorization)
-        add_customer_ip(post, options)
-        add_recurring_payment(post, options)
-        commit(post)
-      end
-
-      def purchase(money, source, options = {})
-        post = {}
-        add_amount(post, money)
-        add_invoice(post, options)
-        add_source(post, source)
-        add_address(post, options)
-        add_transaction_type(post, purchase_action(source))
-        add_customer_ip(post, options)
-        add_recurring_payment(post, options)
-        commit(post)
-      end
-
-      def void(authorization, options = {})
-        reference, amount, type = split_auth(authorization)
-
-        post = {}
-        add_reference(post, reference)
-        add_original_amount(post, amount)
-        add_transaction_type(post, void_action(type))
-        commit(post)
-      end
-
-      def verify(source, options={})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, source, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
-      end
-
-      def success?(response)
-        response[:trnApproved] == '1' || response[:responseCode] == '1'
-      end
-
-      def recurring(money, source, options = {})
-        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
-
-        post = {}
-        add_amount(post, money)
-        add_invoice(post, options)
-        add_credit_card(post, source)
-        add_address(post, options)
-        add_transaction_type(post, purchase_action(source))
-        add_recurring_type(post, options)
-        commit(post)
-      end
-
-      def update_recurring(amount, source, options = {})
-        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
-
-        post = {}
-        add_recurring_amount(post, amount)
-        add_recurring_invoice(post, options)
-        add_credit_card(post, source)
-        add_address(post, options)
-        add_recurring_operation_type(post, :update)
-        add_recurring_service(post, options)
-        recurring_commit(post)
-      end
-
-      def cancel_recurring(options = {})
-        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
-
-        post = {}
-        add_recurring_operation_type(post, :cancel)
-        add_recurring_service(post, options)
-        recurring_commit(post)
-      end
-
-      def interac
-        @interac ||= BeanstreamInteracGateway.new(@options)
-      end
-
-      # To match the other stored-value gateways, like TrustCommerce,
-      # store and unstore need to be defined
-      def store(payment_method, options = {})
-        post = {}
-        add_address(post, options)
-
-        if payment_method.respond_to?(:number)
-          add_credit_card(post, payment_method)
-        else
-          post[:singleUseToken] = payment_method
-        end
-        add_secure_profile_variables(post, options)
-
-        commit(post, true)
-      end
-
-      #can't actually delete a secure profile with the supplicated API. This function sets the status of the profile to closed (C).
-      #Closed profiles will have to removed manually.
-      def delete(vault_id)
-        update(vault_id, false, {:status => 'C'})
-      end
-
-      alias_method :unstore, :delete
-
-      # Update the values (such as CC expiration) stored at
-      # the gateway.  The CC number must be supplied in the
-      # CreditCard object.
-      def update(vault_id, payment_method, options = {})
-        post = {}
-        add_address(post, options)
-        if payment_method.respond_to?(:number)
-          add_credit_card(post, payment_method)
-        else
-          post[:singleUseToken] = payment_method
-        end
-        options.merge!({:vault_id => vault_id, :operation => secure_profile_action(:modify)})
-        add_secure_profile_variables(post,options)
-        commit(post, true)
-      end
-
-      def supports_scrubbing?
-        true
-      end
-
-      def scrub(transcript)
-        transcript.
-          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
-          gsub(/(&?password=)[^&\s]*(&?)/, '\1[FILTERED]\2').
-          gsub(/(&?passcode=)[^&\s]*(&?)/, '\1[FILTERED]\2').
-          gsub(/(&?trnCardCvd=)\d*(&?)/, '\1[FILTERED]\2').
-          gsub(/(&?trnCardNumber=)\d*(&?)/, '\1[FILTERED]\2')
-      end
-
-      private
-      def build_response(*args)
-        Response.new(*args)
+        klass.new(options)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_default.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_default.rb
@@ -1,0 +1,178 @@
+require 'active_merchant/billing/gateways/beanstream/beanstream_core'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BeanstreamDefautGateway < Gateway
+      include BeanstreamCore
+
+      def initialize(options = {})
+        requires!(options, :login)
+
+        super
+      end
+
+      def authorize(money, source, options = {})
+        post = {}
+        add_amount(post, money)
+        add_invoice(post, options)
+        add_source(post, source)
+        add_address(post, options)
+        add_transaction_type(post, :authorization)
+        add_customer_ip(post, options)
+        add_recurring_payment(post, options)
+        commit(post)
+      end
+
+      def purchase(money, source, options = {})
+        post = {}
+        add_amount(post, money)
+        add_invoice(post, options)
+        add_source(post, source)
+        add_address(post, options)
+        add_transaction_type(post, purchase_action(source))
+        add_customer_ip(post, options)
+        add_recurring_payment(post, options)
+        commit(post)
+      end
+
+      def capture(money, authorization, options = {})
+        reference, = split_auth(authorization)
+
+        post = {}
+        add_amount(post, money)
+        add_reference(post, reference)
+        add_transaction_type(post, :capture)
+        add_recurring_payment(post, options)
+        commit(post)
+      end
+
+      def refund(money, source, _options = {})
+        post = {}
+        reference, _, type = split_auth(source)
+        add_reference(post, reference)
+        add_transaction_type(post, refund_action(type))
+        add_amount(post, money)
+        commit(post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+          .gsub(/(Authorization: Basic )\w+/, '\1[FILTERED]')
+          .gsub(/(&?password=)[^&\s]*(&?)/, '\1[FILTERED]\2')
+          .gsub(/(&?trnCardCvd=)\d*(&?)/, '\1[FILTERED]\2')
+          .gsub(/(&?trnCardNumber=)\d*(&?)/, '\1[FILTERED]\2')
+      end
+
+      def void(authorization, _options = {})
+        reference, amount, type = split_auth(authorization)
+
+        post = {}
+        add_reference(post, reference)
+        add_original_amount(post, amount)
+        add_transaction_type(post, void_action(type))
+        commit(post)
+      end
+
+      def verify(source, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, source, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def success?(response)
+        response[:trnApproved] == '1' || response[:responseCode] == '1'
+      end
+
+      def recurring(money, source, options = {})
+        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
+
+        post = {}
+        add_amount(post, money)
+        add_invoice(post, options)
+        add_credit_card(post, source)
+        add_address(post, options)
+        add_transaction_type(post, purchase_action(source))
+        add_recurring_type(post, options)
+        commit(post)
+      end
+
+      def update_recurring(amount, source, options = {})
+        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
+
+        post = {}
+        add_recurring_amount(post, amount)
+        add_recurring_invoice(post, options)
+        add_credit_card(post, source)
+        add_address(post, options)
+        add_recurring_operation_type(post, :update)
+        add_recurring_service(post, options)
+        recurring_commit(post)
+      end
+
+      def cancel_recurring(options = {})
+        ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
+
+        post = {}
+        add_recurring_operation_type(post, :cancel)
+        add_recurring_service(post, options)
+        recurring_commit(post)
+      end
+
+      def interac
+        @interac ||= BeanstreamInteracGateway.new(@options)
+      end
+
+      # To match the other stored-value gateways, like TrustCommerce,
+      # store and unstore need to be defined
+      def store(payment_method, options = {})
+        post = {}
+        add_address(post, options)
+
+        if payment_method.respond_to?(:number)
+          add_credit_card(post, payment_method)
+        else
+          post[:singleUseToken] = payment_method
+        end
+        add_secure_profile_variables(post, options)
+
+        commit(post, true)
+      end
+
+      # can't actually delete a secure profile with the supplicated API. This function sets the status of the profile to closed (C).
+      # Closed profiles will have to removed manually.
+      def delete(vault_id)
+        update(vault_id, false, status: 'C')
+      end
+
+      alias unstore delete
+
+      # Update the values (such as CC expiration) stored at
+      # the gateway.  The CC number must be supplied in the
+      # CreditCard object.
+      def update(vault_id, payment_method, options = {})
+        post = {}
+        add_address(post, options)
+        if payment_method.respond_to?(:number)
+          add_credit_card(post, payment_method)
+        else
+          post[:singleUseToken] = payment_method
+        end
+        options[:vault_id] = vault_id
+        options[:operation] = secure_profile_action(:modify)
+        add_secure_profile_variables(post, options)
+        commit(post, true)
+      end
+
+      private
+
+      def build_response(*args)
+        Response.new(*args)
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_ipp.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_ipp.rb
@@ -1,0 +1,20 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BeanstreamIppGateway < IppGateway
+      self.default_currency = 'AUD'
+      self.live_url = 'https://www.bambora.co.nz/interface/api/dts.asmx'
+      self.test_url = 'https://demo.bambora.co.nz/interface/api/dts.asmx'
+      self.supported_countries = %w[AU NZ]
+      self.supported_cardtypes = %i[visa master american_express diners_club jcb]
+      self.homepage_url = 'http://www.bambora.co.nz/'
+      self.display_name = 'Beanstream IPP'
+      self.money_format = :cents
+
+      def initialize(options = {})
+        requires!(options, :region, :username, :password, :login)
+        
+        super
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -398,6 +398,7 @@ instapay:
 
 # Working credentials, no need to replace
 ipp:
+  login: merchant id
   username: nmi.api
   password: qwerty123
 

--- a/test/remote/gateways/remote_beanstream_ipp_test.rb
+++ b/test/remote/gateways/remote_beanstream_ipp_test.rb
@@ -1,0 +1,120 @@
+require 'test_helper'
+
+class RemoteBeanstreamIppTest < Test::Unit::TestCase
+  def setup
+    @ipp_options = fixtures(:ipp)
+    @ipp_options[:region] = :pacific
+    @gateway = BeanstreamGateway.new(@ipp_options)
+
+    @credit_card_visa = credit_card('4005550000000001')
+
+    @credit_card_visa_declined = credit_card('4123456789010053')
+
+    @credit_card_mastercard = credit_card('5123456789012346')
+
+    @credit_card_mastercard_declined = credit_card('5123456789010043')
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+    }
+
+    @amount = 200
+    @amount_fail = 105
+  end
+
+  def test_dump_transcript
+    skip('Transcript scrubbing for this gateway has been tested.')
+    dump_transcript_and_fail(@gateway, @amount, @credit_card_visa, @options)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card_visa, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card_visa.number, transcript)
+    assert_scrubbed(@credit_card_visa.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card_visa, @options)
+
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @credit_card_visa_declined, @options)
+
+    assert_failure response
+    assert_equal 'Do Not Honour', response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_purchase_mastercard
+    response = @gateway.purchase(@amount, @credit_card_mastercard, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_failed_purchase_mastercard
+    response = @gateway.purchase(@amount, @credit_card_mastercard_declined, @options)
+
+    assert_failure response
+    assert_equal 'Pick Up Card', response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:pickup_card], response.error_code
+  end
+
+  def test_successful_authorize_and_capture
+    response = @gateway.authorize(@amount, @credit_card_visa, @options)
+    assert_success response
+    response = @gateway.capture(@amount, response.authorization)
+    assert_success response
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount_fail, @credit_card_visa, @options)
+    assert_failure response
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+  end
+
+  def test_successful_refund
+    response = @gateway.purchase(@amount, @credit_card_visa, @options)
+    response = @gateway.refund(@amount, response.authorization, @options)
+    assert_success response
+    assert_equal '', response.message
+  end
+
+  def test_failed_refund
+    response = @gateway.purchase(@amount, @credit_card_visa, @options)
+    response = @gateway.refund(300, response.authorization, @options)
+    assert_failure response
+    assert_equal 'Refund amount exceeds original purchase or capture plus any previous refund total', response.message
+  end
+
+  def test_invalid_login
+    gateway = BeanstreamGateway.new(
+      login: '',
+      username: '',
+      password: '',
+      region: :pacific
+    )
+
+    options_test = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+    }
+
+    response = gateway.purchase(@amount, @credit_card_visa, options_test)
+    assert_failure response
+  end
+end

--- a/test/unit/gateways/beanstream_ipp_test.rb
+++ b/test/unit/gateways/beanstream_ipp_test.rb
@@ -1,0 +1,213 @@
+require 'test_helper'
+
+class BeansteamIppTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = BeanstreamGateway.new(
+      login: 'merchant_id',
+      username: 'username',
+      password: 'password',
+      region: :pacific
+    )
+
+    @amount = 100
+    @credit_card = credit_card
+  end
+
+  def test_successful_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_id: 1)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<SubmitSinglePayment }, data)
+      assert_match(%r{<UserName>username<}, data)
+      assert_match(%r{<Password>password<}, data)
+      assert_match(%r{<CustRef>1<}, data)
+      assert_match(%r{<Amount>100<}, data)
+      assert_match(%r{<TrnType>1<}, data)
+      assert_match(%r{<CardNumber>#{@credit_card.number}<}, data)
+      assert_match(%r{<ExpM>#{"%02d" % @credit_card.month}<}, data)
+      assert_match(%r{<ExpY>#{@credit_card.year}<}, data)
+      assert_match(%r{<CVN>#{@credit_card.verification_value}<}, data)
+      assert_match(%r{<CardHolderName>#{@credit_card.name}<}, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal '89435577', response.authorization
+  end
+
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(failed_purchase_response)
+
+    assert_failure response
+    assert_equal 'Do Not Honour', response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    assert_equal '', response.authorization
+  end
+
+  def test_successful_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, order_id: 1)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<SubmitSinglePayment }, data)
+      assert_match(%r{<CustRef>1<}, data)
+      assert_match(%r{<TrnType>2<}, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal '89435583', response.authorization
+  end
+
+  def test_successful_capture
+    response = stub_comms do
+      @gateway.capture(@amount, 'receipt')
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<SubmitSingleCapture }, data)
+      assert_match(%r{<Receipt>receipt<}, data)
+      assert_match(%r{<Amount>100<}, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success response
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.refund(@amount, 'receipt')
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<SubmitSingleRefund }, data)
+      assert_match(%r{<Receipt>receipt<}, data)
+      assert_match(%r{<Amount>100<}, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success response
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-'PRE_SCRUBBED'
+opening connection to demo.ippayments.com.au:443...
+opened
+starting SSL for demo.ippayments.com.au:443...
+SSL established
+<- "POST /interface/api/dts.asmx HTTP/1.1\r\nContent-Type: text/xml; charset=utf-8\r\nSoapaction: http://www.ippayments.com.au/interface/api/dts/SubmitSinglePayment\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: demo.ippayments.com.au\r\nContent-Length: 822\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <SubmitSinglePayment xmlns=\"http://www.ippayments.com.au/interface/api/dts\">\n      <trnXML>\n        <![CDATA[<Transaction>\n  <CustRef>1</CustRef>\n  <Amount/>\n  <TrnType>1</TrnType>\n  <CreditCard Registered=\"False\">\n    <CardNumber>4005550000000001</CardNumber>\n    <ExpM>09</ExpM>\n    <ExpY>2015</ExpY>\n    <CVN>123</CVN>\n    <CardHolderName>Longbob Longsen</CardHolderName>\n  </CreditCard>\n  <Security>\n    <UserName>nmi.api</UserName>\n    <Password>qwerty123</Password>\n  </Security>\n  <TrnSource/>\n</Transaction>\n]]>\n      </trnXML>\n    </SubmitSinglePayment>\n  </soap:Body>\n</soap:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Server: Microsoft-IIS/6.0\r\n"
+-> "X-Robots-Tag: noindex\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: text/xml; charset=utf-8\r\n"
+-> "Content-Length: 767\r\n"
+-> "Date: Fri, 19 Dec 2014 19:55:13 GMT\r\n"
+-> "Connection: close\r\n"
+-> "\r\n"
+reading 767 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><SubmitSinglePaymentResponse xmlns=\"http://www.ippayments.com.au/interface/api/dts\"><SubmitSinglePaymentResult>&lt;Response&gt;\r\n\t&lt;ResponseCode&gt;1&lt;/ResponseCode&gt;\r\n\t&lt;Timestamp&gt;20-Dec-2014 06:55:17&lt;/Timestamp&gt;\r\n\t&lt;Receipt&gt;&lt;/Receipt&gt;\r\n\t&lt;SettlementDate&gt;&lt;/SettlementDate&gt;\r\n\t&lt;DeclinedCode&gt;183&lt;/DeclinedCode&gt;\r\n\t&lt;DeclinedMessage&gt;Exception parsing transaction XML&lt;/DeclinedMessage&gt;\r\n&lt;/Response&gt;\r\n</SubmitSinglePaymentResult></SubmitSinglePaymentResponse></soap:Body></soap:Envelope>"
+read 767 bytes
+Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-'POST_SCRUBBED'
+opening connection to demo.ippayments.com.au:443...
+opened
+starting SSL for demo.ippayments.com.au:443...
+SSL established
+<- "POST /interface/api/dts.asmx HTTP/1.1\r\nContent-Type: text/xml; charset=utf-8\r\nSoapaction: http://www.ippayments.com.au/interface/api/dts/SubmitSinglePayment\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: demo.ippayments.com.au\r\nContent-Length: 822\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <SubmitSinglePayment xmlns=\"http://www.ippayments.com.au/interface/api/dts\">\n      <trnXML>\n        <![CDATA[<Transaction>\n  <CustRef>1</CustRef>\n  <Amount/>\n  <TrnType>1</TrnType>\n  <CreditCard Registered=\"False\">\n    <CardNumber>[FILTERED]</CardNumber>\n    <ExpM>09</ExpM>\n    <ExpY>2015</ExpY>\n    <CVN>[FILTERED]</CVN>\n    <CardHolderName>Longbob Longsen</CardHolderName>\n  </CreditCard>\n  <Security>\n    <UserName>nmi.api</UserName>\n    <Password>[FILTERED]</Password>\n  </Security>\n  <TrnSource/>\n</Transaction>\n]]>\n      </trnXML>\n    </SubmitSinglePayment>\n  </soap:Body>\n</soap:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Server: Microsoft-IIS/6.0\r\n"
+-> "X-Robots-Tag: noindex\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: text/xml; charset=utf-8\r\n"
+-> "Content-Length: 767\r\n"
+-> "Date: Fri, 19 Dec 2014 19:55:13 GMT\r\n"
+-> "Connection: close\r\n"
+-> "\r\n"
+reading 767 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><SubmitSinglePaymentResponse xmlns=\"http://www.ippayments.com.au/interface/api/dts\"><SubmitSinglePaymentResult>&lt;Response&gt;\r\n\t&lt;ResponseCode&gt;1&lt;/ResponseCode&gt;\r\n\t&lt;Timestamp&gt;20-Dec-2014 06:55:17&lt;/Timestamp&gt;\r\n\t&lt;Receipt&gt;&lt;/Receipt&gt;\r\n\t&lt;SettlementDate&gt;&lt;/SettlementDate&gt;\r\n\t&lt;DeclinedCode&gt;183&lt;/DeclinedCode&gt;\r\n\t&lt;DeclinedMessage&gt;Exception parsing transaction XML&lt;/DeclinedMessage&gt;\r\n&lt;/Response&gt;\r\n</SubmitSinglePaymentResult></SubmitSinglePaymentResponse></soap:Body></soap:Envelope>"
+read 767 bytes
+Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SubmitSinglePaymentResponse xmlns="http://www.ippayments.com.au/interface/api/dts"><SubmitSinglePaymentResult>&lt;Response&gt;
+  &lt;ResponseCode&gt;0&lt;/ResponseCode&gt;
+  &lt;Timestamp&gt;20-Dec-2014 04:07:39&lt;/Timestamp&gt;
+  &lt;Receipt&gt;89435577&lt;/Receipt&gt;
+  &lt;SettlementDate&gt;22-Dec-2014&lt;/SettlementDate&gt;
+  &lt;DeclinedCode&gt;&lt;/DeclinedCode&gt;
+  &lt;DeclinedMessage&gt;&lt;/DeclinedMessage&gt;
+&lt;/Response&gt;
+</SubmitSinglePaymentResult></SubmitSinglePaymentResponse></soap:Body></soap:Envelope>
+    XML
+  end
+
+  def failed_purchase_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SubmitSinglePaymentResponse xmlns="http://www.ippayments.com.au/interface/api/dts"><SubmitSinglePaymentResult>&lt;Response&gt;
+  &lt;ResponseCode&gt;1&lt;/ResponseCode&gt;
+  &lt;Timestamp&gt;20-Dec-2014 04:14:56&lt;/Timestamp&gt;
+  &lt;Receipt&gt;&lt;/Receipt&gt;
+  &lt;SettlementDate&gt;22-Dec-2014&lt;/SettlementDate&gt;
+  &lt;DeclinedCode&gt;05&lt;/DeclinedCode&gt;
+  &lt;DeclinedMessage&gt;Do Not Honour&lt;/DeclinedMessage&gt;
+&lt;/Response&gt;
+</SubmitSinglePaymentResult></SubmitSinglePaymentResponse></soap:Body></soap:Envelope>
+    XML
+  end
+
+  def successful_authorize_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SubmitSinglePaymentResponse xmlns="http://www.ippayments.com.au/interface/api/dts"><SubmitSinglePaymentResult>&lt;Response&gt;
+  &lt;ResponseCode&gt;0&lt;/ResponseCode&gt;
+  &lt;Timestamp&gt;20-Dec-2014 04:18:13&lt;/Timestamp&gt;
+  &lt;Receipt&gt;89435583&lt;/Receipt&gt;
+  &lt;SettlementDate&gt;22-Dec-2014&lt;/SettlementDate&gt;
+  &lt;DeclinedCode&gt;&lt;/DeclinedCode&gt;
+  &lt;DeclinedMessage&gt;&lt;/DeclinedMessage&gt;
+&lt;/Response&gt;
+</SubmitSinglePaymentResult></SubmitSinglePaymentResponse></soap:Body></soap:Envelope>
+    XML
+  end
+
+  def successful_capture_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SubmitSingleCaptureResponse xmlns="http://www.ippayments.com.au/interface/api/dts"><SubmitSingleCaptureResult>&lt;Response&gt;
+  &lt;ResponseCode&gt;0&lt;/ResponseCode&gt;
+  &lt;Timestamp&gt;20-Dec-2014 04:18:15&lt;/Timestamp&gt;
+  &lt;Receipt&gt;89435584&lt;/Receipt&gt;
+  &lt;SettlementDate&gt;22-Dec-2014&lt;/SettlementDate&gt;
+  &lt;DeclinedCode&gt;&lt;/DeclinedCode&gt;
+  &lt;DeclinedMessage&gt;&lt;/DeclinedMessage&gt;
+&lt;/Response&gt;
+</SubmitSingleCaptureResult></SubmitSingleCaptureResponse></soap:Body></soap:Envelope>
+    XML
+  end
+
+  def successful_refund_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SubmitSingleRefundResponse xmlns="http://www.ippayments.com.au/interface/api/dts"><SubmitSingleRefundResult>&lt;Response&gt;
+  &lt;ResponseCode&gt;0&lt;/ResponseCode&gt;
+  &lt;Timestamp&gt;20-Dec-2014 04:24:51&lt;/Timestamp&gt;
+  &lt;Receipt&gt;89435596&lt;/Receipt&gt;
+  &lt;SettlementDate&gt;22-Dec-2014&lt;/SettlementDate&gt;
+  &lt;DeclinedCode&gt;&lt;/DeclinedCode&gt;
+  &lt;DeclinedMessage&gt;&lt;/DeclinedMessage&gt;
+&lt;/Response&gt;
+</SubmitSingleRefundResult></SubmitSingleRefundResponse></soap:Body></soap:Envelope>
+    XML
+  end
+end

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -10,7 +10,7 @@ class BeanstreamTest < Test::Unit::TestCase
                  :login => 'merchant id',
                  :user => 'username',
                  :password => 'password',
-                 :api_key => 'api_key'
+                 :region => :america
                )
 
     @credit_card = credit_card


### PR DESCRIPTION
Integrated the IPP gateway into the Beanstream gatewayand use BeanstreamGateway as the unified entrance;

remove IPP gateway files;

Because the two gateways belong to the same company just different branch. So the developers from the company hope to make them an unified gateway to Shopify.

(Beansteam website: http://www.beanstream.com/)