### PR TITLE
Paymentez: Adds support for user.phone field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Braintree: Account for nil billing address fields [curiousepic] #3029
 * Realex: Add verify [kheang] #3030
 * Braintree: Actually account for nil address fields [curiousepic] #3032
+* Paymentez: Adds support for user.phone field [molbrown] #3033
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -134,6 +134,7 @@ module ActiveMerchant #:nodoc:
         post[:user][:email] = options[:email]
         post[:user][:ip_address] = options[:ip] if options[:ip]
         post[:user][:fiscal_number] = options[:fiscal_number] if options[:fiscal_number]
+        post[:user][:phone] = options[:phone] || (options[:billing_address][:phone] if options[:billing_address])
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -26,7 +26,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
     options = {
       order_id: '1',
       ip: '127.0.0.1',
-      tax_percentage: 0.07
+      tax_percentage: 0.07,
+      phone: '333 333 3333'
     }
 
     response = @gateway.purchase(@amount, @credit_card, @options.merge(options))


### PR DESCRIPTION
 Adds user.phone field for Paymentez and updates remote test.

Unit tests:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
17 tests, 33 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
64.7059% passed
These failures due to `The method authorize is not supported by carrier`.
Country credentials used for testing do not support `authorize`. Unrelated.