### PR TITLE
Forte: enable refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -64,6 +64,16 @@ module ActiveMerchant #:nodoc:
         commit(:post, post)
       end
 
+      def refund(money, authorization, options={})
+        post = {}
+        add_amount(post, money, options)
+        post[:original_transaction_id] = transaction_id_from(authorization)
+        post[:authorization_code] = authorization_code_from(authorization)
+        post[:action] = 'reverse'
+
+        commit(:post, post)
+      end
+
       def void(authorization, options={})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -145,6 +145,24 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_match 'field transaction_id', response.message
   end
 
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    wait_for_authorization_to_clear
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_success refund
+    assert_equal 'TEST APPROVAL', refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '', @options)
+    assert_failure response
+    assert_match 'field authorization_code', response.message
+    assert_match 'field original_transaction_id', response.message
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -139,6 +139,20 @@ class ForteTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_refund
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.refund(@amount, "authcode")
+    end.respond_with(MockedResponse.new(successful_refund_response))
+    assert_success response
+  end
+
+  def test_failed_refund
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.refund(@amount, "authcode")
+    end.respond_with(MockedResponse.new(failed_refund_response))
+    assert_failure response
+  end
+
   def test_handles_improper_padding
     @gateway = ForteGateway.new(location_id: ' improperly-padded ', account_id: '  account_id  ', api_key: 'api_key', secret: 'secret')
     response = stub_comms(@gateway, :raw_ssl_request) do
@@ -548,5 +562,55 @@ class ForteTest < Test::Unit::TestCase
         }
       }
     )
+  end
+
+  def successful_refund_response
+    <<-SUCCESS
+    {
+        "transaction_id": "trn_6ad08872-a8c9-44a9-baca-670c31de98a1",
+        "location_id": "loc_176008",
+        "original_transaction_id": "trn_cf645bab-72cc-41d5-a9d2-376845333008",
+        "order_number": "1",
+        "action": "disburse",
+        "authorization_amount": 1,
+        "authorization_code": "123456",
+        "entered_by": "f087a90f00f0ae57050c937ed3815c9f",
+        "billing_address": {
+            "first_name": "Jim",
+            "last_name": "Smith",
+            "physical_address": {
+                "street_line1": "456 My Street",
+                "street_line2": "Apt 1",
+                "locality": "Ottawa",
+                "region": "ON",
+                "postal_code": "K1C2N6"
+            }
+        },
+        "response": {
+            "environment": "sandbox",
+            "response_type": "A",
+            "response_code": "A01",
+            "response_desc": "TEST APPROVAL",
+            "authorization_code": "123456",
+            "avs_result": "Y",
+            "cvv_code": "M"
+        }
+    }
+    SUCCESS
+  end
+
+  def failed_refund_response
+    <<-FAILED
+    {
+      "location_id": "loc_176008",
+      "action": "reverse",
+      "authorization_amount": 1,
+      "entered_by": "f087a90f00f0ae57050c937ed3815c9f",
+      "response": {
+        "environment": "sandbox",
+        "response_desc": "Error[1]: The field authorization_code is required when performing a reverse action. Error[2]: The field original_transaction_id is required when performing a reverse action."
+      }
+    }
+    FAILED
   end
 end


### PR DESCRIPTION
Unit: 20 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 20 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed