### PR TITLE
Added list of currency to be treated as three digit currencies for cybersource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(JPY)
+      self.currencies_with_three_decimal_places = %w(BHD IQD JOD KWD LYD OMR TND)
 
       self.homepage_url = 'http://www.cybersource.com'
       self.display_name = 'CyberSource'


### PR DESCRIPTION
We need to supply the list of currencies that has 3 decimal for them to be properly understood by the gateway.

Ex: 7.500 KWD would be translated to "7500.00" when the amount is calculated when it should be  "7.50".