### PR TITLE
Stripe: Add 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Braintree Blue: Support Level 2 and 3 data fields [curiousepic] #3094
 * Braintree Blue: Refactor line_items field [curiousepic] #3100
 * TrustCommerce: Use `application_id` [nfarve] #3103
+* Stripe: Add 3DS Support [nfarve] #3086
 
 == Version 1.89.0 (December 17, 2018)
 * Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class RemoteStripe3DSTest < Test::Unit::TestCase
+  CHARGE_ID_REGEX = /ch_[a-zA-Z\d]{24}/
+
+  def setup
+    @gateway = StripeGateway.new(fixtures(:stripe))
+    @amount = 100
+
+    @options = {
+      :currency => 'USD',
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com',
+      :execute_threed => true,
+      :redirect_url => 'http://www.example.com/redirect',
+      :callback_url => 'http://www.example.com/callback'
+    }
+    @credit_card = credit_card('4000000000003063')
+    @non_3ds_card = credit_card('378282246310005')
+  end
+
+  def test_create_3ds_card_source
+    assert response = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
+    assert_success response
+    assert_equal 'source', response.params['object']
+    assert_equal 'chargeable', response.params['status']
+    assert_equal 'required', response.params['card']['three_d_secure']
+    assert_equal 'card', response.params['type']
+  end
+
+  def test_create_non3ds_card_source
+    assert response = @gateway.send(:create_source, @amount, @non_3ds_card, 'card', @options)
+    assert_success response
+    assert_equal 'source', response.params['object']
+    assert_equal 'chargeable', response.params['status']
+    assert_equal 'not_supported', response.params['card']['three_d_secure']
+    assert_equal 'card', response.params['type']
+  end
+
+  def test_create_3ds_source
+    card_source  = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
+    assert response = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure',  @options)
+    assert_success response
+    assert_equal 'source', response.params['object']
+    assert_equal 'pending', response.params['status']
+    assert_equal 'three_d_secure', response.params['type']
+    assert_equal false, response.params['three_d_secure']['authenticated']
+  end
+
+  def test_create_webhook_endpoint
+    response = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
+    assert_includes response.params['enabled_events'], 'source.chargeable'
+    assert_equal @options[:callback_url], response.params['url']
+  end
+
+  def test_delete_webhook_endpoint
+    webhook = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
+    response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook.params['id']))
+    assert_equal response.params['id'], webhook.params['id']
+    assert_equal true, response.params['deleted']
+  end
+end


### PR DESCRIPTION
Adds 3DS to the Stripe gateway. Remote tests for 3DS are in their own
file.

Loaded suite test/unit/gateways/stripe_test
.....................................................................................................................................

133 tests, 713 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_stripe_3ds_test
.....

5 tests, 21 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_stripe_test
...................................................................

67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed