### PR TITLE
Add logging of SSL connection details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Allow setting min/max SSL version for a connection on Ruby 2.5 [bdewater] #2775
 * Add `gateways:ssl:min_version` rake task to test upcoming TLS 1.0 deprecation deadline [bdewater] #2775
+* Log negotiated SSL version and cipher [bdewater + methodmissing] #2862
 * Remove support for Rails < 4.2, add support for Rails 5.2 and Ruby 2.5 [bdewater]
 * Spreedly: Support verify and find transactions [abarrak] #2798
 * Adyen: Support merchant-specific subdomains [curiousepic] #2799

--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -40,6 +40,7 @@ require 'socket'
 require 'openssl'
 
 require 'active_merchant/network_connection_retries'
+require 'active_merchant/net_http_ssl_connection'
 require 'active_merchant/connection'
 require 'active_merchant/post_data'
 require 'active_merchant/posts_data'

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -5,6 +5,7 @@ require 'benchmark'
 
 module ActiveMerchant
   class Connection
+    using NetHttpSslConnection
     include NetworkConnectionRetries
 
     MAX_RETRIES = 3
@@ -25,6 +26,7 @@ module ActiveMerchant
       attr_accessor :min_version
       attr_accessor :max_version
     end
+    attr_reader :ssl_connection
     attr_accessor :ca_file
     attr_accessor :ca_path
     attr_accessor :pem
@@ -52,6 +54,7 @@ module ActiveMerchant
         @min_version = nil
         @max_version = nil
       end
+      @ssl_connection = {}
       @proxy_address = :ENV
       @proxy_port = nil
     end
@@ -71,6 +74,10 @@ module ActiveMerchant
           result = nil
 
           realtime = Benchmark.realtime do
+            http.start unless http.started?
+            @ssl_connection = http.ssl_connection
+            info "connection_ssl_version=#{ssl_connection[:version]} connection_ssl_cipher=#{ssl_connection[:cipher]}", tag
+
             result = case method
             when :get
               raise ArgumentError, "GET requests do not support a request body" if body
@@ -109,16 +116,20 @@ module ActiveMerchant
 
     ensure
       info "connection_request_total_time=%.4fs" % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start], tag
+      http.finish if http.started?
     end
 
     private
+
     def http
-      http = Net::HTTP.new(endpoint.host, endpoint.port, proxy_address, proxy_port)
-      configure_debugging(http)
-      configure_timeouts(http)
-      configure_ssl(http)
-      configure_cert(http)
-      http
+      @http ||= begin
+        http = Net::HTTP.new(endpoint.host, endpoint.port, proxy_address, proxy_port)
+        configure_debugging(http)
+        configure_timeouts(http)
+        configure_ssl(http)
+        configure_cert(http)
+        http
+      end
     end
 
     def configure_debugging(http)

--- a/lib/active_merchant/net_http_ssl_connection.rb
+++ b/lib/active_merchant/net_http_ssl_connection.rb
@@ -1,0 +1,9 @@
+require 'net/http'
+
+module NetHttpSslConnection
+  refine Net::HTTP do
+    def ssl_connection
+      { version: @socket.io.ssl_version, cipher: @socket.io.cipher[0] }
+    end
+  end
+end


### PR DESCRIPTION
On June 30 the PCI DSS mandates TLS 1.1 or better for securely transmitting payment data. This refinement to Net::HTTP allows us to get the required details within the scope of the ActiveMerchant::Connection class, without monkey patching globally.

Example output:
```
irb(main):004:0> gw.authorize(100, "test")
I, [2018-05-30T11:22:44.565084 #44620]  INFO -- : [ActiveMerchant::Billing::PayflowGateway] connection_http_method=POST connection_uri=https://payflowpro.paypal.com
I, [2018-05-30T11:22:45.165265 #44620]  INFO -- : [ActiveMerchant::Billing::PayflowGateway] connection_ssl_version=TLSv1.2 connection_ssl_cipher=ECDHE-RSA-AES128-GCM-SHA256
```