### PR TITLE
Require Ruby 2.3 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ rvm:
 - 2.5
 - 2.4
 - 2.3
-- 2.2
 
 gemfile:
 - Gemfile.rails52
@@ -21,7 +20,7 @@ gemfile:
 
 matrix:
   include:
-    - rvm: 2.1
+    - rvm: 2.3
       gemfile: Gemfile.rails42
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ The [ActiveMerchant Wiki](http://github.com/activemerchant/active_merchant/wikis
 ## API stability policy
 
 Functionality or APIs that are deprecated will be marked as such. Deprecated functionality is removed on major version changes - for example, deprecations from 2.x are removed in 3.x.
+
+## Ruby and Rails compatibility policies
+
+Because Active Merchant is a payment library, it needs to take security seriously. For this reason, Active Merchant guarantees compatibility only with actively supported versions of Ruby and Rails. At the time of this writing, that means that the Ruby 2.3+ and Rails 4.2+ are supported.

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://activemerchant.org/'
   s.rubyforge_project = 'activemerchant'
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.3'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: '2.1.0'
+    version: '2.3.0'
 
 dependencies:
   cache_directories:

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -190,10 +190,8 @@ module ActiveMerchant #:nodoc:
 
         if ActiveSupport::Inflector.method(:transliterate).arity == -2
           ActiveSupport::Inflector.transliterate(text,'')
-        elsif RUBY_VERSION >= '1.9'
-          text.gsub(/[^\x00-\x7F]+/, '')
         else
-          ActiveSupport::Inflector.transliterate(text).to_s
+          text.gsub(/[^\x00-\x7F]+/, '')
         end
       end
     end

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -197,10 +197,8 @@ module ActiveMerchant #:nodoc:
 
         if ActiveSupport::Inflector.method(:transliterate).arity == -2
           ActiveSupport::Inflector.transliterate(text,'')
-        elsif RUBY_VERSION >= '1.9'
-          text.gsub(/[^\x00-\x7F]+/, '')
         else
-          ActiveSupport::Inflector.transliterate(text).to_s
+          text.gsub(/[^\x00-\x7F]+/, '')
         end
       end
 

--- a/test/remote/gateways/remote_finansbank_test.rb
+++ b/test/remote/gateways/remote_finansbank_test.rb
@@ -3,11 +3,6 @@ require 'test_helper'
 
 class RemoteFinansbankTest < Test::Unit::TestCase
   def setup
-    if RUBY_VERSION < '1.9' && $KCODE == "NONE"
-      @original_kcode = $KCODE
-      $KCODE = 'u'
-    end
-
     @gateway = FinansbankGateway.new(fixtures(:finansbank))
 
     @amount = 100

--- a/test/remote/gateways/remote_garanti_test.rb
+++ b/test/remote/gateways/remote_garanti_test.rb
@@ -4,11 +4,6 @@ require 'test_helper'
 class RemoteGarantiTest < Test::Unit::TestCase
 
   def setup
-    if RUBY_VERSION < '1.9' && $KCODE == "NONE"
-      @original_kcode = $KCODE
-      $KCODE = 'u'
-    end
-
     @gateway = GarantiGateway.new(fixtures(:garanti))
 
     @amount = 100 # 1 cents = 0.01$

--- a/test/unit/gateways/finansbank_test.rb
+++ b/test/unit/gateways/finansbank_test.rb
@@ -4,10 +4,6 @@ require 'test_helper'
 class FinansbankTest < Test::Unit::TestCase
   def setup
     @original_kcode = nil
-    if RUBY_VERSION < '1.9' && $KCODE == "NONE"
-      @original_kcode = $KCODE
-      $KCODE = 'u'
-    end
 
     @gateway = FinansbankGateway.new(
       :login => 'login',

--- a/test/unit/gateways/garanti_test.rb
+++ b/test/unit/gateways/garanti_test.rb
@@ -5,10 +5,6 @@ require 'test_helper'
 class GarantiTest < Test::Unit::TestCase
   def setup
     @original_kcode = nil
-    if RUBY_VERSION < '1.9' && $KCODE == "NONE"
-      @original_kcode = $KCODE
-      $KCODE = 'u'
-    end
 
     Base.mode = :test
     @gateway = GarantiGateway.new(:login => 'a', :password => 'b', :terminal_id => 'c', :merchant_id => 'd')
@@ -51,12 +47,9 @@ class GarantiTest < Test::Unit::TestCase
     if ActiveSupport::Inflector.method(:transliterate).arity == -2
       assert_equal 'ABCCDEFGGHIIJKLMNOOPRSSTUUVYZ', @gateway.send(:normalize, 'ABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ')
       assert_equal 'abccdefgghiijklmnooprsstuuvyz', @gateway.send(:normalize, 'abcçdefgğhıijklmnoöprsştuüvyz')
-    elsif RUBY_VERSION >= '1.9'
+    else
       assert_equal 'ABCDEFGHIJKLMNOPRSTUVYZ', @gateway.send(:normalize, 'ABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ')
       assert_equal 'abcdefghijklmnoprstuvyz', @gateway.send(:normalize, 'abcçdefgğhıijklmnoöprsştuüvyz')
-    else
-      assert_equal 'ABCCDEFGGHIIJKLMNOOPRSSTUUVYZ', @gateway.send(:normalize, 'ABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ')
-      assert_equal 'abccdefgghijklmnooprsstuuvyz', @gateway.send(:normalize, 'abcçdefgğhıijklmnoöprsştuüvyz')
     end
   end
 

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -32,10 +32,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   end
 
   def test_timeout_errors_raise_correctly
-    exceptions = [Timeout::Error, Errno::ETIMEDOUT]
-    if RUBY_VERSION >= '2.0.0'
-      exceptions += [Net::ReadTimeout, Net::OpenTimeout]
-    end
+    exceptions = [Timeout::Error, Errno::ETIMEDOUT, Net::ReadTimeout, Net::OpenTimeout]
 
     exceptions.each do |exception|
       raised = assert_raises(ActiveMerchant::ConnectionError) do
@@ -57,10 +54,8 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   end
 
   def test_ssl_errors_raise_correctly
-    exceptions = [OpenSSL::SSL::SSLError]
-    if RUBY_VERSION >= '2.1.0'
-      exceptions += [OpenSSL::SSL::SSLErrorWaitWritable, OpenSSL::SSL::SSLErrorWaitReadable]
-    end
+    exceptions = [OpenSSL::SSL::SSLError, OpenSSL::SSL::SSLErrorWaitWritable,
+                  OpenSSL::SSL::SSLErrorWaitReadable]
 
     exceptions.each do |exception|
       raised = assert_raises(ActiveMerchant::ConnectionError) do


### PR DESCRIPTION
Rubies older than 2.3.6 are outside maintenance, so this honestly seems
like the bare minimum for a payment gem.