### PR TITLE
Beanstream: Switch `recurringPayment` flag from boolean to integer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Global Collect: handle internal server errors [molbrown] [#3005]
 * Barclaycard Smartpay: allow third-party payouts for credits [bpollack] #3009
 * RuboCop: AlignHash [nfarve] #3004
+* Beanstream: Switch `recurringPayment` flag from boolean to integer [dtykocki] #3011
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] [#3001]

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -266,7 +266,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_recurring_payment(post, options)
-        post[:recurringPayment] = true if options[:recurring].to_s == 'true'
+        post[:recurringPayment] = 1 if options[:recurring].to_s == 'true'
       end
 
       def add_invoice(post, options)

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -79,10 +79,16 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
   end
 
   def test_successful_visa_purchase_no_cvv
-    assert response = @gateway.purchase(@amount, @visa_no_cvv, @options)
+    assert response = @gateway.purchase(@amount, @visa_no_cvv, @options.merge(recurring: true))
     assert_success response
     assert_false response.authorization.blank?
     assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_visa_purchase_with_no_cvv
+    assert response = @gateway.purchase(@amount, @visa_no_cvv, @options)
+    assert_failure response
+    assert_equal 'Card CVD is invalid.', response.message
   end
 
   def test_unsuccessful_visa_purchase

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -72,7 +72,7 @@ class BeanstreamTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/recurringPayment=true/, data)
+      assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -82,7 +82,7 @@ class BeanstreamTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @decrypted_credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/recurringPayment=true/, data)
+      assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response


### PR DESCRIPTION
Remote:
42 tests, 189 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.2381% passed

Unit:
23 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed