### PR TITLE
Litle: Improve Echeck and enable EcheckToken workflow

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -4,6 +4,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class LitleGateway < Gateway
       SCHEMA_VERSION = '9.12'
+      ECHECK_TOKEN_LENGTH = 17
 
       self.test_url = 'https://www.testvantivcnp.com/sandbox/communicator/online'
       self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -201,8 +201,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def check?(payment_method)
-        return false if payment_method.is_a?(String)
-        card_brand(payment_method) == 'check'
+        if payment_method.is_a?(String)
+          # litle echeck tokens are a uniform length of 17 digits
+          # see section 1.10.2 Token Formats in https://www.vantiv.com/content/dam/vantiv/developers/Vantiv_LitleXML_Reference_Guide_XML10.1_V1.1.pdf
+          payment_method.size == ECHECK_TOKEN_LENGTH
+        else
+          card_brand(payment_method) == 'check'
+        end
       end
 
       def add_authentication(doc)
@@ -259,9 +264,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(doc, payment_method, options)
         if payment_method.is_a?(String)
-          doc.token do
-            doc.litleToken(payment_method)
-          end
+          add_token_payment_method(doc, payment_method, options)
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
             doc.track(payment_method.track_data)
@@ -271,7 +274,7 @@ module ActiveMerchant #:nodoc:
             doc.accType(payment_method.account_type)
             doc.accNum(payment_method.account_number)
             doc.routingNum(payment_method.routing_number)
-            doc.checkNum(payment_method.number)
+            doc.checkNum(payment_method.number) if payment_method.number.present?
           end
         else
           doc.card do
@@ -289,6 +292,23 @@ module ActiveMerchant #:nodoc:
               doc.authenticationValue(options[:cavv]) if options[:cavv]
               doc.authenticationTransactionId(options[:xid]) if options[:xid]
             end
+          end
+        end
+      end
+
+      def add_token_payment_method(doc, payment_method, options)
+        if check?(payment_method)
+          doc.echeckToken do
+            doc.litleToken(payment_method)
+            doc.routingNum(options[:routing_number]) if options[:routing_number]
+            doc.accType(options[:account_type]) if options[:account_type]
+          end
+        else
+          doc.token do
+            doc.litleToken(payment_method)
+            doc.expDate(options[:expiration_date]) if options[:expiration_date].present?
+            doc.cardValidationNum(options[:card_validation_num]) if options[:card_validation_num].present?
+            doc.type(options[:type]) if options[:type].present?
           end
         end
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -226,7 +226,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_failed_refund
     response = stub_comms do
-      @gateway.refund(@amount, "SomeAuthorization")
+      @gateway.refund(@amount, "100000000000000000;authorization;100")
     end.respond_with(failed_refund_response)
 
     assert_failure response
@@ -253,7 +253,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_successful_void_of_other_things
     refund = stub_comms do
-      @gateway.refund(@amount, "SomeAuthorization")
+      @gateway.refund(@amount, "100000000000000000;authorization;100")
     end.respond_with(successful_refund_response)
 
     assert_equal "100000000000000003;credit;", refund.authorization


### PR DESCRIPTION
This removes the requirement for checkNum since it is not required on the echeck endpoints. This will also enable detection of an echeck token and allow for tokens to be used for echeck endpoints. 