### PR TITLE
MercadoPago: change how card brand is passed

### DIFF
--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -149,14 +149,14 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
-  def test_sends_american_express_as_amex
+  def test_does_not_send_brand
     credit_card = credit_card('378282246310005', brand: 'american_express')
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |endpoint, data, headers|
       if endpoint =~ /payments/
-        assert_match(%r("payment_method_id":"amex"), data)
+        assert_not_match(%r("payment_method_id":"amex"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -164,29 +164,14 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal '4141491|1.0', response.authorization
   end
 
-  def test_sends_diners_club_as_diners
-    credit_card = credit_card('30569309025904', brand: 'diners_club')
+  def test_sends_payment_method_id
+    credit_card = credit_card('30569309025904')
 
     response = stub_comms do
-      @gateway.purchase(@amount, credit_card, @options)
+      @gateway.purchase(@amount, credit_card, @options.merge(payment_method_id: 'diners'))
     end.check_request do |endpoint, data, headers|
       if endpoint =~ /payments/
         assert_match(%r("payment_method_id":"diners"), data)
-      end
-    end.respond_with(successful_purchase_response)
-
-    assert_success response
-    assert_equal '4141491|1.0', response.authorization
-  end
-
-  def test_sends_mastercard_as_master
-    credit_card = credit_card('5555555555554444', brand: 'master')
-
-    response = stub_comms do
-      @gateway.purchase(@amount, credit_card, @options)
-    end.check_request do |endpoint, data, headers|
-      if endpoint =~ /payments/
-        assert_match(%r("payment_method_id":"master"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -215,6 +200,19 @@ class MercadoPagoTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
+  end
+
+  def test_includes_issuer_id
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: '1a2b3c4d'))
+    end.check_request do |endpoint, data, headers|
+      if endpoint =~ /payments/
+        assert_match(%r("issuer_id":"1a2b3c4d"), data)
+      end
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal '4141491|1.0', response.authorization
   end
 
   private

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -155,8 +155,8 @@ class MercadoPagoTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"payment_method_id"/
-        assert_match(%r(amex), data)
+      if endpoint =~ /payments/
+        assert_match(%r("payment_method_id":"amex"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -170,8 +170,8 @@ class MercadoPagoTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"payment_method_id"/
-        assert_match(%r(diners), data)
+      if endpoint =~ /payments/
+        assert_match(%r("payment_method_id":"diners"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -185,8 +185,8 @@ class MercadoPagoTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"payment_method_id"/
-        assert_match(%r(master), data)
+      if endpoint =~ /payments/
+        assert_match(%r("payment_method_id":"master"), data)
       end
     end.respond_with(successful_purchase_response)
 


### PR DESCRIPTION
Mercado Pago now infers the card brand from BIN, so it no longer needs to be passed in for normal operations. Instead, they've asked for us to expose `payment_method_id` and `issuer_id` directly. So, that's exactly what I've done.

There are two commits in this series. The first one does nothing other than change the tests specifically so they'd _break_ on the second commit without further changes. It might make it easier to see what I'm doing.