### PR TITLE
Adyen: Implement 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * USA ePay: add support for recurring transactions, custom fields, and line items [lancecarlson] #3069
 * Add dLocal gateway [curiousepic] #3709
 * dLocal: Require secret_key [curiousepic] #3080
+* Adyen: Implement 3DS [nfarve] #3076
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -15,6 +15,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       :brand => 'visa'
     )
 
+    @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
+
     @declined_card = credit_card('4000300011112220')
 
     @improperly_branded_maestro = credit_card(
@@ -58,6 +60,16 @@ class RemoteAdyenTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Authorised', response.message
+  end
+
+  def test_successful_authorize_with_3ds
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: true))
+    assert response.test?
+    refute response.authorization.blank?
+    assert_equal response.params['resultCode'], 'RedirectShopper'
+    refute response.params['issuerUrl'].blank?
+    refute response.params['md'].blank?
+    refute response.params['paRequest'].blank?
   end
 
   def test_failed_authorize


### PR DESCRIPTION
Allows for 3DS implementation on Adyen gateway.

Loaded suite test/remote/gateways/remote_adyen_test
.....................................

37 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/adyen_test
.........................

25 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed