### PR TITLE
WorldPay: Add 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Checkout V2: Additional gateway options [dtykocki] #2821
 * CyberSource: Support 3ds validate request [curiousepic] #2823
 * Paymentez: Remove card tokenization step from authorize [dtykocki] #2825
+* WorldPay: Add 3DS [nfarve] #2819
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779


### PR DESCRIPTION
Adds 3DS ability to Worldpay

Errors are caused by authorize calls requiring time to be captured

Loaded suite test/remote/gateways/remote_worldpay_test
24 tests, 75 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
79.1667% passed

Loaded suite test/unit/gateways/worldpay_test

37 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed