### PR TITLE
Braintree: Update gem to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   exclude:
     - rvm: 2.3
       gemfile: 'gemfiles/Gemfile.rails_master'
+    - rvm: 2.4
+      gemfile: 'gemfiles/Gemfile.rails_master'
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'rubocop', '~> 0.60.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.78.0'
+  gem 'braintree', '>= 2.93.0'
 end


### PR DESCRIPTION
In support of adding Level 2 and 3 data fields. Also updates Travis to
exclude a now-incompatible job.

Blue Remote:
66 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Orange Remote:
21 tests, 91 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Braintree Unit:
6 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Blue Unit:
57 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Orange Unit:
18 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed