### PR TITLE
Adding 3D Secure pass thru capabilities to Braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -558,7 +558,7 @@ module ActiveMerchant #:nodoc:
             :hold_in_escrow => options[:hold_in_escrow],
           }
         }
-        
+
         if options[:skip_advanced_fraud_checking]
           parameters[:options].merge!({ :skip_advanced_fraud_checking => options[:skip_advanced_fraud_checking] })
         end
@@ -631,6 +631,14 @@ module ActiveMerchant #:nodoc:
             name: options[:descriptor_name],
             phone: options[:descriptor_phone],
             url: options[:descriptor_url]
+          }
+        end
+
+        if options[:three_d_secure]
+          parameters[:three_d_secure_pass_thru] = {
+            cavv: options[:three_d_secure][:cavv],
+            eci_flag: options[:three_d_secure][:eci],
+            xid: options[:three_d_secure][:xid],
           }
         end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -368,6 +368,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Mexico', transaction["shipping_details"]["country_name"]
   end
 
+  def test_successful_purchase_with_three_d_secure_pass_thru
+    three_d_secure_params = { eci: "05", cavv: "cavv", xid: "xid" }
+    assert response = @gateway.purchase(@amount, @credit_card,
+                                        three_d_secure: three_d_secure_params
+                                       )
+    assert_success response
+  end
+
   def test_unsuccessful_purchase_declined
     assert response = @gateway.purchase(@declined_amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -142,6 +142,12 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
     assert  response.message.match(/Invalid Transaction ID \/ Object ID specified:/)
   end
 
+  def test_authorize_with_three_d_secure_pass_thru
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(eci: "05", xid: "xid", cavv: "cavv"))
+    assert_success auth
+    assert_equal 'This transaction has been approved', auth.message
+  end
+
   def test_successful_verify
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response
@@ -170,7 +176,7 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
       @gateway.purchase(@declined_amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
-    
+
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -513,6 +513,20 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"), :customer => {:first_name => "Longbob", :last_name => "Longsen"})
   end
 
+  def test_three_d_secure_pass_thru_handling
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(has_entries(three_d_secure_pass_thru: {
+        cavv: "cavv",
+        eci_flag: "eci",
+        xid: "xid",
+    })).
+   returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"), three_d_secure: {cavv: "cavv", eci: "eci", xid: "xid"})
+  end
+
   def test_passes_recurring_flag
     @gateway = BraintreeBlueGateway.new(
       :merchant_id => 'test',


### PR DESCRIPTION
This is simply adding support to `:three_d_secure_pass_thru` params for
Braintree, documented here: https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#three_d_secure_pass_thru