### PR TITLE
Visanet Peru: Corrects Method method

### DIFF
--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def method(action)
-        %w(authorize refund).include? action ? :post : :put
+        (%w(authorize refund).include? action) ? :post : :put
       end
 
       def authorization_from(params, response, options)


### PR DESCRIPTION
This reverts a RuboCop correction by adding parentheses back the `method` method.