### PR TITLE
Mercado Pago: do not infer card type

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -10,11 +10,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Mercado Pago'
       self.money_format = :dollars
 
-      CARD_BRAND = {
-        'american_express' => 'amex',
-        'diners_club' => 'diners'
-      }
-
       def initialize(options={})
         requires!(options, :access_token)
         super
@@ -23,7 +18,6 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options={})
         MultiResponse.run do |r|
           r.process { commit('tokenize', 'card_tokens', card_token_request(money, payment, options)) }
-          options[:card_brand] = (CARD_BRAND[payment.brand] || payment.brand)
           options[:card_token] = r.authorization.split('|').first
           r.process { commit('purchase', 'payments', purchase_request(money, payment, options) ) }
         end
@@ -32,7 +26,6 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment, options={})
         MultiResponse.run do |r|
           r.process { commit('tokenize', 'card_tokens', card_token_request(money, payment, options)) }
-          options[:card_brand] = (CARD_BRAND[payment.brand] || payment.brand)
           options[:card_token] = r.authorization.split('|').first
           r.process { commit('authorize', 'payments', authorize_request(money, payment, options) ) }
         end
@@ -181,7 +174,8 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(post, options)
         post[:token] = options[:card_token]
-        post[:payment_method_id] = options[:card_brand]
+        post[:issuer_id] = options[:issuer_id] if options[:issuer_id]
+        post[:payment_method_id] = options[:payment_method_id] if options[:payment_method_id]
       end
 
       def parse(body)

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -149,14 +149,14 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
-  def test_sends_american_express_as_amex
+  def test_does_not_send_brand
     credit_card = credit_card('378282246310005', brand: 'american_express')
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |endpoint, data, headers|
       if endpoint =~ /payments/
-        assert_match(%r("payment_method_id":"amex"), data)
+        assert_not_match(%r("payment_method_id":"amex"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -164,29 +164,14 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal '4141491|1.0', response.authorization
   end
 
-  def test_sends_diners_club_as_diners
-    credit_card = credit_card('30569309025904', brand: 'diners_club')
+  def test_sends_payment_method_id
+    credit_card = credit_card('30569309025904')
 
     response = stub_comms do
-      @gateway.purchase(@amount, credit_card, @options)
+      @gateway.purchase(@amount, credit_card, @options.merge(payment_method_id: 'diners'))
     end.check_request do |endpoint, data, headers|
       if endpoint =~ /payments/
         assert_match(%r("payment_method_id":"diners"), data)
-      end
-    end.respond_with(successful_purchase_response)
-
-    assert_success response
-    assert_equal '4141491|1.0', response.authorization
-  end
-
-  def test_sends_mastercard_as_master
-    credit_card = credit_card('5555555555554444', brand: 'master')
-
-    response = stub_comms do
-      @gateway.purchase(@amount, credit_card, @options)
-    end.check_request do |endpoint, data, headers|
-      if endpoint =~ /payments/
-        assert_match(%r("payment_method_id":"master"), data)
       end
     end.respond_with(successful_purchase_response)
 
@@ -215,6 +200,19 @@ class MercadoPagoTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     assert_success response
+  end
+
+  def test_includes_issuer_id
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: '1a2b3c4d'))
+    end.check_request do |endpoint, data, headers|
+      if endpoint =~ /payments/
+        assert_match(%r("issuer_id":"1a2b3c4d"), data)
+      end
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal '4141491|1.0', response.authorization
   end
 
   private


### PR DESCRIPTION
This is a re-application of d9c5a1a0.


Allow the card type to be passed in explicitly instead via the
:payment_method_id option. Additionally, allow sending the :issuer_id.

Unit: 19 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

We've now done explicit reviews with Mercado Pago, and the code as-is works properly.

Remote: 17 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed