### PR TITLE
Paymentez: Read messages on Failure with no error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Realex: Update Country List [nfarve] #2842
 * QBMS: Support transcript scrubbing [curiousepic] #2849
 * Adyen: Add support for installments [nfarve] #2839
+* Paymentez: Read messages on Failure with no error [nfarve] #2850
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -219,7 +219,11 @@ module ActiveMerchant #:nodoc:
         if success_from(response)
           response['transaction'] && response['transaction']['message']
         else
-          response['error'] && response['error']['type']
+          if response['error']
+            response['error'] && response['error']['type']
+          else
+            response['transaction']['message']
+          end
         end
       end
 

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -43,6 +43,15 @@ class PaymentezTest < Test::Unit::TestCase
     assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
+  def test_expired_card
+    @gateway.expects(:ssl_post).returns(expired_card_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    assert_equal 'Expired card', response.message
+  end
+
   def test_successful_authorize
     @gateway.stubs(:ssl_post).returns(successful_authorize_response)
 
@@ -370,6 +379,34 @@ Conn close
           "type": "vi",
           "number": "4242"
         }
+      }
+    )
+  end
+
+  def expired_card_response
+    %q(
+      {
+       "transaction":{
+          "status":"failure",
+          "payment_date":null,
+          "amount":1.0,
+          "authorization_code":null,
+          "installments":1,
+          "dev_reference":"ci123",
+          "message":"Expired card",
+          "carrier_code":"54",
+          "id":"PR-25",
+          "status_detail":9
+       },
+       "card":{
+          "bin":"528851",
+          "expiry_year":"2024",
+          "expiry_month":"4",
+          "transaction_reference":"PR-25",
+          "type":"mc",
+          "number":"9794",
+          "origin":"Paymentez"
+       }
       }
     )
   end


### PR DESCRIPTION
Extends parsing messages on failure. Messages can be returned that are not included in the error
field.

Loaded suite test/unit/gateways/paymentez_test
................

16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_paymentez_test
................

16 tests, 39 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed