### PR TITLE
Beanstream: Update to use api key with login credentials

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -199,6 +199,7 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(/(&?password=)[^&\s]*(&?)/, '\1[FILTERED]\2').
+          gsub(/(&?passcode=)[^&\s]*(&?)/, '\1[FILTERED]\2').
           gsub(/(&?trnCardCvd=)\d*(&?)/, '\1[FILTERED]\2').
           gsub(/(&?trnCardNumber=)\d*(&?)/, '\1[FILTERED]\2')
       end

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -156,7 +156,6 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         reference, _, _ = split_auth(authorization)
-
         post = {}
         add_amount(post, money)
         add_reference(post, reference)
@@ -313,7 +312,6 @@ module ActiveMerchant #:nodoc:
         post[:serviceVersion] = SP_SERVICE_VERSION
         post[:responseFormat] = 'QS'
         post[:cardValidation] = (options[:cardValidation].to_i == 1) || '0'
-
         post[:operationType] = options[:operationType] || options[:operation] || secure_profile_action(:new)
         post[:customerCode] = options[:billing_id] || options[:vault_id] || false
         post[:status] = options[:status]
@@ -462,6 +460,7 @@ module ActiveMerchant #:nodoc:
           params[:username] = @options[:user] if @options[:user]
           params[:password] = @options[:password] if @options[:password]
           params[:merchant_id] = @options[:login]
+          params[:passcode] = @options[:api_key]
         end
         params[:vbvEnabled] = '0'
         params[:scEnabled] = '0'

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -67,6 +67,7 @@ beanstream:
   password: password
   secure_profile_api_key: API Access Passcode
   recurring_api_key: API Access Passcode
+  api_key: API KEY
 
 beanstream_interac:
   login: merchant id

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -384,6 +384,7 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert_scrubbed(@visa.number, clean_transcript)
     assert_scrubbed(@visa.verification_value.to_s, clean_transcript)
     assert_scrubbed(@gateway.options[:password], clean_transcript)
+    assert_scrubbed(@gateway.options[:api_key], clean_transcript)
   end
 
   private

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -9,7 +9,8 @@ class BeanstreamTest < Test::Unit::TestCase
     @gateway = BeanstreamGateway.new(
                  :login => 'merchant id',
                  :user => 'username',
-                 :password => 'password'
+                 :password => 'password',
+                 :api_key => 'api_key'
                )
 
     @credit_card = credit_card


### PR DESCRIPTION
Beanstream is requiring that users that connect via username and
password also supply a api key. 2 echeck tests are failing unrelated to
this change.

Loaded suite test/remote/gateways/remote_beanstream_test

41 tests, 185 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.122% passed

Loaded suite test/unit/gateways/beanstream_test

23 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed