### PR TITLE
Paymentez: Does not send phone parameter unless it is defined

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Braintree: Account for nil billing address fields [curiousepic] #3029
 * Realex: Add verify [kheang] #3030
 * Braintree: Actually account for nil address fields [curiousepic] #3032
+* Paymentez: Does not send phone parameter unless it is defined [molbrown] #3037
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -134,6 +134,9 @@ module ActiveMerchant #:nodoc:
         post[:user][:email] = options[:email]
         post[:user][:ip_address] = options[:ip] if options[:ip]
         post[:user][:fiscal_number] = options[:fiscal_number] if options[:fiscal_number]
+        if phone = options[:phone] || options[:billing_address][:phone]
+          post[:user][:phone] = phone
+        end
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -5,8 +5,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @gateway = PaymentezGateway.new(fixtures(:paymentez))
 
     @amount = 100
-    @credit_card = credit_card('4111111111111111', verification_value: '555')
-    @declined_card = credit_card('4242424242424242', verification_value: '555')
+    @credit_card = credit_card('4111111111111111', verification_value: '666')
+    @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {
       billing_address: address,
       description: 'Store Purchase',
@@ -26,7 +26,22 @@ class RemotePaymentezTest < Test::Unit::TestCase
     options = {
       order_id: '1',
       ip: '127.0.0.1',
-      tax_percentage: 0.07
+      tax_percentage: 0.07,
+      phone: '333 333 3333'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+  end
+
+  def test_successful_purchase_without_phone_option
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      tax_percentage: 0.07,
+      billing_address: {
+        phone: nil
+      }
     }
 
     response = @gateway.purchase(@amount, @credit_card, @options.merge(options))


### PR DESCRIPTION
Unit tests:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
18 tests, 34 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
61.1111% passed
These failures due to `The method authorize is not supported by carrier`.
Country credentials used for testing do not support authorize. Unrelated.