### PR TITLE
Check if using SSL before getting SSL conn info.

### DIFF
--- a/lib/active_merchant/net_http_ssl_connection.rb
+++ b/lib/active_merchant/net_http_ssl_connection.rb
@@ -3,7 +3,7 @@ require 'net/http'
 module NetHttpSslConnection
   refine Net::HTTP do
     def ssl_connection
-      return {} unless @socket.present?
+      return {} unless use_ssl? && @socket.present?
       { version: @socket.io.ssl_version, cipher: @socket.io.cipher[0] }
     end
   end


### PR DESCRIPTION
Was getting this error in a project when running its acceptance tests
against a mocking service that used a `http` schema.
```
undefined method `ssl_version' for #<TCPSocket:(closed)>
$GEMS/bundler/gems/active_merchant-f3d11caabc66/lib/active_merchant/net_http_ssl_connection.rb:7:in `ssl_connection'
$GEMS/bundler/gems/active_merchant-f3d11caabc66/lib/active_merchant/connection.rb:82:in `block (2 levels) in request'
```