### PR TITLE
FirstPay: Handle missing billing addresses

### DIFF
--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -70,15 +70,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, creditcard, options)
-        address = options[:billing_address] || options[:address]
-        post[:owner_name] = address[:name]
-        post[:owner_street] = address[:address1]
-        post[:owner_street2] = address[:address2] if address[:address2]
-        post[:owner_city] = address[:city]
-        post[:owner_state] = address[:state]
-        post[:owner_zip] = address[:zip]
-        post[:owner_country] = address[:country]
-        post[:owner_phone] = address[:phone] if address[:phone]
+        if address = options[:billing_address] || options[:address]
+          post[:owner_name] = address[:name]
+          post[:owner_street] = address[:address1]
+          post[:owner_street2] = address[:address2] if address[:address2]
+          post[:owner_city] = address[:city]
+          post[:owner_state] = address[:state]
+          post[:owner_zip] = address[:zip]
+          post[:owner_country] = address[:country]
+          post[:owner_phone] = address[:phone] if address[:phone]
+        end
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_first_pay_test.rb
+++ b/test/remote/gateways/remote_first_pay_test.rb
@@ -27,6 +27,14 @@ class RemoteFirstPayTest < Test::Unit::TestCase
     assert_equal 'Declined', response.message
   end
 
+  def test_failed_purchase_with_no_address
+    @options.delete(:billing_address)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal 'Address is invalid (street, city, zip, state and or country fields)', response.message
+  end
+
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
When a billing address or address is not specified, the adapter
will raise an exception. This adds a guard around the address
to prevent these exceptions from occurring.

Remote:
12 tests, 27 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
10 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed