### PR TITLE
Barclaycard: Pass device_fingerprint when specified

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * PayU Latam: support partial captures [bpollack] #2974
 * FirstPay: Expose error code [curiousepic] #2979
+* Barclaycard Smartpay: Pass device_fingerprint when specified [dtykocki] #2981
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -307,6 +307,7 @@ module ActiveMerchant #:nodoc:
         hash[:shopperIP]        = options[:ip] if options[:ip]
         hash[:shopperReference] = options[:customer] if options[:customer]
         hash[:shopperInteraction] = options[:shopper_interaction] if options[:shopper_interaction]
+        hash[:deviceFingerprint]  = options[:device_fingerprint] if options[:device_fingerprint]
         hash.keep_if { |_, v| v }
       end
 

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -159,6 +159,12 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_device_fingerprint
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(device_fingerprint: 'abcde1123'))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_authorize_with_3ds
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: true))
     assert_equal 'RedirectShopper', response.message

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -159,9 +159,10 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_extra_options
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(shopper_interaction: 'ContAuth'))
+      @gateway.authorize(@amount, @credit_card, @options.merge(shopper_interaction: 'ContAuth', device_fingerprint: 'abcde123'))
     end.check_request do |endpoint, data, headers|
       assert_match(/shopperInteraction=ContAuth/, data)
+      assert_match(/deviceFingerprint=abcde123/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Unit:
25 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed