### PR TITLE
BlueSnap: Add StoreCard Field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Payflow Express: Use SHIPTONAME instead of `full_name` for shipping address [filipebarcos] #2945
 * FirstData: add support for WalletProviderID in v27 gateway [bpollack] #2946
 * BlueSnap: Handle 403 responses [curiousepic] #2948
+* BlueSnap: Add StoreCard Field [nfarve] #2953
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -140,6 +140,7 @@ module ActiveMerchant
       def add_auth_purchase(doc, money, payment_method, options)
         doc.send('recurring-transaction', options[:recurring] ? 'RECURRING' : 'ECOMMERCE')
         add_order(doc, options)
+        doc.send('storeCard', options[:store_card] || false)
         add_amount(doc, money, options)
         doc.send('transaction-fraud-info') do
           doc.send('shopper-ip-address', options[:ip]) if options[:ip]

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -27,9 +27,11 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
-    @gateway.expects(:raw_ssl_request).returns(successful_authorize_response)
-
-    response = @gateway.authorize(@amount, @credit_card, @options)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |type, endpoint, data, headers|
+      assert_match '<storeCard>false</storeCard>', data
+    end.respond_with(successful_authorize_response)
     assert_success response
     assert_equal '1012082893', response.authorization
   end


### PR DESCRIPTION
With increase in visa regulations, merchants must pass a `storeCard`
value which shows if a user has authorized their card to be stored. One
test failing in remote unrelated to these changes.

Loaded suite test/unit/gateways/blue_snap_test

19 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Loaded suite test/remote/gateways/remote_blue_snap_test

25 tests, 72 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96% passed