### PR TITLE
Braintree Blue: actually, really, truly fix nil address fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
     #
     class BraintreeBlueGateway < Gateway
       include BraintreeCommon
+      include Empty
 
       self.display_name = 'Braintree (Blue Platform)'
 
@@ -261,7 +262,7 @@ module ActiveMerchant #:nodoc:
           }
           if options[:billing_address]
             address = map_address(options[:billing_address])
-            parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| v.nil? }
+            parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| empty?(v) }
           end
 
           result = @braintree_gateway.credit_card.create(parameters)
@@ -309,7 +310,7 @@ module ActiveMerchant #:nodoc:
         parameters[:credit_card][:options] = valid_options
         if options[:billing_address]
           address = map_address(options[:billing_address])
-          parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| v.nil? }
+          parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| empty?(v) }
         end
         parameters
       end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -46,7 +46,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
         :phone => '123-456-7890',
         :company => nil,
         :address1 => nil,
-        :address2 => nil,
+        :address2 => '',
         :city => nil,
         :state => nil,
         :zip => nil,

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -386,7 +386,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       :phone => '123-456-7890',
       :company => nil,
       :address1 => nil,
-      :address2 => nil,
+      :address2 => '',
       :city => nil,
       :state => nil,
       :zip => nil,


### PR DESCRIPTION
Previously, on Battlestar Galactica, we only filtered out the address if the fields were `nil`. But some of our library consumers like to pass in empty strings, which we treated as actual data, whereas Braintree Blue weirdly insists `""` is not a valid address. We now instead treat empty strings the same as `nil` values.

Unit: 57 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 66 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed