### PR TITLE
Payflow: Update ACH tests

### DIFF
--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -27,7 +27,7 @@ class RemotePayflowTest < Test::Unit::TestCase
 
     @check = check(
       :routing_number => '111111118',
-      :account_number => '1234567801'
+      :account_number => '1111111111'
     )
   end
 
@@ -87,6 +87,16 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_equal "Approved", response.message
     assert response.test?
     assert_not_nil response.authorization
+  end
+
+  def test_ach_purchase_and_refund
+    assert response = @gateway.purchase(50, @check)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert !response.authorization.blank?
+
+    assert credit = @gateway.refund(50, response.authorization)
+    assert_success credit
   end
 
   def test_successful_authorization


### PR DESCRIPTION
Remote tests were erroring due to the previous account number having
reached it's "return limit" (despite this being in sandbox). The new
number succeeds.

Remote: (All failures are due to the test account not being flagged for
recurring profiles or unreferenced credits)
30 tests, 119 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
70% passed

Unit:
46 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed