### PR TITLE
TrustCommerce: Use `application_id`

### DIFF
--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -312,9 +312,9 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_aggregator(params, options)
-        if @options[:aggregator_id]
+        if @options[:aggregator_id] || application_id != Gateway.application_id
           params[:aggregators] = 1
-          params[:aggregator1] = @options[:aggregator_id]
+          params[:aggregator1] = @options[:aggregator_id] || application_id
         end
       end
 

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -32,6 +32,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_succesful_purchase_with_check
+    ActiveMerchant::Billing::TrustCommerceGateway.application_id = 'abc123'
     stub_comms do
       @gateway.purchase(@amount, @check)
     end.check_request do |endpoint, data, headers|


### PR DESCRIPTION
Allows for `application_id` to be used as `aggregatorID`. 3 failing
remotes test unrelated to this change.

- test_store_failure
- test_unstore_failure
- test_recurring_failure

Loaded suite test/unit/gateways/trust_commerce_test
Started
..........

10 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_trust_commerce_test

Finished in 32.663168 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
16 tests, 59 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
81.25% passed