### PR TITLE
CT Payment: Add new gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Redsys: Fix payments with cc token [Leonardo Diez] #2586
 * Redsys: Missing cardnumber params in xml_signed_fields [nerburish] #2628
 * Bogus: allow authorizing with a tokenized card [Azdaroth] #2703
+* CT Payment: Add new gateway [nfarve]  #2911
 
 == Version 1.79.2 (June 2, 2018)
 * Fix Gateway#max_version= overwriting min_version [bdewater]

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -1,0 +1,267 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class CtPaymentGateway < Gateway
+      self.test_url = 'https://test.ctpaiement.ca/v1/'
+      self.live_url = 'hhtps://www.ctpaiement.com/v1/'
+
+      self.supported_countries = ['US', 'CA']
+      self.default_currency = 'CAD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club]
+
+      self.homepage_url = 'http://www.ct-payment.com/'
+      self.display_name = 'CT Payment'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '14' => STANDARD_ERROR_CODE[:invalid_number],
+        '05' => STANDARD_ERROR_CODE[:card_declined],
+        'M6' => STANDARD_ERROR_CODE[:card_declined],
+        '9068' => STANDARD_ERROR_CODE[:incorrect_number],
+        '9067' => STANDARD_ERROR_CODE[:incorrect_number]
+      }
+      CARD_BRAND = {
+        'american_express' => 'A',
+        'master' => 'M',
+        'diners_club' => 'I',
+        'visa' => 'V',
+        'discover' => 'O'
+      }
+
+      def initialize(options={})
+        requires!(options, :api_key, :company_number, :merchant_number)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_terminal_number(post, options)
+        add_money(post, money)
+        add_operator_id(post, options)
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        payment.is_a?(String) ? commit('purchaseWithToken', post) : commit('purchase', post)
+      end
+
+      def authorize(money, payment, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_money(post, money)
+        add_terminal_number(post, options)
+        add_operator_id(post, options)
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        payment.is_a?(String) ? commit('preAuthorizationWithToken', post) : commit('preAuthorization', post)
+      end
+
+      def capture(money, authorization, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_invoice(post, money, options)
+        add_money(post, money)
+        add_customer_data(post, options)
+        transaction_number, authorization_number, invoice_number = split_authorization(authorization)
+        post[:OriginalTransactionNumber] = transaction_number
+        post[:OriginalAuthorizationNumber] = authorization_number
+        post[:OriginalInvoiceNumber] = invoice_number
+
+        commit('completion', post)
+      end
+
+      def refund(money, authorization, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_invoice(post, money, options)
+        add_money(post, money)
+        add_customer_data(post, options)
+        transaction_number, _, invoice_number = split_authorization(authorization)
+        post[:OriginalTransactionNumber] = transaction_number
+        post[:OriginalInvoiceNumber] = invoice_number
+
+        commit('refundWithoutCard', post)
+      end
+
+      def credit(money, payment, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_terminal_number(post, options)
+        add_money(post, money)
+        add_operator_id(post, options)
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        payment.is_a?(String) ? commit('refundWithToken', post) : commit('refund', post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        post[:InputType] = 'I'
+        post[:LanguageCode] = 'E'
+        transaction_number, _, invoice_number = split_authorization(authorization)
+        post[:OriginalTransactionNumber] = transaction_number
+        post[:OriginalInvoiceNumber] = invoice_number
+        add_operator_id(post, options)
+        add_customer_data(post, options)
+
+        commit('void', post)
+      end
+
+      def verify(credit_card, options={})
+        requires!(options, :order_id)
+        post = {}
+        add_terminal_number(post, options)
+        add_operator_id(post, options)
+        add_invoice(post,0, options)
+        add_payment(post, credit_card)
+        add_customer_data(post, options)
+
+        commit('verifyAccount', post)
+      end
+
+      def store(credit_card, options={})
+        requires!(options, :email)
+        post = {
+          LanguageCode: 'E',
+          Name: credit_card.name.rjust(50, ' '),
+          Email: options[:email].rjust(240, ' ')
+        }
+        add_operator_id(post, options)
+        add_payment(post, credit_card)
+        add_customer_data(post, options)
+
+        commit('recur/AddUser', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((&?auth-api-key=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?payload=)[a-zA-Z%0-9=]+)i, '\1[FILTERED]').
+          gsub(%r((&?token:)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?cardNumber:)[^&]*)i, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_terminal_number(post, options)
+        post[:MerchantTerminalNumber] = options[:merchant_terminal_number] || ' ' * 5
+      end
+
+      def add_money(post, money)
+        post[:Amount] = money.to_s.rjust(11,'0')
+      end
+
+      def add_operator_id(post, options)
+        post[:OperatorID] = options[:operator_id] || '0' * 8
+      end
+
+      def add_customer_data(post, options)
+        post[:CustomerNumber] = options[:customer_number] || '0' * 8
+      end
+
+      def add_address(post, creditcard, options)
+        if address = options[:billing_address] || options[:address]
+          post[:CardHolderAddress] = ("#{address[:address1]} #{address[:address2]}").rjust(20, ' ')
+          post[:CardHolderPostalCode] = address[:zip].gsub(/\s+/, '').rjust(9, ' ')
+        end
+      end
+
+      def add_invoice(post, money,  options)
+        post[:CurrencyCode] = options[:currency] || (currency(money) if money)
+        post[:InvoiceNumber] = options[:order_id].rjust(12,'0')
+        post[:InputType] = 'I'
+        post[:LanguageCode] = 'E'
+      end
+
+      def add_payment(post, payment)
+        if payment.is_a?(String)
+          post[:Token] = split_authorization(payment)[3].strip
+        else
+          post[:CardType] = CARD_BRAND[payment.brand] || ' '
+          post[:CardNumber] = payment.number.rjust(40,' ')
+          post[:ExpirationDate] = expdate(payment)
+          post[:Cvv2Cvc2Number] = payment.verification_value
+        end
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def split_authorization(authorization)
+        authorization.split(';')
+      end
+
+      def commit_raw(action, parameters)
+        url = (test? ? test_url : live_url) + action
+        response = parse(ssl_post(url, post_data(action, parameters)))
+
+        final_response = Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response['avsStatus']),
+          cvv_result: CVVResult.new(response['cvv2Cvc2Status']),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def commit(action, parameters)
+        if action == 'void'
+          commit_raw(action, parameters)
+        else
+          MultiResponse.run(true) do |r|
+            r.process { commit_raw(action, parameters)}
+            r.process {
+              split_auth = split_authorization(r.authorization)
+              auth =  (action.include?('recur')? split_auth[4] : split_auth[0])
+              action.include?('recur') ? commit_raw('recur/ack', {ID: auth}) : commit_raw('ack', {TransactionNumber: auth})
+            }
+          end
+        end
+      end
+
+      def success_from(response)
+        return true if response['returnCode'] == '  00'
+        return true if response['returnCode'] == 'true'
+        return true if response['recurReturnCode'] == '  00'
+        return false
+      end
+
+      def message_from(response)
+        response['errorDescription'] || (response['terminalDisp'].strip if response['terminalDisp'])
+      end
+
+      def authorization_from(response)
+        "#{response['transactionNumber']};#{response['authorizationNumber']};"\
+        "#{response['invoiceNumber']};#{response['token']};#{response['id']}"
+      end
+
+      def post_data(action, parameters = {})
+        parameters[:CompanyNumber] = @options[:company_number]
+        parameters[:MerchantNumber] = @options[:merchant_number]
+        parameters = parameters.collect do |key, value|
+          "#{key}=#{value}" unless (value.nil? || value.empty?)
+        end.join('&')
+        payload = Base64.strict_encode64(parameters)
+        "auth-api-key=#{@options[:api_key]}&payload=#{payload}".strip
+      end
+
+      def error_code_from(response)
+        STANDARD_ERROR_CODE_MAPPING[response['returnCode'].strip || response['recurReturnCode'.strip]] unless success_from(response)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -219,6 +219,11 @@ credorax:
   merchant_id: 'merchant_id'
   cipher_key: 'cipher_key'
 
+ct_payment:
+  api_key: SOMECREDENTIAL
+  company_number: '12345'
+  merchant_number: '12345678'
+
 # Culqi does not provide public testing data
 culqi:
   merchant_id: MERCHANT

--- a/test/remote/gateways/remote_ct_payment_certification_test.rb
+++ b/test/remote/gateways/remote_ct_payment_certification_test.rb
@@ -1,0 +1,243 @@
+require 'test_helper'
+
+class RemoteCtPaymentCertificationTest < Test::Unit::TestCase
+  def setup
+    @gateway = CtPaymentGateway.new(fixtures(:ct_payment))
+
+    @amount = 100
+    @declined_card = credit_card('4502244713161718')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      merchant_terminal_number: '     ',
+      order_id: generate_unique_id[0,11]
+    }
+  end
+
+  def test1
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(1, response)
+  end
+
+  def test2
+    @credit_card = credit_card('5194419000000007', month: '07', year: 2025)
+    @credit_card.brand = 'master'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(2, response)
+  end
+
+  def test3
+    @credit_card = credit_card('341400000000000', month: '07', year: 2025, verification_value: '1234')
+    @credit_card.brand = 'american_express'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(3, response)
+  end
+
+  def test6
+    @credit_card = credit_card('341400000000000', month: '07', year: 2025, verification_value: '1234')
+    @credit_card.brand = 'american_express'
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(6, response)
+  end
+
+  def test4
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(4, response)
+  end
+
+  def test5
+    @credit_card = credit_card('5194419000000007', month: '07', year: 2025)
+    @credit_card.brand = 'master'
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(5, response)
+  end
+
+  def test7
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    print_result(7, response)
+
+    capture_response = @gateway.capture(@amount, response.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    print_result(10, capture_response)
+  end
+
+  def test8
+    @credit_card = credit_card('5194419000000007', month: '07', year: 2025)
+    @credit_card.brand = 'master'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    print_result(8, response)
+
+    capture_response = @gateway.capture(@amount, response.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    print_result(11, capture_response)
+  end
+
+  def test9
+    @credit_card = credit_card('341400000000000', month: '07', year: 2025, verification_value: '1234')
+    @credit_card.brand = 'american_express'
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(order_id: generate_unique_id[0,11]))
+    print_result(9, response)
+
+    capture_response = @gateway.capture(@amount, response.authorization, @options)
+    print_result(12, capture_response)
+  end
+
+  def test13
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase('000', @credit_card, @options)
+    print_result(13, response)
+  end
+
+  def test14
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase(-100, @credit_card, @options)
+    print_result(14, response)
+  end
+
+  def test15
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase('-1A0', @credit_card, @options)
+    print_result(15, response)
+  end
+
+  def test16
+    @credit_card = credit_card('5194419000000007', month: '07', year: 2025)
+    @credit_card.brand = 'visa'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(16, response)
+  end
+
+  def test17
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    @credit_card.brand = 'master'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(17, response)
+  end
+
+  def test18
+    @credit_card = credit_card('', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(18, response)
+  end
+
+  def test19
+    @credit_card = credit_card('4501123412341234', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(19, response)
+  end
+
+  def test20
+    #requires editing the model to run with a 3 digit expiration date
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(20, response)
+  end
+
+  def test21
+    @credit_card = credit_card('4501161107217214', month: 17, year: 2017)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(21, response)
+  end
+
+  def test22
+    @credit_card = credit_card('4501161107217214', month: '01', year: 2016)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(22, response)
+  end
+
+  def test24
+    @credit_card = credit_card('4502244713161718', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(24, response)
+  end
+
+  def test25
+    # Needs an edit to the Model to run
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(25, response)
+  end
+
+  def test26
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.credit('000', @credit_card, @options)
+    print_result(26, response)
+  end
+
+  def test27
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.credit(-100, @credit_card, @options)
+    print_result(27, response)
+  end
+
+  def test28
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.credit('-1A0', @credit_card, @options)
+    print_result(28, response)
+  end
+
+  def test29
+    @credit_card = credit_card('5194419000000007', month: '07', year: 2025)
+    @credit_card.brand = 'visa'
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(29, response)
+  end
+
+  def test30
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    @credit_card.brand = 'master'
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(30, response)
+  end
+
+  def test31
+    @credit_card = credit_card('', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(31, response)
+  end
+
+  def test32
+    @credit_card = credit_card('4501123412341234', month: '07', year: 2025)
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(32, response)
+  end
+
+  def test33
+    #requires edit to model to make 3 digit expiration date
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2)
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(33, response)
+  end
+
+  def test34
+    @credit_card = credit_card('4501161107217214', month: 17, year: 2017)
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(34, response)
+  end
+
+  def test35
+    @credit_card = credit_card('4501161107217214', month: '01', year: 2016)
+    response = @gateway.credit(@amount, @credit_card, @options)
+    print_result(35, response)
+  end
+
+  def test37
+    @credit_card = credit_card('4502244713161718', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(37, response)
+  end
+
+  def test38
+    # Needs an edit to the Model to run
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2025)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    print_result(38, response)
+  end
+
+  def print_result(test_number, response)
+    puts "Test #{test_number} | transaction number: #{response.params['transactionNumber']}, invoice number #{response.params['invoiceNumber']}, timestamp: #{response.params['timeStamp']}, result: #{response.params['returnCode']}"
+    puts response.inspect
+  end
+
+end

--- a/test/remote/gateways/remote_ct_payment_test.rb
+++ b/test/remote/gateways/remote_ct_payment_test.rb
@@ -1,0 +1,173 @@
+require 'test_helper'
+
+class RemoteCtPaymentTest < Test::Unit::TestCase
+  def setup
+    @gateway = CtPaymentGateway.new(fixtures(:ct_payment))
+
+    @amount = 100
+    @credit_card = credit_card('4501161107217214', month: '07', year: 2020)
+    @declined_card = credit_card('4502244713161718')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      order_id: generate_unique_id[0,11],
+      email: 'bigbird@sesamestreet.com'
+
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Transaction declined', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    assert_success capture
+    assert_equal 'APPROVED', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Transaction declined', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '0123456789asd;0123456789asdf;12345678', @options)
+    assert_failure response
+    assert_equal 'The original transaction number does not match any actual transaction', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    assert_success refund
+    assert_equal 'APPROVED', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization, @options.merge(order_id: generate_unique_id[0,11]))
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '0123456789asd;0123456789asdf;12345678', @options.merge(order_id: generate_unique_id[0,11]))
+    assert_failure response
+    assert_equal 'The original transaction number does not match any actual transaction', response.message
+  end
+
+  def test_successful_void
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert void = @gateway.void(purchase.authorization)
+    assert_success void
+    assert_equal 'APPROVED', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('0123456789asd;0123456789asdf;12345678')
+    assert_failure response
+    assert_equal 'The original transaction number does not match any actual transaction', response.message
+  end
+
+  def test_successful_credit
+    assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert !response.authorization.split(';')[3].nil?
+  end
+
+  def test_successful_purchase_using_stored_card
+    assert store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+
+    response = @gateway.purchase(@amount, store_response.authorization, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_successful_authorize_using_stored_card
+    assert store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+
+    response = @gateway.authorize(@amount, store_response.authorization, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{APPROVED}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{Transaction declined}, response.message
+  end
+
+  def test_invalid_login
+    gateway = CtPaymentGateway.new(api_key: '', company_number: '12345', merchant_number: '12345')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid API KEY}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(Base64.strict_encode64(@credit_card.number), transcript)
+    assert_scrubbed(@gateway.options[:api_key], transcript)
+  end
+
+  def test_transcript_scrubbing_store
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(Base64.strict_encode64(@credit_card.number), transcript)
+    assert_scrubbed(@gateway.options[:api_key], transcript)
+  end
+
+end

--- a/test/unit/gateways/ct_payment_test.rb
+++ b/test/unit/gateways/ct_payment_test.rb
@@ -1,0 +1,302 @@
+require 'test_helper'
+
+class CtPaymentTest < Test::Unit::TestCase
+  def setup
+    @gateway = CtPaymentGateway.new(api_key: 'api_key', company_number: 'company number', merchant_number: 'merchant_number')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).twice.returns(successful_purchase_response, successful_ack_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '000007708972;443752  ;021efc336262;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).twice.returns(successful_authorize_response, successful_ack_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '000007708990;448572  ;0e7ebe0a804f;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).twice.returns(successful_capture_response, successful_ack_response)
+
+    response = @gateway.capture(@amount, '000007708990;448572  ;0e7ebe0a804f;', @options)
+    assert_success response
+
+    assert_equal '000007708991;        ;0636aca3dd8e;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_post).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, '0123456789asd;0123456789asdf;12345678', @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).twice.returns(successful_refund_response, successful_ack_response)
+
+    response = @gateway.refund(@amount, '000007708990;448572  ;0e7ebe0a804f;', @options)
+    assert_success response
+
+    assert_equal '000007709004;        ;0a08f144b6ea;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.capture(@amount, '0123456789asd;0123456789asdf;12345678', @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    response = @gateway.void('000007708990;448572  ;0e7ebe0a804f;', @options)
+    assert_success response
+
+    assert_equal '000007709013;        ;0de38871ce96;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    response = @gateway.void('0123456789asd;0123456789asdf;12345678')
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).twice.returns(successful_verify_response, successful_ack_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal '000007709025;        ;0b882fe35f69;;', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_verify
+    @gateway.expects(:ssl_post).returns(failed_verify_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_credit
+    @gateway.expects(:ssl_post).twice.returns(successful_credit_response, successful_ack_response)
+
+    response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '000007709063;        ;054902f2ded0;;', response.authorization
+    assert response.test?
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      opening connection to test.ctpaiement.ca:443...
+      opened
+      starting SSL for test.ctpaiement.ca:443...
+      SSL established
+      <- "POST /v1/purchase HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: test.ctpaiement.ca\r\nContent-Length: 528\r\n\r\n"
+      <- "auth-api-key=R46SNTJ42UCJ3264182Y0T087YHBA50RTK&payload=TWVyY2hhbnRUZXJtaW5hbE51bWJlcj0gICAgICZBbW91bnQ9MDAwMDAwMDAxMDAmT3BlcmF0b3JJRD0wMDAwMDAwMCZDdXJyZW5jeUNvZGU9VVNEJkludm9pY2VOdW1iZXI9MDYzZmI1MmMyOTc2JklucHV0VHlwZT1JJkxhbmd1YWdlQ29kZT1FJkNhcmRUeXBlPVYmQ2FyZE51bWJlcj00NTAxMTYxMTA3MjE3MjE0JkV4cGlyYXRpb25EYXRlPTA3MjAmQ2FyZEhvbGRlckFkZHJlc3M9NDU2IE15IFN0cmVldE90dGF3YSAgICAgICAgICAgICAgICAgIE9OJkNhcmRIb2xkZXJQb3N0YWxDb2RlPSAgIEsxQzJONiZDdXN0b21lck51bWJlcj0wMDAwMDAwMCZDb21wYW55TnVtYmVyPTAwNTg5Jk1lcmNoYW50TnVtYmVyPTUzNDAwMDMw"
+      -> "HTTP/1.1 200 200\r\n"
+      -> "Date: Fri, 29 Jun 2018 18:21:07 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=ISO-8859-1\r\n"
+      -> "\r\n"
+      -> "480\r\n"
+      reading 1152 bytes...
+      -> "{\"returnCode\":\"  00\",\"errorDescription\":null,\"authorizationNumber\":\"448186  \",\"referenceNumber\":\"          \",\"transactionNumber\":\"000007709037\",\"batchNumber\":\"0001\",\"terminalNumber\":\"13366\",\"serverNumber\":\"0001\",\"timeStamp\":\"20180629-14210749\",\"trxCode\":\"00\",\"merchantNumber\":\"53400030\",\"amount\":\"00000000100\",\"invoiceNumber\":\"063fb52c2976\",\"trxType\":\"C\",\"cardType\":\"V\",\"cardNumber\":\"450116XXXXXX7214                        \",\"expirationDate\":\"0720\",\"bankTerminalNumber\":\"53400188\",\"trxDate\":\"06292018\",\"trxTime\":\"142107\",\"accountType\":\"0\",\"trxMethod\":\"T@1\",\"languageCode\":\"E\",\"sequenceNumber\":\"000000000028\",\"receiptDisp\":\"       APPROVED-THANK YOU       \",\"terminalDisp\":\"APPROVED                \",\"operatorId\":\"00000000\",\"surchargeAmount\":\"\",\"companyNumber\":\"00589\",\"secureID\":\"\",\"cvv2Cvc2Status\":\" \",\"iopIssuerConfirmationNumber\":null,\"iopIssuerName\":null,\"avsStatus\":null,\"holderName\":null,\"threeDSStatus\":null,\"emvLabel\":null,\"emvAID\":null,\"emvTVR\":null,\"emvTSI\":null,\"emvTC\":null,\"demoMode\":null,\"terminalInvoiceNumber\":null,\"cashbackAmount\":null,\"tipAmount\":null,\"taxAmount\":null,\"cvmResults\":null,\"token\":null,\"customerNumber\":null,\"email\":\"\"}"
+      read 1152 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+      opening connection to test.ctpaiement.ca:443...
+      opened
+      starting SSL for test.ctpaiement.ca:443...
+      SSL established
+      <- "POST /v1/ack HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: test.ctpaiement.ca\r\nContent-Length: 156\r\n\r\n"
+      <- "auth-api-key=R46SNTJ42UCJ3264182Y0T087YHBA50RTK&payload=VHJhbnNhY3Rpb25OdW1iZXI9MDAwMDA3NzA5MDM3JkNvbXBhbnlOdW1iZXI9MDA1ODkmTWVyY2hhbnROdW1iZXI9NTM0MDAwMzA="
+      -> "HTTP/1.1 200 200\r\n"
+      -> "Date: Fri, 29 Jun 2018 18:21:08 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=ISO-8859-1\r\n"
+      -> "\r\n"
+      -> "15\r\n"
+      reading 21 bytes...
+      -> "{\"returnCode\":\"true\"}"
+      read 21 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      opening connection to test.ctpaiement.ca:443...
+      opened
+      starting SSL for test.ctpaiement.ca:443...
+      SSL established
+      <- "POST /v1/purchase HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: test.ctpaiement.ca\r\nContent-Length: 528\r\n\r\n"
+      <- "auth-api-key=[FILTERED]&payload=[FILTERED]"
+      -> "HTTP/1.1 200 200\r\n"
+      -> "Date: Fri, 29 Jun 2018 18:21:07 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=ISO-8859-1\r\n"
+      -> "\r\n"
+      -> "480\r\n"
+      reading 1152 bytes...
+      -> "{\"returnCode\":\"  00\",\"errorDescription\":null,\"authorizationNumber\":\"448186  \",\"referenceNumber\":\"          \",\"transactionNumber\":\"000007709037\",\"batchNumber\":\"0001\",\"terminalNumber\":\"13366\",\"serverNumber\":\"0001\",\"timeStamp\":\"20180629-14210749\",\"trxCode\":\"00\",\"merchantNumber\":\"53400030\",\"amount\":\"00000000100\",\"invoiceNumber\":\"063fb52c2976\",\"trxType\":\"C\",\"cardType\":\"V\",\"cardNumber\":\"450116XXXXXX7214                        \",\"expirationDate\":\"0720\",\"bankTerminalNumber\":\"53400188\",\"trxDate\":\"06292018\",\"trxTime\":\"142107\",\"accountType\":\"0\",\"trxMethod\":\"T@1\",\"languageCode\":\"E\",\"sequenceNumber\":\"000000000028\",\"receiptDisp\":\"       APPROVED-THANK YOU       \",\"terminalDisp\":\"APPROVED                \",\"operatorId\":\"00000000\",\"surchargeAmount\":\"\",\"companyNumber\":\"00589\",\"secureID\":\"\",\"cvv2Cvc2Status\":\" \",\"iopIssuerConfirmationNumber\":null,\"iopIssuerName\":null,\"avsStatus\":null,\"holderName\":null,\"threeDSStatus\":null,\"emvLabel\":null,\"emvAID\":null,\"emvTVR\":null,\"emvTSI\":null,\"emvTC\":null,\"demoMode\":null,\"terminalInvoiceNumber\":null,\"cashbackAmount\":null,\"tipAmount\":null,\"taxAmount\":null,\"cvmResults\":null,\"token\":null,\"customerNumber\":null,\"email\":\"\"}"
+      read 1152 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+      opening connection to test.ctpaiement.ca:443...
+      opened
+      starting SSL for test.ctpaiement.ca:443...
+      SSL established
+      <- "POST /v1/ack HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: test.ctpaiement.ca\r\nContent-Length: 156\r\n\r\n"
+      <- "auth-api-key=[FILTERED]&payload=[FILTERED]"
+      -> "HTTP/1.1 200 200\r\n"
+      -> "Date: Fri, 29 Jun 2018 18:21:08 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=ISO-8859-1\r\n"
+      -> "\r\n"
+      -> "15\r\n"
+      reading 21 bytes...
+      -> "{\"returnCode\":\"true\"}"
+      read 21 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    )
+  end
+
+  def successful_purchase_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"443752  ","referenceNumber":"          ","transactionNumber":"000007708972","batchNumber":"0001","terminalNumber":"13366","serverNumber":"0001","timeStamp":"20180629-12110905","trxCode":"00","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"021efc336262","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400188","trxDate":"06292018","trxTime":"121109","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000008","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_ack_response
+    '{"returnCode":"true"}'
+  end
+
+  def failed_purchase_response
+    '{"returnCode":"  05","errorDescription":"Transaction declined","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007708975","batchNumber":"0000","terminalNumber":"13366","serverNumber":"0001","timeStamp":"20180629-12272768","trxCode":"00","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"098096b31937","trxType":"C","cardType":"V","cardNumber":"450224XXXXXX1718                        ","expirationDate":"0919","bankTerminalNumber":"53400188","trxDate":"06292018","trxTime":"122727","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000009","receiptDisp":"    TRANSACTION NOT APPROVED    ","terminalDisp":"05-DECLINE              ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_authorize_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"448572  ","referenceNumber":"          ","transactionNumber":"000007708990","batchNumber":"0001","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-12501747","trxCode":"01","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"0e7ebe0a804f","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"125017","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000014","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def failed_authorize_response
+    '{"returnCode":"  05","errorDescription":"Transaction declined","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007708993","batchNumber":"0000","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-13072751","trxCode":"01","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"02ec22cbb5db","trxType":"C","cardType":"V","cardNumber":"450224XXXXXX1718                        ","expirationDate":"0919","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"130727","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000015","receiptDisp":"    TRANSACTION NOT APPROVED    ","terminalDisp":"05-DECLINE              ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_capture_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007708991","batchNumber":"0001","terminalNumber":"13366","serverNumber":"0001","timeStamp":"20180629-12501869","trxCode":"02","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"0636aca3dd8e","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400188","trxDate":"06292018","trxTime":"125018","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000015","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def failed_capture_response
+    '{"returnCode":"9068","errorDescription":"The original transaction number does not match any actual transaction","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007708999","batchNumber":"    ","terminalNumber":"     ","serverNumber":"    ","timeStamp":"20180629-13224441","trxCode":"  ","merchantNumber":"        ","amount":"00000000000","invoiceNumber":"            ","trxType":" ","cardType":" ","cardNumber":"                                        ","expirationDate":"    ","bankTerminalNumber":"        ","trxDate":"        ","trxTime":"      ","accountType":" ","trxMethod":"   ","languageCode":" ","sequenceNumber":"               ","receiptDisp":"    OPERATION NON COMPLETEE     ","terminalDisp":"9068: Contactez support.","operatorId":"        ","surchargeAmount":"           ","companyNumber":"     ","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_refund_response
+    ' {"returnCode":"  00","errorDescription":null,"authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709004","batchNumber":"0001","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-13294388","trxCode":"03","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"0a08f144b6ea","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"132944","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000019","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def failed_refund_response
+    '{"returnCode":"9068","errorDescription":"The original transaction number does not match any actual transaction","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709009","batchNumber":"    ","terminalNumber":"     ","serverNumber":"    ","timeStamp":"20180629-13402119","trxCode":"  ","merchantNumber":"        ","amount":"00000000000","invoiceNumber":"            ","trxType":" ","cardType":" ","cardNumber":"                                        ","expirationDate":"    ","bankTerminalNumber":"        ","trxDate":"        ","trxTime":"      ","accountType":" ","trxMethod":"   ","languageCode":" ","sequenceNumber":"               ","receiptDisp":"    OPERATION NON COMPLETEE     ","terminalDisp":"9068: Contactez support.","operatorId":"        ","surchargeAmount":"           ","companyNumber":"     ","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_void_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709013","batchNumber":"0001","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-13451840","trxCode":"04","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"0de38871ce96","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214","expirationDate":"0720","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"134518","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000023","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"           ","companyNumber":"     ","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def failed_void_response
+    '{"returnCode":"9068","errorDescription":"The original transaction number does not match any actual transaction","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"0000000000-1","batchNumber":"    ","terminalNumber":"     ","serverNumber":"    ","timeStamp":"20180629-13520693","trxCode":"  ","merchantNumber":"        ","amount":"00000000000","invoiceNumber":"            ","trxType":" ","cardType":" ","cardNumber":"                                        ","expirationDate":"    ","bankTerminalNumber":"        ","trxDate":"        ","trxTime":"      ","accountType":" ","trxMethod":"   ","languageCode":" ","sequenceNumber":"               ","receiptDisp":"    OPERATION NOT COMPLETED     ","terminalDisp":"9068: Contact support.  ","operatorId":"        ","surchargeAmount":"           ","companyNumber":"     ","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_verify_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709025","batchNumber":"0001","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-14023575","trxCode":"08","merchantNumber":"53400030","amount":"00000000000","invoiceNumber":"0b882fe35f69","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"140236","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000025","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def failed_verify_response
+    '{"returnCode":"  05","errorDescription":"Transaction declined","authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709029","batchNumber":"0000","terminalNumber":"13367","serverNumber":"0001","timeStamp":"20180629-14104707","trxCode":"08","merchantNumber":"53400030","amount":"00000000000","invoiceNumber":"0c0054d2bb7a","trxType":"C","cardType":"V","cardNumber":"450224XXXXXX1718                        ","expirationDate":"0919","bankTerminalNumber":"53400189","trxDate":"06292018","trxTime":"141047","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000026","receiptDisp":"    TRANSACTION NOT APPROVED    ","terminalDisp":"05-DECLINE              ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+
+  def successful_credit_response
+    '{"returnCode":"  00","errorDescription":null,"authorizationNumber":"        ","referenceNumber":"          ","transactionNumber":"000007709063","batchNumber":"0001","terminalNumber":"13366","serverNumber":"0001","timeStamp":"20180629-14420931","trxCode":"03","merchantNumber":"53400030","amount":"00000000100","invoiceNumber":"054902f2ded0","trxType":"C","cardType":"V","cardNumber":"450116XXXXXX7214                        ","expirationDate":"0720","bankTerminalNumber":"53400188","trxDate":"06292018","trxTime":"144209","accountType":"0","trxMethod":"T@1","languageCode":"E","sequenceNumber":"000000000032","receiptDisp":"       APPROVED-THANK YOU       ","terminalDisp":"APPROVED                ","operatorId":"00000000","surchargeAmount":"","companyNumber":"00589","secureID":"","cvv2Cvc2Status":" ","iopIssuerConfirmationNumber":null,"iopIssuerName":null,"avsStatus":null,"holderName":null,"threeDSStatus":null,"emvLabel":null,"emvAID":null,"emvTVR":null,"emvTSI":null,"emvTC":null,"demoMode":null,"terminalInvoiceNumber":null,"cashbackAmount":null,"tipAmount":null,"taxAmount":null,"cvmResults":null,"token":null,"customerNumber":null,"email":""}'
+  end
+end


### PR DESCRIPTION
Adds a new gateway (ct_payment) along with a certicication test file

Loaded suite test/unit/gateways/ct_payment_test

14 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_ct_payment_test

20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed