### PR TITLE
Paymentez: Fixes extra_params field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
+* Worldpay: Add AVS and CVC Mapping [nfarve] #3107
+* Paymentez: Fixes extra_params field [molbrown] #3108
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087
@@ -12,9 +15,6 @@
 * Braintree Blue: Refactor line_items field [curiousepic] #3100
 * TrustCommerce: Use `application_id` [nfarve] #3103
 * Stripe: Add 3DS Support [nfarve] #3086
-* WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
-* Worldpay: Add AVS and CVC Mapping [nfarve] #3107
-
 
 == Version 1.89.0 (December 17, 2018)
 * Worldpay: handle Visa and MasterCard payouts differently [bpollack] #3068

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -171,15 +171,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_extra_params(post, options)
-        if options[:extra_params]
-          items = {}
-          options[:extra_params].each do |param|
-            param.each do |key, value|
-              items[key.to_sym] = value
-            end
-          end
-          post[:extra_params] = items
-        end
+        extra_params = {}
+        extra_params.merge!(options[:extra_params]) if options[:extra_params]
+
+        post['extra_params'] = extra_params unless extra_params.empty?
       end
 
       def parse(body)


### PR DESCRIPTION
Simpler method to add JSON object to request in extra_params, and fixes buggy behavior.

ENE-80

Unit Tests:
19 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
20 tests, 47 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
Failures unrelated to this change, have to do with country-specific allowances for
partial capture/ refund.