### PR TITLE
Add additional countries for EBANX

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://sandbox.ebanx.com/ws/'
       self.live_url = 'https://api.ebanx.com/ws/'
 
-      self.supported_countries = ['BR', 'MX', 'CO']
+      self.supported_countries = ['BR', 'MX', 'CO', 'CL', 'AR']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club]
 


### PR DESCRIPTION
EBANX accepts credit card payments from Chile and Argentina (https://business.ebanx.com/en/payment-methods)