### PR TITLE
Modify komoju gateway test url

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -3,7 +3,7 @@ require 'json'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class KomojuGateway < Gateway
-      self.test_url = 'https://sandbox.komoju.com/api/v1'
+      self.test_url = 'https://komoju.com/api/v1'
       self.live_url = 'https://komoju.com/api/v1'
       self.supported_countries = ['JP']
       self.default_currency = 'JPY'


### PR DESCRIPTION
Komoju abolished sandbox environment, but instead we support test mode in our production environment. So we change `test_url` for it.