### PR TITLE
Remove last bits of Switch and Solo functionality

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -56,8 +56,6 @@ module ActiveMerchant #:nodoc:
       include PostsData
       include CreditCardFormatting
 
-      DEBIT_CARDS = [ :switch, :solo ]
-
       CREDIT_DEPRECATION_MESSAGE = 'Support for using credit to refund existing transactions is deprecated and will be removed from a future release of ActiveMerchant. Please use the refund method instead.'
       RECURRING_DEPRECATION_MESSAGE = 'Recurring functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.'
 
@@ -303,11 +301,6 @@ module ActiveMerchant #:nodoc:
         last_name  = names.pop
         first_name = names.join(' ')
         [first_name, last_name]
-      end
-
-      def requires_start_date_or_issue_number?(credit_card)
-        return false if card_brand(credit_card).blank?
-        DEBIT_CARDS.include?(card_brand(credit_card).to_sym)
       end
 
       def requires!(hash, *params)

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       
       self.money_format = :cents
       self.default_currency = 'GBP'
-      self.supported_cardtypes = [ :visa, :switch, :maestro, :master, :american_express, :jcb ]
+      self.supported_cardtypes = [ :visa, :maestro, :master, :american_express, :jcb ]
       self.supported_countries = [ 'GB' ]
       self.homepage_url = 'http://www.cardsave.net/'
       self.display_name = 'CardSave'

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -272,17 +272,8 @@ module ActiveMerchant #:nodoc:
       def add_credit_card(post, credit_card)
         add_pair(post, :customerName, credit_card.name, :required => true)
         add_pair(post, :cardNumber, credit_card.number, :required => true)
-
         add_pair(post, :cardExpiryMonth, format(credit_card.month, :two_digits), :required => true)
         add_pair(post, :cardExpiryYear, format(credit_card.year, :two_digits), :required => true)
-
-        if requires_start_date_or_issue_number?(credit_card)
-          add_pair(post, :cardStartMonth, format(credit_card.start_month, :two_digits))
-          add_pair(post, :cardStartYear, format(credit_card.start_year, :two_digits))
-
-          add_pair(post, :cardIssueNumber, credit_card.issue_number)
-        end
-
         add_pair(post, :cardCVV, credit_card.verification_value)
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
 
       XSD_VERSION = '1.121'
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :switch, :dankort, :maestro]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :dankort, :maestro]
       self.supported_countries = %w(US BR CA CN DK FI FR DE JP MX NO SE GB SG LB)
 
       self.default_currency = 'USD'
@@ -42,7 +42,6 @@ module ActiveMerchant #:nodoc:
         :discover => '004',
         :diners_club => '005',
         :jcb => '007',
-        :switch => '024',
         :dankort => '034',
         :maestro => '042'
       }

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -237,10 +237,6 @@ module ActiveMerchant #:nodoc:
             end
           end
 
-          if requires_start_date_or_issue_number?(credit_card)
-            xml.tag!('ExtData', 'Name' => 'CardStart', 'Value' => startdate(credit_card)) unless credit_card.start_month.blank? || credit_card.start_year.blank?
-            xml.tag!('ExtData', 'Name' => 'CardIssue', 'Value' => format(credit_card.issue_number, :two_digits)) unless credit_card.issue_number.blank?
-          end
           xml.tag! 'ExtData', 'Name' => 'LASTNAME', 'Value' =>  credit_card.last_name
         end
       end

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -193,11 +193,6 @@ module ActiveMerchant #:nodoc:
           xml.add_element('Cvc2').text = credit_card.verification_value
           xml.add_element('Cvc2Presence').text = '1'
         end
-
-        if requires_start_date_or_issue_number?(credit_card)
-          xml.add_element('DateStart').text = format_date(credit_card.start_month, credit_card.start_year) unless credit_card.start_month.blank? || credit_card.start_year.blank?
-          xml.add_element('IssueNumber').text = credit_card.issue_number unless credit_card.issue_number.blank?
-        end
       end
 
       def add_billing_token(xml, token)

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -174,12 +174,6 @@ module ActiveMerchant
         post[:ExpMonth] = credit_card.month
         post[:ExpYear] = credit_card.year
 
-        if requires_start_date_or_issue_number?(credit_card)
-          post[:IssueNumber] = credit_card.issue_number unless credit_card.issue_number.blank?
-          post[:StartMonth] = credit_card.start_month unless credit_card.start_month.blank?
-          post[:StartYear] = credit_card.start_year unless credit_card.start_year.blank?
-        end
-
         # CV2 check
         post[:AVSCV2Check] = credit_card.verification_value? ? 'YES' : 'NO'
         post[:CV2] = credit_card.verification_value if credit_card.verification_value?

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -289,11 +289,6 @@ module ActiveMerchant #:nodoc:
         add_pair(post, :CardNumber, credit_card.number, :required => true)
 
         add_pair(post, :ExpiryDate, format_date(credit_card.month, credit_card.year), :required => true)
-
-        if requires_start_date_or_issue_number?(credit_card)
-          add_pair(post, :StartDate, format_date(credit_card.start_month, credit_card.start_year))
-          add_pair(post, :IssueNumber, credit_card.issue_number)
-        end
         add_pair(post, :CardType, map_card_type(credit_card))
 
         add_pair(post, :CV2, credit_card.verification_value)

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
       # number 5551234 within area code 202 (country code 1).
       VALID_PHONE_FORMAT = /\+\d{1,3}(\(?\d{3}\)?)?\d{3}-\d{4}-\d{3}/
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb, :switch ]
+      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb ]
       self.supported_countries = %w(AD CY GI IM MT RO CH AT DK GR IT MC SM TR BE EE HU LV NL SK GB BG FI IS LI NO SI VA FR IL LT PL ES CZ DE IE LU PT SE)
       self.homepage_url = 'http://www.wirecard.com'
       self.display_name = 'Wirecard'

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'GBP'
       self.money_format = :cents
       self.supported_countries = %w(HK GB AU AD AR BE BR CA CH CN CO CR CY CZ DE DK ES FI FR GI GR HU IE IN IT JP LI LU MC MT MY MX NL NO NZ PA PE PL PT SE SG SI SM TR UM VA)
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :switch]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro]
       self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
       self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.homepage_url = 'http://www.worldpay.com/'
@@ -21,7 +21,6 @@ module ActiveMerchant #:nodoc:
         'jcb'              => 'JCB-SSL',
         'maestro'          => 'MAESTRO-SSL',
         'diners_club'      => 'DINERS-SSL',
-        'switch'           => 'MAESTRO-SSL'
       }
 
       def initialize(options = {})

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
 
       self.supported_countries = %w(HK US GB BE CH CZ DE DK ES FI FR GR HU IE IT LU MT NL NO PL PT SE SG TR)
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :switch]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro]
 
       self.homepage_url = 'http://online.worldpay.com'
       self.display_name = 'Worldpay Online Payments'


### PR DESCRIPTION
When examining changes required on the Spreedly side for the Switch/Solo changes, we realized a few gateways still supported Switch. This in turn led me to find a bit of extra functionality we could ditch. This PR solves both issues (as separate commits).

3923 tests, 68177 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed