### PR TITLE
Pass card owner when storing tokenized cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Bambora formerly Beanstream: Pass card owner when storing tokenized cards [#3006]
+* UsaEpayTransaction: Support UMcheckformat option for echecks [dtykocki] [#3002]
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -153,6 +153,8 @@ module ActiveMerchant #:nodoc:
 
       # To match the other stored-value gateways, like TrustCommerce,
       # store and unstore need to be defined
+      #
+      # When passing a single-use token the :name option is required
       def store(payment_method, options = {})
         post = {}
         add_address(post, options)

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -315,6 +315,9 @@ module ActiveMerchant #:nodoc:
         post[:operationType] = options[:operationType] || options[:operation] || secure_profile_action(:new)
         post[:customerCode] = options[:billing_id] || options[:vault_id] || false
         post[:status] = options[:status]
+
+        billing_address = options[:billing_address] || options[:address]
+        post[:trnCardOwner] = billing_address[:name]
       end
 
       def add_recurring_amount(post, money)


### PR DESCRIPTION
Per issue #3006 -- Beanstream requires `trnCardOwner` when storing a tokenized credit card.