### PR TITLE
Adyen: Add support for GooglePay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Adyen: allow overriding card brands [bpollack] #2968
 * Adyen: allow custom routing [bpollack] #2969
 * First Pay: Adds scrubbing [deedeelavinder] #2972
+* Adyen: Add support for GooglePay [dtykocki] #2971
 
 == Version 1.82.0 (August 13, 2018)
 * FirstData: add support for WalletProviderID in v27 gateway [bpollack] #2946

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -121,6 +121,7 @@ module ActiveMerchant #:nodoc:
         post[:additionalData] ||= {}
         post[:additionalData][:overwriteBrand] = normalize(options[:overwrite_brand]) if options[:overwrite_brand]
         post[:additionalData][:customRoutingFlag] = options[:custom_routing_flag] if options[:custom_routing_flag]
+        post[:additionalData]['paymentdatasource.type'] = NETWORK_TOKENIZATION_CARD_SOURCE[payment.source.to_s] if payment.is_a?(NetworkTokenizationCreditCard)
       end
 
       def add_shopper_interaction(post, payment, options={})

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -35,6 +35,14 @@ class RemoteAdyenTest < Test::Unit::TestCase
       :verification_value => nil
     )
 
+    @google_pay_card = network_tokenization_credit_card('4111111111111111',
+      :payment_cryptogram => 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      :month              => '08',
+      :year               => '2018',
+      :source             => :google_pay,
+      :verification_value => nil
+    )
+
     @options = {
       reference: '345123',
       shopper_email: 'john.smith@test.com',
@@ -87,6 +95,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   def test_succesful_purchase_with_brand_override
     response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({overwrite_brand: true, selected_brand: 'maestro'}))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_purchase_with_google_pay
+    response = @gateway.purchase(@amount, @google_pay_card, @options)
     assert_success response
     assert_equal '[capture-received]', response.message
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -261,8 +261,10 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @apple_pay_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_equal 'YwAAAAAABaYcCMX/OhNRQAAAAAA=', JSON.parse(data)['mpiData']['cavv']
-      assert_equal '07', JSON.parse(data)['mpiData']['eci']
+      parsed = JSON.parse(data)
+      assert_equal 'YwAAAAAABaYcCMX/OhNRQAAAAAA=', parsed['mpiData']['cavv']
+      assert_equal '07', parsed['mpiData']['eci']
+      assert_equal 'applepay', parsed['additionalData']['paymentdatasource.type']
     end.respond_with(successful_authorize_response)
     assert_success response
   end


### PR DESCRIPTION
Unit:
24 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
36 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed