### PR TITLE
Spreedly one request + Add support for bank accounts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * NMI: Add level 3 gateway-specific fields tax, shipping, and ponumber [jasonxp] #3239
 * Checkout V2: Update stored card flag [curiousepic] #3247
 * NMI: Add support for stored credentials [bayprogrammer] #3243
+* Spreedly: Consolidate API requests and support bank accounts [lancecarlson] #3105
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -8,6 +8,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('5555555555554444')
     @declined_card = credit_card('4012888888881881')
+    @check = check({routing_number: '021000021', account_number: '9876543210'})
     @existing_payment_method = '3rEkRlZur2hXKbwwRBidHJAIUTO'
     @declined_payment_method = 'UPfh3J3JbekLeYC88BP741JWnS5'
     @existing_transaction = 'PJ5ICgM6h7v9pBNxDCJjRHDDxBC'
@@ -60,6 +61,14 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert_equal 'cached', response.params['payment_method_storage_state']
   end
 
+  def test_successful_purchase_with_check
+    assert response = @gateway.purchase(@amount, @check)
+    assert_success response
+    assert_equal 'Succeeded!', response.message
+    assert_equal 'Purchase', response.params['transaction_type']
+    assert_equal 'cached', response.params['payment_method_storage_state']
+  end
+
   def test_successful_purchase_with_card_and_address
     options = {
       :email => 'joebob@example.com',
@@ -88,7 +97,8 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     @credit_card.first_name = ' '
     assert response = @gateway.purchase(@amount, @credit_card)
     assert_failure response
-    assert_equal "First name can't be blank", response.message
+    assert_equal 'The payment method is invalid.', response.message
+    assert_equal "First name can't be blank", response.params['payment_method_errors'].strip
   end
 
   def test_successful_purchase_with_store
@@ -96,7 +106,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded!', response.message
     assert_equal 'Purchase', response.params['transaction_type']
-    assert_equal 'retained', response.params['payment_method_storage_state']
+    assert %w(retained cached).include?(response.params['payment_method_storage_state'])
     assert !response.params['payment_method_token'].blank?
   end
 
@@ -141,7 +151,8 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     @credit_card.first_name = ' '
     assert response = @gateway.authorize(@amount, @credit_card)
     assert_failure response
-    assert_equal "First name can't be blank", response.message
+    assert_equal 'The payment method is invalid.', response.message
+    assert_equal "First name can't be blank", response.params['payment_method_errors'].strip
   end
 
   def test_successful_authorize_with_store
@@ -149,7 +160,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded!', response.message
     assert_equal 'Authorization', response.params['transaction_type']
-    assert_equal 'retained', response.params['payment_method_storage_state']
+    assert %w(retained cached).include?(response.params['payment_method_storage_state'])
     assert !response.params['payment_method_token'].blank?
   end
 

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -7,6 +7,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     @payment_method_token = 'E3eQGR3E0xiosj7FOJRtIKbF8Ch'
 
     @credit_card = credit_card
+    @check = check
     @amount = 103
     @existing_transaction  = 'LKA3RchoqYO0njAfhHVw60ohjrC'
     @not_found_transaction = 'AdyQXaG0SVpSoMPdmFlvd3aA3uz'
@@ -41,7 +42,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_credit_card
-    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, successful_purchase_response)
+    @gateway.stubs(:raw_ssl_request).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
 
     assert_success response
@@ -57,6 +58,21 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     assert_equal 'used', response.params['payment_method_storage_state']
   end
 
+  def test_successful_purchase_with_check
+    @gateway.stubs(:raw_ssl_request).returns(successful_check_purchase_response)
+    response = @gateway.purchase(@amount, @check)
+
+    assert_success response
+    assert !response.test?
+
+    assert_equal 'ZwnfZs3Qy4gRDPWXHopamNuarCJ', response.authorization
+    assert_equal 'Succeeded!', response.message
+    assert_equal 'Purchase', response.params['transaction_type']
+    assert_equal 'HtCrYfW17wEzWWfrMbwDX4TwPVW', response.params['payment_method_token']
+    assert_equal '021*', response.params['payment_method_routing_number']
+    assert_equal '*3210', response.params['payment_method_account_number']
+  end
+
   def test_failed_purchase_with_invalid_credit_card
     @gateway.expects(:raw_ssl_request).returns(failed_store_response)
     response = @gateway.purchase(@amount, @credit_card)
@@ -65,7 +81,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_credit_card
-    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, failed_purchase_response)
+    @gateway.stubs(:raw_ssl_request).returns(failed_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
     assert_failure response
 
@@ -121,7 +137,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_credit_card_and_capture
-    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, successful_authorize_response)
+    @gateway.stubs(:raw_ssl_request).returns(successful_authorize_response)
     response = @gateway.authorize(@amount, @credit_card)
 
     assert_success response
@@ -144,7 +160,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize_with_credit_card
-    @gateway.stubs(:raw_ssl_request).returns(successful_store_response, failed_authorize_response)
+    @gateway.stubs(:raw_ssl_request).returns(failed_authorize_response)
     response = @gateway.authorize(@amount, @credit_card)
     assert_failure response
     assert_equal 'This transaction cannot be processed.', response.message
@@ -347,6 +363,97 @@ class SpreedlyCoreTest < Test::Unit::TestCase
         </payment_method>
         <api_urls>
         </api_urls>
+      </transaction>
+    XML
+  end
+
+  def successful_check_purchase_response
+    MockResponse.succeeded <<-XML
+      <transaction>
+        <on_test_gateway type="boolean">false</on_test_gateway>
+        <created_at type="dateTime">2019-01-06T18:24:33Z</created_at>
+        <updated_at type="dateTime">2019-01-06T18:24:33Z</updated_at>
+        <succeeded type="boolean">true</succeeded>
+        <state>succeeded</state>
+        <token>ZwnfZs3Qy4gRDPWXHopamNuarCJ</token>
+        <transaction_type>Purchase</transaction_type>
+        <order_id nil="true"/>
+        <ip nil="true"/>
+        <description nil="true"/>
+        <email nil="true"/>
+        <merchant_name_descriptor nil="true"/>
+        <merchant_location_descriptor nil="true"/>
+        <gateway_specific_fields nil="true"/>
+        <gateway_specific_response_fields>
+        </gateway_specific_response_fields>
+        <gateway_transaction_id>49</gateway_transaction_id>
+        <gateway_latency_ms type="integer">0</gateway_latency_ms>
+        <amount type="integer">100</amount>
+        <currency_code>USD</currency_code>
+        <retain_on_success type="boolean">false</retain_on_success>
+        <payment_method_added type="boolean">true</payment_method_added>
+        <message key="messages.transaction_succeeded">Succeeded!</message>
+        <gateway_token>3gLeg4726V5P0HK7cq7QzHsL0a6</gateway_token>
+        <gateway_type>test</gateway_type>
+        <shipping_address>
+          <name nil="true"/>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"/>
+        </shipping_address>
+        <response>
+          <success type="boolean">true</success>
+          <message>Successful purchase</message>
+          <avs_code nil="true"/>
+          <avs_message nil="true"/>
+          <cvv_code nil="true"/>
+          <cvv_message nil="true"/>
+          <pending type="boolean">false</pending>
+          <result_unknown type="boolean">false</result_unknown>
+          <error_code nil="true"/>
+          <error_detail nil="true"/>
+          <cancelled type="boolean">false</cancelled>
+          <fraud_review nil="true"/>
+          <created_at type="dateTime">2019-01-06T18:24:33Z</created_at>
+          <updated_at type="dateTime">2019-01-06T18:24:33Z</updated_at>
+        </response>
+        <api_urls>
+        </api_urls>
+        <payment_method>
+          <token>HtCrYfW17wEzWWfrMbwDX4TwPVW</token>
+          <created_at type="dateTime">2019-01-06T18:24:33Z</created_at>
+          <updated_at type="dateTime">2019-01-06T18:24:33Z</updated_at>
+          <email nil="true"/>
+          <data nil="true"/>
+          <storage_state>cached</storage_state>
+          <test type="boolean">true</test>
+          <metadata nil="true"/>
+          <full_name>Jim Smith</full_name>
+          <bank_name nil="true"/>
+          <account_type>checking</account_type>
+          <account_holder_type>personal</account_holder_type>
+          <routing_number_display_digits>021</routing_number_display_digits>
+          <account_number_display_digits>3210</account_number_display_digits>
+          <first_name>Jim</first_name>
+          <last_name>Smith</last_name>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"/>
+          <company nil="true"/>
+          <payment_method_type>bank_account</payment_method_type>
+          <errors>
+          </errors>
+          <routing_number>021*</routing_number>
+          <account_number>*3210</account_number>
+        </payment_method>
       </transaction>
     XML
   end


### PR DESCRIPTION
Consolidates purchase and authorization requests down to 1.

See issue: https://github.com/activemerchant/active_merchant/issues/3078