### PR TITLE
Fix typo in gateway generator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Optimal Payments: update country list [bpollack] #2961
 * Ebanx: update sandbox and production URLs [vnbrs] #2949
 * Ebanx: support additional countries [vnbrs] #2950
+* Gateway generator: fix a typo that would cause the script to crash [bpollack] #2962
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/generators/gateway/gateway_generator.rb
+++ b/generators/gateway/gateway_generator.rb
@@ -38,7 +38,7 @@ EOYAML
   end
 
   def next_identifier
-    fixtures = (YAML.safe_load(File.read(fixtures_file)).keys + [identifier], [], [], true).uniq.sort
+    fixtures = (YAML.safe_load(File.read(fixtures_file), [], [], true).keys + [identifier]).uniq.sort
     fixtures[fixtures.sort.index(identifier)+1]
   end
 end


### PR DESCRIPTION
When I fixed YAML, I accidentally committed this script with parens in the wrong place. Fix that.