### PR TITLE
Worldpay: set name to 3D when 3DS attempted

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068
 * QuickPay: update supported countries [ta] #3049
+* WorldPay: set cardholder name to "3D" for 3DS transactions [bpollack] #3071
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -237,7 +237,7 @@ module ActiveMerchant #:nodoc:
                 xml.tag! 'date', 'month' => format(payment_method.month, :two_digits), 'year' => format(payment_method.year, :four_digits)
               end
 
-              xml.tag! 'cardHolderName', payment_method.name
+              xml.tag! 'cardHolderName', options[:execute_threed] ? '3D' : payment_method.name
               xml.tag! 'cvc', payment_method.verification_value
 
               add_address(xml, (options[:billing_address] || options[:address]))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -506,6 +506,18 @@ class WorldpayTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_3ds_name_coersion
+    @options[:execute_threed] = true
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if /<submit>/ =~ data
+        assert_match %r{<cardHolderName>3D</cardHolderName>}, data
+      end
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
Unit: 41 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed