### PR TITLE
Default SSL min_version to TLS 1.1 to comply with PCI DSS deadline

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909
 * Paymentez: return a Result object even when the upstream server 500s [bpollack] #2871
 * Drop support for Ruby versions older than 2.3 [bpollack] #2863
 * Bridge Pay: don't throw an exception when bank account type is omitted [bpollack] #2873

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -14,6 +14,7 @@ module ActiveMerchant
     VERIFY_PEER = true
     CA_FILE = File.expand_path('../certs/cacert.pem', File.dirname(__FILE__))
     CA_PATH = nil
+    MIN_VERSION = :TLS1_1
     RETRY_SAFE = false
     RUBY_184_POST_HEADERS = { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
@@ -51,7 +52,7 @@ module ActiveMerchant
       @ignore_http_status = false
       @ssl_version = nil
       if Net::HTTP.instance_methods.include?(:min_version=)
-        @min_version = nil
+        @min_version = MIN_VERSION
         @max_version = nil
       end
       @ssl_connection = {}

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       base.ssl_version = nil
 
       base.class_attribute :min_version
-      base.min_version = nil
+      base.min_version = Connection::MIN_VERSION
 
       base.class_attribute :max_version
       base.max_version = nil

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -115,9 +115,9 @@ class ConnectionTest < Test::Unit::TestCase
   def test_override_min_version
     omit_if Net::HTTP.instance_methods.exclude?(:min_version=)
 
-    refute_equal :TLS1_1, @connection.min_version
-    @connection.min_version = :TLS1_1
-    assert_equal :TLS1_1, @connection.min_version
+    refute_equal :TLS1_2, @connection.min_version
+    @connection.min_version = :TLS1_2
+    assert_equal :TLS1_2, @connection.min_version
   end
 
   def test_override_max_version


### PR DESCRIPTION
Ruby supports setting this from version 2.5, I backported this for 2.3 and 2.4 with the [min_max_ssl](https://github.com/bdewater/min_max_ssl) gem. Also see https://github.com/activemerchant/active_merchant/pull/2775

For more details about the deadline: https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls