### PR TITLE
Use contemporary Pin Payments URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The [ActiveMerchant Wiki](http://github.com/activemerchant/active_merchant/wikis
 * [Paystation](http://paystation.co.nz) - NZ
 * [Pay Way](http://www.payway.com.au) - AU
 * [PayU India](https://www.payu.in/) - IN
-* [Pin Payments](http://www.pin.net.au/) - AU
+* [Pin Payments](http://www.pinpayments.com/) - AU
 * [Plug'n Pay](http://www.plugnpay.com/) - US
 * [Psigate](http://www.psigate.com/) - CA
 * [PSL Payment Solutions](http://www.paymentsolutionsltd.com/) - GB

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -1,14 +1,14 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PinGateway < Gateway
-      self.test_url = 'https://test-api.pin.net.au/1'
-      self.live_url = 'https://api.pin.net.au/1'
+      self.test_url = 'https://test-api.pinpayments.com/1'
+      self.live_url = 'https://api.pinpayments.com/1'
 
       self.default_currency = 'AUD'
       self.money_format = :cents
       self.supported_countries = ['AU']
       self.supported_cardtypes = [:visa, :master, :american_express]
-      self.homepage_url = 'http://www.pin.net.au/'
+      self.homepage_url = 'http://www.pinpayments.com/'
       self.display_name = 'Pin Payments'
 
       def initialize(options = {})
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def unparsable_response(raw_response)
-        message = 'Invalid JSON response received from Pin Payments. Please contact support@pin.net.au if you continue to receive this message.'
+        message = 'Invalid JSON response received from Pin Payments. Please contact support@pinpayments.com if you continue to receive this message.'
         message += " (The raw response returned by the API was #{raw_response.inspect})"
         return Response.new(false, message)
       end

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -10,7 +10,7 @@ class RemotePinTest < Test::Unit::TestCase
     @declined_card = credit_card('4100000000000001')
 
     @options = {
-      :email => 'roland@pin.net.au',
+      :email => 'roland@pinpayments.com',
       :ip => '203.59.39.62',
       :order_id => '1',
       :billing_address => address,

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -8,7 +8,7 @@ class PinTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :email => 'roland@pin.net.au',
+      :email => 'roland@pinpayments.com',
       :billing_address => address,
       :description => 'Store Purchase',
       :ip => '127.0.0.1'
@@ -30,11 +30,11 @@ class PinTest < Test::Unit::TestCase
   end
 
   def test_url
-    assert_equal 'https://test-api.pin.net.au/1', PinGateway.test_url
+    assert_equal 'https://test-api.pinpayments.com/1', PinGateway.test_url
   end
 
   def test_live_url
-    assert_equal 'https://api.pin.net.au/1', PinGateway.live_url
+    assert_equal 'https://api.pinpayments.com/1', PinGateway.live_url
   end
 
   def test_supported_countries
@@ -66,7 +66,7 @@ class PinTest < Test::Unit::TestCase
     headers = {}
     @gateway.stubs(:headers).returns(headers)
     @gateway.stubs(:post_data).returns(post_data)
-    @gateway.expects(:ssl_request).with(:post, 'https://test-api.pin.net.au/1/charges', post_data, headers).returns(successful_purchase_response)
+    @gateway.expects(:ssl_request).with(:post, 'https://test-api.pinpayments.com/1/charges', post_data, headers).returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -120,7 +120,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_successful_update
     token = 'cus_05p0n7UFPmcyCNjD8c6HdA'
-    @gateway.expects(:ssl_request).with(:put, "https://test-api.pin.net.au/1/customers/#{token}", instance_of(String), instance_of(Hash)).returns(successful_customer_store_response)
+    @gateway.expects(:ssl_request).with(:put, "https://test-api.pinpayments.com/1/customers/#{token}", instance_of(String), instance_of(Hash)).returns(successful_customer_store_response)
     assert response = @gateway.update('cus_05p0n7UFPmcyCNjD8c6HdA', @credit_card, @options)
     assert_success response
     assert_equal 'cus_05p0n7UFPmcyCNjD8c6HdA', response.authorization
@@ -130,7 +130,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_successful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pin.net.au/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_equal 'rf_d2C7M6Mn4z2m3APqarNN6w', response.authorization
@@ -140,7 +140,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_unsuccessful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pin.net.au/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_failure response
@@ -153,7 +153,7 @@ class PinTest < Test::Unit::TestCase
     headers = {}
     @gateway.stubs(:headers).returns(headers)
     @gateway.stubs(:post_data).returns(post_data)
-    @gateway.expects(:ssl_request).with(:post, 'https://test-api.pin.net.au/1/charges', post_data, headers).returns(successful_purchase_response)
+    @gateway.expects(:ssl_request).with(:post, 'https://test-api.pinpayments.com/1/charges', post_data, headers).returns(successful_purchase_response)
 
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
@@ -168,7 +168,7 @@ class PinTest < Test::Unit::TestCase
     token = 'ch_encBuMDf17qTabmVjDsQlg'
     @gateway.stubs(:headers).returns(headers)
     @gateway.stubs(:post_data).returns(post_data)
-    @gateway.expects(:ssl_request).with(:put, "https://test-api.pin.net.au/1/charges/#{token}/capture", post_data, headers).returns(successful_capture_response)
+    @gateway.expects(:ssl_request).with(:put, "https://test-api.pinpayments.com/1/charges/#{token}/capture", post_data, headers).returns(successful_capture_response)
 
     assert response = @gateway.capture(100, token)
     assert_success response
@@ -225,7 +225,7 @@ class PinTest < Test::Unit::TestCase
 
     @gateway.send(:add_customer_data, post, @options)
 
-    assert_equal 'roland@pin.net.au', post[:email]
+    assert_equal 'roland@pinpayments.com', post[:email]
     assert_equal '127.0.0.1', post[:ip_address]
   end
 
@@ -327,7 +327,7 @@ class PinTest < Test::Unit::TestCase
         "amount":400,
         "currency":"AUD",
         "description":"test charge",
-        "email":"roland@pin.net.au",
+        "email":"roland@pinpayments.com",
         "ip_address":"203.192.1.172",
         "created_at":"2013-01-14T03:00:41Z",
         "status_message":"Success!",
@@ -407,7 +407,7 @@ class PinTest < Test::Unit::TestCase
     '{
       "response":{
         "token":"cus_05p0n7UFPmcyCNjD8c6HdA",
-        "email":"roland@pin.net.au",
+        "email":"roland@pinpayments.com",
         "created_at":"2013-01-16T03:16:11Z",
         "card":{
           "token":"card__o8I8GmoXDF0d35LEDZbNQ",
@@ -473,7 +473,7 @@ class PinTest < Test::Unit::TestCase
         "amount":400,
         "currency":"AUD",
         "description":"test charge",
-        "email":"roland@pin.net.au",
+        "email":"roland@pinpayments.com",
         "ip_address":"203.192.1.172",
         "created_at":"2013-01-14T03:00:41Z",
         "status_message":"Success!",
@@ -504,7 +504,7 @@ class PinTest < Test::Unit::TestCase
     '{
       "amount":"100",
       "currency":"AUD",
-      "email":"roland@pin.net.au",
+      "email":"roland@pinpayments.com",
       "ip_address":"203.59.39.62",
       "description":"Store Purchase 1437598192",
       "card":{
@@ -526,7 +526,7 @@ class PinTest < Test::Unit::TestCase
     '{
       "amount":"100",
       "currency":"AUD",
-      "email":"roland@pin.net.au",
+      "email":"roland@pinpayments.com",
       "ip_address":"203.59.39.62",
       "description":"Store Purchase 1437598192",
       "card":{


### PR DESCRIPTION
While the old URL(s) are still supported and will be for the foreseeable future Pin Payments is actively preferencing the pinpayments.com domain.