### PR TITLE
Barclaycard Smartpay: Pass shopper_interaction

### DIFF
--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -305,6 +305,7 @@ module ActiveMerchant #:nodoc:
         hash[:shopperEmail]     = options[:email] if options[:email]
         hash[:shopperIP]        = options[:ip] if options[:ip]
         hash[:shopperReference] = options[:customer] if options[:customer]
+        hash[:shopperInteraction] = options[:shopper_interaction] if options[:shopper_interaction]
         hash.keep_if { |_, v| v }
       end
 

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -153,6 +153,12 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_shopper_interaction
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(shopper_interaction: 'ContAuth'))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_authorize_with_3ds
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: true))
     assert_equal 'RedirectShopper', response.message

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -157,6 +157,16 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal '7914002629995504', response.authorization
   end
 
+  def test_successful_authorize_with_extra_options
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(shopper_interaction: 'ContAuth'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/shopperInteraction=ContAuth/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_successful_authorize
     @gateway.stubs(:ssl_post).returns(successful_authorize_response)
 


### PR DESCRIPTION
Remote:
29 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
25 tests, 114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed