### PR TITLE
Paymentez: Supports phone field, does not send if empty

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Braintree: Actually account for nil address fields [curiousepic] #3032
 * Credorax: allow sending submerchant ID (h3 parameter) [bpollack] #3040
 * Worldpay: Pass stored credential option fields [curiousepic] #3041
+* Paymentez: Supports phone field, does not send if empty [molbrown] #3043
 
 == Version 1.85.0 (September 28, 2018)
 * Authorize.Net: Support custom delimiter for cim [curiousepic] #3001

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -134,6 +134,9 @@ module ActiveMerchant #:nodoc:
         post[:user][:email] = options[:email]
         post[:user][:ip_address] = options[:ip] if options[:ip]
         post[:user][:fiscal_number] = options[:fiscal_number] if options[:fiscal_number]
+        if phone = options[:phone] || options.dig(:billing_address, :phone)
+          post[:user][:phone] = phone
+        end
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -5,8 +5,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @gateway = PaymentezGateway.new(fixtures(:paymentez))
 
     @amount = 100
-    @credit_card = credit_card('4111111111111111', verification_value: '555')
-    @declined_card = credit_card('4242424242424242', verification_value: '555')
+    @credit_card = credit_card('4111111111111111', verification_value: '666')
+    @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {
       billing_address: address,
       description: 'Store Purchase',
@@ -23,6 +23,32 @@ class RemotePaymentezTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      tax_percentage: 0.07,
+      phone: '333 333 3333'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+  end
+
+  def test_successful_purchase_without_phone_billing_address_option
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      tax_percentage: 0.07,
+      billing_address: {
+        phone: nil
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+  end
+
+  def test_successful_purchase_without_phone_option
     options = {
       order_id: '1',
       ip: '127.0.0.1',


### PR DESCRIPTION
Unit:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
19 tests, 35 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
68.4211% passed
These failures due to `The method authorize is not supported by carrier`.
Country credentials used for testing do not support authorize. Unrelated.