### PR TITLE
Convert all YAML calls from .load to .safe_load

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -860,15 +860,6 @@ Performance/StringReplacement:
     - 'lib/active_merchant/billing/gateways/realex.rb'
     - 'test/unit/gateways/nab_transact_test.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-Security/YAMLLoad:
-  Exclude:
-    - 'test/test_helper.rb'
-    - 'test/unit/fixtures_test.rb'
-    - 'test/unit/gateways/firstdata_e4_test.rb'
-    - 'test/unit/gateways/payeezy_test.rb'
-
 # Offense count: 2
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/generators/gateway/gateway_generator.rb
+++ b/generators/gateway/gateway_generator.rb
@@ -38,7 +38,7 @@ EOYAML
   end
 
   def next_identifier
-    fixtures = (YAML.load(File.read(fixtures_file)).keys + [identifier]).uniq.sort
+    fixtures = (YAML.safe_load(File.read(fixtures_file)).keys + [identifier], [], [], true).uniq.sort
     fixtures[fixtures.sort.index(identifier)+1]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -261,7 +261,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.load(File.read(file_name))
+          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials

--- a/test/unit/fixtures_test.rb
+++ b/test/unit/fixtures_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FixturesTest < Test::Unit::TestCase
   def test_sort
-    keys = YAML.load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS)).keys
+    keys = YAML.safe_load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS), [], [], true).keys
     assert_equal(
       keys,
       keys.sort

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -1037,7 +1037,7 @@ response: !ruby/object:Net::HTTPBadRequest
   read: true
   socket:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1074,7 +1074,7 @@ response: !ruby/object:Net::HTTPUnauthorized
   http_version: '1.1'
   socket:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -511,7 +511,7 @@ response: !ruby/object:Net::HTTPBadRequest
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_authorize_response
@@ -586,7 +586,7 @@ response: !ruby/object:Net::HTTPBadRequest
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response
@@ -631,7 +631,7 @@ response: !ruby/object:Net::HTTPBadRequest
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def failed_capture_response
@@ -671,7 +671,7 @@ response: !ruby/object:Net::HTTPBadRequest
   body_exist: true
 message:
   RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response
@@ -710,7 +710,7 @@ response: !ruby/object:Net::HTTPUnauthorized
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response_integration
@@ -735,7 +735,7 @@ response: !ruby/object:Net::HTTPUnauthorized
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -760,6 +760,6 @@ response: !ruby/object:Net::HTTPForbidden
   body_exist: true
 message:
     RESPONSE
-    YAML.load(yamlexcep)
+    YAML.safe_load(yamlexcep, ['Net::HTTPForbidden', 'ActiveMerchant::ResponseError'])
   end
 end


### PR DESCRIPTION
.load can deserialize arbitrary Ruby classes. Currently, we only use YAML for
fixtures and other patently safe purposes, but leaving them sets a bad
precedent, and prevents us using RuboCop's security linter for YAML properly.
Enable the linter and fix the usages.