### PR TITLE
Clearhaus: use $0 for verification tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Ebanx: update sandbox and production URLs [vnbrs] #2949
 * Ebanx: support additional countries [vnbrs] #2950
 * Gateway generator: fix a typo that would cause the script to crash [bpollack] #2962
+* Clearhaus: use $0 for verify transactions [bpollack] #2964
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(credit_card, options={})
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
+          r.process { authorize(0, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end


### PR DESCRIPTION
Clearhaus now allows $0 auths, allowing us to tweak verify to use a
$0 transaction.

Unit: 22 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 23 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed