### PR TITLE
Kuski: do not send extraTaxes if no value provided

### DIFF
--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -94,14 +94,7 @@ module ActiveMerchant #:nodoc:
         sum[:iva] = 0
         sum[:subtotalIva0] = 0
 
-        if sum[:currency] == "COP"
-          extra_taxes = {}
-          extra_taxes[:propina] = 0
-          extra_taxes[:tasaAeroportuaria] = 0
-          extra_taxes[:agenciaDeViaje] = 0
-          extra_taxes[:iac] = 0
-          sum[:extraTaxes] = extra_taxes
-        else
+        if sum[:currency] != "COP"
           sum[:ice] = 0
         end
       end
@@ -112,7 +105,8 @@ module ActiveMerchant #:nodoc:
           sum[:iva] = amount[:iva].to_f if amount[:iva]
           sum[:subtotalIva0] = amount[:subtotal_iva_0].to_f if amount[:subtotal_iva_0]
           sum[:ice] = amount[:ice].to_f if amount[:ice]
-          if extra_taxes = amount[:extra_taxes] && sum[:currency] == "COP"
+          if (extra_taxes = amount[:extra_taxes]) && sum[:currency] == "COP"
+            sum[:extraTaxes] ||= Hash.new
             sum[:extraTaxes][:propina] = extra_taxes[:propina].to_f if extra_taxes[:propina]
             sum[:extraTaxes][:tasaAeroportuaria] = extra_taxes[:tasa_aeroportuaria].to_f if extra_taxes[:tasa_aeroportuaria]
             sum[:extraTaxes][:agenciaDeViaje] = extra_taxes[:agencia_de_viaje].to_f if extra_taxes[:agencia_de_viaje]

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class KushkiTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = KushkiGateway.new(public_merchant_id: '_', private_merchant_id: '_')
     @amount = 100
@@ -44,6 +46,106 @@ class KushkiTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
     assert_match %r(^\d+$), response.authorization
     assert response.test?
+  end
+
+  def test_taxes_are_excluded_when_not_provided
+    options = {
+        currency: "COP",
+        amount: {
+            subtotal_iva_0: "4.95",
+            subtotal_iva: "10",
+            iva: "1.54",
+            ice: "3.50"
+        }
+    }
+
+    amount = 100 * (
+        options[:amount][:subtotal_iva_0].to_f +
+        options[:amount][:subtotal_iva].to_f +
+        options[:amount][:iva].to_f +
+        options[:amount][:ice].to_f
+    )
+
+    response = stub_comms do
+      @gateway.purchase(amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      if /charges/ =~ endpoint
+        assert_no_match %r{extraTaxes}, data
+      end
+    end.respond_with(successful_charge_response, successful_token_response)
+
+    assert_success response
+  end
+
+  def test_partial_taxes_do_not_error
+    options = {
+        currency: "COP",
+        amount: {
+            subtotal_iva_0: "4.95",
+            subtotal_iva: "10",
+            iva: "1.54",
+            ice: "3.50",
+            extra_taxes: {
+                tasa_aeroportuaria: 0.2,
+                iac: 0.4
+            }
+        }
+    }
+
+    amount = 100 * (
+    options[:amount][:subtotal_iva_0].to_f +
+        options[:amount][:subtotal_iva].to_f +
+        options[:amount][:iva].to_f +
+        options[:amount][:ice].to_f
+    )
+
+    response = stub_comms do
+      @gateway.purchase(amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      if /charges/ =~ endpoint
+        assert_match %r{extraTaxes}, data
+        assert_no_match %r{propina}, data
+        assert_match %r{iac}, data
+      end
+    end.respond_with(successful_charge_response, successful_token_response)
+
+    assert_success response
+  end
+
+  def test_taxes_are_included_when_provided
+    options = {
+        currency: "COP",
+        amount: {
+            subtotal_iva_0: "4.95",
+            subtotal_iva: "10",
+            iva: "1.54",
+            ice: "3.50",
+            extra_taxes: {
+                propina: 0.1,
+                tasa_aeroportuaria: 0.2,
+                agencia_de_viaje: 0.3,
+                iac: 0.4
+            }
+        }
+    }
+
+    amount = 100 * (
+    options[:amount][:subtotal_iva_0].to_f +
+        options[:amount][:subtotal_iva].to_f +
+        options[:amount][:iva].to_f +
+        options[:amount][:ice].to_f
+    )
+
+    response = stub_comms do
+      @gateway.purchase(amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      if /charges/ =~ endpoint
+        assert_match %r{extraTaxes}, data
+        assert_match %r{propina}, data
+      end
+    end.respond_with(successful_charge_response, successful_token_response)
+
+    assert_success response
   end
 
   def test_failed_purchase


### PR DESCRIPTION
The failing remote test is a refund, which fails with a note that
refunds for the test card aren't supported (I think; my Spanish isn't
great).

Unit: 8 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 9 tests, 27 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.8889% passed