### PR TITLE
Paymentez: Add tax_percentage optional parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Credorax: Update tests [curiousepic] #2809
 * Braintree: Remove decimal for non-fractional currencies [nfarve] #2806
 * Realex: Add documented country support for US and CA [a-salty-strudel] #2810
+* Paymentez: Add `tax_percentage` optional parameter [deedeelavinder] #2814
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -150,6 +150,7 @@ module ActiveMerchant #:nodoc:
         post[:order][:installments] = options[:installments] if options[:installments]
         post[:order][:installments_type] = options[:installments_type] if options[:installments_type]
         post[:order][:taxable_amount] = options[:taxable_amount] if options[:taxable_amount]
+        post[:order][:tax_percentage] = options[:tax_percentage] if options[:tax_percentage]
       end
 
       def add_payment(post, payment)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -25,7 +25,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
   def test_successful_purchase_with_more_options
     options = {
       order_id: '1',
-      ip: '127.0.0.1'
+      ip: '127.0.0.1',
+      tax_percentage: 0.07
     }
 
     response = @gateway.purchase(@amount, @credit_card, @options.merge(options))


### PR DESCRIPTION
The 5 test failures are due to using credentials from Ecuador which
does not permit `authorize` and does not recoginize the `declined_card`
test number.

Remote Tests:
15 tests, 28 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
66.6667% passed

Unit Tests:
15 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed