### PR TITLE
Payeezy: Support $0 for verify transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Authorize.Net: Support refunds for bank accounts [nfarve] #3063
 * Stripe: support specifying a reason for refunds [yosukehasumi] #3056
 * TrustCommerce: Add ACH Ability [nfarve] #3073
+* Payeezy: Support $0 for verify transactions [molbrown] #3074
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -94,7 +94,7 @@ module ActiveMerchant
 
       def verify(credit_card, options={})
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
+          r.process { authorize(0, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end


### PR DESCRIPTION
Payeezy allows $0 authorization. Updating from $1 verify
to $0 to resolve failures for customer.

ENE-59

Unit Tests:
33 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
33 tests, 131 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed