### PR TITLE
[Payflow Express] Use phone returned from payload on Response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Barclaycard Smartpay: allow third-party payouts for credits [bpollack] #3009
 * RuboCop: AlignHash [nfarve] #3004
 * Beanstream: Switch `recurringPayment` flag from boolean to integer [dtykocki] #3011
+* Payflow Express: Add phone to returned Response [filipebarcos] [#3003]
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] [#3001]

--- a/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
@@ -22,6 +22,10 @@ module ActiveMerchant #:nodoc:
         address['country']
       end
 
+      def phone
+        @params['phone']
+      end
+
       def address
         {  'name'       => @params['shiptoname'] || full_name,
            'company'    => nil,
@@ -31,7 +35,7 @@ module ActiveMerchant #:nodoc:
            'state'      => @params['state'],
            'country'    => @params['country'],
            'zip'        => @params['zip'],
-           'phone'      => nil
+           'phone'      => phone,
         }
       end
     end

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -114,7 +114,7 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert_equal 'CA', address['state']
     assert_equal '95100', address['zip']
     assert_equal 'US', address['country']
-    assert_nil address['phone']
+    assert_equal '555-555-5555', address['phone']
   end
 
   def test_get_express_details_with_ship_to_name
@@ -139,7 +139,7 @@ class PayflowExpressTest < Test::Unit::TestCase
     assert_equal 'CA', address['state']
     assert_equal '95100', address['zip']
     assert_equal 'US', address['country']
-    assert_nil address['phone']
+    assert_equal '555-555-5555', address['phone']
   end
 
   def test_get_express_details_with_invalid_xml
@@ -179,6 +179,7 @@ class PayflowExpressTest < Test::Unit::TestCase
           <FeeAmount>0</FeeAmount>
           <PayerStatus>verified</PayerStatus>
           <Name>Joe</Name>
+          <Phone>555-555-5555</Phone>
           <ShipTo>
             <Address>
               <Street>#{options[:street]}</Street>
@@ -215,6 +216,7 @@ class PayflowExpressTest < Test::Unit::TestCase
           <FeeAmount>0</FeeAmount>
           <PayerStatus>verified</PayerStatus>
           <Name>Joe</Name>
+          <Phone>555-555-5555</Phone>
           <ShipTo>
             <Address>
               <Street>111 Main St.</Street>


### PR DESCRIPTION
Get phone number from Payflow Express response payload

This provides feature parity with Paypal Express.

In Paypal Express, we fetch this information from elsewhere, since payload is different, but we simply don't set this info when the integration is with Payflow.
https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb#L49