### PR TITLE
Does not fail validation for blank cvv on maestro cards

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -362,7 +362,7 @@ module ActiveMerchant #:nodoc:
           unless valid_card_verification_value?(verification_value, brand)
             errors << [:verification_value, "should be #{card_verification_value_length(brand)} digits"]
           end
-        elsif requires_verification_value?
+        elsif requires_verification_value? && !valid_card_verification_value?(verification_value, brand)
           errors << [:verification_value, 'is required']
         end
         errors

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -36,6 +36,11 @@ class CreditCardTest < Test::Unit::TestCase
     assert_valid @maestro
   end
 
+  def test_should_be_a_valid_maestro_card_when_require_cvv_is_true
+    CreditCard.require_verification_value = true
+    assert_valid @maestro
+  end
+
   def test_cards_with_empty_names_should_not_be_valid
     @visa.first_name = ''
     @visa.last_name  = ''


### PR DESCRIPTION
This change is allowing users to pass `cvv: blank` and pass validation
even when `CreditCard.require_verification_value = true` for maestro,
since cvv length is 0.

I believe this was some backward compatibility issue when we changed maestro card validations to include the new/correct numbers.