### PR TITLE
Braintree: Add support for GooglePay

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -659,6 +659,8 @@ Metrics/ParameterLists:
 # Offense count: 126
 Metrics/PerceivedComplexity:
   Max: 32
+  Exclude:
+    - 'lib/active_merchant/billing/gateways/braintree_blue.rb'
 
 # Offense count: 6
 Naming/AccessorMethodName:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Gateway generator: fix a typo that would cause the script to crash [bpollack] #2962
 * Clearhaus: use $0 for verify transactions [bpollack] #2964
 * Global Collect: properly handle partial captures [bpollack] #2967
+* Braintree: Add support for GooglePay [dtykocki] [#2966]
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -598,7 +598,7 @@ module ActiveMerchant #:nodoc:
                 :cryptogram => credit_card_or_vault_id.payment_cryptogram,
                 :eci_indicator => credit_card_or_vault_id.eci
               }
-          elsif credit_card_or_vault_id.source == :android_pay
+            elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
               parameters[:android_pay_card] = {
                 :number => credit_card_or_vault_id.number,
                 :cryptogram => credit_card_or_vault_id.payment_cryptogram,

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -432,6 +432,24 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_and_capture_with_google_pay_card
+    credit_card = network_tokenization_credit_card('4111111111111111',
+      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      :month              => '01',
+      :year               => '2024',
+      :source             => :google_pay,
+      :transaction_id     => '123456789',
+      :eci                => '05'
+    )
+
+    assert auth = @gateway.authorize(@amount, credit_card, @options)
+    assert_success auth
+    assert_equal '1000 Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
   def test_authorize_and_void
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -681,6 +681,40 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'transaction_id', response.authorization
   end
 
+  def test_google_pay_card
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(
+        :amount => '1.00',
+        :order_id => '1',
+        :customer => {:id => nil, :email => nil, :phone => nil,
+                      :first_name => 'Longbob', :last_name => 'Longsen'},
+        :options => {:store_in_vault => false, :submit_for_settlement => nil, :hold_in_escrow => nil},
+        :custom_fields => nil,
+        :android_pay_card => {
+          :number => '4111111111111111',
+          :expiration_month => '09',
+          :expiration_year => (Time.now.year + 1).to_s,
+          :cryptogram => '111111111100cryptogram',
+          :google_transaction_id => '1234567890',
+          :source_card_type => 'visa',
+          :source_card_last_four => '1111',
+          :eci_indicator => '05'
+        }
+      ).
+      returns(braintree_result(:id => 'transaction_id'))
+
+    credit_card = network_tokenization_credit_card('4111111111111111',
+      :brand              => 'visa',
+      :eci                => '05',
+      :payment_cryptogram => '111111111100cryptogram',
+      :source             => :google_pay,
+      :transaction_id     => '1234567890'
+    )
+
+    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1')
+    assert_equal 'transaction_id', response.authorization
+  end
+
   def test_supports_network_tokenization
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
   end


### PR DESCRIPTION
Adds support for processing GooglePay payment methods. It appears that
Braintree treats GooglePay in the same manner as AndroidPay. Even their
documentation (linked below) claims that GooglePay cards are represented
as AndroidPay cards. As such, the only way to get the GooglePay remote
test to pass is to pass the payment information in as `android_pay`.

Ref: https://developers.braintreepayments.com/guides/google-pay/server-side/ruby

Remote:
63 tests, 361 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
50 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed