### PR TITLE
QBMS: Support transcript scrubbing

### DIFF
--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -113,6 +113,17 @@ module ActiveMerchant #:nodoc:
         commit(:query, nil, {})
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<ConnectionTicket>)[^<]*(</ConnectionTicket>))i, '\1[FILTERED]\2').
+          gsub(%r((<CreditCardNumber>)[^<]*(</CreditCardNumber>))i, '\1[FILTERED]\2').
+          gsub(%r((<CardSecurityCode>)[^<]*(</CardSecurityCode>))i, '\1[FILTERED]\2')
+      end
+
       private
 
       def hosted?

--- a/test/remote/gateways/remote_qbms_test.rb
+++ b/test/remote/gateways/remote_qbms_test.rb
@@ -88,6 +88,17 @@ class QbmsTest < Test::Unit::TestCase
     assert_equal "The request to process this transaction has been declined.", response.message
   end
 
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:ticket], transcript)
+  end
+
   private
 
   def error_card(config_id)

--- a/test/unit/gateways/qbms_test.rb
+++ b/test/unit/gateways/qbms_test.rb
@@ -155,6 +155,11 @@ class QbmsTest < Test::Unit::TestCase
     ActiveMerchant::Billing::Base.mode = :test
   end
 
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
   # helper methods start here
 
   def query_response(opts = {})
@@ -253,5 +258,67 @@ class QbmsTest < Test::Unit::TestCase
        </QBMSXMLMsgsRs>
      </QBMSXML>
      XML
+  end
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+    <?xml version="1.0" encoding="utf-8"?><?qbmsxml version="4.0"?><QBMSXML><SignonMsgsRq><SignonDesktopRq><ClientDateTime>2012-07-06T11:48:30-07:00</ClientDateTime><ApplicationLogin>subscriptions-test.spreedly.com</ApplicationLogin><ConnectionTicket>TGT-135-0exSkgC_I9tvKAxCwOE$Eg</ConnectionTicket></SignonDesktopRq></SignonMsgsRq><QBMSXMLMsgsRq><CustomerCreditCardChargeRq><TransRequestID>859e649c87f9ac698536</TransRequestID><CreditCardNumber>4111111111111111</CreditCardNumber><ExpirationMonth>9</ExpirationMonth><ExpirationYear>2013</ExpirationYear><IsECommerce>true</IsECommerce><Amount>1.00</Amount><NameOnCard>Longbob Longsen</NameOnCard><CreditCardAddress>1234 My Street</CreditCardAddress><CreditCardPostalCode>K1C2N6</CreditCardPostalCode><CardSecurityCode>123</CardSecurityCode></CustomerCreditCardChargeRq></QBMSXMLMsgsRq></QBMSXML>
+    <!DOCTYPE QBMSXML PUBLIC "-//INTUIT//DTD QBMSXML QBMS 4.0//EN" "http://webmerchantaccount.ptc.quickbooks.com/dtds/qbmsxml40.dtd">
+    <QBMSXML>
+     <SignonMsgsRs>
+      <SignonDesktopRs statusCode="0" statusSeverity="INFO">
+       <ServerDateTime>2012-07-06T18:48:31</ServerDateTime>
+       <SessionTicket>V1-110-Q31341600511142d1e4131:133159303</SessionTicket>
+      </SignonDesktopRs>
+     </SignonMsgsRs>
+     <QBMSXMLMsgsRs>
+      <CustomerCreditCardChargeRs statusCode="0" statusMessage="Status OK" statusSeverity="INFO">
+       <CreditCardTransID>YY1002519111</CreditCardTransID>
+       <AuthorizationCode>135927</AuthorizationCode>
+       <AVSStreet>Pass</AVSStreet>
+       <AVSZip>Pass</AVSZip>
+       <CardSecurityCodeMatch>Pass</CardSecurityCodeMatch>
+       <MerchantAccountNumber>5247711053184054</MerchantAccountNumber>
+       <ReconBatchID>420120706 1Q11485247711053184054AUTO04</ReconBatchID>
+       <PaymentGroupingCode>5</PaymentGroupingCode>
+       <PaymentStatus>Completed</PaymentStatus>
+       <TxnAuthorizationTime>2012-07-06T18:48:31</TxnAuthorizationTime>
+       <TxnAuthorizationStamp>1341600511</TxnAuthorizationStamp>
+       <ClientTransID>q0b539f2</ClientTransID>
+      </CustomerCreditCardChargeRs>
+     </QBMSXMLMsgsRs>
+    </QBMSXML>
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+    <?xml version="1.0" encoding="utf-8"?><?qbmsxml version="4.0"?><QBMSXML><SignonMsgsRq><SignonDesktopRq><ClientDateTime>2012-07-06T11:48:30-07:00</ClientDateTime><ApplicationLogin>subscriptions-test.spreedly.com</ApplicationLogin><ConnectionTicket>[FILTERED]</ConnectionTicket></SignonDesktopRq></SignonMsgsRq><QBMSXMLMsgsRq><CustomerCreditCardChargeRq><TransRequestID>859e649c87f9ac698536</TransRequestID><CreditCardNumber>[FILTERED]</CreditCardNumber><ExpirationMonth>9</ExpirationMonth><ExpirationYear>2013</ExpirationYear><IsECommerce>true</IsECommerce><Amount>1.00</Amount><NameOnCard>Longbob Longsen</NameOnCard><CreditCardAddress>1234 My Street</CreditCardAddress><CreditCardPostalCode>K1C2N6</CreditCardPostalCode><CardSecurityCode>[FILTERED]</CardSecurityCode></CustomerCreditCardChargeRq></QBMSXMLMsgsRq></QBMSXML>
+    <!DOCTYPE QBMSXML PUBLIC "-//INTUIT//DTD QBMSXML QBMS 4.0//EN" "http://webmerchantaccount.ptc.quickbooks.com/dtds/qbmsxml40.dtd">
+    <QBMSXML>
+     <SignonMsgsRs>
+      <SignonDesktopRs statusCode="0" statusSeverity="INFO">
+       <ServerDateTime>2012-07-06T18:48:31</ServerDateTime>
+       <SessionTicket>V1-110-Q31341600511142d1e4131:133159303</SessionTicket>
+      </SignonDesktopRs>
+     </SignonMsgsRs>
+     <QBMSXMLMsgsRs>
+      <CustomerCreditCardChargeRs statusCode="0" statusMessage="Status OK" statusSeverity="INFO">
+       <CreditCardTransID>YY1002519111</CreditCardTransID>
+       <AuthorizationCode>135927</AuthorizationCode>
+       <AVSStreet>Pass</AVSStreet>
+       <AVSZip>Pass</AVSZip>
+       <CardSecurityCodeMatch>Pass</CardSecurityCodeMatch>
+       <MerchantAccountNumber>5247711053184054</MerchantAccountNumber>
+       <ReconBatchID>420120706 1Q11485247711053184054AUTO04</ReconBatchID>
+       <PaymentGroupingCode>5</PaymentGroupingCode>
+       <PaymentStatus>Completed</PaymentStatus>
+       <TxnAuthorizationTime>2012-07-06T18:48:31</TxnAuthorizationTime>
+       <TxnAuthorizationStamp>1341600511</TxnAuthorizationStamp>
+       <ClientTransID>q0b539f2</ClientTransID>
+      </CustomerCreditCardChargeRs>
+     </QBMSXMLMsgsRs>
+    </QBMSXML>
+    POST_SCRUBBED
   end
 end


### PR DESCRIPTION
We do not have test credentials for QBMS and they claim their test
sandbox is not currently working, so the remote tests cannot be run. The
mock transcripts added here in the unit tests should be accurate; they
come from an external scrub test that dates to the same time and API
version for the gateway implementation here in Active Merchant. We also
can confirm properly scrubbed recent transcripts using the same scrub
method externally.

Unit:
15 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed