### PR TITLE
Remove the upperbound constraint on ActiveSupport:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ gemfile:
 - gemfiles/Gemfile.rails51
 - gemfiles/Gemfile.rails50
 - gemfiles/Gemfile.rails42
+- gemfiles/Gemfile.rails_master
 
 jobs:
   include:
       rvm: 2.5
       gemfile: Gemfile
       script: bundle exec rubocop --parallel
+
+matrix:
+  exclude:
+    - rvm: 2.3
+      gemfile: 'gemfiles/Gemfile.rails_master'
 
 notifications:
   email:

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 4.2', '< 6.x')
+  s.add_dependency('activesupport', '>= 4.2')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', '~> 1.4')

--- a/gemfiles/Gemfile.rails_master
+++ b/gemfiles/Gemfile.rails_master
@@ -1,0 +1,3 @@
+eval_gemfile '../Gemfile'
+
+gem 'activesupport', github: 'rails/rails'


### PR DESCRIPTION
- During every ActiveSupport major bump, this gemspec needs to be updated,
  I think we are being too conservative and having an upperbound limit
  doesn't help.

  If we wanted to be really conservative we would have to add a
  upperbound constraint on the minor version as well (`< 5.x`) since
  Rails doesn't follow semver and minor version can introduce breaking
  changes.

  What I think is better is to remove the upperbound constraint,
  and test AM directly on ActiveSupport edge.
  Looking at the commit rates on this project, CI would run
  largely enough to cover us. But we can also add another safety net
  and run travis on a schedule.

For 👀@bdewater @filipebarcos 