### PR TITLE
Paymentez: Does not send nil for empty parameter phone

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Realex: Add verify [kheang] #3030
 * Braintree: Actually account for nil address fields [curiousepic] #3032
 * Paymentez: Adds support for user.phone field [molbrown] #3033
+* Paymentez: Does not send nil for empty parameter phone [molbrown] #3036
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -134,7 +134,8 @@ module ActiveMerchant #:nodoc:
         post[:user][:email] = options[:email]
         post[:user][:ip_address] = options[:ip] if options[:ip]
         post[:user][:fiscal_number] = options[:fiscal_number] if options[:fiscal_number]
-        post[:user][:phone] = options[:phone] || (options[:billing_address][:phone] if options[:billing_address])
+        post[:user][:phone] = options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+          options[:billing_address][:phone])
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -34,6 +34,18 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_without_phone_option
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      tax_percentage: 0.07
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+    refute_includes(response.params, 'phone')
+  end
+
   def test_successful_purchase_with_token
     store_response = @gateway.store(@credit_card, @options)
     assert_success store_response


### PR DESCRIPTION
Unit tests:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
18 tests, 34 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
61.1111% passed
These failures due to The method authorize is not supported by carrier.
Country credentials used for testing do not support authorize. Unrelated.