### PR TITLE
Braintree: Send all country fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -324,15 +324,13 @@ module ActiveMerchant #:nodoc:
           :region => address[:state],
           :postal_code => scrub_zip(address[:zip]),
         }
-        if address[:country] || address[:country_code_alpha2]
-          mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2])
-        elsif address[:country_name]
-          mapped[:country_name] = address[:country_name]
-        elsif address[:country_code_alpha3]
-          mapped[:country_code_alpha3] = address[:country_code_alpha3]
-        elsif address[:country_code_numeric]
-          mapped[:country_code_numeric] = address[:country_code_numeric]
-        end
+
+        mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2]) if address[:country] || address[:country_code_alpha2]
+        mapped[:country_name] = address[:country_name] if address[:country_name]
+        mapped[:country_code_alpha3] = address[:country_code_alpha3] if address[:country_code_alpha3]
+        mapped[:country_code_alpha3] ||= Country.find(address[:country]).code(:alpha3).value if address[:country]
+        mapped[:country_code_numeric] = address[:country_code_numeric] if address[:country_code_numeric]
+
         mapped
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -12,7 +12,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
     @options = {
       :order_id => '1',
-      :billing_address => address(:country_name => 'United States of America'),
+      :billing_address => address(:country_name => 'Canada'),
       :description => 'Store Purchase'
     }
   end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -576,7 +576,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
           :locality => 'Chicago',
           :region => 'Illinois',
           :postal_code => '60622',
-          :country_code_alpha2 => 'US'
+          :country_code_alpha2 => 'US',
+          :country_code_alpha3 => 'USA'
         },
         :options => {}
       }


### PR DESCRIPTION
According to Braintree docs, sending Level 3 data requires the presence
of the shipping country in alpha3 format. Since we can't easily
determine which format should be sent in various situations, default to
sending all formats that are present (which seems permissible, from
remote testing), and then ensure the alpha3 is sent by using the Country
module.

Unit:
57 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
68 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed