### PR TITLE
Prevent connections being made in unit tests

### DIFF
--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -46,7 +46,9 @@ class ConnectionTest < Test::Unit::TestCase
 
   def test_connection_does_not_mutate_headers_argument
     headers = { 'Content-Type' => 'text/xml' }.freeze
-    @connection.request(:get, nil, headers)
+    Net::HTTP.any_instance.expects(:get).with('/tx.php', headers.merge({'connection' => 'close'})).returns(@ok)
+    Net::HTTP.any_instance.expects(:start).returns(true)
+    response = @connection.request(:get, nil, headers)
     assert_equal({ 'Content-Type' => 'text/xml' }, headers)
   end
 


### PR DESCRIPTION
The test introduced in 262b65c45bf9 was not properly stubbed, and
would attempt to make connections. This fixes it.

Unit: 3866 tests, 67888 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed