### PR TITLE
Forte: strip location_id and account_id for URLs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Payflow: Update ACH tests [curiousepic] #2887
 * Credorax: support passing billing description [bpollack] #2889
 * MiGS: scrub 3DS fields [abarrak] #2771
+* Forte: avoid crashing when location_id or account_id have spaces [bpollack] #2890
 
 == Version 1.79.2 (June 2, 2018)
 * Fix Gateway#max_version= overwriting min_version [bdewater]

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -214,7 +214,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def endpoint
-        "/accounts/act_#{@options[:account_id]}/locations/loc_#{@options[:location_id]}/transactions/"
+        "/accounts/act_#{@options[:account_id].strip}/locations/loc_#{@options[:location_id].strip}/transactions/"
       end
 
       def headers

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -139,6 +139,16 @@ class ForteTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_handles_improper_padding
+    @gateway = ForteGateway.new(location_id: ' improperly-padded ', account_id: '  account_id  ', api_key: 'api_key', secret: 'secret')
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |type, url, parameters, headers|
+      URI.parse(url)
+    end.respond_with(MockedResponse.new(successful_purchase_response))
+    assert_success response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
This strictly speaking should not be necessary, but we're seeing
enough of this happening that it seems worth doing (and is otherwise
harmless).

Unit: 18 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 18 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed