### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,12 +74,6 @@ Layout/IndentHash:
 Layout/IndentHeredoc:
   Enabled: false
 
-# Offense count: 193
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,13 +74,6 @@ Layout/IndentHash:
 Layout/IndentHeredoc:
   Enabled: false
 
-# Offense count: 92
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: normal, rails
-Layout/IndentationConsistency:
-  Enabled: false
-
 # Offense count: 193
 # Cop supports --auto-correct.
 # Configuration parameters: Width, IgnoredPatterns.

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -837,7 +837,7 @@ module ActiveMerchant
         response = {action: action}
 
         response[:response_code] = if(element = doc.at_xpath('//transactionResponse/responseCode'))
-          (empty?(element.content) ? nil : element.content.to_i)
+                                     (empty?(element.content) ? nil : element.content.to_i)
         end
 
         if(element = doc.at_xpath('//errors/error'))
@@ -855,35 +855,35 @@ module ActiveMerchant
         end
 
         response[:avs_result_code] = if(element = doc.at_xpath('//avsResultCode'))
-          (empty?(element.content) ? nil : element.content)
+                                       (empty?(element.content) ? nil : element.content)
         end
 
         response[:transaction_id] = if(element = doc.at_xpath('//transId'))
-          (empty?(element.content) ? nil : element.content)
+                                      (empty?(element.content) ? nil : element.content)
         end
 
         response[:card_code] = if(element = doc.at_xpath('//cvvResultCode'))
-          (empty?(element.content) ? nil : element.content)
+                                 (empty?(element.content) ? nil : element.content)
         end
 
         response[:authorization_code] = if(element = doc.at_xpath('//authCode'))
-          (empty?(element.content) ? nil : element.content)
+                                          (empty?(element.content) ? nil : element.content)
         end
 
         response[:cardholder_authentication_code] = if(element = doc.at_xpath('//cavvResultCode'))
-          (empty?(element.content) ? nil : element.content)
+                                                      (empty?(element.content) ? nil : element.content)
         end
 
         response[:account_number] = if(element = doc.at_xpath('//accountNumber'))
-          (empty?(element.content) ? nil : element.content[-4..-1])
+                                      (empty?(element.content) ? nil : element.content[-4..-1])
         end
 
         response[:test_request] = if(element = doc.at_xpath('//testRequest'))
-          (empty?(element.content) ? nil : element.content)
+                                    (empty?(element.content) ? nil : element.content)
         end
 
         response[:full_response_code] = if(element = doc.at_xpath('//messages/message/code'))
-          (empty?(element.content) ? nil : element.content)
+                                          (empty?(element.content) ? nil : element.content)
         end
 
         response
@@ -900,28 +900,28 @@ module ActiveMerchant
         end
 
         response[:result_code] = if(element = doc.at_xpath('//messages/resultCode'))
-          (empty?(element.content) ? nil : element.content)
+                                   (empty?(element.content) ? nil : element.content)
         end
 
         response[:test_request] = if(element = doc.at_xpath('//testRequest'))
-          (empty?(element.content) ? nil : element.content)
+                                    (empty?(element.content) ? nil : element.content)
         end
 
         response[:customer_profile_id] = if(element = doc.at_xpath('//customerProfileId'))
-          (empty?(element.content) ? nil : element.content)
+                                           (empty?(element.content) ? nil : element.content)
         end
 
         response[:customer_payment_profile_id] = if(element = doc.at_xpath('//customerPaymentProfileIdList/numericString'))
-          (empty?(element.content) ? nil : element.content)
+                                                   (empty?(element.content) ? nil : element.content)
         end
 
         response[:customer_payment_profile_id] = if(element = doc.at_xpath('//customerPaymentProfileIdList/numericString') ||
                                                               doc.at_xpath('//customerPaymentProfileId'))
-          (empty?(element.content) ? nil : element.content)
+                                                   (empty?(element.content) ? nil : element.content)
         end
 
         response[:direct_response] = if(element = doc.at_xpath('//directResponse'))
-          (empty?(element.content) ? nil : element.content)
+                                       (empty?(element.content) ? nil : element.content)
         end
 
         response.merge!(parse_direct_response_elements(response, options))

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -380,18 +380,18 @@ module ActiveMerchant #:nodoc:
         requires!(options[:transaction], :type)
         case options[:transaction][:type]
         when :void
-            requires!(options[:transaction], :trans_id)
+          requires!(options[:transaction], :trans_id)
         when :refund
-            requires!(options[:transaction], :trans_id) &&
-              (
-                (options[:transaction][:customer_profile_id] && options[:transaction][:customer_payment_profile_id]) ||
-                options[:transaction][:credit_card_number_masked] ||
-                (options[:transaction][:bank_routing_number_masked] && options[:transaction][:bank_account_number_masked])
-              )
+          requires!(options[:transaction], :trans_id) &&
+            (
+              (options[:transaction][:customer_profile_id] && options[:transaction][:customer_payment_profile_id]) ||
+              options[:transaction][:credit_card_number_masked] ||
+              (options[:transaction][:bank_routing_number_masked] && options[:transaction][:bank_account_number_masked])
+            )
         when :prior_auth_capture
-            requires!(options[:transaction], :amount, :trans_id)
+          requires!(options[:transaction], :amount, :trans_id)
         else
-            requires!(options[:transaction], :amount, :customer_profile_id, :customer_payment_profile_id)
+          requires!(options[:transaction], :amount, :customer_profile_id, :customer_payment_profile_id)
         end
         request = build_request(:create_customer_profile_transaction, options)
         commit(:create_customer_profile_transaction, request)
@@ -666,33 +666,33 @@ module ActiveMerchant #:nodoc:
             # The amount to be billed to the customer
             case transaction[:type]
             when :void
-                tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
-                tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
-                tag_unless_blank(xml, 'customerShippingAddressId', transaction[:customer_shipping_address_id])
-                xml.tag!('transId', transaction[:trans_id])
+              tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
+              tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
+              tag_unless_blank(xml, 'customerShippingAddressId', transaction[:customer_shipping_address_id])
+              xml.tag!('transId', transaction[:trans_id])
             when :refund
-                xml.tag!('amount', transaction[:amount])
-                tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
-                tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
-                tag_unless_blank(xml, 'customerShippingAddressId', transaction[:customer_shipping_address_id])
-                tag_unless_blank(xml, 'creditCardNumberMasked', transaction[:credit_card_number_masked])
-                tag_unless_blank(xml, 'bankRoutingNumberMasked', transaction[:bank_routing_number_masked])
-                tag_unless_blank(xml, 'bankAccountNumberMasked', transaction[:bank_account_number_masked])
-                add_order(xml, transaction[:order]) if transaction[:order].present?
-                xml.tag!('transId', transaction[:trans_id])
-                add_tax(xml, transaction[:tax]) if transaction[:tax]
-                add_duty(xml, transaction[:duty]) if transaction[:duty]
-                add_shipping(xml, transaction[:shipping]) if transaction[:shipping]
+              xml.tag!('amount', transaction[:amount])
+              tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
+              tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
+              tag_unless_blank(xml, 'customerShippingAddressId', transaction[:customer_shipping_address_id])
+              tag_unless_blank(xml, 'creditCardNumberMasked', transaction[:credit_card_number_masked])
+              tag_unless_blank(xml, 'bankRoutingNumberMasked', transaction[:bank_routing_number_masked])
+              tag_unless_blank(xml, 'bankAccountNumberMasked', transaction[:bank_account_number_masked])
+              add_order(xml, transaction[:order]) if transaction[:order].present?
+              xml.tag!('transId', transaction[:trans_id])
+              add_tax(xml, transaction[:tax]) if transaction[:tax]
+              add_duty(xml, transaction[:duty]) if transaction[:duty]
+              add_shipping(xml, transaction[:shipping]) if transaction[:shipping]
             when :prior_auth_capture
-                xml.tag!('amount', transaction[:amount])
-                add_order(xml, transaction[:order]) if transaction[:order].present?
-                xml.tag!('transId', transaction[:trans_id])
+              xml.tag!('amount', transaction[:amount])
+              add_order(xml, transaction[:order]) if transaction[:order].present?
+              xml.tag!('transId', transaction[:trans_id])
             else
-                xml.tag!('amount', transaction[:amount])
-                xml.tag!('customerProfileId', transaction[:customer_profile_id])
-                xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
-                xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
-                add_order(xml, transaction[:order]) if transaction[:order].present?
+              xml.tag!('amount', transaction[:amount])
+              xml.tag!('customerProfileId', transaction[:customer_profile_id])
+              xml.tag!('customerPaymentProfileId', transaction[:customer_payment_profile_id])
+              xml.tag!('approvalCode', transaction[:approval_code]) if transaction[:type] == :capture_only
+              add_order(xml, transaction[:order]) if transaction[:order].present?
 
             end
             if [:auth_capture, :auth_only, :capture_only].include?(transaction[:type])

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -81,8 +81,8 @@ module ActiveMerchant #:nodoc:
 
       def verify(credit_card, options={})
         MultiResponse.run(:use_first_response) do |r|
-         r.process { authorize(100, credit_card, options) }
-         r.process(:ignore_result) { void(r.authorization, options) }
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -282,14 +282,14 @@ module ActiveMerchant #:nodoc:
       def commit(action, source_type, parameters)
         response = parse(ssl_post(live_url, post_data(COMMANDS[source_type][action], parameters)))
 
-       Response.new(
-         (response[:status] == 'Approved'),
-         message_from(response),
-         response,
-         authorization: authorization_from(response, source_type),
-         avs_result: { code: response[:avs_result_code] },
-         cvv_result: response[:cvv_result_code]
-       )
+        Response.new(
+          (response[:status] == 'Approved'),
+          message_from(response),
+          response,
+          authorization: authorization_from(response, source_type),
+          avs_result: { code: response[:avs_result_code] },
+          cvv_result: response[:cvv_result_code]
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -683,23 +683,23 @@ module ActiveMerchant #:nodoc:
       # Where we actually build the full SOAP request using builder
       def build_request(body, options)
         xml = Builder::XmlMarkup.new :indent => 2
-          xml.instruct!
-          xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
-            xml.tag! 's:Header' do
-              xml.tag! 'wsse:Security', {'s:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'} do
-                xml.tag! 'wsse:UsernameToken' do
-                  xml.tag! 'wsse:Username', @options[:login]
-                  xml.tag! 'wsse:Password', @options[:password], 'Type' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
-                end
-              end
-            end
-            xml.tag! 's:Body', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
-              xml.tag! 'requestMessage', {'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{XSD_VERSION}"} do
-                add_merchant_data(xml, options)
-                xml << body
+        xml.instruct!
+        xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
+          xml.tag! 's:Header' do
+            xml.tag! 'wsse:Security', {'s:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'} do
+              xml.tag! 'wsse:UsernameToken' do
+                xml.tag! 'wsse:Username', @options[:login]
+                xml.tag! 'wsse:Password', @options[:password], 'Type' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
               end
             end
           end
+          xml.tag! 's:Body', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
+            xml.tag! 'requestMessage', {'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{XSD_VERSION}"} do
+              add_merchant_data(xml, options)
+              xml << body
+            end
+          end
+        end
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -252,17 +252,17 @@ module ActiveMerchant #:nodoc:
       def xml_builder(params, soap_call)
         xml = Builder::XmlMarkup.new(:indent => 2)
         xml.instruct!
-          xml.tag! 'soap:Envelope', { 'xmlns:xsi' => 'http://schemas.xmlsoap.org/soap/envelope/',
-                                      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-                                      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/' } do
-            xml.tag! 'soap:Body' do
-              xml.tag! soap_call, { 'xmlns' => "#{self.live_url}remote/payment" } do
-                xml.tag! 'merchantnumber', @options[:login]
-                xml.tag! 'transactionid', params[:transaction]
-                xml.tag! 'amount', params[:amount].to_s if soap_call != 'delete'
-              end
+        xml.tag! 'soap:Envelope', { 'xmlns:xsi' => 'http://schemas.xmlsoap.org/soap/envelope/',
+                                    'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+                                    'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/' } do
+          xml.tag! 'soap:Body' do
+            xml.tag! soap_call, { 'xmlns' => "#{self.live_url}remote/payment" } do
+              xml.tag! 'merchantnumber', @options[:login]
+              xml.tag! 'transactionid', params[:transaction]
+              xml.tag! 'amount', params[:amount].to_s if soap_call != 'delete'
             end
           end
+        end
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -150,7 +150,7 @@ module ActiveMerchant #:nodoc:
         reply = {}
         xml = REXML::Document.new(body)
         if root = REXML::XPath.first(xml, '//soap:Fault') then
-           reply=parse_fault(root)
+          reply=parse_fault(root)
         else
           if root = REXML::XPath.first(xml, '//ProcessPaymentResponse/ewayResponse') then
             # Successful payment
@@ -232,13 +232,13 @@ module ActiveMerchant #:nodoc:
         # eWay demands all fields be sent, but contain an empty string if blank
         post = case action
                when 'QueryCustomer'
-                  arguments
+                 arguments
                when 'ProcessPayment'
-                  default_payment_fields.merge(arguments)
+                 default_payment_fields.merge(arguments)
                when 'CreateCustomer'
-                  default_customer_fields.merge(arguments)
+                 default_customer_fields.merge(arguments)
                when 'UpdateCustomer'
-                  default_customer_fields.merge(arguments)
+                 default_customer_fields.merge(arguments)
                end
 
         xml = Builder::XmlMarkup.new :indent => 2

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -242,23 +242,23 @@ module ActiveMerchant #:nodoc:
                end
 
         xml = Builder::XmlMarkup.new :indent => 2
-          xml.instruct!
-          xml.tag! 'soap12:Envelope', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'} do
-            xml.tag! 'soap12:Header' do
-              xml.tag! 'eWAYHeader', {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do
-                xml.tag! 'eWAYCustomerID', @options[:login]
-                xml.tag! 'Username', @options[:username]
-                xml.tag! 'Password', @options[:password]
-              end
+        xml.instruct!
+        xml.tag! 'soap12:Envelope', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'} do
+          xml.tag! 'soap12:Header' do
+            xml.tag! 'eWAYHeader', {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do
+              xml.tag! 'eWAYCustomerID', @options[:login]
+              xml.tag! 'Username', @options[:username]
+              xml.tag! 'Password', @options[:password]
             end
-            xml.tag! 'soap12:Body' do |x|
-              x.tag! action, {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do |y|
-                post.each do |key, value|
-                  y.tag! key, value
-                end
+          end
+          xml.tag! 'soap12:Body' do |x|
+            x.tag! action, {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do |y|
+              post.each do |key, value|
+                y.tag! key, value
               end
             end
           end
+        end
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -160,14 +160,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, request)
-         response = parse(ssl_post(self.live_url, build_request(action, request), POST_HEADERS))
+        response = parse(ssl_post(self.live_url, build_request(action, request), POST_HEADERS))
 
-         Response.new(successful?(response), message_from(response), response,
-           :test => test?,
-           :authorization => authorization_from(response),
-           :avs_result => { :code => response[:avs] },
-           :cvv_result => response[:cvv2]
-         )
+        Response.new(successful?(response), message_from(response), response,
+          :test => test?,
+          :authorization => authorization_from(response),
+          :avs_result => { :code => response[:avs] },
+          :cvv_result => response[:cvv2]
+        )
       rescue ResponseError => e
         case e.response.code
         when '401'
@@ -183,9 +183,9 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response)
         if response[:authorization_num] && response[:transaction_tag]
-           "#{response[:authorization_num]};#{response[:transaction_tag]}"
+          "#{response[:authorization_num]};#{response[:transaction_tag]}"
         else
-           ''
+          ''
         end
       end
 

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -33,7 +33,7 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
-       check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
+        check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
       end
 
       def authorize(money, payment_method, options={})

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -75,9 +75,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_creditcard(post, creditcard)
-       post['cvv'] = creditcard.verification_value
-       post['ccnumber'] = creditcard.number
-       post['ccexp'] = "#{sprintf("%02d", creditcard.month)}#{creditcard.year.to_s[-2, 2]}"
+        post['cvv'] = creditcard.verification_value
+        post['ccnumber'] = creditcard.number
+        post['ccexp'] = "#{sprintf("%02d", creditcard.month)}#{creditcard.year.to_s[-2, 2]}"
       end
 
       def commit(action, money, parameters={})

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -226,10 +226,10 @@ module ActiveMerchant #:nodoc:
         if credit_card.respond_to?(:track_data) && credit_card.track_data.present?
           xml.tag! 'trackData', credit_card.track_data
         else
-         xml.tag! 'strPAN', credit_card.number
-         xml.tag! 'strExpDate', expdate(credit_card)
-         xml.tag! 'strCardHolder', credit_card.name
-         xml.tag! 'strCVCode', credit_card.verification_value if credit_card.verification_value?
+          xml.tag! 'strPAN', credit_card.number
+          xml.tag! 'strExpDate', expdate(credit_card)
+          xml.tag! 'strCardHolder', credit_card.name
+          xml.tag! 'strCVCode', credit_card.verification_value if credit_card.verification_value?
         end
       end
 

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -224,7 +224,7 @@ module ActiveMerchant #:nodoc:
         when 'capture'
           "#{url}/charges/#{auth}/capture/"
         else
-         "#{url}/charges/"
+          "#{url}/charges/"
         end
       end
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -143,14 +143,14 @@ module ActiveMerchant #:nodoc:
           post[:bill_state]      = billing_address[:state]
         end
 
-       if shipping_address = options[:shipping_address]
-         post[:ship_name1], post[:ship_name2] = split_names(shipping_address[:name])
-         post[:ship_street]     = shipping_address[:address1]
-         post[:ship_zip]        = shipping_address[:zip]
-         post[:ship_city]       = shipping_address[:city]
-         post[:ship_country]    = shipping_address[:country]
-         post[:ship_state]      = shipping_address[:state]
-       end
+        if shipping_address = options[:shipping_address]
+          post[:ship_name1], post[:ship_name2] = split_names(shipping_address[:name])
+          post[:ship_street]     = shipping_address[:address1]
+          post[:ship_zip]        = shipping_address[:zip]
+          post[:ship_city]       = shipping_address[:city]
+          post[:ship_country]    = shipping_address[:country]
+          post[:ship_state]      = shipping_address[:state]
+        end
       end
 
       def add_invoice(post, options)

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -408,8 +408,8 @@ module ActiveMerchant #:nodoc:
 
       def add_signature(parameters)
         if @options[:signature].blank?
-           ActiveMerchant.deprecated(OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) unless(@options[:signature_encryptor] == 'none')
-           return
+          ActiveMerchant.deprecated(OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) unless(@options[:signature_encryptor] == 'none')
+          return
         end
 
         add_pair parameters, 'SHASign', calculate_signature(parameters, @options[:signature_encryptor], @options[:signature])

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -247,15 +247,15 @@ module ActiveMerchant #:nodoc:
         message = response['message'] if response['code'] == 'invalid_card'
         case message
         when /brand not supported/
-            STANDARD_ERROR_CODE[:invalid_number]
+          STANDARD_ERROR_CODE[:invalid_number]
         when /number is invalid/
-            STANDARD_ERROR_CODE[:incorrect_number]
+          STANDARD_ERROR_CODE[:incorrect_number]
         when /expiration date cannot be in the past/
-            STANDARD_ERROR_CODE[:expired_card]
+          STANDARD_ERROR_CODE[:expired_card]
         when /expiration \w+ is invalid/
-            STANDARD_ERROR_CODE[:invalid_expiry_date]
+          STANDARD_ERROR_CODE[:invalid_expiry_date]
         else
-            STANDARD_ERROR_CODE[:processing_error]
+          STANDARD_ERROR_CODE[:processing_error]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -189,7 +189,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_authentication(post)
-          post[:authentication] = { entityId: @options[:entity_id], password: @options[:password], userId: @options[:user_id]}
+        post[:authentication] = { entityId: @options[:entity_id], password: @options[:password], userId: @options[:user_id]}
       end
 
       def add_customer_data(post, payment, options)

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -129,12 +129,12 @@ module ActiveMerchant #:nodoc:
         options[:money] = money
         case payment_method
         when String
-            self.send("#{action}_with_token", money, payment_method, options)
+          self.send("#{action}_with_token", money, payment_method, options)
         else
-            MultiResponse.run do |r|
-              r.process { save_card(payment_method, options) }
-              r.process { self.send("#{action}_with_token", money, r.authorization, options) }
-            end
+          MultiResponse.run do |r|
+            r.process { save_card(payment_method, options) }
+            r.process { self.send("#{action}_with_token", money, r.authorization, options) }
+          end
         end
       end
 

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_response(success, message, response, options = {})
-         Response.new(success, message, response, options)
+        Response.new(success, message, response, options)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -365,7 +365,7 @@ module ActiveMerchant #:nodoc:
         when 'verify_credentials'
           response['code'] == 'SUCCESS'
         when 'refund', 'void'
-        response['code'] == 'SUCCESS' && response['transactionResponse'] && (response['transactionResponse']['state'] == 'PENDING' || response['transactionResponse']['state'] == 'APPROVED')
+          response['code'] == 'SUCCESS' && response['transactionResponse'] && (response['transactionResponse']['state'] == 'PENDING' || response['transactionResponse']['state'] == 'APPROVED')
         else
           response['code'] == 'SUCCESS' && response['transactionResponse'] && (response['transactionResponse']['state'] == 'APPROVED')
         end

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -252,9 +252,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def success?(response)
-      return FRAUD_WARNING_CODES.concat(['0']).include?(response['errors'].first['code']) if response['errors']
+        return FRAUD_WARNING_CODES.concat(['0']).include?(response['errors'].first['code']) if response['errors']
 
-      !['DECLINED', 'CANCELLED'].include?(response['status'])
+        !['DECLINED', 'CANCELLED'].include?(response['status'])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -163,7 +163,7 @@ module ActiveMerchant
         if response['token']
           response['token'].to_s
         else
-           response['id'].to_s
+          response['id'].to_s
         end
       end
 

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -99,197 +99,197 @@ module ActiveMerchant
 
       private
 
-        def authorization_params(money, credit_card_or_reference, options = {})
-          post = {}
+      def authorization_params(money, credit_card_or_reference, options = {})
+        post = {}
 
-          add_amount(post, money, options)
-          add_credit_card_or_reference(post, credit_card_or_reference)
-          add_additional_params(:authorize, post, options)
+        add_amount(post, money, options)
+        add_credit_card_or_reference(post, credit_card_or_reference)
+        add_additional_params(:authorize, post, options)
 
-          post
-        end
+        post
+      end
 
-        def capture_params(money, credit_card, options = {})
-          post = {}
+      def capture_params(money, credit_card, options = {})
+        post = {}
 
-          add_amount(post, money, options)
-          add_additional_params(:capture, post, options)
+        add_amount(post, money, options)
+        add_additional_params(:capture, post, options)
 
-          post
-        end
+        post
+      end
 
-        def create_store(options = {})
-          post = {}
-          commit('/cards', post)
-        end
+      def create_store(options = {})
+        post = {}
+        commit('/cards', post)
+      end
 
-        def authorize_store(identification, credit_card, options = {})
-          post = {}
+      def authorize_store(identification, credit_card, options = {})
+        post = {}
 
-          add_credit_card_or_reference(post, credit_card, options)
-          commit(synchronized_path("/cards/#{identification}/authorize"), post)
-        end
+        add_credit_card_or_reference(post, credit_card, options)
+        commit(synchronized_path("/cards/#{identification}/authorize"), post)
+      end
 
-        def create_token(identification, options)
-          post = {}
-          commit(synchronized_path("/cards/#{identification}/tokens"), post)
-        end
+      def create_token(identification, options)
+        post = {}
+        commit(synchronized_path("/cards/#{identification}/tokens"), post)
+      end
 
-        def create_payment(money, options = {})
-          post = {}
-          add_currency(post, money, options)
-          add_invoice(post, options)
-          commit('/payments', post)
-        end
+      def create_payment(money, options = {})
+        post = {}
+        add_currency(post, money, options)
+        add_invoice(post, options)
+        commit('/payments', post)
+      end
 
-        def commit(action, params = {})
-          success = false
-          begin
-            response = parse(ssl_post(self.live_url + action, params.to_json, headers))
-            success = successful?(response)
-          rescue ResponseError => e
-            response = response_error(e.response.body)
-          rescue JSON::ParserError
-            response = json_error(response)
-          end
-
-          Response.new(success, message_from(success, response), response,
-            :test => test?,
-            :authorization => authorization_from(response)
-          )
-        end
-
-        def authorization_from(response)
-          if response['token']
-            response['token'].to_s
-          else
-             response['id'].to_s
-          end
-        end
-
-        def add_currency(post, money, options)
-          post[:currency] = options[:currency] || currency(money)
-        end
-
-        def add_amount(post, money, options)
-          post[:amount] = options[:amount] || amount(money)
-        end
-
-        def add_autocapture(post, value)
-          post[:auto_capture] = value
-        end
-
-        def add_order_id(post, options)
-          requires!(options, :order_id)
-          post[:order_id] = format_order_id(options[:order_id])
-        end
-
-        def add_invoice(post, options)
-          add_order_id(post, options)
-
-          if options[:billing_address]
-            post[:invoice_address]  = map_address(options[:billing_address])
-          end
-
-          if options[:shipping_address]
-            post[:shipping_address] = map_address(options[:shipping_address])
-          end
-
-          [:metadata, :branding_id, :variables].each do |field|
-            post[field] = options[field] if options[field]
-          end
-        end
-
-        def add_additional_params(action, post, options = {})
-          MD5_CHECK_FIELDS[API_VERSION][action].each do |key|
-            key       = key.to_sym
-            post[key] = options[key] if options[key]
-          end
-        end
-
-        def add_credit_card_or_reference(post, credit_card_or_reference, options = {})
-          post[:card]             ||= {}
-          if credit_card_or_reference.is_a?(String)
-            post[:card][:token] = credit_card_or_reference
-          else
-            post[:card][:number]     = credit_card_or_reference.number
-            post[:card][:cvd]        = credit_card_or_reference.verification_value
-            post[:card][:expiration] = expdate(credit_card_or_reference)
-            post[:card][:issued_to]  = credit_card_or_reference.name
-          end
-        end
-
-        def parse(body)
-          JSON.parse(body)
-        end
-
-        def successful?(response)
-          has_error    = response['errors']
-          invalid_code = invalid_operation_code?(response)
-
-          !(has_error || invalid_code)
-        end
-
-        def message_from(success, response)
-          success ? 'OK' : (response['message'] || invalid_operation_message(response) || 'Unknown error - please contact QuickPay')
-        end
-
-        def invalid_operation_code?(response)
-          if response['operations']
-            operation = response['operations'].last
-            operation && operation['qp_status_code'] != '20000'
-          end
-        end
-
-        def invalid_operation_message(response)
-          response['operations'] && response['operations'].last['qp_status_msg']
-        end
-
-        def map_address(address)
-          return {} if address.nil?
-          requires!(address, :name, :address1, :city, :zip, :country)
-          country = Country.find(address[:country])
-          mapped = {
-            :name         => address[:name],
-            :street       => address[:address1],
-            :city         => address[:city],
-            :region       => address[:address2],
-            :zip_code     => address[:zip],
-            :country_code => country.code(:alpha3).value
-          }
-          mapped
-        end
-
-        def format_order_id(order_id)
-          truncate(order_id.to_s.gsub(/#/, ''), 20)
-        end
-
-        def headers
-          auth = Base64.strict_encode64(":#{@options[:api_key]}")
-          {
-            'Authorization'  => 'Basic ' + auth,
-            'User-Agent'     => "Quickpay-v#{API_VERSION} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
-            'Accept'         => 'application/json',
-            'Accept-Version' => "v#{API_VERSION}",
-            'Content-Type'   => 'application/json'
-          }
-        end
-
-        def response_error(raw_response)
-          parse(raw_response)
+      def commit(action, params = {})
+        success = false
+        begin
+          response = parse(ssl_post(self.live_url + action, params.to_json, headers))
+          success = successful?(response)
+        rescue ResponseError => e
+          response = response_error(e.response.body)
         rescue JSON::ParserError
-          json_error(raw_response)
+          response = json_error(response)
         end
 
-        def json_error(raw_response)
-          msg = 'Invalid response received from the Quickpay API.'
-          msg += "  (The raw response returned by the API was #{raw_response.inspect})"
-          { 'message' => msg }
+        Response.new(success, message_from(success, response), response,
+          :test => test?,
+          :authorization => authorization_from(response)
+        )
+      end
+
+      def authorization_from(response)
+        if response['token']
+          response['token'].to_s
+        else
+           response['id'].to_s
+        end
+      end
+
+      def add_currency(post, money, options)
+        post[:currency] = options[:currency] || currency(money)
+      end
+
+      def add_amount(post, money, options)
+        post[:amount] = options[:amount] || amount(money)
+      end
+
+      def add_autocapture(post, value)
+        post[:auto_capture] = value
+      end
+
+      def add_order_id(post, options)
+        requires!(options, :order_id)
+        post[:order_id] = format_order_id(options[:order_id])
+      end
+
+      def add_invoice(post, options)
+        add_order_id(post, options)
+
+        if options[:billing_address]
+          post[:invoice_address]  = map_address(options[:billing_address])
         end
 
-        def synchronized_path(path)
-          "#{path}?synchronized"
+        if options[:shipping_address]
+          post[:shipping_address] = map_address(options[:shipping_address])
         end
+
+        [:metadata, :branding_id, :variables].each do |field|
+          post[field] = options[field] if options[field]
+        end
+      end
+
+      def add_additional_params(action, post, options = {})
+        MD5_CHECK_FIELDS[API_VERSION][action].each do |key|
+          key       = key.to_sym
+          post[key] = options[key] if options[key]
+        end
+      end
+
+      def add_credit_card_or_reference(post, credit_card_or_reference, options = {})
+        post[:card]             ||= {}
+        if credit_card_or_reference.is_a?(String)
+          post[:card][:token] = credit_card_or_reference
+        else
+          post[:card][:number]     = credit_card_or_reference.number
+          post[:card][:cvd]        = credit_card_or_reference.verification_value
+          post[:card][:expiration] = expdate(credit_card_or_reference)
+          post[:card][:issued_to]  = credit_card_or_reference.name
+        end
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def successful?(response)
+        has_error    = response['errors']
+        invalid_code = invalid_operation_code?(response)
+
+        !(has_error || invalid_code)
+      end
+
+      def message_from(success, response)
+        success ? 'OK' : (response['message'] || invalid_operation_message(response) || 'Unknown error - please contact QuickPay')
+      end
+
+      def invalid_operation_code?(response)
+        if response['operations']
+          operation = response['operations'].last
+          operation && operation['qp_status_code'] != '20000'
+        end
+      end
+
+      def invalid_operation_message(response)
+        response['operations'] && response['operations'].last['qp_status_msg']
+      end
+
+      def map_address(address)
+        return {} if address.nil?
+        requires!(address, :name, :address1, :city, :zip, :country)
+        country = Country.find(address[:country])
+        mapped = {
+          :name         => address[:name],
+          :street       => address[:address1],
+          :city         => address[:city],
+          :region       => address[:address2],
+          :zip_code     => address[:zip],
+          :country_code => country.code(:alpha3).value
+        }
+        mapped
+      end
+
+      def format_order_id(order_id)
+        truncate(order_id.to_s.gsub(/#/, ''), 20)
+      end
+
+      def headers
+        auth = Base64.strict_encode64(":#{@options[:api_key]}")
+        {
+          'Authorization'  => 'Basic ' + auth,
+          'User-Agent'     => "Quickpay-v#{API_VERSION} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'Accept'         => 'application/json',
+          'Accept-Version' => "v#{API_VERSION}",
+          'Content-Type'   => 'application/json'
+        }
+      end
+
+      def response_error(raw_response)
+        parse(raw_response)
+      rescue JSON::ParserError
+        json_error(raw_response)
+      end
+
+      def json_error(raw_response)
+        msg = 'Invalid response received from the Quickpay API.'
+        msg += "  (The raw response returned by the API was #{raw_response.inspect})"
+        { 'message' => msg }
+      end
+
+      def synchronized_path(path)
+        "#{path}?synchronized"
+      end
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -97,17 +97,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def scrub(transcript)
-         force_utf8(transcript).
-           gsub(%r((M_id=)[^&]*), '\1[FILTERED]').
-           gsub(%r((M_key=)[^&]*), '\1[FILTERED]').
-           gsub(%r((C_cardnumber=)[^&]*), '\1[FILTERED]').
-           gsub(%r((C_cvv=)[^&]*), '\1[FILTERED]').
-           gsub(%r((C_rte=)[^&]*), '\1[FILTERED]').
-           gsub(%r((C_acct=)[^&]*), '\1[FILTERED]').
-           gsub(%r((C_ssn=)[^&]*), '\1[FILTERED]').
-           gsub(%r((<ns1:CARDNUMBER>).+(</ns1:CARDNUMBER>)), '\1[FILTERED]\2').
-           gsub(%r((<ns1:M_ID>).+(</ns1:M_ID>)), '\1[FILTERED]\2').
-           gsub(%r((<ns1:M_KEY>).+(</ns1:M_KEY>)), '\1[FILTERED]\2')
+        force_utf8(transcript).
+          gsub(%r((M_id=)[^&]*), '\1[FILTERED]').
+          gsub(%r((M_key=)[^&]*), '\1[FILTERED]').
+          gsub(%r((C_cardnumber=)[^&]*), '\1[FILTERED]').
+          gsub(%r((C_cvv=)[^&]*), '\1[FILTERED]').
+          gsub(%r((C_rte=)[^&]*), '\1[FILTERED]').
+          gsub(%r((C_acct=)[^&]*), '\1[FILTERED]').
+          gsub(%r((C_ssn=)[^&]*), '\1[FILTERED]').
+          gsub(%r((<ns1:CARDNUMBER>).+(</ns1:CARDNUMBER>)), '\1[FILTERED]\2').
+          gsub(%r((<ns1:M_ID>).+(</ns1:M_ID>)), '\1[FILTERED]\2').
+          gsub(%r((<ns1:M_KEY>).+(</ns1:M_KEY>)), '\1[FILTERED]\2')
       end
 
       private

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -361,11 +361,11 @@ module ActiveMerchant #:nodoc:
         when :store
           response['Token']
         else
-         [ params[:VendorTxCode],
-           response['VPSTxId'] || params[:VPSTxId],
-           response['TxAuthNo'],
-           response['SecurityKey'] || params[:SecurityKey],
-           action ].join(';')
+          [ params[:VendorTxCode],
+            response['VPSTxId'] || params[:VPSTxId],
+            response['TxAuthNo'],
+            response['SecurityKey'] || params[:SecurityKey],
+            action ].join(';')
         end
       end
 

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -202,11 +202,11 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'WIRECARD_BXML' do
           xml.tag! 'W_REQUEST' do
             xml.tag! 'W_JOB' do
-               xml.tag! 'JobID', ''
-               # UserID for this transaction
-               xml.tag! 'BusinessCaseSignature', options[:signature] || options[:login]
-               # Create the whole rest of the message
-               add_transaction_data(xml, money, options)
+              xml.tag! 'JobID', ''
+              # UserID for this transaction
+              xml.tag! 'BusinessCaseSignature', options[:signature] || options[:login]
+              # Create the whole rest of the message
+              add_transaction_data(xml, money, options)
             end
           end
         end

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -53,14 +53,14 @@ class RemoteBanwireTest < Test::Unit::TestCase
     assert_equal 'ID de cuenta invalido', response.message
   end
 
-def test_transcript_scrubbing
-  transcript = capture_transcript(@gateway) do
-    @gateway.purchase(@amount, @credit_card, @options)
-  end
-  clean_transcript = @gateway.scrub(transcript)
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
 
-  assert_scrubbed(@credit_card.number, clean_transcript)
-  assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
-end
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
 
 end

--- a/test/remote/gateways/remote_cardknox_test.rb
+++ b/test/remote/gateways/remote_cardknox_test.rb
@@ -37,7 +37,7 @@ class RemoteCardknoxTest < Test::Unit::TestCase
       }
     }
 
-     @options = {}
+    @options = {}
   end
 
   def test_successful_credit_card_purchase

--- a/test/remote/gateways/remote_first_giving_test.rb
+++ b/test/remote/gateways/remote_first_giving_test.rb
@@ -32,11 +32,11 @@ class RemoteFirstGivingTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-   assert purchase = @gateway.purchase(@amount, @credit_card, @options)
-   assert_success purchase
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
 
-   assert response = @gateway.refund(@amount, purchase.authorization)
-   assert_equal 'REFUND_REQUESTED_AWAITING_REFUND', response.message
+    assert response = @gateway.refund(@amount, purchase.authorization)
+    assert_equal 'REFUND_REQUESTED_AWAITING_REFUND', response.message
   end
 
   def test_failed_refund

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -48,8 +48,8 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-   assert response = @gateway.capture(@amount, '')
-   assert_failure response
+    assert response = @gateway.capture(@amount, '')
+    assert_failure response
   end
 
   def test_invalid_login

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -31,34 +31,34 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
-   def test_unsuccessful_purchase
-     assert response = @gateway.purchase(@amount, @declined_card, @options)
-     assert_failure response
-     assert response.message.include? 'Invalid Credit Card Number'
-   end
-
-   def test_authorize_and_capture
-     amount = @amount
-     assert auth = @gateway.authorize(amount, @credit_card, @options)
-     assert_success auth
-     assert_equal 'SUCCESS', auth.message
-     assert auth.authorization, auth.to_yaml
-     assert capture = @gateway.capture(amount, auth.authorization)
-     assert_success capture
-   end
-
-   def test_failed_capture
-    assert response = @gateway.capture(@amount, '')
+  def test_unsuccessful_purchase
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-   end
+    assert response.message.include? 'Invalid Credit Card Number'
+  end
 
-   def test_invalid_login
-     gateway = MerchantOneGateway.new(
-                 :username => 'nnn',
-                 :password => 'nnn'
-               )
-     assert response = gateway.purchase(@amount, @credit_card, @options)
-     assert_failure response
-     assert_equal 'Authentication Failed', response.message
-   end
+  def test_authorize_and_capture
+    amount = @amount
+    assert auth = @gateway.authorize(amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'SUCCESS', auth.message
+    assert auth.authorization, auth.to_yaml
+    assert capture = @gateway.capture(amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+   assert response = @gateway.capture(@amount, '')
+   assert_failure response
+  end
+
+  def test_invalid_login
+    gateway = MerchantOneGateway.new(
+                :username => 'nnn',
+                :password => 'nnn'
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Authentication Failed', response.message
+  end
 end

--- a/test/remote/gateways/remote_netaxept_test.rb
+++ b/test/remote/gateways/remote_netaxept_test.rb
@@ -20,24 +20,24 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-   assert response = @gateway.purchase(@amount, @declined_card, @options)
-   assert_failure response
-   assert_match(/failure/i, response.message)
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_match(/failure/i, response.message)
   end
 
   def test_authorize_and_capture
-   assert auth = @gateway.authorize(@amount, @credit_card, @options)
-   assert_success auth
-   assert_equal 'OK', auth.message
-   assert auth.authorization
-   assert capture = @gateway.capture(@amount, auth.authorization)
-   assert_success capture
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'OK', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
   end
 
   def test_failed_capture
-   assert response = @gateway.capture(@amount, '')
-   assert_failure response
-   assert_equal 'Unable to find transaction', response.message
+    assert response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'Unable to find transaction', response.message
   end
 
   def test_successful_refund
@@ -49,12 +49,12 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-   assert response = @gateway.purchase(@amount, @credit_card, @options)
-   assert_success response
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
 
-   response = @gateway.refund(@amount+100, response.authorization)
-   assert_failure response
-   assert_equal 'Unable to credit more than captured amount', response.message
+    response = @gateway.refund(@amount+100, response.authorization)
+    assert_failure response
+    assert_equal 'Unable to credit more than captured amount', response.message
   end
 
   def test_successful_void
@@ -66,46 +66,46 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-   assert response = @gateway.purchase(@amount, @credit_card, @options)
-   assert_success response
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
 
-   response = @gateway.void(response.authorization)
-   assert_failure response
-   assert_equal 'Unable to annul, wrong state', response.message
+    response = @gateway.void(response.authorization)
+    assert_failure response
+    assert_equal 'Unable to annul, wrong state', response.message
   end
 
   def test_error_in_transaction_setup
-   assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'BOGG'))
-   assert_failure response
-   assert_match(/currency code/, response.message)
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'BOGG'))
+    assert_failure response
+    assert_match(/currency code/, response.message)
   end
 
   def test_successful_amex_purchase
-   credit_card = credit_card('378282246310005', :brand => 'american_express')
-   assert response = @gateway.purchase(@amount, credit_card, @options)
-   assert_success response
-   assert_equal 'OK', response.message
+    credit_card = credit_card('378282246310005', :brand => 'american_express')
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'OK', response.message
   end
 
   def test_successful_master_purchase
-   credit_card = credit_card('5413000000000000', :brand => 'master')
-   assert response = @gateway.purchase(@amount, credit_card, @options)
-   assert_success response
-   assert_equal 'OK', response.message
+    credit_card = credit_card('5413000000000000', :brand => 'master')
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'OK', response.message
   end
 
   def test_error_in_payment_details
-   assert response = @gateway.purchase(@amount, credit_card(''), @options)
-   assert_failure response
-   assert_equal 'Cardnumber:Required', response.message
+    assert response = @gateway.purchase(@amount, credit_card(''), @options)
+    assert_failure response
+    assert_equal 'Cardnumber:Required', response.message
   end
 
   def test_amount_is_not_required_again_when_capturing_authorization
-   assert response = @gateway.authorize(@amount, @credit_card, @options)
-   assert_success response
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
 
-   assert response = @gateway.capture(nil, response.authorization)
-   assert_equal 'OK', response.message
+    assert response = @gateway.capture(nil, response.authorization)
+    assert_equal 'OK', response.message
   end
 
   def test_query_fails
@@ -115,12 +115,12 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-   gateway = NetaxeptGateway.new(
-               :login => '',
-               :password => ''
-             )
-   assert response = gateway.purchase(@amount, @credit_card, @options)
-   assert_failure response
-   assert_match(/Unable to authenticate merchant/, response.message)
+    gateway = NetaxeptGateway.new(
+                :login => '',
+                :password => ''
+              )
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match(/Unable to authenticate merchant/, response.message)
   end
 end

--- a/test/remote/gateways/remote_payflow_uk_test.rb
+++ b/test/remote/gateways/remote_payflow_uk_test.rb
@@ -47,11 +47,11 @@ class RemotePayflowUkTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_solo
-     assert response = @gateway.purchase(100000, @solo, @options)
-     assert_equal 'Approved', response.message
-     assert_success response
-     assert response.test?
-     assert_not_nil response.authorization
+    assert response = @gateway.purchase(100000, @solo, @options)
+    assert_equal 'Approved', response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
   end
 
   def test_no_card_issue_or_card_start_with_switch

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -44,10 +44,10 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_manual_entry
-   @credit_card.manual_entry = true
-   assert response = @gateway.purchase(@amount, @credit_card, @options)
-   assert_equal 'Success', response.message
-   assert_success response
+    @credit_card.manual_entry = true
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'Success', response.message
+    assert_success response
   end
 
   def test_successful_purchase_with_extra_details

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -43,12 +43,12 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
-   def test_successful_purchase_with_manual_entry
-    @credit_card.manual_entry = true
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_equal 'Success', response.message
-    assert_success response
-   end
+  def test_successful_purchase_with_manual_entry
+   @credit_card.manual_entry = true
+   assert response = @gateway.purchase(@amount, @credit_card, @options)
+   assert_equal 'Success', response.message
+   assert_success response
+  end
 
   def test_successful_purchase_with_extra_details
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:order_id => generate_unique_id, :description => 'socool'))

--- a/test/unit/gateways/bpoint_test.rb
+++ b/test/unit/gateways/bpoint_test.rb
@@ -399,23 +399,23 @@ class BpointTest < Test::Unit::TestCase
   end
 
   def successful_store_response
-   %(
-    <?xml version="1.0" encoding="UTF-8"?>
-    <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <soap:Body>
-        <AddTokenResponse xmlns="urn:Eve_1_4_4">
-          <AddTokenResult>
-            <Token>5999992142370790</Token>
-            <MaskedCardNumber>498765...769</MaskedCardNumber>
-            <CardType>VC</CardType>
-          </AddTokenResult>
-          <response>
-            <ResponseCode>SUCCESS</ResponseCode>
-          </response>
-        </AddTokenResponse>
-      </soap:Body>
-    </soap:Envelope>
-   )
+    %(
+     <?xml version="1.0" encoding="UTF-8"?>
+     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+       <soap:Body>
+         <AddTokenResponse xmlns="urn:Eve_1_4_4">
+           <AddTokenResult>
+             <Token>5999992142370790</Token>
+             <MaskedCardNumber>498765...769</MaskedCardNumber>
+             <CardType>VC</CardType>
+           </AddTokenResult>
+           <response>
+             <ResponseCode>SUCCESS</ResponseCode>
+           </response>
+         </AddTokenResponse>
+       </soap:Body>
+     </soap:Envelope>
+    )
   end
 
   def failed_store_response

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -347,7 +347,7 @@ class CardStreamTest < Test::Unit::TestCase
   end
 
   def scrubbed_transcript
-     <<-eos
+    <<-eos
      POST /direct/ HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: gateway.cardstream.com\r\nContent-Length: 501\r\n\r\n"
      amount=&currencyCode=826&transactionUnique=a017ca2ac0569188517ad8368c36a06d&orderRef=AM+test+purchase&customerName=Longbob+Longsen&cardNumber=[FILTERED]&cardExpiryMonth=12&cardExpiryYear=14&cardCVV=[FILTERED]&customerAddress=Flat+6%2C+Primrose+Rise+347+Lavender+Road&customerPostCode=NN17+8YG+&merchantID=102922&action=SALE&type=1&countryCode=GB&threeDSRequired=N&signature=970b3fe099a85c9922a79af46c2cb798616b9fbd044a921ac5eb46cd1907a5e89b8c720aae59c7eb1d81a59563f209d5db51aa3c270838199f2bfdcbe2c1149d
     eos

--- a/test/unit/gateways/cardknox_test.rb
+++ b/test/unit/gateways/cardknox_test.rb
@@ -201,7 +201,7 @@ class CardknoxTest < Test::Unit::TestCase
   private
 
   def purchase_request
-   'xKey=api_key&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=4242424242424242&xCVV=123&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
+    'xKey=api_key&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=4242424242424242&xCVV=123&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
   end
 
   def successful_purchase_response # passed avs and cvv
@@ -256,7 +256,7 @@ class CardknoxTest < Test::Unit::TestCase
   end
 
   def successful_verify_response
-   'xResult=A&xStatus=Approved&xError=&xRefNum=15314566&xAuthCode=608755&xBatch=&xAvsResultCode=NNN&xAvsResult=Address%3a+No+Match+%26+5+Digit+Zip%3a+No+Match&xCvvResultCode=N&xCvvResult=No+Match&xAuthAmount=1.00&xToken=09dc51aceb98440fbf0847cad2941d45&xMaskedCardNumber=4xxxxxxxxxxx2224&xName=Longbob+Longsen'
+    'xResult=A&xStatus=Approved&xError=&xRefNum=15314566&xAuthCode=608755&xBatch=&xAvsResultCode=NNN&xAvsResult=Address%3a+No+Match+%26+5+Digit+Zip%3a+No+Match&xCvvResultCode=N&xCvvResult=No+Match&xAuthAmount=1.00&xToken=09dc51aceb98440fbf0847cad2941d45&xMaskedCardNumber=4xxxxxxxxxxx2224&xName=Longbob+Longsen'
   end
 
   def failed_verify_response
@@ -264,10 +264,10 @@ class CardknoxTest < Test::Unit::TestCase
   end
 
   def pre_scrubbed
-   'xKey=api_key&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=4242424242424242&xCVV=123&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
+    'xKey=api_key&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=4242424242424242&xCVV=123&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
   end
 
   def post_scrubbed
-   'xKey=[FILTERED]&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=[FILTERED]&xCVV=[FILTERED]&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
+    'xKey=[FILTERED]&xVersion=4.5.4&xSoftwareName=Active+Merchant&xSoftwareVersion=1.52.0&xCommand=cc%3Asale&xAmount=1.00&xCardNum=[FILTERED]&xCVV=[FILTERED]&xExp=0916&xName=Longbob+Longsen&xBillFirstName=Longbob&xBillLastName=Longsen&xBillCompany=Widgets+Inc&xBillStreet=456+My+Street&xBillStreet2=Apt+1&xBillCity=Ottawa&xBillState=ON&xBillZip=K1C2N6&xBillCountry=CA&xBillPhone=%28555%29555-5555&xShipFirstName=Longbob&xShipLastName=Longsen&xShipCompany=Widgets+Inc&xShipStreet=456+My+Street&xShipStreet2=Apt+1&xShipCity=Ottawa&xShipState=ON&xShipZip=K1C2N6&xShipCountry=CA&xShipPhone=%28555%29555-5555&xStreet=456+My+Street&xZip=K1C2N6'
   end
 end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -372,7 +372,7 @@ class ElavonTest < Test::Unit::TestCase
   end
 
   def invalid_login_response
-        <<-RESPONSE
+    <<-RESPONSE
     ssl_result=7000\r
     ssl_result_message=The VirtualMerchant ID and/or User ID supplied in the authorization request is invalid.\r
         RESPONSE

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -372,9 +372,9 @@ class EwayManagedTest < Test::Unit::TestCase
     XML
   end
 
-    # Documented here: https://www.eway.com.au/gateway/ManagedPaymentService/managedCreditCardPayment.asmx?op=CreateCustomer
-    def expected_purchase_request
-      <<-XML
+  # Documented here: https://www.eway.com.au/gateway/ManagedPaymentService/managedCreditCardPayment.asmx?op=CreateCustomer
+  def expected_purchase_request
+    <<-XML
 <?xml version="1.0" encoding="utf-8"?>
 <soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
   <soap12:Header>
@@ -393,8 +393,8 @@ class EwayManagedTest < Test::Unit::TestCase
     </ProcessPayment>
   </soap12:Body>
 </soap12:Envelope>
-      XML
-    end
+    XML
+  end
 
   # Documented here: https://www.eway.com.au/gateway/ManagedPaymentService/managedCreditCardPayment.asmx?op=QueryCustomer
   def expected_retrieve_request
@@ -416,5 +416,4 @@ class EwayManagedTest < Test::Unit::TestCase
   </soap12:Envelope>
     XML
   end
-
 end

--- a/test/unit/gateways/eway_test.rb
+++ b/test/unit/gateways/eway_test.rb
@@ -70,11 +70,11 @@ class EwayTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '1034', @gateway.send(:amount, 1034)
+    assert_equal '1034', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_ensure_does_not_respond_to_authorize

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -46,11 +46,11 @@ class GatewayTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_card_brand

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -270,7 +270,7 @@ class HpsTest < Test::Unit::TestCase
   end
 
   def successful_authorize_response
-   <<-RESPONSE
+    <<-RESPONSE
 <?xml version="1.0" encoding="UTF-8"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <soap:Body>

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -90,12 +90,12 @@ class MetricsGlobalTest < Test::Unit::TestCase
   end
 
   def test_purchase_is_valid_csv
-   params = { :amount => '1.01' }
+    params = { :amount => '1.01' }
 
-   @gateway.send(:add_creditcard, params, @credit_card)
+    @gateway.send(:add_creditcard, params, @credit_card)
 
-   assert data = @gateway.send(:post_data, 'AUTH_ONLY', params)
-   assert_equal post_data_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'AUTH_ONLY', params)
+    assert_equal post_data_fixture.size, data.size
   end
 
   def test_purchase_meets_minimum_requirements

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -122,53 +122,53 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_preauth_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_purchase_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'purchase', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_purchase_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'purchase', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_purchase_fixture.size, data.size
   end
 
   def test_capture_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_successful_verify
@@ -717,11 +717,11 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def xml_purchase_fixture
-   '<request><store_id>store1</store_id><api_token>yesguy</api_token><purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></purchase></request>'
+    '<request><store_id>store1</store_id><api_token>yesguy</api_token><purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></purchase></request>'
   end
 
   def xml_capture_fixture
-   '<request><store_id>store1</store_id><api_token>yesguy</api_token><preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></preauth></request>'
+    '<request><store_id>store1</store_id><api_token>yesguy</api_token><preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></preauth></request>'
   end
 
   def pre_scrub

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -90,53 +90,53 @@ class MonerisUsTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_preauth_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'us_preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'us_preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_purchase_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'us_purchase', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_purchase_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'us_purchase', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_purchase_fixture.size, data.size
   end
 
   def test_capture_is_valid_xml
-   params = {
-     :order_id => 'order1',
-     :amount => '1.01',
-     :pan => '4242424242424242',
-     :expdate => '0303',
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'us_preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'us_preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_supported_countries
@@ -591,11 +591,11 @@ class MonerisUsTest < Test::Unit::TestCase
   end
 
   def xml_purchase_fixture
-   '<request><store_id>monusqa002</store_id><api_token>qatoken</api_token><us_purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></us_purchase></request>'
+    '<request><store_id>monusqa002</store_id><api_token>qatoken</api_token><us_purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></us_purchase></request>'
   end
 
   def xml_capture_fixture
-   '<request><store_id>monusqa002</store_id><api_token>qatoken</api_token><us_preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></us_preauth></request>'
+    '<request><store_id>monusqa002</store_id><api_token>qatoken</api_token><us_preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></us_preauth></request>'
   end
 
   def pre_scrub

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -146,9 +146,9 @@ class NetbanxTest < Test::Unit::TestCase
      assert_success response
      assert response.test?
 
-    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
-    assert_success response
-    assert response.test?
+     response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
+     assert_success response
+     assert response.test?
   end
 
   def test_scrub

--- a/test/unit/gateways/netbanx_test.rb
+++ b/test/unit/gateways/netbanx_test.rb
@@ -140,15 +140,15 @@ class NetbanxTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-     @gateway.expects(:ssl_request).twice.returns(successful_unstore_response)
+    @gateway.expects(:ssl_request).twice.returns(successful_unstore_response)
 
-     response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015|e4a3cd5a-56db-4d9b-97d3-fdd9ab3bd0f4')
-     assert_success response
-     assert response.test?
+    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015|e4a3cd5a-56db-4d9b-97d3-fdd9ab3bd0f4')
+    assert_success response
+    assert response.test?
 
-     response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
-     assert_success response
-     assert response.test?
+    response = @gateway.unstore('2f840ab3-0e71-4387-bad3-4705e6f4b015')
+    assert_success response
+    assert response.test?
   end
 
   def test_scrub

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -39,8 +39,8 @@ class OmiseTest < Test::Unit::TestCase
   end
 
   def test_gateway_url
-     assert_equal 'https://api.omise.co/', OmiseGateway::API_URL
-     assert_equal 'https://vault.omise.co/', OmiseGateway::VAULT_URL
+    assert_equal 'https://api.omise.co/', OmiseGateway::API_URL
+    assert_equal 'https://vault.omise.co/', OmiseGateway::VAULT_URL
   end
 
   def test_request_headers

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -179,11 +179,11 @@ class OppTest < Test::Unit::TestCase
   private
 
   def pre_scrubbed
-      'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=4200000000000000&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=123&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=sy6KJsT8&authentication.userId=8a8294174b7ecb28014b9699220015cc'
+    'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=4200000000000000&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=123&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=sy6KJsT8&authentication.userId=8a8294174b7ecb28014b9699220015cc'
   end
 
   def post_scrubbed
-      'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=[FILTERED]&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=[FILTERED]&authentication.userId=8a8294174b7ecb28014b9699220015cc'
+    'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=[FILTERED]&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=[FILTERED]&authentication.userId=8a8294174b7ecb28014b9699220015cc'
   end
 
   def successful_response(type, id)

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -219,12 +219,12 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_truncates_zip
    long_zip = '1234567890123'
 
-    response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:zip => long_zip))
-    end.check_request do |endpoint, data, headers|
-      assert_match(/1234567890</, data)
-    end.respond_with(successful_purchase_response)
-    assert_success response
+   response = stub_comms do
+     @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:zip => long_zip))
+   end.check_request do |endpoint, data, headers|
+     assert_match(/1234567890</, data)
+   end.respond_with(successful_purchase_response)
+   assert_success response
   end
 
   def test_address_format

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -217,14 +217,14 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_truncates_zip
-   long_zip = '1234567890123'
+    long_zip = '1234567890123'
 
-   response = stub_comms do
-     @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:zip => long_zip))
-   end.check_request do |endpoint, data, headers|
-     assert_match(/1234567890</, data)
-   end.respond_with(successful_purchase_response)
-   assert_success response
+    response = stub_comms do
+      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:zip => long_zip))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/1234567890</, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
   end
 
   def test_address_format

--- a/test/unit/gateways/pagarme_test.rb
+++ b/test/unit/gateways/pagarme_test.rb
@@ -614,7 +614,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def failed_capture_response
-  <<-FAILED_RESPONSE
+    <<-FAILED_RESPONSE
     {
       "errors": [
         {
@@ -630,7 +630,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def successful_refund_response
-  <<-SUCCESS_RESPONSE
+    <<-SUCCESS_RESPONSE
     {
       "acquirer_name": "development",
       "acquirer_response_code": "00",
@@ -688,7 +688,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def failed_refund_response
-  <<-FAILED_RESPONSE
+    <<-FAILED_RESPONSE
     {
       "errors": [
         {
@@ -704,7 +704,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def successful_void_response
-  <<-SUCCESS_RESPONSE
+    <<-SUCCESS_RESPONSE
     {
       "acquirer_name": "pagarme",
       "acquirer_response_code": "00",
@@ -762,7 +762,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def failed_void_response
-  <<-FAILED_RESPONSE
+    <<-FAILED_RESPONSE
     {
       "errors": [
         {
@@ -778,7 +778,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def successful_verify_response
-  <<-SUCCESS_RESPONSE
+    <<-SUCCESS_RESPONSE
     {
       "acquirer_name": "pagarme",
       "acquirer_response_code": "00",
@@ -836,7 +836,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def successful_verify_void_response
-  <<-SUCCESS_RESPONSE
+    <<-SUCCESS_RESPONSE
     {
       "acquirer_name": "pagarme",
       "acquirer_response_code": "00",
@@ -894,7 +894,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def failed_verify_response
-  <<-FAILED_RESPONSE
+    <<-FAILED_RESPONSE
     {
       "acquirer_name": "pagarme",
       "acquirer_response_code": "88",
@@ -968,7 +968,7 @@ class PagarmeTest < Test::Unit::TestCase
   end
 
   def failed_json_response
-  <<-SUCCESS_RESPONSE
+    <<-SUCCESS_RESPONSE
     {
       foo: bar
     }

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -540,7 +540,7 @@ Conn close
   end
 
   def start_date_error_recurring_response
-      <<-XML
+    <<-XML
   <ResponseData>
     <Result>0</Result>
     <Message>Field format error: START or NEXTPAYMENTDATE older than last payment date</Message>
@@ -553,7 +553,7 @@ Conn close
   end
 
   def start_date_missing_recurring_response
-      <<-XML
+    <<-XML
   <ResponseData>
     <Result>0</Result>
     <Message>Field format error: START field missing</Message>

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -86,7 +86,7 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_build_request_wrapper_with_request_details
     result = @gateway.send(:build_request_wrapper, 'Action', :request_details => true) do |xml|
-       xml.tag! 'n2:TransactionID', 'baz'
+      xml.tag! 'n2:TransactionID', 'baz'
     end
     assert_equal 'baz', REXML::XPath.first(REXML::Document.new(result), '//ActionReq/ActionRequest/n2:ActionRequestDetails/n2:TransactionID').text
   end

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -33,45 +33,45 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
   end
 
   def test_setup_request_invalid_requests
-   assert_raise ArgumentError do
-    @gateway.setup_purchase(100,
-      :ip                => '127.0.0.1',
-      :description       => 'Test Title',
-      :return_url        => 'http://return.url',
-      :cancel_return_url => 'http://cancel.url')
-   end
+    assert_raise ArgumentError do
+      @gateway.setup_purchase(100,
+        :ip                => '127.0.0.1',
+        :description       => 'Test Title',
+        :return_url        => 'http://return.url',
+        :cancel_return_url => 'http://cancel.url')
+    end
 
-   assert_raise ArgumentError do
-    @gateway.setup_purchase(100,
-      :ip                => '127.0.0.1',
-      :description       => 'Test Title',
-      :return_url        => 'http://return.url',
-      :cancel_return_url => 'http://cancel.url',
-      :items             => [ ])
-   end
+    assert_raise ArgumentError do
+      @gateway.setup_purchase(100,
+        :ip                => '127.0.0.1',
+        :description       => 'Test Title',
+        :return_url        => 'http://return.url',
+        :cancel_return_url => 'http://cancel.url',
+        :items             => [ ])
+    end
 
-   assert_raise ArgumentError do
-    @gateway.setup_purchase(100,
-      :ip                => '127.0.0.1',
-      :description       => 'Test Title',
-      :return_url        => 'http://return.url',
-      :cancel_return_url => 'http://cancel.url',
-      :items             => [ Hash.new ])
-   end
+    assert_raise ArgumentError do
+      @gateway.setup_purchase(100,
+        :ip                => '127.0.0.1',
+        :description       => 'Test Title',
+        :return_url        => 'http://return.url',
+        :cancel_return_url => 'http://cancel.url',
+        :items             => [ Hash.new ])
+    end
 
-   assert_raise ArgumentError do
-    @gateway.setup_purchase(100,
-      :ip                => '127.0.0.1',
-      :description       => 'Test Title',
-      :return_url        => 'http://return.url',
-      :cancel_return_url => 'http://cancel.url',
-      :items             => [ { :name => 'Charge',
-                                :number => '1',
-                                :quantity => '1',
-                                :amount   => 100,
-                                :description => 'Description',
-                                :category => 'Physical' } ])
-   end
+    assert_raise ArgumentError do
+      @gateway.setup_purchase(100,
+        :ip                => '127.0.0.1',
+        :description       => 'Test Title',
+        :return_url        => 'http://return.url',
+        :cancel_return_url => 'http://cancel.url',
+        :items             => [ { :name => 'Charge',
+                                  :number => '1',
+                                  :quantity => '1',
+                                  :amount   => 100,
+                                  :description => 'Description',
+                                  :category => 'Physical' } ])
+    end
   end
 
   def test_build_setup_request_valid
@@ -93,30 +93,30 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
   private
 
   def successful_setup_response
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\">
-	<SOAP-ENV:Header>
-		<Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security>
-		<RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\">
-			<Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\">
-				<Username xsi:type=\"xs:string\"></Username>
-				<Password xsi:type=\"xs:string\"></Password>
-				<Signature xsi:type=\"xs:string\">OMGOMGOMGOMGOMG</Signature>
-				<Subject xsi:type=\"xs:string\"></Subject>
-				</Credentials>
-			</RequesterCredentials>
-		</SOAP-ENV:Header>
-	<SOAP-ENV:Body id=\"_0\">
-		<SetExpressCheckoutResponse xmlns=\"urn:ebay:api:PayPalAPI\">
-			<Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2011-05-19T20:13:30Z</Timestamp>
-			<Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack>
-			<CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">da0ed6bc90ef1</CorrelationID>
-			<Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version>
-			<Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">1882144</Build>
-			<Token xsi:type=\"ebl:ExpressCheckoutTokenType\">EC-0XOMGOMGOMG</Token>
-			</SetExpressCheckoutResponse>
-		</SOAP-ENV:Body>
-	</SOAP-ENV:Envelope>"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\">
+    	<SOAP-ENV:Header>
+    		<Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security>
+    		<RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\">
+    			<Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\">
+    				<Username xsi:type=\"xs:string\"></Username>
+    				<Password xsi:type=\"xs:string\"></Password>
+    				<Signature xsi:type=\"xs:string\">OMGOMGOMGOMGOMG</Signature>
+    				<Subject xsi:type=\"xs:string\"></Subject>
+    				</Credentials>
+    			</RequesterCredentials>
+    		</SOAP-ENV:Header>
+    	<SOAP-ENV:Body id=\"_0\">
+    		<SetExpressCheckoutResponse xmlns=\"urn:ebay:api:PayPalAPI\">
+    			<Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2011-05-19T20:13:30Z</Timestamp>
+    			<Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack>
+    			<CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">da0ed6bc90ef1</CorrelationID>
+    			<Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">72</Version>
+    			<Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">1882144</Build>
+    			<Token xsi:type=\"ebl:ExpressCheckoutTokenType\">EC-0XOMGOMGOMG</Token>
+    			</SetExpressCheckoutResponse>
+    		</SOAP-ENV:Body>
+    	</SOAP-ENV:Envelope>"
   end
 
 end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -1056,8 +1056,8 @@ class PaypalExpressTest < Test::Unit::TestCase
     RESPONSE
   end
 
-    def response_with_errors
-      <<-RESPONSE
+  def response_with_errors
+    <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>
   <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:market="urn:ebay:apis:Market" xmlns:auction="urn:ebay:apis:Auction" xmlns:sizeship="urn:ebay:api:PayPalAPI/sizeship.xsd" xmlns:ship="urn:ebay:apis:ship" xmlns:skype="urn:ebay:apis:skype" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
     <SOAP-ENV:Header>
@@ -1093,10 +1093,10 @@ class PaypalExpressTest < Test::Unit::TestCase
     </SOAP-ENV:Body>
   </SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def response_with_duplicate_errors
-      <<-RESPONSE
+  def response_with_duplicate_errors
+    <<-RESPONSE
   <?xml version="1.0" encoding="UTF-8"?>
   <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:market="urn:ebay:apis:Market" xmlns:auction="urn:ebay:apis:Auction" xmlns:sizeship="urn:ebay:api:PayPalAPI/sizeship.xsd" xmlns:ship="urn:ebay:apis:ship" xmlns:skype="urn:ebay:apis:skype" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
     <SOAP-ENV:Header>
@@ -1132,10 +1132,10 @@ class PaypalExpressTest < Test::Unit::TestCase
     </SOAP-ENV:Body>
   </SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def successful_cancel_billing_agreement_response
-      <<-RESPONSE
+  def successful_cancel_billing_agreement_response
+    <<-RESPONSE
         <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes"
         xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
@@ -1159,10 +1159,10 @@ class PaypalExpressTest < Test::Unit::TestCase
         xsi:type="xs:string"></ExternalAddressID><AddressStatus
         xsi:type="ebl:AddressStatusCodeType">None</AddressStatus></Address></PayerInfo></BAUpdateResponseDetails></BAUpdateResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def failed_cancel_billing_agreement_response
-      <<-RESPONSE
+  def failed_cancel_billing_agreement_response
+    <<-RESPONSE
         <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes"
         xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
@@ -1185,10 +1185,10 @@ class PaypalExpressTest < Test::Unit::TestCase
         xsi:type="xs:string"></AddressID><AddressOwner xsi:type="ebl:AddressOwnerCodeType">PayPal</AddressOwner><ExternalAddressID xsi:type="xs:string"></ExternalAddressID><AddressStatus
         xsi:type="ebl:AddressStatusCodeType">None</AddressStatus></Address></PayerInfo></BAUpdateResponseDetails></BAUpdateResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def successful_billing_agreement_details_response
-      <<-RESPONSE
+  def successful_billing_agreement_details_response
+    <<-RESPONSE
         <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes"
@@ -1218,10 +1218,10 @@ class PaypalExpressTest < Test::Unit::TestCase
         <ExternalAddressID xsi:type="xs:string"></ExternalAddressID><AddressStatus xsi:type="ebl:AddressStatusCodeType">None</AddressStatus>
         </Address></PayerInfo></BAUpdateResponseDetails></BAUpdateResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def failure_billing_agreement_details_response
-      <<-RESPONSE
+  def failure_billing_agreement_details_response
+    <<-RESPONSE
       <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
       xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes"
@@ -1250,10 +1250,10 @@ class PaypalExpressTest < Test::Unit::TestCase
       <ExternalAddressID xsi:type="xs:string"></ExternalAddressID><AddressStatus xsi:type="ebl:AddressStatusCodeType">None</AddressStatus></Address>
       </PayerInfo></BAUpdateResponseDetails></BAUpdateResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       RESPONSE
-    end
+  end
 
-    def pre_scrubbed
-      <<-TRANSCRIPT
+  def pre_scrubbed
+    <<-TRANSCRIPT
 <?xml version=\"1.0\" encoding=\"UTF-8\"?><env:Envelope xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><env:Header><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xmlns:n1=\"urn:ebay:apis:eBLBaseComponents\" env:mustUnderstand=\"0\"><n1:Credentials><n1:Username>activemerchant-cert-test_api1.example.com</n1:Username><n1:Password>ERDD3JRFU5H5DQXS</n1:Password><n1:Subject/></n1:Credentials></RequesterCredentials></env:Header><env:Body><SetExpressCheckoutReq xmlns=\"urn:ebay:api:PayPalAPI\">
   <SetExpressCheckoutRequest xmlns:n2=\"urn:ebay:apis:eBLBaseComponents\">
     <n2:Version>124</n2:Version>
@@ -1276,10 +1276,10 @@ class PaypalExpressTest < Test::Unit::TestCase
 </env:Body></env:Envelope>
 <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><SetExpressCheckoutResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2018-05-24T20:23:54Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">b6dd2a043921b</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">124</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">46549960</Build><Token xsi:type=\"ebl:ExpressCheckoutTokenType\">EC-7KR85820NC734104L</Token></SetExpressCheckoutResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       TRANSCRIPT
-    end
+  end
 
-    def post_scrubbed
-      <<-TRANSCRIPT
+  def post_scrubbed
+    <<-TRANSCRIPT
 <?xml version=\"1.0\" encoding=\"UTF-8\"?><env:Envelope xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><env:Header><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xmlns:n1=\"urn:ebay:apis:eBLBaseComponents\" env:mustUnderstand=\"0\"><n1:Credentials><n1:Username>[FILTERED]</n1:Username><n1:Password>[FILTERED]</n1:Password><n1:Subject/></n1:Credentials></RequesterCredentials></env:Header><env:Body><SetExpressCheckoutReq xmlns=\"urn:ebay:api:PayPalAPI\">
   <SetExpressCheckoutRequest xmlns:n2=\"urn:ebay:apis:eBLBaseComponents\">
     <n2:Version>124</n2:Version>
@@ -1302,5 +1302,5 @@ class PaypalExpressTest < Test::Unit::TestCase
 </env:Body></env:Envelope>
 <?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:cc=\"urn:ebay:apis:CoreComponentTypes\" xmlns:wsu=\"http://schemas.xmlsoap.org/ws/2002/07/utility\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:wsse=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xmlns:ed=\"urn:ebay:apis:EnhancedDataTypes\" xmlns:ebl=\"urn:ebay:apis:eBLBaseComponents\" xmlns:ns=\"urn:ebay:api:PayPalAPI\"><SOAP-ENV:Header><Security xmlns=\"http://schemas.xmlsoap.org/ws/2002/12/secext\" xsi:type=\"wsse:SecurityType\"></Security><RequesterCredentials xmlns=\"urn:ebay:api:PayPalAPI\" xsi:type=\"ebl:CustomSecurityHeaderType\"><Credentials xmlns=\"urn:ebay:apis:eBLBaseComponents\" xsi:type=\"ebl:UserIdPasswordType\"><Username xsi:type=\"xs:string\"></Username><Password xsi:type=\"xs:string\"></Password><Signature xsi:type=\"xs:string\"></Signature><Subject xsi:type=\"xs:string\"></Subject></Credentials></RequesterCredentials></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><SetExpressCheckoutResponse xmlns=\"urn:ebay:api:PayPalAPI\"><Timestamp xmlns=\"urn:ebay:apis:eBLBaseComponents\">2018-05-24T20:23:54Z</Timestamp><Ack xmlns=\"urn:ebay:apis:eBLBaseComponents\">Success</Ack><CorrelationID xmlns=\"urn:ebay:apis:eBLBaseComponents\">b6dd2a043921b</CorrelationID><Version xmlns=\"urn:ebay:apis:eBLBaseComponents\">124</Version><Build xmlns=\"urn:ebay:apis:eBLBaseComponents\">46549960</Build><Token xsi:type=\"ebl:ExpressCheckoutTokenType\">EC-7KR85820NC734104L</Token></SetExpressCheckoutResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
       TRANSCRIPT
-    end
+  end
 end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -779,7 +779,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def successful_authorize_reference_transaction_response
-  <<-RESPONSE
+    <<-RESPONSE
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
   <SOAP-ENV:Header>

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -118,312 +118,312 @@ class PaystationTest < Test::Unit::TestCase
 
   private
 
-    def successful_purchase_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <response>
-      <ec>0</ec>
-      <em>Transaction successful</em>
-      <ti>0006713018-01</ti>
-      <ct>mastercard</ct>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>1</MerchantSession>
-      <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
-      <TransactionID>0008813023-01</TransactionID>
-      <PurchaseAmount>10000</PurchaseAmount>
-      <Locale/>
-      <ReturnReceiptNumber>8813023</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>00</AcqResponseCode>
-      <QSIResponseCode>0</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-06-22 00:05:52</TransactionTime>
-      <PaystationErrorCode>0</PaystationErrorCode>
-      <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0622</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype>MC</Cardtype>
-      <Username>12345</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-06-22 00:05:52</PaymentRequestTime>
-      <DigitalOrderTime/>
-      <DigitalReceiptTime>2011-06-22 00:05:52</DigitalReceiptTime>
-      <PaystationTransactionID>0008813023-01</PaystationTransactionID>
-      <IssuerName>unknown</IssuerName>
-      <IssuerCountry>unknown</IssuerCountry>
-      </response>)
-    end
+  def successful_purchase_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <response>
+    <ec>0</ec>
+    <em>Transaction successful</em>
+    <ti>0006713018-01</ti>
+    <ct>mastercard</ct>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>1</MerchantSession>
+    <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
+    <TransactionID>0008813023-01</TransactionID>
+    <PurchaseAmount>10000</PurchaseAmount>
+    <Locale/>
+    <ReturnReceiptNumber>8813023</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>00</AcqResponseCode>
+    <QSIResponseCode>0</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-06-22 00:05:52</TransactionTime>
+    <PaystationErrorCode>0</PaystationErrorCode>
+    <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0622</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype>MC</Cardtype>
+    <Username>12345</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-06-22 00:05:52</PaymentRequestTime>
+    <DigitalOrderTime/>
+    <DigitalReceiptTime>2011-06-22 00:05:52</DigitalReceiptTime>
+    <PaystationTransactionID>0008813023-01</PaystationTransactionID>
+    <IssuerName>unknown</IssuerName>
+    <IssuerCountry>unknown</IssuerCountry>
+    </response>)
+  end
 
-    def failed_purchase_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <response>
-      <ec>5</ec>
-      <em>Insufficient Funds</em>
-      <ti>0006713018-01</ti>
-      <ct>mastercard</ct>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>1</MerchantSession>
-      <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
-      <TransactionID>0008813018-01</TransactionID>
-      <PurchaseAmount>10051</PurchaseAmount>
-      <Locale/>
-      <ReturnReceiptNumber>8813018</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>51</AcqResponseCode>
-      <QSIResponseCode>5</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-06-22 00:05:46</TransactionTime>
-      <PaystationErrorCode>5</PaystationErrorCode>
-      <PaystationErrorMessage>Insufficient Funds</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0622</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype>MC</Cardtype>
-      <Username>123456</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-06-22 00:05:46</PaymentRequestTime>
-      <DigitalOrderTime/>
-      <DigitalReceiptTime>2011-06-22 00:05:46</DigitalReceiptTime>
-      <PaystationTransactionID>0008813018-01</PaystationTransactionID>
-      <IssuerName>unknown</IssuerName>
-      <IssuerCountry>unknown</IssuerCountry>
-      </response>)
-    end
+  def failed_purchase_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <response>
+    <ec>5</ec>
+    <em>Insufficient Funds</em>
+    <ti>0006713018-01</ti>
+    <ct>mastercard</ct>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>1</MerchantSession>
+    <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
+    <TransactionID>0008813018-01</TransactionID>
+    <PurchaseAmount>10051</PurchaseAmount>
+    <Locale/>
+    <ReturnReceiptNumber>8813018</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>51</AcqResponseCode>
+    <QSIResponseCode>5</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-06-22 00:05:46</TransactionTime>
+    <PaystationErrorCode>5</PaystationErrorCode>
+    <PaystationErrorMessage>Insufficient Funds</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0622</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype>MC</Cardtype>
+    <Username>123456</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-06-22 00:05:46</PaymentRequestTime>
+    <DigitalOrderTime/>
+    <DigitalReceiptTime>2011-06-22 00:05:46</DigitalReceiptTime>
+    <PaystationTransactionID>0008813018-01</PaystationTransactionID>
+    <IssuerName>unknown</IssuerName>
+    <IssuerCountry>unknown</IssuerCountry>
+    </response>)
+  end
 
-    def successful_store_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <PaystationFuturePaymentResponse>
-      <ec>34</ec>
-      <em>Future Payment Saved Ok</em>
-      <ti/>
-      <ct/>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>3e48fa9a6b0fe36177adf7269db7a3c4</MerchantSession>
-      <UsedAcquirerMerchantID/>
-      <TransactionID/>
-      <PurchaseAmount>0</PurchaseAmount>
-      <Locale/>
-      <ReturnReceiptNumber/>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode/>
-      <QSIResponseCode/>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-07-10 13:58:55</TransactionTime>
-      <PaystationErrorCode>34</PaystationErrorCode>
-      <PaystationErrorMessage>Future Payment Saved Ok</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber/>
-      <AuthorizeID/>
-      <Cardtype/>
-      <Username>123456</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-07-10 13:58:55</PaymentRequestTime>
-      <DigitalOrderTime/>
-      <DigitalReceiptTime>2011-07-10 13:58:55</DigitalReceiptTime>
-      <PaystationTransactionID>0009062177-01</PaystationTransactionID>
-      <FuturePaymentToken>justatest1310263135</FuturePaymentToken>
-      <IssuerName>unknown</IssuerName>
-      <IssuerCountry>unknown</IssuerCountry>
-      </PaystationFuturePaymentResponse>)
-    end
+  def successful_store_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <PaystationFuturePaymentResponse>
+    <ec>34</ec>
+    <em>Future Payment Saved Ok</em>
+    <ti/>
+    <ct/>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>3e48fa9a6b0fe36177adf7269db7a3c4</MerchantSession>
+    <UsedAcquirerMerchantID/>
+    <TransactionID/>
+    <PurchaseAmount>0</PurchaseAmount>
+    <Locale/>
+    <ReturnReceiptNumber/>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode/>
+    <QSIResponseCode/>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-07-10 13:58:55</TransactionTime>
+    <PaystationErrorCode>34</PaystationErrorCode>
+    <PaystationErrorMessage>Future Payment Saved Ok</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber/>
+    <AuthorizeID/>
+    <Cardtype/>
+    <Username>123456</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-07-10 13:58:55</PaymentRequestTime>
+    <DigitalOrderTime/>
+    <DigitalReceiptTime>2011-07-10 13:58:55</DigitalReceiptTime>
+    <PaystationTransactionID>0009062177-01</PaystationTransactionID>
+    <FuturePaymentToken>justatest1310263135</FuturePaymentToken>
+    <IssuerName>unknown</IssuerName>
+    <IssuerCountry>unknown</IssuerCountry>
+    </PaystationFuturePaymentResponse>)
+  end
 
-    def successful_stored_purchase_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <PaystationFuturePaymentResponse>
-      <ec>0</ec>
-      <em>Transaction successful</em>
-      <ti>0006713018-01</ti>
-      <ct>visa</ct>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>0fc70a577f19ae63f651f53c7044640a</MerchantSession>
-      <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
-      <TransactionID>0009062149-01</TransactionID>
-      <PurchaseAmount>10000</PurchaseAmount>
-      <Locale/>
-      <ReturnReceiptNumber>9062149</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>00</AcqResponseCode>
-      <QSIResponseCode>0</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-07-10 13:55:00</TransactionTime>
-      <PaystationErrorCode>0</PaystationErrorCode>
-      <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0710</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype>VC</Cardtype>
-      <Username>123456</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-07-10 13:55:00</PaymentRequestTime>
-      <DigitalOrderTime/>
-      <DigitalReceiptTime>2011-07-10 13:55:00</DigitalReceiptTime>
-      <PaystationTransactionID>0009062149-01</PaystationTransactionID>
-      <FuturePaymentToken>u09fxli14afpnd6022x0z82317beqe9e2w048l9it8286k6lpvz9x27hdal9bl95</FuturePaymentToken>
-      <IssuerName>unknown</IssuerName>
-      <IssuerCountry>unknown</IssuerCountry>
-      </PaystationFuturePaymentResponse>)
-    end
+  def successful_stored_purchase_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <PaystationFuturePaymentResponse>
+    <ec>0</ec>
+    <em>Transaction successful</em>
+    <ti>0006713018-01</ti>
+    <ct>visa</ct>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>0fc70a577f19ae63f651f53c7044640a</MerchantSession>
+    <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
+    <TransactionID>0009062149-01</TransactionID>
+    <PurchaseAmount>10000</PurchaseAmount>
+    <Locale/>
+    <ReturnReceiptNumber>9062149</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>00</AcqResponseCode>
+    <QSIResponseCode>0</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-07-10 13:55:00</TransactionTime>
+    <PaystationErrorCode>0</PaystationErrorCode>
+    <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0710</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype>VC</Cardtype>
+    <Username>123456</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-07-10 13:55:00</PaymentRequestTime>
+    <DigitalOrderTime/>
+    <DigitalReceiptTime>2011-07-10 13:55:00</DigitalReceiptTime>
+    <PaystationTransactionID>0009062149-01</PaystationTransactionID>
+    <FuturePaymentToken>u09fxli14afpnd6022x0z82317beqe9e2w048l9it8286k6lpvz9x27hdal9bl95</FuturePaymentToken>
+    <IssuerName>unknown</IssuerName>
+    <IssuerCountry>unknown</IssuerCountry>
+    </PaystationFuturePaymentResponse>)
+  end
 
-    def successful_authorization_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <response>
-      <ec>0</ec>
-      <em>Transaction successful</em>
-      <ti>0009062250-01</ti>
-      <ct>visa</ct>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>b2168af96076522466af4e3d61e5ba0c</MerchantSession>
-      <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
-      <TransactionID>0009062250-01</TransactionID>
-      <PurchaseAmount>10000</PurchaseAmount>
-      <Locale/>
-      <ReturnReceiptNumber>9062250</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>00</AcqResponseCode>
-      <QSIResponseCode>0</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-07-10 14:11:00</TransactionTime>
-      <PaystationErrorCode>0</PaystationErrorCode>
-      <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0710</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype>VC</Cardtype>
-      <Username>123456</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-07-10 14:11:00</PaymentRequestTime>
-      <DigitalOrderTime/>
-      <DigitalReceiptTime>2011-07-10 14:11:00</DigitalReceiptTime>
-      <PaystationTransactionID>0009062250-01</PaystationTransactionID>
-      <IssuerName>unknown</IssuerName>
-      <IssuerCountry>unknown</IssuerCountry>
-      </response>)
-    end
+  def successful_authorization_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <response>
+    <ec>0</ec>
+    <em>Transaction successful</em>
+    <ti>0009062250-01</ti>
+    <ct>visa</ct>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>b2168af96076522466af4e3d61e5ba0c</MerchantSession>
+    <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
+    <TransactionID>0009062250-01</TransactionID>
+    <PurchaseAmount>10000</PurchaseAmount>
+    <Locale/>
+    <ReturnReceiptNumber>9062250</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>00</AcqResponseCode>
+    <QSIResponseCode>0</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-07-10 14:11:00</TransactionTime>
+    <PaystationErrorCode>0</PaystationErrorCode>
+    <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0710</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype>VC</Cardtype>
+    <Username>123456</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-07-10 14:11:00</PaymentRequestTime>
+    <DigitalOrderTime/>
+    <DigitalReceiptTime>2011-07-10 14:11:00</DigitalReceiptTime>
+    <PaystationTransactionID>0009062250-01</PaystationTransactionID>
+    <IssuerName>unknown</IssuerName>
+    <IssuerCountry>unknown</IssuerCountry>
+    </response>)
+  end
 
-    def successful_capture_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <PaystationCaptureResponse>
-      <ec>0</ec>
-      <em>Transaction successful</em>
-      <ti>0009062289-01</ti>
-      <ct/>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>485fdedc81dc83848dd799cd10a869db</MerchantSession>
-      <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
-      <TransactionID>0009062289-01</TransactionID>
-      <CaptureAmount>10000</CaptureAmount>
-      <Locale/>
-      <ReturnReceiptNumber>9062289</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>00</AcqResponseCode>
-      <QSIResponseCode>0</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2011-07-10 14:17:36</TransactionTime>
-      <PaystationErrorCode>0</PaystationErrorCode>
-      <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0710</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype/>
-      <Username>123456</Username>
-      <RequestIP>192.168.0.1</RequestIP>
-      <RequestUserAgent/>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2011-07-10 14:17:36</PaymentRequestTime>
-      <DigitalOrderTime>2011-07-10 14:17:36</DigitalOrderTime>
-      <DigitalReceiptTime>2011-07-10 14:17:36</DigitalReceiptTime>
-      <PaystationTransactionID/>
-      <RefundedAmount/>
-      <CapturedAmount>10000</CapturedAmount>
-      <AuthorisedAmount/>
-      </PaystationCaptureResponse>)
-    end
+  def successful_capture_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <PaystationCaptureResponse>
+    <ec>0</ec>
+    <em>Transaction successful</em>
+    <ti>0009062289-01</ti>
+    <ct/>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>485fdedc81dc83848dd799cd10a869db</MerchantSession>
+    <UsedAcquirerMerchantID>123456</UsedAcquirerMerchantID>
+    <TransactionID>0009062289-01</TransactionID>
+    <CaptureAmount>10000</CaptureAmount>
+    <Locale/>
+    <ReturnReceiptNumber>9062289</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>00</AcqResponseCode>
+    <QSIResponseCode>0</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2011-07-10 14:17:36</TransactionTime>
+    <PaystationErrorCode>0</PaystationErrorCode>
+    <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0710</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype/>
+    <Username>123456</Username>
+    <RequestIP>192.168.0.1</RequestIP>
+    <RequestUserAgent/>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2011-07-10 14:17:36</PaymentRequestTime>
+    <DigitalOrderTime>2011-07-10 14:17:36</DigitalOrderTime>
+    <DigitalReceiptTime>2011-07-10 14:17:36</DigitalReceiptTime>
+    <PaystationTransactionID/>
+    <RefundedAmount/>
+    <CapturedAmount>10000</CapturedAmount>
+    <AuthorisedAmount/>
+    </PaystationCaptureResponse>)
+  end
 
-    def successful_refund_response
-      %(<?xml version="1.0" standalone="yes"?>
-      <PaystationRefundResponse>
-      <ec>0</ec>
-      <em>Transaction successful</em>
-      <ti>0008813023-01</ti>
-      <ct>mastercard</ct>
-      <merchant_ref>Store Purchase</merchant_ref>
-      <tm>T</tm>
-      <MerchantSession>70ceae1b3f069e41ca7f4350a1180cb1</MerchantSession>
-      <UsedAcquirerMerchantID>924518</UsedAcquirerMerchantID>
-      <TransactionID>0008813023-01</TransactionID>
-      <RefundAmount>10000</RefundAmount>
-      <SurchargeAmount/>
-      <Locale>en</Locale>
-      <ReturnReceiptNumber>58160420</ReturnReceiptNumber>
-      <ShoppingTransactionNumber/>
-      <AcqResponseCode>00</AcqResponseCode>
-      <QSIResponseCode>0</QSIResponseCode>
-      <CSCResultCode/>
-      <AVSResultCode/>
-      <TransactionTime>2015-06-25 03:23:24</TransactionTime>
-      <PaystationErrorCode>0</PaystationErrorCode>
-      <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
-      <PaystationExtendedErrorMessage/>
-      <MerchantReference>Store Purchase</MerchantReference>
-      <CardNo>512345XXXXXXX346</CardNo>
-      <CardExpiry>1305</CardExpiry>
-      <TransactionProcess>refund</TransactionProcess>
-      <TransactionMode>T</TransactionMode>
-      <BatchNumber>0625</BatchNumber>
-      <AuthorizeID/>
-      <Cardtype>MC</Cardtype>
-      <Username>609035</Username>
-      <RequestIP>173.95.131.239</RequestIP>
-      <RequestUserAgent>Ruby</RequestUserAgent>
-      <RequestHttpReferrer/>
-      <PaymentRequestTime>2015-06-25 03:23:24</PaymentRequestTime>
-      <DigitalOrderTime>2015-06-25 03:23:24</DigitalOrderTime>
-      <DigitalReceiptTime/>
-      <PaystationTransactionID/>
-      <RefundedAmount>10000</RefundedAmount>
-      <CapturedAmount/>
-      </PaystationRefundResponse>)
-    end
+  def successful_refund_response
+    %(<?xml version="1.0" standalone="yes"?>
+    <PaystationRefundResponse>
+    <ec>0</ec>
+    <em>Transaction successful</em>
+    <ti>0008813023-01</ti>
+    <ct>mastercard</ct>
+    <merchant_ref>Store Purchase</merchant_ref>
+    <tm>T</tm>
+    <MerchantSession>70ceae1b3f069e41ca7f4350a1180cb1</MerchantSession>
+    <UsedAcquirerMerchantID>924518</UsedAcquirerMerchantID>
+    <TransactionID>0008813023-01</TransactionID>
+    <RefundAmount>10000</RefundAmount>
+    <SurchargeAmount/>
+    <Locale>en</Locale>
+    <ReturnReceiptNumber>58160420</ReturnReceiptNumber>
+    <ShoppingTransactionNumber/>
+    <AcqResponseCode>00</AcqResponseCode>
+    <QSIResponseCode>0</QSIResponseCode>
+    <CSCResultCode/>
+    <AVSResultCode/>
+    <TransactionTime>2015-06-25 03:23:24</TransactionTime>
+    <PaystationErrorCode>0</PaystationErrorCode>
+    <PaystationErrorMessage>Transaction successful</PaystationErrorMessage>
+    <PaystationExtendedErrorMessage/>
+    <MerchantReference>Store Purchase</MerchantReference>
+    <CardNo>512345XXXXXXX346</CardNo>
+    <CardExpiry>1305</CardExpiry>
+    <TransactionProcess>refund</TransactionProcess>
+    <TransactionMode>T</TransactionMode>
+    <BatchNumber>0625</BatchNumber>
+    <AuthorizeID/>
+    <Cardtype>MC</Cardtype>
+    <Username>609035</Username>
+    <RequestIP>173.95.131.239</RequestIP>
+    <RequestUserAgent>Ruby</RequestUserAgent>
+    <RequestHttpReferrer/>
+    <PaymentRequestTime>2015-06-25 03:23:24</PaymentRequestTime>
+    <DigitalOrderTime>2015-06-25 03:23:24</DigitalOrderTime>
+    <DigitalReceiptTime/>
+    <PaystationTransactionID/>
+    <RefundedAmount>10000</RefundedAmount>
+    <CapturedAmount/>
+    </PaystationRefundResponse>)
+  end
 
-    def failed_refund_response
-      %(<?xml version="1.0" standalone="yes"?>
-        <FONT FACE="Arial" SIZE="2"><strong>Error 11:</strong> Not enough input parameters.</FONT>)
-    end
+  def failed_refund_response
+    %(<?xml version="1.0" standalone="yes"?>
+      <FONT FACE="Arial" SIZE="2"><strong>Error 11:</strong> Not enough input parameters.</FONT>)
+  end
 
-    def pre_scrubbed
-      'pstn_pi=609035&pstn_gi=PUSHPAY&pstn_2p=t&pstn_nr=t&pstn_df=yymm&pstn_ms=a755b9c84a530aee91dc3077f57294b0&pstn_mo=Store+Purchase&pstn_mr=&pstn_am=&pstn_cu=NZD&pstn_cn=5123456789012346&pstn_ct=visa&pstn_ex=1305&pstn_cc=123&pstn_tm=T&paystation=_empty'
-    end
+  def pre_scrubbed
+    'pstn_pi=609035&pstn_gi=PUSHPAY&pstn_2p=t&pstn_nr=t&pstn_df=yymm&pstn_ms=a755b9c84a530aee91dc3077f57294b0&pstn_mo=Store+Purchase&pstn_mr=&pstn_am=&pstn_cu=NZD&pstn_cn=5123456789012346&pstn_ct=visa&pstn_ex=1305&pstn_cc=123&pstn_tm=T&paystation=_empty'
+  end
 
-    def post_scrubbed
-      'pstn_pi=609035&pstn_gi=PUSHPAY&pstn_2p=t&pstn_nr=t&pstn_df=yymm&pstn_ms=a755b9c84a530aee91dc3077f57294b0&pstn_mo=Store+Purchase&pstn_mr=&pstn_am=&pstn_cu=NZD&pstn_cn=[FILTERED]&pstn_ct=visa&pstn_ex=1305&pstn_cc=[FILTERED]&pstn_tm=T&paystation=_empty'
-    end
+  def post_scrubbed
+    'pstn_pi=609035&pstn_gi=PUSHPAY&pstn_2p=t&pstn_nr=t&pstn_df=yymm&pstn_ms=a755b9c84a530aee91dc3077f57294b0&pstn_mo=Store+Purchase&pstn_mr=&pstn_am=&pstn_cu=NZD&pstn_cn=[FILTERED]&pstn_ct=visa&pstn_ex=1305&pstn_cc=[FILTERED]&pstn_tm=T&paystation=_empty'
+  end
 
 end

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -219,40 +219,40 @@ class PaywayTest < Test::Unit::TestCase
 
   private
 
-    def successful_response_store
-      'response.responseCode=00'
-    end
+  def successful_response_store
+    'response.responseCode=00'
+  end
 
-    def successful_response_visa
-      'response.summaryCode=0&response.responseCode=08&response.cardSchemeName=VISA'
-    end
+  def successful_response_visa
+    'response.summaryCode=0&response.responseCode=08&response.cardSchemeName=VISA'
+  end
 
-    def successful_response_master_card
-      'response.summaryCode=0&response.responseCode=08&response.cardSchemeName=MASTERCARD'
-    end
+  def successful_response_master_card
+    'response.summaryCode=0&response.responseCode=08&response.cardSchemeName=MASTERCARD'
+  end
 
-    def purchase_with_invalid_credit_card_response
-      'response.summaryCode=1&response.responseCode=14'
-    end
+  def purchase_with_invalid_credit_card_response
+    'response.summaryCode=1&response.responseCode=14'
+  end
 
-    def purchase_with_expired_credit_card_response
-      'response.summaryCode=1&response.responseCode=54'
-    end
+  def purchase_with_expired_credit_card_response
+    'response.summaryCode=1&response.responseCode=54'
+  end
 
-    def purchase_with_invalid_month_response
-      'response.summaryCode=3&response.responseCode=QA'
-    end
+  def purchase_with_invalid_month_response
+    'response.summaryCode=3&response.responseCode=QA'
+  end
 
-    def bad_login_response
-      'response.summaryCode=3&response.responseCode=QH'
-    end
+  def bad_login_response
+    'response.summaryCode=3&response.responseCode=QH'
+  end
 
-    def bad_merchant_response
-      'response.summaryCode=3&response.responseCode=QK'
-    end
+  def bad_merchant_response
+    'response.summaryCode=3&response.responseCode=QK'
+  end
 
-    def certificate
-      '------BEGIN CERTIFICATE-----
+  def certificate
+    '------BEGIN CERTIFICATE-----
  -MIIDeDCCAmCgAwIBAgIBATANBgkqhkiG9w0BAQUFADBBMRMwEQYDVQQDDApjb2R5
  -ZmF1c2VyMRUwEwYKCZImiZPyLGQBGRYFZ21haWwxEzARBgoJkiaJk/IsZAEZFgNj
  -b20wHhcNMTMxMTEzMTk1NjE2WhcNMTQxMTEzMTk1NjE2WjBBMRMwEQYDVQQDDApj
@@ -273,5 +273,5 @@ class PaywayTest < Test::Unit::TestCase
  -ZJB9YPQZG+vWBdDSca3sUMtvFxpLUFwdKF5APSPOVnhbFJ3vSXY1ulP/R6XW9vnw
  -6kkQi2fHhU20ugMzp881Eixr+TjC0RvUerLG7g==
  ------END CERTIFICATE-----'
-    end
+  end
 end

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -29,11 +29,11 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '1034', @gateway.send(:amount, 1034)
+    assert_equal '1034', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_avs_result

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -348,11 +348,11 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_supported_countries

--- a/test/unit/gateways/verifi_test.rb
+++ b/test/unit/gateways/verifi_test.rb
@@ -61,7 +61,7 @@ class VerifiTest < Test::Unit::TestCase
     assert_equal '10.34', @gateway.send(:amount, 1034)
 
     assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
+      @gateway.send(:amount, '10.34')
     end
   end
 

--- a/test/unit/gateways/visanet_peru_test.rb
+++ b/test/unit/gateways/visanet_peru_test.rb
@@ -299,7 +299,7 @@ class VisanetPeruTest < Test::Unit::TestCase
   end
 
   def successful_capture_response
-   '{"errorCode":0,"errorMessage":"OK","transactionUUID":"8517cf68-4820-4224-959b-01c8117385e0","externalTransactionId":"de9dc65c094fb4f1defddc562731af81","transactionDateTime":1519937673906,"transactionDuration":0,"merchantId":"543025501","userTokenId":null,"aliasName":null,"data":{"FECHAYHORA_TX":null,"DSC_ECI":null,"DSC_COD_ACCION":null,"NOM_EMISOR":null,"ESTADO":"Depositado","RESPUESTA":"1","ID_UNICO":null,"NUMORDEN":null,"CODACCION":null,"ETICKET":null,"IMP_AUTORIZADO":null,"DECISIONCS":null,"COD_AUTORIZA":null,"CODTIENDA":"543025501","PAN":null,"ORI_TARJETA":null}}'
+    '{"errorCode":0,"errorMessage":"OK","transactionUUID":"8517cf68-4820-4224-959b-01c8117385e0","externalTransactionId":"de9dc65c094fb4f1defddc562731af81","transactionDateTime":1519937673906,"transactionDuration":0,"merchantId":"543025501","userTokenId":null,"aliasName":null,"data":{"FECHAYHORA_TX":null,"DSC_ECI":null,"DSC_COD_ACCION":null,"NOM_EMISOR":null,"ESTADO":"Depositado","RESPUESTA":"1","ID_UNICO":null,"NUMORDEN":null,"CODACCION":null,"ETICKET":null,"IMP_AUTORIZADO":null,"DECISIONCS":null,"COD_AUTORIZA":null,"CODTIENDA":"543025501","PAN":null,"ORI_TARJETA":null}}'
   end
 
   def failed_capture_response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -4,14 +4,14 @@ class WorldpayTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-   @gateway = WorldpayGateway.new(
-      :login => 'testlogin',
-      :password => 'testpassword'
-    )
+    @gateway = WorldpayGateway.new(
+       :login => 'testlogin',
+       :password => 'testpassword'
+     )
 
-   @amount = 100
-   @credit_card = credit_card('4242424242424242')
-   @options = {:order_id => 1}
+    @amount = 100
+    @credit_card = credit_card('4242424242424242')
+    @options = {:order_id => 1}
   end
 
   def test_successful_authorize

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -9,9 +9,9 @@ class WorldpayTest < Test::Unit::TestCase
       :password => 'testpassword'
     )
 
-    @amount = 100
-    @credit_card = credit_card('4242424242424242')
-    @options = {:order_id => 1}
+   @amount = 100
+   @credit_card = credit_card('4242424242424242')
+   @options = {:order_id => 1}
   end
 
   def test_successful_authorize


### PR DESCRIPTION
These are all leading whitespace fixes. While the number of lines changed looks scary, if you turn on "ignore whitespace," basically the whole thing goes away.