### PR TITLE
Remove unused variables and fix ambiguous invocations

### DIFF
--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
         url = (test? ? test_url : live_url) + action
         response = parse(ssl_post(url, post_data(action, parameters)))
 
-        final_response = Response.new(
+        Response.new(
           success_from(response),
           message_from(response),
           response,

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -48,7 +48,7 @@ class ConnectionTest < Test::Unit::TestCase
     headers = { 'Content-Type' => 'text/xml' }.freeze
     Net::HTTP.any_instance.expects(:get).with('/tx.php', headers.merge({'connection' => 'close'})).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
-    response = @connection.request(:get, nil, headers)
+    @connection.request(:get, nil, headers)
     assert_equal({ 'Content-Type' => 'text/xml' }, headers)
   end
 

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -53,7 +53,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge!({wallet_provider_id: 4}))
     end.check_request do |endpoint, data, headers|
-      assert_match /WalletProviderID>4</, data
+      assert_match(/WalletProviderID>4</, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -118,7 +118,7 @@ class PaymentezTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.refund(@amount, '1234', @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match /"amount":1.0/, data
+      assert_match(/"amount":1.0/, data)
     end.respond_with(successful_refund_response)
     assert_success response
     assert response.test?


### PR DESCRIPTION
This patch contains four quick fixes, all for ambiguous code or unused variables. Specifically, the following issues are rectified:

 - test/unit/connection_test.rb:51: warning: assigned but unused variable - response
 - test/unit/gateways/firstdata_e4_v27_test.rb:56: warning: ambiguous first argument; put parentheses or a space even after `/' operator
 - test/unit/gateways/paymentez_test.rb:121: warning: ambiguous first argument; put parentheses or a space even after `/' operator
 - lib/active_merchant/billing/gateways/ct_payment.rb:210: warning: assigned but unused variable - final_response