### PR TITLE
Authorize.net: Add ability to pass `customer_payment_profile_id`

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -167,7 +167,7 @@ module ActiveMerchant
             xml.transactionType('refundTransaction')
             xml.amount(amount(amount))
 
-            add_payment_source(xml, payment, :credit)
+            add_payment_source(xml, payment, :credit, options)
             xml.refTransId(transaction_id_from(options[:transaction_id])) if options[:transaction_id]
             add_invoice(xml, 'refundTransaction', options)
             add_customer_data(xml, payment, options)
@@ -246,7 +246,7 @@ module ActiveMerchant
         xml.transactionRequest do
           xml.transactionType(transaction_type)
           xml.amount(amount(amount))
-          add_payment_source(xml, payment)
+          add_payment_source(xml, payment, options=options)
           add_invoice(xml, transaction_type, options)
           add_tax_fields(xml, options)
           add_duty_fields(xml, options)
@@ -268,7 +268,7 @@ module ActiveMerchant
             add_tax_fields(xml, options)
             add_shipping_fields(xml, options)
             add_duty_fields(xml, options)
-            add_payment_source(xml, payment)
+            add_payment_source(xml, payment, options=options)
             add_invoice(xml, transaction_type, options)
             add_tax_exempt_status(xml, options)
           end
@@ -375,10 +375,10 @@ module ActiveMerchant
         end
       end
 
-      def add_payment_source(xml, source, action = nil)
+      def add_payment_source(xml, source, action = nil, options)
         return unless source
         if source.is_a?(String)
-          add_token_payment_method(xml, source)
+          add_token_payment_method(xml, source, options)
         elsif card_brand(source) == 'check'
           add_check(xml, source)
         elsif card_brand(source) == 'apple_pay'
@@ -489,8 +489,9 @@ module ActiveMerchant
         end
       end
 
-      def add_token_payment_method(xml, token)
+      def add_token_payment_method(xml, token, options)
         customer_profile_id, customer_payment_profile_id, _ = split_authorization(token)
+        customer_payment_profile_id = options[:customer_payment_profile_id] if options[:customer_payment_profile_id]
         xml.customerProfileId(customer_profile_id)
         xml.customerPaymentProfileId(customer_payment_profile_id)
       end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -392,6 +392,15 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_match %r{Address not verified}, response.avs_result["message"]
   end
 
+  def test_failed_authorize_using_wrong_token
+    response = @gateway.store(@declined_card)
+    assert_success response
+
+    response = @gateway.authorize(@amount, response.authorization, @options.merge(customer_payment_profile_id: 12345))
+    assert_failure response
+
+    assert_equal 'Customer Profile ID or Customer Payment Profile ID not found', response.message
+  end
   def test_failed_capture_using_stored_card
     store = @gateway.store(@credit_card, @options)
     assert_success store


### PR DESCRIPTION
Adds the ability to actively set the `customer_payment_profile_id`
field.

Loaded suite test/remote/gateways/remote_authorize_net_test
..................................................................

66 tests, 224 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/authorize_net_test
............................................................................................

92 tests, 521 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed