### PR TITLE
Authorize.Net: Support refunds for bank accounts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068
 * QuickPay: update supported countries [ta] #3049
 * WorldPay: set cardholder name to "3D" for 3DS transactions [bpollack] #3071
+* Authorize.Net: Support refunds for bank accounts [nfarve]  #3063
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -339,9 +339,18 @@ module ActiveMerchant
             xml.transactionType('refundTransaction')
             xml.amount(amount.nil? ? 0 : amount(amount))
             xml.payment do
-              xml.creditCard do
-                xml.cardNumber(card_number || options[:card_number])
-                xml.expirationDate('XXXX')
+              if options[:routing_number]
+                xml.bankAccount do
+                  xml.accountType(options[:account_type])
+                  xml.routingNumber(options[:routing_number])
+                  xml.accountNumber(options[:account_number])
+                  xml.nameOnAccount("#{options[:first_name]} #{options[:last_name]}")
+                end
+              else
+                xml.creditCard do
+                  xml.cardNumber(card_number || options[:card_number])
+                  xml.expirationDate('XXXX')
+                end
               end
             end
             xml.refTransId(transaction_id)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -877,6 +877,20 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal '2214602071#2224#refund', refund.authorization
   end
 
+  def test_successful_bank_refund
+    response = stub_comms do
+      @gateway.refund(50, '12345667', account_type: 'checking', routing_number: '123450987', account_number: '12345667', first_name: 'Louise', last_name: 'Belcher')
+    end.check_request do |endpoint, data, headers|
+      parse(data) do |doc|
+        assert_equal 'checking', doc.at_xpath('//transactionRequest/payment/bankAccount/accountType').content
+        assert_equal '123450987', doc.at_xpath('//transactionRequest/payment/bankAccount/routingNumber').content
+        assert_equal '12345667', doc.at_xpath('//transactionRequest/payment/bankAccount/accountNumber').content
+        assert_equal 'Louise Belcher', doc.at_xpath('//transactionRequest/payment/bankAccount/nameOnAccount').content
+      end
+    end.respond_with(successful_refund_response)
+    assert_success response
+  end
+
   def test_refund_passing_extra_info
     response = stub_comms do
       @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', order_id: '1', description: 'Refund for order 1')


### PR DESCRIPTION
Refunds for bank accounts require a different structure than credit
cards. The routing number, account number and account type must also be
passed in the request.

Loaded suite test/unit/gateways/authorize_net_test
................................................................................................

96 tests, 565 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_authorize_net_test
.....................................................................
69 tests, 238 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed