### PR TITLE
WorldPay: Pull CVC and AVS Result from Response

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -370,7 +370,10 @@ module ActiveMerchant #:nodoc:
           raw,
           :authorization => authorization_from(raw),
           :error_code => error_code_from(success, raw),
-          :test => test?)
+          :test => test?,
+          :avs_result => AVSResult.new(code: AVS_CODE_MAP[raw[:avs_result_code_description]]),
+          :cvv_result => CVVResult.new(CVC_CODE_MAP[raw[:cvc_result_code_description]])
+        )
       rescue ActiveMerchant::ResponseError => e
         if e.response.code.to_s == '401'
           return Response.new(false, 'Invalid credentials', {}, :test => test?)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -23,6 +23,15 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_authorize_avs_and_cvv
+    card = credit_card('4111111111111111', :verification_value => 555)
+    assert response = @gateway.authorize(@amount, card, @options.merge(billing_address: address.update(zip: 'CCCC')))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert_match %r{Street address does not match, but 5-digit postal code matches}, response.avs_result['message']
+    assert_match %r{CVV matches}, response.cvv_result['message']
+  end
+
   def test_successful_purchase_with_hcg_additional_data
     @options[:hcg_additional_data] = {
       key1: 'value1',


### PR DESCRIPTION
Pull out the appropriate values from the response.

Loaded suite test/remote/gateways/remote_worldpay_test
.............................

29 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/worldpay_test
.........................................

41 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed