### PR TITLE
Mundipagg: Remove Billing Address if no Address Sent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@
 * Add ability to send email receipt [nfarve] #2852
 * Barclaycard Smartpay: Pass shopper_interaction [curiousepic] #2853
 * Stripe: Treat UGX as a zero-decimal currency [bpollack] #2857
+* Mundipagg: Remove Billing Address if no Address Sent [nfarve] #2855
 
 == Version 1.78.0 (March 29, 2018)
 * Litle: Add store for echecks [nfarve] #2779

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -109,18 +109,20 @@ module ActiveMerchant #:nodoc:
         post[:customer][:email] = options[:email]
       end
 
-      def add_billing_address(options)
-        billing = {}
-        address = options[:billing_address] || options[:address]
-        billing[:street] = address[:address1].match(/\D+/)[0].strip if address[:address1]
-        billing[:number] = address[:address1].match(/\d+/)[0] if address[:address1]
-        billing[:compliment] = address[:address2] if address[:address2]
-        billing[:city] = address[:city] if address[:city]
-        billing[:state] = address[:state] if address[:state]
-        billing[:country] = address[:country] if address[:country]
-        billing[:zip_code] = address[:zip] if address[:zip]
-        billing[:neighborhood] = address[:neighborhood]
-        billing
+      def add_billing_address(post, type, options)
+        if address = (options[:billing_address] || options[:address])
+          billing = {}
+          address = options[:billing_address] || options[:address]
+          billing[:street] = address[:address1].match(/\D+/)[0].strip if address[:address1]
+          billing[:number] = address[:address1].match(/\d+/)[0] if address[:address1]
+          billing[:compliment] = address[:address2] if address[:address2]
+          billing[:city] = address[:city] if address[:city]
+          billing[:state] = address[:state] if address[:state]
+          billing[:country] = address[:country] if address[:country]
+          billing[:zip_code] = address[:zip] if address[:zip]
+          billing[:neighborhood] = address[:neighborhood]
+          post[:payment][type.to_sym][:card][:billing_address] = billing
+        end
       end
 
       def add_shipping_address(post, options)
@@ -153,7 +155,7 @@ module ActiveMerchant #:nodoc:
         post[:customer][:name] = payment.name if post[:customer]
         post[:customer_id] = parse_auth(payment)[0] if payment.is_a?(String)
         post[:payment] = {}
-        post[:payment][:gateway_affiliation_id] = @options[:gateway_id]
+        post[:payment][:gateway_affiliation_id] = @options[:gateway_id] if @options[:gateway_id]
         post[:payment][:metadata] = { mundipagg_payment_method_code: '1' } if test?
         if voucher?(payment)
           add_voucher(post, payment, options)
@@ -174,7 +176,7 @@ module ActiveMerchant #:nodoc:
           post[:payment][:credit_card][:card][:exp_month] = payment.month
           post[:payment][:credit_card][:card][:exp_year] = payment.year
           post[:payment][:credit_card][:card][:cvv] = payment.verification_value
-          post[:payment][:credit_card][:card][:billing_address] = add_billing_address(options)
+          add_billing_address(post,'credit_card', options)
         end
       end
 
@@ -189,7 +191,7 @@ module ActiveMerchant #:nodoc:
         post[:payment][:voucher][:card][:exp_month] = payment.month
         post[:payment][:voucher][:card][:exp_year] = payment.year
         post[:payment][:voucher][:card][:cvv] = payment.verification_value
-        post[:payment][:voucher][:card][:billing_address] = add_billing_address(options)
+        add_billing_address(post, 'voucher', options)
       end
 
       def voucher?(payment)

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -20,6 +20,13 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
   end
 
+  def test_successful_purchase_no_address
+    @options.delete(:billing_address)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+  end
+
   def test_successful_purchase_with_more_options
     options = @options.update({
       order_id: '1',

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -24,6 +24,15 @@ class MundipaggTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_billing_not_sent
+    @options.delete(:billing_address)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      refute data["billing_address"]
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Removes the `billing_address` object if no address is sent.

Loaded suite test/unit/gateways/mundipagg_test
...............

15 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_mundipagg_test
....................

20 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed