### PR TITLE
Credorax: support billing description field

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -215,6 +215,7 @@ module ActiveMerchant #:nodoc:
         post[:a1] = generate_unique_id
         post[:a5] = currency
         post[:h9] = options[:order_id]
+        post[:i2] = options[:billing_descriptor] if options[:billing_descriptor]
       end
 
       CARD_TYPES = {

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -214,6 +214,15 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_supports_billing_descriptor
+    @options.merge!({ billing_descriptor: "abcdefghijkl"})
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match /i2=abcdefghijkl/, data
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Pretty much all remote tests fail, saying the card has been declined,
with no additional information. I'm tracking that down, but I'm
disinclined to hold based on that.

Unit: 19 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 19 tests, 27 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
47.3684% passed