### PR TITLE
Paymentez: handle server internal errors

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -171,7 +171,12 @@ module ActiveMerchant #:nodoc:
         rescue ResponseError => e
           raw_response = e.response.body
         end
-        parse(raw_response)
+
+        begin
+          parse(raw_response)
+        rescue JSON::ParserError
+          {'status' => 'Internal server error'}
+        end
       end
 
       def commit_transaction(action, parameters)

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -141,6 +141,14 @@ class PaymentezTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_paymentez_crashes_fail
+    @gateway.stubs(:ssl_post).returns(crash_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -408,6 +416,20 @@ Conn close
           "origin":"Paymentez"
        }
       }
+    )
+  end
+
+  def crash_response
+    %q(
+      <html>
+        <head>
+          <title>Internal Server Error</title>
+        </head>
+        <body>
+          <h1><p>Internal Server Error</p></h1>
+
+        </body>
+      </html>
     )
   end
 end


### PR DESCRIPTION
For the last couple of weeks, Paymentez has been 500ing and sending
down HTML pages, which crashes the JSON parser and results in
less-than-helpful exception. This patch handles HTML responses without
crashing.

NB, the remote test failures are because not all Paymentez gateways
support authorize, and the remote tests do hit them, but they otherwise
are fine.

Unit: 17 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 15 tests, 29 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
73.3333% passed