### PR TITLE
FirstPay: Update Fields For Recurring Payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * CT Payments: Fix a typo in the live URL scheme [bpollack] #2936
 * CyberSource: Don't throw exceptions on HTML responses [bpollack] #2937
 * CyberSource: Remove extraneous parameter blocking echecks [chriscz] #2861
+* FirstPay: Update Fields For Recurring Payments [nfarve] #2940
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -93,8 +93,9 @@ module ActiveMerchant #:nodoc:
         post[:card_exp] = expdate(payment)
         post[:cvv2] = payment.verification_value
         post[:recurring] = options[:recurring] if options[:recurring]
-        post[:recurringStartDate] = options[:recurring_start_date] if options[:recurring_start_date]
-        post[:recurringEndDate] = options[:recurring_end_date] if options[:recurring_end_date]
+        post[:recurring_start_date] = options[:recurring_start_date] if options[:recurring_start_date]
+        post[:recurring_end_date] = options[:recurring_end_date] if options[:recurring_end_date]
+        post[:recurring_type] = options[:recurring_type] if options[:recurring_type]
       end
 
       def add_reference(post, action, money, authorization)

--- a/test/remote/gateways/remote_first_pay_test.rb
+++ b/test/remote/gateways/remote_first_pay_test.rb
@@ -111,7 +111,7 @@ class RemoteFirstPayTest < Test::Unit::TestCase
   end
 
   def test_recurring_payment
-    @options.merge!({recurring: 'none', recurring_start_date: DateTime.now, recurring_end_date: DateTime.now})
+    @options.merge!({recurring: 1, recurring_start_date: DateTime.now.strftime('%m/%d/%Y'), recurring_end_date: DateTime.now.strftime('%m/%d/%Y'), recurring_type: 'monthly'})
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message

--- a/test/unit/gateways/first_pay_test.rb
+++ b/test/unit/gateways/first_pay_test.rb
@@ -182,15 +182,17 @@ class FirstPayTest < Test::Unit::TestCase
   end
 
   def test_recurring_payments
-    @options[:recurring] = 'none'
+    @options[:recurring] = 1
     @options[:recurring_start_date] = '01/01/1900'
     @options[:recurring_end_date] = '02/02/1901'
+    @options[:recurring_type] = 'monthly'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_match(%r{<FIELD KEY="recurring">none</FIELD>}, data)
-      assert_match(%r{<FIELD KEY="recurringStartDate">01/01/1900</FIELD>}, data)
-      assert_match(%r{<FIELD KEY="recurringEndDate">02/02/1901</FIELD>}, data)
+      assert_match(%r{<FIELD KEY="recurring">1</FIELD>}, data)
+      assert_match(%r{<FIELD KEY="recurring_start_date">01/01/1900</FIELD>}, data)
+      assert_match(%r{<FIELD KEY="recurring_end_date">02/02/1901</FIELD>}, data)
+      assert_match(%r{<FIELD KEY="recurring_type">monthly</FIELD>}, data)
     end.respond_with(successful_purchase_response)
 
     assert response


### PR DESCRIPTION
Updates fields for recurring payment and adds a new field for recurring
type.

Loaded suite test/remote/gateways/remote_first_pay_test
Started
.............

13 tests, 29 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Loaded suite test/unit/gateways/first_pay_test
...........

11 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed