### PR TITLE
Prevent keepalives by default

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -65,6 +65,8 @@ module ActiveMerchant
     end
 
     def request(method, body, headers = {})
+      headers['connection'] ||= 'close'
+
       request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -29,7 +29,7 @@ class ConnectionTest < Test::Unit::TestCase
   def test_connection_passes_env_proxy_by_default
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, :ENV, nil).returns(spy)
-    spy.expects(:get).with('/tx.php', {}).returns(@ok)
+    spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     @connection.request(:get, nil, {})
   end
 
@@ -38,31 +38,31 @@ class ConnectionTest < Test::Unit::TestCase
     @connection.proxy_port = 8080
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, "proxy.example.com", 8080).returns(spy)
-    spy.expects(:get).with('/tx.php', {}).returns(@ok)
+    spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     @connection.request(:get, nil, {})
   end
 
   def test_successful_get_request
     @connection.logger.expects(:info).twice
-    Net::HTTP.any_instance.expects(:get).with('/tx.php', {}).returns(@ok)
+    Net::HTTP.any_instance.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     response = @connection.request(:get, nil, {})
     assert_equal 'success', response.body
   end
 
   def test_successful_post_request
-    Net::HTTP.any_instance.expects(:post).with('/tx.php', 'data', ActiveMerchant::Connection::RUBY_184_POST_HEADERS).returns(@ok)
+    Net::HTTP.any_instance.expects(:post).with('/tx.php', 'data', ActiveMerchant::Connection::RUBY_184_POST_HEADERS.merge({'connection' => 'close'})).returns(@ok)
     response = @connection.request(:post, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_put_request
-    Net::HTTP.any_instance.expects(:put).with('/tx.php', 'data', {}).returns(@ok)
+    Net::HTTP.any_instance.expects(:put).with('/tx.php', 'data', {'connection' => 'close'}).returns(@ok)
     response = @connection.request(:put, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_delete_request
-    Net::HTTP.any_instance.expects(:delete).with('/tx.php', {}).returns(@ok)
+    Net::HTTP.any_instance.expects(:delete).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     response = @connection.request(:delete, nil, {})
     assert_equal 'success', response.body
   end


### PR DESCRIPTION
With b20ad8a287567, the connection logic changed such that keep-alives would suddenly be used, where previously, Connection: close would be sent. This patch reverts to the old behavior. Keep-alives can still be manually requested by passing the relevant header.

I'm not 100% sure this is the right fix, and I'd love a regression test, but this resolves some issues we were seeing over at Spreedly with integrating this version of AM.