### PR TITLE
Disable Metrics/ClassLength and ModuleLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,11 +17,9 @@ AllCops:
   ExtraDetails: false
   TargetRubyVersion: 2.3
 
-# Limiting module/class lengths in specs is counterproductive
+# Active Merchant gateways are not amenable to length restrictions
 Metrics/ClassLength:
-  Exclude:
-    - 'test/**/*'
+  Enabled: false
 
 Metrics/ModuleLength:
-  Exclude:
-    - 'test/**/*'
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -642,11 +642,6 @@ Metrics/BlockLength:
 Metrics/BlockNesting:
   Max: 6
 
-# Offense count: 489
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 2135
-
 # Offense count: 175
 Metrics/CyclomaticComplexity:
   Max: 36
@@ -655,11 +650,6 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 163
-
-# Offense count: 5
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Max: 383
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.


### PR DESCRIPTION
These are great restrictions in theory, but the running design pattern in our gateways means that basically *all* of them violate these rules. Given most of the tests do also, let's just kill these entirely.