### PR TITLE
Changing PayU Argentina minimum payment amount

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -22,7 +22,7 @@ module ActiveMerchant #:nodoc:
       }
 
       MINIMUMS = {
-        "ARS" => 1700,
+        "ARS" => 500,
         "BRL" => 600,
         "MXN" => 3900,
         "PEN" => 500

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -338,17 +338,17 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_failed_verify_with_specified_amount
-    verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 1699))
+    verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 499))
 
     assert_failure verify
-    assert_equal "The order value is less than minimum allowed. Minimum value allowed 17 ARS", verify.message
+    assert_equal "The order value is less than minimum allowed. Minimum value allowed 5 ARS", verify.message
   end
 
   def test_failed_verify_with_specified_language
-    verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 1699, language: 'es'))
+    verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 499, language: 'es'))
 
     assert_failure verify
-    assert_equal "The order value is less than minimum allowed. Minimum value allowed 17 ARS", verify.message
+    assert_equal "The order value is less than minimum allowed. Minimum value allowed 5 ARS", verify.message
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
Now PayU request a minimum of 5 Argentine pesos. Fixing the amount and tests.

```
rake test:units
3857 tests, 67882 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications                                                                                 
100% passed

rake test:remote TEST=test/remote/gateways/remote_payu_latam_test.rb
30 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications                                                                                       
100% passed
