### PR TITLE
Litle: Capitalize check account type

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -268,7 +268,7 @@ module ActiveMerchant #:nodoc:
           end
         elsif check?(payment_method)
           doc.echeck do
-            doc.accType(payment_method.account_type)
+            doc.accType(payment_method.account_type.capitalize)
             doc.accNum(payment_method.account_number)
             doc.routingNum(payment_method.routing_number)
             doc.checkNum(payment_method.number)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -67,13 +67,13 @@ class RemoteLitleTest < Test::Unit::TestCase
       name: 'Tom Black',
       routing_number:  '011075150',
       account_number: '4099999992',
-      account_type: 'Checking'
+      account_type: 'checking'
     )
     @authorize_check = check(
       name: 'John Smith',
       routing_number: '011075150',
       account_number: '1099999999',
-      account_type: 'Checking'
+      account_type: 'checking'
     )
     @store_check = check(
       routing_number: '011100012',

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -36,13 +36,13 @@ class LitleTest < Test::Unit::TestCase
       name: 'Tom Black',
       routing_number:  '011075150',
       account_number: '4099999992',
-      account_type: 'Checking'
+      account_type: 'checking'
     )
     @authorize_check = check(
       name: 'John Smith',
       routing_number: '011075150',
       account_number: '1099999999',
-      account_type: 'Checking'
+      account_type: 'checking'
     )
   end
 


### PR DESCRIPTION
Check payment methods may have lowercase account_type properties, but
the api expects it to be capitalized.

Remote (10 unrelated failures, mostly unexpected successes):
37 tests, 137 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
72.973% passed

Unit:
35 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed