### PR TITLE
Add support for Carnet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Improve Maestro card detection [bpollack] #2983
 * Add ROU alpha3 code for Romania [dtykocki] #2989
 * [POSSIBLE BREAKAGE] Drop support for Solo and Switch cards [bpollack] #2991
+* Add support for Carnet cards [bpollack] #2992
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -13,7 +13,13 @@ module ActiveMerchant #:nodoc:
         'maestro'            => ->(num) { (12..19).include?(num&.size) && in_bin_range?(num.slice(0, 6), MAESTRO_RANGES) },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{8}$/ },
-        'vr'                 => ->(num) { num =~ /^(627416|637036)\d{8}$/ }
+        'vr'                 => ->(num) { num =~ /^(627416|637036)\d{8}$/ },
+        'carnet'             => lambda { |num|
+          num&.size == 16 && (
+            in_bin_range?(num.slice(0, 6), CARNET_RANGES) ||
+            CARNET_BINS.any? { |bin| num.slice(0, bin.size) == bin }
+          )
+        }
       }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
@@ -35,6 +41,18 @@ module ActiveMerchant #:nodoc:
         (484428..484455),
         (491730..491759),
       ]
+
+      CARNET_RANGES = [
+        (506199..506499),
+      ]
+
+      CARNET_BINS = Set.new(
+        [
+          '286900', '502275', '606333', '627535', '636318', '636379', '639388',
+          '639484', '639559', '50633601', '50633606', '58877274', '62753500',
+          '60462203', '60462204', '588772'
+        ]
+      )
 
       # https://www.mastercard.us/content/dam/mccom/global/documents/mastercard-rules.pdf, page 73
       MASTERCARD_RANGES = [

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -187,6 +187,19 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'maestro', CreditCard.brand?(number)
   end
 
+  def test_carnet_cards
+    numbers = [
+      '5062280000000000',
+      '6046220312312312',
+      '6393889871239871',
+      '5022751231231231',
+    ]
+    numbers.each do |num|
+      assert_equal 16, num.length
+      assert_equal 'carnet', CreditCard.brand?(num)
+    end
+  end
+
   def test_electron_cards
     # return the card number so assert failures are easy to isolate
     electron_test = Proc.new do |card_number|


### PR DESCRIPTION
Carnet is only used in Mexico, and the only test number I could find I found by googling for pictures of Carnet cards until I found someone with one who didn't blur out the number (although the test number here was mutated to be in the same bin range but have different subsequent digits).