### PR TITLE
Braintree: Account for nil billing address fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -305,7 +305,7 @@ module ActiveMerchant #:nodoc:
         parameters[:credit_card] ||= {}
         parameters[:credit_card].merge!(:options => valid_options)
         address = options[:billing_address]&.except(:phone)
-        return parameters if address.nil? || address.empty?
+        return parameters if address.nil? || address.values.compact.empty?
         parameters[:credit_card][:billing_address] = map_address(address)
         parameters
       end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -170,7 +170,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_store_with_phone_only_billing_address_option
     billing_address = {
-      :phone => '123-456-7890'
+      :phone => '123-456-7890',
+      :city => nil
     }
     credit_card = credit_card('5105105105105100')
     assert response = @gateway.store(credit_card, :billing_address => billing_address)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -373,6 +373,34 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
   end
 
+  def test_store_with_phone_only_non_nil_billing_address_option
+    customer_attributes = {
+      :credit_cards => [stub_everything],
+      :email => 'email',
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :phone => '123-456-7890'
+    }
+    billing_address = {
+      :phone => '123-456-7890',
+      :address1 => nil,
+      :address2 => nil,
+      :city => nil,
+      :state => nil,
+      :zip => nil,
+      :country_name => nil
+    }
+    customer = stub(customer_attributes)
+    customer.stubs(:id).returns('123')
+    result = Braintree::SuccessfulResult.new(:customer => customer)
+    Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
+      assert_nil params[:credit_card][:billing_address]
+      params
+    end.returns(result)
+
+    @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
+  end
+
   def test_store_with_credit_card_token
     customer = stub(
       :email => 'email',


### PR DESCRIPTION
The earlier fix for phone-only billing address options did not account
for other elements being present but nil. Now we compact the address.

Remote:
64 tests, 365 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
56 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed