### PR TITLE
Fix WebMock regression in 1.79.2

### DIFF
--- a/lib/active_merchant/net_http_ssl_connection.rb
+++ b/lib/active_merchant/net_http_ssl_connection.rb
@@ -3,6 +3,7 @@ require 'net/http'
 module NetHttpSslConnection
   refine Net::HTTP do
     def ssl_connection
+      return {} unless @socket.present?
       { version: @socket.io.ssl_version, cipher: @socket.io.cipher[0] }
     end
   end


### PR DESCRIPTION
Since Webmock [overrides the Net::HTTP#start
method](https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/net_http.rb#L144)
to simulate HTTP requests, unsafe usage of `@socket` in ActiveMerchant's
`Net::HTTP#ssl_connection` refinement caused cryptic errors in tests
that used VCR along with ActiveMerchant:

```
MyProject::TotallyFabulousIntegrationTest#test_fabulosity:
NoMethodError: undefined method `io' for nil:NilClass
    test/test_helper.rb:44:in `use_cassette'

.../gems/activemerchant-1.79.0/lib/active_merchant/net_http_ssl_connection.rb:6:in `ssl_connection'
.../gems/activemerchant-1.79.0/lib/active_merchant/connection.rb:78:in `block (2 levels) in request'
...
```