### PR TITLE
Paymentez: support captures with different amounts

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -67,8 +67,11 @@ module ActiveMerchant #:nodoc:
         commit_transaction('authorize', post)
       end
 
-      def capture(_money, authorization, _options = {})
-        post = { transaction: { id: authorization } }
+      def capture(money, authorization, _options = {})
+        post = {
+            transaction: { id: authorization }
+        }
+        post[:order] = {amount: amount(money).to_f} if money
 
         commit_transaction('capture', post)
       end

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -81,23 +81,31 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_equal 'Response by mock', capture.message
   end
 
+  def test_successful_authorize_and_capture_with_different_amount
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert capture = @gateway.capture(@amount + 100, auth.authorization)
+    assert_success capture
+    assert_equal 'Response by mock', capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal nil, response.message
+    assert_equal 'Response by mock', response.message
   end
 
   def test_partial_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert capture = @gateway.capture(@amount - 1, auth.authorization)
-    assert_success capture
+    assert_failure capture # Paymentez explicitly does not support partial capture; only GREATER than auth capture
   end
 
   def test_failed_capture
     response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_equal 'The capture method is not supported by carrier', response.message
+    assert_equal 'The modification of the amount is not supported by carrier', response.message
   end
 
   def test_store

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -81,7 +81,16 @@ class PaymentezTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
 
-    response = @gateway.capture(@amount, '1234', @options)
+    response = @gateway.capture(nil, '1234', @options)
+    assert_success response
+    assert_equal 'CI-635', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_capture_with_amount
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+
+    response = @gateway.capture(@amount + 1, '1234', @options)
     assert_success response
     assert_equal 'CI-635', response.authorization
     assert response.test?


### PR DESCRIPTION
Previously, Paymentez only supported capturing the original amount. It
now supports capturing any amount the processor is okay with--by
default, 100% or more of the amount specified.

As part of this commit, I've repaired all remote tests, plus altered
the partial cpature test, since it's now explicitly documented that the
test, as written, should fail (which it does).

Unit: 16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 16 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed