### PR TITLE
Braintree: Account for nil address with existing customer

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -259,7 +259,10 @@ module ActiveMerchant #:nodoc:
             expiration_year: credit_card.year.to_s,
             device_data: options[:device_data],
           }
-          parameters[:billing_address] = map_address(options[:billing_address]) if options[:billing_address]
+          if options[:billing_address]
+            address = map_address(options[:billing_address])
+            parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| v.nil? }
+          end
 
           result = @braintree_gateway.credit_card.create(parameters)
           ActiveMerchant::Billing::Response.new(

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -473,6 +473,42 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'cctoken', response.params['credit_card_token']
   end
 
+  def test_store_with_existing_customer_id_and_nil_billing_address_options
+    credit_card = stub(
+      customer_id: 'customerid',
+      token: 'cctoken'
+    )
+    options = {
+      :customer => 'customerid',
+      :billing_address => {
+        :name => 'John Smith',
+        :phone => '123-456-7890',
+        :company => nil,
+        :address1 => nil,
+        :address2 => nil,
+        :city => nil,
+        :state => nil,
+        :zip => nil,
+        :country_name => nil
+      }
+    }
+
+    result = Braintree::SuccessfulResult.new(credit_card: credit_card)
+    Braintree::CustomerGateway.any_instance.expects(:find).with('customerid')
+    Braintree::CreditCardGateway.any_instance.expects(:create).with do |params|
+      assert_equal 'customerid', params[:customer_id]
+      assert_equal '41111111111111111111', params[:number]
+      assert_equal 'Longbob Longsen', params[:cardholder_name]
+      params
+    end.returns(result)
+
+    response = @gateway.store(credit_card('41111111111111111111'), options)
+    assert_success response
+    assert_nil response.params['braintree_customer']
+    assert_equal 'customerid', response.params['customer_vault_id']
+    assert_equal 'cctoken', response.params['credit_card_token']
+  end
+
   def test_update_with_cvv
     stored_credit_card = mock(:token => 'token', :default? => true)
     customer = mock(:credit_cards => [stored_credit_card], :id => '123')


### PR DESCRIPTION
The prior fix only worked for naive first-time stores. Now it's also
used when adding a card to an existing customer profile.

Remote:
66 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
57 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed