### PR TITLE
Pass shipping address to Stripe

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -312,6 +312,7 @@ module ActiveMerchant #:nodoc:
         else
           add_amount(post, money, options, true)
           add_customer_data(post, options)
+          add_shipping_address(post, options)
           post[:description] = options[:description]
           post[:statement_descriptor] = options[:statement_description]
           post[:receipt_email] = options[:receipt_email] if options[:receipt_email]
@@ -378,6 +379,20 @@ module ActiveMerchant #:nodoc:
           post[:card][:address_state] = address[:state] if address[:state]
           post[:card][:address_city] = address[:city] if address[:city]
         end
+      end
+
+      def add_shipping_address(post, options)
+        return unless (address = options[:shipping_address] || options[:address])
+
+        post[:shipping] = { address: {} }
+
+        post[:shipping][:name] = "#{address[:first_name]} #{address[:last_name]}"
+        post[:shipping][:address][:line1] = address[:address1] if address[:address1]
+        post[:shipping][:address][:line2] = address[:address2] if address[:address2]
+        post[:shipping][:address][:country] = address[:country] if address[:country]
+        post[:shipping][:address][:postal_code] = address[:zip] if address[:zip]
+        post[:shipping][:address][:state] = address[:state] if address[:state]
+        post[:shipping][:address][:city] = address[:city] if address[:city]
       end
 
       def add_statement_address(post, options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -12,6 +12,7 @@ class StripeTest < Test::Unit::TestCase
 
     @options = {
       :billing_address => address(),
+      :shipping_address => address(),
       :statement_address => statement_address(),
       :description => 'Test Purchase'
     }
@@ -981,6 +982,20 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @options[:billing_address][:address2], post[:card][:address_line2]
     assert_equal @options[:billing_address][:country], post[:card][:address_country]
     assert_equal @options[:billing_address][:city], post[:card][:address_city]
+  end
+
+  def test_add_shipping_address
+    post = {}
+    @gateway.send(:add_shipping_address, post, @options)
+
+    name = "#{@options[:shipping_address][:first_name]} #{@options[:shipping_address][:last_name]}"
+    assert_equal name, post[:shipping][:name]
+    assert_equal @options[:shipping_address][:zip], post[:shipping][:address][:postal_code]
+    assert_equal @options[:shipping_address][:state], post[:shipping][:address][:state]
+    assert_equal @options[:shipping_address][:address1], post[:shipping][:address][:line1]
+    assert_equal @options[:shipping_address][:address2], post[:shipping][:address][:line2]
+    assert_equal @options[:shipping_address][:country], post[:shipping][:address][:country]
+    assert_equal @options[:shipping_address][:city], post[:shipping][:address][:city]
   end
 
   def test_add_statement_address


### PR DESCRIPTION
Stripe accepts a shipping address as an optional parameter, use the :shipping_address from the options hash to fill this in when available.

Stripe uses this for fraud detection, see https://stripe.com/docs/api#create_charge-shipping