### PR TITLE
Paymentez: Adds support for extra_params optional field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087
 * Braintree: Update gem to latest version [curiousepic] #3091
 * Adyen: Pass arbitrary riskData fields [curiousepic] #3089
+* Paymentez: Adds support for extra_params optional field [molbrown] #3095
 
 == Version 1.89.0 (December 17, 2018)
 * Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -52,6 +52,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment)
         add_customer_data(post, options)
+        add_extra_params(post, options)
         action = payment.is_a?(String) ? 'debit' : 'debit_cc'
 
         commit_transaction(action, post)
@@ -63,6 +64,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment)
         add_customer_data(post, options)
+        add_extra_params(post, options)
 
         commit_transaction('authorize', post)
       end
@@ -165,6 +167,18 @@ module ActiveMerchant #:nodoc:
           post[:card][:expiry_year] = payment.year
           post[:card][:cvc] = payment.verification_value
           post[:card][:type] = CARD_MAPPING[payment.brand]
+        end
+      end
+
+      def add_extra_params(post, options)
+        if options[:extra_params]
+          items = {}
+          options[:extra_params].each do |param|
+            param.each do |key, value|
+              items[key.to_sym] = value
+            end
+          end
+          post[:extra_params] = items
         end
       end
 

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -59,6 +59,18 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_extra_params
+    options = {
+      extra_params: {
+        configuration1: 'value1',
+        configuration2: 'value2',
+        configuration3: 'value3'
+      }}
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+  end
+
   def test_successful_purchase_with_token
     store_response = @gateway.store(@credit_card, @options)
     assert_success store_response


### PR DESCRIPTION
Merchant may define custom optional fields in their Paymentez account, to
send with debit requests under extra_params object.

ENE-80

Unit:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Remote:
20 tests, 47 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
Failures unrelated to this change, have to do with country-specific allowances for
partial capture/ refund.