### PR TITLE
Paymentez: add support for partial refunds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * BlueSnap: Handle 403 responses [curiousepic] #2948
 * BlueSnap: Add StoreCard Field [nfarve] #2953
 * Worldpay: support installments [bpollack] #2957
+* Paymentez: support partial refunds [bpollack] #2959
 
 == Version 1.80.0 (July 4, 2018)
 * Default SSL min_version to TLS 1.1 to comply with June 30 PCI DSS deadline [bdewater] #2909

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -76,8 +76,11 @@ module ActiveMerchant #:nodoc:
         commit_transaction('capture', post)
       end
 
-      def refund(_money, authorization, options = {})
-        void(authorization, options)
+      def refund(money, authorization, options = {})
+        post = {transaction: {id: authorization}}
+        post[:order] = {amount: amount(money).to_f} if money
+
+        commit_transaction('refund', post)
       end
 
       def void(authorization, _options = {})

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -47,6 +47,14 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
+  def test_successful_refund
+    auth = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert refund = @gateway.refund(@amount, @credit_card, @options)
+    assert_success refund
+  end
+
   def test_successful_void
     auth = @gateway.purchase(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
Note, the remote tests that fail do actually include the new noe, but just with "The partial refund is not supported by carrier", which means everything is happening correctly; they just misconfigured stuff on their side.

Unit: 19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 17 tests, 44 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.2353% passed