### PR TITLE
Bridge Pay: restore some aspects of check handling

### DIFF
--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -114,7 +114,7 @@ module ActiveMerchant #:nodoc:
           post[:TransitNum] = payment_method.routing_number
           post[:AccountNum] = payment_method.account_number
           post[:NameOnCheck] = payment_method.name
-          post[:ExtData] = "<AccountType>#{payment_method.account_type[0].capitalize}</AccountType>" if payment_method.account_type
+          post[:ExtData] = "<AccountType>#{payment_method.account_type.capitalize}</AccountType>" if payment_method.account_type
         end
       end
 


### PR DESCRIPTION
While the Bridge Pay docs seem to indicate that account_type
should be `C` or `S`, practice indicates that's incorrect. Restore
the old functionality.

This is in response to https://github.com/activemerchant/active_merchant/commit/e48a6a81e8deb47460710c3aae8fd841ec63adda#commitcomment-29273916

Unit: 15 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 17 tests, 38 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.1176% passed