### PR TITLE
handle symbol keys for custom fields hash in usaepay

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -265,7 +265,7 @@ module ActiveMerchant #:nodoc:
         return unless options[:custom_fields].is_a?(Hash)
 
         options[:custom_fields].each do |index, custom|
-          raise ArgumentError.new('Cannot specify custom field with index 0') if index.to_i.zero?
+          raise ArgumentError.new('Cannot specify custom field with index 0') if index.to_s.to_i.zero?
 
           post["custom#{index}"] = custom
         end


### PR DESCRIPTION
Really small change, but I ran into this when I was serializing back and forth with JSON.