### PR TITLE
Adyen: Add support for installments

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -47,6 +47,7 @@ module ActiveMerchant #:nodoc:
         add_extra_data(post, options)
         add_shopper_interaction(post, payment, options)
         add_address(post, options)
+        add_installments(post, options) if options[:installments]
         commit('authorise', post)
       end
 
@@ -194,6 +195,12 @@ module ActiveMerchant #:nodoc:
         }
 
         post[:recurring] = recurring
+      end
+
+      def add_installments(post, options)
+        post[:installments] = {
+          value: options[:installments]
+        }
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -23,7 +23,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_ip: "77.110.174.153",
       shopper_reference: "John Smith",
       billing_address: address(),
-      order_id: "123"
+      order_id: "123",
+      installments: 2
     }
   end
 


### PR DESCRIPTION
Adds the ability to spread a purchase over several installments.

Loaded suite test/remote/gateways/remote_adyen_test

32 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
..................

Loaded suite test/unit/gateways/adyen_test

18 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed