### PR TITLE
Worldpay: Add AVS and CVC Mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * TrustCommerce: Use `application_id` [nfarve] #3103
 * Stripe: Add 3DS Support [nfarve] #3086
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
+* Worldpay: Add AVS and CVC Mapping [nfarve] #3107
 
 
 == Version 1.89.0 (December 17, 2018)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -23,6 +23,26 @@ module ActiveMerchant #:nodoc:
         'diners_club'      => 'DINERS-SSL',
       }
 
+      AVS_CODE_MAP = {
+        'A' => 'M', # Match
+        'B' => 'P', # Postcode matches, address not verified
+        'C' => 'Z', # Postcode matches, address does not match
+        'D' => 'B', # Address matched; postcode not checked
+        'E' => 'I', # Address and postal code not checked
+        'F' => 'A', # Address matches, postcode does not match
+        'G' => 'C', # Address does not match, postcode not checked
+        'H' => 'I', # Address and postcode not provided
+        'I' => 'C', # Address not checked postcode does not match
+        'J' => 'C', # Address and postcode does not match
+      }
+
+      CVC_CODE_MAP = {
+        'A' => 'M', # CVV matches
+        'B' => 'P', # Not provided
+        'C' => 'P', # Not checked
+        'D' => 'N', # Does not match
+      }
+
       def initialize(options = {})
         requires!(options, :login, :password)
         super


### PR DESCRIPTION
Somehow in the process of squashing, the map needed to add avs and cvc
mapping was lost.

Loaded suite test/remote/gateways/remote_worldpay_test

29 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/worldpay_test

41 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed