### PR TITLE
Adyen: Set Default Name for Apple Pay Transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -179,6 +179,7 @@ module ActiveMerchant #:nodoc:
         }
 
         card.delete_if{|k,v| v.blank? }
+        card[:holderName] ||= 'Not Provided' if credit_card.is_a?(NetworkTokenizationCreditCard)
         requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:card] = card
       end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -233,7 +233,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     card = credit_card('4242424242424242', month: 16)
     assert response = @gateway.purchase(@amount, card, @options)
     assert_failure response
-    assert_equal 'Expiry month should be between 1 and 12 inclusive', response.message
+    assert_equal 'Expiry Date Invalid: Expiry month should be between 1 and 12 inclusive', response.message
   end
 
   def test_invalid_expiry_year_for_purchase

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -220,6 +220,17 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:billing_address][:country], post[:card][:billingAddress][:country]
   end
 
+  def test_authorize_with_network_tokenization_credit_card_no_name
+    @apple_pay_card.first_name = nil
+    @apple_pay_card.last_name = nil
+    response = stub_comms do
+      @gateway.authorize(@amount, @apple_pay_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_equal 'Not Provided', JSON.parse(data)['card']['holderName']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_authorize_with_network_tokenization_credit_card
     response = stub_comms do
       @gateway.authorize(@amount, @apple_pay_card, @options)


### PR DESCRIPTION
Name is required for Adyen but not always paseed on Apple Pay
transactions. This creates the default name place holder of `Not
Provided` on apply pay transactions. Updates one remote test with new
message.

Loaded suite test/unit/gateways/adyen_test
......................

22 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_adyen_test
Started
..................................

34 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed