### PR TITLE
Pin Payments: Pass reference for statement desc

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -114,6 +114,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, options)
         post[:description] = options[:description] || 'Active Merchant Purchase'
+        post[:reference] = options[:reference] if options[:reference]
       end
 
       def add_capture(post, options)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -38,6 +38,11 @@ class RemotePinTest < Test::Unit::TestCase
     assert_equal options_with_metadata[:metadata][:purchase_number], response.params['response']['metadata']['purchase_number']
   end
 
+  def test_successful_purchase_with_reference
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(reference: 'statement descriptor'))
+    assert_success response
+  end
+
   def test_successful_authorize_and_capture
     authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization


### PR DESCRIPTION
This passes an undocumented field that is used to specify a descriptor
that appears on the customer's statement.

Remote:
16 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
37 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed