### PR TITLE
Reflect correct test mode in Braintree responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * PayU Latam: support partial captures [bpollack] #2974
+* Braintree: Reflect correct test mode in Braintree responses [elfassy] [#2980]
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -347,11 +347,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_from_result(result)
+        response_hash = { braintree_transaction: transaction_hash(result) }
+
         Response.new(
           result.success?,
           message_from_result(result),
-          { braintree_transaction: transaction_hash(result) },
-          { authorization: (result.transaction.id if result.transaction) }
+          response_hash,
+          authorization: (result.transaction.id if result.transaction),
+          test: test?
         )
       end
 
@@ -369,6 +372,7 @@ module ActiveMerchant #:nodoc:
           options[:avs_result] = { code: avs_code_from(result.transaction) }
           options[:cvv_result] = result.transaction.cvv_response_code
         end
+        options[:test] = test?
         options
       end
 


### PR DESCRIPTION
# Why

Reflect correct test mode in Braintree responses. 

The request was using the correct environment for test transactions (sandbox) but the response object returned did not include which mode was used. 

# What

Set `test` option, as per template https://github.com/activemerchant/active_merchant/blob/85c57a6c2d15ae86ab3713120bf9d2277260cd26/generators/gateway/templates/gateway.rb#L92-L101

---
## Remote tests

```
Finished in 99.933189 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
63 tests, 357 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.2381% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.63 tests/s, 3.57 assertions/s
```

All three failing remote tests have `You must get credits enabled in your Sandbox account for this to pass` (not sure how to set that up, if anyone has a clue)
