### PR TITLE
RuboCop: fix most EmptyLines* rules

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,32 +60,11 @@ Layout/ElseAlignment:
     - 'lib/active_merchant/billing/gateways/trust_commerce.rb'
     - 'lib/active_merchant/billing/response.rb'
 
-# Offense count: 66
-# Cop supports --auto-correct.
-# Configuration parameters: AllowAdjacentOneLineDefs, NumberOfEmptyLines.
-Layout/EmptyLineBetweenDefs:
-  Enabled: false
-
-# Offense count: 97
-# Cop supports --auto-correct.
-Layout/EmptyLines:
-  Enabled: false
-
-# Offense count: 49
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: false
-
 # Offense count: 165
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines, beginning_only, ending_only
 Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
-# Offense count: 64
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundMethodBody:
   Enabled: false
 
 # Offense count: 40

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -53,6 +53,7 @@ module ActiveMerchant #:nodoc:
       def credit_card?
         false
       end
+
       # Routing numbers may be validated by calculating a checksum and dividing it by 10. The
       # formula is:
       #   (3(d1 + d4 + d7) + 7(d2 + d5 + d8) + 1(d3 + d6 + d9))mod 10 = 0

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -386,6 +386,7 @@ module ActiveMerchant #:nodoc:
         end
 
         private
+
         def month_days
           mdays = [nil,31,28,31,30,31,30,31,31,30,31,30,31]
           mdays[2] = 29 if Date.leap?(year)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -249,7 +249,6 @@ module ActiveMerchant #:nodoc:
           test: test?,
           error_code: success ? nil : error_code_from(response)
         )
-
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -128,7 +128,6 @@ module ActiveMerchant #:nodoc:
         post[transactions[action]] = authorization
       end
 
-
       ACTIONS = {
         purchase: 'SALE',
         authorize: 'AUTHORIZE',

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -604,7 +604,6 @@ module ActiveMerchant
           xml.zip(truncate(address[:zip], 20))
           xml.country(truncate(address[:country], 60))
         end
-
       end
 
       def add_order_id(xml, options)

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -205,6 +205,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def build_response(*args)
         Response.new(*args)
       end

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -13,7 +13,6 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
 
-
       def initialize(options={})
         requires!(options, :user_name, :password)
         super

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -350,7 +350,6 @@ module ActiveMerchant #:nodoc:
         })
       end
 
-
       def currency_code(currency)
         CURRENCY_CODES[currency]
       end

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -279,7 +279,6 @@ module ActiveMerchant #:nodoc:
         }.delete_if{|k, v| v.nil?}
       end
 
-
       def commit(action, source_type, parameters)
         response = parse(ssl_post(live_url, post_data(COMMANDS[source_type][action], parameters)))
 

--- a/lib/active_merchant/billing/gateways/commercegate.rb
+++ b/lib/active_merchant/billing/gateways/commercegate.rb
@@ -76,7 +76,6 @@ module ActiveMerchant #:nodoc:
         post[:email]       = options[:email] || 'unknown@example.com'
         post[:currencyCode]= options[:currency] || currency(money)
         post[:merchAcct]   = options[:merchant]
-
       end
 
       def add_creditcard(params, creditcard)

--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -214,7 +214,6 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-
         response
       end
 

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -214,7 +214,6 @@ module ActiveMerchant
       end
 
       def add_credit_card(xml, credit_card, address)
-
         xml.tag! :Card do
           # DataCash calls the CC number 'pan'
           xml.tag! :pan, credit_card.number
@@ -274,7 +273,6 @@ module ActiveMerchant
       end
 
       def parse(body)
-
         response = {}
         xml = REXML::Document.new(body)
         root = REXML::XPath.first(xml, '//Response')

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -34,7 +34,6 @@ module ActiveMerchant #:nodoc:
           add_ticket_id(post, payment_method)
           commit(:authorize_ticket, post)
         end
-
       end
 
       def capture(amount, authorization, options={})
@@ -113,7 +112,6 @@ module ActiveMerchant #:nodoc:
         post[:clientIp] = options[:ip] || '127.0.0.1'
         post[:test] = true if test?
       end
-
 
       def add_reference(post, authorization)
         post[:transactionId] = authorization

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -142,7 +142,6 @@ module ActiveMerchant #:nodoc:
         post[:expiration_year]  = sprintf('%.4i', creditcard.year)[-2..-1]
       end
 
-
       def commit(action, parameters)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(action, parameters), 'Content-Type' => 'text/xml'))
 

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -120,7 +120,6 @@ module ActiveMerchant #:nodoc:
           gsub(%r((&?cvc=)\d*(&?)), '\1[FILTERED]\2')
       end
 
-
       private
 
       def add_amount(post, money, options)

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -64,6 +64,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def requires_address!(options)
         raise ArgumentError.new('Missing eWay required parameters: address or billing_address') unless (options.has_key?(:address) or options.has_key?(:billing_address))
       end

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -136,7 +136,6 @@ module ActiveMerchant #:nodoc:
         post[:invoiceDescription] = options[:description]
       end
 
-
       # add credit card details to be stored by eway. NOTE eway requires "title" field
       def add_creditcard(post, creditcard)
         post[:CCNumber]  = creditcard.number

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -13,7 +13,6 @@ module ActiveMerchant #:nodoc:
                        :capture       => '32',
                        :credit        => '34' }
 
-
       ENVELOPE_NAMESPACES = { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
                               'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/',
                               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -30,7 +30,6 @@ module ActiveMerchant #:nodoc:
         'JPY' => 392
       }
 
-
       def initialize(options = {})
         requires!(options, :login, :password, :terminal_id, :merchant_id)
         super

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -246,7 +246,6 @@ module ActiveMerchant #:nodoc:
           error_code: error_code_from(succeeded, response),
           test: test?
         )
-
       end
 
       def headers(action, post, authorization = nil)

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -99,6 +99,7 @@ module ActiveMerchant #:nodoc:
       alias_method :unstore, :delete
 
       private
+
       def add_customer_data(post, options)
         if options.has_key? :email
           post[:email] = options[:email]
@@ -181,7 +182,6 @@ module ActiveMerchant #:nodoc:
           :cvv_result => response['cvvresponse'],
           :avs_result => { :code => response['avsresponse'] }
         )
-
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/latitude19.rb
+++ b/lib/active_merchant/billing/gateways/latitude19.rb
@@ -147,7 +147,6 @@ module ActiveMerchant #:nodoc:
           gsub(%r((\"cvv\\\":\\\")\d+), '\1[FILTERED]')
       end
 
-
       private
 
       def add_request_id(post)

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -258,6 +258,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       # Commit the transaction by posting the XML file to the LinkPoint server
       def commit(money, creditcard, options = {})
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(money, creditcard, options)))
@@ -323,7 +324,6 @@ module ActiveMerchant #:nodoc:
       # Set up the parameters hash just once so we don't have to do it
       # for every action.
       def parameters(money, creditcard, options = {})
-
         params = {
           :payment => {
             :subtotal => amount(options[:subtotal]),
@@ -417,7 +417,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(xml)
-
         # For reference, a typical response...
         # <r_csp></r_csp>
         # <r_time></r_time>

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -80,6 +80,7 @@ module ActiveMerchant
       end
 
       private
+
       def new_post
         {
           order: {},

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -119,7 +119,6 @@ module ActiveMerchant #:nodoc:
           ip_address: options[:ip_address]
         }.merge(options[:additional_info] || {})
 
-
         add_address(post, options)
         add_shipping_address(post, options)
       end

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -158,7 +158,6 @@ module ActiveMerchant #:nodoc:
         url = test? ? self.test_url : self.live_url
         parameters[:transaction_amount]  = amount(money) if money unless action == 'V'
 
-
         response = begin
           parse( ssl_post(url, post_data(action,parameters)) )
         rescue ActiveMerchant::ResponseError => e

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -12,7 +12,6 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.supported_cardtypes = [:visa, :master, :american_express]
 
-
       def initialize(options={})
         requires!(options, :access_key)
         super
@@ -57,7 +56,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options={})
-
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(250, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/modern_payments.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def cim
         @cim ||= ModernPaymentsCimGateway.new(@options)
       end

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -66,6 +66,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def add_payment_details(post, options)
         post[:pmtDate] = (options[:payment_date] || Time.now.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         post[:pmtType] = PAYMENT_METHOD[options[:payment_method] || :credit_card]

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -41,7 +41,6 @@ module ActiveMerchant #:nodoc:
 
       SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
 
-
       def initialize(options = {})
         requires!(options, :login, :password)
         super

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -122,6 +122,7 @@ module ActiveMerchant
       end
 
       private
+
       def add_request_details(params, options)
         params['COMMENT'] = options[:description] unless options[:description].blank?
       end

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -214,7 +214,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, params)
-
         params[action == 'add_customer' ? :customer_vault : :type] = action
         params[:username] = @options[:login]
         params[:password] = @options[:password]

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -104,6 +104,7 @@ module ActiveMerchant #:nodoc:
           gsub(%r((cvv2\\?":\\?")\\?"), '\1[BLANK]"').
           gsub(%r((cvv2\\?":\\?")\s+), '\1[BLANK]')
       end
+
       private
 
       def create_post_for_auth_or_purchase(money, creditcard, options)

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -19,7 +19,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Optimal Payments'
 
       def initialize(options = {})
-
         if(options[:login])
           ActiveMerchant.deprecated("The 'login' option is deprecated in favor of 'store_id' and will be removed in a future version.")
           options[:store_id] = options[:login]

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -251,7 +251,6 @@ module ActiveMerchant #:nodoc:
         commit(order, :void, options[:trace_number])
       end
 
-
       # ==== Customer Profiles
       # :customer_ref_num should be set unless you're happy with Orbital providing one
       #

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       # Used for capturing, which is currently not supported.
       def add_reference(post, identification)
         auth, trans_id = identification.split(';')
@@ -71,7 +72,6 @@ module ActiveMerchant #:nodoc:
           :test => test_response?(response),
           :authorization => authorization_from(response)
         )
-
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -174,7 +174,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, parameters = {})
-
         parameters.update(
           :version => API_VERSION,
           :type => TRANSACTIONS[action.to_sym],

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -70,7 +70,6 @@ module ActiveMerchant #:nodoc:
           # stored authorization
           send_autopay(amount, payment_method, true, options)
         end
-
       end
 
       # Public: Send a purchase Payex request

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -78,6 +78,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def build_request(body, options = {})
         xml = Builder::XmlMarkup.new
         xml.instruct!

--- a/lib/active_merchant/billing/gateways/payflow_express.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express.rb
@@ -58,7 +58,6 @@ module ActiveMerchant #:nodoc:
     # [<tt>:header_background_color</tt>] (opt) Your URL for receiving Instant Payment Notification (IPN) about this transaction.
     # [<tt>:header_border_color</tt>] (opt) Your URL for receiving Instant Payment Notification (IPN) about this transaction.
 
-
     class PayflowExpressGateway < Gateway
       include PayflowCommonAPI
       include PaypalExpressCommon
@@ -109,6 +108,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def build_get_express_details_request(token)
         xml = Builder::XmlMarkup.new :indent => 2
         xml.tag! 'GetExpressCheckout' do

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -240,7 +240,6 @@ module ActiveMerchant #:nodoc:
         31203 => 'Pending due to currency conflict (accept manually)',
         31204 => 'Pending due to fraud filters (accept manually)',
 
-
         40000 => 'Problem with transaction data',
         40001 => 'Problem with payment data',
         40002 => 'Invalid checksum',
@@ -320,7 +319,6 @@ module ActiveMerchant #:nodoc:
         code = parsed_response['data']['response_code'].to_i
         RESPONSE_CODES[code] || code.to_s
       end
-
 
       class ResponseParser
         attr_reader :raw_response, :parsed, :succeeded, :message, :options

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -41,7 +41,6 @@ module ActiveMerchant #:nodoc:
         commit('capture', money, post)
       end
 
-
       def refund(money, authorization, options = {})
         post = {}
         post[:transactionid] = authorization

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -84,6 +84,7 @@ module ActiveMerchant #:nodoc:
           gsub(/(number\\?":\\?")(\d*)/, '\1[FILTERED]').
           gsub(/(cvc\\?":\\?")(\d*)/, '\1[FILTERED]')
       end
+
       private
 
       def add_amount(post, money, options)

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -172,6 +172,7 @@ module ActiveMerchant
       end
 
       private
+
       def commit(action, post)
         response = parse( ssl_post(self.live_url, post_data(action, post)) )
         success = SUCCESS_CODES.include?(response[:finalstatus])

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -240,7 +240,6 @@ module ActiveMerchant
       #   -a hash with all of the values returned in the PSL response
       #
       def parse(body)
-
         fields = {}
         for line in body.split('&')
           key, value = *line.scan( %r{^(\w+)\=(.*)$} ).flatten

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
@@ -174,7 +174,6 @@ module QuickpayCommon
     base.supported_countries = ['DE', 'DK', 'ES', 'FI', 'FR', 'FO', 'GB', 'IS', 'NO', 'SE']
     base.homepage_url = 'http://quickpay.net/'
     base.display_name = 'QuickPay'
-
   end
     
   def expdate(credit_card)

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -91,6 +91,7 @@ module ActiveMerchant
       end
 
       private
+
       def commit(request)
         response = parse(ssl_post(self.live_url, request))
 

--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -96,7 +96,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-
       def supports_scrubbing?
         true
       end

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -181,6 +181,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def truncate(value, max_size)
         return nil unless value
         return value.to_s if CGI.escape(value.to_s).length <= max_size

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -189,7 +189,6 @@ module ActiveMerchant #:nodoc:
           xml.tag!('CUSTOMER_SHIP', NIL_ATTRIBUTE) do
           end
         end
-
       end
 
       def add_merchant_key(xml, options)

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -4,7 +4,6 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://api.securionpay.com/'
       self.live_url = 'https://api.securionpay.com/'
 
-
       self.supported_countries = %w(AL AD AT BY BE BG HR CY CZ RE DK EE IS FI FR DE GI GR HU IS IE IT IL LV LI LT LU
                                     MK MT MD MC NL NO PL PT RO RU MA RS SK SI ES SE CH UA GB KI CI ME)
 

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -106,7 +106,6 @@ module ActiveMerchant #:nodoc:
         commit('update', nil, post)
       end
 
-
       def delete(vault_id)
         post = {}
         post[:customer_vault] = 'delete_customer'
@@ -128,6 +127,7 @@ module ActiveMerchant #:nodoc:
       alias_method :unstore, :delete
 
       private
+
       def add_customer_data(post, options)
         if options.has_key? :email
           post[:email] = options[:email]
@@ -237,7 +237,6 @@ module ActiveMerchant #:nodoc:
           :cvv_result => response['cvvresponse'],
           :avs_result => { :code => response['avsresponse'] }
         )
-
       end
 
       def expdate(creditcard)
@@ -246,7 +245,6 @@ module ActiveMerchant #:nodoc:
 
         "#{month}#{year[-2..-1]}"
       end
-
 
       def message_from(response)
         case response['responsetext']

--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -88,7 +88,6 @@ module ActiveMerchant #:nodoc:
         commit("transactions/#{authorization}/void.xml", '')
       end
 
-
       # Public: Determine whether a credit card is chargeable card and available for purchases.
       #
       # payment_method - The CreditCard or the Spreedly payment method token.

--- a/lib/active_merchant/billing/gateways/trexle.rb
+++ b/lib/active_merchant/billing/gateways/trexle.rb
@@ -90,6 +90,7 @@ module ActiveMerchant #:nodoc:
           gsub(/(number\\?":\\?")(\d*)/, '\1[FILTERED]').
           gsub(/(cvc\\?":\\?")(\d*)/, '\1[FILTERED]')
       end
+
       private
 
       def add_amount(post, money, options)

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -304,6 +304,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def add_payment_source(params, source)
         if source.is_a?(String)
           add_billing_id(params, source)

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -63,6 +63,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def add_test_mode(form, options)
         form[:test_mode] = 'TRUE' if options[:test_mode]
       end

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -138,6 +138,7 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
       def clean_description(description)
         description.to_s.slice(0,32).encode('US-ASCII', invalid: :replace, undef: :replace, replace: '?')
       end

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -161,7 +161,6 @@ module ActiveMerchant
       else
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
-
     end
 
     def configure_cert(http)

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -69,6 +69,7 @@ module ActiveMerchant
     end
 
     private
+
     def log_with_retry_details(logger, attempts, time, message, tag)
       NetworkConnectionRetries.log(logger, :info, 'connection_attempt=%d connection_request_time=%.4fs connection_msg="%s"' % [attempts, time, message], tag)
     end

--- a/lib/active_merchant/post_data.rb
+++ b/lib/active_merchant/post_data.rb
@@ -17,6 +17,7 @@ module ActiveMerchant
     alias_method :to_s, :to_post_data
 
     private
+
     def required?(key)
       required_fields.include?(key)
     end

--- a/lib/support/gateway_support.rb
+++ b/lib/support/gateway_support.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'active_support'
 require 'active_merchant'
 
-
 class GatewaySupport #:nodoc:
   ACTIONS = [:purchase, :authorize, :capture, :void, :credit, :recurring]
 

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -60,7 +60,6 @@ class SSLVerify
         puts d.name
       end
     end
-
   end
 
   def try_host(http, path)

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -60,7 +60,6 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
     assert_equal 'processing_error', response.error_code
   end
 
-
   private
 
   def apple_pay_payment_token(options = {})

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -873,5 +873,4 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     return response
   end
 
-
 end

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -37,7 +37,6 @@ class RemoteBanwireTest < Test::Unit::TestCase
     assert_success response
   end
 
-
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -196,7 +196,6 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
-
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -705,8 +705,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
-
   private
+
   def assert_avs(address1, zip, expected_avs_code)
     response = @gateway.purchase(@amount, @credit_card, billing_address: {address1: address1, zip: zip})
 

--- a/test/remote/gateways/remote_cardknox_test.rb
+++ b/test/remote/gateways/remote_cardknox_test.rb
@@ -149,7 +149,6 @@ class RemoteCardknoxTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount-1, auth.authorization)
     assert_failure refund
     assert_equal 'Refund not allowed on non-captured auth.', refund.message
-
   end
 
   def test_failed_partial_check_refund # the gate way does not support this transaction

--- a/test/remote/gateways/remote_cecabank_test.rb
+++ b/test/remote/gateways/remote_cecabank_test.rb
@@ -26,7 +26,6 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert_equal 'ERROR', response.message
   end
 
-
   def test_successful_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase

--- a/test/remote/gateways/remote_creditcall_test.rb
+++ b/test/remote/gateways/remote_creditcall_test.rb
@@ -167,6 +167,5 @@ class RemoteCreditcallTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:transaction_key], transcript)
-
   end
 end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -300,7 +300,6 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-
   def test_successful_subscription_credit
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_equal 'Successful transaction', response.message

--- a/test/remote/gateways/remote_first_giving_test.rb
+++ b/test/remote/gateways/remote_first_giving_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class RemoteFirstGivingTest < Test::Unit::TestCase
 
-
   def setup
     @gateway = FirstGivingGateway.new(fixtures(:first_giving))
 

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -24,7 +24,6 @@ class RemoteForteTest < Test::Unit::TestCase
       description: 'Store Purchase',
       order_id: '1'
     }
-
   end
 
   def test_invalid_login

--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -48,7 +48,6 @@ class RemoteIveriTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
-
   def test_failed_purchase
     response = @gateway.purchase(@amount, @bad_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_jetpay_test.rb
+++ b/test/remote/gateways/remote_jetpay_test.rb
@@ -75,7 +75,6 @@ class RemoteJetpayTest < Test::Unit::TestCase
     assert_success capture
   end
 
-
   def test_void
     # must void a valid auth
     assert auth = @gateway.authorize(9900, @credit_card, @options)
@@ -83,7 +82,6 @@ class RemoteJetpayTest < Test::Unit::TestCase
     assert_equal 'APPROVED', auth.message
     assert_not_nil auth.authorization
     assert_not_nil auth.params['approval']
-
 
     assert void = @gateway.void(auth.authorization)
     assert_success void

--- a/test/remote/gateways/remote_jetpay_v2_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_test.rb
@@ -100,7 +100,6 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
     assert_not_nil auth.authorization
     assert_not_nil auth.params['approval']
 
-
     assert void = @gateway.void(auth.authorization, @options)
     assert_success void
   end

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -96,7 +96,6 @@ class LinkpointTest < Test::Unit::TestCase
         {:id => '111', :description => 'keychain', :price => '3.00', :quantity => '1'}]})
     assert purchase = @gateway.purchase(1500, @credit_card, @options)
     assert_success purchase
-
   end
 
   def test_successful_recurring_payment

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -170,13 +170,11 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal 'P', response.cvv_result['code']
     puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
 
-
     # 6A. void
     assert response = @gateway.void(response.authorization, {:order_id => '6A'})
     assert_equal '360', response.params['response']
     assert_equal 'No transaction found with specified transaction Id', response.message
     puts "Test #{options[:order_id]}A: #{txn_id(response)}"
-
   end
 
   def test7
@@ -1207,7 +1205,6 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal assertions[:cvv], response.cvv_result['code'] if assertions[:cvv]
     assert_equal auth_code(options[:order_id]), response.params['authCode']
     puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
-
 
     # 1B: credit
     assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})

--- a/test/remote/gateways/remote_modern_payments_test.rb
+++ b/test/remote/gateways/remote_modern_payments_test.rb
@@ -14,7 +14,6 @@ class RemoteModernPaymentTest < Test::Unit::TestCase
       :billing_address => address,
       :description => 'Store Purchase'
     }
-
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -160,7 +160,6 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
-
   def test_successful_credit
     response = @gateway.credit(@amount, @credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_pay_junction_test.rb
+++ b/test/remote/gateways/remote_pay_junction_test.rb
@@ -136,6 +136,7 @@ class PayJunctionTest < Test::Unit::TestCase
   end
 
   private
+
   def success_price
     200 + rand(200)
   end

--- a/test/remote/gateways/remote_payscout_test.rb
+++ b/test/remote/gateways/remote_payscout_test.rb
@@ -21,12 +21,10 @@ class RemotePayscoutTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
     assert response = @gateway.purchase(@amount, @credit_card, @options)
 
-
     assert_success response
     assert_equal 'The transaction has been approved', response.message
     assert_equal 'N', response.cvv_result['code']
   end
-
 
   def test_approved_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_quickpay_v4_test.rb
+++ b/test/remote/gateways/remote_quickpay_v4_test.rb
@@ -51,8 +51,6 @@ class RemoteQuickpayV4Test < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
-
-
   def test_successful_usd_purchase
     assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
     assert_equal 'OK', response.message

--- a/test/remote/gateways/remote_quickpay_v5_test.rb
+++ b/test/remote/gateways/remote_quickpay_v5_test.rb
@@ -51,8 +51,6 @@ class RemoteQuickpayV5Test < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
-
-
   def test_successful_usd_purchase
     assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
     assert_equal 'OK', response.message

--- a/test/remote/gateways/remote_quickpay_v6_test.rb
+++ b/test/remote/gateways/remote_quickpay_v6_test.rb
@@ -51,8 +51,6 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
-
-
   def test_successful_usd_purchase
     assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
     assert_equal 'OK', response.message

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -105,7 +105,6 @@ class RemoteRealexTest < Test::Unit::TestCase
       assert_equal '101', response.params['result']
       assert_equal response.params['message'], response.message
     end
-
   end
 
   def test_realex_purchase_with_apple_pay_declined
@@ -141,7 +140,6 @@ class RemoteRealexTest < Test::Unit::TestCase
       assert_equal '103', response.params['result']
       assert_equal RealexGateway::DECLINED, response.message
     end
-
   end
 
   def test_realex_purchase_coms_error
@@ -157,7 +155,6 @@ class RemoteRealexTest < Test::Unit::TestCase
       assert_equal '200', response.params['result']
       assert_equal RealexGateway::BANK_ERROR, response.message
     end
-
   end
 
   def test_realex_expiry_month_error

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -177,6 +177,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
 
     assert_equal clean_transcript.include?('[BLANK]'), true
   end
+
   private
 
   def generate_order_id

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -179,6 +179,7 @@ class RemoteRedsysTest < Test::Unit::TestCase
 
     assert_equal clean_transcript.include?('[BLANK]'), true
   end
+
   private
 
   def generate_order_id

--- a/test/remote/gateways/remote_so_easy_pay_test.rb
+++ b/test/remote/gateways/remote_so_easy_pay_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class RemoteSoEasyPayTest < Test::Unit::TestCase
 
-
   def setup
     @gateway = SoEasyPayGateway.new(fixtures(:so_easy_pay))
 

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -76,7 +76,6 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal 'CVV matches', response.cvv_result['message']
   end
 
-
   def test_successful_purchase_without_cvv
     credit_card_opts = {
       :number => 4485896261017708,

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -240,7 +240,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
 
-
   # Worldpay has a delay between asking for a transaction to be captured and actually marking it as captured
   # These 2 tests work if you get authorizations from a purchase, wait some time and then perform the refund/void operation.
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -127,6 +127,7 @@ module ActiveMerchant
     end
 
     private
+
     def clean_backtrace(&block)
       yield
     rescue AssertionClass => e
@@ -141,6 +142,7 @@ module ActiveMerchant
     DEFAULT_CREDENTIALS = File.join(File.dirname(__FILE__), 'fixtures.yml') unless defined?(DEFAULT_CREDENTIALS)
 
     private
+
     def default_expiration_date
       @default_expiration_date ||= Date.new((Time.now.year + 1), 9, 30)
     end
@@ -325,11 +327,11 @@ module ActionViewHelperTestHelper
   end
 
   protected
+
   def protect_against_forgery?
     false
   end
 end
-
 
 class MockResponse
   attr_reader   :code, :body, :message

--- a/test/unit/gateways/allied_wallet_test.rb
+++ b/test/unit/gateways/allied_wallet_test.rb
@@ -278,7 +278,6 @@ class AlliedWalletTest < Test::Unit::TestCase
     )
   end
 
-
   def empty_purchase_response
     %(
     {
@@ -296,7 +295,6 @@ class AlliedWalletTest < Test::Unit::TestCase
       "id": "123456",
     )
   end
-
 
   def transcript
     %(

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -879,7 +879,6 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'Y', response.avs_result['street_match']
     assert_equal 'Y', response.avs_result['postal_match']
 
-
     @gateway.expects(:ssl_post).returns(address_not_provided_avs_response)
 
     response = @gateway.purchase(@amount, @credit_card)
@@ -2209,7 +2208,6 @@ class AuthorizeNetTest < Test::Unit::TestCase
         </messages>
       </createCustomerProfileTransactionResponse>
     eos
-
   end
 
   def successful_void_using_stored_card_response

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -539,7 +539,6 @@ RESPONSE
 RESPONSE
   end
 
-
   def declined_response
     <<-RESPONSE
 {

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -89,7 +89,6 @@ class BanwireTest < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
-
   private
 
   def failed_purchase_response

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -162,7 +162,6 @@ class BeanstreamTest < Test::Unit::TestCase
     assert_equal 'DECLINE', response.message
   end
 
-
   # Testing Non-American countries
 
   def test_german_address_sets_state_to_the_required_dummy_value

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -68,7 +68,6 @@ class BluePayTest < Test::Unit::TestCase
     assert_equal 'AK', result[:STATE]
     assert_equal '123 Test St.', result[:ADDR1]
     assert_equal 'US', result[:COUNTRY]
-
   end
 
   def test_name_comes_from_payment_method
@@ -177,7 +176,6 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_message_from
-
     def get_msg(query)
       @gateway.send(:parse, query).message
     end

--- a/test/unit/gateways/card_connect_test.rb
+++ b/test/unit/gateways/card_connect_test.rb
@@ -192,7 +192,6 @@ class CardConnectTest < Test::Unit::TestCase
   end
 
   def test_failed_unstore
-
   end
 
   def test_scrub

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -196,7 +196,6 @@ class CardStreamTest < Test::Unit::TestCase
   end
 
   def test_purchase_options
-
     # Default
     purchase = stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options)

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -147,6 +147,7 @@ class Cashnet < Test::Unit::TestCase
   end
 
   private
+
   def expected_expiration_date
     '%02d%02d' % [@credit_card.month, @credit_card.year.to_s[2..4]]
   end

--- a/test/unit/gateways/cecabank_test.rb
+++ b/test/unit/gateways/cecabank_test.rb
@@ -77,7 +77,6 @@ class CecabankTest < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
-
   private
 
   def successful_purchase_response

--- a/test/unit/gateways/cenpos_test.rb
+++ b/test/unit/gateways/cenpos_test.rb
@@ -307,7 +307,6 @@ class CenposTest < Test::Unit::TestCase
     )
   end
 
-
   def successful_credit_response
     %(
       <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><ProcessCreditCardResponse xmlns="http://tempuri.org/"><ProcessCreditCardResult i:type="a:ProcessRecurringSaleResponse" xmlns:a="http://schemas.datacontract.org/2004/07/Acriter.ABI.CenPOS.EPayment.VirtualTerminal.v6.Common" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Message xmlns="http://schemas.datacontract.org/2004/07/Acriter.ABI.CenPOS.EPayment.VirtualTerminal.Common">Approved</Message><Result xmlns="http://schemas.datacontract.org/2004/07/Acriter.ABI.CenPOS.EPayment.VirtualTerminal.Common">0</Result><a:AccountBalanceAmount i:nil="true"/><a:Amount>91.13</a:Amount><a:AutorizationNumber i:nil="true"/><a:CardType>VISA</a:CardType><a:Discount>0</a:Discount><a:DiscountAmount>0</a:DiscountAmount><a:EmvData i:nil="true"/><a:OriginalAmount>91.13</a:OriginalAmount><a:ParameterValidationResultList/><a:PartiallyAuthorizedAmount i:nil="true"/><a:ReferenceNumber>1609996211</a:ReferenceNumber><a:Surcharge>0</a:Surcharge><a:SurchargeAmount>0</a:SurchargeAmount><a:TraceNumber i:nil="true"/><a:ProtectedCardNumber i:nil="true"/><a:RecurringSaleTokenId i:nil="true"/></ProcessCreditCardResult></ProcessCreditCardResponse></s:Body></s:Envelope>

--- a/test/unit/gateways/commercegate_test.rb
+++ b/test/unit/gateways/commercegate_test.rb
@@ -59,7 +59,6 @@ class CommercegateTest < Test::Unit::TestCase
     assert_equal 'EUR', response.params['currencyCode']
   end
 
-
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
     assert response = @gateway.void('100130291412', @options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -88,7 +88,6 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
-
   def test_successful_check_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -122,6 +122,7 @@ class DataCashTest < Test::Unit::TestCase
   end
 
   private
+
   def failed_purchase_response
     <<-XML
 <Response>

--- a/test/unit/gateways/digitzs_test.rb
+++ b/test/unit/gateways/digitzs_test.rb
@@ -231,7 +231,6 @@ Conn close
     )
   end
 
-
   def failed_purchase_response
     %(
       {\"meta\":{},\"errors\":[{\"status\":\"400\",\"source\":{\"pointer\":\"/payments\"},\"title\":\"Bad Request\",\"detail\":\"Partner error: Credit card declined (transaction element shows reason for decline)\",\"code\":\"58\",\"meta\":{\"debug\":{\"message\":\"Include debug info with support request.\",\"resource\":\"/payments POST\",\"log\":\"2017/02/02/[23]eb325f3ca78b4f7eb2178a0d1e635a0e\",\"request\":\"73c22dc3-e980-11e6-9390-69c24d5ed1f4\"},\"transaction\":{\"code\":\"51\",\"message\":\"Insufficient funds\",\"invoice\":\"3d1f247d9112349e3db252f9f3327047\",\"authCode\":\"A11111\",\"avsResult\":\"T\"}}}]}

--- a/test/unit/gateways/efsnet_test.rb
+++ b/test/unit/gateways/efsnet_test.rb
@@ -22,7 +22,6 @@ class EfsnetTest < Test::Unit::TestCase
     assert response.test?
     assert_equal '100018347764;1.00', response.authorization
     assert_equal 'Approved', response.message
-
   end
 
   def test_unsuccessful_purchase
@@ -92,6 +91,7 @@ class EfsnetTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     <<-XML
 <?xml version="1.0"?>

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -61,6 +61,7 @@ class ElementTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, 'bad-payment-account-token-id', @options)
     assert_failure response
   end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -125,7 +125,6 @@ class EwayManagedTest < Test::Unit::TestCase
       request_hash['Envelope']['Body']['ProcessPayment']['invoiceReference'] == 'order_id'
     }.returns(successful_purchase_response)
     @gateway.purchase(@amount, @valid_customer_id, options)
-
   end
 
   def test_invalid_customer_id

--- a/test/unit/gateways/eway_test.rb
+++ b/test/unit/gateways/eway_test.rb
@@ -97,6 +97,7 @@ class EwayTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     <<-XML
       <?xml version="1.0"?>

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -48,7 +48,6 @@ class ExactTest < Test::Unit::TestCase
     assert_failure response
   end
 
-
   def test_expdate
     assert_equal( '%02d%s' % [ @credit_card.month,
                                @credit_card.year.to_s[-2..-1] ],
@@ -85,8 +84,8 @@ class ExactTest < Test::Unit::TestCase
     assert_equal 'M', response.cvv_result['code']
   end
 
-
   private
+
   def successful_purchase_response
     <<-RESPONSE
 <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/" xmlns:types="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><q1:SendAndCommitResponse xmlns:q1="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/Response"><SendAndCommitResult href="#id1" /></q1:SendAndCommitResponse><types:TransactionResult id="id1" xsi:type="types:TransactionResult"><ExactID xsi:type="xsd:string">A00427-01</ExactID><Password xsi:type="xsd:string">#######</Password><Transaction_Type xsi:type="xsd:string">00</Transaction_Type><DollarAmount xsi:type="xsd:string">1</DollarAmount><SurchargeAmount xsi:type="xsd:string">0</SurchargeAmount><Card_Number xsi:type="xsd:string">4242424242424242</Card_Number><Transaction_Tag xsi:type="xsd:string">106625152</Transaction_Tag><Authorization_Num xsi:type="xsd:string">ET1700</Authorization_Num><Expiry_Date xsi:type="xsd:string">0909</Expiry_Date><CardHoldersName xsi:type="xsd:string">Longbob Longsen</CardHoldersName><VerificationStr2 xsi:type="xsd:string">123</VerificationStr2><CVD_Presence_Ind xsi:type="xsd:string">1</CVD_Presence_Ind><Secure_AuthRequired xsi:type="xsd:string">0</Secure_AuthRequired><Secure_AuthResult xsi:type="xsd:string">0</Secure_AuthResult><Ecommerce_Flag xsi:type="xsd:string">0</Ecommerce_Flag><CAVV_Algorithm xsi:type="xsd:string">0</CAVV_Algorithm><Reference_No xsi:type="xsd:string">1</Reference_No><Reference_3 xsi:type="xsd:string">Store Purchase</Reference_3><Language xsi:type="xsd:string">0</Language><LogonMessage xsi:type="xsd:string">Processed by:
@@ -122,6 +121,7 @@ _______________________________________
 </CTR></types:TransactionResult></soap:Body></soap:Envelope>
     RESPONSE
   end
+
   def successful_refund_response
     <<-RESPONSE
 <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/" xmlns:types="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><q1:SendAndCommitResponse xmlns:q1="http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/Response"><SendAndCommitResult href="#id1" /></q1:SendAndCommitResponse><types:TransactionResult id="id1" xsi:type="types:TransactionResult"><ExactID xsi:type="xsd:string">A00427-01</ExactID><Password xsi:type="xsd:string">#######</Password><Transaction_Type xsi:type="xsd:string">00</Transaction_Type><DollarAmount xsi:type="xsd:string">1</DollarAmount><SurchargeAmount xsi:type="xsd:string">0</SurchargeAmount><Card_Number xsi:type="xsd:string">4242424242424242</Card_Number><Transaction_Tag xsi:type="xsd:string">106625152</Transaction_Tag><Authorization_Num xsi:type="xsd:string">ET1700</Authorization_Num><Expiry_Date xsi:type="xsd:string">0909</Expiry_Date><CardHoldersName xsi:type="xsd:string">Longbob Longsen</CardHoldersName><VerificationStr2 xsi:type="xsd:string">123</VerificationStr2><CVD_Presence_Ind xsi:type="xsd:string">1</CVD_Presence_Ind><Secure_AuthRequired xsi:type="xsd:string">0</Secure_AuthRequired><Secure_AuthResult xsi:type="xsd:string">0</Secure_AuthResult><Ecommerce_Flag xsi:type="xsd:string">0</Ecommerce_Flag><CAVV_Algorithm xsi:type="xsd:string">0</CAVV_Algorithm><Reference_No xsi:type="xsd:string">1</Reference_No><Reference_3 xsi:type="xsd:string">Store Purchase</Reference_3><Language xsi:type="xsd:string">0</Language><LogonMessage xsi:type="xsd:string">Processed by:

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -236,6 +236,7 @@ read 214 bytes
 Conn close
     POST_SCRUBBED
   end
+
   # Place raw successful response from gateway here
   def successful_purchase_response
     {

--- a/test/unit/gateways/federated_canada_test.rb
+++ b/test/unit/gateways/federated_canada_test.rb
@@ -26,8 +26,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
     assert_success response
     assert_equal '1355694937', response.authorization
     assert_equal 'auth', response.params['type']
-  end
-  
+  end  
   
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
@@ -69,8 +68,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
 
     assert data = @gateway.send(:post_data, 'auth', params)
     assert_equal post_data_fixture.size, data.size
-  end
-  
+  end  
   
   def test_purchase_meets_minimum_requirements
     params = {:amount => @amount}

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -481,6 +481,7 @@ issuer pursuant to cardholder agreement.
   </TransactionResult>
     RESPONSE
   end
+
   def successful_purchase_with_specified_currency_response
     <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>
@@ -569,6 +570,7 @@ issuer pursuant to cardholder agreement.
   </TransactionResult>
     RESPONSE
   end
+
   def successful_purchase_response_without_transarmor
     <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>
@@ -657,6 +659,7 @@ issuer pursuant to cardholder agreement.
   </TransactionResult>
     RESPONSE
   end
+
   def successful_refund_response
     <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -116,7 +116,6 @@ class GatewayTest < Test::Unit::TestCase
     assert_equal [nil, nil], @gateway.send(:split_names, ' ')
   end
 
-
   def test_supports_scrubbing?
     gateway = Gateway.new
     refute gateway.supports_scrubbing?

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -36,7 +36,6 @@ class IridiumTest < Test::Unit::TestCase
     assert response.test?
   end
 
-
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -110,11 +109,9 @@ class IridiumTest < Test::Unit::TestCase
     end
   end
 
-
   def test_transcript_scrubbing
     assert_equal post_scrubbed, @gateway.scrub(pre_scrubbed)
   end
-
 
   private
 

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -141,6 +141,7 @@ class JetpayTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     <<-EOF
     <JetPayResponse>

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -119,7 +119,6 @@ class LinkpointTest < Test::Unit::TestCase
             '12.00', :quantity => '1', :options => [{:name => 'Color', :value =>
                 'Red'}, {:name => 'Size', :value => 'XL'}]},{:id => '111', :description => 'keychain', :price => '3.00', :quantity => '1'}]}
 
-
     assert data = @gateway.send(:post_data, @amount, @credit_card, options)
     assert REXML::Document.new(data)
   end
@@ -191,6 +190,7 @@ class LinkpointTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_authorization_response
     '<r_csp>CSI</r_csp><r_time>Sun Jan 6 21:41:31 2008</r_time><r_ref>0004486182</r_ref><r_error/><r_ordernum>1000</r_ordernum><r_message>APPROVED</r_message><r_code>1234560004486182:NNNM:100018312899:</r_code><r_tdate>1199680890</r_tdate><r_score/><r_authresponse/><r_approved>APPROVED</r_approved><r_avs>NNNM</r_avs>'
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -396,7 +396,6 @@ class LitleTest < Test::Unit::TestCase
     assert @gateway.supports_scrubbing?
   end
 
-
   private
 
   def successful_purchase_response

--- a/test/unit/gateways/maxipago_test.rb
+++ b/test/unit/gateways/maxipago_test.rb
@@ -74,7 +74,6 @@ class MaxipagoTest < Test::Unit::TestCase
     void = @gateway.void(auth.authorization)
     assert_success void
     assert_equal 'VOIDED', void.params['response_message']
-
   end
 
   def test_failed_void

--- a/test/unit/gateways/merchant_partners_test.rb
+++ b/test/unit/gateways/merchant_partners_test.rb
@@ -628,7 +628,6 @@ class MerchantPartnersTest < Test::Unit::TestCase
     )
   end
 
-
   def successful_store_response
     %(<?xml version="1.0"?><interface_driver>
 <trans_catalog>

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -61,7 +61,6 @@ class MetricsGlobalTest < Test::Unit::TestCase
     assert_equal 'CO', result[:state]
     assert_equal '164 Waverley Street', result[:address]
     assert_equal 'US', result[:country]
-
   end
 
   def test_add_invoice

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -98,7 +98,6 @@ class MonerisUsTest < Test::Unit::TestCase
   end
 
   def test_preauth_is_valid_xml
-
    params = {
      :order_id => 'order1',
      :amount => '1.01',
@@ -113,7 +112,6 @@ class MonerisUsTest < Test::Unit::TestCase
   end
 
   def test_purchase_is_valid_xml
-
    params = {
      :order_id => 'order1',
      :amount => '1.01',
@@ -128,7 +126,6 @@ class MonerisUsTest < Test::Unit::TestCase
   end
 
   def test_capture_is_valid_xml
-
    params = {
      :order_id => 'order1',
      :amount => '1.01',

--- a/test/unit/gateways/ncr_secure_pay_test.rb
+++ b/test/unit/gateways/ncr_secure_pay_test.rb
@@ -16,7 +16,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -42,7 +41,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
-
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -67,7 +65,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_capture
-
     response = stub_comms do
       @gateway.capture(@amount, '12345', @options)
     end.check_request do |endpoint, data, headers|
@@ -91,7 +88,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-
     response = stub_comms do
       @gateway.refund(@amount, '12345', @options)
     end.check_request do |endpoint, data, headers|
@@ -115,7 +111,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-
     response = stub_comms do
       @gateway.void('12345', @options)
     end.check_request do |endpoint, data, headers|
@@ -138,7 +133,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, successful_void_response)
@@ -148,7 +142,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_failed_void
-
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
@@ -158,7 +151,6 @@ class NcrSecurePayTest < Test::Unit::TestCase
   end
 
   def test_failed_verify
-
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorize_response, failed_void_response)

--- a/test/unit/gateways/net_registry_test.rb
+++ b/test/unit/gateways/net_registry_test.rb
@@ -105,6 +105,7 @@ class NetRegistryTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     <<-RESPONSE
 approved

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -151,7 +151,6 @@ class NetbanxTest < Test::Unit::TestCase
     assert response.test?
   end
 
-
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed

--- a/test/unit/gateways/netbilling_test.rb
+++ b/test/unit/gateways/netbilling_test.rb
@@ -114,6 +114,7 @@ class NetbillingTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     'avs_code=X&cvv2_code=M&status_code=1&auth_code=999999&trans_id=110270311543&auth_msg=TEST+APPROVED&auth_date=2008-01-25+16:43:54'
   end

--- a/test/unit/gateways/netpay_test.rb
+++ b/test/unit/gateways/netpay_test.rb
@@ -76,7 +76,6 @@ class NetpayTest < Test::Unit::TestCase
     assert response.test?
   end
 
-
   def test_successful_authorize
     @gateway.expects(:ssl_post).with(
       anything,

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -212,7 +212,6 @@ class OptimalPaymentTest < Test::Unit::TestCase
   end
 
   def test_deprecated_options
-
     assert_deprecation_warning("The 'account' option is deprecated in favor of 'account_number' and will be removed in a future version.") do
       @gateway = OptimalPaymentGateway.new(
         :account => '12345678',

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -30,7 +30,6 @@ class PayGateTest < Test::Unit::TestCase
     assert response.test?
   end
 
-
   def test_successful_settlement
     @gateway.expects(:ssl_post).returns(successful_settlement_response)
 
@@ -102,6 +101,5 @@ class PayGateTest < Test::Unit::TestCase
     </protocol>
     ENDOFXML
   end
-
 
 end

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -20,7 +20,6 @@ class PayJunctionTest < Test::Unit::TestCase
     @amount = 100
   end
 
-
   def test_detect_test_credentials_when_in_production
     Base.mode = :production
 
@@ -95,8 +94,8 @@ class PayJunctionTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
-
   private
+
   def successful_authorization_response
     <<-RESPONSE
 dc_merchant_name=PayJunction - (demo)dc_merchant_address=3 W. Carrillodc_merchant_city=Santa Barbaradc_merchant_state=CAdc_merchant_zip=93101dc_merchant_phone=800-601-0230dc_device_id=1174dc_transaction_date=2007-11-28 19:22:33.791634dc_transaction_action=chargedc_approval_code=TAS193dc_response_code=00dc_response_message=APPROVAL TAS193 dc_transaction_id=3144302dc_posture=holddc_invoice_number=9f76c4e4bd66a36dc5aeb4bd7b3a02fadc_notes=--START QUICK-LINK DEBUG--

--- a/test/unit/gateways/pay_secure_test.rb
+++ b/test/unit/gateways/pay_secure_test.rb
@@ -49,6 +49,7 @@ class PaySecureTest < Test::Unit::TestCase
   end
   
   private
+
   def successful_purchase_response
     <<-RESPONSE
 Status: Accepted

--- a/test/unit/gateways/payflow_express_uk_test.rb
+++ b/test/unit/gateways/payflow_express_uk_test.rb
@@ -63,6 +63,7 @@ class PayflowExpressUkTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_get_express_details_response
     <<-RESPONSE
 <?xml version="1.0"?>

--- a/test/unit/gateways/paymill_test.rb
+++ b/test/unit/gateways/paymill_test.rb
@@ -224,6 +224,7 @@ class PaymillTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_store_response
     MockResponse.new 200, %[jsonPFunction({"transaction":{"mode":"CONNECTOR_TEST","channel":"57313835619696ac361dc591bc973626","response":"SYNC","payment":{"code":"CC.DB"},"processing":{"code":"CC.DB.90.00","reason":{"code":"00","message":"Successful Processing"},"result":"ACK","return":{"code":"000.100.112","message":"Request successfully processed in 'Merchant in Connector Test Mode'"},"timestamp":"2013-02-12 21:33:43"},"identification":{"shortId":"1998.1832.1612","uniqueId":"tok_4f9a571b39bd8d0b4db5"}}})]
   end

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -6,7 +6,9 @@ require 'nokogiri'
 class CommonPaypalGateway < ActiveMerchant::Billing::Gateway
   include ActiveMerchant::Billing::PaypalCommonAPI
   def currency(code); 'USD'; end
+
   def localized_amount(num, code); num; end
+
   def commit(a, b); end
 end
 
@@ -119,7 +121,6 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_equal '123', REXML::XPath.first(request, '//DoAuthorizationReq/DoAuthorizationRequest/TransactionID').text
     assert_equal '1.00', REXML::XPath.first(request, '//DoAuthorizationReq/DoAuthorizationRequest/Amount').text
   end
-
 
   def test_build_manage_pending_transaction_status_request
     request = REXML::Document.new(@gateway.send(:build_manage_pending_transaction_status,123, 'Accept'))

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -74,7 +74,6 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
    end
   end
 
-
   def test_build_setup_request_valid
     @gateway.expects(:ssl_post).returns(successful_setup_response)
 
@@ -89,9 +88,7 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
                                 :amount   => 100,
                                 :description => 'Description',
                                 :category => 'Digital' } ] )
-
   end
-
 
   private
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -374,7 +374,6 @@ class PaypalExpressTest < Test::Unit::TestCase
                                             {:name => 'item two', :description => 'item two description', :amount => 20000, :number => 2, :quantity => 4}
     ]}))
 
-
     assert_equal 'item one', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name').text
     assert_equal 'item one description', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Description').text
     assert_equal '100.00', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Amount').text
@@ -446,7 +445,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'Billing Agreement Id or transaction Id is not valid', response.message
     assert_equal '11451', response.params['error_codes']
   end
-
 
   def test_build_reference_transaction_test
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
@@ -666,7 +664,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     RESPONSE
   end
 
-
   def successful_authorize_reference_transaction_response
   <<-RESPONSE
 <?xml version="1.0" encoding="UTF-8"?>
@@ -762,7 +759,6 @@ class PaypalExpressTest < Test::Unit::TestCase
 	</SOAP-ENV:Envelope>
     RESPONSE
   end
-
 
   def successful_details_response
     <<-RESPONSE

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -1380,7 +1380,6 @@ class PaypalTest < Test::Unit::TestCase
     RESPONSE
   end
 
-
   def successful_update_recurring_payment_profile_response
     <<-RESPONSE
     <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\">

--- a/test/unit/gateways/payscout_test.rb
+++ b/test/unit/gateways/payscout_test.rb
@@ -214,7 +214,6 @@ class PayscoutTest < Test::Unit::TestCase
     assert_equal address[:email],      post[:shipping_email]
   end
 
-
   def test_add_currency_from_options
     post = {}
     @gateway.send(:add_currency, post, 100, { currency: 'CAD' })

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class PaystationTest < Test::Unit::TestCase
   include CommStub
   def setup
-
     @gateway = PaystationGateway.new(
                  :paystation_id => 'some_id_number',
                  :gateway_id    => 'another_id_number'
@@ -80,7 +79,6 @@ class PaystationTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -50,7 +50,6 @@ class PaywayTest < Test::Unit::TestCase
     assert_match '0', response.params['summary_code']
     assert_match '08', response.params['response_code']
     assert_match 'VISA', response.params['card_scheme_name']
-
   end
 
   def test_successful_purchase_master_card

--- a/test/unit/gateways/plugnpay_test.rb
+++ b/test/unit/gateways/plugnpay_test.rb
@@ -80,7 +80,6 @@ class PlugnpayTest < Test::Unit::TestCase
 
     assert_equal result[:card_address1], '164 Waverley Street'
     assert_equal result[:card_country], 'DE'
-
   end
 
   def test_add_address
@@ -108,6 +107,7 @@ class PlugnpayTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_purchase_response
     "FinalStatus=success&IPaddress=72%2e138%2e32%2e216&MStatus=success&User_Agent=&acct_code3=newcard&address1=1234%20My%20Street&address2=Apt%201&app_level=5&auth_code=TSTAUT&auth_date=20080125&auth_msg=%20&authtype=authpostauth&avs_code=X&card_address1=1234%20My%20Street&card_amount=1%2e00&card_city=Ottawa&card_country=CA&card_name=Longbob%20Longsen&card_state=ON&card_type=VISA&card_zip=K1C2N6&city=Ottawa&convert=underscores&country=CA&currency=usd&cvvresp=M&dontsndmail=yes&easycart=0&merchant=pnpdemo2&merchfraudlev=&mode=auth&orderID=2008012522252119738&phone=555%2d555%2d5555&publisher_email=trash%40plugnpay%2ecom&publisher_name=pnpdemo2&publisher_password=pnpdemo222&resp_code=00&shipinfo=0&shipname=Jim%20Smith&sresp=A&state=ON&success=yes&zip=K1C2N6&a=b\n"
   end

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -54,6 +54,7 @@ class PslCardTest < Test::Unit::TestCase
   end
   
   private
+
   def successful_purchase_response
     'ResponseCode=00&Message=AUTHCODE:01256&CrossReference=08012522454901256086&First4=4543&Last4=9982&ExpMonth=12&ExpYear=2010&AVSCV2Check=ALL MATCH&Amount=1000&QAAddress=76 Roseby Avenue Manchester&QAPostcode=M63X 7TH&MerchantName=Merchant Name&QAName=John Smith'
   end

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -242,7 +242,6 @@ SRC
 SRC
 
     assert_xml_equal valid_refund_request_xml, @gateway.build_refund_request(@amount, '1;4321;1234', {})
-
   end
 
   def test_refund_with_rebate_secret_xml
@@ -265,7 +264,6 @@ SRC
 SRC
 
     assert_xml_equal valid_refund_request_xml, gateway.build_refund_request(@amount, '1;4321;1234', {})
-
   end
 
   def test_auth_with_address
@@ -283,7 +281,6 @@ SRC
     assert_instance_of Response, response
     assert_success response
     assert response.test?
-
   end
 
   def test_zip_in_shipping_address

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -470,7 +470,6 @@ DeclineCode=00
 ExpiryDate=0616
 BankAuthCode=999777
   TRANSCRIPT
-
   end
 
   def scrubbed_transcript
@@ -492,6 +491,5 @@ DeclineCode=00
 ExpiryDate=0616
 BankAuthCode=999777
   TRANSCRIPT
-
   end
 end

--- a/test/unit/gateways/sage_test.rb
+++ b/test/unit/gateways/sage_test.rb
@@ -324,6 +324,7 @@ class SageGatewayTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_authorization_response
     "\002A911911APPROVED                        00MX001234567890\0341000\0340\034\003"
   end

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -27,7 +27,6 @@ class SecurePayAuTest < Test::Unit::TestCase
     assert_equal [:visa, :master, :american_express, :diners_club, :jcb], SecurePayAuGateway.supported_cardtypes
   end
 
-
   def test_successful_purchase_with_live_data
     @gateway.expects(:ssl_post).returns(successful_live_purchase_response)
 

--- a/test/unit/gateways/secure_pay_tech_test.rb
+++ b/test/unit/gateways/secure_pay_tech_test.rb
@@ -34,6 +34,7 @@ class SecurePayTechTest < Test::Unit::TestCase
   end
  
   private
+
   def successful_purchase_response
     "1,4--120119220646821,000000014511,23284,014511,20080125\r\n"
   end

--- a/test/unit/gateways/secure_pay_test.rb
+++ b/test/unit/gateways/secure_pay_test.rb
@@ -48,7 +48,6 @@ class SecurePayTest < Test::Unit::TestCase
     assert response.authorization
   end
 
-
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 

--- a/test/unit/gateways/skip_jack_test.rb
+++ b/test/unit/gateways/skip_jack_test.rb
@@ -193,7 +193,6 @@ class SkipJackTest < Test::Unit::TestCase
     assert_failure response
   end
 
-
   def test_serial_number_is_added_before_developer_serial_number_for_authorization
     expected ="Year=#{Time.now.year + 1}&TransactionAmount=1.00&ShipToPhone=&SerialNumber=X&SJName=Longbob+Longsen&OrderString=1~None~0.00~0~N~%7C%7C&OrderNumber=1&OrderDescription=&Month=9&InvoiceNumber=&Email=cody%40example.com&DeveloperSerialNumber=Y&CustomerCode=&CVV2=123&AccountNumber=4242424242424242"
     expected = expected.gsub('~', '%7E') if RUBY_VERSION < '2.5.0'
@@ -235,6 +234,7 @@ class SkipJackTest < Test::Unit::TestCase
   end
 
   private
+
   def successful_authorization_response
     <<-CSV
 "AUTHCODE","szSerialNumber","szTransactionAmount","szAuthorizationDeclinedMessage","szAVSResponseCode","szAVSResponseMessage","szOrderNumber","szAuthorizationResponseCode","szIsApproved","szCVV2ResponseCode","szCVV2ResponseMessage","szReturnCode","szTransactionFileName","szCAVVResponseCode"

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1413,7 +1413,6 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
   end
 
-
   def test_passing_stripe_account_header
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
       headers.include?('Stripe-Account')

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -493,7 +493,6 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     'UMversion=2.9&UMstatus=Approved&UMauthCode=TM80A5&UMrefNum=133134971&UMavsResult=No%20AVS%20response%20%28Typically%20no%20AVS%20data%20sent%20or%20swiped%20transaction%29&UMavsResultCode=&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMfiller=filled'
   end
 
-
   def pre_scrubbed
     <<-EOS
 opening connection to sandbox.usaepay.com:443...

--- a/test/unit/gateways/verifi_test.rb
+++ b/test/unit/gateways/verifi_test.rb
@@ -69,7 +69,6 @@ class VerifiTest < Test::Unit::TestCase
     result = {}
     @gateway.send(:add_invoice_data, result, :description => 'My Purchase is great')
     assert_equal 'My Purchase is great', result[:orderdescription]
-
   end
 
   def test_purchase_meets_minimum_requirements
@@ -83,7 +82,6 @@ class VerifiTest < Test::Unit::TestCase
     minimum_requirements.each do |key|
       assert_not_nil(data =~ /#{key}=/)
     end
-
   end
 
   def test_avs_result

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -579,7 +579,6 @@ class WirecardTest < Test::Unit::TestCase
     XML
   end
 
-
   # Purchase failure
   def wrong_creditcard_purchase_response
     <<-XML

--- a/test/unit/gateways/worldpay_online_payments_test.rb
+++ b/test/unit/gateways/worldpay_online_payments_test.rb
@@ -198,9 +198,11 @@ class WorldpayOnlinePaymentsTest < Test::Unit::TestCase
   def successful_token_response
     %({"token": "TEST_RU_8fcc4f2f-8c0d-483d-a0a3-eaad7356623e","paymentMethod": {"type": "ObfuscatedCard","name": "Longbob Longsen","expiryMonth": 10,"expiryYear": 2016,"cardType": "VISA","maskedCardNumber": "**** **** **** 1111"},"reusable": true})
   end
+
   def successful_authorize_response
     %({"orderCode": "a46502d0-80ba-425b-a6db-2c57e9de91da","token": "TEST_RU_8fcc4f2f-8c0d-483d-a0a3-eaad7356623e","orderDescription": "Test Purchase","amount": 0,"currencyCode": "GBP","authorizeOnly": true,"paymentStatus": "AUTHORIZED","paymentResponse": {"type": "ObfuscatedCard","name": "Longbob Longsen","expiryMonth": 10,"expiryYear": 2016,"cardType": "VISA_CREDIT","maskedCardNumber": "**** **** **** 1111"},"environment": "TEST","authorizedAmount": 1000})
   end
+
   def failed_authorize_response
     %({"httpStatusCode":400,"customCode":"BAD_REQUEST","message":"CVC can't be null/empty","description":"Some of request parameters are invalid, please check your request. For more information please refer to Json schema.","errorHelpUrl":null,"originalRequest":"{'reusable':false,'paymentMethod':{'type':'Card','name':'Example Name','expiryMonth':'**','expiryYear':'****','cardNumber':'**** **** **** 1111','cvc':''},'clientKey':'T_C_845d39f4-f33c-430c-8fca-ad89bf1e5810'}"}    )
   end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -67,7 +67,6 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     end
   end
 
-
   def test_invalid_response_error
     assert_raises(ActiveMerchant::InvalidResponseError) do
       retry_exceptions do


### PR DESCRIPTION
Okay, this touches a lot of files. But it's literally all just removing or adding blank lines, and I skipped the only vaguely controversial ones (blank lines around class defs), so it shouldn't be a bad audit/should avoid the issues we hit in #2906