### PR TITLE
UsaEpayTransaction: Support UMcheckformat option for echecks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* UsaEpayTransaction: Support UMcheckformat option for echecks [dtykocki] [#3002]
+
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] [#3001]
 

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
 
         add_amount(post, money)
         add_invoice(post, options)
-        add_payment(post, payment)
+        add_payment(post, payment, options)
         unless payment.respond_to?(:track_data) && payment.track_data.present?
           add_address(post, payment, options)
           add_customer_data(post, options)
@@ -195,8 +195,9 @@ module ActiveMerchant #:nodoc:
         post[:description]  = options[:description]
       end
 
-      def add_payment(post, payment)
+      def add_payment(post, payment, options={})
         if payment.respond_to?(:routing_number)
+          post[:checkformat] = options[:check_format] if options[:check_format]
           post[:account] = payment.account_number
           post[:routing] = payment.routing_number
           post[:name]    = payment.name unless payment.name.blank?

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -29,6 +29,13 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_echeck_and_extra_options
+    extra_options = @options.merge(check_format: 'ARC')
+    assert response = @gateway.purchase(@amount, @check, extra_options)
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
   def test_successful_authorization_with_manual_entry
     @credit_card.manual_entry = true
     assert response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -53,6 +53,19 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_echeck_and_extra_options
+    response = stub_comms do
+      @gateway.purchase(@amount, @check, @options.merge(check_format: 'ARC'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/UMcheckformat=ARC/, data)
+    end.respond_with(successful_purchase_response_echeck)
+
+    assert_equal 'Success', response.message
+    assert_equal '133134803', response.authorization
+    assert_success response
+    assert response.test?
+  end
+
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(unsuccessful_purchase_response)
 


### PR DESCRIPTION
Remote:
26 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
46 tests, 270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed