### PR TITLE
Mercado Pago: Support "gateway" processing mode

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -95,6 +95,7 @@ module ActiveMerchant #:nodoc:
         add_additional_data(post, options)
         add_customer_data(post, payment, options)
         add_address(post, options)
+        add_processing_mode(post, options)
         post[:binary_mode] = (options[:binary_mode].nil? ? true : options[:binary_mode])
         post
       end
@@ -103,6 +104,21 @@ module ActiveMerchant #:nodoc:
         post = purchase_request(money, payment, options)
         post[:capture] = false
         post
+      end
+
+      def add_processing_mode(post, options)
+        return unless options[:processing_mode]
+        post[:processing_mode] = options[:processing_mode]
+        post[:merchant_account_id] = options[:merchant_account_id] if options[:merchant_account_id]
+        add_merchant_services(post, options)
+      end
+
+      def add_merchant_services(post, options)
+        return unless options[:fraud_scoring] || options[:fraud_manual_review]
+        merchant_services = {}
+        merchant_services[:fraud_scoring] = options[:fraud_scoring] if options[:fraud_scoring]
+        merchant_services[:fraud_manual_review] = options[:fraud_manual_review] if options[:fraud_manual_review]
+        post[:merchant_services] = merchant_services
       end
 
       def add_additional_data(post, options)


### PR DESCRIPTION
Includes a few updates to remote tests to account for changes in gateway/sandbox behavior.

Remote (1 unrelated failure and 1 for the processing mode specific to
another test account, passes locally):
18 tests, 46 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.8889% passed

Unit:
19 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed