### PR TITLE
More aggressivley don't make connections

### DIFF
--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -29,6 +29,7 @@ class ConnectionTest < Test::Unit::TestCase
   def test_connection_passes_env_proxy_by_default
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, :ENV, nil).returns(spy)
+    spy.expects(:start).returns(true)
     spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     @connection.request(:get, nil, {})
   end
@@ -38,6 +39,7 @@ class ConnectionTest < Test::Unit::TestCase
     @connection.proxy_port = 8080
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, "proxy.example.com", 8080).returns(spy)
+    spy.expects(:start).returns(true)
     spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
     @connection.request(:get, nil, {})
   end
@@ -45,42 +47,49 @@ class ConnectionTest < Test::Unit::TestCase
   def test_successful_get_request
     @connection.logger.expects(:info).twice
     Net::HTTP.any_instance.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:get, nil, {})
     assert_equal 'success', response.body
   end
 
   def test_successful_post_request
     Net::HTTP.any_instance.expects(:post).with('/tx.php', 'data', ActiveMerchant::Connection::RUBY_184_POST_HEADERS.merge({'connection' => 'close'})).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:post, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_put_request
     Net::HTTP.any_instance.expects(:put).with('/tx.php', 'data', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:put, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_delete_request
     Net::HTTP.any_instance.expects(:delete).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:delete, nil, {})
     assert_equal 'success', response.body
   end
 
   def test_successful_delete_with_body_request
     Net::HTTP.any_instance.expects(:request).at_most(3).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:delete, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_get_raises_argument_error_if_passed_data
     assert_raises(ArgumentError) do
+      Net::HTTP.any_instance.expects(:start).returns(true)
       @connection.request(:get, 'data', {})
     end
   end
 
   def test_request_raises_when_request_method_not_supported
     assert_raises(ArgumentError) do
+      Net::HTTP.any_instance.expects(:start).returns(true)
       @connection.request(:head, nil, {})
     end
   end
@@ -164,7 +173,7 @@ class ConnectionTest < Test::Unit::TestCase
 
   def test_unrecoverable_exception
     @connection.logger.expects(:info).once
-    Net::HTTP.any_instance.expects(:post).raises(EOFError)
+    Net::HTTP.any_instance.expects(:start).raises(EOFError)
 
     assert_raises(ActiveMerchant::ConnectionError) do
       @connection.request(:post, '')
@@ -173,14 +182,15 @@ class ConnectionTest < Test::Unit::TestCase
 
   def test_failure_then_success_with_recoverable_exception
     @connection.logger.expects(:info).never
-    Net::HTTP.any_instance.expects(:post).times(2).raises(Errno::ECONNREFUSED).then.returns(@ok)
+    Net::HTTP.any_instance.expects(:start).times(2).raises(Errno::ECONNREFUSED).then.returns(true)
+    Net::HTTP.any_instance.expects(:post).returns(@ok)
 
     @connection.request(:post, '')
   end
 
   def test_failure_limit_reached
     @connection.logger.expects(:info).once
-    Net::HTTP.any_instance.expects(:post).times(ActiveMerchant::Connection::MAX_RETRIES).raises(Errno::ECONNREFUSED)
+    Net::HTTP.any_instance.expects(:start).times(ActiveMerchant::Connection::MAX_RETRIES).raises(Errno::ECONNREFUSED)
 
     assert_raises(ActiveMerchant::ConnectionError) do
       @connection.request(:post, '')
@@ -188,7 +198,8 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_failure_then_success_with_retry_safe_enabled
-    Net::HTTP.any_instance.expects(:post).times(2).raises(EOFError).then.returns(@ok)
+    Net::HTTP.any_instance.expects(:start).times(2).raises(EOFError).then.returns(@ok)
+    Net::HTTP.any_instance.expects(:post).returns(@ok)
 
     @connection.retry_safe = true
 
@@ -196,7 +207,7 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_mixture_of_failures_with_retry_safe_enabled
-    Net::HTTP.any_instance.expects(:post).times(3).raises(Errno::ECONNRESET).
+    Net::HTTP.any_instance.expects(:start).times(3).raises(Errno::ECONNRESET).
                                                    raises(Errno::ECONNREFUSED).
                                                    raises(EOFError)
 
@@ -209,7 +220,7 @@ class ConnectionTest < Test::Unit::TestCase
 
   def test_failure_with_ssl_certificate
     @connection.logger.expects(:error).once
-    Net::HTTP.any_instance.expects(:post).raises(OpenSSL::X509::CertificateError)
+    Net::HTTP.any_instance.expects(:start).raises(OpenSSL::X509::CertificateError)
 
     assert_raises(ActiveMerchant::ClientCertificateError) do
       @connection.request(:post, '')


### PR DESCRIPTION
The changes introduced for SSL logging cause our stubs in the
connection test to fail, resulting in actual connections being made.
This patch restores the stubs, and unit tests can no run with no
connectivity whatsoever.

3855 tests, 67872 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed