### PR TITLE
Barclaycard Smartpay: bump API to v30

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * FirstPay: Update Fields For Recurring Payments [nfarve] #2940
 * BlueSnap: Update list of supported countries [curiousepic] #2942
 * Remove unused handle_response method [bl] #2309
+* Barclaycard Smartpay: bump API version to v30 [bpollack] #2941
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -13,6 +13,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.barclaycardsmartpay.com/'
       self.display_name = 'Barclaycard Smartpay'
 
+      API_VERSION = 'v30'
+
       def initialize(options = {})
         requires!(options, :company, :merchant, :password)
         super
@@ -222,11 +224,11 @@ module ActiveMerchant #:nodoc:
       def build_url(action)
         case action
         when 'store'
-          "#{test? ? self.test_url : self.live_url}/Recurring/v12/storeToken"
+          "#{test? ? self.test_url : self.live_url}/Recurring/#{API_VERSION}/storeToken"
         when 'finalize3ds'
-          "#{test? ? self.test_url : self.live_url}/Payment/v12/authorise3d"
+          "#{test? ? self.test_url : self.live_url}/Payment/#{API_VERSION}/authorise3d"
         else
-          "#{test? ? self.test_url : self.live_url}/Payment/v12/#{action}"
+          "#{test? ? self.test_url : self.live_url}/Payment/#{API_VERSION}/#{action}"
         end
       end
 


### PR DESCRIPTION
This currently shouldn't change any behavior, but preps for handling third-party payouts and also serves as a marker that the API package should run cleanly on v30 of the API.

Unit: 25 tests, 114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 29 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed