### PR TITLE
Do not make remote connections in unit tests

### DIFF
--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -123,9 +123,9 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_currency_added_correctly
-    stub_comms do
+    stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |method, url, data|
       assert_match(/<currency>CAD<\/currency>/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -126,6 +126,7 @@ class MundipaggTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
+    @gateway.expects(:ssl_request).returns(successful_authorize_response)
     @gateway.expects(:ssl_post).returns(successful_verify_response)
 
     response = @gateway.verify(@credit_card, @options)


### PR DESCRIPTION
Blue Snap and Mundipagg unit tests made remote connections. Now they
don't.