### PR TITLE
RuboCop: fix block spacing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -134,14 +134,6 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundOperators:
   Enabled: false
 
-# Offense count: 182
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceBeforeBlockBraces:
-  Enabled: false
-
 # Offense count: 118
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
@@ -155,14 +147,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideArrayPercentLiteral:
   Exclude:
     - 'lib/active_merchant/billing/gateways/migs/migs_codes.rb'
-
-# Offense count: 345
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Enabled: false
 
 # Offense count: 1186
 # Cop supports --auto-correct.

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
       #   (3(d1 + d4 + d7) + 7(d2 + d5 + d8) + 1(d3 + d6 + d9))mod 10 = 0
       # See http://en.wikipedia.org/wiki/Routing_transit_number#Internal_checksums
       def valid_routing_number?
-        digits = routing_number.to_s.split('').map(&:to_i).select{|d| (0..9).cover?(d)}
+        digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
         case digits.size
         when 9
           checksum = ((3 * (digits[0] + digits[3] + digits[6])) +

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -61,7 +61,7 @@ module ActiveMerchant
 
         class Errors < Hash
           def initialize
-            super(){|h, k| h[k] = []}
+            super() { |h, k| h[k] = [] }
           end
 
           alias count size
@@ -75,7 +75,7 @@ module ActiveMerchant
           end
 
           def empty?
-            all?{|k, v| v&.empty?}
+            all? { |k, v| v&.empty? }
           end
 
           def on(field)
@@ -91,7 +91,7 @@ module ActiveMerchant
           end
 
           def each_full
-            full_messages.each{|msg| yield msg}
+            full_messages.each { |msg| yield msg }
           end
 
           def full_messages

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -34,8 +34,8 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options={})
         MultiResponse.run do |r|
-          r.process{authorize(money, payment, options)}
-          r.process{capture(money, r.authorization, options)}
+          r.process { authorize(money, payment, options) }
+          r.process { capture(money, r.authorization, options) }
         end
       end
 
@@ -216,7 +216,7 @@ module ActiveMerchant #:nodoc:
           cvc: credit_card.verification_value
         }
 
-        card.delete_if{|k, v| v.blank? }
+        card.delete_if { |k, v| v.blank? }
         card[:holderName] ||= 'Not Provided' if credit_card.is_a?(NetworkTokenizationCreditCard)
         requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:card] = card

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -182,7 +182,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -199,7 +199,7 @@ module ActiveMerchant
       end
 
       def verify_credentials
-        response = commit(:verify_credentials) { }
+        response = commit(:verify_credentials) {}
         response.success?
       end
 
@@ -394,7 +394,7 @@ module ActiveMerchant
       end
 
       def camel_case_lower(key)
-        String(key).split('_').inject([]){ |buffer, e| buffer.push(buffer.empty? ? e : e.capitalize) }.join
+        String(key).split('_').inject([]) { |buffer, e| buffer.push(buffer.empty? ? e : e.capitalize) }.join
       end
 
       def add_settings(xml, source, options)

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -407,7 +407,7 @@ module ActiveMerchant #:nodoc:
 
       def recurring_parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|e| recurring_parse_element(response, e) }
+          node.elements.each { |e| recurring_parse_element(response, e) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -878,7 +878,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def format_extra_options(options)
-        options&.map{ |k, v| "#{k}=#{v}" }&.join('&')
+        options&.map { |k, v| "#{k}=#{v}" }&.join('&')
       end
 
       def parse_direct_response(params)
@@ -952,7 +952,7 @@ module ActiveMerchant #:nodoc:
       def parse_element(node)
         if node.has_elements?
           response = {}
-          node.elements.each{ |e|
+          node.elements.each { |e|
             key = e.name.underscore
             value = parse_element(e)
             if response.has_key?(key)

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -94,11 +94,11 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_attributes?
-          node.attributes.each{|name, value| response["#{node.name}_#{name}".underscore.to_sym] = value }
+          node.attributes.each { |name, value| response["#{node.name}_#{name}".underscore.to_sym] = value }
         end
 
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -45,12 +45,12 @@ module ActiveMerchant #:nodoc:
 
         MultiResponse.run do |r|
           identifier = if(payment_method.respond_to?(:number))
-                         r.process{store(payment_method, options)}
+                         r.process { store(payment_method, options) }
                          r.authorization
                        else
                          payment_method
           end
-          r.process{commit('debits', "cards/#{card_identifier_from(identifier)}/debits", post)}
+          r.process { commit('debits', "cards/#{card_identifier_from(identifier)}/debits", post) }
         end
       end
 
@@ -62,12 +62,12 @@ module ActiveMerchant #:nodoc:
 
         MultiResponse.run do |r|
           identifier = if(payment_method.respond_to?(:number))
-                         r.process{store(payment_method, options)}
+                         r.process { store(payment_method, options) }
                          r.authorization
                        else
                          payment_method
           end
-          r.process{commit('card_holds', "cards/#{card_identifier_from(identifier)}/card_holds", post)}
+          r.process { commit('card_holds', "cards/#{card_identifier_from(identifier)}/card_holds", post) }
         end
       end
 
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
         when %r{\|}
           uri = identifier.
                 split('|').
-                detect{|part| part.size > 0}
+                detect { |part| part.size > 0 }
           uri.split('/')[2]
         when %r{\/}
           identifier.split('/')[5]

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -463,7 +463,7 @@ module ActiveMerchant #:nodoc:
         params[:vbvEnabled] = '0'
         params[:scEnabled] = '0'
 
-        params.reject{|k, v| v.blank?}.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        params.reject { |k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -345,7 +345,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         # The bp20api has max one value per form field.
-        response_fields = Hash[CGI::parse(body).map{|k, v| [k.upcase, v.first]}]
+        response_fields = Hash[CGI::parse(body).map { |k, v| [k.upcase, v.first] }]
 
         if response_fields.include? 'REBILL_ID'
           return parse_recurring(response_fields)

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -230,7 +230,7 @@ module ActiveMerchant
 
       def parse_element(parsed, node)
         if !node.elements.empty?
-          node.elements.each {|e| parse_element(parsed, e) }
+          node.elements.each { |e| parse_element(parsed, e) }
         else
           parsed[node.name.downcase] = node.text
         end

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
       CURRENCY_CODES['ISK'] = '352'
       CURRENCY_CODES['EUR'] = '978'
       CURRENCY_CODES['USD'] = '840'

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
         if options[:customer].present?
           MultiResponse.new.tap do |r|
             customer_exists_response = nil
-            r.process{customer_exists_response = check_customer_exists(options[:customer])}
+            r.process { customer_exists_response = check_customer_exists(options[:customer]) }
             r.process do
               if customer_exists_response.params['exists']
                 add_credit_card_to_customer(creditcard, options)

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -237,7 +237,7 @@ module ActiveMerchant #:nodoc:
         {
           :UserName => @options[:user_name],
           :Password => @options[:password]
-        }.merge(post).collect{|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        }.merge(post).collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/cams.rb
+++ b/lib/active_merchant/billing/gateways/cams.rb
@@ -219,7 +219,7 @@ module ActiveMerchant #:nodoc:
         parameters[:password] = @options[:password]
         parameters[:username] = @options[:username]
 
-        parameters.collect{|k, v| "#{k}=#{v}" }.join('&')
+        parameters.collect { |k, v| "#{k}=#{v}" }.join('&')
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -276,7 +276,7 @@ module ActiveMerchant #:nodoc:
           amount:            fields['xAuthAmount'],
           masked_card_num:   fields['xMaskedCardNumber'],
           masked_account_number: fields['MaskedAccountNumber']
-        }.delete_if{|k, v| v.nil?}
+        }.delete_if { |k, v| v.nil? }
       end
 
       def commit(action, source_type, parameters)
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
         initial_parameters[:Hash] = "s/#{seed}/#{hash}/n" unless @options[:pin].blank?
         parameters = initial_parameters.merge(parameters)
 
-        parameters.reject{|k, v| v.blank?}.collect{ |key, value| "x#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |k, v| v.blank? }.collect { |key, value| "x#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/cardprocess.rb
+++ b/lib/active_merchant/billing/gateways/cardprocess.rb
@@ -189,7 +189,7 @@ module ActiveMerchant #:nodoc:
         post[:authentication][:password] = @options[:password]
         post[:authentication][:entityId] = @options[:entity_id]
         post[:paymentType] = action
-        dot_flatten_hash(post).map {|key, value| "#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+        dot_flatten_hash(post).map { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
         match = body.match(/<cngateway>(.*)<\/cngateway>/)
         return nil unless match
 
-        Hash[CGI::parse(match[1]).map{|k, v| [k.to_sym, v.first]}]
+        Hash[CGI::parse(match[1]).map { |k, v| [k.to_sym, v.first] }]
       end
 
       def handle_response(response)

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -174,7 +174,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -147,7 +147,7 @@ module ActiveMerchant #:nodoc:
       def add_transaction_details(xml, amount, authorization, type, options={})
         xml.TransactionDetails do
           xml.MessageType type
-          xml.Amount(unit: 'Minor'){ xml.text(amount) } if amount
+          xml.Amount(unit: 'Minor') { xml.text(amount) } if amount
           xml.CardEaseReference authorization if authorization
           xml.VoidReason '01' if type == 'Void'
         end
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
         xml.TerminalDetails do
           xml.TerminalID @options[:terminal_id]
           xml.TransactionKey @options[:transaction_key]
-          xml.Software(version: 'SoftwareVersion'){ xml.text('SoftwareName') }
+          xml.Software(version: 'SoftwareVersion') { xml.text('SoftwareName') }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -317,11 +317,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, params, reference_action)
-        params.keys.each { |key| params[key] = params[key].to_s}
+        params.keys.each { |key| params[key] = params[key].to_s }
         params[:M] = @options[:merchant_id]
         params[:O] = request_action(action, reference_action)
         params[:K] = sign_request(params)
-        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def request_action(action, reference_action)
@@ -337,7 +337,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        Hash[CGI::parse(body).map{|k, v| [k.upcase, v.first]}]
+        Hash[CGI::parse(body).map { |k, v| [k.upcase, v.first] }]
       end
 
       def success_from(response)

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -224,7 +224,7 @@ module ActiveMerchant #:nodoc:
           commit_raw(action, parameters)
         else
           MultiResponse.run(true) do |r|
-            r.process { commit_raw(action, parameters)}
+            r.process { commit_raw(action, parameters) }
             r.process {
               split_auth = split_authorization(r.authorization)
               auth =  (action.include?('recur')? split_auth[4] : split_auth[0])

--- a/lib/active_merchant/billing/gateways/culqi.rb
+++ b/lib/active_merchant/billing/gateways/culqi.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, params)
-        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -755,7 +755,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(reply, node)
         if node.has_elements?
-          node.elements.each{|e| parse_element(reply, e) }
+          node.elements.each { |e| parse_element(reply, e) }
         else
           if node.parent.name =~ /item/
             parent = node.parent.name

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -286,7 +286,7 @@ module ActiveMerchant
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|e| parse_element(response, e) }
+          node.elements.each { |e| parse_element(response, e) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -87,7 +87,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = '840'
       CURRENCY_CODES['DKK'] = '208'
       CURRENCY_CODES['NOK'] = '578'

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -228,7 +228,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         return response['message'] if response['message']
         return 'Success' if success_from(response)
-        response['errors'].map {|error_hash| error_hash['detail'] }.join(', ')
+        response['errors'].map { |error_hash| error_hash['detail'] }.join(', ')
       end
 
       def authorization_from(response)
@@ -263,7 +263,7 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(response)
         unless success_from(response)
-          response['errors'].nil? ? response['message'] : response['errors'].map {|error_hash| error_hash['code'] }.join(', ')
+          response['errors'].nil? ? response['message'] : response['errors'].map { |error_hash| error_hash['code'] }.join(', ')
         end
       end
 

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -299,7 +299,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(msg)
         resp = {}
-        msg.split(self.delimiter).collect{|li|
+        msg.split(self.delimiter).collect { |li|
           key, value = li.split('=')
           resp[key.to_s.strip.gsub(/^ssl_/, '')] = value.to_s.strip
         }

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -299,7 +299,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse_errors(message)
-        errors = message.split(',').collect{|code| MESSAGES[code.strip]}.flatten.join(',')
+        errors = message.split(',').collect { |code| MESSAGES[code.strip] }.flatten.join(',')
         errors.presence || message
       end
 

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -211,7 +211,7 @@ module ActiveMerchant #:nodoc:
           parse_elements(response, root)
         end
 
-        response.delete_if{ |k, v| SENSITIVE_FIELDS.include?(k) }
+        response.delete_if { |k, v| SENSITIVE_FIELDS.include?(k) }
       end
 
       def parse_elements(response, root)

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
         parameters[:type] = action
         parameters[:username] = @options[:login]
         parameters[:password] = @options[:password]
-        parameters.map{|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        parameters.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def encode(hash)
-        hash.collect{|(k, v)| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
+        hash.collect { |(k, v)| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def creditcard_brand(brand)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -438,7 +438,7 @@ module ActiveMerchant #:nodoc:
           parse_elements(response, root)
         end
 
-        response.delete_if{ |k, v| SENSITIVE_FIELDS.include?(k) }
+        response.delete_if { |k, v| SENSITIVE_FIELDS.include?(k) }
       end
 
       def parse_elements(response, root)

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['NZD'] = '554'
 
       def add_invoice(post, money, options)
@@ -172,7 +172,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -240,7 +240,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -329,7 +329,7 @@ EOS
       end
 
       def nestable_hash
-        Hash.new {|h, k| h[k] = Hash.new(&h.default_proc) }
+        Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
       end
 
       def capture_requested?(response)

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
       CURRENCY_CODES['AED'] = '784'
       CURRENCY_CODES['AUD'] = '036'
       CURRENCY_CODES['CAD'] = '124'

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
         post[:password]   = @options[:password]
         post[:type]       = action if action
 
-        request = post.merge(parameters).map {|key, value| "#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+        request = post.merge(parameters).map { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
         request
       end
 

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -422,36 +422,36 @@ module ActiveMerchant #:nodoc:
           node.attributes.each do |a, b|
             reply[:transaction_result][a.underscore.to_sym] = b
           end
-          node.elements.each{|e| parse_element(reply[:transaction_result], e) } if node.has_elements?
+          node.elements.each { |e| parse_element(reply[:transaction_result], e) } if node.has_elements?
 
         when 'CardDetailsTransactionResult'
           reply[:transaction_result] = {}
           node.attributes.each do |a, b|
             reply[:transaction_result][a.underscore.to_sym] = b
           end
-          node.elements.each{|e| parse_element(reply[:transaction_result], e) } if node.has_elements?
+          node.elements.each { |e| parse_element(reply[:transaction_result], e) } if node.has_elements?
 
         when 'TransactionOutputData'
           reply[:transaction_output_data] = {}
-          node.attributes.each{|a, b| reply[:transaction_output_data][a.underscore.to_sym] = b }
-          node.elements.each{|e| parse_element(reply[:transaction_output_data], e) } if node.has_elements?
+          node.attributes.each { |a, b| reply[:transaction_output_data][a.underscore.to_sym] = b }
+          node.elements.each { |e| parse_element(reply[:transaction_output_data], e) } if node.has_elements?
         when 'CustomVariables'
           reply[:custom_variables] = {}
-          node.attributes.each{|a, b| reply[:custom_variables][a.underscore.to_sym] = b }
-          node.elements.each{|e| parse_element(reply[:custom_variables], e) } if node.has_elements?
+          node.attributes.each { |a, b| reply[:custom_variables][a.underscore.to_sym] = b }
+          node.elements.each { |e| parse_element(reply[:custom_variables], e) } if node.has_elements?
         when 'GatewayEntryPoints'
           reply[:gateway_entry_points] = {}
-          node.attributes.each{|a, b| reply[:gateway_entry_points][a.underscore.to_sym] = b }
-          node.elements.each{|e| parse_element(reply[:gateway_entry_points], e) } if node.has_elements?
+          node.attributes.each { |a, b| reply[:gateway_entry_points][a.underscore.to_sym] = b }
+          node.elements.each { |e| parse_element(reply[:gateway_entry_points], e) } if node.has_elements?
         else
           k = node.name.underscore.to_sym
           if node.has_elements?
             reply[k] = {}
-            node.elements.each{|e| parse_element(reply[k], e) }
+            node.elements.each { |e| parse_element(reply[k], e) }
           else
             if node.has_attributes?
               reply[k] = {}
-              node.attributes.each{|a, b| reply[k][a.underscore.to_sym] = b }
+              node.attributes.each { |a, b| reply[k][a.underscore.to_sym] = b }
             else
               reply[k] = node.text
             end

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -206,7 +206,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if !node.elements.empty?
-          node.elements.each {|e| parse_element(parsed, e) }
+          node.elements.each { |e| parse_element(parsed, e) }
         else
           parsed[underscore(node.name)] = node.text
         end

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -315,7 +315,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -324,7 +324,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/maxipago.rb
+++ b/lib/active_merchant/billing/gateways/maxipago.rb
@@ -142,7 +142,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
         post[:profile_key] = @options[:password]
         post[:transaction_type] = action if action
 
-        request = post.merge(parameters).map {|key, value| "#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+        request = post.merge(parameters).map { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
         request
       end
     end

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(data)
-        responses =  CGI.parse(data).inject({}){|h, (k, v)| h[k] = v.first; h}
+        responses =  CGI.parse(data).inject({}) { |h, (k, v)| h[k] = v.first; h }
         Response.new(
           (responses['response'].to_i == 1),
           responses['responsetext'],

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -212,7 +212,7 @@ module ActiveMerchant #:nodoc:
         if node.elements.size == 0
           response[node.name.downcase.underscore.to_sym] = node.text
         else
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element)}
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(post)
-        post.collect{|k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        post.collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -140,7 +140,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, params)
-        params.map {|k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def url(action)

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -249,7 +249,7 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard_type(post, card_type)
         post[:Gateway]  = 'ssl'
-        post[:card] = CARD_TYPES.detect{|ct| ct.am_code == card_type}.migs_long_code
+        post[:card] = CARD_TYPES.detect { |ct| ct.am_code == card_type }.migs_long_code
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -122,7 +122,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! action, { 'xmlns' => xmlns(action) } do
               xml.tag! 'clientId', @options[:login]
               xml.tag! 'clientCode', @options[:password]
-              params.each {|key, value| xml.tag! key, value }
+              params.each { |key, value| xml.tag! key, value }
             end
           end
         end
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|e| parse_element(response, e) }
+          node.elements.each { |e| parse_element(response, e) }
         else
           response[node.name.underscore.to_sym] = node.text.to_s.strip
         end

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -307,8 +307,8 @@ module ActiveMerchant #:nodoc:
         tokens = full_address.split(/\s+/)
 
         element = REXML::Element.new('avs_info')
-        element.add_element('avs_street_number').text = tokens.select {|x| x =~ /\d/}.join(' ')
-        element.add_element('avs_street_name').text = tokens.reject {|x| x =~ /\d/}.join(' ')
+        element.add_element('avs_street_number').text = tokens.select { |x| x =~ /\d/ }.join(' ')
+        element.add_element('avs_street_name').text = tokens.reject { |x| x =~ /\d/ }.join(' ')
         element.add_element('avs_zipcode').text = address[:zip]
         element
       end

--- a/lib/active_merchant/billing/gateways/moneris_us.rb
+++ b/lib/active_merchant/billing/gateways/moneris_us.rb
@@ -291,8 +291,8 @@ module ActiveMerchant #:nodoc:
         tokens = full_address.split(/\s+/)
 
         element = REXML::Element.new('avs_info')
-        element.add_element('avs_street_number').text = tokens.select{|x| x =~ /\d/}.join(' ')
-        element.add_element('avs_street_name').text = tokens.reject{|x| x =~ /\d/}.join(' ')
+        element.add_element('avs_street_number').text = tokens.select { |x| x =~ /\d/ }.join(' ')
+        element.add_element('avs_street_name').text = tokens.reject { |x| x =~ /\d/ }.join(' ')
         element.add_element('avs_zipcode').text = address[:zip]
         element
       end

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
         parameters[:type] = action
         parameters[:username] = @options[:login]
         parameters[:password] = @options[:password]
-        parameters.map{|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        parameters.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -280,7 +280,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -152,7 +152,7 @@ module ActiveMerchant
       def post_data(action, params)
         params['COMMAND'] = TRANSACTIONS[action]
         params['LOGIN'] = "#{@options[:login]}/#{@options[:password]}"
-        escape_uri(params.map{|k, v| "#{k}=#{v}"}.join('&'))
+        escape_uri(params.map { |k, v| "#{k}=#{v}" }.join('&'))
       end
 
       # The upstream is picky and so we can't use CGI.escape like we want to

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -31,8 +31,8 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
 
         MultiResponse.run do |r|
-          r.process{authorize(money, creditcard, options)}
-          r.process{capture(money, r.authorization, options)}
+          r.process { authorize(money, creditcard, options) }
+          r.process { capture(money, r.authorization, options) }
         end
       end
 
@@ -40,9 +40,9 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
 
         MultiResponse.run do |r|
-          r.process{setup_transaction(money, options)}
-          r.process{add_and_auth_credit_card(r.authorization, creditcard, options)}
-          r.process{query_transaction(r.authorization, options)}
+          r.process { setup_transaction(money, options) }
+          r.process { add_and_auth_credit_card(r.authorization, creditcard, options) }
+          r.process { query_transaction(r.authorization, options) }
         end
       end
 
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def encode(hash)
-        hash.collect{|(k, v)| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
+        hash.collect { |(k, v)| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -224,7 +224,7 @@ module ActiveMerchant #:nodoc:
         parameters[:pay_type] = 'C'
         parameters[:tran_type] = TRANSACTIONS[action]
 
-        parameters.reject{|k, v| v.blank?}.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
 
     end

--- a/lib/active_merchant/billing/gateways/netpay.rb
+++ b/lib/active_merchant/billing/gateways/netpay.rb
@@ -190,7 +190,7 @@ module ActiveMerchant #:nodoc:
         add_login_data(parameters)
         add_action(parameters, action, options)
 
-        post = parameters.collect{|key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        post = parameters.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
         parse(ssl_post(url, post), parameters)
       end
 

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -246,7 +246,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, params)
-        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -429,9 +429,9 @@ module ActiveMerchant #:nodoc:
           raise "Unknown signature algorithm #{algorithm}"
         end
 
-        filtered_params = signed_parameters.select{|k, v| !v.blank?}
+        filtered_params = signed_parameters.select { |k, v| !v.blank? }
         sha_encryptor.hexdigest(
-          filtered_params.sort_by{|k, v| k.upcase}.map{|k, v| "#{k.upcase}=#{v}#{secret}"}.join('')
+          filtered_params.sort_by { |k, v| k.upcase }.map { |k, v| "#{k.upcase}=#{v}#{secret}" }.join('')
         ).upcase
       end
 
@@ -446,7 +446,7 @@ module ActiveMerchant #:nodoc:
               PSPID
               Operation
               ALIAS
-            ).map{|key| parameters[key]} +
+            ).map { |key| parameters[key] } +
             [secret]
           ).join('')
         ).upcase

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -272,7 +272,7 @@ module ActiveMerchant #:nodoc:
       def add_options(post, options)
         post[:createRegistration] = options[:create_registration] if options[:create_registration] && !options[:registrationId]
         post[:testMode] = options[:test_mode] if test? && options[:test_mode]
-        options.each {|key, value| post[key] = value if key.to_s.match('customParameters\[[a-zA-Z0-9\._]{3,64}\]') }
+        options.each { |key, value| post[key] = value if key.to_s.match('customParameters\[[a-zA-Z0-9\._]{3,64}\]') }
         post['customParameters[SHOPPER_pluginId]'] = 'activemerchant'
         post['customParameters[custom_disable3DSecure]'] = options[:disable_3d_secure] if options[:disable_3d_secure]
       end

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -521,7 +521,7 @@ module ActiveMerchant #:nodoc:
 
       def recurring_parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|e| recurring_parse_element(response, e) }
+          node.elements.each { |e| recurring_parse_element(response, e) }
         else
           response[node.name.underscore.to_sym] = node.text
         end
@@ -533,7 +533,7 @@ module ActiveMerchant #:nodoc:
           headers['Trace-number'] = trace_number.to_s
           headers['Merchant-Id'] = @options[:merchant_id]
         end
-        request = ->(url){ parse(ssl_post(url, order, headers))}
+        request = ->(url) { parse(ssl_post(url, order, headers)) }
 
         # Failover URL will be attempted in the event of a connection error
         response = begin

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        Hash[body.split('&').map{|x| x.split('=').map{|y| CGI.unescape(y)}}]
+        Hash[body.split('&').map { |x| x.split('=').map { |y| CGI.unescape(y) } }]
       end
 
       def commit(action, money, parameters)

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -231,7 +231,7 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, params)
         params[:transaction_type] = action
-        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def unparsable_response(raw_response)

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -162,8 +162,8 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, creditcard, options = {})
         MultiResponse.run do |r|
-          r.process{authorize(money, creditcard, options)}
-          r.process{capture(money, r.authorization, options)}
+          r.process { authorize(money, creditcard, options) }
+          r.process { capture(money, r.authorization, options) }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -366,7 +366,7 @@ module ActiveMerchant #:nodoc:
         params[:version] = API_VERSION
         params[:transaction_type] = action
 
-        params.reject{|k, v| v.blank?}.collect{ |k, v| "dc_#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        params.reject { |k, v| v.blank? }.collect { |k, v| "dc_#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -146,7 +146,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(params)
-        params.map {|k, v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def url(params={})
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         return response['response']['message'] if response['response']
 
-        response['errors']&.inject(''){ |message, error| error['message'] + '|' + message }
+        response['errors']&.inject('') { |message, error| error['message'] + '|' + message }
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
         parameters[:merchant_id]      = @options[:login]
         parameters[:password]         = @options[:password]
 
-        parameters.reject{|k, v| v.blank?}.collect { |key, value| "#{key.to_s.upcase}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |k, v| v.blank? }.collect { |key, value| "#{key.to_s.upcase}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
           :test => test?,
           :authorization => response[:numappel].to_s + response[:numtrans].to_s,
           :fraud_review => false,
-          :sent_params => parameters.delete_if{|key, value| ['porteur', 'dateval', 'cvv'].include?(key.to_s)}
+          :sent_params => parameters.delete_if { |key, value| ['porteur', 'dateval', 'cvv'].include?(key.to_s) }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -63,8 +63,8 @@ module ActiveMerchant #:nodoc:
         if payment_method.respond_to?(:number)
           # credit card authorization
           MultiResponse.new.tap do |r|
-            r.process {send_initialize(amount, true, options)}
-            r.process {send_purchasecc(payment_method, r.params['orderref'])}
+            r.process { send_initialize(amount, true, options) }
+            r.process { send_purchasecc(payment_method, r.params['orderref']) }
           end
         else
           # stored authorization
@@ -91,8 +91,8 @@ module ActiveMerchant #:nodoc:
         if payment_method.respond_to?(:number)
           # credit card purchase
           MultiResponse.new.tap do |r|
-            r.process {send_initialize(amount, false, options)}
-            r.process {send_purchasecc(payment_method, r.params['orderref'])}
+            r.process { send_initialize(amount, false, options) }
+            r.process { send_purchasecc(payment_method, r.params['orderref']) }
           end
         else
           # stored purchase
@@ -154,10 +154,10 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
         amount = amount(1) # 1 cent for authorization
         MultiResponse.run(:first) do |r|
-          r.process {send_create_agreement(options)}
-          r.process {send_initialize(amount, true, options.merge({agreement_ref: r.authorization}))}
+          r.process { send_create_agreement(options) }
+          r.process { send_initialize(amount, true, options.merge({agreement_ref: r.authorization})) }
           order_ref = r.params['orderref']
-          r.process {send_purchasecc(creditcard, order_ref)}
+          r.process { send_purchasecc(creditcard, order_ref) }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -179,9 +179,9 @@ module ActiveMerchant #:nodoc:
           # in an RPPaymentResults element so we'll come here multiple times
           response[node_name] ||= []
           response[node_name] << (payment_result_response = {})
-          node.xpath('.//*').each{ |e| parse_element(payment_result_response, e) }
+          node.xpath('.//*').each { |e| parse_element(payment_result_response, e) }
         when node.xpath('.//*').to_a.any?
-          node.xpath('.//*').each{|e| parse_element(response, e) }
+          node.xpath('.//*').each { |e| parse_element(response, e) }
         when node_name.to_s =~ /amt$/
           # *Amt elements don't put the value in the #text - instead they use a Currency attribute
           response[node_name] = node.attributes['Currency'].to_s

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        Hash[body.split('&').map{|x| x.split('=')}]
+        Hash[body.split('&').map { |x| x.split('=') }]
       end
 
       def commit(action, money, parameters)

--- a/lib/active_merchant/billing/gateways/payu_in.rb
+++ b/lib/active_merchant/billing/gateways/payu_in.rb
@@ -32,11 +32,11 @@ module ActiveMerchant #:nodoc:
         add_auth(post)
 
         MultiResponse.run do |r|
-          r.process{commit(url('purchase'), post)}
+          r.process { commit(url('purchase'), post) }
           if(r.params['enrolled'].to_s == '0')
-            r.process{commit(r.params['post_uri'], r.params['form_post_vars'])}
+            r.process { commit(r.params['post_uri'], r.params['form_post_vars']) }
           else
-            r.process{handle_3dsecure(r)}
+            r.process { handle_3dsecure(r) }
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -183,7 +183,7 @@ module ActiveMerchant
         address = options[:billing_address] || options[:address]
         return if address.nil?
 
-        post[:QAAddress] = [:address1, :address2, :city, :state].collect{|a| address[a]}.reject(&:blank?).join(' ')
+        post[:QAAddress] = [:address1, :address2, :city, :state].collect { |a| address[a] }.reject(&:blank?).join(' ')
         post[:QAPostcode] = address[:zip]
       end
 

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -251,7 +251,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(reply, node)
         if node.has_elements?
-          node.elements.each{|e| parse_element(reply, e) }
+          node.elements.each { |e| parse_element(reply, e) }
         else
           if node.parent.name =~ /item/
             parent = node.parent.name + (node.parent.attributes['id'] ? '_' + node.parent.attributes['id'] : '')

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -224,17 +224,17 @@ module ActiveMerchant #:nodoc:
         }
 
         # prepare components for signature
-        oauth_signature_base_string = [method.to_s.upcase, request_uri.to_s, oauth_parameters.to_param].map{|v| CGI.escape(v) }.join('&')
-        oauth_signing_key = [@options[:consumer_secret], @options[:token_secret]].map{|v| CGI.escape(v)}.join('&')
+        oauth_signature_base_string = [method.to_s.upcase, request_uri.to_s, oauth_parameters.to_param].map { |v| CGI.escape(v) }.join('&')
+        oauth_signing_key = [@options[:consumer_secret], @options[:token_secret]].map { |v| CGI.escape(v) }.join('&')
         hmac_signature = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), oauth_signing_key, oauth_signature_base_string)
 
         # append signature to required OAuth parameters
         oauth_parameters[:oauth_signature] = CGI.escape(Base64.encode64(hmac_signature).chomp.gsub(/\n/, ''))
 
         # prepare Authorization header string
-        oauth_parameters = Hash[oauth_parameters.sort_by {|k, _| k}]
+        oauth_parameters = Hash[oauth_parameters.sort_by { |k, _| k }]
         oauth_headers = ["OAuth realm=\"#{@options[:realm]}\""]
-        oauth_headers += oauth_parameters.map {|k, v| "#{k}=\"#{v}\""}
+        oauth_headers += oauth_parameters.map { |k, v| "#{k}=\"#{v}\"" }
 
         {
           'Content-type' => 'application/json',
@@ -258,7 +258,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        response['errors'].present? ? response['errors'].map {|error_hash| error_hash['message'] }.join(' ') : response['status']
+        response['errors'].present? ? response['errors'].map { |error_hash| error_hash['message'] }.join(' ') : response['status']
       end
 
       def errors_from(response)

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -78,7 +78,7 @@ module ActiveMerchant
       def store(credit_card, options = {})
         MultiResponse.run do |r|
           r.process { create_store(options) }
-          r.process { authorize_store(r.authorization, credit_card, options)}
+          r.process { authorize_store(r.authorization, credit_card, options) }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['AUD'] = 'AUD'
       CURRENCY_CODES['INR'] = 'INR'
 
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -286,7 +286,7 @@ module ActiveMerchant
 
       def format_address_code(address)
         code = [address[:zip].to_s, address[:address1].to_s + address[:address2].to_s]
-        code.collect{|e| e.gsub(/\D/, '')}.reject(&:empty?).join('|')
+        code.collect { |e| e.gsub(/\D/, '') }.reject(&:empty?).join('|')
       end
 
       def new_timestamp

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -247,7 +247,7 @@ module ActiveMerchant #:nodoc:
 
       def recurring_parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|e| recurring_parse_element(response, e) }
+          node.elements.each { |e| recurring_parse_element(response, e) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -276,7 +276,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_element(response, node)
         if node.has_elements?
-          node.elements.each{|element| parse_element(response, element) }
+          node.elements.each { |element| parse_element(response, element) }
         else
           response[node.name.underscore.to_sym] = node.text
         end

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -368,7 +368,7 @@ module ActiveMerchant #:nodoc:
         post[:OrderDescription] = options[:description]
 
         if order_items = options[:items]
-          post[:OrderString] = order_items.collect { |item| "#{item[:sku]}~#{item[:description].tr('~', '-')}~#{item[:declared_value]}~#{item[:quantity]}~#{item[:taxable]}~~~~~~~~#{item[:tax_rate]}~||"}.join
+          post[:OrderString] = order_items.collect { |item| "#{item[:sku]}~#{item[:description].tr('~', '-')}~#{item[:declared_value]}~#{item[:quantity]}~#{item[:taxable]}~~~~~~~~#{item[:tax_rate]}~||" }.join
         else
           post[:OrderString] = '1~None~0.00~0~N~||'
         end

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -263,7 +263,7 @@ module ActiveMerchant #:nodoc:
         post[:password]   = @options[:password]
         post[:type]       = action if action
 
-        request = post.merge(parameters).map {|key, value| "#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+        request = post.merge(parameters).map { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
         request
       end
 

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -321,7 +321,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = '840'
 
       def headers

--- a/lib/active_merchant/billing/gateways/transact_pro.rb
+++ b/lib/active_merchant/billing/gateways/transact_pro.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         post[:rs] = @options[:terminal]
 
         MultiResponse.run do |r|
-          r.process{commit('init', post)}
+          r.process { commit('init', post) }
           r.process do
             post = PostData.new
             post[:init_transaction_id] = r.authorization
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
         post[:rs] = @options[:terminal]
 
         MultiResponse.run do |r|
-          r.process{commit('init_dms', post)}
+          r.process { commit('init_dms', post) }
           r.process do
             post = PostData.new
             post[:init_transaction_id] = r.authorization

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -253,7 +253,7 @@ module ActiveMerchant #:nodoc:
           :error_code       => fields['UMerrorcode'],
           :acs_url          => fields['UMacsurl'],
           :payload          => fields['UMpayload']
-        }.delete_if{|k, v| v.nil?}
+        }.delete_if { |k, v| v.nil? }
       end
 
       def commit(action, parameters)

--- a/lib/active_merchant/billing/gateways/vanco.rb
+++ b/lib/active_merchant/billing/gateways/vanco.rb
@@ -82,8 +82,8 @@ module ActiveMerchant
           response[:error_message] = error['ErrorDescription']
           response[:error_codes] = error['ErrorCode']
         elsif error.kind_of?(Array)
-          error_str = error.map { |e| e['ErrorDescription']}.join('. ')
-          error_codes = error.map { |e| e['ErrorCode']}.join(', ')
+          error_str = error.map { |e| e['ErrorDescription'] }.join('. ')
+          error_codes = error.map { |e| e['ErrorCode'] }.join(', ')
           response[:error_message] = "#{error_str}."
           response[:error_codes] = error_codes
         end

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
       # Parse the response message
       def parse(msg)
         resp = {}
-        msg.split(self.delimiter).collect{|li|
+        msg.split(self.delimiter).collect { |li|
           key, value = li.split('=')
           resp[key.strip.gsub(/^ssl_/, '')] = value.to_s.strip
         }

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new{|h, k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = 840
       CURRENCY_CODES['PEN'] = 604
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -30,8 +30,8 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment_method, options = {})
         MultiResponse.run do |r|
-          r.process{authorize(money, payment_method, options)}
-          r.process{capture(money, r.authorization, options.merge(:authorization_validated => true))}
+          r.process { authorize(money, payment_method, options) }
+          r.process { capture(money, r.authorization, options.merge(:authorization_validated => true)) }
         end
       end
 
@@ -42,19 +42,19 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         MultiResponse.run do |r|
-          r.process{inquire_request(authorization, options, 'AUTHORISED')} unless options[:authorization_validated]
+          r.process { inquire_request(authorization, options, 'AUTHORISED') } unless options[:authorization_validated]
           if r.params
             authorization_currency = r.params['amount_currency_code']
             options = options.merge(:currency => authorization_currency) if authorization_currency.present?
           end
-          r.process{capture_request(money, authorization, options)}
+          r.process { capture_request(money, authorization, options) }
         end
       end
 
       def void(authorization, options = {})
         MultiResponse.run do |r|
-          r.process{inquire_request(authorization, options, 'AUTHORISED')} unless options[:authorization_validated]
-          r.process{cancel_request(authorization, options)}
+          r.process { inquire_request(authorization, options, 'AUTHORISED') } unless options[:authorization_validated]
+          r.process { cancel_request(authorization, options) }
         end
       end
 
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def order_tag_attributes(options)
-        { 'orderCode' => options[:order_id], 'installationId' => options[:inst_id] || @options[:inst_id] }.reject{|_, v| !v}
+        { 'orderCode' => options[:order_id], 'installationId' => options[:inst_id] || @options[:inst_id] }.reject { |_, v| !v }
       end
 
       def build_capture_request(money, authorization, options)
@@ -337,7 +337,7 @@ module ActiveMerchant #:nodoc:
         end
         if node.has_elements?
           raw[node.name.underscore.to_sym] = true unless node.name.blank?
-          node.elements.each{|e| parse_element(raw, e) }
+          node.elements.each { |e| parse_element(raw, e) }
         else
           raw[node.name.underscore.to_sym] = node.text unless node.text.nil?
         end
@@ -418,12 +418,12 @@ module ActiveMerchant #:nodoc:
 
       def required_status_message(raw, success_criteria)
         if(!success_criteria.include?(raw[:last_event]))
-          "A transaction status of #{success_criteria.collect{|c| "'#{c}'"}.join(" or ")} is required."
+          "A transaction status of #{success_criteria.collect { |c| "'#{c}'" }.join(" or ")} is required."
         end
       end
 
       def authorization_from(raw)
-        pair = raw.detect{|k, v| k.to_s =~ /_order_code$/}
+        pair = raw.detect { |k, v| k.to_s =~ /_order_code$/ }
         (pair ? pair.last : nil)
       end
 

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
 
       def <<(response)
         if response.is_a?(MultiResponse)
-          response.responses.each{|r| @responses << r}
+          response.responses.each { |r| @responses << r }
         else
           @responses << response
         end

--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -39,11 +39,11 @@ module ActiveMerchant #:nodoc:
 
     def initialize(options = {})
       @name = options.delete(:name)
-      @codes = options.collect{|k, v| CountryCode.new(v)}
+      @codes = options.collect { |k, v| CountryCode.new(v) }
     end
 
     def code(format)
-      @codes.detect{|c| c.format == format}
+      @codes.detect { |c| c.format == format }
     end
 
     def ==(other)
@@ -324,9 +324,9 @@ module ActiveMerchant #:nodoc:
       when 2, 3
         upcase_name = name.upcase
         country_code = CountryCode.new(name)
-        country = COUNTRIES.detect{|c| c[country_code.format] == upcase_name }
+        country = COUNTRIES.detect { |c| c[country_code.format] == upcase_name }
       else
-        country = COUNTRIES.detect{|c| c[:name].casecmp(name).zero? }
+        country = COUNTRIES.detect { |c| c[:name].casecmp(name).zero? }
       end
       raise InvalidCountryCodeError, "No country could be found for the country #{name}" if country.nil?
       Country.new(country.dup)

--- a/lib/support/gateway_support.rb
+++ b/lib/support/gateway_support.rb
@@ -24,14 +24,14 @@ class GatewaySupport #:nodoc:
   end
 
   def each_gateway
-    @gateways.each{|g| yield g }
+    @gateways.each { |g| yield g }
   end
 
   def features
     width = 15
 
     print 'Name'.center(width + 20)
-    ACTIONS.each{|f| print f.to_s.capitalize.center(width) }
+    ACTIONS.each { |f| print f.to_s.capitalize.center(width) }
     puts
 
     each_gateway do |g|

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def setup
     @gateway = BraintreeGateway.new(fixtures(:braintree_blue))
-    @braintree_backend = @gateway.instance_eval{@braintree_gateway}
+    @braintree_backend = @gateway.instance_eval { @braintree_gateway }
 
     @amount = 100
     @declined_amount = 2000_00

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -271,7 +271,7 @@ class MonerisRemoteTest < Test::Unit::TestCase
   def test_avs_result_nil_when_address_absent
     gateway = MonerisGateway.new(fixtures(:moneris).merge(avs_enabled: true))
 
-    assert response = gateway.purchase(1010, @credit_card, @options.tap {|x| x.delete(:billing_address)})
+    assert response = gateway.purchase(1010, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     assert_success response
     assert_equal(response.avs_result, {
         'code' => nil,

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -216,7 +216,7 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
 
     # You can only include up to 250 recipients
-    recipients = (1..251).collect {|i| [100, "person#{i}@example.com"]}
+    recipients = (1..251).collect { |i| [100, "person#{i}@example.com"] }
     response = @gateway.transfer(*recipients)
     assert_failure response
   end

--- a/test/remote/gateways/remote_securion_pay_test.rb
+++ b/test/remote/gateways/remote_securion_pay_test.rb
@@ -106,7 +106,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert refund.params['refunded']
     assert_equal 0, refund.params['amount']
     assert_equal 1, refund.params['refunds'].size
-    assert_equal @amount, refund.params['refunds'].map{|r| r['amount']}.sum
+    assert_equal @amount, refund.params['refunds'].map { |r| r['amount'] }.sum
 
     assert refund.authorization
   end
@@ -124,7 +124,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert second_refund.params['refunded']
     assert_equal @amount - 2 * @refund_amount, second_refund.params['amount']
     assert_equal 2, second_refund.params['refunds'].size
-    assert_equal 2 * @refund_amount, second_refund.params['refunds'].map{|r| r['amount']}.sum
+    assert_equal 2 * @refund_amount, second_refund.params['refunds'].map { |r| r['amount'] }.sum
     assert second_refund.authorization
   end
 
@@ -154,7 +154,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert void.params['refunded']
     assert_equal 0, void.params['amount']
     assert_equal 1, void.params['refunds'].size
-    assert_equal @amount, void.params['refunds'].map{|r| r['amount']}.sum
+    assert_equal @amount, void.params['refunds'].map { |r| r['amount'] }.sum
     assert void.authorization
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -273,7 +273,7 @@ module ActiveMerchant
       return unless hash.is_a?(Hash)
 
       hash.symbolize_keys!
-      hash.each{|k, v| symbolize_keys(v)}
+      hash.each { |k, v| symbolize_keys(v) }
     end
   end
 end

--- a/test/unit/country_code_test.rb
+++ b/test/unit/country_code_test.rb
@@ -26,6 +26,6 @@ class CountryCodeTest < Test::Unit::TestCase
   end
 
   def test_invalid_code_format
-    assert_raises(ActiveMerchant::CountryCodeFormatError){ ActiveMerchant::CountryCode.new('Canada') }
+    assert_raises(ActiveMerchant::CountryCodeFormatError) { ActiveMerchant::CountryCode.new('Canada') }
   end
 end

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -188,7 +188,7 @@ class CreditCardTest < Test::Unit::TestCase
     assert_equal 'visa',             CreditCard.brand?('4242424242424242')
     assert_equal 'american_express', CreditCard.brand?('341111111111111')
     assert_equal 'master', CreditCard.brand?('5105105105105100')
-    (222100..272099).each {|bin| assert_equal 'master', CreditCard.brand?(bin.to_s + '1111111111'), "Failed with BIN #{bin}"}
+    (222100..272099).each { |bin| assert_equal 'master', CreditCard.brand?(bin.to_s + '1111111111'), "Failed with BIN #{bin}" }
     assert_nil CreditCard.brand?('')
   end
 

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -277,7 +277,7 @@ class BalancedTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, address: a)
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
-      clean = proc{|s| Regexp.escape(CGI.escape(s))}
+      clean = proc { |s| Regexp.escape(CGI.escape(s)) }
       assert_match(%r{address\[line1\]=#{clean[a[:address1]]}}, data)
       assert_match(%r{address\[line2\]=#{clean[a[:address2]]}}, data)
       assert_match(%r{address\[city\]=#{clean[a[:city]]}}, data)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -231,7 +231,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_requires_error_on_tax_calculation_without_line_items
-    assert_raise(ArgumentError){ @gateway.calculate_tax(@credit_card, @options.delete_if{|key, val| key == :line_items})}
+    assert_raise(ArgumentError) { @gateway.calculate_tax(@credit_card, @options.delete_if { |key, val| key == :line_items }) }
   end
 
   def test_default_currency

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -87,11 +87,11 @@ class DataCashTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_missing_order_id_option
-    assert_raise(ArgumentError){ @gateway.purchase(100, @credit_card, {}) }
+    assert_raise(ArgumentError) { @gateway.purchase(100, @credit_card, {}) }
   end
 
   def test_authorize_with_missing_order_id_option
-    assert_raise(ArgumentError){ @gateway.authorize(100, @credit_card, {}) }
+    assert_raise(ArgumentError) { @gateway.authorize(100, @credit_card, {}) }
   end
 
   def test_purchase_does_not_raise_exception_with_missing_billing_address

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -22,7 +22,7 @@ class ExactTest < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Transaction Normal - VER UNAVAILABLE', response.message
 
-    ExactGateway::SENSITIVE_FIELDS.each{ |f| assert !response.params.has_key?(f.to_s) }
+    ExactGateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_refund

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -38,7 +38,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Transaction Normal - Approved', response.message
 
-    FirstdataE4Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+    FirstdataE4Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_purchase_with_specified_currency
@@ -51,7 +51,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert_equal 'Transaction Normal - Approved', response.message
     assert_equal 'GBP', response.params['currency']
 
-    FirstdataE4Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+    FirstdataE4Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_purchase_with_token

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -40,7 +40,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Transaction Normal - Approved', response.message
 
-    FirstdataE4V27Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+    FirstdataE4V27Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_purchase_with_token

--- a/test/unit/gateways/migs_test.rb
+++ b/test/unit/gateways/migs_test.rb
@@ -63,10 +63,10 @@ class MigsTest < Test::Unit::TestCase
     assert_success response
 
     tampered_response1 = response_params.gsub('20DE', '20DF')
-    assert_raise(SecurityError){@gateway.purchase_offsite_response(tampered_response1)}
+    assert_raise(SecurityError) { @gateway.purchase_offsite_response(tampered_response1) }
 
     tampered_response2 = response_params.gsub('Locale=en', 'Locale=es')
-    assert_raise(SecurityError){@gateway.purchase_offsite_response(tampered_response2)}
+    assert_raise(SecurityError) { @gateway.purchase_offsite_response(tampered_response2) }
   end
 
   def test_scrub
@@ -93,7 +93,7 @@ class MigsTest < Test::Unit::TestCase
   end
 
   def build_response(options)
-    options.collect { |key, value| "vpc_#{key}=#{CGI.escape(value.to_s)}"}.join('&')
+    options.collect { |key, value| "vpc_#{key}=#{CGI.escape(value.to_s)}" }.join('&')
   end
 
   def pre_scrubbed

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -101,7 +101,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_purchase_with_shipping_address
     @options[:shipping_address] = {:country => 'CA'}
     @gateway.expects(:ssl_post).with do |url, data|
-      xml = data.split('&').detect{|string| string =~ /txnRequest=/}.gsub('txnRequest=', '')
+      xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))
       doc.xpath('//xmlns:shippingDetails/xmlns:country').first.text == 'CA' && doc.to_s.include?('<shippingDetails>')
     end.returns(successful_purchase_response)
@@ -112,7 +112,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_purchase_without_shipping_address
     @options[:shipping_address] = nil
     @gateway.expects(:ssl_post).with do |url, data|
-      xml = data.split('&').detect{|string| string =~ /txnRequest=/}.gsub('txnRequest=', '')
+      xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))
       doc.to_s.include?('<shippingDetails>') == false
     end.returns(successful_purchase_response)

--- a/test/unit/gateways/pac_net_raven_test.rb
+++ b/test/unit/gateways/pac_net_raven_test.rb
@@ -157,21 +157,21 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
   end
 
   def test_argument_error_prn
-    exception = assert_raises(ArgumentError){
+    exception = assert_raises(ArgumentError) {
       PacNetRavenGateway.new(:user => 'user', :secret => 'secret')
     }
     assert_equal 'Missing required parameter: prn', exception.message
   end
 
   def test_argument_error_user
-    exception = assert_raises(ArgumentError){
+    exception = assert_raises(ArgumentError) {
       PacNetRavenGateway.new(:secret => 'secret', :prn => 123456)
     }
     assert_equal 'Missing required parameter: user', exception.message
   end
 
   def test_argument_error_secret
-    exception = assert_raises(ArgumentError){
+    exception = assert_raises(ArgumentError) {
       PacNetRavenGateway.new(:user => 'user', :prn => 123456)
     }
     assert_equal 'Missing required parameter: secret', exception.message

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -540,6 +540,6 @@ SRC
       assert_equal a1.name, b1.name
       assert_equal a1.value, b1.value
     end
-    a.children.zip(b.children).all?{|a1, b1| assert_xml_equal_recursive(a1, b1)}
+    a.children.zip(b.children).all? { |a1, b1| assert_xml_equal_recursive(a1, b1) }
   end
 end

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -202,7 +202,7 @@ class SecurionPayTest < Test::Unit::TestCase
     assert response.params['refunded']
     assert_equal 0, response.params['amount']
     assert_equal 1, response.params['refunds'].size
-    assert_equal @amount, response.params['refunds'].map{|r| r['amount']}.sum
+    assert_equal @amount, response.params['refunds'].map { |r| r['amount'] }.sum
     assert_equal 'char_DQca5ZjbewP2Oe0lIsNe4EXP', response.authorization
     assert response.test?
   end
@@ -215,7 +215,7 @@ class SecurionPayTest < Test::Unit::TestCase
     assert_success response
     assert response.params['refunded']
     assert_equal @amount - @refund_amount, response.params['amount']
-    assert_equal @refund_amount, response.params['refunds'].map{|r| r['amount']}.sum
+    assert_equal @refund_amount, response.params['refunds'].map { |r| r['amount'] }.sum
     assert_equal 'char_oVnJ1j6fZqOvnopBBvlnpEuX', response.authorization
     assert response.test?
   end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1071,7 +1071,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_metadata_header
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['X-Stripe-Client-User-Metadata'] == {:ip => '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 
@@ -1079,7 +1079,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_version_header
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['Stripe-Version'] == '2013-10-29'
     }.returns(successful_purchase_response)
 
@@ -1087,7 +1087,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_key_header
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response)
 
@@ -1096,7 +1096,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_on_void
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response(true))
 
@@ -1119,7 +1119,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_initialize_gateway_with_version
     @gateway = StripeGateway.new(:login => 'login', :version => '2013-12-03')
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['Stripe-Version'] == '2013-12-03'
     }.returns(successful_purchase_response)
 

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -158,7 +158,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def test_metadata_header
-    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['X-Webpay-Client-User-Metadata'] == {:ip => '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -112,7 +112,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
 
     assert_success response
-    assert_equal(%w(authorize capture), response.responses.collect{|e| e.params['action']})
+    assert_equal(%w(authorize capture), response.responses.collect { |e| e.params['action'] })
   end
 
   def test_successful_void

--- a/test/unit/multi_response_test.rb
+++ b/test/unit/multi_response_test.rb
@@ -12,8 +12,8 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(true, '1', {})
     r2 = Response.new(true, '2', {})
     m = MultiResponse.run do |r|
-      r.process{r1}
-      r.process{r2}
+      r.process { r1 }
+      r.process { r2 }
     end
     assert_equal [r1, r2], m.responses
   end
@@ -22,8 +22,8 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(true, '1', {})
     r2 = Response.new(true, '2', {})
     m = MultiResponse.run do |r|
-      r.process{r1}
-      r.process{r2}
+      r.process { r1 }
+      r.process { r2 }
     end
     assert_equal [r1, r2], m.responses
   end
@@ -42,7 +42,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :error_code => :card_declined,
       :fraud_review => true
     )
-    m.process{r1}
+    m.process { r1 }
     assert_equal({'one' => 1}, m.params)
     assert_equal '1', m.message
     assert m.test
@@ -63,7 +63,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :cvv_result => 'CVV2',
       :fraud_review => false
     )
-    m.process{r2}
+    m.process { r2 }
     assert_equal({'two' => 2}, m.params)
     assert_equal '2', m.message
     assert !m.test
@@ -87,7 +87,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :cvv_result => 'CVV1',
       :fraud_review => true
     )
-    m.process{r1}
+    m.process { r1 }
     assert_equal({'one' => 1}, m.params)
     assert_equal '1', m.message
     assert m.test
@@ -107,7 +107,7 @@ class MultiResponseTest < Test::Unit::TestCase
       :cvv_result => 'CVV2',
       :fraud_review => false
     )
-    m.process{r2}
+    m.process { r2 }
     assert_equal({'one' => 1}, m.params)
     assert_equal '1', m.message
     assert m.test
@@ -124,9 +124,9 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(true, '1', {}, {})
     r2 = Response.new(false, '2', {}, {})
     r3 = Response.new(false, '3', {}, {})
-    m.process{r1}
-    m.process{r2}
-    m.process{r3}
+    m.process { r1 }
+    m.process { r2 }
+    m.process { r3 }
     assert_equal r2, m.primary_response
     assert_equal '2', m.message
   end
@@ -135,8 +135,8 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(false, '1', {})
     r2 = Response.new(true, '2', {})
     m = MultiResponse.run do |r|
-      r.process{r1}
-      r.process{r2}
+      r.process { r1 }
+      r.process { r2 }
     end
     assert !m.success?
     assert_equal [r1], m.responses
@@ -147,12 +147,12 @@ class MultiResponseTest < Test::Unit::TestCase
     r2 = Response.new(true, '2', {})
     r3 = Response.new(true, '3', {})
     m1 = MultiResponse.run do |r|
-      r.process{r1}
-      r.process{r2}
+      r.process { r1 }
+      r.process { r2 }
     end
     m = MultiResponse.run do |r|
-      r.process{m1}
-      r.process{r3}
+      r.process { m1 }
+      r.process { r3 }
     end
     assert_equal [r1, r2, r3], m.responses
   end
@@ -161,12 +161,12 @@ class MultiResponseTest < Test::Unit::TestCase
     m = MultiResponse.new
 
     r1 = Response.new(true, '1')
-    m.process{r1}
+    m.process { r1 }
     assert_equal '1', m.message
     assert_equal [r1], m.responses
 
     r2 = Response.new(false, '2')
-    m.process(:ignore_result){r2}
+    m.process(:ignore_result) { r2 }
     assert_equal '1', m.message
     assert_equal [r1, r2], m.responses
 


### PR DESCRIPTION
This is actually two fixes, Layout/SpaceInsideBlockBraces and
Layout/SpaceBeforeBlockBraces, because the diff actually looks worse
if you do either of them alone (and the same lines largely get touched
on the follow-up diff anyway).