### PR TITLE
Add support for customer vault operations to Merchant One

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -27,28 +27,59 @@ module ActiveMerchant #:nodoc:
       def authorize(money, creditcard, options = {})
         post = {}
         add_customer_data(post, options)
-        add_creditcard(post, creditcard)
+        add_creditcard(post, creditcard, options)
         add_address(post, creditcard, options)
         add_customer_data(post, options)
         add_amount(post, money, options)
-        commit('auth', money, post)
+        commit('auth', post)
       end
 
       def purchase(money, creditcard, options = {})
         post = {}
         add_customer_data(post, options)
-        add_creditcard(post, creditcard)
+        add_creditcard(post, creditcard, options)
         add_address(post, creditcard, options)
         add_customer_data(post, options)
         add_amount(post, money, options)
-        commit('sale', money, post)
+        commit('sale', post)
       end
 
       def capture(money, authorization, options = {})
         post = {}
         post.merge!(:transactionid => authorization)
         add_amount(post, money, options)
-        commit('capture', money, post)
+        commit('capture', post)
+      end
+
+      def void(authorization, option = {})
+        post = {}
+        add_transaction_data(post, authorization)
+        commit('void', post)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {}
+        post.merge!(:transactionid => authorization)
+        add_amount(post, money, options)
+        commit('refund', post)
+      end
+
+      def store(creditcard, options = {})
+        post = {}
+        type = nil
+        add_customer_vault_method_call(post, 'add_customer')
+        add_customer_data(post, options)
+        add_creditcard(post, creditcard, options)
+        add_address(post, creditcard, options)
+        commit(type, post)
+      end
+
+      def unstore(customer_vault_id, options = {})
+        post = {}
+        type = nil
+        add_customer_vault_method_call(post, 'delete_customer')
+        add_customer_profile(post, customer_vault_id)
+        commit(type, post)
       end
 
       def new_connection(endpoint)
@@ -58,36 +89,53 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_customer_data(post, options)
-        post['firstname'] = options[:billing_address][:first_name]
-        post['lastname'] = options[:billing_address][:last_name]
+        post[:firstname] = options[:billing_address][:first_name]
+        post[:lastname] = options[:billing_address][:last_name]
+      end
+
+      def add_customer_profile(post, customer_vault_id)
+        post[:customer_vault_id] = customer_vault_id
+      end
+
+      def add_customer_vault_method_call(post, method)
+        post[:customer_vault] = method
       end
 
       def add_amount(post, money, options)
-        post['amount'] = amount(money)
+        post[:amount] = amount(money)
       end
 
       def add_address(post, creditcard, options)
-        post['address1'] = options[:billing_address][:address1]
-        post['city'] = options[:billing_address][:city]
-        post['state'] = options[:billing_address][:state]
-        post['zip'] = options[:billing_address][:zip]
-        post['country'] = options[:billing_address][:country]
+        post[:address1] = options[:billing_address][:address1]
+        post[:city] = options[:billing_address][:city]
+        post[:state] = options[:billing_address][:state]
+        post[:zip] = options[:billing_address][:zip]
+        post[:country] = options[:billing_address][:country]
       end
 
-      def add_creditcard(post, creditcard)
-       post['cvv'] = creditcard.verification_value
-       post['ccnumber'] = creditcard.number
-       post['ccexp'] =  "#{sprintf("%02d", creditcard.month)}#{"#{creditcard.year}"[-2, 2]}"
+      def add_creditcard(post, creditcard, options = {})
+        if creditcard.is_a?(String)
+          post[:customer_vault_id] = creditcard
+          post[:cvv]               = options[:cvv]
+        else
+          post[:cvv] = creditcard.verification_value
+          post[:ccnumber] = creditcard.number
+          post[:ccexp] =  "#{sprintf("%02d", creditcard.month)}#{"#{creditcard.year}"[-2, 2]}"
+        end
       end
 
-      def commit(action, money, parameters={})
+      def add_transaction_data(post, authorization)
+        post[:transactionid] = authorization
+      end
+
+      def commit(action, parameters={})
         parameters['username'] = @options[:username]
         parameters['password'] = @options[:password]
         parse(ssl_post(BASE_URL,post_data(action, parameters)))
       end
 
       def post_data(action, parameters = {})
-        parameters.merge!({:type => action})
+        parameters.merge!({:type => action}) unless action.nil? || action.empty?
         ret = ""
         for key in parameters.keys
           ret += "#{key}=#{CGI.escape(parameters[key].to_s)}"
@@ -105,8 +153,16 @@ module ActiveMerchant #:nodoc:
           responses["responsetext"],
           responses,
           :test => test?,
-          :authorization => responses["transactionid"]
+          :authorization => authorization_for(responses)
         )
+      end
+
+      def authorization_for(response)
+        if response["transactionid"].to_s.empty?
+          response["customer_vault_id"]
+        else
+          response["transactionid"]
+        end
       end
     end
   end

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -31,34 +31,96 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
-   def test_unsuccessful_purchase
-     assert response = @gateway.purchase(@amount, @declined_card, @options)
-     assert_failure response
-     assert response.message.include? 'Invalid Credit Card Number'
-   end
+  def test_unsuccessful_purchase
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert response.message.include? 'Invalid Credit Card Number'
+  end
 
-   def test_authorize_and_capture
-     amount = @amount
-     assert auth = @gateway.authorize(amount, @credit_card, @options)
-     assert_success auth
-     assert_equal 'SUCCESS', auth.message
-     assert auth.authorization, auth.to_yaml
-     assert capture = @gateway.capture(amount, auth.authorization)
-     assert_success capture
-   end
+  def test_authorize_and_capture
+    amount = @amount
+    assert auth = @gateway.authorize(amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'SUCCESS', auth.message
+    assert auth.authorization, auth.to_yaml
+    assert capture = @gateway.capture(amount, auth.authorization)
+    assert_success capture
+  end
 
-   def test_failed_capture
+  def test_failed_capture
     assert response = @gateway.capture(@amount, '')
     assert_failure response
-   end
+  end
 
-   def test_invalid_login
-     gateway = MerchantOneGateway.new(
-                 :username => 'nnn',
-                 :password => 'nnn'
-               )
-     assert response = gateway.purchase(@amount, @credit_card, @options)
-     assert_failure response
-     assert_equal 'Authentication Failed', response.message
-   end
+  def test_invalid_login
+    gateway = MerchantOneGateway.new(
+      :username => 'nnn',
+      :password => 'nnn'
+    )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Authentication Failed', response.message
+  end
+
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal "Customer Added", response.message
+    assert_equal "100", response.params["response_code"]
+  end
+
+  def test_unsuccessful_store
+    assert response = @gateway.store(@declined_card, @options)
+    assert_failure response
+    assert response.message.include? 'Invalid Credit Card Number'
+  end
+
+  def test_successful_purchase_using_stored_card
+    assert store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    assert response = @gateway.purchase(@amount, store.authorization, @options)
+
+    assert_success response
+    assert_equal "SUCCESS", response.message
+    assert response.params["customer_vault_id"]
+  end
+
+  def test_successful_void
+    assert authorization = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorization
+
+    assert response = @gateway.void(authorization.authorization)
+    assert_success response
+    assert_equal "Transaction Void Successful", response.message
+  end
+
+  def test_unsuccessful_void
+    assert response = @gateway.void("active_merchant_fake_charge")
+    assert_failure response
+    assert response.message.start_with?("Invalid Transaction ID specified")
+  end
+
+  def test_successful_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert response = @gateway.refund(@amount - 20, purchase.authorization)
+    assert_success response
+    assert_equal "SUCCESS", response.message
+  end
+
+  def test_unsuccessful_refund
+    assert response = @gateway.refund(@amount, "active_merchant_fake_charge")
+    assert_failure response
+    assert response.message.start_with?("Invalid Transaction ID specified")
+  end
+
+  def test_successful_unstore
+    card = @gateway.store(@credit_card, @options)
+
+    assert response = @gateway.unstore(card.authorization)
+    assert_success response
+    assert_equal "Customer Deleted", response.message
+  end
 end

--- a/test/unit/gateways/merchant_one_test.rb
+++ b/test/unit/gateways/merchant_one_test.rb
@@ -57,6 +57,44 @@ class MerchantOneTest < Test::Unit::TestCase
     assert response.test?, response.test.to_s
   end
 
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    assert response = @gateway.void('281719471', @options)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '3533347610', response.authorization
+    assert response.test?, response.test.to_s
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    assert response = @gateway.refund(@amount, '281719471', @options)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '3533343128', response.authorization
+    assert response.test?, response.test.to_s
+  end
+
+  def test_successful_store_profile
+    @gateway.expects(:ssl_post).returns(successful_store_profile_response)
+
+    assert response = @gateway.store(@credit_card, @options)
+    assert_instance_of Response, response
+    assert_equal "337907840", response.params['customer_vault_id']
+    assert response.test?, response.test.to_s
+  end
+
+  def test_successful_unstore_profile
+    @gateway.expects(:ssl_post).returns(successful_unstore_profile_response)
+
+    assert response = @gateway.unstore("337907840", @options)
+    assert_instance_of Response, response
+    assert_equal "Customer Deleted", response.params['responsetext']
+    assert response.test?, response.test.to_s
+  end
+
   private
 
   def successful_purchase_response
@@ -65,5 +103,21 @@ class MerchantOneTest < Test::Unit::TestCase
 
   def failed_purchase_response
     "response=3&responsetext=DECLINE&authcode=123456&transactionid=281719471&avsresponse=&cvvresponse=M&orderid=&type=sale&response_code=300"
+  end
+
+  def successful_void_response
+    "response=1&responsetext=Transaction Void Successful&authcode=123456&transactionid=3533347610&avsresponse=&cvvresponse=&orderid=&type=void&response_code=100"
+  end
+
+  def successful_refund_response
+    "response=1&responsetext=SUCCESS&authcode=&transactionid=3533343128&avsresponse=&cvvresponse=&orderid=&type=refund&response_code=100&customer_vault_id=286214357"
+  end
+
+  def successful_store_profile_response
+    "response=1&responsetext=Customer Added&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=&type=&response_code=100&customer_vault_id=337907840"
+  end
+
+  def successful_unstore_profile_response
+    "response=1&responsetext=Customer Deleted&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=&type=&response_code=100"
   end
 end


### PR DESCRIPTION
Implement customer and card tokenization and associated operations for the Merchant one gateway.

Adds the following methods with associated tests:
- store
- unstore
- void
- refund

 This also updates the existing `authorize` and `purchase` methods to accept a token.