### PR TITLE
Mundipagg: pass holder_document for CC purchases

### DIFF
--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -176,6 +176,7 @@ module ActiveMerchant #:nodoc:
           post[:payment][:credit_card][:card][:exp_month] = payment.month
           post[:payment][:credit_card][:card][:exp_year] = payment.year
           post[:payment][:credit_card][:card][:cvv] = payment.verification_value
+          post[:payment][:credit_card][:card][:holder_document] = options[:holder_document] if options[:holder_document]
           add_billing_address(post,'credit_card', options)
         end
       end

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -24,6 +24,18 @@ class MundipaggTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_holder_document
+    @options.merge!(holder_document: "a1b2c3d4")
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/a1b2c3d4/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+
+    assert response.test?
+  end
+
   def test_billing_not_sent
     @options.delete(:billing_address)
     stub_comms do


### PR DESCRIPTION
Unit: 16 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 20 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed