### PR TITLE
Remove redundant lines from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: ruby
-script: "bundle exec rake test:units"
 sudo: false
 cache: bundler
-before_install:
-  # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
-  - gem update --system
-  - gem install bundler
 
 rvm:
 - 2.5


### PR DESCRIPTION
Several additional settings were introduced to work around Travis bug 8978, but that has since been resolved.

Additionally, also remove a fully redundant `script` line.