### PR TITLE
CyberSource: Support 3DS validation for authorize

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -258,7 +258,7 @@ module ActiveMerchant #:nodoc:
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
         add_auth_service(xml, creditcard_or_reference, options)
-        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} if options[:payer_auth_enroll_service]
+        add_threeds_services(xml, options)
         add_payment_network_token(xml) if network_tokenization?(creditcard_or_reference)
         add_business_rules_data(xml, creditcard_or_reference, options)
         xml.target!
@@ -403,7 +403,7 @@ module ActiveMerchant #:nodoc:
       def add_business_rules_data(xml, payment_method, options)
         prioritized_options = [options, @options]
 
-        unless network_tokenization?(payment_method) || options[:payer_auth_validate_service]
+        unless network_tokenization?(payment_method)
           xml.tag! 'businessRules' do
             xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
             xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -9,7 +9,19 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111', verification_value: '321')
     @declined_card = credit_card('801111111111111')
     @pinless_debit_card = credit_card('4002269999999999')
+    @three_ds_unenrolled_card = credit_card('4000000000000051',
+      verification_value: '321',
+      month: "12",
+      year: "#{Time.now.year + 2}",
+      brand: :visa
+    )
     @three_ds_enrolled_card = credit_card('4000000000000002',
+      verification_value: '321',
+      month: "12",
+      year: "#{Time.now.year + 2}",
+      brand: :visa
+    )
+    @three_ds_invalid_card = credit_card('4000000000000010',
       verification_value: '321',
       month: "12",
       year: "#{Time.now.year + 2}",
@@ -389,17 +401,37 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_3ds_requests_with_unenrolled_card
-    assert response = @gateway.purchase(1202, @credit_card, @options.merge(payer_auth_enroll_service: true))
+    assert response = @gateway.purchase(1202, @three_ds_unenrolled_card, @options.merge(payer_auth_enroll_service: true))
     assert response.success?
 
-    assert response = @gateway.authorize(1202, @credit_card, @options.merge(payer_auth_enroll_service: true))
+    assert response = @gateway.authorize(1202, @three_ds_unenrolled_card, @options.merge(payer_auth_enroll_service: true))
     assert response.success?
   end
 
-  def test_3ds_validate_request
+  def test_successful_3ds_validate_purchase_request
     assert response = @gateway.purchase(1202, @three_ds_enrolled_card, @options.merge(payer_auth_validate_service: true, pares: pares))
     assert_equal "100", response.params["reasonCode"]
+    assert_equal "0", response.params["authenticationResult"]
     assert response.success?
+  end
+
+  def test_failed_3ds_validate_purchase_request
+    assert response = @gateway.purchase(1202, @three_ds_invalid_card, @options.merge(payer_auth_validate_service: true, pares: pares))
+    assert_equal "476", response.params["reasonCode"]
+    assert !response.success?
+  end
+
+  def test_successful_3ds_validate_authorize_request
+    assert response = @gateway.authorize(1202, @three_ds_enrolled_card, @options.merge(payer_auth_validate_service: true, pares: pares))
+    assert_equal "100", response.params["reasonCode"]
+    assert_equal "0", response.params["authenticationResult"]
+    assert response.success?
+  end
+
+  def test_failed_3ds_validate_authorize_request
+    assert response = @gateway.authorize(1202, @three_ds_invalid_card, @options.merge(payer_auth_validate_service: true, pares: pares))
+    assert_equal "476", response.params["reasonCode"]
+    assert !response.success?
   end
 
   def pares


### PR DESCRIPTION
Also allows businessRules fields to be passed for 3DS transactions and
adds more 3DS tests.

Remote (3 unrelated failures for pinless debit cards):
43 tests, 192 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.0233% passed

Unit:
45 tests, 217 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed