### PR TITLE
Prevent headers mutation

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -67,6 +67,7 @@ module ActiveMerchant
     def request(method, body, headers = {})
       request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+      headers = headers.dup
       headers['connection'] ||= 'close'
 
       retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -65,9 +65,9 @@ module ActiveMerchant
     end
 
     def request(method, body, headers = {})
-      headers['connection'] ||= 'close'
-
       request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      headers['connection'] ||= 'close'
 
       retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do
         begin

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -44,6 +44,12 @@ class ConnectionTest < Test::Unit::TestCase
     @connection.request(:get, nil, {})
   end
 
+  def test_connection_does_not_mutate_headers_argument
+    headers = { "Content-Type" => "text/xml" }.freeze
+    @connection.request(:get, nil, headers)
+    assert_equal({ "Content-Type" => "text/xml" }, headers)
+  end
+
   def test_successful_get_request
     @connection.logger.expects(:info).twice
     Net::HTTP.any_instance.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -42,6 +42,14 @@ class PostsDataTests < Test::Unit::TestCase
     assert_equal @ok, @gateway.raw_ssl_request(:post, @url, '')
   end
 
+  def test_raw_ssl_request_does_not_mutate_headers_argument
+    ActiveMerchant::Connection.any_instance.expects(:request).returns(@ok)
+
+    headers = { "Content-Type" => "text/xml" }.freeze
+    @gateway.raw_ssl_request(:post, @url, '', headers)
+    assert_equal({ "Content-Type" => "text/xml" }, headers)
+  end
+
   def test_setting_ssl_strict_outside_class_definition
     assert_equal SimpleTestGateway.ssl_strict, SubclassGateway.ssl_strict
     SimpleTestGateway.ssl_strict = !SimpleTestGateway.ssl_strict


### PR DESCRIPTION
#2868 added modifications to the connection request headers. This PR duplicates the headers argument before modifying the headers to prevent mutation of the original object as a side-effect. This also fixes exceptions being raised if the headers argument was a frozen hash.

This PR also moves assigning `request_start` back to the top of the method so that everything is instrumented and `ensure` won't raise an exception due to an undefined variable.