### PR TITLE
CT Payment: Update How Address is Passed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Worldpay: support installments [bpollack] #2957
 * Paymentez: support partial refunds [bpollack] #2959
 * Payflow: allow support for partial captures [pi3r] #2952
+* CT Payment: Update How Address is Passed [nfarve] #2960
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -120,6 +120,7 @@ module ActiveMerchant #:nodoc:
         add_operator_id(post, options)
         add_invoice(post,0, options)
         add_payment(post, credit_card)
+        add_address(post, credit_card, options)
         add_customer_data(post, options)
 
         commit('verifyAccount', post)
@@ -171,7 +172,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, creditcard, options)
         if address = options[:billing_address] || options[:address]
-          post[:CardHolderAddress] = ("#{address[:address1]} #{address[:address2]}").rjust(20, ' ')
+          post[:CardHolderAddress] = ("#{address[:address1]} #{address[:address2]} #{address[:city]} #{address[:state]}").rjust(20, ' ')
           post[:CardHolderPostalCode] = address[:zip].gsub(/\s+/, '').rjust(9, ' ')
         end
       end


### PR DESCRIPTION
Adds city and state to the address information passed in
`CardHolderAddress`. Also allows for verify method to send address
information.

Loaded suite test/unit/gateways/ct_payment_test
..............

14 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_ct_payment_test
....................

20 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed