### PR TITLE
Regression: Account for nil CC number

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -160,7 +160,7 @@ module ActiveMerchant #:nodoc:
         end
 
         def electron?(number)
-          return false unless [16, 19].include?(number.length)
+          return false unless [16, 19].include?(number&.length)
 
           # don't recalculate for each range
           bank_identification_number = first_digits(number).to_i
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
         end
 
         def first_digits(number)
-          number.slice(0,6)
+          number&.slice(0,6) || ''
         end
 
         def last_digits(number)
@@ -201,11 +201,12 @@ module ActiveMerchant #:nodoc:
         private
 
         def valid_card_number_length?(number) #:nodoc:
+          return false if number.nil?
           number.length >= 12
         end
 
         def valid_card_number_characters?(number) #:nodoc:
-          !number.match(/\D/)
+          !number&.match(/\D/)
         end
 
         def valid_test_mode_card_number?(number) #:nodoc:

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -167,6 +167,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_matching_invalid_card
     assert_nil CreditCard.brand?('XXXXXXXXXXXX0000')
     assert_false CreditCard.valid_number?('XXXXXXXXXXXX0000')
+    assert_false CreditCard.valid_number?(nil)
   end
 
   def test_16_digit_maestro_uk
@@ -212,6 +213,9 @@ class CreditCardMethodsTest < Test::Unit::TestCase
         assert_equal card_number, electron_test.call(card_number)
       end
     end
+
+    # nil check
+    assert_false electron_test.call(nil)
 
     # Visa range
     assert_false electron_test.call('4245180000000000')

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -246,6 +246,16 @@ class CreditCardTest < Test::Unit::TestCase
     assert_equal '1', ccn.last_digits
   end
 
+  def test_should_return_empty_string_for_first_digits_of_nil_card_number
+    ccn = CreditCard.new
+    assert_equal '', ccn.first_digits
+  end
+
+  def test_should_return_empty_string_for_last_digits_of_nil_card_number
+    ccn = CreditCard.new
+    assert_equal '', ccn.last_digits
+  end
+
   def test_should_return_first_four_digits_of_card_number
     ccn = CreditCard.new(:number => '4779139500118580')
     assert_equal '477913', ccn.first_digits


### PR DESCRIPTION
Fixes exceptions created by 2bc7493 when CC number is nil

```
3933 tests, 68237 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```