### PR TITLE
Global Collect: handle internal server errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1394,6 +1394,10 @@ Style/SpecialGlobalVars:
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
+Style/StringLiterals:
+  Exclude:
+    - 'test/unit/gateways/global_collect_test.rb'
+
 # Offense count: 307
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, MinSize.
@@ -1460,3 +1464,5 @@ Style/ZeroLengthPredicate:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 2484
+  Exclude:
+    - 'test/unit/gateways/global_collect_test.rb'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * UsaEpayTransaction: Support UMcheckformat option for echecks [dtykocki] [#3002]
+* Global Collect: handle internal server errors [molbrown] [#3005]
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] [#3001]


### PR DESCRIPTION
Ingenico returns HTML when it has a 500 error, which this gateway has
not handled and would crash on a JSON parse error. New rescue provides a
more informative error and prevents crashing in this situation.

Remote:
16 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
19 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed