### PR TITLE
Barclaycard Smartpay: Improves Error Handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Payflow Express: Add phone to returned Response [filipebarcos] #3003
 * Authorize.Net: Pass some level 3 fields [curiousepic] #3022
 * Add state to the netbanx payload [Girardvjonathan] #3024
+* Barclaycard Smartpay: Improves Error Handling [deedeelavinder] #3026
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -168,11 +168,11 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, 'Invalid credentials', {}, :test => test?)
         when '403'
           return Response.new(false, 'Not allowed', {}, :test => test?)
-        when '422'
-          return Response.new(false, 'Unprocessable Entity', {}, :test => test?)
-        when '500'
-          if e.response.body.split(' ')[0] == 'validation'
-            return Response.new(false, e.response.body.split(' ', 3)[2], {}, :test => test?)
+        when '422', '500'
+          if e.response.body.split(/\W+/).any? { |word| %w(validation configuration security).include?(word) }
+            error_message = e.response.body[/#{Regexp.escape('message=')}(.*?)#{Regexp.escape('&')}/m, 1].tr('+', ' ')
+            error_code = e.response.body[/#{Regexp.escape('errorCode=')}(.*?)#{Regexp.escape('&')}/m, 1]
+            return Response.new(false, error_code + ': ' + error_message, {}, :test => test?)
           end
         end
         raise


### PR DESCRIPTION
The error handling was not exposing detailed error codes and messages in
the response. This returns those codes and messages where appropriate.
This also adds and updates several tests.

Unit tests:
27 tests, 133 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote tests:
33 tests, 69 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
96.9697% passed

This failure is for "Invalid credentials" for
`test_successful_third_party_payout` and is
unrelated.