### PR TITLE
Authorize.net: pass email_customer if set

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -412,10 +412,10 @@ module ActiveMerchant
             ActiveMerchant.deprecated "Using the duplicate_window class_attribute is deprecated. Use the transaction options hash instead."
             set_duplicate_window(xml, self.class.duplicate_window)
           end
-          if options[:email_customer]
+          if options.key?(:email_customer)
             xml.setting do
               xml.settingName("emailCustomer")
-              xml.settingValue("true")
+              xml.settingValue(options[:email_customer] ? "true" : "false")
             end
           end
           if options[:header_email_receipt]

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -62,6 +62,14 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_false_email_customer
+    response = @gateway.purchase(@amount, @credit_card, duplicate_window: 0, email_customer: false, email: 'anet@example.com', billing_address: address)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
   def test_successful_purchase_with_header_email_receipt
     response = @gateway.purchase(@amount, @credit_card, duplicate_window: 0, header_email_receipt: "subject line", email: 'anet@example.com', billing_address: address)
     assert_success response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -307,6 +307,13 @@ class AuthorizeNetTest < Test::Unit::TestCase
       assert_match(/<settingName>emailCustomer<\/settingName>/, data)
       assert_match(/<settingValue>true<\/settingValue>/, data)
     end.respond_with(successful_purchase_response)
+
+    stub_comms do
+      @gateway.purchase(@amount, credit_card, email_customer: false)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<settingName>emailCustomer<\/settingName>/, data)
+      assert_match(/<settingValue>false<\/settingValue>/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_passes_header_email_receipt


### PR DESCRIPTION
Previously, we would only pass email_customer if it was set true, and omit the value otherwise. But this could result in emails being sent in some cases. Instead, if any value is provided, pass it along.

Unit: 92 tests, 524 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 67 tests, 230 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed