### PR TITLE
Realex: Add verify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Braintree: Fix passing phone-only billing address [curiousepic] #3025
 * Litle: Capitalize check account type [curiousepic] #3028
 * Braintree: Account for nil billing address fields [curiousepic] #3029
+* Realex: Add verify [kheang] #3030
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -328,6 +328,32 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_equal 'Successful', rebate_response.message
   end
 
+  def test_realex_verify
+    response = @gateway.verify(@visa,
+      :order_id => generate_unique_id,
+      :description => 'Test Realex verify'
+    )
+
+    assert_not_nil response
+    assert_success response
+    assert response.test?
+    assert response.authorization.length > 0
+    assert_equal 'Successful', response.message
+  end
+
+  def test_realex_verify_declined
+    response = @gateway.verify(@visa_declined,
+      :order_id => generate_unique_id,
+      :description => 'Test Realex verify declined'
+    )
+
+    assert_not_nil response
+    assert_failure response
+    assert response.test?
+    assert_equal '101', response.params['result']
+    assert_match %r{DECLINED}i, response.message
+  end
+
   def test_maps_avs_and_cvv_response_codes
     [ @visa, @mastercard ].each do |card|
       response = @gateway.purchase(@amount, card,

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class RealexTest < Test::Unit::TestCase
   class ActiveMerchant::Billing::RealexGateway
     # For the purposes of testing, lets redefine some protected methods as public.
-    public :build_purchase_or_authorization_request, :build_refund_request, :build_void_request, :build_capture_request
+    public :build_purchase_or_authorization_request, :build_refund_request, :build_void_request,
+      :build_capture_request, :build_verify_request
   end
 
   def setup
@@ -191,6 +192,35 @@ SRC
 SRC
 
     assert_xml_equal valid_void_request_xml, @gateway.build_void_request('1;4321;1234', {})
+  end
+
+  def test_verify_xml
+    options = {
+      :order_id => '1'
+    }
+    @gateway.expects(:new_timestamp).returns('20181026114304')
+
+    valid_verify_request_xml = <<-SRC
+<request timestamp="20181026114304" type="otb">
+  <merchantid>your_merchant_id</merchantid>
+  <account>your_account</account>
+  <orderid>1</orderid>
+  <card>
+    <number>4263971921001307</number>
+    <expdate>0808</expdate>
+    <chname>Longbob Longsen</chname>
+    <type>VISA</type>
+    <issueno></issueno>
+    <cvn>
+      <number></number>
+      <presind></presind>
+    </cvn>
+  </card>
+  <sha1hash>d53aebf1eaee4c3ff4c30f83f27b80ce99ba5644</sha1hash>
+</request>
+SRC
+
+    assert_xml_equal valid_verify_request_xml, @gateway.build_verify_request(@credit_card, options)
   end
 
   def test_auth_xml


### PR DESCRIPTION
Add verify method by making an Open to Buy (OTB) request:
https://developer.realexpayments.com/#!/api/process-payment/otb

Remote (1 unrelated failure from `test_realex_purchase_then_refund`):
23 tests, 122 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.6522% passed

Unit:
22 tests, 526 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed