### PR TITLE
Paymentez: Remove card tokenization step from authorize

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -61,18 +61,10 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_invoice(post, money, options)
+        add_payment(post, payment)
         add_customer_data(post, options)
 
-        if payment.is_a?(String)
-          post[:card] = { token: payment }
-          commit_transaction('authorize', post)
-        else
-          MultiResponse.run do |r|
-            r.process { store(payment, options) }
-            post[:card] = { token: r.authorization }
-            r.process { commit_transaction('authorize', post) }
-          end
-        end
+        commit_transaction('authorize', post)
       end
 
       def capture(_money, authorization, _options = {})

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -67,7 +67,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success auth
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-    assert_equal 'Operation Successful', capture.message
+    assert_equal 'Response by mock', capture.message
   end
 
   def test_successful_authorize_and_capture_with_token
@@ -78,13 +78,13 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success auth
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-    assert_equal 'Operation Successful', capture.message
+    assert_equal 'Response by mock', capture.message
   end
 
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Not Authorized', response.message
+    assert_equal nil, response.message
   end
 
   def test_partial_capture

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -44,7 +44,7 @@ class PaymentezTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
-    @gateway.stubs(:ssl_post).returns(successful_store_response, successful_authorize_response)
+    @gateway.stubs(:ssl_post).returns(successful_authorize_response)
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
@@ -62,7 +62,7 @@ class PaymentezTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    @gateway.expects(:ssl_post).returns(failed_store_response)
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
@@ -272,17 +272,29 @@ Conn close
 
   def failed_authorize_response
     %q(
-     {
+      {
+        "transaction": {
+          "status": "failure",
+          "payment_date": null,
+          "amount": 1.0,
+          "authorization_code": null,
+          "installments": 1,
+          "dev_reference": "Testing",
+          "message": null,
+          "carrier_code": "3",
+          "id": "CI-1223",
+          "status_detail": 9
+        },
         "card": {
           "bin": "424242",
-          "status": "rejected",
-          "token": "2026849624512750545",
-          "message": "Not Authorized",
-          "expiry_year": "2018",
+          "status": null,
+          "token": "6461587429110733892",
+          "expiry_year": "2019",
           "expiry_month": "9",
-          "transaction_reference": "CI-606",
+          "transaction_reference": "CI-1223",
           "type": "vi",
-          "number": "4242"
+          "number": "4242",
+          "origin": "Paymentez"
         }
       }
     )


### PR DESCRIPTION
It turns out that Paymentez does accept card data when performing an
authorization. Previously, `authorize` would attempt to tokenize a card
via store if not already tokenized. This removes the tokenization step
while still allowing for authorizations to be performed with a tokenized
card.

Unit:
15 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
15 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed