### PR TITLE
Credorax: add submerchant_id support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Braintree: Account for nil billing address fields [curiousepic] #3029
 * Realex: Add verify [kheang] #3030
 * Braintree: Actually account for nil address fields [curiousepic] #3032
+* Credorax: allow sending submerchant ID (h3 parameter) [bpollack] #3040
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -129,6 +129,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        add_submerchant_id(post, options)
         add_transaction_type(post, options)
 
         commit(:purchase, post)
@@ -142,6 +143,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
         add_3d_secure(post, options)
         add_echo(post, options)
+        add_submerchant_id(post, options)
         add_transaction_type(post, options)
 
         commit(:authorize, post)
@@ -153,6 +155,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization)
         add_customer_data(post, options)
         add_echo(post, options)
+        add_submerchant_id(post, options)
 
         commit(:capture, post)
       end
@@ -162,6 +165,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         reference_action = add_reference(post, authorization)
         add_echo(post, options)
+        add_submerchant_id(post, options)
         post[:a1] = generate_unique_id
 
         commit(:void, post, reference_action)
@@ -173,6 +177,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization)
         add_customer_data(post, options)
         add_echo(post, options)
+        add_submerchant_id(post, options)
 
         commit(:refund, post)
       end
@@ -184,6 +189,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_email(post, options)
         add_echo(post, options)
+        add_submerchant_id(post, options)
         add_transaction_type(post, options)
 
         commit(:credit, post)
@@ -266,6 +272,10 @@ module ActiveMerchant #:nodoc:
         # The d2 parameter is used during the certification process
         # See remote tests for full certification test suite
         post[:d2] = options[:echo] unless options[:echo].blank?
+      end
+
+      def add_submerchant_id(post, options)
+        post[:h3] = options[:submerchant_id] if options[:submerchant_id]
       end
 
       def add_transaction_type(post, options)

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -214,6 +214,15 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_adds_submerchant_id
+    @options[:submerchant_id] = '12345'
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/h3=12345/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_supports_billing_descriptor
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do


### PR DESCRIPTION
Unit: 20 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed