### PR TITLE
Provide fallback for nil `socket.io.cipher`

### DIFF
--- a/lib/active_merchant/net_http_ssl_connection.rb
+++ b/lib/active_merchant/net_http_ssl_connection.rb
@@ -4,7 +4,7 @@ module NetHttpSslConnection
   refine Net::HTTP do
     def ssl_connection
       return {} unless @socket.present?
-      { version: @socket.io.ssl_version, cipher: @socket.io.cipher[0] }
+      { version: @socket.io.ssl_version, cipher: @socket.io.cipher&.[](0) || 'unknown' }
     end
   end
 end


### PR DESCRIPTION
We've seen a few odd cases where this array was nil. Instead of blowing up the transaction just log as 'unknown'.

```ruby
irb(main):001:0> nil&.[](0) || 'unknown'
=> "unknown"
irb(main):002:0> %w()&.[](0) || 'unknown'
=> "unknown"
irb(main):003:0> %w(FOO)&.[](0) || 'unknown'
=> "FOO"
```