### PR TITLE
Forte: Allow void on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Cenpos: update supported countries [bpollack] #3055
 * CyberSource: update supported countries [bpollack] #3055
 * MiGS: update supported countries [bpollack] #3055
+* Forte: Allow void on capture #3059
 
 == Version 1.86.0 (October 26, 2018)
 * UsaEpayTransaction: Support UMcheckformat option for echecks [dtykocki] #3002

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -82,6 +82,22 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal 'APPROVED', capture.message
   end
 
+  def test_successful_authorize_capture_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    wait_for_authorization_to_clear
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+    assert_match auth.authorization.split('#')[0], capture.authorization
+    assert_match auth.authorization.split('#')[1], capture.authorization
+    assert_equal 'APPROVED', capture.message
+
+    void = @gateway.void(capture.authorization)
+    assert_success void
+  end
+
   def test_failed_authorize
     @amount = 1985
     response = @gateway.authorize(@amount, @declined_card, @options)


### PR DESCRIPTION
Forte uses different transaction id's for captures. When trying to void
a capture this results in a error. This saves the original auth
transaction id and authorization id in the capture authorization so the original auth will be voided
or refunded.

Loaded suite test/unit/gateways/forte_test

20 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Loaded suite test/remote/gateways/remote_forte_test

21 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------