### PR TITLE
Adyen: Add RecurringProcessingModel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Paymentez: support partial refunds [bpollack] #2959
 * Payflow: allow support for partial captures [pi3r] #2952
 * CT Payment: Update How Address is Passed [nfarve] #2960
+* Adyen: Add RecurringProcessingModel [nfarve] #2951
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -148,6 +148,7 @@ module ActiveMerchant #:nodoc:
           currency: options[:currency] || currency(money)
         }
         post[:amount] = amount
+        post[:recurringProcessingModel] = options[:recurring_processing_model] if options[:recurring_processing_model]
       end
 
       def add_invoice_for_modification(post, money, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -31,7 +31,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_ip: '77.110.174.153',
       shopper_reference: 'John Smith',
       billing_address: address(),
-      order_id: '123'
+      order_id: '123',
+      recurring_processing_model: 'CardOnFile'
     }
   end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -33,7 +33,8 @@ class AdyenTest < Test::Unit::TestCase
       billing_address: address(),
       shopper_reference: 'John Smith',
       order_id: '345123',
-      installments: 2
+      installments: 2,
+      recurring_processing_model: 'CardOnFile'
     }
   end
 
@@ -156,8 +157,11 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    @gateway.expects(:ssl_post).returns(successful_store_response)
-    response = @gateway.store(@credit_card, @options)
+    response = stub_comms do
+      @gateway.store(@credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
+    end.respond_with(successful_store_response)
     assert_success response
     assert_equal '#8835205392522157#8315202663743702', response.authorization
   end


### PR DESCRIPTION
With visa updates, Adyen now requires the type of recurring processing
model for all recurring transactions. This adds the neccessary field.

Loaded suite test/remote/gateways/remote_adyen_test
..................................

34 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/adyen_test
......................

22 tests, 102 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed