### PR TITLE
Payeezy: Add `stored_credentials`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * dLocal: Require secret_key [curiousepic] #3080
 * Adyen: Implement 3DS [nfarve] #3076
 * Adyen: Add 3DS Fix [nfarve] #3081
+* Payeezy: Add `stored_credentials` [nfarve] #3083)
 
 == Version 1.88.0 (November 30, 2018)
 * Added ActiveSupport/Rails master support [Edouard-chin] #3065

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -39,6 +39,7 @@ module ActiveMerchant
         add_address(params, options)
         add_amount(params, amount, options)
         add_soft_descriptors(params, options)
+        add_stored_credentials(params, options)
 
         commit(params, options)
       end
@@ -52,6 +53,7 @@ module ActiveMerchant
         add_address(params, options)
         add_amount(params, amount, options)
         add_soft_descriptors(params, options)
+        add_stored_credentials(params, options)
 
         commit(params, options)
       end
@@ -242,6 +244,17 @@ module ActiveMerchant
 
       def add_soft_descriptors(params, options)
         params[:soft_descriptors] = options[:soft_descriptors] if options[:soft_descriptors]
+      end
+
+      def add_stored_credentials(params, options)
+        if options[:sequence]
+          params[:stored_credentials] = {}
+          params[:stored_credentials][:cardbrand_original_transaction_id] = options[:cardbrand_original_transaction_id] if options[:cardbrand_original_transaction_id]
+          params[:stored_credentials][:sequence] = options[:sequence]
+          params[:stored_credentials][:initiator] = options[:initiator] if options[:initiator]
+          params[:stored_credentials][:is_scheduled] = options[:is_scheduled]
+          params[:stored_credentials][:auth_type_override] = options[:auth_type_override] if options[:auth_type_override]
+        end
       end
 
       def commit(params, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -26,6 +26,13 @@ class RemotePayeezyTest < Test::Unit::TestCase
         merchant_contact_info: '8885551212'
       }
     }
+    @options_stored_credentials = {
+      cardbrand_original_transaction_id: 'abc123',
+      sequence: 'FIRST',
+      is_scheduled: true,
+      initiator: 'MERCHANT',
+      auth_type_override: 'A'
+    }
   end
 
   def test_successful_store
@@ -64,6 +71,12 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_soft_descriptors
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_mdd))
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_stored_credentials
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))
     assert_match(/Transaction Normal/, response.message)
     assert_success response
   end


### PR DESCRIPTION
Adds params for `stored_credentials` to support compliance with Visa/MC.

Loaded suite test/remote/gateways/remote_payeezy_test
..................................

34 tests, 134 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/payeezy_test
..................................

34 tests, 162 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed