### PR TITLE
Braintree: Actually account for nil address fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -304,9 +304,10 @@ module ActiveMerchant #:nodoc:
 
         parameters[:credit_card] ||= {}
         parameters[:credit_card].merge!(:options => valid_options)
-        address = options[:billing_address]&.except(:phone)
-        return parameters if address.nil? || address.values.compact.empty?
-        parameters[:credit_card][:billing_address] = map_address(address)
+        if options[:billing_address]
+          address = map_address(options[:billing_address])
+          parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| v.nil? }
+        end
         parameters
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -168,10 +168,17 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal purchase_response.params['braintree_transaction']['billing_details'], response_billing_details
   end
 
-  def test_successful_store_with_phone_only_billing_address_option
+  def test_successful_store_with_nil_billing_address_options
     billing_address = {
+      :name => 'John Smith',
       :phone => '123-456-7890',
-      :city => nil
+      :company => nil,
+      :address1 => nil,
+      :address2 => nil,
+      :city => nil,
+      :state => nil,
+      :zip => nil,
+      :country_name => nil
     }
     credit_card = credit_card('5105105105105100')
     assert response = @gateway.store(credit_card, :billing_address => billing_address)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -373,7 +373,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
   end
 
-  def test_store_with_phone_only_non_nil_billing_address_option
+  def test_store_with_nil_billing_address_options
     customer_attributes = {
       :credit_cards => [stub_everything],
       :email => 'email',
@@ -382,7 +382,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :phone => '123-456-7890'
     }
     billing_address = {
+      :name => 'John Smith',
       :phone => '123-456-7890',
+      :company => nil,
       :address1 => nil,
       :address2 => nil,
       :city => nil,


### PR DESCRIPTION
Guess what time it is? Time for another patch to this functionality.

Phone is not the only field a billing address option may contain that
the gateway doesn't want here, so we now instead simply map the fields
first and then don't add the hash if it's empty.

Remote:
64 tests, 365 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
56 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed