### PR TITLE
Feature Add Amex Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/amex.rb
+++ b/lib/active_merchant/billing/gateways/amex.rb
@@ -1,0 +1,270 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class AmexGateway < Gateway
+      attr_reader :currency, :api_version, :username, :password
+      DEFAULT_URL = 'https://gateway-na.americanexpress.com/api/rest'.freeze
+
+      def initialize(options = {})
+        requires!(options, :currency, :username, :password, :api_version)
+        @currency, @username, @password, @api_version = options.values_at(:currency, :username, :password, :api_version)
+        super
+      end
+
+      def purchase(amount, credit_card_or_token, options = {})
+        if credit_card_or_token.is_a?(ActiveMerchant::Billing::CreditCard)
+          credit_card_or_token = get_token(credit_card_or_token)
+        end
+        commit(:put, transaction_endpoint(options), post_data(pay_body(amount, credit_card_or_token, options)), request_headers)
+      end
+
+      def refund(amount, options = {})
+        commit(:put, transaction_endpoint(options), post_data(refund_body(amount, options)), request_headers)
+      end
+
+      def store(credit_card)
+        commit(:post, tokenization_endpoint, post_data(store_body(credit_card)), request_headers)
+      end
+
+      def update_card(credit_card)
+        commit(:post, tokenization_endpoint, post_data(update_body(credit_card)), request_headers)
+      end
+
+      def delete_token(credit_card_or_token)
+        if credit_card_or_token.is_a?(ActiveMerchant::Billing::CreditCard)
+          credit_card_or_token = get_token(credit_card_or_token)
+        end
+        commit(:delete, delete_token_endpoint(credit_card_or_token), post_data({}), request_headers)
+      end
+
+      # Authorize and Capture cannot be used with the Amex Gateway when pay is
+      # enabled. Pay is enabled in our environment and because of this we could
+      # not test these methods.
+      # def authorize(amount, credit_card_or_token, options = {})
+      #   if credit_card_or_token.is_a?(ActiveMerchant::Billing::CreditCard)
+      #     credit_card_or_token = store(credit_card_or_token).params['token']
+      #   end
+      #   commit(:put, transaction_endpoint(options), post_data(authorize_body(amount, credit_card_or_token)), request_headers)
+      # end
+
+      # def capture(amount, options = {})
+      #   commit(:put, transaction_endpoint(options), post_data(capture_body(amount)), request_headers)
+      # end
+
+      def void(target_transaction_id, options = {})
+        commit(:put, transaction_endpoint(options), post_data(void_body(target_transaction_id, options)), request_headers)
+      end
+
+      def verify(options)
+        commit(:put, transaction_endpoint(options), post_data(verify_body(options)), request_headers)
+      end
+
+      def find_transaction(options)
+        commit(:get, transaction_endpoint(options), post_data({}), request_headers)
+      end
+
+      private
+
+      def post_data(parameters = {})
+        return nil if parameters.empty?
+        JSON.generate(parameters)
+      end
+
+      def pay_body(amount, token, options)
+        body = {
+                 apiOperation: 'PAY',
+                 order: {
+                   amount: amount,
+                   currency: currency
+                 },
+                 sourceOfFunds: {
+                   token: token
+                 }
+        }
+        add_additonal_params(body, options)
+      end
+
+      def refund_body(amount, options)
+        body = {
+          apiOperation: 'REFUND',
+          transaction: {
+            amount:    amount,
+            currency:  currency
+          }
+        }
+        body[:transaction].merge!(options[:body][:transaction]) if options.key?(:body) && !options[:body][:transaction].nil?
+        body
+      end
+
+      def authorize_body(amount, token)
+        {
+          apiOperation: 'AUTHORIZE',
+          order: {
+            amount:    amount,
+            currency:  currency
+          },
+          sourceOfFunds: {
+            token: token
+          }
+        }
+      end
+
+      def capture_body(amount, options)
+        {
+          apiOperation: 'CAPTURE',
+          transaction: {
+            amount:    amount,
+            currency:  currency
+          }
+        }
+      end
+
+      def void_body(target_transaction_id, options)
+        body = {
+                  apiOperation: 'VOID',
+                  transaction: {
+                    targetTransactionId: target_transaction_id
+                  }
+                }
+        add_additonal_params(body, options)
+      end
+
+      def verify_body(options)
+        body = {
+          apiOperation: 'VERIFY',
+          order: {
+            currency: currency
+          },
+          sourceOfFunds: {
+            token: options[:token]
+          }
+        }
+        add_additonal_params(body, options)
+      end
+
+      def store_body(credit_card)
+        {
+          sourceOfFunds: {
+            type: 'CARD',
+            provided: {
+              card: {
+                expiry: {
+                  month: credit_card.month,
+                  year:  convert_year(credit_card.year)
+                },
+                number:       credit_card.number,
+                securityCode: credit_card.verification_value
+              }
+            }
+          }
+        }
+      end
+
+      def update_body(credit_card)
+        {
+          sourceOfFunds: {
+            token: get_token(credit_card),
+            type: 'CARD',
+            provided: {
+              card: {
+                expiry: {
+                  month: credit_card.month,
+                  year:  convert_year(credit_card.year)
+                },
+                number:       credit_card.number,
+                securityCode: credit_card.verification_value
+              }
+            }
+          }
+        }
+      end
+
+      def get_token(credit_card)
+        store(credit_card).params['token']
+      end
+
+      def tokenization_endpoint
+        "#{version_path}/merchant/#{username}/token"
+      end
+
+      def transaction_endpoint(options)
+        "#{version_path}/merchant/#{username}/order/#{options[:order_id]}/transaction/#{options[:transaction_id]}"
+      end
+
+      def delete_token_endpoint(token)
+        "#{version_path}/merchant/#{username}/token/#{token}"
+      end
+
+      def version_path
+        "#{DEFAULT_URL}/version/#{api_version}"
+      end
+
+      def basic_auth
+        Base64.strict_encode64("merchant.#{username}:#{password}")
+      end
+
+      def request_headers
+        {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Basic #{basic_auth}"
+        }
+      end
+
+      def convert_year(year)
+        year.to_s[-2, 2]
+      end
+
+      def add_additonal_params(body, options)
+        adjust_order_params(body, options)
+        body[:shipping] = options[:body][:shipping] if options.key?(:body) && !options[:body][:shipping].nil?
+        body
+      end
+
+      def adjust_order_params(body, options)
+        return if !options.key?(:body) || options[:body][:order].nil?
+        if body.key?(:order)
+          body[:order].merge!(options[:body][:order])
+        else
+          body[:order] = options[:body][:order]
+        end
+      end
+
+      def parse(body)
+        return nil if body.blank?
+        JSON.parse(body)
+      end
+
+      def success_from(response)
+        response['result'] == 'SUCCESS'
+      end
+
+      def message_from(response)
+        response['response']
+      end
+
+      def authorization_from(response)
+        response['authorizationResponse']
+      end
+
+      def commit(method, endpoint, data, headers)
+        response = parse(ssl_request(method, endpoint, data, headers))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: /TEST/.match(username)
+        )
+      end
+
+      def handle_response(response)
+        case response.code.to_i
+        when 200...500
+          response.body
+        else
+          raise ResponseError.new(response)
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -21,6 +21,12 @@ allied_wallet:
   merchant_id: merchant_id
   token: token
 
+amex:
+  currency: USD
+  api_version: 40
+  username: username
+  password: password
+
 # Working credentials, no need to replace as of Oct 28 2014
 authorize_net:
   login: 7Tt72zseSzH

--- a/test/remote/gateways/remote_amex_test.rb
+++ b/test/remote/gateways/remote_amex_test.rb
@@ -1,0 +1,298 @@
+require 'test_helper'
+
+class RemoteAmexTest < Test::Unit::TestCase
+  def setup
+    @gateway = AmexGateway.new(fixtures(:amex))
+
+    @credit_card = ActiveMerchant::Billing::CreditCard.new(first_name: 'Bob',
+                                                           last_name: 'Bobsen',
+                                                           number: '345678901234564',
+                                                           month: '5',
+                                                           year: '21',
+                                                           verification_value: '0000')
+
+    @order_id       = SecureRandom.hex
+    @transaction_id = SecureRandom.hex
+  end
+
+  def test_purchase_response_with_token
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.purchase(12, token, order_id: @order_id, transaction_id: @transaction_id)
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert_equal 'CAPTURE', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_purchase_response_with_token_and_extra_order_options
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.purchase(81.40, token, order_id: @order_id, transaction_id: @transaction_id, body: order)
+    parsed_data = JSON.parse(order.to_json)
+    order_one = parsed_data['order']['item'][0]
+    order_two = parsed_data['order']['item'][1]
+    response_order_item_one = response.params['order']['item'][0]
+    response_order_item_two = response.params['order']['item'][1]
+    assert response.success?
+    assert_equal 81.40, response.params['order']['amount']
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal 81.40, response.params['transaction']['amount']
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert_equal 'CAPTURE', response.params['transaction']['type']
+    assert_equal order_one['unitTaxAmount'], response_order_item_one['unitTaxAmount'].to_s
+    assert_equal order_one['quantity'], response_order_item_one['quantity']
+    assert_equal order_one['unitPrice'], response_order_item_one['unitPrice'].to_s
+    assert_equal order_one['description'], response_order_item_one['description'].to_s
+    assert_equal order_one['name'], response_order_item_one['name']
+    assert_equal order_two['unitTaxAmount'], response_order_item_two['unitTaxAmount'].to_s
+    assert_equal order_two['quantity'], response_order_item_two['quantity']
+    assert_equal order_two['unitPrice'], response_order_item_two['unitPrice'].to_s
+    assert_equal order_two['description'], response_order_item_two['description'].to_s
+    assert_equal order_two['name'], response_order_item_two['name']
+    assert_equal parsed_data['order']['custom']['customerNumber'], response.params['order']['custom']['customerNumber']
+    assert_equal parsed_data['order']['custom']['cardMemberNumber'], response.params['order']['custom']['cardMemberNumber']
+    assert_equal parsed_data['order']['customerOrderDate'], response.params['order']['customerOrderDate']
+    assert_equal parsed_data['order']['customerReference'], response.params['order']['customerReference']
+    assert_equal parsed_data['order']['taxAmount'], response.params['order']['taxAmount'].to_s
+    assert_equal parsed_data['shipping'], response.params['shipping']
+    assert response.test?
+  end
+
+  def test_purchase_response_with_credit_card
+    response = @gateway.purchase(12, @credit_card, order_id: @order_id, transaction_id: @transaction_id)
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert_equal 'CAPTURE', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_successful_refund_response
+    refund_transaction_id = SecureRandom.hex
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    @gateway.purchase(12, token, order_id: @order_id, transaction_id: @transaction_id)
+    response = @gateway.refund(12, order_id: @order_id, transaction_id: refund_transaction_id )
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal refund_transaction_id, response.params['transaction']['id']
+    assert_equal 'REFUND', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_successful_refund_response_with_additonal_transaction_options
+    transaction = {
+      transaction: {
+        item: [
+          {
+            unitTaxAmount: '0.5',
+            quantity: 5,
+            unitPrice: '5.0',
+            description: 'Description Item 1',
+            name: 'Item 1'
+          },
+          {
+            unitTaxAmount: '0.7',
+            quantity: 7,
+            unitPrice: '7.0',
+            description: 'Description Item 2',
+            name: 'Item 2'
+          }
+        ],
+        taxAmount: '7.4'
+      }
+    }
+    refund_transaction_id = SecureRandom.hex
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    @gateway.purchase(81.40, token, order_id: @order_id, transaction_id: @transaction_id, body: order)
+    response = @gateway.refund(81.40, order_id: @order_id, transaction_id: refund_transaction_id, body: transaction )
+    parsed_data = JSON.parse(transaction.to_json)
+    transaction_one = parsed_data['transaction']['item'][0]
+    transaction_two = parsed_data['transaction']['item'][1]
+    response_transaction_item_one = response.params['transaction']['item'][0]
+    response_transaction_item_two = response.params['transaction']['item'][1]
+    assert response.success?
+    assert_equal 81.4, response.params['order']['amount']
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal 81.4, response.params['transaction']['amount']
+    assert_equal refund_transaction_id, response.params['transaction']['id']
+    assert_equal 'REFUND', response.params['transaction']['type']
+    assert_equal transaction_one['unitTaxAmount'], response_transaction_item_one['unitTaxAmount'].to_s
+    assert_equal transaction_one['quantity'], response_transaction_item_one['quantity']
+    assert_equal transaction_one['unitPrice'], response_transaction_item_one['unitPrice'].to_s
+    assert_equal transaction_one['description'], response_transaction_item_one['description'].to_s
+    assert_equal transaction_one['name'], response_transaction_item_one['name']
+    assert_equal transaction_two['unitTaxAmount'], response_transaction_item_two['unitTaxAmount'].to_s
+    assert_equal transaction_two['quantity'], response_transaction_item_two['quantity']
+    assert_equal transaction_two['unitPrice'], response_transaction_item_two['unitPrice'].to_s
+    assert_equal transaction_two['description'], response_transaction_item_two['description'].to_s
+    assert_equal transaction_two['name'], response_transaction_item_two['name']
+    assert_equal parsed_data['transaction']['taxAmount'], response.params['transaction']['taxAmount'].to_s
+    assert response.test?
+  end
+
+  def test_successful_store_response
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.store(@credit_card)
+    assert response.success?
+    assert_equal token, response.params['token']
+    assert response.test?
+  end
+
+  def test_successful_update_card_response
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.update_card(@credit_card)
+    assert response.success?
+    assert_equal token, response.params['token']
+    assert response.test?
+  end
+
+  def test_successful_verify_response
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.verify(token: token, order_id: @order_id, transaction_id: @transaction_id)
+    assert response.success?
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert response.test?
+  end
+
+  def test_successful_verify_response_with_extra_order_options
+    verify_body_options = order
+    verify_body_options[:order].delete(:customerOrderDate) && verify_body_options[:order].delete(:customerReference) 
+    verify_body_options[:order][:amount] = '81.40'
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.verify(token: token, order_id: @order_id, transaction_id: @transaction_id, body: verify_body_options)
+    parsed_data = JSON.parse(order.to_json)
+    order_one = parsed_data['order']['item'][0]
+    order_two = parsed_data['order']['item'][1]
+    response_order_item_one = response.params['order']['item'][0]
+    response_order_item_two = response.params['order']['item'][1]
+    assert response.success?
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert_equal order_one['unitTaxAmount'], response_order_item_one['unitTaxAmount'].to_s
+    assert_equal order_one['quantity'], response_order_item_one['quantity']
+    assert_equal order_one['unitPrice'], response_order_item_one['unitPrice'].to_s
+    assert_equal order_one['description'], response_order_item_one['description'].to_s
+    assert_equal order_one['name'], response_order_item_one['name']
+    assert_equal order_two['unitTaxAmount'], response_order_item_two['unitTaxAmount'].to_s
+    assert_equal order_two['quantity'], response_order_item_two['quantity']
+    assert_equal order_two['unitPrice'], response_order_item_two['unitPrice'].to_s
+    assert_equal order_two['description'], response_order_item_two['description'].to_s
+    assert_equal order_two['name'], response_order_item_two['name']
+    assert_equal parsed_data['order']['custom']['customerNumber'], response.params['order']['custom']['customerNumber']
+    assert_equal parsed_data['order']['custom']['cardMemberNumber'], response.params['order']['custom']['cardMemberNumber']
+    assert_equal parsed_data['order']['taxAmount'], response.params['order']['taxAmount'].to_s
+    assert_equal parsed_data['shipping'], response.params['shipping']
+    assert response.test?
+  end
+
+  def test_successful_void_response
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    @gateway.purchase(12, token, order_id: @order_id, transaction_id: @transaction_id)
+    void_transaction_id = SecureRandom.hex
+    response = @gateway.void(@transaction_id, order_id: @order_id, transaction_id: void_transaction_id)
+    assert response.success?
+    assert response.test?
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal void_transaction_id, response.params['transaction']['id']
+    assert_equal @transaction_id, response.params['transaction']['targetTransactionId']
+    assert_equal 'VOID_CAPTURE', response.params['transaction']['type']
+  end
+
+  def test_successful_void_response_with_custom_order_options
+    order = {
+      order: {
+        custom: {
+          customerOrderDate: '2018-07-15'
+        }
+      }
+    }
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    @gateway.purchase(12, token, order_id: @order_id, transaction_id: @transaction_id)
+    void_transaction_id = SecureRandom.hex
+    response = @gateway.void(@transaction_id, order_id: @order_id, transaction_id: void_transaction_id, body: order)
+    assert response.success?
+    assert response.test?
+    assert_equal @order_id, response.params['order']['id']
+    assert_equal void_transaction_id, response.params['transaction']['id']
+    assert_equal @transaction_id, response.params['transaction']['targetTransactionId']
+    assert_equal 'VOID_CAPTURE', response.params['transaction']['type']
+    assert_equal order[:order][:custom][:customerOrderDate], response.params['order']['custom']['customerOrderDate']
+  end
+
+  def test_delete_token_when_given_credit_card
+    response = @gateway.delete_token(@credit_card)
+    assert response.success?
+    assert response.test?
+  end
+
+  def test_delete_token_when_given_token
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    response = @gateway.delete_token(token)
+    assert response.success?
+    assert response.test?
+  end
+
+  def test_find_transaction
+    response = @gateway.store(@credit_card)
+    token = response.params['token']
+    @gateway.purchase(12, token, order_id: @order_id, transaction_id:  @transaction_id)
+    response = @gateway.find_transaction(order_id: @order_id, transaction_id: @transaction_id)
+    assert response.success?
+    assert_equal @transaction_id, response.params['transaction']['id']
+    assert response.test?
+  end
+
+  private
+  def order
+    {
+      order: {
+        custom: {
+          customerNumber: '100',
+          cardMemberNumber: '11223344'
+        },
+        customerOrderDate: '2018-07-15',
+        customerReference: '7633721GMJ8A',
+        item: [
+          {
+            unitTaxAmount: '0.5',
+            quantity: 5,
+            unitPrice: '5.0',
+            description: 'Description Item 1',
+            name: 'Item 1'
+          },
+          {
+            unitTaxAmount: '0.7',
+            quantity: 7,
+            unitPrice: '7.0',
+            description: 'Description Item 2',
+            name: 'Item 2'
+          }
+        ],
+          taxAmount: '7.4'
+      },
+      shipping: {
+        address: {
+          postcodeZip: '46237'
+        }
+      }
+    }
+  end
+end

--- a/test/unit/gateways/amex_test.rb
+++ b/test/unit/gateways/amex_test.rb
@@ -1,0 +1,184 @@
+require 'test_helper'
+
+class AmexTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = AmexGateway.new(
+      currency: 'USD',
+      username: 'TESTusername',
+      password: 'password',
+      api_version: 47
+    )
+
+    @credit_card = ActiveMerchant::Billing::CreditCard.new(first_name:         'Bob',
+                                                           last_name:          'Bobsen',
+                                                           number:             '345678901234564',
+                                                           month:              '5',
+                                                           year:               '21',
+                                                           verification_value: '0000')
+  end
+
+  def test_gateway_requires_parameters
+    assert_raises(ArgumentError, 'Missing required parameter: currency') do
+      AmexGateway.new
+    end
+  end
+
+  def test_successful_purchase_response_with_token
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    response = @gateway.purchase(12, '9739586533803075', order_id: 'xxxxx', transaction_id: 'xxxxx')
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal 'xxxxx', response.params['transaction']['id']
+    assert_equal 'CAPTURE', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_successful_purchase_response_with_credit_card
+    @gateway.expects(:store).returns(build_response(successful_store_response))
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    response = @gateway.purchase(12, @credit_card, order_id: 'xxxxx', transaction_id: 'xxxxx')
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal 'xxxxx', response.params['transaction']['id']
+    assert_equal 'CAPTURE', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_successful_refund_response
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+    response = @gateway.refund(12, order_id: 'xxxxx', transaction_id: 'xxxxx')
+    assert response.success?
+    assert_equal 12.0, response.params['order']['amount']
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert_equal 12.0, response.params['transaction']['amount']
+    assert_equal 'xxxxx', response.params['transaction']['id']
+    assert_equal 'REFUND', response.params['transaction']['type']
+    assert response.test?
+  end
+
+  def test_successful_store_response
+    @gateway.expects(:ssl_request).returns(successful_store_response)
+    response = @gateway.store(@credit_card)
+    assert response.success?
+    assert_equal '9855696296999511', response.params['token']
+    assert response.test?
+  end
+
+  def test_successful_update_card_response
+    @gateway.expects(:store).returns(build_response(successful_store_response))
+    @gateway.expects(:ssl_request).returns(successful_update_response)
+    response = @gateway.update_card(@credit_card)
+    assert response.success?
+    assert_equal '9739586533803075', response.params['token']
+    assert response.test?
+  end
+
+  # def test_successful_authorize_response
+  #   response = @gateway.authorize(12, "9739586533803075", order_id: "aabbccddzyaabb", transaction_id: "aabbccddzyzaabb")
+  # end
+
+  # def test_successful_capture_response
+  #   # @gateway.expects(:ssl_request).returns(successful_refund_response)
+  #   response = @gateway.capture(12, order_id: "aabbccddzy", transaction_id: "aabbccddzyzaa")
+  # end
+
+  def test_successful_void_response
+    @gateway.expects(:ssl_request).returns(successful_void_response)
+    response = @gateway.void('xxxxx', order_id: 'xxxxx', transaction_id: 'newtransactionid')
+    assert response.success?
+    assert response.test?
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert_equal 'newtransactionid', response.params['transaction']['id']
+    assert_equal 'xxxxx', response.params['transaction']['targetTransactionId']
+    assert_equal 'VOID_CAPTURE', response.params['transaction']['type']
+  end
+
+  def test_successful_verify_response
+    @gateway.expects(:ssl_request).returns(successful_verify_response)
+    response = @gateway.verify(token: '9739586533803075', order_id: 'xxxxx', transaction_id: 'xxxxx')
+    assert response.success?
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert_equal 'xxxxx', response.params['transaction']['id']
+    assert response.test?
+  end
+
+  def test_successful_find_transaction_response
+    @gateway.expects(:ssl_request).returns(successful_find_transaction_response)
+    response = @gateway.find_transaction(order_id: 'xxxxx', transaction_id: 'xxxxx')
+    assert response.success?
+    assert_equal 'xxxxx', response.params['transaction']['id']
+    assert_equal 'xxxxx', response.params['order']['id']
+    assert response.test?
+  end
+
+  def test_successful_delete_token_response
+    @gateway.expects(:ssl_request).returns(successful_delete_token_response)
+    response = @gateway.delete_token('9943618748371663')
+    assert response.success?
+    assert response.test?
+  end
+
+  def successful_update_response
+    <<-RESPONSE
+    {\"repositoryId\":\"TESTusername_0618\",\"response\":{\"gatewayCode\":\"BASIC_VERIFICATION_SUCCESSFUL\"},\"result\":\"SUCCESS\",\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":\"0521\",\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"type\":\"CARD\"},\"status\":\"VALID\",\"token\":\"9739586533803075\",\"usage\":{\"lastUpdated\":\"2018-06-26T20:26:33.623Z\",\"lastUpdatedBy\":\"TESTusername\",\"lastUsed\":\"2018-06-26T20:22:56.573Z\"},\"verificationStrategy\":\"BASIC\"}
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+    {\"authorizationResponse\":{\"posData\":\"xxx\",\"transactionIdentifier\":\"AmexTidTest\"},\"gatewayEntryPoint\":\"WEB_SERVICES_API\",\"merchant\":\"TESTusername\",\"order\":{\"amount\":12.0,\"chargeback\":{\"amount\":0,\"currency\":\"USD\"},\"creationTime\":\"2018-06-26T17:33:54.534Z\",\"currency\":\"USD\",\"id\":\"xxxxx\",\"merchantCategoryCode\":\"7399\",\"status\":\"REFUNDED\",\"totalAuthorizedAmount\":12.0,\"totalCapturedAmount\":12.0,\"totalRefundedAmount\":12.0},\"response\":{\"acquirerCode\":\"000\",\"acquirerMessage\":\"Successful request\",\"gatewayCode\":\"APPROVED\"},\"result\":\"SUCCESS\",\"risk\":{\"response\":{\"gatewayCode\":\"NOT_CHECKED\",\"review\":{\"decision\":\"NOT_REQUIRED\"}}},\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":{\"month\":\"5\",\"year\":\"21\"},\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"token\":\"9739586533803075\",\"type\":\"CARD\"},\"timeOfRecord\":\"2018-06-26T18:18:46.334Z\",\"transaction\":{\"acquirer\":{\"batch\":123,\"id\":\"AMEXGWS\",\"merchantId\":\"username\"},\"amount\":12.0,\"currency\":\"USD\",\"frequency\":\"SINGLE\",\"id\":\"xxxxx\",\"receipt\":\"180626271\",\"source\":\"MOTO\",\"terminal\":\"00001\",\"type\":\"REFUND\"},\"version\":\"47\"}
+    RESPONSE
+  end
+
+  def successful_purchase_response
+    <<-RESPONSE
+    {\"authorizationResponse\":{\"posData\":\"xxx\",\"transactionIdentifier\":\"AmexTidTest\"},\"gatewayEntryPoint\":\"AUTO\",\"merchant\":\"TESTusername\",\"order\":{\"amount\":12.0,\"chargeback\":{\"amount\":0,\"currency\":\"USD\"},\"creationTime\":\"2018-06-26T17:33:54.534Z\",\"currency\":\"USD\",\"id\":\"xxxxx\",\"merchantCategoryCode\":\"7399\",\"status\":\"CAPTURED\",\"totalAuthorizedAmount\":12.0,\"totalCapturedAmount\":12.0,\"totalRefundedAmount\":0.0},\"response\":{\"acquirerCode\":\"000\",\"acquirerMessage\":\"Successful request\",\"gatewayCode\":\"APPROVED\"},\"result\":\"SUCCESS\",\"risk\":{\"response\":{\"gatewayCode\":\"NOT_CHECKED\",\"review\":{\"decision\":\"NOT_REQUIRED\"}}},\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":{\"month\":\"5\",\"year\":\"21\"},\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"token\":\"9739586533803075\",\"type\":\"CARD\"},\"timeOfRecord\":\"2018-06-26T17:33:54.627Z\",\"transaction\":{\"acquirer\":{\"batch\":123,\"id\":\"AMEXGWS\",\"merchantId\":\"username\"},\"amount\":12.0,\"authorizationCode\":\"012299\",\"currency\":\"USD\",\"frequency\":\"SINGLE\",\"id\":\"xxxxx\",\"receipt\":\"180626270\",\"source\":\"MOTO\",\"taxAmount\":0.0,\"terminal\":\"00001\",\"type\":\"CAPTURE\"},\"version\":\"47\"}
+    RESPONSE
+  end
+
+  def successful_store_response
+    <<-RESPONSE
+    {\"repositoryId\":\"TESTusername_0618\",\"response\":{\"gatewayCode\":\"BASIC_VERIFICATION_SUCCESSFUL\"},\"result\":\"SUCCESS\",\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"VISA\",\"expiry\":\"0818\",\"fundingMethod\":\"CREDIT\",\"issuer\":\"JPMORGAN CHASE BANK, N.A.\",\"number\":\"411111xxxxxx1111\",\"scheme\":\"VISA\"}},\"type\":\"CARD\"},\"status\":\"VALID\",\"token\":\"9855696296999511\",\"usage\":{\"lastUpdated\":\"2018-06-25T21:32:03.013Z\",\"lastUpdatedBy\":\"TESTusername\",\"lastUsed\":\"2018-06-01T18:11:39.423Z\"},\"verificationStrategy\":\"BASIC\"}
+    RESPONSE
+  end
+
+  def successful_verify_response
+    <<-RESPONSE
+    {\"gatewayEntryPoint\":\"WEB_SERVICES_API\",\"merchant\":\"TESTusername\",\"order\":{\"amount\":0.0,\"chargeback\":{\"amount\":0,\"currency\":\"USD\"},\"creationTime\":\"2018-06-26T20:08:22.976Z\",\"currency\":\"USD\",\"id\":\"xxxxx\",\"merchantCategoryCode\":\"7399\",\"status\":\"VERIFIED\",\"totalAuthorizedAmount\":0.0,\"totalCapturedAmount\":0.0,\"totalRefundedAmount\":0.0},\"response\":{\"acquirerCode\":\"000\",\"gatewayCode\":\"APPROVED\"},\"result\":\"SUCCESS\",\"risk\":{\"response\":{\"gatewayCode\":\"NOT_CHECKED\",\"review\":{\"decision\":\"NOT_REQUIRED\"}}},\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":{\"month\":\"5\",\"year\":\"21\"},\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"token\":\"9739586533803075\",\"type\":\"CARD\"},\"timeOfRecord\":\"2018-06-26T20:08:22.976Z\",\"transaction\":{\"acquirer\":{\"id\":\"AMEXGWS\",\"merchantId\":\"username\"},\"amount\":0.0,\"currency\":\"USD\",\"frequency\":\"SINGLE\",\"id\":\"xxxxx\",\"receipt\":\"180626279\",\"source\":\"MOTO\",\"terminal\":\"00001\",\"type\":\"VERIFICATION\"},\"version\":\"47\"}
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+    {\"authorizationResponse\":{\"posData\":\"xxx\",\"transactionIdentifier\":\"AmexTidTest\"},\"gatewayEntryPoint\":\"WEB_SERVICES_API\",\"merchant\":\"TESTusername\",\"order\":{\"amount\":12.0,\"chargeback\":{\"amount\":0,\"currency\":\"USD\"},\"creationTime\":\"2018-06-26T20:22:56.473Z\",\"currency\":\"USD\",\"id\":\"xxxxx\",\"merchantCategoryCode\":\"7399\",\"status\":\"CANCELLED\",\"totalAuthorizedAmount\":0.0,\"totalCapturedAmount\":0.0,\"totalRefundedAmount\":0.0},\"response\":{\"acquirerCode\":\"000\",\"acquirerMessage\":\"Successful request\",\"gatewayCode\":\"APPROVED\"},\"result\":\"SUCCESS\",\"risk\":{\"response\":{\"gatewayCode\":\"NOT_CHECKED\",\"review\":{\"decision\":\"NOT_REQUIRED\"}}},\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":{\"month\":\"5\",\"year\":\"21\"},\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"token\":\"9739586533803075\",\"type\":\"CARD\"},\"timeOfRecord\":\"2018-06-27T15:14:20.782Z\",\"transaction\":{\"acquirer\":{\"batch\":124,\"id\":\"AMEXGWS\",\"merchantId\":\"username\"},\"amount\":12.0,\"currency\":\"USD\",\"frequency\":\"SINGLE\",\"id\":\"newtransactionid\",\"receipt\":\"180627352\",\"source\":\"MOTO\",\"targetTransactionId\":\"xxxxx\",\"taxAmount\":0.0,\"terminal\":\"00001\",\"type\":\"VOID_CAPTURE\"},\"version\":\"47\"}
+    RESPONSE
+  end
+
+  def successful_find_transaction_response
+    <<-RESPONSE
+    {\"authorizationResponse\":{\"posData\":\"1605S0100130\",\"transactionIdentifier\":\"AmexTidTest\"},\"gatewayEntryPoint\":\"AUTO\",\"merchant\":\"TESTusername\",\"order\":{\"amount\":12.0,\"creationTime\":\"2018-07-26T13:56:30.317Z\",\"currency\":\"USD\",\"id\":\"xxxxx\",\"status\":\"CAPTURED\",\"totalAuthorizedAmount\":12.0,\"totalCapturedAmount\":12.0,\"totalRefundedAmount\":0.0},\"response\":{\"acquirerCode\":\"000\",\"acquirerMessage\":\"Successful request\",\"gatewayCode\":\"APPROVED\"},\"result\":\"SUCCESS\",\"risk\":{\"response\":{\"gatewayCode\":\"NOT_CHECKED\",\"review\":{\"decision\":\"NOT_REQUIRED\"}}},\"sourceOfFunds\":{\"provided\":{\"card\":{\"brand\":\"AMEX\",\"expiry\":{\"month\":\"5\",\"year\":\"21\"},\"fundingMethod\":\"CREDIT\",\"number\":\"345678xxxxx4564\",\"scheme\":\"AMEX\"}},\"token\":\"9943618748371663\",\"type\":\"CARD\"},\"timeOfRecord\":\"2018-07-26T13:56:30.348Z\",\"transaction\":{\"acquirer\":{\"batch\":153,\"id\":\"AMEXGWS\",\"merchantId\":\"xxxxxx\"},\"amount\":12.0,\"authorizationCode\":\"001813\",\"currency\":\"USD\",\"frequency\":\"SINGLE\",\"id\":\"xxxxx\",\"receipt\":\"1807261106\",\"source\":\"MOTO\",\"terminal\":\"00001\",\"type\":\"CAPTURE\"},\"version\":\"40\"}
+    RESPONSE
+  end
+
+  def successful_delete_token_response
+    <<-RESPONSE
+    {\"result\":\"SUCCESS\"}
+    RESPONSE
+  end
+
+  def build_response(response)
+    response = JSON.parse(response)
+    Response.new(response['result'],
+                 response['response'],
+                 response,
+                 authorization: response['authorizationResponse'],
+                 test: true,
+                 error_code: response['result'])
+  end
+end


### PR DESCRIPTION
Adds new Gateway for Amex.

The following actions have been implemented in the gateway

- purchase
- refund
- store
- update_card
- void
- verify

The following methods are in the gateway but commented out:

- authorize
- capture

They are commented out because Amex will not open those endpoints to a user if they have already opened purchase.  Purchase runs both authorize and capture in the same action.