### PR TITLE
TrustCommerce: Add ACH Ability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * WorldPay: set cardholder name to "3D" for 3DS transactions [bpollack] #3071
 * Authorize.Net: Support refunds for bank accounts [nfarve] #3063
 * Stripe: support specifying a reason for refunds [yosukehasumi] #3056
+* TrustCommerce: Add ACH Ability [nfarve] #3073
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065
@@ -31,7 +32,7 @@
 * CyberSource: update supported countries [bpollack] #3055
 * MiGS: update supported countries [bpollack] #3055
 * Clearhaus: update submission data format [bpollack] #3053
-* Forte: Allow void on capture #3059
+* Forte: Allow void on capture [nfarve] #3059
 
 == Version 1.86.0 (October 26, 2018)
 * UsaEpayTransaction: Support UMcheckformat option for echecks [dtykocki] #3002

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1183,6 +1183,7 @@ trexle:
 trust_commerce:
   login: 'TestMerchant'
   password: 'password'
+  aggregator_id: 'abc123'
 
 # Working credentials, no need to replace
 usa_epay:


### PR DESCRIPTION
TrustCommerce supports ach transactions for purchase and credit. This
also adds the `aggregator_id` which will become mandatory.

Loaded suite test/remote/gateways/remote_trust_commerce_test
.......

15 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/trust_commerce_test
.........

9 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed