### PR TITLE
RuboCop: fix Style/SafeNavigation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1259,13 +1259,6 @@ Style/RescueStandardError:
   Exclude:
     - 'lib/active_merchant/billing/base.rb'
 
-# Offense count: 33
-# Cop supports --auto-correct.
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.
-# Whitelist: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/SelfAssignment:

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -75,7 +75,7 @@ module ActiveMerchant
           end
 
           def empty?
-            all?{|k, v| v && v.empty?}
+            all?{|k, v| v&.empty?}
           end
 
           def on(field)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -135,7 +135,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless post[:card] && post[:card].kind_of?(Hash)
+        return unless post[:card]&.kind_of?(Hash)
         if (address = options[:billing_address] || options[:address]) && address[:country]
           post[:card][:billingAddress] = {}
           post[:card][:billingAddress][:street] = address[:address1] || 'N/A'

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -878,7 +878,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def format_extra_options(options)
-        options.map{ |k, v| "#{k}=#{v}" }.join('&') unless options.nil?
+        options&.map{ |k, v| "#{k}=#{v}" }&.join('&')
       end
 
       def parse_direct_response(params)

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -375,11 +375,9 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         results = {}
-        if !body.nil?
-          body.split(/&/).each do |pair|
-            key, val = pair.split(/\=/)
-            results[key.to_sym] = val.nil? ? nil : CGI.unescape(val)
-          end
+        body&.split(/&/)&.each do |pair|
+          key, val = pair.split(/\=/)
+          results[key.to_sym] = val.nil? ? nil : CGI.unescape(val)
         end
 
         # Clean up the message text if there is any

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit(money, payment_object, options = {})
-        if(payment_object && payment_object.kind_of?(String))
+        if payment_object&.kind_of?(String)
           ActiveMerchant.deprecated 'credit should only be used to credit a payment method'
           return refund(money, payment_object, options)
         end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -355,7 +355,7 @@ module ActiveMerchant #:nodoc:
           result.success?,
           message_from_result(result),
           response_hash,
-          authorization: (result.transaction.id if result.transaction),
+          authorization: result.transaction&.id,
           test: test?
         )
       end

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -166,8 +166,8 @@ module ActiveMerchant #:nodoc:
         response = {}
 
         doc = Nokogiri::XML(xml)
-        doc.root.xpath('*').each do |node|
-          if (node.elements.size == 0)
+        doc.root&.xpath('*')&.each do |node|
+          if node.elements.size == 0
             response[node.name.downcase.to_sym] = node.text
           else
             node.elements.each do |childnode|
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
               response[name.to_sym] = childnode.text
             end
           end
-        end unless doc.root.nil?
+        end
 
         response
       end

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        response['errorDescription'] || (response['terminalDisp'].strip if response['terminalDisp'])
+        response['errorDescription'] || response['terminalDisp']&.strip
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -677,7 +677,7 @@ module ActiveMerchant #:nodoc:
 
       def lookup_country_code(country_field)
         country_code = Country.find(country_field) rescue nil
-        country_code.code(:alpha2) if country_code
+        country_code&.code(:alpha2)
       end
 
       # Where we actually build the full SOAP request using builder

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -191,10 +191,8 @@ module ActiveMerchant #:nodoc:
         form[:email] = truncate(options[:email], 100) unless empty?(options[:email])
         form[:customer_code] = truncate(options[:customer], 10) unless empty?(options[:customer])
         form[:customer_number] = options[:customer_number] unless empty?(options[:customer_number])
-        if options[:custom_fields]
-          options[:custom_fields].each do |key, value|
-            form[key.to_s] = value
-          end
+        options[:custom_fields]&.each do |key, value|
+          form[key.to_s] = value
         end
       end
 
@@ -283,7 +281,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def custom_field?(field_name, options)
-        return true if options[:custom_fields] && options[:custom_fields].include?(field_name.to_sym)
+        return true if options[:custom_fields]&.include?(field_name.to_sym)
         field_name == :customer_number
       end
 

--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -119,9 +119,9 @@ module ActiveMerchant #:nodoc:
         response = {}
 
         doc = Nokogiri::XML(xml)
-        doc.root.xpath('//RESPONSE/FIELDS/FIELD').each do |field|
+        doc.root&.xpath('//RESPONSE/FIELDS/FIELD')&.each do |field|
           response[field['KEY']] = field.text
-        end unless doc.root.nil?
+        end
 
         response
       end
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         # Silly inconsistent gateway. Always make capitalized (but not all caps)
         msg = (response['auth_response'] || response['response1'])
-        msg.downcase.capitalize if msg
+        msg&.downcase&.capitalize
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -274,7 +274,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def test?
-        (@options[:secret_api_key] && @options[:secret_api_key].include?('_cert_'))
+        @options[:secret_api_key]&.include?('_cert_')
       end
 
       ISSUER_MESSAGES = {

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -395,7 +395,7 @@ module ActiveMerchant #:nodoc:
 
       def lookup_country_code(code)
         country = Country.find(code) rescue nil
-        country && country.code(:alpha3)
+        country&.code(:alpha3)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -430,7 +430,7 @@ module ActiveMerchant #:nodoc:
 
       def lookup_country_code(code)
         country = Country.find(code) rescue nil
-        country && country.code(:alpha3)
+        country&.code(:alpha3)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -434,9 +434,9 @@ module ActiveMerchant #:nodoc:
         response = {:message => 'Global Error Receipt', :complete => false}
 
         xml = REXML::Document.new("<response>#{xml}</response>")
-        xml.root.elements.each do |node|
+        xml.root&.elements&.each do |node|
           response[node.name.downcase.sub(/^r_/, '').to_sym] = normalize(node.text)
-        end unless xml.root.nil?
+        end
 
         response
       end

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -284,7 +284,7 @@ module ActiveMerchant #:nodoc:
             doc.cardholderAuthentication do
               doc.authenticationValue(payment_method.payment_cryptogram)
             end
-          elsif options[:order_source] && options[:order_source].start_with?('3ds')
+          elsif options[:order_source]&.start_with?('3ds')
             doc.cardholderAuthentication do
               doc.authenticationValue(options[:cavv]) if options[:cavv]
               doc.authenticationTransactionId(options[:xid]) if options[:xid]

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
 
       def get_text_from_document(document, node)
         node = REXML::XPath.first(document, node)
-        node && node.text
+        node&.text
       end
 
       def cc_auth_request(money, opts)

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -396,7 +396,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! :AVSphoneNum, (address[:phone] ? address[:phone].scan(/\d/).join.to_s[0..13] : nil)
           end
 
-          xml.tag! :AVSname, ((creditcard && creditcard.name) ? creditcard.name[0..29] : nil)
+          xml.tag! :AVSname, (creditcard&.name ? creditcard.name[0..29] : nil)
           xml.tag! :AVScountryCode, (avs_supported ? byte_limit(format_address_field(address[:country]), 2) : '')
 
           # Needs to come after AVScountryCode

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         return response['response']['message'] if response['response']
 
-        response['errors'].inject(''){ |message,error| error['message'] + '|' + message } if response['errors']
+        response['errors']&.inject(''){ |message,error| error['message'] + '|' + message }
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -374,7 +374,7 @@ module ActiveMerchant
             response['transaction_id'],
             response['transaction_tag'],
             params[:method],
-            (response['amount'] && response['amount'].to_i)
+            response['amount']&.to_i
           ].join('|')
         end
       end

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -363,7 +363,7 @@ module ActiveMerchant #:nodoc:
 
         doc = Nokogiri::XML(body)
 
-        doc.root.xpath('*').each do |node|
+        doc.root&.xpath('*')&.each do |node|
           if (node.elements.size == 0)
             response[node.name.downcase.to_sym] = node.text
           else
@@ -372,7 +372,7 @@ module ActiveMerchant #:nodoc:
               response[name.to_sym] = childnode.text
             end
           end
-        end unless doc.root.nil?
+        end
 
         response
       end

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless post[:card] && post[:card].kind_of?(Hash)
+        return unless post[:card]&.kind_of?(Hash)
 
         card_address = {}
         if address = options[:billing_address] || options[:address]

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless post[:card] && post[:card].kind_of?(Hash)
+        return unless post[:card]&.kind_of?(Hash)
         if address = options[:billing_address]
           post[:card][:addressLine1] = address[:address1] if address[:address1]
           post[:card][:addressLine2] = address[:address2] if address[:address2]
@@ -257,7 +257,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def test?
-        (@options[:secret_key] && @options[:secret_key].include?('_test_'))
+        (@options[:secret_key]&.include?('_test_'))
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -386,7 +386,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless post[:card] && post[:card].kind_of?(Hash)
+        return unless post[:card]&.kind_of?(Hash)
         if address = options[:billing_address] || options[:address]
           post[:card][:address_line1] = address[:address1] if address[:address1]
           post[:card][:address_line2] = address[:address2] if address[:address2]

--- a/lib/active_merchant/billing/gateways/telr.rb
+++ b/lib/active_merchant/billing/gateways/telr.rb
@@ -214,7 +214,7 @@ module ActiveMerchant #:nodoc:
         response = {}
 
         doc = Nokogiri::XML(xml)
-        doc.root.xpath('*').each do |node|
+        doc.root&.xpath('*')&.each do |node|
           if (node.elements.size == 0)
             response[node.name.downcase.to_sym] = node.text
           else
@@ -223,7 +223,7 @@ module ActiveMerchant #:nodoc:
               response[name.to_sym] = childnode.text
             end
           end
-        end unless doc.root.nil?
+        end
 
         response
       end

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -61,7 +61,7 @@ module ActiveMerchant
     end
 
     def wiredump_device=(device)
-      raise ArgumentError, "can't wiredump to frozen #{device.class}" if device && device.frozen?
+      raise ArgumentError, "can't wiredump to frozen #{device.class}" if device&.frozen?
       @wiredump_device = device
     end
 
@@ -189,7 +189,7 @@ module ActiveMerchant
 
     def log(level, message, tag)
       message = "[#{tag}] #{message}" if tag
-      logger.send(level, message) if logger
+      logger&.send(level, message)
     end
   end
 end

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -65,7 +65,7 @@ module ActiveMerchant
     def self.log(logger, level, message, tag=nil)
       tag ||= self.class.to_s
       message = "[#{tag}] #{message}"
-      logger.send(level, message) if logger
+      logger&.send(level, message)
     end
 
     private

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -45,8 +45,8 @@ module ActiveMerchant #:nodoc:
     end
 
     def raw_ssl_request(method, endpoint, data, headers = {})
-      logger.warn "#{self.class} using ssl_strict=false, which is insecure" if logger unless ssl_strict
-      logger.warn "#{self.class} posting to plaintext endpoint, which is insecure" if logger unless endpoint.to_s =~ /^https:/
+      logger&.warn "#{self.class} using ssl_strict=false, which is insecure" unless ssl_strict
+      logger&.warn "#{self.class} posting to plaintext endpoint, which is insecure" unless endpoint.to_s =~ /^https:/
 
       connection = new_connection(endpoint)
       connection.open_timeout = open_timeout

--- a/test/comm_stub.rb
+++ b/test/comm_stub.rb
@@ -19,7 +19,7 @@ module CommStub
       singleton_class = (class << @gateway; self; end)
       singleton_class.send(:undef_method, @method_to_stub)
       singleton_class.send(:define_method, @method_to_stub) do |*args|
-        check.call(*args) if check
+        check&.call(*args)
         (responses.size == 1 ? responses.last : responses.shift)
       end
       @action.call


### PR DESCRIPTION
This actually has some *solid* readability improvements, especially around the pattern

```ruby
foobar.each do |a, b|
  ...
  ...
  ...
end if foobar
```

which is _far_ easier to miss than

```ruby
foobar&.each do |a, b|
  ...
  ...
  ...
end
```