### PR TITLE
Moneris: Allows cof_enabled gateway to process non-cof transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -293,7 +293,7 @@ module ActiveMerchant #:nodoc:
           when :cvd_info
             transaction.add_element(cvd_element(parameters[:cvd_value])) if @cvv_enabled
           when :cof_info
-            transaction.add_element(credential_on_file(parameters)) if @cof_enabled
+            transaction.add_element(credential_on_file(parameters)) if @cof_enabled && cof_details_present?(parameters)
           else
             transaction.add_element(key.to_s).text = parameters[key] unless parameters[key].blank?
           end
@@ -324,10 +324,14 @@ module ActiveMerchant #:nodoc:
         element
       end
 
+      def cof_details_present?(parameters)
+        parameters[:issuer_id] && parameters[:payment_indicator] && parameters[:payment_information]
+      end
+
       def credential_on_file(parameters)
-        issuer_id = parameters[:issuer_id] || ''
-        payment_indicator = parameters[:payment_indicator] if parameters[:payment_indicator]
-        payment_information = parameters[:payment_information] if parameters[:payment_information]
+        issuer_id = parameters[:issuer_id]
+        payment_indicator = parameters[:payment_indicator]
+        payment_information = parameters[:payment_information]
 
         cof_info = REXML::Element.new('cof_info')
         cof_info.add_element('issuer_id').text = issuer_id

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -30,6 +30,23 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert_not_empty response.params['issuer_id']
   end
 
+  def test_successful_purchase_with_cof_enabled_and_no_cof_options
+    gateway = MonerisGateway.new(fixtures(:moneris).merge(cof_enabled: true))
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_non_cof_purchase_with_cof_enabled_and_only_issuer_id_sent
+    gateway = MonerisGateway.new(fixtures(:moneris).merge(cof_enabled: true))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: ''))
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+    assert_nil response.params['issuer_id']
+  end
+
   def test_successful_subsequent_purchase_with_credential_on_file
     gateway = MonerisGateway.new(fixtures(:moneris).merge(cof_enabled: true))
     assert response = gateway.authorize(


### PR DESCRIPTION
Adds a bypass for transactions without credential-on-file details when @cof_enabled is
true.

Unit Tests:
37 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote Tests:
31 tests, 119 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
93.5484% passed

(The two failing tests are not related and appear to be timing-based.)