### PR TITLE
NAB Transact: Pass nonfractional amounts correctly

### DIFF
--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
 
       class_attribute :test_periodic_url, :live_periodic_url
 
-      self.test_url = 'https://transact.nab.com.au/test/xmlapi/payment'
+      self.test_url = 'https://demo.transact.nab.com.au/xmlapi/payment'
       self.live_url = 'https://transact.nab.com.au/live/xmlapi/payment'
       self.test_periodic_url = 'https://transact.nab.com.au/xmlapidemo/periodic'
       self.live_periodic_url = 'https://transact.nab.com.au/xmlapi/periodic'
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
 
       def build_purchase_request(money, credit_card, options)
         xml = Builder::XmlMarkup.new
-        xml.tag! 'amount', amount(money)
+        xml.tag! 'amount', localized_amount(money, options[:currency] || currency(money))
         xml.tag! 'currency', options[:currency] || currency(money)
         xml.tag! 'purchaseOrderNo', options[:order_id].to_s.gsub(/[ ']/, '')
 
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
 
         transaction_id, order_id, preauth_id, original_amount = reference.split('*')
 
-        xml.tag! 'amount', (money ? amount(money) : original_amount)
+        xml.tag! 'amount', (money ? localized_amount(money, options[:currency] || currency(money)) : original_amount)
         xml.tag! 'currency', options[:currency] || currency(money)
         xml.tag! 'txnID', transaction_id
         xml.tag! 'purchaseOrderNo', order_id
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
 
         xml.tag! 'crn', identification
         xml.tag! 'currency', options[:currency] || currency(money)
-        xml.tag! 'amount', amount(money)
+        xml.tag! 'amount', localized_amount(money, options[:currency] || currency(money))
 
         xml.target!
       end

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -177,7 +177,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     authorization = response.authorization
     assert response = @gateway.refund(@amount+1, authorization)
     assert_failure response
-    assert_equal 'Only $2.0 available for refund', response.message
+    assert_equal 'Only 2.00 AUD available for refund', response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -153,6 +153,14 @@ class NabTransactTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_nonfractional_currencies
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(10000, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<amount>100<\/amount>/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
Also updates test url, but there are still remote test failures using
the "Card Acceptor" (flag on the test account) and the "Periodic"
endpoint (which is failing connection). But these are unrelated to the
change.

Remote:
22 tests, 54 assertions, 4 failures, 6 errors, 0 pendings, 0 omissions, 0 notifications
54.5455% passed

Unit:
18 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed