### PR TITLE
Revert "Stripe: support shipping info in purchases"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,6 @@
 * Stripe: support a reason for voiding a transaction [whitby3001] #2378
 * Payeezy: Add reversal_id in support of timeout reversals [dtykocki] #2997
 * Stripe: support Level 3 transaction fields [bpollack] #2996
-* Stripe: support passing shipping info for purchases [whitby3001] #2379
 
 == Version 1.83.0 (August 30, 2018)
 * CT Payment: Update How Address is Passed [nfarve] #2960

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -321,7 +321,6 @@ module ActiveMerchant #:nodoc:
         end
 
         add_metadata(post, options)
-        add_shipping_info(post, options)
         add_application_fee(post, options)
         add_exchange_rate(post, options)
         add_destination(post, options)
@@ -489,28 +488,6 @@ module ActiveMerchant #:nodoc:
       def add_emv_metadata(post, creditcard)
         post[:metadata] ||= {}
         post[:metadata][:card_read_method] = creditcard.read_method if creditcard.respond_to?(:read_method)
-      end
-      
-      def add_shipping_info(post, options = {})
-        post[:shipping] = {}
-
-        if address = options[:shipping_address]
-          address_params = {}
-          address_params[:line1] = address[:address1] if address[:address1]
-          address_params[:line2] = address[:address2] if address[:address2]
-          address_params[:city] = address[:city] if address[:city]
-          address_params[:state] = address[:state] if address[:state]
-          address_params[:postal_code] = address[:zip] if address[:zip]
-          address_params[:country] = address[:country] if address[:country]
-          post[:shipping][:address] = address_params unless address_params.empty?
-          post[:shipping][:name] = address[:name] if address[:name]
-          post[:shipping][:phone] = address[:phone] if address[:phone]
-        end
-
-        post[:shipping][:carrier] = options[:carrier] if options[:carrier]
-        post[:shipping][:tracking_number] = options[:tracking_number] if options[:tracking_number]
-
-        post.delete(:shipping) if post[:shipping].empty?
       end
 
       def fetch_application_fee(identification, options = {})

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -122,24 +122,6 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'wow@example.com', response.params['metadata']['email']
   end
 
-  def test_successful_purchase_with_shipping_info
-    custom_options = @options.merge(:shipping_address => address(), :carrier => 'UPS', :tracking_number => '12345')
-    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
-    assert_success response
-    assert_equal 'charge', response.params['object']
-    assert response.params['paid']
-    assert_equal custom_options[:shipping_address][:name], response.params['shipping']['name']
-    assert_equal custom_options[:shipping_address][:address1], response.params['shipping']['address']['line1']
-    assert_equal custom_options[:shipping_address][:address2], response.params['shipping']['address']['line2']
-    assert_equal custom_options[:shipping_address][:city], response.params['shipping']['address']['city']
-    assert_equal custom_options[:shipping_address][:state], response.params['shipping']['address']['state']
-    assert_equal custom_options[:shipping_address][:zip], response.params['shipping']['address']['postal_code']
-    assert_equal custom_options[:shipping_address][:country], response.params['shipping']['address']['country']
-    assert_equal custom_options[:shipping_address][:phone], response.params['shipping']['phone']
-    assert_equal custom_options[:carrier], response.params['shipping']['carrier']
-    assert_equal custom_options[:tracking_number], response.params['shipping']['tracking_number']
-  end
-
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -13,10 +13,7 @@ class StripeTest < Test::Unit::TestCase
     @options = {
       :billing_address => address(),
       :statement_address => statement_address(),
-      :description => 'Test Purchase',
-      :shipping_address => address(),
-      :carrier => 'UPS',
-      :tracking_number => '12345'
+      :description => 'Test Purchase'
     }
 
     @apple_pay_payment_token = apple_pay_payment_token
@@ -1061,21 +1058,6 @@ class StripeTest < Test::Unit::TestCase
 
       assert_equal nil, post[:statement_address]
     end
-  end
-
-  def test_add_shipping_info
-    post = {:card => {}}
-    @gateway.send(:add_shipping_info, post, @options)
-    assert_equal @options[:shipping_address][:zip], post[:shipping][:address][:postal_code]
-    assert_equal @options[:shipping_address][:state], post[:shipping][:address][:state]
-    assert_equal @options[:shipping_address][:address1], post[:shipping][:address][:line1]
-    assert_equal @options[:shipping_address][:address2], post[:shipping][:address][:line2]
-    assert_equal @options[:shipping_address][:country], post[:shipping][:address][:country]
-    assert_equal @options[:shipping_address][:city], post[:shipping][:address][:city]
-    assert_equal @options[:shipping_address][:name], post[:shipping][:name]
-    assert_equal @options[:shipping_address][:phone], post[:shipping][:phone]
-    assert_equal @options[:carrier], post[:shipping][:carrier]
-    assert_equal @options[:tracking_number], post[:shipping][:tracking_number]
   end
 
   def test_ensure_does_not_respond_to_credit


### PR DESCRIPTION
This reverts commit d4d927e42a6ac7c0ce15be7e9a14f6c2f00a0ff5. As-written, this could cause transaction to fail in some situations: Stripe will validate *all* shipping parameters if *any* are present, so attempting a purchase with some but not all shipping params could cause the entire purchase to be rejected. The proper fix is to not include any shipping details unless all are present, but for now, simply remove the functionality entirely.