### PR TITLE
Firstdata E4 (GGE4) v27: Add new gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915
 * Pin Payments: Pass reference for statement desc [curiousepic] #2919
+* FirstData: introduce v27 gateway [shasum] #2912
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -1,0 +1,444 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class FirstdataE4V27Gateway < Gateway
+      self.test_url = 'https://api.demo.globalgatewaye4.firstdata.com/transaction/v27'
+      self.live_url = 'https://api.globalgatewaye4.firstdata.com/transaction/v27'
+
+      TRANSACTIONS = {
+        sale:          '00',
+        authorization: '01',
+        verify:        '05',
+        capture:       '32',
+        void:          '33',
+        credit:        '34',
+        store:         '05'
+      }
+
+      SUCCESS = 'true'
+
+      SENSITIVE_FIELDS = [:cvdcode, :expiry_date, :card_number]
+
+      BRANDS = {
+        :visa => 'Visa',
+        :master => 'Mastercard',
+        :american_express => 'American Express',
+        :jcb => 'JCB',
+        :discover => 'Discover'
+      }
+
+      DEFAULT_ECI = '07'
+
+      self.supported_cardtypes = BRANDS.keys
+      self.supported_countries = ['CA', 'US']
+      self.default_currency = 'USD'
+      self.homepage_url = 'http://www.firstdata.com'
+      self.display_name = 'FirstData Global Gateway e4 v27'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        # Bank error codes: https://support.payeezy.com/hc/en-us/articles/203730509-First-Data-Global-Gateway-e4-Bank-Response-Codes
+        '201' => STANDARD_ERROR_CODE[:incorrect_number],
+        '531' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '503' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '811' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '605' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '522' => STANDARD_ERROR_CODE[:expired_card],
+        '303' => STANDARD_ERROR_CODE[:card_declined],
+        '530' => STANDARD_ERROR_CODE[:card_declined],
+        '401' => STANDARD_ERROR_CODE[:call_issuer],
+        '402' => STANDARD_ERROR_CODE[:call_issuer],
+        '501' => STANDARD_ERROR_CODE[:pickup_card],
+        # Ecommerce error codes: https://support.payeezy.com/hc/en-us/articles/203730499-eCommerce-Response-Codes-ETG-e4-Transaction-Gateway-Codes
+        '22' => STANDARD_ERROR_CODE[:invalid_number],
+        '25' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '31' => STANDARD_ERROR_CODE[:incorrect_cvc],
+        '44' => STANDARD_ERROR_CODE[:incorrect_zip],
+        '42' => STANDARD_ERROR_CODE[:processing_error]
+      }
+
+      def initialize(options = {})
+        requires!(options, :login, :password, :key_id, :hmac_key)
+        @options = options
+
+        super
+      end
+
+      def authorize(money, credit_card_or_store_authorization, options = {})
+        commit(:authorization, build_sale_or_authorization_request(money, credit_card_or_store_authorization, options))
+      end
+
+      def purchase(money, credit_card_or_store_authorization, options = {})
+        commit(:sale, build_sale_or_authorization_request(money, credit_card_or_store_authorization, options))
+      end
+
+      def capture(money, authorization, options = {})
+        commit(:capture, build_capture_or_credit_request(money, authorization, options))
+      end
+
+      def void(authorization, options = {})
+        commit(:void, build_capture_or_credit_request(money_from_authorization(authorization), authorization, options))
+      end
+
+      def refund(money, authorization, options = {})
+        commit(:credit, build_capture_or_credit_request(money, authorization, options))
+      end
+
+      def verify(credit_card, options = {})
+        commit(:verify, build_sale_or_authorization_request(0, credit_card, options))
+      end
+
+      # Tokenize a credit card with TransArmor
+      #
+      # The TransArmor token and other card data necessary for subsequent
+      # transactions is stored in the response's +authorization+ attribute.
+      # The authorization string may be passed to +authorize+ and +purchase+
+      # instead of a +ActiveMerchant::Billing::CreditCard+ instance.
+      #
+      # TransArmor support must be explicitly activated on your gateway
+      # account by FirstData. If your authorization string is empty, contact
+      # FirstData support for account setup assistance.
+      #
+      # https://support.payeezy.com/hc/en-us/articles/203731189-TransArmor-Tokenization
+      def store(credit_card, options = {})
+        commit(:store, build_store_request(credit_card, options), credit_card)
+      end
+
+      def verify_credentials
+        response = void('0')
+        response.message != 'Unauthorized Request. Bad or missing credentials.'
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+          .gsub(%r((<Card_Number>).+(</Card_Number>)), '\1[FILTERED]\2')
+          .gsub(%r((<CVDCode>).+(</CVDCode>)), '\1[FILTERED]\2')
+          .gsub(%r((<Password>).+(</Password>))i, '\1[FILTERED]\2')
+          .gsub(%r((<CAVV>).+(</CAVV>)), '\1[FILTERED]\2')
+          .gsub(%r((CARD NUMBER\s+: )#+\d+), '\1[FILTERED]')
+      end
+
+      def supports_network_tokenization?
+        true
+      end
+
+      private
+
+      def build_request(action, body)
+        xml = Builder::XmlMarkup.new
+
+        xml.instruct!
+        xml.tag! 'Transaction', xmlns: 'http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes' do
+          add_credentials(xml)
+          add_transaction_type(xml, action)
+          xml << body
+        end
+
+        xml.target!
+      end
+
+      def build_sale_or_authorization_request(money, credit_card_or_store_authorization, options)
+        xml = Builder::XmlMarkup.new
+
+        add_amount(xml, money, options)
+
+        if credit_card_or_store_authorization.is_a? String
+          add_credit_card_token(xml, credit_card_or_store_authorization, options)
+        else
+          add_credit_card(xml, credit_card_or_store_authorization, options)
+        end
+
+        add_address(xml, options)
+        add_customer_data(xml, options)
+        add_invoice(xml, options)
+        add_tax_fields(xml, options)
+        add_level_3(xml, options)
+
+        xml.target!
+      end
+
+      def build_capture_or_credit_request(money, identification, options)
+        xml = Builder::XmlMarkup.new
+
+        add_identification(xml, identification)
+        add_amount(xml, money, options)
+        add_customer_data(xml, options)
+        add_card_authentication_data(xml, options)
+
+        xml.target!
+      end
+
+      def build_store_request(credit_card, options)
+        xml = Builder::XmlMarkup.new
+
+        add_credit_card(xml, credit_card, options)
+        add_address(xml, options)
+        add_customer_data(xml, options)
+
+        xml.target!
+      end
+
+      def add_credentials(xml)
+        xml.tag! 'ExactID', @options[:login]
+        xml.tag! 'Password', @options[:password]
+      end
+
+      def add_transaction_type(xml, action)
+        xml.tag! 'Transaction_Type', TRANSACTIONS[action]
+      end
+
+      def add_identification(xml, identification)
+        authorization_num, transaction_tag, _ = identification.split(';')
+
+        xml.tag! 'Authorization_Num', authorization_num
+        xml.tag! 'Transaction_Tag', transaction_tag
+      end
+
+      def add_amount(xml, money, options)
+        currency_code = options[:currency] || default_currency
+        xml.tag! 'DollarAmount', localized_amount(money, currency_code)
+        xml.tag! 'Currency', currency_code
+      end
+
+      def add_credit_card(xml, credit_card, options)
+        if credit_card.respond_to?(:track_data) && credit_card.track_data.present?
+          xml.tag! 'Track1', credit_card.track_data
+          xml.tag! 'Ecommerce_Flag', 'R'
+        else
+          xml.tag! 'Card_Number', credit_card.number
+          xml.tag! 'Expiry_Date', expdate(credit_card)
+          xml.tag! 'CardHoldersName', credit_card.name
+          xml.tag! 'CardType', card_type(credit_card.brand)
+
+          add_credit_card_eci(xml, credit_card, options)
+          add_credit_card_verification_strings(xml, credit_card, options)
+        end
+      end
+
+      def add_credit_card_eci(xml, credit_card, options)
+        eci = if credit_card.is_a?(NetworkTokenizationCreditCard) && credit_card.source == :apple_pay && card_brand(credit_card) == 'discover'
+                # Discover requires any Apple Pay transaction, regardless of in-app
+                # or web, and regardless of the ECI contained in the PKPaymentToken,
+                # to have an ECI value explicitly of 04.
+                '04'
+              else
+                (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
+              end
+
+        xml.tag! 'Ecommerce_Flag', eci.to_s =~ /^[0-9]+$/ ? eci.to_s.rjust(2, '0') : eci
+      end
+
+      def add_credit_card_verification_strings(xml, credit_card, options)
+        if credit_card.is_a?(NetworkTokenizationCreditCard)
+          add_network_tokenization_credit_card(xml, credit_card)
+        else
+          if credit_card.verification_value?
+            xml.tag! 'CVD_Presence_Ind', '1'
+            xml.tag! 'CVDCode', credit_card.verification_value
+          end
+
+          add_card_authentication_data(xml, options)
+        end
+      end
+
+      def add_network_tokenization_credit_card(xml, credit_card)
+        case card_brand(credit_card).to_sym
+        when :american_express
+          cryptogram = Base64.decode64(credit_card.payment_cryptogram)
+          xml.tag!('XID', Base64.encode64(cryptogram[20...40]))
+          xml.tag!('CAVV', Base64.encode64(cryptogram[0...20]))
+        else
+          xml.tag!('XID', credit_card.transaction_id) if credit_card.transaction_id
+          xml.tag!('CAVV', credit_card.payment_cryptogram)
+        end
+      end
+
+      def add_card_authentication_data(xml, options)
+        xml.tag! 'CAVV', options[:cavv]
+        xml.tag! 'XID', options[:xid]
+      end
+
+      def add_credit_card_token(xml, store_authorization, options)
+        params = store_authorization.split(';')
+        credit_card = CreditCard.new(
+          :brand      => params[1],
+          :first_name => params[2],
+          :last_name  => params[3],
+          :month      => params[4],
+          :year       => params[5])
+
+        xml.tag! 'TransarmorToken', params[0]
+        xml.tag! 'Expiry_Date', expdate(credit_card)
+        xml.tag! 'CardHoldersName', credit_card.name
+        xml.tag! 'CardType', card_type(credit_card.brand)
+        add_card_authentication_data(xml, options)
+      end
+
+      def add_customer_data(xml, options)
+        xml.tag! 'Customer_Ref', options[:customer] if options[:customer]
+        xml.tag! 'Client_IP', options[:ip] if options[:ip]
+        xml.tag! 'Client_Email', options[:email] if options[:email]
+      end
+
+      def add_address(xml, options)
+        if (address = options[:billing_address] || options[:address])
+          xml.tag! 'Address' do
+            xml.tag! 'Address1', address[:address1]
+            xml.tag! 'Address2', address[:address2] if address[:address2]
+            xml.tag! 'City', address[:city]
+            xml.tag! 'State', address[:state]
+            xml.tag! 'Zip', address[:zip]
+            xml.tag! 'CountryCode', address[:country]
+          end
+          xml.tag! 'ZipCode', address[:zip]
+        end
+      end
+
+      def add_invoice(xml, options)
+        xml.tag! 'Reference_No', options[:order_id]
+        xml.tag! 'Reference_3',  options[:description] if options[:description]
+      end
+
+      def add_tax_fields(xml, options)
+        xml.tag! 'Tax1Amount',  options[:tax1_amount] if options[:tax1_amount]
+        xml.tag! 'Tax1Number',  options[:tax1_number] if options[:tax1_number]
+      end
+
+      def add_level_3(xml, options)
+        xml.tag!('Level3') { |x| x << options[:level_3] } if options[:level_3]
+      end
+
+      def expdate(credit_card)
+        "#{format(credit_card.month, :two_digits)}#{format(credit_card.year, :two_digits)}"
+      end
+
+      def card_type(credit_card_brand)
+        BRANDS[credit_card_brand.to_sym] if credit_card_brand
+      end
+
+      def commit(action, data, credit_card = nil)
+        url = (test? ? self.test_url : self.live_url)
+        request = build_request(action, data)
+        begin
+          response = parse(ssl_post(url, request, headers('POST', url, request)))
+        rescue ResponseError => e
+          response = parse_error(e.response)
+        end
+
+        Response.new(successful?(response), message_from(response), response,
+          :test => test?,
+          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : '',
+          :avs_result => {:code => response[:avs]},
+          :cvv_result => response[:cvv2],
+          :error_code => standard_error_code(response)
+        )
+      end
+
+      def headers(method, url, request)
+        content_type = 'application/xml'
+        content_digest = Digest::SHA1.hexdigest(request)
+        sending_time = Time.now.utc.iso8601
+        payload = [method, content_type, content_digest, sending_time, url.split('.com')[1]].join("\n")
+        hmac = OpenSSL::HMAC.digest('sha1', @options[:hmac_key], payload)
+        encoded = Base64.strict_encode64(hmac)
+
+        {
+          'x-gge4-date' => sending_time,
+          'x-gge4-content-sha1' => content_digest,
+          'Authorization' => 'GGE4_API ' + @options[:key_id].to_s + ':' + encoded,
+          'Accepts' => content_type,
+          'Content-Type' => content_type
+        }
+      end
+
+      def successful?(response)
+        response[:transaction_approved] == SUCCESS
+      end
+
+      def response_authorization(action, response, credit_card)
+        if action == :store
+          store_authorization_from(response, credit_card)
+        else
+          authorization_from(response)
+        end
+      end
+
+      def authorization_from(response)
+        if response[:authorization_num] && response[:transaction_tag]
+          [
+            response[:authorization_num],
+            response[:transaction_tag],
+            (response[:dollar_amount].to_f * 100).round
+          ].join(';')
+        else
+          ''
+        end
+      end
+
+      def store_authorization_from(response, credit_card)
+        if response[:transarmor_token].present?
+          [
+            response[:transarmor_token],
+            credit_card.brand,
+            credit_card.first_name,
+            credit_card.last_name,
+            credit_card.month,
+            credit_card.year
+          ].map { |value| value.to_s.tr(';', '') }.join(';')
+        else
+          raise StandardError, "TransArmor support is not enabled on your #{display_name} account"
+        end
+      end
+
+      def money_from_authorization(auth)
+        _, _, amount = auth.split(/;/, 3)
+        amount.to_i
+      end
+
+      def message_from(response)
+        if(response[:faultcode] && response[:faultstring])
+          response[:faultstring]
+        elsif(response[:error_number] && response[:error_number] != '0')
+          response[:error_description]
+        else
+          result = (response[:exact_message] || '')
+          result << " - #{response[:bank_message]}" if response[:bank_message].present?
+          result
+        end
+      end
+
+      def parse_error(error)
+        {
+          :transaction_approved => 'false',
+          :error_number => error.code,
+          :error_description => error.body,
+          :ecommerce_error_code => error.body.gsub(/[^\d]/, '')
+        }
+      end
+
+      def standard_error_code(response)
+        STANDARD_ERROR_CODE_MAPPING[response[:bank_resp_code] || response[:ecommerce_error_code]]
+      end
+
+      def parse(xml)
+        response = {}
+        xml = REXML::Document.new(xml)
+
+        if (root = REXML::XPath.first(xml, '//TransactionResult'))
+          parse_elements(response, root)
+        end
+
+        SENSITIVE_FIELDS.each { |key| response.delete(key) }
+        response
+      end
+
+      def parse_elements(response, root)
+        root.elements.to_a.each do |node|
+          response[node.name.gsub(/EXact/, 'Exact').underscore.to_sym] = (node.text || '').strip
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -331,6 +331,12 @@ firstdata_e4:
   login: SD8821-67
   password: T6bxSywbcccbJ19eDXNIGaCDOBg1W7T8
 
+firstdata_e4_v27:
+  login: ALOGIN
+  password: APASSWORD
+  key_id: ANINTEGER
+  hmac_key: AMAGICALKEY
+
 flo2cash:
   username: SOMECREDENTIAL
   password: ANOTHERCREDENTIAL

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -1,0 +1,222 @@
+require 'test_helper'
+
+class RemoteFirstdataE4V27Test < Test::Unit::TestCase
+  def setup
+    @gateway = FirstdataE4V27Gateway.new(fixtures(:firstdata_e4_v27))
+    @credit_card = credit_card
+    @bad_credit_card = credit_card('4111111111111113')
+    @credit_card_with_track_data = credit_card_with_track_data('4003000123456781')
+    @amount = 100
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase'
+    }
+    @options_with_authentication_data = @options.merge({
+      eci: '5',
+      cavv: 'TESTCAVV',
+      xid: 'TESTXID'
+    })
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_network_tokenization
+    @credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: nil
+    )
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction Normal - Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_track_data
+    assert response = @gateway.purchase(@amount, @credit_card_with_track_data, @options)
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_level_3
+    level_3_xml = <<-LEVEL3
+        <LineItem>
+          <LineItemTotal>107.20</LineItemTotal>
+          <Quantity>3</Quantity>
+          <Description>The Description</Description>
+          <UnitCost>2.33</UnitCost>
+        </LineItem>
+    LEVEL3
+
+    response = @gateway.purchase(500, @credit_card, @options.merge(level_3: level_3_xml))
+    assert_success response
+    assert_equal 'Transaction Normal - Approved', response.message
+  end
+
+  def test_successful_purchase_with_tax_fields
+    response = @gateway.purchase(500, @credit_card, @options.merge(tax1_amount: 50, tax1_number: 'A458'))
+    assert_success response
+    assert_equal '50.0', response.params['tax1_amount']
+    assert_equal '', response.params['tax1_number'], 'E4 blanks this out in the response'
+  end
+
+  def test_successful_purchase_with_customer_ref
+    response = @gateway.purchase(500, @credit_card, @options.merge(customer: '267'))
+    assert_success response
+    assert_equal '267', response.params['customer_ref']
+  end
+
+  def test_successful_purchase_with_card_authentication
+    assert response = @gateway.purchase(@amount, @credit_card, @options_with_authentication_data)
+    assert_equal response.params['cavv'], @options_with_authentication_data[:cavv]
+    assert_equal response.params['ecommerce_flag'], @options_with_authentication_data[:eci]
+    assert_equal response.params['xid'], @options_with_authentication_data[:xid]
+    assert_success response
+  end
+
+  def test_unsuccessful_purchase
+    # ask for error 13 response (Amount Error) via dollar amount 5,000 + error
+    @amount = 501300
+    assert response = @gateway.purchase(@amount, @credit_card, @options )
+    assert_match(/Transaction Normal/, response.message)
+    assert_failure response
+  end
+
+  def test_bad_creditcard_number
+    assert response = @gateway.purchase(@amount, @bad_credit_card, @options)
+    assert_match(/Invalid Credit Card/, response.message)
+    assert_failure response
+    assert_equal response.error_code, 'invalid_number'
+  end
+
+  def test_trans_error
+    # ask for error 42 (unable to send trans) as the cents bit...
+    @amount = 500042
+    assert response = @gateway.purchase(@amount, @credit_card, @options )
+    assert_match(/Unable to Send Transaction/, response.message) # 42 is 'unable to send trans'
+    assert_failure response
+    assert_equal response.error_code, 'processing_error'
+  end
+
+  def test_purchase_and_credit
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert purchase.authorization
+    assert credit = @gateway.refund(@amount, purchase.authorization)
+    assert_success credit
+  end
+
+  def test_purchase_and_void
+    assert purchase = @gateway.purchase(29234, @credit_card, @options)
+    assert_success purchase
+
+    assert purchase.authorization
+    assert void = @gateway.void(purchase.authorization)
+    assert_success void
+  end
+
+  def test_purchase_and_void_with_even_dollar_amount
+    assert purchase = @gateway.purchase(5000, @credit_card, @options)
+    assert_success purchase
+
+    assert purchase.authorization
+    assert void = @gateway.void(purchase.authorization)
+    assert_success void
+  end
+
+  def test_authorize_and_capture
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    assert response = @gateway.capture(@amount, 'ET838747474;frob')
+    assert_failure response
+    assert_match(/Invalid Authorization Number/i, response.message)
+  end
+
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal 'Transaction Normal - Approved', response.message
+    assert_equal '0.0', response.params['dollar_amount']
+    assert_equal '05', response.params['transaction_type']
+  end
+
+  def test_failed_verify
+    assert response = @gateway.verify(@bad_credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid Credit Card Number}, response.message
+    assert_equal response.error_code, 'invalid_number'
+  end
+
+  def test_invalid_login
+    gateway = FirstdataE4V27Gateway.new(:login    => 'NotARealUser',
+                                     :password => 'NotARealPassword',
+                                     :key_id   => 'NotARealKey',
+                                     :hmac_key => 'NotARealHMAC' )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_match %r{Unauthorized Request}, response.message
+    assert_failure response
+  end
+
+  def test_response_contains_cvv_and_avs_results
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'M', response.cvv_result['code']
+    assert_equal '4', response.avs_result['code']
+  end
+
+  def test_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+
+    assert response = @gateway.refund(50, purchase.authorization)
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+  end
+
+  def test_refund_with_track_data
+    assert purchase = @gateway.purchase(@amount, @credit_card_with_track_data, @options)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+
+    assert response = @gateway.refund(50, purchase.authorization)
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+  end
+
+  def test_verify_credentials
+    assert @gateway.verify_credentials
+
+    gateway = FirstdataE4V27Gateway.new(login: 'unknown', password: 'unknown', key_id: 'unknown', hmac_key: 'unknown')
+    assert !gateway.verify_credentials
+    gateway = FirstdataE4V27Gateway.new(login: fixtures(:firstdata_e4)[:login], password: 'unknown', key_id: 'unknown', hmac_key: 'unknown')
+    assert !gateway.verify_credentials
+  end
+
+  def test_transcript_scrubbing
+    cc_with_different_cvc = credit_card(verification_value: '999')
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, cc_with_different_cvc, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(cc_with_different_cvc.number, transcript)
+    assert_scrubbed(cc_with_different_cvc.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:hmac_key], transcript)
+  end
+
+end

--- a/test/schema/firstdata_e4/v27.xsd
+++ b/test/schema/firstdata_e4/v27.xsd
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:schema
+   elementFormDefault="qualified"
+   xmlns:s="http://www.w3.org/2001/XMLSchema"
+   xmlns:s0="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes"
+   xmlns="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes"
+   targetNamespace="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes">
+  <s:complexType name="SoftDescriptor_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="DBAName" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Street" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Region" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PostalCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CountryCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MCC" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MerchantContactInfo" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MVV_MAID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="AMEXMerchantPhone" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="AMEXMerchantEmail" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PFacSubmerchantId" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PFacName" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_ShipToAddress_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="Address1" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Country" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CustomerNumber" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Phone" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Name" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Zip" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_LineItem_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="CommodityCode" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Description" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountIndicator" type="s:boolean"/>
+      <s:element minOccurs="0" maxOccurs="1" name="GrossNetIndicator" type="s:boolean"/>
+      <s:element minOccurs="1" maxOccurs="1" name="LineItemTotal" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ProductCode" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Quantity" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxRate" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxType" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="UnitCost" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="UnitOfMeasure" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Level3_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TaxRate" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="AltTaxAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="AltTaxId" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DutyAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="FreightAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DiscountAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ShipFromZip" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="ShipToAddress" type="Level3_ShipToAddress_Type"/>
+      <s:element minOccurs="1" maxOccurs="98" name="LineItem" type="Level3_LineItem_Type"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="PaypalTransactionDetails">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="PayerID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="GrossAmountCurrencyID" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Authorization" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CorrelationID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Timestamp" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Address_Type">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="Address1" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Address2" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Zip" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CountryCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PhoneNumber" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PhoneType" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="DynamicCurrency">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="OptedIn" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="RateResponseSignature" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="DynamicPricing">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="OptedIn" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="RateResponseSignature" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="ForeignCurrencyDetails">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="DCCIndicator" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ForeignAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ForeignCurrencyCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ExchangeRate" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MarginRate" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="RateSource" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="FraudDetectResult">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="Score" type="s:integer"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Recommendation" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="5" name="Explanation" type="FraudDetectExplanation_Type"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="FraudDetectExplanation_Type">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="type" type="s:integer"/>
+      <s:element minOccurs="1" maxOccurs="1" name="description" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="VisaCheckout">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="CallID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PromoCode" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="MasterPass">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="TransactionID" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="WalletID" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Indicator" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Transaction">
+    <s:all>
+      <s:element minOccurs="1" maxOccurs="1" name="ExactID" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Password" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Transaction_Type" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DollarAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SurchargeAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Card_Number" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Transaction_Tag" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SplitTenderID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Track1" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Track2" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PAN" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Authorization_Num" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Expiry_Date" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CardHoldersName" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CVDCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CVD_Presence_Ind" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="ZipCode" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Tax1Amount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Tax1Number" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Tax2Amount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Tax2Number" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Ecommerce_Flag" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="XID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CAVV" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Reference_No" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Customer_Ref" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Reference_3" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Language" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Client_IP" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Client_Email" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="User_Name" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Currency" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PartialRedemption" type="s:boolean"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Level3" type="Level3_Type"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TransarmorToken" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CardType" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="EAN" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="VirtualCard" type="s:boolean"/>
+      <s:element minOccurs="0" maxOccurs="1" name="CardCost" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="FraudSuspected" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PaypalResponse" type="PaypalTransactionDetails"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SoftDescriptor" type="SoftDescriptor_Type"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Address" type="Address_Type"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TPPID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SplitShipmentNumber" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="AmexFraud" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DynamicCurrency" type="DynamicCurrency"/>
+      <s:element minOccurs="0" maxOccurs="1" name="DynamicPricing" type="DynamicPricing"/>
+      <s:element minOccurs="0" maxOccurs="1" name="FeeAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="VisaCheckout" type="VisaCheckout"/>
+      <s:element minOccurs="0" maxOccurs="1" name="PostDate" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="OtherAmount" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="GiftDepositAvailable" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SpecialPayment" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="WalletProviderID" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="MasterPass" type="MasterPass"/>
+      <s:element minOccurs="0" maxOccurs="1" name="FraudDetectInAuthTransId" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="SCV" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="StoredCredentials" type="StoredCredentialsType"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Extra" type="Extra_Type"/>
+    </s:all>
+  </s:complexType>
+  <s:complexType name="StoredCredentialsType">
+    <s:sequence>
+      <s:element minOccurs="0" maxOccurs="1" name="AuthorizationTypeOverride" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Initiation" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Indicator" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="Schedule" type="s:string"/>
+      <s:element minOccurs="0" maxOccurs="1" name="TransactionId" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+  <s:complexType name="Extra_Type">
+    <s:sequence>
+      <s:element minOccurs="1" maxOccurs="1" name="Field" type="s:string"/>
+      <s:element minOccurs="1" maxOccurs="1" name="Value" type="s:string"/>
+    </s:sequence>
+  </s:complexType>
+
+  <s:element name="Transaction" type="s0:Transaction"/>
+
+</s:schema>

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -1,0 +1,979 @@
+require 'test_helper'
+require 'nokogiri'
+require 'yaml'
+
+class FirstdataE4V27Test < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = FirstdataE4V27Gateway.new(
+      :login    => 'A00427-01',
+      :password => 'testus',
+      :key_id   => '12345',
+      :hmac_key => 'hexkey'
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase'
+    }
+    @authorization = 'ET1700;106625152;4738'
+  end
+
+  def test_invalid_credentials
+    @gateway.expects(:ssl_post).raises(bad_credentials_response)
+    assert response = @gateway.store(@credit_card, {})
+    assert_failure response
+    assert response.test?
+    assert_equal '', response.authorization
+    assert_equal 'Unauthorized Request. Bad or missing credentials.', response.message
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'ET1700;106625152;4738', response.authorization
+    assert response.test?
+    assert_equal 'Transaction Normal - Approved', response.message
+
+    FirstdataE4V27Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+  end
+
+  def test_successful_purchase_with_token
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014')
+    assert_success response
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+    assert response = @gateway.void(@authorization, @options)
+    assert_success response
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    assert response = @gateway.refund(@amount, @authorization)
+    assert_success response
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal '8938737759041111', response.params['transarmor_token']
+    assert_equal "8938737759041111;visa;Longbob;Longsen;9;#{@credit_card.year}", response.authorization
+  end
+
+  def test_failed_store_without_transarmor_support
+    @gateway.expects(:ssl_post).returns(successful_purchase_response_without_transarmor)
+    assert_raise StandardError do
+      @gateway.store(@credit_card, @options)
+    end
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_failure response
+    assert_equal response.error_code, 'invalid_expiry_date'
+  end
+
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_verify_response)
+    assert_success response
+  end
+
+  def test_expdate
+    assert_equal(
+      '%02d%2s' % [@credit_card.month, @credit_card.year.to_s[-2..-1]],
+      @gateway.send(:expdate, @credit_card)
+    )
+  end
+
+  def test_no_transaction
+    @gateway.expects(:ssl_post).raises(no_transaction_response())
+    assert response = @gateway.purchase(100, @credit_card, {})
+    assert_failure response
+    assert response.test?
+    assert_equal 'Malformed request: Transaction Type is missing.', response.message
+  end
+
+  def test_supported_countries
+    assert_equal ['CA', 'US'], FirstdataE4V27Gateway.supported_countries
+  end
+
+  def test_supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4V27Gateway.supported_cardtypes
+  end
+
+  def test_avs_result
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_equal 'U', response.avs_result['code']
+  end
+
+  def test_cvv_result
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_equal 'M', response.cvv_result['code']
+  end
+
+  def test_request_includes_address
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_tax_fields_are_sent
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(tax1_amount: 830, tax1_number: 'Br59a'))
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Tax1Amount>830', data
+      assert_match '<Tax1Number>Br59a', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_customer_ref_is_sent
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(customer: '932'))
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Customer_Ref>932', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_eci_default_value
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Ecommerce_Flag>07</Ecommerce_Flag>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_eci_numeric_padding
+    @credit_card = network_tokenization_credit_card
+    @credit_card.eci = '5'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
+    end.respond_with(successful_purchase_response)
+
+    @credit_card = network_tokenization_credit_card
+    @credit_card.eci = 5
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_eci_option_value
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(eci: '05'))
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_network_tokenization_requests_with_amex
+    stub_comms do
+      credit_card = network_tokenization_credit_card(
+        '378282246310005',
+        brand: 'american_express',
+        transaction_id: '123',
+        eci: '05',
+        payment_cryptogram: 'whatever_the_cryptogram_of_at_least_20_characters_is',
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_, data, _|
+      assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
+      assert_match "<XID>mrLdtHIWq2nLXq7IrA==\n</XID>", data
+      assert_match "<CAVV>whateverthecryptogramofatlc=\n</CAVV>", data
+      assert_xml_valid_to_wsdl(data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_network_tokenization_requests_with_discover
+    stub_comms do
+      credit_card = network_tokenization_credit_card(
+        '6011111111111117',
+        brand: 'discover',
+        transaction_id: '123',
+        eci: '05',
+        payment_cryptogram: 'whatever_the_cryptogram_is',
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_, data, _|
+      assert_match '<Ecommerce_Flag>04</Ecommerce_Flag>', data
+      assert_match '<XID>123</XID>', data
+      assert_match '<CAVV>whatever_the_cryptogram_is</CAVV>', data
+      assert_xml_valid_to_wsdl(data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_network_tokenization_requests_with_other_brands
+    %w(visa mastercard other).each do |brand|
+      stub_comms do
+        credit_card = network_tokenization_credit_card(
+          '378282246310005',
+          brand: brand,
+          transaction_id: '123',
+          eci: '05',
+          payment_cryptogram: 'whatever_the_cryptogram_is',
+        )
+
+        @gateway.purchase(@amount, credit_card, @options)
+      end.check_request do |_, data, _|
+        assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
+        assert_match '<XID>123</XID>', data
+        assert_match '<CAVV>whatever_the_cryptogram_is</CAVV>', data
+        assert_xml_valid_to_wsdl(data)
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
+  def test_requests_include_card_authentication_data
+    authentication_hash = {
+      eci: '06',
+      cavv: 'SAMPLECAVV',
+      xid: 'SAMPLEXID'
+    }
+    options_with_authentication_data = @options.merge(authentication_hash)
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_authentication_data)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Ecommerce_Flag>06</Ecommerce_Flag>', data
+      assert_match '<CAVV>SAMPLECAVV</CAVV>', data
+      assert_match '<XID>SAMPLEXID</XID>', data
+      assert_xml_valid_to_wsdl(data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_card_type
+    assert_equal 'Visa', @gateway.send(:card_type, 'visa')
+    assert_equal 'Mastercard', @gateway.send(:card_type, 'master')
+    assert_equal 'American Express', @gateway.send(:card_type, 'american_express')
+    assert_equal 'JCB', @gateway.send(:card_type, 'jcb')
+    assert_equal 'Discover', @gateway.send(:card_type, 'discover')
+  end
+
+  def test_add_swipe_data_with_creditcard
+    @credit_card.track_data = 'Track Data'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Track1>Track Data</Track1>', data
+      assert_match '<Ecommerce_Flag>R</Ecommerce_Flag>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_transcript_scrubbing
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrub), post_scrub
+  end
+
+  def test_supports_network_tokenization
+    assert_instance_of TrueClass, @gateway.supports_network_tokenization?
+  end
+
+  private
+
+  def assert_xml_valid_to_wsdl(data)
+    xsd = Nokogiri::XML::Schema(File.open("#{File.dirname(__FILE__)}/../../schema/firstdata_e4/v27.xsd"))
+    doc = Nokogiri::XML(data)
+    errors = xsd.validate(doc)
+    assert_empty errors, "XSD validation errors in the following XML:\n#{doc}"
+  end
+
+  def pre_scrub
+    <<-PRE_SCRUBBED
+      opening connection to api.demo.globalgatewaye4.firstdata.com:443...
+      opened
+      starting SSL for api.demo.globalgatewaye4.firstdata.com:443...
+      SSL established
+      <- "POST /transaction/v27 HTTP/1.1\r\nContent-Type: application/xml\r\nX-Gge4-Date: 2018-07-03T07:35:34Z\r\nX-Gge4-Content-Sha1: 5335f81daf59c493fe5d4c18910d17eba69558d4\r\nAuthorization: GGE4_API 397439:iwaxRr8f3GQIMSucb+dmDeiwoAk=\r\nAccepts: application/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.demo.globalgatewaye4.firstdata.com\r\nContent-Length: 807\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Transaction xmlns=\"http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes\"><ExactID>SD8821-67</ExactID><Password>cBhEc4GENtZ5fnVtpb2qlrhKUDprqtar</Password><Transaction_Type>00</Transaction_Type><DollarAmount>1.00</DollarAmount><Currency>USD</Currency><Card_Number>4242424242424242</Card_Number><Expiry_Date>0919</Expiry_Date><CardHoldersName>Longbob Longsen</CardHoldersName><CardType>Visa</CardType><Ecommerce_Flag>07</Ecommerce_Flag><CVD_Presence_Ind>1</CVD_Presence_Ind><CVDCode>123</CVDCode><CAVV/><XID/><Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address><Reference_No>1</Reference_No><Reference_3>Store Purchase</Reference_3></Transaction>"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Tue, 03 Jul 2018 07:35:34 GMT\r\n"
+      -> "Content-Type: application/xml; charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-GGE4-Date: 2018-07-03T07:35:34Z\r\n"
+      -> "X-GGE4-CONTENT-SHA1: 87ae8c40ae5afbfd060c7569645f3f6b4045994f\r\n"
+      -> "Authorization: GGE4_API 397439:dPOI+d2MkNJjBJhHTYUo0ieILw4=\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Expires: Tue, 03 Jul 2018 06:35:34 GMT\r\n"
+      -> "Cache-Control: no-store, no-cache\r\n"
+      -> "X-Request-Id: 0f9ba7k2rd80a2tpch40\r\n"
+      -> "Location: https://api.demo.globalgatewaye4.firstdata.com/transaction/v27/2264726018\r\n"
+      -> "Status: 201 Created\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "Strict-Transport-Security: max-age=315360000; includeSubdomains\r\n"
+      -> "\r\n"
+      -> "2da\r\n"
+      reading 2944 bytes...
+      -> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<TransactionResult>\n  <ExactID>SD8821-67</ExactID>\n  <Password/>\n  <Transaction_Type>00</Transaction_Type>\n  <DollarAmount>1.0</DollarAmount>\n  <SurchargeAmount/>\n  <Card_Number>############4242</Card_Number>\n  <Transaction_Tag>2264726018</Transaction_Tag>\n  <SplitTenderID/>\n  <Track1/>\n  <Track2/>\n  <PAN/>\n  <Authorization_Num>ET121995</Authorization_Num>\n  <Expiry_Date>0919</Expiry_Date>\n  <CardHoldersName>Longbob Longsen</CardHoldersName>\n  <CVD_Presence_Ind>1</CVD_Presence_Ind>\n  <ZipCode/>\n  <Tax1Amount/>\n  <Tax1Number/>\n  <Tax2Amount/>\n  <Tax2Number/>\n  <Secure_AuthRequired/>\n  <Secure_AuthResult/>\n  <Ecommerce_Flag>7</Ecommerce_Flag>\n  <XID/>\n  <CAVV/>\n  <Reference_No>1</Reference_No>\n  <Customer_Ref/>\n  <Reference_3>Store Purchase</Reference_3>\n  <Language/>\n  <Client_IP/>\n  <Client_Email/>\n  <User_Name/>\n  <Transaction_Error>false</Transaction_Error>\n  <Transaction_Approved>true</Transaction_Approved>\n  <EXact_Resp_Code>00</EXact_Resp_Code>\n  <EXact_Message>Transaction Normal</EXact_Message>\n  <Bank_Resp_Code>100</Bank_Resp_Code>\n  <Bank_Message>Approved</Bank_Message>\n  <Bank_Resp_Code_2/>\n  <SequenceNo>001157</SequenceNo>\n  <AVS>4</AVS>\n  <CVV2>M</CVV2>\n  <Retrieval_Ref_No>1196543</Retrieval_Ref_No>\n  <CAVV_Response/>\n  <Currency>USD</Currency>\n  <AmountRequested/>\n  <PartialRedemption>false</PartialRedemption>\n  <MerchantName>Spreedly DEMO0095</MerchantName>\n  <MerchantAddress>123 Testing</MerchantAddress>\n  <MerchantCity>Durham</MerchantCity>\n  <MerchantProvince>North Carolina</MerchantProvince>\n  <MerchantCountry>United States</MerchantCountry>\n  <MerchantPostal>27701</MerchantPostal>\n  <MerchantURL/>\n  <TransarmorToken/>\n  <CardType>Visa</CardType>\n  <CurrentBalance/>\n  <PreviousBalance/>\n  <EAN/>\n  <CardCost/>\n  <VirtualCard>false</VirtualCard>\n  <CTR>========== TRANSACTION RECORD ==========\nSpreedly DEMO0095\n123 Testing\nDurham, NC 27701\nUnited States\n\n\nTYPE: Purchase\n\nACCT: Visa                    $ 1.00 USD\n\nCARDHOLDER NAME : Longbob Longsen\nCARD NUMBER     : ############4242\nDATE/TIME       : 03 Jul 18 03:35:34\nREFERENCE #     : 03 001157 M\nAUTHOR. #       : ET121995\nTRANS. REF.     : 1\n\n    Approved - Thank You 100\n\n\nPlease retain this copy for your records.\n\nCardholder will pay above amount to\ncard issuer pursuant to cardholder\nagreement.\n========================================</CTR>\n  <FraudSuspected/>\n  <Address>\n    <Address1>456 My Street</Address1>\n    <Address2>Apt 1</Address2>\n    <City>Ottawa</City>\n    <State>ON</State>\n    <Zip>K1C2N6</Zip>\n    <CountryCode>CA</CountryCode>\n  </Address>\n  <CVDCode>123</CVDCode>\n  <SplitShipmentNumber/>\n</TransactionResult>\n"
+      read 2944 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrub
+    <<-POST_SCRUBBED
+      opening connection to api.demo.globalgatewaye4.firstdata.com:443...
+      opened
+      starting SSL for api.demo.globalgatewaye4.firstdata.com:443...
+      SSL established
+      <- "POST /transaction/v27 HTTP/1.1\r\nContent-Type: application/xml\r\nX-Gge4-Date: 2018-07-03T07:35:34Z\r\nX-Gge4-Content-Sha1: 5335f81daf59c493fe5d4c18910d17eba69558d4\r\nAuthorization: GGE4_API 397439:iwaxRr8f3GQIMSucb+dmDeiwoAk=\r\nAccepts: application/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.demo.globalgatewaye4.firstdata.com\r\nContent-Length: 807\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Transaction xmlns=\"http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes\"><ExactID>SD8821-67</ExactID><Password>[FILTERED]</Password><Transaction_Type>00</Transaction_Type><DollarAmount>1.00</DollarAmount><Currency>USD</Currency><Card_Number>[FILTERED]</Card_Number><Expiry_Date>0919</Expiry_Date><CardHoldersName>Longbob Longsen</CardHoldersName><CardType>Visa</CardType><Ecommerce_Flag>07</Ecommerce_Flag><CVD_Presence_Ind>1</CVD_Presence_Ind><CVDCode>[FILTERED]</CVDCode><CAVV/><XID/><Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address><Reference_No>1</Reference_No><Reference_3>Store Purchase</Reference_3></Transaction>"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Tue, 03 Jul 2018 07:35:34 GMT\r\n"
+      -> "Content-Type: application/xml; charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-GGE4-Date: 2018-07-03T07:35:34Z\r\n"
+      -> "X-GGE4-CONTENT-SHA1: 87ae8c40ae5afbfd060c7569645f3f6b4045994f\r\n"
+      -> "Authorization: GGE4_API 397439:dPOI+d2MkNJjBJhHTYUo0ieILw4=\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Expires: Tue, 03 Jul 2018 06:35:34 GMT\r\n"
+      -> "Cache-Control: no-store, no-cache\r\n"
+      -> "X-Request-Id: 0f9ba7k2rd80a2tpch40\r\n"
+      -> "Location: https://api.demo.globalgatewaye4.firstdata.com/transaction/v27/2264726018\r\n"
+      -> "Status: 201 Created\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "Strict-Transport-Security: max-age=315360000; includeSubdomains\r\n"
+      -> "\r\n"
+      -> "2da\r\n"
+      reading 2944 bytes...
+      -> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<TransactionResult>\n  <ExactID>SD8821-67</ExactID>\n  <Password/>\n  <Transaction_Type>00</Transaction_Type>\n  <DollarAmount>1.0</DollarAmount>\n  <SurchargeAmount/>\n  <Card_Number>[FILTERED]</Card_Number>\n  <Transaction_Tag>2264726018</Transaction_Tag>\n  <SplitTenderID/>\n  <Track1/>\n  <Track2/>\n  <PAN/>\n  <Authorization_Num>ET121995</Authorization_Num>\n  <Expiry_Date>0919</Expiry_Date>\n  <CardHoldersName>Longbob Longsen</CardHoldersName>\n  <CVD_Presence_Ind>1</CVD_Presence_Ind>\n  <ZipCode/>\n  <Tax1Amount/>\n  <Tax1Number/>\n  <Tax2Amount/>\n  <Tax2Number/>\n  <Secure_AuthRequired/>\n  <Secure_AuthResult/>\n  <Ecommerce_Flag>7</Ecommerce_Flag>\n  <XID/>\n  <CAVV/>\n  <Reference_No>1</Reference_No>\n  <Customer_Ref/>\n  <Reference_3>Store Purchase</Reference_3>\n  <Language/>\n  <Client_IP/>\n  <Client_Email/>\n  <User_Name/>\n  <Transaction_Error>false</Transaction_Error>\n  <Transaction_Approved>true</Transaction_Approved>\n  <EXact_Resp_Code>00</EXact_Resp_Code>\n  <EXact_Message>Transaction Normal</EXact_Message>\n  <Bank_Resp_Code>100</Bank_Resp_Code>\n  <Bank_Message>Approved</Bank_Message>\n  <Bank_Resp_Code_2/>\n  <SequenceNo>001157</SequenceNo>\n  <AVS>4</AVS>\n  <CVV2>M</CVV2>\n  <Retrieval_Ref_No>1196543</Retrieval_Ref_No>\n  <CAVV_Response/>\n  <Currency>USD</Currency>\n  <AmountRequested/>\n  <PartialRedemption>false</PartialRedemption>\n  <MerchantName>Spreedly DEMO0095</MerchantName>\n  <MerchantAddress>123 Testing</MerchantAddress>\n  <MerchantCity>Durham</MerchantCity>\n  <MerchantProvince>North Carolina</MerchantProvince>\n  <MerchantCountry>United States</MerchantCountry>\n  <MerchantPostal>27701</MerchantPostal>\n  <MerchantURL/>\n  <TransarmorToken/>\n  <CardType>Visa</CardType>\n  <CurrentBalance/>\n  <PreviousBalance/>\n  <EAN/>\n  <CardCost/>\n  <VirtualCard>false</VirtualCard>\n  <CTR>========== TRANSACTION RECORD ==========\nSpreedly DEMO0095\n123 Testing\nDurham, NC 27701\nUnited States\n\n\nTYPE: Purchase\n\nACCT: Visa                    $ 1.00 USD\n\nCARDHOLDER NAME : Longbob Longsen\nCARD NUMBER     : [FILTERED]\nDATE/TIME       : 03 Jul 18 03:35:34\nREFERENCE #     : 03 001157 M\nAUTHOR. #       : ET121995\nTRANS. REF.     : 1\n\n    Approved - Thank You 100\n\n\nPlease retain this copy for your records.\n\nCardholder will pay above amount to\ncard issuer pursuant to cardholder\nagreement.\n========================================</CTR>\n  <FraudSuspected/>\n  <Address>\n    <Address1>456 My Street</Address1>\n    <Address2>Apt 1</Address2>\n    <City>Ottawa</City>\n    <State>ON</State>\n    <Zip>K1C2N6</Zip>\n    <CountryCode>CA</CountryCode>\n  </Address>\n  <CVDCode>[FILTERED]</CVDCode>\n  <SplitShipmentNumber/>\n</TransactionResult>\n"
+      read 2944 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    <<-RESPONSE
+  <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>00</Transaction_Type>
+    <DollarAmount>47.38</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>106625152</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET1700</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No>77</Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000040</SequenceNo>
+    <AVS>U</AVS>
+    <CVV2>M</CVV2>
+    <Retrieval_Ref_No>3146117</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>USD</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>Friendly Inc DEMO0983</MerchantName>
+    <MerchantAddress>123 King St</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>L7Z 3K8</MerchantPostal>
+    <MerchantURL></MerchantURL>
+    <TransarmorToken>8938737759041111</TransarmorToken>
+    <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Purchase
+
+ACCT: Visa  $ 47.38 USD
+
+CARD NUMBER : ############1111
+DATE/TIME   : 28 Sep 12 07:54:48
+REFERENCE # :  000040 M
+AUTHOR. #   : ET120454
+TRANS. REF. : 77
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+    <Address>
+      <Address1>456 My Street</Address1>
+      <Address2>Apt 1</Address2>
+      <City>Ottawa</City>
+      <State>ON</State>
+      <Zip>K1C2N6</Zip>
+      <CountryCode>CA</CountryCode>
+    </Address>
+  </TransactionResult>
+    RESPONSE
+  end
+
+  def successful_purchase_response_without_transarmor
+    <<-RESPONSE
+  <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>00</Transaction_Type>
+    <DollarAmount>47.38</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>106625152</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET1700</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No>77</Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000040</SequenceNo>
+    <AVS>U</AVS>
+    <CVV2>M</CVV2>
+    <Retrieval_Ref_No>3146117</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>USD</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>Friendly Inc DEMO0983</MerchantName>
+    <MerchantAddress>123 King St</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>L7Z 3K8</MerchantPostal>
+    <MerchantURL></MerchantURL>
+    <TransarmorToken></TransarmorToken>
+    <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Purchase
+
+ACCT: Visa  $ 47.38 USD
+
+CARD NUMBER : ############1111
+DATE/TIME   : 28 Sep 12 07:54:48
+REFERENCE # :  000040 M
+AUTHOR. #   : ET120454
+TRANS. REF. : 77
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+  </TransactionResult>
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+  <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>34</Transaction_Type>
+    <DollarAmount>123</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>888</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET112216</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No></Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000041</SequenceNo>
+    <AVS></AVS>
+    <CVV2>I</CVV2>
+    <Retrieval_Ref_No>9176784</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>USD</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>Friendly Inc DEMO0983</MerchantName>
+    <MerchantAddress>123 King St</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>L7Z 3K8</MerchantPostal>
+    <MerchantURL></MerchantURL>
+    <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Refund
+
+ACCT: Visa  $ 23.69 USD
+
+CARD NUMBER : ############1111
+DATE/TIME   : 28 Sep 12 08:31:23
+REFERENCE # :  000041 M
+AUTHOR. #   : ET112216
+TRANS. REF. :
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+=========================================</CTR>
+  </TransactionResult>
+    RESPONSE
+  end
+
+  def failed_purchase_response
+    <<-RESPONSE
+    <?xml version="1.0" encoding="UTF-8"?>
+    <TransactionResult>
+      <ExactID>AD1234-56</ExactID>
+      <Password></Password>
+      <Transaction_Type>00</Transaction_Type>
+      <DollarAmount>5013.0</DollarAmount>
+      <SurchargeAmount></SurchargeAmount>
+      <Card_Number>############1111</Card_Number>
+      <Transaction_Tag>555555</Transaction_Tag>
+      <Track1></Track1>
+      <Track2></Track2>
+      <PAN></PAN>
+      <Authorization_Num></Authorization_Num>
+      <Expiry_Date>0911</Expiry_Date>
+      <CardHoldersName>Fred Burfle</CardHoldersName>
+      <CVD_Presence_Ind>0</CVD_Presence_Ind>
+      <ZipCode></ZipCode>
+      <Tax1Amount></Tax1Amount>
+      <Tax1Number></Tax1Number>
+      <Tax2Amount></Tax2Amount>
+      <Tax2Number></Tax2Number>
+      <Secure_AuthRequired></Secure_AuthRequired>
+      <Secure_AuthResult></Secure_AuthResult>
+      <Ecommerce_Flag></Ecommerce_Flag>
+      <XID></XID>
+      <CAVV></CAVV>
+      <CAVV_Algorithm></CAVV_Algorithm>
+      <Reference_No>77</Reference_No>
+      <Customer_Ref></Customer_Ref>
+      <Reference_3></Reference_3>
+      <Language></Language>
+      <Client_IP>1.1.1.10</Client_IP>
+      <Client_Email></Client_Email>
+      <LogonMessage></LogonMessage>
+      <Error_Number>0</Error_Number>
+      <Error_Description> </Error_Description>
+      <Transaction_Error>false</Transaction_Error>
+      <Transaction_Approved>false</Transaction_Approved>
+      <EXact_Resp_Code>00</EXact_Resp_Code>
+      <EXact_Message>Transaction Normal</EXact_Message>
+      <Bank_Resp_Code>605</Bank_Resp_Code>
+      <Bank_Message>Invalid Expiration Date</Bank_Message>
+      <Bank_Resp_Code_2></Bank_Resp_Code_2>
+      <SequenceNo>000033</SequenceNo>
+      <AVS></AVS>
+      <CVV2></CVV2>
+      <Retrieval_Ref_No></Retrieval_Ref_No>
+      <CAVV_Response></CAVV_Response>
+      <Currency>USD</Currency>
+      <AmountRequested></AmountRequested>
+      <PartialRedemption>false</PartialRedemption>
+      <MerchantName>Friendly Inc DEMO0983</MerchantName>
+      <MerchantAddress>123 King St</MerchantAddress>
+      <MerchantCity>Toronto</MerchantCity>
+      <MerchantProvince>Ontario</MerchantProvince>
+      <MerchantCountry>Canada</MerchantCountry>
+      <MerchantPostal>L7Z 3K8</MerchantPostal>
+      <MerchantURL></MerchantURL>
+      <CTR>=========== TRANSACTION RECORD ==========
+Friendly Inc DEMO0983
+123 King St
+Toronto, ON L7Z 3K8
+Canada
+
+
+TYPE: Purchase
+ACCT: Visa  $ 5,013.00 USD
+CARD NUMBER : ############1111
+DATE/TIME   : 25 Sep 12 07:27:00
+REFERENCE # :  000033 M
+AUTHOR. #   :
+TRANS. REF. : 77
+Transaction not approved 605
+Please retain this copy for your records.
+=========================================</CTR>
+    </TransactionResult>
+    RESPONSE
+  end
+
+  def successful_verify_response
+    <<-RESPONSE
+<?xml version="1.0" encoding="UTF-8"?>
+<TransactionResult>
+  <ExactID>AD2552-05</ExactID>
+  <Password></Password>
+  <Transaction_Type>05</Transaction_Type>
+  <DollarAmount>0.0</DollarAmount>
+  <SurchargeAmount></SurchargeAmount>
+  <Card_Number>############4242</Card_Number>
+  <Transaction_Tag>25101911</Transaction_Tag>
+  <Track1></Track1>
+  <Track2></Track2>
+  <PAN></PAN>
+  <Authorization_Num>ET184931</Authorization_Num>
+  <Expiry_Date>0915</Expiry_Date>
+  <CardHoldersName>Longbob Longsen</CardHoldersName>
+  <CVD_Presence_Ind>0</CVD_Presence_Ind>
+  <ZipCode></ZipCode>
+  <Tax1Amount></Tax1Amount>
+  <Tax1Number></Tax1Number>
+  <Tax2Amount></Tax2Amount>
+  <Tax2Number></Tax2Number>
+  <Secure_AuthRequired></Secure_AuthRequired>
+  <Secure_AuthResult></Secure_AuthResult>
+  <Ecommerce_Flag></Ecommerce_Flag>
+  <XID></XID>
+  <CAVV></CAVV>
+  <CAVV_Algorithm></CAVV_Algorithm>
+  <Reference_No>1</Reference_No>
+  <Customer_Ref></Customer_Ref>
+  <Reference_3>Store Purchase</Reference_3>
+  <Language></Language>
+  <Client_IP>75.182.123.244</Client_IP>
+  <Client_Email></Client_Email>
+  <Transaction_Error>false</Transaction_Error>
+  <Transaction_Approved>true</Transaction_Approved>
+  <EXact_Resp_Code>00</EXact_Resp_Code>
+  <EXact_Message>Transaction Normal</EXact_Message>
+  <Bank_Resp_Code>100</Bank_Resp_Code>
+  <Bank_Message>Approved</Bank_Message>
+  <Bank_Resp_Code_2></Bank_Resp_Code_2>
+  <SequenceNo>000040</SequenceNo>
+  <AVS>1</AVS>
+  <CVV2>M</CVV2>
+  <Retrieval_Ref_No>7228838</Retrieval_Ref_No>
+  <CAVV_Response></CAVV_Response>
+  <Currency>USD</Currency>
+  <AmountRequested></AmountRequested>
+  <PartialRedemption>false</PartialRedemption>
+  <MerchantName>FriendlyInc</MerchantName>
+  <MerchantAddress>123 Main Street</MerchantAddress>
+  <MerchantCity>Durham</MerchantCity>
+  <MerchantProvince>North Carolina</MerchantProvince>
+  <MerchantCountry>United States</MerchantCountry>
+  <MerchantPostal>27592</MerchantPostal>
+  <MerchantURL></MerchantURL>
+  <TransarmorToken></TransarmorToken>
+  <CardType>Visa</CardType>
+  <CurrentBalance></CurrentBalance>
+  <PreviousBalance></PreviousBalance>
+  <EAN></EAN>
+  <CardCost></CardCost>
+  <VirtualCard>false</VirtualCard>
+  <CTR>=========== TRANSACTION RECORD ==========
+FriendlyInc DEMO0
+123 Main Street
+Durham, NC 27592
+United States
+
+
+TYPE: Auth Only
+
+ACCT: Visa  $ 0.00 USD
+
+CARDHOLDER NAME : Longbob Longsen
+CARD NUMBER     : ############4242
+DATE/TIME       : 04 Jul 14 14:21:52
+REFERENCE #     :  000040 M
+AUTHOR. #       : ET184931
+TRANS. REF.     : 1
+
+    Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+</TransactionResult>
+    RESPONSE
+  end
+
+  def no_transaction_response
+    yamlexcep = <<-RESPONSE
+--- !ruby/exception:ActiveMerchant::ResponseError
+message: Failed with 400 Bad Request
+message:
+response: !ruby/object:Net::HTTPBadRequest
+  body: "Malformed request: Transaction Type is missing."
+  body_exist: true
+  code: "400"
+  header:
+    connection:
+    - Close
+    content-type:
+    - text/html; charset=utf-8
+    server:
+    - Apache
+    date:
+    - Fri, 28 Sep 2012 18:21:37 GMT
+    content-length:
+    - "47"
+    status:
+    - "400"
+    cache-control:
+    - no-cache
+  http_version: "1.1"
+  message: Bad Request
+  read: true
+  socket:
+    RESPONSE
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+  end
+
+  def bad_credentials_response
+    yamlexcep = <<-RESPONSE
+--- !ruby/exception:ActiveMerchant::ResponseError
+message:
+response: !ruby/object:Net::HTTPUnauthorized
+  code: '401'
+  message: Authorization Required
+  body: Unauthorized Request. Bad or missing credentials.
+  read: true
+  header:
+    cache-control:
+    - no-cache
+    content-type:
+    - text/html; charset=utf-8
+    date:
+    - Tue, 30 Dec 2014 23:28:32 GMT
+    server:
+    - Apache
+    status:
+    - '401'
+    x-rack-cache:
+    - invalidate, pass
+    x-request-id:
+    - 4157e21cc5620a95ead8d2025b55bdf4
+    x-ua-compatible:
+    - IE=Edge,chrome=1
+    content-length:
+    - '49'
+    connection:
+    - Close
+  body_exist: true
+  http_version: '1.1'
+  socket:
+    RESPONSE
+    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+    <?xml version="1.0" encoding="UTF-8"?>
+  <TransactionResult>
+    <ExactID>AD1234-56</ExactID>
+    <Password></Password>
+    <Transaction_Type>33</Transaction_Type>
+    <DollarAmount>11.45</DollarAmount>
+    <SurchargeAmount></SurchargeAmount>
+    <Card_Number>############1111</Card_Number>
+    <Transaction_Tag>987123</Transaction_Tag>
+    <Track1></Track1>
+    <Track2></Track2>
+    <PAN></PAN>
+    <Authorization_Num>ET112112</Authorization_Num>
+    <Expiry_Date>0913</Expiry_Date>
+    <CardHoldersName>Fred Burfle</CardHoldersName>
+    <CVD_Presence_Ind>0</CVD_Presence_Ind>
+    <ZipCode></ZipCode>
+    <Tax1Amount></Tax1Amount>
+    <Tax1Number></Tax1Number>
+    <Tax2Amount></Tax2Amount>
+    <Tax2Number></Tax2Number>
+    <Secure_AuthRequired></Secure_AuthRequired>
+    <Secure_AuthResult></Secure_AuthResult>
+    <Ecommerce_Flag></Ecommerce_Flag>
+    <XID></XID>
+    <CAVV></CAVV>
+    <CAVV_Algorithm></CAVV_Algorithm>
+    <Reference_No></Reference_No>
+    <Customer_Ref></Customer_Ref>
+    <Reference_3></Reference_3>
+    <Language></Language>
+    <Client_IP>1.1.1.10</Client_IP>
+    <Client_Email></Client_Email>
+    <LogonMessage></LogonMessage>
+    <Error_Number>0</Error_Number>
+    <Error_Description> </Error_Description>
+    <Transaction_Error>false</Transaction_Error>
+    <Transaction_Approved>true</Transaction_Approved>
+    <EXact_Resp_Code>00</EXact_Resp_Code>
+    <EXact_Message>Transaction Normal</EXact_Message>
+    <Bank_Resp_Code>100</Bank_Resp_Code>
+    <Bank_Message>Approved</Bank_Message>
+    <Bank_Resp_Code_2></Bank_Resp_Code_2>
+    <SequenceNo>000166</SequenceNo>
+    <AVS></AVS>
+    <CVV2>I</CVV2>
+    <Retrieval_Ref_No>2046743</Retrieval_Ref_No>
+    <CAVV_Response></CAVV_Response>
+    <Currency>USD</Currency>
+    <AmountRequested></AmountRequested>
+    <PartialRedemption>false</PartialRedemption>
+    <MerchantName>FreshBooks DEMO0785</MerchantName>
+    <MerchantAddress>35 Golden Ave</MerchantAddress>
+    <MerchantCity>Toronto</MerchantCity>
+    <MerchantProvince>Ontario</MerchantProvince>
+    <MerchantCountry>Canada</MerchantCountry>
+    <MerchantPostal>M6R 2J5</MerchantPostal>
+    <MerchantURL></MerchantURL>
+<CTR>=========== TRANSACTION RECORD ==========
+FreshBooks DEMO0785
+35 Golden Ave
+Toronto, ON M6R 2J5
+Canada
+
+
+TYPE: Void
+
+ACCT: Visa  $ 47.38 USD
+
+CARD NUMBER : ############1111
+DATE/TIME   : 15 Nov 12 08:20:36
+REFERENCE # :  000166 M
+AUTHOR. #   : ET112112
+TRANS. REF. :
+
+Approved - Thank You 100
+
+
+Please retain this copy for your records.
+
+Cardholder will pay above amount to card
+issuer pursuant to cardholder agreement.
+=========================================</CTR>
+    </TransactionResult>
+RESPONSE
+  end
+end


### PR DESCRIPTION
This is based off of existing gateway [firstdata_e4](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/firstdata_e4.rb). v27 diverges significantly from existing v11 in terms of additional credentials for HMAC and multiple field changes including address & cvv fields. 

---

```
$ RUBYOPT=W0 be rake test:remote TEST=test/remote/gateways/remote_firstdata_e4_v27_test.rb 
.......................

Finished in 53.177556 seconds.
----------------------------------------------------------------------------------------------------------------------
23 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
0.43 tests/s, 1.73 assertions/s
```

---

```
$ RUBYOPT=W0 be rake test:units TEST=test/unit/gateways/firstdata_e4_v27_test.rb 
.............................

Finished in 0.302474 seconds.
----------------------------------------------------------------------------------------------------------------------
29 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------
95.88 tests/s, 449.63 assertions/s
```