### PR TITLE
Payeezy: Add reversal_id in support of timeout reversals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * [POSSIBLE BREAKAGE] Drop support for Solo and Switch cards [bpollack] #2991
 * Add support for Carnet cards [bpollack] #2992
 * Stripe: support a reason for voiding a transaction [whitby3001] #2378
+* Payeezy: Add reversal_id in support of timeout reversals [dtykocki] #2997
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960


### PR DESCRIPTION
The `reversal_id` field can be added to any auth or purchase
transaction. In the event of a timeout, the same `reversal_id` can then
be specified via `void` to reverse the transaction. According to
Payeezy's documentation, this API is only available in production, but
the remote tests demonstrate that the API may function on the sandbox.

Ref: https://developer.payeezy.com/payeezy-api/apis/post/transactions-1

Unit:
33 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
33 tests, 131 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed