### PR TITLE
Use SHIPTONAME instead of `full_name` for Payflow Express

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
@@ -4,24 +4,24 @@ module ActiveMerchant #:nodoc:
       def email
         @params['e_mail']
       end
-      
+
       def full_name
         "#{@params['name']} #{@params['lastname']}"
       end
-      
+
       def token
         @params['token']
       end
-      
+
       def payer_id
         @params['payer_id']
       end
-      
+
       # Really the shipping country, but it is all the information provided
       def payer_country
         address['country']
       end
-      
+
       def address
         {  'name'       => full_name,
            'company'    => nil,

--- a/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def address
-        {  'name'       => full_name,
+        {  'name'       => @params['shiptoname'] || full_name,
            'company'    => nil,
            'address1'   => @params['street'],
            'address2'   => @params['shiptostreet2'] || @params['street2'],

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -117,6 +117,31 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert_nil address['phone']
   end
 
+  def test_get_express_details_with_ship_to_name
+    @gateway.expects(:ssl_post).returns(successful_get_express_details_response_with_ship_to_name)
+    response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
+    assert_instance_of PayflowExpressResponse, response
+    assert_success response
+    assert response.test?
+
+    assert_equal 'EC-2OPN7UJGFWK9OYFV', response.token
+    assert_equal '12345678901234567', response.payer_id
+    assert_equal 'Buyer1@paypal.com', response.email
+    assert_equal 'Joe Smith', response.full_name
+    assert_equal 'US', response.payer_country
+
+    assert address = response.address
+    assert_equal 'John Joseph', address['name']
+    assert_nil address['company']
+    assert_equal '111 Main St.', address['address1']
+    assert_nil address['address2']
+    assert_equal 'San Jose', address['city']
+    assert_equal 'CA', address['state']
+    assert_equal '95100', address['zip']
+    assert_equal 'US', address['country']
+    assert_nil address['phone']
+  end
+
   def test_get_express_details_with_invalid_xml
     @gateway.expects(:ssl_post).returns(successful_get_express_details_response(:street => 'Main & Magic'))
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
@@ -166,6 +191,43 @@ class PayflowExpressTest < Test::Unit::TestCase
           <CorrelationID>9c3706997455e</CorrelationID>
         </PayPalResult>
         <ExtData Name='LASTNAME' Value='Smith'/>
+      </TransactionResult>
+    </TransactionResults>
+  </ResponseData>
+  </XMLPayResponse>
+    RESPONSE
+  end
+
+  def successful_get_express_details_response_with_ship_to_name
+    <<-RESPONSE
+<XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
+  <ResponseData>
+    <Vendor>TEST</Vendor>
+    <Partner>verisign</Partner>
+    <TransactionResults>
+      <TransactionResult>
+        <Result>0</Result>
+        <Message>Approved</Message>
+        <PayPalResult>
+          <EMail>Buyer1@paypal.com</EMail>
+          <PayerID>12345678901234567</PayerID>
+          <Token>EC-2OPN7UJGFWK9OYFV</Token>
+          <FeeAmount>0</FeeAmount>
+          <PayerStatus>verified</PayerStatus>
+          <Name>Joe</Name>
+          <ShipTo>
+            <Address>
+              <Street>111 Main St.</Street>
+              <City>San Jose</City>
+              <State>CA</State>
+              <Zip>95100</Zip>
+              <Country>US</Country>
+            </Address>
+          </ShipTo>
+          <CorrelationID>9c3706997455e</CorrelationID>
+        </PayPalResult>
+        <ExtData Name='LASTNAME' Value='Smith'/>
+        <ExtData Name='SHIPTONAME' Value='John Joseph'/>
       </TransactionResult>
     </TransactionResults>
   </ResponseData>

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -5,15 +5,15 @@ class PayflowExpressTest < Test::Unit::TestCase
   TEST_REDIRECT_URL_MOBILE = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
   LIVE_REDIRECT_URL        = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
   LIVE_REDIRECT_URL_MOBILE = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
-  
+
   TEST_REDIRECT_URL_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL}&useraction=commit"
   LIVE_REDIRECT_URL_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL}&useraction=commit"
   TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_MOBILE}&useraction=commit"
   LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE}&useraction=commit"
-  
+
   def setup
     Base.mode = :test
-  
+
     @gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD'
@@ -29,61 +29,61 @@ class PayflowExpressTest < Test::Unit::TestCase
                  :phone => '(555)555-5555'
                }
   end
-  
+
   def teardown
     Base.mode = :test
   end
-  
+
   def test_using_test_mode
     assert @gateway.test?
   end
-  
+
   def test_overriding_test_mode
     Base.mode = :production
-    
+
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD',
       :test => true
     )
-    
+
     assert gateway.test?
   end
-  
+
   def test_using_production_mode
     Base.mode = :production
-    
+
     gateway = PayflowExpressGateway.new(
       :login => 'LOGIN',
       :password => 'PASSWORD'
     )
-    
+
     assert !gateway.test?
   end
-  
+
   def test_live_redirect_url
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
-  
+
   def test_test_redirect_url
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
   end
-  
+
   def test_live_redirect_url_without_review
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
-  
+
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
     assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
   end
-  
+
   def test_invalid_get_express_details_request
     @gateway.expects(:ssl_post).returns(invalid_get_express_details_response)
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
@@ -91,20 +91,20 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Field format error: Invalid Token', response.message
   end
-  
+
   def test_get_express_details
     @gateway.expects(:ssl_post).returns(successful_get_express_details_response)
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
     assert_instance_of PayflowExpressResponse, response
     assert_success response
     assert response.test?
-    
+
     assert_equal 'EC-2OPN7UJGFWK9OYFV', response.token
     assert_equal '12345678901234567', response.payer_id
     assert_equal 'Buyer1@paypal.com', response.email
     assert_equal 'Joe Smith', response.full_name
     assert_equal 'US', response.payer_country
-    
+
     assert address = response.address
     assert_equal 'Joe Smith', address['name']
     assert_nil address['company']
@@ -134,9 +134,9 @@ class PayflowExpressTest < Test::Unit::TestCase
     xml_doc = REXML::Document.new(xml.target!)
     assert_nil REXML::XPath.first(xml_doc, '/PayPal/ButtonSource')
   end
-  
+
   private
-  
+
   def successful_get_express_details_response(options={:street => '111 Main St.'})
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
@@ -172,7 +172,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   </XMLPayResponse>
     RESPONSE
   end
-  
+
   def invalid_get_express_details_response
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
@@ -186,7 +186,7 @@ class PayflowExpressTest < Test::Unit::TestCase
       </TransactionResult>
     </TransactionResults>
   </ResponseData>
-</XMLPayResponse>    
+</XMLPayResponse>
     RESPONSE
   end
 end

--- a/test/unit/gateways/payflow_express_uk_test.rb
+++ b/test/unit/gateways/payflow_express_uk_test.rb
@@ -37,6 +37,31 @@ class PayflowExpressUkTest < Test::Unit::TestCase
     assert_nil address['phone']
   end
 
+  def test_get_express_details_with_ship_to_name
+    @gateway.expects(:ssl_post).returns(successful_get_express_details_response_with_ship_to_name)
+    response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
+    assert_instance_of PayflowExpressResponse, response
+    assert_success response
+    assert response.test?
+
+    assert_equal 'EC-2OPN7UJGFWK9OYFV', response.token
+    assert_equal 'LYWCMEN4FA7ZQ', response.payer_id
+    assert_equal 'paul@test.com', response.email
+    assert_equal 'paul smith', response.full_name
+    assert_equal 'GB', response.payer_country
+
+    assert address = response.address
+    assert_equal 'John Joseph', address['name']
+    assert_nil address['company']
+    assert_equal '10 keyworth avenue', address['address1']
+    assert_equal 'grangetown', address['address2']
+    assert_equal 'hinterland', address['city']
+    assert_equal 'Tyne and Wear', address['state']
+    assert_equal 'sr5 2uh', address['zip']
+    assert_equal 'GB', address['country']
+    assert_nil address['phone']
+  end
+
   private
   def successful_get_express_details_response
     <<-RESPONSE
@@ -73,7 +98,52 @@ class PayflowExpressUkTest < Test::Unit::TestCase
         </PayPalResult>
         <ExtData Name="LASTNAME" Value="smith"/>
         <ExtData Name="SHIPTOSTREET2" Value="grangetown"/>
-        <ExtData Name="SHIPTONAME" Value="paul smith"/>
+        <ExtData Name="STREET2" Value="ALLAWAY AVENUE"/>
+        <ExtData Name="COUNTRYCODE" Value="GB"/>
+        <ExtData Name="ADDRESSSTATUS" Value="Y"/>
+      </TransactionResult>
+    </TransactionResults>
+  </ResponseData>
+</XMLPayResponse>
+    RESPONSE
+  end
+
+  def successful_get_express_details_response_with_ship_to_name
+    <<-RESPONSE
+<?xml version="1.0"?>
+<XMLPayResponse xmlns="http://www.paypal.com/XMLPay">
+  <ResponseData>
+    <Vendor>markcoop</Vendor>
+    <Partner>paypaluk</Partner>
+    <TransactionResults>
+      <TransactionResult>
+        <Result>0</Result>
+        <AVSResult>
+          <StreetMatch>Match</StreetMatch>
+          <ZipMatch>Match</ZipMatch>
+        </AVSResult>
+        <Message>Approved</Message>
+        <PayPalResult>
+          <EMail>paul@test.com</EMail>
+          <PayerID>LYWCMEN4FA7ZQ</PayerID>
+          <Token>EC-2OPN7UJGFWK9OYFV</Token>
+          <FeeAmount>0</FeeAmount>
+          <PayerStatus>unverified</PayerStatus>
+          <Name>paul</Name>
+          <ShipTo>
+            <Address>
+              <Street>10 keyworth avenue</Street>
+              <City>hinterland</City>
+              <State>Tyne and Wear</State>
+              <Zip>sr5 2uh</Zip>
+              <Country>GB</Country>
+            </Address>
+          </ShipTo>
+          <CorrelationID>1ea22ef3873ba</CorrelationID>
+        </PayPalResult>
+        <ExtData Name="LASTNAME" Value="smith"/>
+        <ExtData Name="SHIPTOSTREET2" Value="grangetown"/>
+        <ExtData Name="SHIPTONAME" Value="John Joseph"/>
         <ExtData Name="STREET2" Value="ALLAWAY AVENUE"/>
         <ExtData Name="COUNTRYCODE" Value="GB"/>
         <ExtData Name="ADDRESSSTATUS" Value="Y"/>


### PR DESCRIPTION
This has a _potential_ backward compatibility issue, where people would expect `full_name` to be used. But this is causing a awkward UX for buyers. If you have Payflow Express, the buyer select a shipping address, the name on that Shipping address is different from the account owner, when selected, we would receive/use the account owner name, not the shipping address name.