### PR TITLE
GlobalCollect: Don't overwrite contactDetails

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'GlobalCollect'
       self.homepage_url = 'http://www.globalcollect.com/'
 
-      self.test_url = 'https://api-sandbox.globalcollect.com/'
+      self.test_url = 'https://eu.sandbox.api-ingenico.com/'
       self.live_url = 'https://api.globalcollect.com/'
 
       self.supported_countries = ['AD', 'AE', 'AG', 'AI', 'AL', 'AM', 'AO', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC', 'EE', 'EG', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY', 'HK', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE', 'IL', 'IM', 'IN', 'IS', 'IT', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PL', 'PN', 'PS', 'PT', 'PW', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SR', 'ST', 'SV', 'SZ', 'TC', 'TD', 'TG', 'TH', 'TJ', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'US', 'UY', 'UZ', 'VC', 'VE', 'VG', 'VI', 'VN', 'WF', 'WS', 'ZA', 'ZM', 'ZW']
@@ -154,13 +154,9 @@ module ActiveMerchant #:nodoc:
         post['order']['companyInformation'] = {
           'name' => options[:company]
         }
-        post['order']['contactDetails'] = {
-          'emailAddress' => options[:email]
-        }
+        post['order']['contactDetails']['emailAddress'] = options[:email] if options[:email]
         if address = options[:billing_address] || options[:address]
-          post['order']['contactDetails'] = {
-            'phoneNumber' => address[:phone]
-          }
+          post['order']['contactDetails']['phoneNumber'] = address[:phone] if address[:phone]
         end
       end
 
@@ -169,10 +165,10 @@ module ActiveMerchant #:nodoc:
           post['customer']['address'] = {
             'countryCode' => address[:country]
           }
-          post['customer']['contactDetails'] = {
-            'emailAddress' => options[:email],
-            'phoneNumber' => address[:phone]
-          }
+          post['customer']['contactDetails']['emailAddress'] = options[:email] if options[:email]
+          if address = options[:billing_address] || options[:address]
+            post['customer']['contactDetails']['phoneNumber'] = address[:phone] if address[:phone]
+          end
         end
       end
 

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -10,6 +10,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @accepted_amount = 4005
     @rejected_amount = 2997
     @options = {
+      email: 'example@example.com',
       billing_address: address,
       description: 'Store Purchase'
     }
@@ -153,7 +154,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_match %r{MISSING_OR_INVALID_AUTHORIZATION}, response.message
+    assert_match %r{UNKNOWN_SERVER_ERROR}, response.message
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -68,6 +68,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_successful_authorization_with_extra_options
     options = @options.merge(
       {
+        email: 'example@example.com',
         order_id: '123',
         ip: '127.0.0.1',
         fraud_fields:
@@ -83,6 +84,8 @@ class GlobalCollectTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match %r("fraudFields":{"website":"www.example.com","giftMessage":"Happy Day!","customerIpAddress":"127.0.0.1"}), data
       assert_match %r("merchantReference":"123"), data
+      assert_match %r("emailAddress":"example@example.com"), data
+      assert_match %r("phoneNumber":"\(555\)555-5555"), data
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Previously, if there was an address provided, it would overwrite the
contactDeatails field which may have already had an email field added.
Now we have a conditional for both email and phone number elements
within contactDetails.

Also updates the sandbox url to the current endpoint.

Remote:
16 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
17 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed