### PR TITLE
Adyen: add support for customRoutingFlag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Global Collect: properly handle partial captures [bpollack] #2967
 * Braintree: Add support for GooglePay [dtykocki] [#2966]
 * Adyen: allow overriding card brands [bpollack] #2968
+* Adyen: allow custom routing [bpollack] #2969
 
 == Version 1.81.0 (July 30, 2018)
 * GlobalCollect: Don't overwrite contactDetails [curiousepic] #2915

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -120,6 +120,7 @@ module ActiveMerchant #:nodoc:
         post[:merchantOrderReference] = options[:merchant_order_reference] if options[:merchant_order_reference]
         post[:additionalData] ||= {}
         post[:additionalData][:overwriteBrand] = normalize(options[:overwrite_brand]) if options[:overwrite_brand]
+        post[:additionalData][:customRoutingFlag] = options[:custom_routing_flag] if options[:custom_routing_flag]
       end
 
       def add_shopper_interaction(post, payment, options={})

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -122,6 +122,14 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_custom_routing_sent
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({custom_routing_flag: 'abcdefg'}))
+    end.check_request do |endpoint, data, headers|
+      assert_equal 'abcdefg', JSON.parse(data)['additionalData']['customRoutingFlag']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Note that this can't really be tested in the sandbox (it's changing how Adyen processes the card, so the sandbox doesn't do anything with it), so remote tests are omitted.

Also note that this depends on/incorporates #2968 (since they both need to muck with `adddionalData`), so please take a look at that first/in addition to this.