### PR TITLE
Set contactless_magstripe_mode when transaction is contactless magstripe. Fix silently failing tests.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915
 * Pin Payments: Pass reference for statement desc [curiousepic] #2919
 * FirstData: introduce v27 gateway [shasum] #2912
+* Stripe: Fix contactless magstripe support [abhiin1947] #2917
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -397,6 +397,7 @@ module ActiveMerchant #:nodoc:
         if emv_payment?(creditcard)
           add_emv_creditcard(post, creditcard.icc_data)
           post[:card][:read_method] = 'contactless' if creditcard.read_method == 'contactless'
+          post[:card][:read_method] = 'contactless_magstripe_mode' if creditcard.read_method == 'contactless_magstripe'
           if creditcard.encrypted_pin_cryptogram.present? && creditcard.encrypted_pin_ksn.present?
             post[:card][:encrypted_pin] = creditcard.encrypted_pin_cryptogram
             post[:card][:encrypted_pin_key_id] = creditcard.encrypted_pin_ksn

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1105,7 +1105,7 @@ class StripeTest < Test::Unit::TestCase
       @emv_credit_card.read_method = 'contactless'
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      data =~ /card\[read_method\]=contactless/
+      assert data =~ /card\[read_method\]=contactless/
     end.respond_with(successful_purchase_response)
   end
 
@@ -1114,7 +1114,7 @@ class StripeTest < Test::Unit::TestCase
       @emv_credit_card.read_method = 'contactless_magstripe'
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      data =~ /card\[read_method\]=contactless_magstripe_mode/
+      assert data =~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
 
@@ -1122,7 +1122,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @emv_credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      data !~ /card\[read_method\]=contactless/ && data !~ /card\[read_method\]=contactless_magstripe_mode/
+      assert data !~ /card\[read_method\]=contactless/ && data !~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
# What was the problem?
- When processing a contactless magstripe transaction if `icc_data` on the credit card is present, stripe gateway does not set `read_method` on the `post` to `contactless_magstripe_mode`

Resolves https://github.com/activemerchant/active_merchant/issues/2916

# Why this change?
- Set `contactless_magstripe_mode` if the read method is contactless magstripe.

# Test failures
- Activemerchant does have a test to make sure that `contactless_magstripe_mode` flag is set when it is part of EMV data. But these tests did not assert that the check is valid.
