### PR TITLE
Remove the rest of Solo and Sripe support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Drop support for Laser cards [bpollack] #2983
 * Improve Maestro card detection [bpollack] #2983
 * Add ROU alpha3 code for Romania [dtykocki] #2989
+* [POSSIBLE BREAKAGE] Drop support for Solo and Switch cards [bpollack] #2991
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -15,8 +15,6 @@ module ActiveMerchant #:nodoc:
     # * American Express
     # * Diner's Club
     # * JCB
-    # * Switch
-    # * Solo
     # * Dankort
     # * Maestro
     # * Forbrugsforeningen
@@ -87,8 +85,6 @@ module ActiveMerchant #:nodoc:
       # * +'american_express'+
       # * +'diners_club'+
       # * +'jcb'+
-      # * +'switch'+
-      # * +'solo'+
       # * +'dankort'+
       # * +'maestro'+
       # * +'forbrugsforeningen'+
@@ -118,10 +114,6 @@ module ActiveMerchant #:nodoc:
       #
       # @return [String]
       attr_accessor :last_name
-
-      # Required for Switch / Solo cards
-      attr_reader :start_month, :start_year
-      attr_accessor :issue_number
 
       # Returns or sets the card verification value.
       #
@@ -301,8 +293,7 @@ module ActiveMerchant #:nodoc:
 
         errors_hash(
           errors +
-          validate_card_brand_and_number +
-          validate_switch_or_solo_attributes
+          validate_card_brand_and_number
         )
       end
 
@@ -374,27 +365,6 @@ module ActiveMerchant #:nodoc:
         elsif requires_verification_value?
           errors << [:verification_value, 'is required']
         end
-        errors
-      end
-
-      def validate_switch_or_solo_attributes #:nodoc:
-        errors = []
-
-        if %w[switch solo].include?(brand)
-          valid_start_month = valid_month?(start_month)
-          valid_start_year = valid_start_year?(start_year)
-
-          if((!valid_start_month || !valid_start_year) && !valid_issue_number?(issue_number))
-            if empty?(issue_number)
-              errors << [:issue_number, 'cannot be empty']
-              errors << [:start_month, 'is invalid'] if !valid_start_month
-              errors << [:start_year,  'is invalid'] if !valid_start_year
-            else
-              errors << [:issue_number, 'is invalid'] if !valid_issue_number?(issue_number)
-            end
-          end
-        end
-
         errors
       end
 

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
                                     GI GR HR HU IE IL IM IS IT LI LT LU LV MC MT MX NL
                                     NO PL PT RO RU SE SI SK TR US VA)
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :solo]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro]
 
       self.homepage_url = 'http://www.axcessms.com/'
       self.display_name = 'Axcess MS'

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       
       self.money_format = :cents
       self.default_currency = 'GBP'
-      self.supported_cardtypes = [ :visa, :switch, :maestro, :master, :solo, :american_express, :jcb ]
+      self.supported_cardtypes = [ :visa, :switch, :maestro, :master, :american_express, :jcb ]
       self.supported_countries = [ 'GB' ]
       self.homepage_url = 'http://www.cardsave.net/'
       self.display_name = 'CardSave'

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.default_currency = 'GBP'
       self.supported_countries = ['GB', 'US', 'CH', 'SE', 'SG', 'NO', 'JP', 'IS', 'HK', 'NL', 'CZ', 'CA', 'AU']
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro, :solo, :switch]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro]
       self.homepage_url = 'http://www.cardstream.com/'
       self.display_name = 'CardStream'
 

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -6,7 +6,7 @@ module ActiveMerchant
       self.default_currency = 'GBP'
       self.supported_countries = ['GB']
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :switch, :solo ]
+      self.supported_cardtypes = [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro ]
 
       self.homepage_url = 'http://www.datacash.com/'
       self.display_name = 'DataCash'
@@ -219,16 +219,6 @@ module ActiveMerchant
           # DataCash calls the CC number 'pan'
           xml.tag! :pan, credit_card.number
           xml.tag! :expirydate, format_date(credit_card.month, credit_card.year)
-
-          # optional values - for Solo etc
-          if [ 'switch', 'solo' ].include?(card_brand(credit_card).to_s)
-
-            xml.tag! :issuenumber, credit_card.issue_number unless credit_card.issue_number.blank?
-
-            if !credit_card.start_month.blank? && !credit_card.start_year.blank?
-              xml.tag! :startdate, format_date(credit_card.start_month, credit_card.start_year)
-            end
-          end
 
           xml.tag! :Cv2Avs do
             xml.tag! :cv2, credit_card.verification_value if credit_card.verification_value?

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -110,10 +110,6 @@ module ActiveMerchant #:nodoc:
         post[:cvc] = payment_method.verification_value if payment_method.verification_value
         post[:expYear] = format(payment_method.year, :two_digits)
         post[:expMonth] = payment_method.month
-
-        post[:startMonth] = payment_method.start_month if payment_method.start_month
-        post[:startYear] = payment_method.start_year if payment_method.start_year
-        post[:issueNumber] = payment_method.issue_number if payment_method.issue_number
         post[:clientIp] = options[:ip] || '127.0.0.1'
         post[:test] = true if test?
       end

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
 
       # The card types supported by the payment gateway
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :maestro, :jcb, :solo, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :maestro, :jcb, :diners_club]
 
       # The homepage URL of the gateway
       self.homepage_url = 'http://www.iridiumcorp.co.uk/'

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
                                   'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'CH']
 
       # The card types supported by the payment gateway
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :solo] # :switch?
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club]
 
       # The homepage URL of the gateway
       self.homepage_url = 'http://www.optimalpayments.com/'
@@ -320,8 +320,6 @@ module ActiveMerchant #:nodoc:
           'american_express'=> 'AM',
           'discover'        => 'DI',
           'diners_club'     => 'DC',
-          #'switch'          => '',
-          'solo'            => 'SO'
         }[key]
       end
 

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -43,8 +43,6 @@ module ActiveMerchant #:nodoc:
         :american_express => 'Amex',
         :jcb => 'JCB',
         :diners_club => 'DinersClub',
-        :switch => 'Switch',
-        :solo => 'Solo'
       }
 
       TRANSACTIONS = {

--- a/lib/active_merchant/billing/gateways/payflow_uk.rb
+++ b/lib/active_merchant/billing/gateways/payflow_uk.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
         @express ||= PayflowExpressUkGateway.new(@options)
       end
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :solo, :switch]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
       self.supported_countries = ['GB']
       self.homepage_url = 'https://www.paypal.com/uk/webapps/mpp/pro'
       self.display_name = 'PayPal Payments Pro (UK)'

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -81,12 +81,6 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'n2:ExpYear', format(credit_card.year, :four_digits)
           xml.tag! 'n2:CVV2', credit_card.verification_value unless credit_card.verification_value.blank?
 
-          if [ 'switch', 'solo' ].include?(card_brand(credit_card).to_s)
-            xml.tag! 'n2:StartMonth', format(credit_card.start_month, :two_digits) unless credit_card.start_month.blank?
-            xml.tag! 'n2:StartYear', format(credit_card.start_year, :four_digits) unless credit_card.start_year.blank?
-            xml.tag! 'n2:IssueNumber', format(credit_card.issue_number, :two_digits) unless credit_card.issue_number.blank?
-          end
-
           xml.tag! 'n2:CardOwner' do
             xml.tag! 'n2:PayerName' do
               xml.tag! 'n2:FirstName', credit_card.first_name
@@ -110,8 +104,6 @@ module ActiveMerchant #:nodoc:
         when 'master'           then 'MasterCard'
         when 'discover'         then 'Discover'
         when 'american_express' then 'Amex'
-        when 'switch'           then 'Switch'
-        when 'solo'             then 'Solo'
         end
       end
 

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -17,11 +17,11 @@ module ActiveMerchant
       self.default_currency = 'GBP'
 
       self.supported_countries = ['GB']
-      # Visa Credit, Visa Debit, Mastercard, Maestro, Solo, Electron,
+      # Visa Credit, Visa Debit, Mastercard, Maestro, Electron,
       # American Express, Diners Club, JCB, International Maestro,
       # Style, Clydesdale Financial Services, Other
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb, :switch, :solo, :maestro ]
+      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb, :maestro ]
       self.homepage_url = 'http://www.paymentsolutionsltd.com/'
       self.display_name = 'PSL Payment Solutions'
 

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -26,14 +26,12 @@ module ActiveMerchant
         'visa'              => 'VISA',
         'american_express'  => 'AMEX',
         'diners_club'       => 'DINERS',
-        'switch'            => 'SWITCH',
-        'solo'              => 'SWITCH',
         'maestro'           => 'MC'
       }
 
       self.money_format = :cents
       self.default_currency = 'EUR'
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :switch, :solo ]
+      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club ]
       self.supported_countries = %w(IE GB FR BE NL LU IT US CA ES)
       self.homepage_url = 'http://www.realexpayments.com/'
       self.display_name = 'Realex'
@@ -244,7 +242,7 @@ module ActiveMerchant
           xml.tag! 'expdate', expiry_date(credit_card)
           xml.tag! 'chname', credit_card.name
           xml.tag! 'type', CARD_MAPPING[card_brand(credit_card).to_s]
-          xml.tag! 'issueno', credit_card.issue_number
+          xml.tag! 'issueno', ''
           xml.tag! 'cvn' do
             xml.tag! 'number', credit_card.verification_value
             xml.tag! 'presind', (options['presind'] || (credit_card.verification_value? ? 1 : nil))

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -28,8 +28,6 @@ module ActiveMerchant #:nodoc:
         :visa => 'VISA',
         :master => 'MC',
         :delta => 'DELTA',
-        :solo => 'SOLO',
-        :switch => 'MAESTRO',
         :maestro => 'MAESTRO',
         :american_express => 'AMEX',
         :electron => 'UKE',
@@ -71,7 +69,7 @@ module ActiveMerchant #:nodoc:
         recipient_dob: :FIRecipientDoB
       }
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :switch, :solo, :maestro, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :diners_club]
       self.supported_countries = ['GB', 'IE']
       self.default_currency = 'GBP'
 

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
         'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'GB',
         'IS', 'NO', 'CH'
       ]
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :maestro, :jcb, :solo, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :maestro, :jcb, :diners_club]
       self.homepage_url = 'http://www.soeasypay.com/'
       self.display_name = 'SoEasyPay'
 

--- a/lib/active_merchant/billing/gateways/telr.rb
+++ b/lib/active_merchant/billing/gateways/telr.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AE', 'IN', 'SA']
       self.default_currency = 'AED'
       self.money_format = :dollars
-      self.supported_cardtypes = [:visa, :master, :american_express, :maestro, :solo, :jcb]
+      self.supported_cardtypes = [:visa, :master, :american_express, :maestro, :jcb]
 
       CVC_CODE_TRANSLATOR = {
         'Y' => 'M',

--- a/test/remote/gateways/remote_payflow_uk_test.rb
+++ b/test/remote/gateways/remote_payflow_uk_test.rb
@@ -16,26 +16,6 @@ class RemotePayflowUkTest < Test::Unit::TestCase
       :verification_value => '000',
       :brand => 'master'
     )
-    
-    @solo = CreditCard.new(
-      :brand  => 'solo',
-      :number => '6334900000000005',
-      :month  => Time.now.month,
-      :year   => Time.now.year + 1,
-      :first_name  => 'Test',
-      :last_name   => 'Mensch',
-      :issue_number => '01'
-    )
-    
-    @switch = CreditCard.new(
-      :brand               => 'switch',
-      :number              => '5641820000000005',
-      :verification_value => '000',
-      :month               => 1,
-      :year                => 2008,
-      :first_name          => 'Fred',
-      :last_name           => 'Brooks'
-    )
 
     @options = { 
       :billing_address => {

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -414,11 +414,6 @@ class CreditCardTest < Test::Unit::TestCase
     assert_nil card.month
     card.year = nil
     assert_nil card.year
-
-    card.start_month = '1'
-    assert_equal 1, card.start_month
-    card.start_year = '1'
-    assert_equal 1, card.start_year
   end
 
   def test_should_report_as_emv_if_icc_data_present

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -83,7 +83,7 @@ class DataCashTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro, :switch, :solo ], DataCashGateway.supported_cardtypes
+    assert_equal [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro ], DataCashGateway.supported_cardtypes
   end
 
   def test_purchase_with_missing_order_id_option

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -364,25 +364,11 @@ class PayflowTest < Test::Unit::TestCase
     assert_match %r(<PaymentHistory>Y</PaymentHistory), request
   end
 
-  def test_format_issue_number
-    xml = Builder::XmlMarkup.new
-    credit_card = credit_card('5641820000000005',
-      :brand         => 'switch',
-      :issue_number  => 1
-    )
-
-    @gateway.send(:add_credit_card, xml, credit_card)
-    doc = REXML::Document.new(xml.target!)
-    node = REXML::XPath.first(doc, '/Card/ExtData')
-    assert_equal '01', node.attributes['Value']
-  end
-
   def test_add_credit_card_with_three_d_secure
     xml = Builder::XmlMarkup.new
     credit_card = credit_card(
       '5641820000000005',
-      :brand => 'switch',
-      :issue_number => 1
+      :brand => 'maestro'
     )
 
     @gateway.send(:add_credit_card, xml, credit_card, @options.merge(three_d_secure_option))

--- a/test/unit/gateways/payflow_uk_test.rb
+++ b/test/unit/gateways/payflow_uk_test.rb
@@ -25,6 +25,6 @@ class PayflowUkTest < Test::Unit::TestCase
   end
   
   def test_supported_card_types
-    assert_equal [:visa, :master, :american_express, :discover, :solo, :switch], PayflowUkGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :discover], PayflowUkGateway.supported_cardtypes
   end
 end

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -11,7 +11,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
     @visa = credit_card
 
-    @solo = credit_card('6334900000000005', :brand => 'solo', :issue_number => '01')
+    @solo = credit_card('6334900000000005', :brand => 'maestro')
 
     @options = {
       :order_id => generate_unique_id,

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -36,7 +36,7 @@ class PslCardTest < Test::Unit::TestCase
   end
   
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :diners_club, :jcb, :switch, :solo, :maestro ], PslCardGateway.supported_cardtypes
+    assert_equal [ :visa, :master, :american_express, :diners_club, :jcb, :maestro ], PslCardGateway.supported_cardtypes
   end
   
   def test_avs_result

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -99,7 +99,7 @@ class RealexTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :diners_club, :switch, :solo ], RealexGateway.supported_cardtypes
+    assert_equal [ :visa, :master, :american_express, :diners_club ], RealexGateway.supported_cardtypes
   end
 
   def test_avs_result_not_supported


### PR DESCRIPTION
This is the continuation of #2990, and finishes removing Solo and Switch fully from the code base. It was kept separate because it's riskier (in particular, some of the remote tests were using Switch and Solo cards, and I have a hunch this breaks them--though they haven't been touched in forever and I can't imagine how they were working previously, anyway, given the cards have been sunset for *years*), but I still believe it's safe to land.