### PR TITLE
Add ability to send email receipt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Adyen: Add support for installments [nfarve] #2839
 * Paymentez: Read messages on Failure with no error [nfarve] #2850
 * Paymentez: Fix response message conditional [curiousepic] #2851
+* Add ability to send email receipt [nfarve] #2852
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -140,7 +140,12 @@ module ActiveMerchant #:nodoc:
 
         if options.has_key? :email
           post[:custemail] = options[:email]
-          post[:custreceipt] = 'No'
+          if options[:cust_receipt]
+            post[:custreceipt] = options[:cust_receipt]
+            post[:custreceiptname] = options[:cust_receipt_name] if options[:cust_receipt_name]
+          else
+            post[:custreceipt] = 'No'
+          end
         end
 
         if options.has_key? :customer

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -55,6 +55,12 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_email_receipt
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:email => 'hank@hill.com',:cust_receipt => 'Yes'))
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
   def test_unsuccessful_purchase
     # For some reason this will fail with "You have tried this card too
     # many times, please contact merchant" unless a unique order id is

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -82,6 +82,17 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_email_receipt
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(:email => 'bobby@hill.com', :cust_receipt => 'Yes', :cust_receipt_name => "socool"))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMcustreceipt=Yes/, data)
+      assert_match(/UMcustreceiptname=socool/, data)
+      assert_match(/UMtestmode=0/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   def test_successful_purchase_split_payment
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(


### PR DESCRIPTION
Adds the ability to set a flag to return emailed receipts as well as the
template to use when sending the receipt.

Loaded suite test/unit/gateways/usa_epay_transaction_test
Started
.............................................

45 tests, 263 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
100% passed

Loaded suite test/remote/gateways/remote_usa_epay_transaction_test
.........................

25 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
100% passed