### PR TITLE
Upgrade RuboCop to 0.58.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile.rails52
+++ b/Gemfile.rails52
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Transaction' do
             xml.tag! 'TranType', 'Credit'
             xml.tag! 'TranCode', action
-            if options[:allow_partial_auth] && (action == 'PreAuth' || action == 'Sale')
+            if options[:allow_partial_auth] && ['PreAuth', 'Sale'].include?(action)
               xml.tag! 'PartialAuth', 'Allow'
             end
             add_invoice(xml, options[:order_id], nil, options)


### PR DESCRIPTION
This version includes a bugfix (https://github.com/rubocop-hq/rubocop/issues/6092)
that should allow us to add PayPal-related code to the RuboCop checks.
For this patch, though, only RuboCop is upgraded (and a tiny tweak to
Mercury implemented to handle a new RuboCop test); the PayPal compliance
changes will be a separate commit.