### PR TITLE
Shove Rails-specific Gemfiles into their own directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ rvm:
 - 2.3
 
 gemfile:
-- Gemfile.rails52
-- Gemfile.rails51
-- Gemfile.rails50
-- Gemfile.rails42
+- gemfiles/Gemfile.rails52
+- gemfiles/Gemfile.rails51
+- gemfiles/Gemfile.rails50
+- gemfiles/Gemfile.rails42
 
 jobs:
   include:

--- a/gemfiles/Gemfile.rails42
+++ b/gemfiles/Gemfile.rails42
@@ -1,3 +1,3 @@
-eval File.read('Gemfile')
+eval_gemfile '../Gemfile'
 
 gem 'activesupport', '~> 4.2.0'

--- a/gemfiles/Gemfile.rails50
+++ b/gemfiles/Gemfile.rails50
@@ -1,3 +1,3 @@
-eval File.read('Gemfile')
+eval_gemfile '../Gemfile'
 
 gem 'activesupport', '~> 5.0.0'

--- a/gemfiles/Gemfile.rails51
+++ b/gemfiles/Gemfile.rails51
@@ -1,3 +1,3 @@
-eval File.read('Gemfile')
+eval_gemfile '../Gemfile'
 
 gem 'activesupport', '~> 5.1.0'

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,3 +1,3 @@
-eval File.read('Gemfile')
+eval_gemfile '../Gemfile'
 
 gem 'activesupport', '~> 5.2.0.rc1'


### PR DESCRIPTION
As @varyonic [pointed out in a comment](https://github.com/activemerchant/active_merchant/pull/2928#pullrequestreview-137126136), `eval_gemfile` is a more standard way to do [what I did](https://github.com/activemerchant/active_merchant/commit/f20dfab46920874a9317643bd2392437421106f4) to make our multiple `Gemfile`s work cleanly. But that version has an advantage, which is that it allows shoving these only-used-by-Travis `Gemfile`s into their own directory as well. So both switch to `eval_gemfile` and immediately reap its rewards.

Again, hat-tip @varyonic for the suggestion.