### PR TITLE
Begin removing Solo and Switch

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -9,8 +9,6 @@ module ActiveMerchant #:nodoc:
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11}$/ },
         'jcb'                => ->(num) { num =~ /^35(28|29|[3-8]\d)\d{12}$/ },
-        'switch'             => ->(num) { num =~ /^6759\d{12}(\d{2,3})?$/ },
-        'solo'               => ->(num) { num =~ /^6767\d{12}(\d{2,3})?$/ },
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
         'maestro'            => ->(num) { (12..19).include?(num.to_s.size) && in_bin_range?(num.to_s.slice(0, 6), MAESTRO_RANGES) },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -172,19 +172,19 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_16_digit_maestro_uk
     number = '6759000000000000'
     assert_equal 16, number.length
-    assert_equal 'switch', CreditCard.brand?(number)
+    assert_equal 'maestro', CreditCard.brand?(number)
   end
 
   def test_18_digit_maestro_uk
     number = '675900000000000000'
     assert_equal 18, number.length
-    assert_equal 'switch', CreditCard.brand?(number)
+    assert_equal 'maestro', CreditCard.brand?(number)
   end
 
   def test_19_digit_maestro_uk
     number = '6759000000000000000'
     assert_equal 19, number.length
-    assert_equal 'switch', CreditCard.brand?(number)
+    assert_equal 'maestro', CreditCard.brand?(number)
   end
 
   def test_electron_cards

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class CreditCardTest < Test::Unit::TestCase
   def setup
     CreditCard.require_verification_value = false
-    @visa = credit_card('4779139500118580',   :brand => 'visa')
-    @solo = credit_card('676700000000000000', :brand => 'solo', :issue_number => '01')
+    @visa = credit_card('4779139500118580', brand: 'visa')
+    @maestro = credit_card('676700000000000000', brand: 'maestro', verification_value: '')
   end
 
   def teardown
@@ -32,8 +32,8 @@ class CreditCardTest < Test::Unit::TestCase
     assert_valid @visa
   end
 
-  def test_should_be_a_valid_solo_card
-    assert_valid @solo
+  def test_should_be_a_valid_maestro_card
+    assert_valid @maestro
   end
 
   def test_cards_with_empty_names_should_not_be_valid
@@ -167,12 +167,6 @@ class CreditCardTest < Test::Unit::TestCase
     assert_match(/expired/, errors[:year].first)
   end
 
-  def test_should_be_valid_with_start_month_and_year_as_string
-    @solo.start_month = '2'
-    @solo.start_year = '2007'
-    assert_valid @solo
-  end
-
   def test_should_identify_wrong_card_brand
     c = credit_card(:brand => 'master')
     assert_not_valid c
@@ -240,44 +234,6 @@ class CreditCardTest < Test::Unit::TestCase
     CreditCard.require_verification_value = true
     card = credit_card('1', brand: 'bogus', verification_value: nil)
     assert_not_valid card
-  end
-
-  def test_should_require_valid_start_date_for_solo_or_switch
-    @solo.start_month  = nil
-    @solo.start_year   = nil
-    @solo.issue_number = nil
-
-    errors = assert_not_valid @solo
-    assert errors[:start_month]
-    assert errors[:start_year]
-    assert errors[:issue_number]
-
-    @solo.start_month = 2
-    @solo.start_year  = 2007
-    assert_valid @solo
-  end
-
-  def test_should_require_a_valid_issue_number_for_solo_or_switch
-    @solo.start_month  = nil
-    @solo.start_year   = 2005
-    @solo.issue_number = nil
-
-    errors = assert_not_valid @solo
-    assert errors[:start_month]
-    assert_equal ['cannot be empty'], errors[:issue_number]
-
-    @solo.issue_number = 3
-    assert_valid @solo
-  end
-
-  def test_should_require_a_validate_non_empty_issue_number_for_solo_or_switch
-    @solo.issue_number = 'invalid'
-
-    errors = assert_not_valid @solo
-    assert_equal ['is invalid'], errors[:issue_number]
-
-    @solo.issue_number = 3
-    assert_valid @solo
   end
 
   def test_should_return_last_four_digits_of_card_number
@@ -437,7 +393,7 @@ class CreditCardTest < Test::Unit::TestCase
       assert_equal @visa.type, @visa.brand
     end
     assert_deprecation_warning('CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead.') do
-      assert_equal @solo.type, @solo.brand
+      assert_equal @maestro.type, @maestro.brand
     end
   end
 


### PR DESCRIPTION
Both [Switch][1] and [Solo][2] were purchased by Maestro, and haven't been issued since 2002 and 2011, respectively. That's good, because their old bin ranges overlap with Maestro's current ones (surprise).

We should fully remove Solo and Switch, but some oddities about them (such as having start dates) has special handling in AM. Some gateways also run remote tests with old Switch/Solo cards. As a result, fully removing all Solo and Switch support *immediately* is counterproductive. This is the minimal amount of change required to properly handle modern Maestro cards.

[Switch]: https://en.wikipedia.org/wiki/Switch_(debit_card)
[Solo]: https://en.wikipedia.org/wiki/Solo_(debit_card)

3922 tests, 68171 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed