### PR TITLE
Bridge Pay: don't throw when account_type omitted

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -114,7 +114,7 @@ module ActiveMerchant #:nodoc:
           post[:TransitNum] = payment_method.routing_number
           post[:AccountNum] = payment_method.account_number
           post[:NameOnCheck] = payment_method.name
-          post[:ExtData] = "<AccountType>#{payment_method.account_type.capitalize}</AccountType>"
+          post[:ExtData] = "<AccountType>#{payment_method.account_type[0].capitalize}</AccountType>" if payment_method.account_type
         end
       end
 

--- a/test/unit/gateways/bridge_pay_test.rb
+++ b/test/unit/gateways/bridge_pay_test.rb
@@ -45,6 +45,14 @@ class BridgePayTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_failed_purchase_with_bad_echeck
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    @check.account_type = nil
+    response = @gateway.purchase(@amount, @check)
+    assert_failure response
+  end
+
   def test_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)


### PR DESCRIPTION
One remote test fails (for echecks, no less), but it does so both
with and without this patch, and the error appears internal (it fails
with a .NET XSD validation error for an element we're not sending and
isn't documented).

Unit: 14 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 17 tests, 38 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.1176% passed