### PR TITLE
Braintree: Fix passing phone-only billing address

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -304,12 +304,13 @@ module ActiveMerchant #:nodoc:
 
         parameters[:credit_card] ||= {}
         parameters[:credit_card].merge!(:options => valid_options)
-        parameters[:credit_card][:billing_address] = map_address(options[:billing_address]) if options[:billing_address]
+        address = options[:billing_address]&.except(:phone)
+        return parameters if address.nil? || address.empty?
+        parameters[:credit_card][:billing_address] = map_address(address)
         parameters
       end
 
       def map_address(address)
-        return {} if address.nil?
         mapped = {
           :street_address => address[:address1],
           :extended_address => address[:address2],

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -168,6 +168,20 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal purchase_response.params['braintree_transaction']['billing_details'], response_billing_details
   end
 
+  def test_successful_store_with_phone_only_billing_address_option
+    billing_address = {
+      :phone => '123-456-7890'
+    }
+    credit_card = credit_card('5105105105105100')
+    assert response = @gateway.store(credit_card, :billing_address => billing_address)
+    assert_success response
+    assert_equal 'OK', response.message
+
+    vault_id = response.params['customer_vault_id']
+    purchase_response = @gateway.purchase(@amount, vault_id)
+    assert_success purchase_response
+  end
+
   def test_successful_store_with_credit_card_token
     credit_card = credit_card('5105105105105100')
     credit_card_token = generate_unique_id

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -351,6 +351,28 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
   end
 
+  def test_store_with_phone_only_billing_address_option
+    customer_attributes = {
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :phone => '123-456-7890'
+    }
+    billing_address = {
+      :phone => '123-456-7890'
+    }
+    customer = stub(customer_attributes)
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_nil params[:credit_card][:billing_address]
+      params
+    end.returns(result)
+
+    @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
+  end
+
   def test_store_with_credit_card_token
     customer = stub(
       :email => 'email',


### PR DESCRIPTION
If a billing address option had only a phone number, the billing address
element was still included in the request with all empty fields, which
causes a failure. Now we remove the phone from the billing address hash
before it's added.

Remote:
64 tests, 365 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
55 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed