### PR TITLE
Paymentez: Fix response message conditional

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -216,14 +216,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        if success_from(response)
-          response['transaction'] && response['transaction']['message']
+        if !success_from(response) && response['error']
+          response['error'] && response['error']['type']
         else
-          if response['error']
-            response['error'] && response['error']['type']
-          else
-            response['transaction']['message']
-          end
+          response['transaction'] && response['transaction']['message']
         end
       end
 


### PR DESCRIPTION
Previously, an exception was occurring if there was no transaction
message. This catches instances where there is no transaction element
using guard clauses.

Remote: 15 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed