### PR TITLE
Worldpay: support MasterCard credits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -119,7 +119,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit_request(money, payment_method, options)
-        commit('credit', build_authorization_request(money, payment_method, options), :ok, options)
+        commit('credit', build_authorization_request(money, payment_method, options), :ok, 'SENT_FOR_REFUND', options)
       end
 
       def build_request

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -271,8 +271,15 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_match %r{REFUSED}, response.message
   end
 
-  def test_successful_credit_on_cft_gateway
+  def test_successful_visa_credit_on_cft_gateway
     credit = @cftgateway.credit(@amount, @credit_card, @options)
+    assert_success credit
+    assert_equal 'SUCCESS', credit.message
+  end
+
+  def test_successful_mastercard_credit_on_cft_gateway
+    cc = credit_card('5555555555554444')
+    credit = @cftgateway.credit(@amount, cc, @options)
     assert_success credit
     assert_equal 'SUCCESS', credit.message
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -179,14 +179,24 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_successful_credit
+  def test_successful_visa_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_match(/<paymentDetails action="REFUND">/, data)
-    end.respond_with(successful_credit_response)
+    end.respond_with(successful_visa_credit_response)
     assert_success response
     assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
+  end
+
+  def test_successful_mastercard_credit
+    response = stub_comms do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<paymentDetails action="REFUND">/, data)
+    end.respond_with(successful_mastercard_credit_response)
+    assert_success response
+    assert_equal 'f25257d251b81fb1fd9c210973c941ff', response.authorization
   end
 
   def test_description
@@ -748,7 +758,7 @@ class WorldpayTest < Test::Unit::TestCase
     REQUEST
   end
 
-  def successful_credit_response
+  def successful_visa_credit_response
     <<-RESPONSE
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
@@ -762,6 +772,29 @@ class WorldpayTest < Test::Unit::TestCase
           </ok>
         </reply>
       </paymentService>
+    RESPONSE
+  end
+
+  def successful_mastercard_credit_response
+    <<~RESPONSE
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                    "http://dtd.worldpay.com/paymentService_v1.dtd">
+    <paymentService version="1.4" merchantCode="YOUR_MERCHANT_CODE">
+      <reply>
+        <orderStatus orderCode="f25257d251b81fb1fd9c210973c941ff\">
+          <payment>
+            <paymentMethod>ECMC_DEBIT-SSL</paymentMethod>
+            <amount value="1110" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+            <lastEvent>SENT_FOR_REFUND</lastEvent>
+            <AuthorisationId id="987654"/>
+            <balance accountType="IN_PROCESS_CAPTURED">
+              <amount value="1110" currencyCode="GBP" exponent="2" debitCreditIndicator="debit"/>
+            </balance>
+          </payment>
+        </orderStatus>
+      </reply>
+    </paymentService>
     RESPONSE
   end
 


### PR DESCRIPTION
MasterCard and Visa credits do not work the same way, so we were erroneously counting MasterCard credits as failed. Count them as successful.

Unit: 40 tests, 227 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 28 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed