### PR TITLE
Realex: Add ApplePay Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Braintree: Add `skip_advanced_fraud_checking` optional parameter [deedeelavinder] #2811
 * SafeCharge: Additional gateway options [dtykocki] #2816
 * FirstPay: Handle missing billing addresses [dtykocki] #2822
+* Realex: Add ApplePay Support [nfarve] #2820
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -140,6 +140,7 @@ module ActiveMerchant
           add_card(xml, credit_card)
           xml.tag! 'autosettle', 'flag' => auto_settle_flag(action)
           add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), amount(money), (options[:currency] || currency(money)), credit_card.number)
+          add_network_tokenization_card(xml, credit_card) if credit_card.is_a?(NetworkTokenizationCreditCard)
           add_comments(xml, options)
           add_address_and_customer_info(xml, options)
         end
@@ -247,6 +248,18 @@ module ActiveMerchant
           xml.tag! 'cvn' do
             xml.tag! 'number', credit_card.verification_value
             xml.tag! 'presind', (options['presind'] || (credit_card.verification_value? ? 1 : nil))
+          end
+        end
+      end
+
+      def add_network_tokenization_card(xml, payment)
+        xml.tag! 'mpi' do
+          xml.tag! 'cavv', payment.payment_cryptogram
+          xml.tag! 'eci', payment.eci
+        end
+        xml.tag! 'supplementarydata' do
+          xml.tag! 'item', 'type' => 'mobile' do
+            xml.tag! 'field01', payment.source.to_s.gsub('_','-')
           end
         end
       end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -978,64 +978,69 @@ realex:
   password: Y
 
 realex_mastercard:
-  number:
+  number: '5425230000004415'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_coms_error:
-  number:
+  number: '5135020000005871'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_declined:
-  number:
+  number: '5114610000004778'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_a:
-  number:
+  number: '5121220000006921'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_b:
-  number:
+  number: '5114630000009791'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 # Realex doesn't provide public testing data
 # Fill in the card numbers with the Realex test
 # data.
 realex_visa:
-  number:
+  number: '4263970000005262'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_coms_error:
-  number:
+  number: '4009830000001985'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_declined:
-  number:
+  number: '4000120000001154'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_a:
-  number:
+  number: '4000160000004147'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_b:
-  number:
+  number: '4000130000001724'
   month: '6'
   year: '2020'
   verification_value: '123'


### PR DESCRIPTION
Adds support for apple pay and updates card numbers as they are now
publicly available.

Loaded suite test/remote/gateways/remote_realex_test
20 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95% passed

Loaded suite test/unit/gateways/realex_test
21 tests, 439 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed