### PR TITLE
Clean up the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ gemfile:
 - Gemfile.rails50
 - Gemfile.rails42
 
-matrix:
+jobs:
   include:
-    - rvm: 2.3
-      gemfile: Gemfile.rails42
+      rvm: 2.5
+      gemfile: Gemfile
+      script: bundle exec rubocop --parallel
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
+gem 'rubocop', '~> 0.58.1', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -1,12 +1,3 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
-
-group :test, :remote_test do
-  # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
-end
+eval File.read('Gemfile')
 
 gem 'activesupport', '~> 4.2.0'

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,12 +1,3 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
-
-group :test, :remote_test do
-  # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
-end
+eval File.read('Gemfile')
 
 gem 'activesupport', '~> 5.0.0'

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -1,12 +1,3 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
-
-group :test, :remote_test do
-  # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
-end
+eval File.read('Gemfile')
 
 gem 'activesupport', '~> 5.1.0'

--- a/Gemfile.rails52
+++ b/Gemfile.rails52
@@ -1,12 +1,3 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'jruby-openssl', :platforms => :jruby
-gem 'rubocop', '~> 0.57.2', require: false
-
-group :test, :remote_test do
-  # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
-end
+eval File.read('Gemfile')
 
 gem 'activesupport', '~> 5.2.0.rc1'

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :tag_release do
 end
 
 desc 'Run the unit test suite'
-task :default => 'test:local'
+task :default => 'test:units'
 task :test => 'test:units'
 
 RuboCop::RakeTask.new

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Transaction' do
             xml.tag! 'TranType', 'Credit'
             xml.tag! 'TranCode', action
-            if options[:allow_partial_auth] && (action == 'PreAuth' || action == 'Sale')
+            if options[:allow_partial_auth] && ['PreAuth', 'Sale'].include?(action)
               xml.tag! 'PartialAuth', 'Allow'
             end
             add_invoice(xml, options[:order_id], nil, options)


### PR DESCRIPTION
Right now, each Gemfile has a *huge* amount of redundancy, so any change to dependencies requires altering a minimum of five files. On top of that, we run RuboCop way too much.

These patches do two things:
 - Clean up the Gemfiles to remove redundancy
 - Clean up Travis to only do RuboCop once, not every build
 - Demonstrate the two working together by upgrading RuboCop only once, not for every Gemfile