### PR TITLE
Add Street2 to payflow fields for avs

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -137,6 +137,7 @@ module ActiveMerchant #:nodoc:
 
           xml.tag! 'Address' do
             xml.tag! 'Street', address[:address1] unless address[:address1].blank?
+            xml.tag! 'Street2', address[:address2] unless address[:address2].blank?
             xml.tag! 'City', address[:city] unless address[:city].blank?
             xml.tag! 'State', address[:state].blank? ? "N/A" : address[:state]
             xml.tag! 'Country', address[:country] unless address[:country].blank?


### PR DESCRIPTION
Paypal need both address lines to be passed through for the AVS check to work properly.
This PR adds the missing address lines.

🎩 that the XMLPayRequest contain a `Street2` field inside address.