### PR TITLE
Merchant Warrior: Support transcript scrubbing

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -68,6 +68,18 @@ module ActiveMerchant #:nodoc:
         commit('addCard', post)
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((&?paymentCardNumber=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((CardNumber=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?paymentCardCSC=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?apiKey=)[^&]*)i, '\1[FILTERED]')
+      end
+
       private
 
       def add_transaction(post, identification)

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -139,6 +139,11 @@ class MerchantWarriorTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
   private
 
   def successful_purchase_response
@@ -215,5 +220,13 @@ class MerchantWarriorTest < Test::Unit::TestCase
   <ivrCardID>10023982</ivrCardID>
 </mwResponse>
     XML
+  end
+
+  def pre_scrubbed
+    %q(transactionAmount=1.00&transactionCurrency=AUD&hash=adb50f6ff360f861e6f525e8daae76b5&transactionProduct=98fc25d40a47f3d24da460c0ca307c&customerName=Longbob+Longsen&customerCountry=AU&customerState=Queensland&customerCity=Brisbane&customerAddress=123+test+st&customerPostCode=4000&customerIP=&customerPhone=&customerEmail=&paymentCardNumber=5123456789012346&paymentCardName=Longbob+Longsen&paymentCardExpiry=0520&paymentCardCSC=123&merchantUUID=51f7da294af8f&apiKey=nooudtd0&method=processCard)
+  end
+
+  def post_scrubbed
+    %q(transactionAmount=1.00&transactionCurrency=AUD&hash=adb50f6ff360f861e6f525e8daae76b5&transactionProduct=98fc25d40a47f3d24da460c0ca307c&customerName=Longbob+Longsen&customerCountry=AU&customerState=Queensland&customerCity=Brisbane&customerAddress=123+test+st&customerPostCode=4000&customerIP=&customerPhone=&customerEmail=&paymentCardNumber=[FILTERED]&paymentCardName=Longbob+Longsen&paymentCardExpiry=0520&paymentCardCSC=[FILTERED]&merchantUUID=51f7da294af8f&apiKey=[FILTERED]&method=processCard)
   end
 end


### PR DESCRIPTION
Most of the remote tests fail mostly due to test-account decay, but the
scrubbing tests are good and should be sufficiently exercised even in
this state.

Remote:
11 tests, 37 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
36.3636% passed

Unit:
10 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed