### PR TITLE
Fix Type Error on Orbital Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -185,6 +185,7 @@ module ActiveMerchant #:nodoc:
         requires!(options, :merchant_id)
         requires!(options, :login, :password) unless options[:ip_authentication]
         super
+        @options[:merchant_id] = @options[:merchant_id].to_s
       end
 
       # A – Authorization request

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -106,6 +106,22 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_numeric_merchant_id_for_caputre
+    gateway = ActiveMerchant::Billing::OrbitalGateway.new(
+      :login => 'login',
+      :password => 'password',
+      :merchant_id => 700000123456
+    )
+
+    response = stub_comms(gateway) do
+      gateway.capture(101, "4A5398CF9B87744GG84A1D30F2F2321C66249416;1", @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<MerchantID>700000123456<\/MerchantID>/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+
   def test_expiry_date
     year = (DateTime.now + 1.year).strftime("%y")
     assert_equal "09#{year}", @gateway.send(:expiry_date, credit_card)


### PR DESCRIPTION
## Issue

On our production system we updated some configs and our chase merchant id changed from a string to an integer.  Since since length is simply called on the merchant_id without coercion or any type of type checking, this was a tough error to track down.

## What Changed
* Added a test demonstrating the error.
* Coerce the merchant_id to a string in the initializer

![screen shot 2018-12-04 at 10 46 32 am](https://user-images.githubusercontent.com/1141502/49455961-15ffe300-f7b6-11e8-9fe7-1b55a73d2cac.png)
