### PR TITLE
Allow setting CAPTURECOMPLETE on Payflow capture transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -119,6 +119,11 @@ module ActiveMerchant #:nodoc:
               xml.tag!('Description', options[:description]) unless options[:description].blank?
               xml.tag!('Comment', options[:comment]) unless options[:comment].blank?
               xml.tag!('ExtData', 'Name'=> 'COMMENT2', 'Value'=> options[:comment2]) unless options[:comment2].blank?
+              xml.tag!(
+                'ExtData',
+                'Name' => 'CAPTURECOMPLETE',
+                'Value' => options[:capture_complete]
+              ) unless options[:capture_complete].blank?
             end
           end
         end

--- a/lib/active_merchant/billing/gateways/payflow_express.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express.rb
@@ -9,9 +9,7 @@ module ActiveMerchant #:nodoc:
       # in the docs that they recommend you pass the exact same parameters to both setup and authorize/purchase.
       #
       # This information was gleaned from a mix of:
-      # * PayFlow documentation
-      #   * for key value pairs: {Express Checkout for Payflow Pro (PDF)}[https://cms.paypal.com/cms_content/US/en_US/files/developer/PFP_ExpressCheckout_PP.pdf]
-      #   * XMLPay: {Payflow Pro XMLPay Developer's Guide (PDF)}[https://cms.paypal.com/cms_content/US/en_US/files/developer/PP_PayflowPro_XMLPay_Guide.pdf]
+      # * {PayFlow documentation}[https://developer.paypal.com/docs/classic/payflow/integration-guide/]
       # * previous ActiveMerchant code
       # * trial & error
       #
@@ -221,4 +219,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -135,6 +135,32 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_and_complete_capture
+    assert auth = @gateway.authorize(100 * 2, @credit_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+
+    assert capture = @gateway.capture(100, auth.authorization, :capture_complete => 'Y')
+    assert_success capture
+
+    assert capture = @gateway.capture(100, auth.authorization)
+    assert_failure capture
+  end
+
+  def test_authorize_and_uncomplete_capture
+    assert auth = @gateway.authorize(100 * 2, @credit_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+
+    assert capture = @gateway.capture(100, auth.authorization, :capture_complete => 'N')
+    assert_success capture
+
+    assert capture = @gateway.capture(100, auth.authorization)
+    assert_success capture
+  end
+
   def test_failed_capture
     assert response = @gateway.capture(100, '999')
     assert_failure response


### PR DESCRIPTION
By default Payflow will consider the first capture the final one, by passing
`CAPTURECOMPLETE=N` it lets us capture again later on.

[Docs](https://developer.paypal.com/docs/classic/payflow/integration-guide/#paypal-credit-card-transaction-request-parameters)

Remote: (Failures related to ACH and recurring billing)
32 tests, 137 assertions, 8 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
75% passed

Unit:
46 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed