### PR TITLE
Authorize.Net: Don't truncate response reason codes

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -822,13 +822,13 @@ module ActiveMerchant
         end
 
         if(element = doc.at_xpath('//errors/error'))
-          response[:response_reason_code] = element.at_xpath('errorCode').content[/0*(\d+)$/, 1]
+          response[:response_reason_code] = element.at_xpath('errorCode').content
           response[:response_reason_text] = element.at_xpath('errorText').content.chomp('.')
         elsif(element = doc.at_xpath('//transactionResponse/messages/message'))
-          response[:response_reason_code] = element.at_xpath('code').content[/0*(\d+)$/, 1]
+          response[:response_reason_code] = element.at_xpath('code').content
           response[:response_reason_text] = element.at_xpath('description').content.chomp('.')
         elsif(element = doc.at_xpath('//messages/message'))
-          response[:response_reason_code] = element.at_xpath('code').content[/0*(\d+)$/, 1]
+          response[:response_reason_code] = element.at_xpath('code').content
           response[:response_reason_text] = element.at_xpath('text').content.chomp('.')
         else
           response[:response_reason_code] = nil
@@ -876,7 +876,7 @@ module ActiveMerchant
         doc = Nokogiri::XML(body).remove_namespaces!
 
         if (element = doc.at_xpath('//messages/message'))
-          response[:message_code] = element.at_xpath('code').content[/0*(\d+)$/, 1]
+          response[:message_code] = element.at_xpath('code').content
           response[:message_text] = element.at_xpath('text').content.chomp('.')
         end
 
@@ -960,7 +960,8 @@ module ActiveMerchant
       end
 
       def map_error_code(response_code, response_reason_code)
-        STANDARD_ERROR_CODE_MAPPING["#{response_code}#{response_reason_code}"]
+        reason = response_reason_code.match(/0*(\d+)$/)[1] if response_reason_code
+        STANDARD_ERROR_CODE_MAPPING["#{response_code}#{reason}"]
       end
 
       def auth_was_for_cim?(authorization)

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -276,7 +276,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
     assert_equal 'Successful', response.message
-    assert_equal '1', response.params['message_code']
+    assert_equal 'I00001', response.params['message_code']
   end
 
   def test_successful_store_new_payment_profile
@@ -290,7 +290,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response = @gateway.store(new_card, customer_profile_id: customer_profile_id)
     assert_success response
     assert_equal 'Successful', response.message
-    assert_equal '1', response.params['message_code']
+    assert_equal 'I00001', response.params['message_code']
   end
 
   def test_failed_store_new_payment_profile
@@ -310,7 +310,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response = @gateway.store(credit_card('141241'))
     assert_failure response
     assert_equal 'The field length is invalid for Card Number', response.message
-    assert_equal '15', response.params['message_code']
+    assert_equal 'E00015', response.params['message_code']
   end
 
   def test_successful_purchase_using_stored_card
@@ -330,7 +330,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'The credit card number is invalid.', response.message
     assert_equal 'incorrect_number', response.error_code
-    assert_equal '27', response.params['message_code']
+    assert_equal 'E00027', response.params['message_code']
     assert_equal '6', response.params['response_reason_code']
     assert_match %r{Address not verified}, response.avs_result['message']
   end
@@ -395,7 +395,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
     assert_equal 'The credit card number is invalid.', response.message
     assert_equal 'incorrect_number', response.error_code
-    assert_equal '27', response.params['message_code']
+    assert_equal 'E00027', response.params['message_code']
     assert_equal '6', response.params['response_reason_code']
     assert_match %r{Address not verified}, response.avs_result['message']
   end
@@ -534,6 +534,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     ), response.params.keys.sort
 
     assert_equal 'User authentication failed due to invalid authentication values', response.message
+    assert_equal 'E00007', response.params['response_reason_code']
   end
 
   def test_partial_capture

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -596,7 +596,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     store = @gateway.store(@credit_card, @options)
     assert_failure store
     assert_match(/The field length is invalid/, store.message)
-    assert_equal('15', store.params['message_code'])
+    assert_equal('E00015', store.params['message_code'])
   end
 
   def test_successful_unstore
@@ -617,7 +617,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     unstore = @gateway.unstore('35959426#32506918#cim_store')
     assert_failure unstore
     assert_match(/The record cannot be found/, unstore.message)
-    assert_equal('40', unstore.params['message_code'])
+    assert_equal('E00040', unstore.params['message_code'])
   end
 
   def test_successful_store_new_payment_profile


### PR DESCRIPTION
Information was being lost in this parsing method because there is a
meaningful distinction between codes such as "7" and "EOOOO7", which
were both being truncated to "7".

Unit:
authorize_net
92 tests, 525 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

authorize_net_cim
29 tests, 302 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

authorize_net_arb
5 tests, 32 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
authorize_net
67 tests, 230 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

authorize_net_cim has many unrelated failures

authorize_net_arb
3 tests, 15 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed