### PR TITLE
Adyen: Handles blank state address field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Improved support for account_type using Check class's account_type instead [lancecarlson] #3097
 * USA Epay: Allow quantity to be passed and check custom fields [lancecarlson] #3090
 * Fix usaepay transaction invoice [lancecarlson] #3093
+* Adyen: Handles blank state address field [molbrown] #3113
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
           post[:card][:billingAddress][:houseNumberOrName] = address[:address2] || 'N/A'
           post[:card][:billingAddress][:postalCode] = address[:zip] if address[:zip]
           post[:card][:billingAddress][:city] = address[:city] || 'N/A'
-          post[:card][:billingAddress][:stateOrProvince] = address[:state] if address[:state]
+          post[:card][:billingAddress][:stateOrProvince] = address[:state] || 'N/A'
           post[:card][:billingAddress][:country] = address[:country] if address[:country]
         end
       end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -327,6 +327,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_missing_state_for_purchase
+    @options[:billing_address].delete(:state)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_invalid_country_for_purchase
     @options[:billing_address][:country] = ''
     response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -262,12 +262,13 @@ class AdyenTest < Test::Unit::TestCase
     post = {:card => {:billingAddress => {}}}
     @options[:billing_address].delete(:address1)
     @options[:billing_address].delete(:address2)
+    @options[:billing_address].delete(:state)
     @gateway.send(:add_address, post, @options)
     assert_equal 'N/A', post[:card][:billingAddress][:street]
     assert_equal 'N/A', post[:card][:billingAddress][:houseNumberOrName]
+    assert_equal 'N/A', post[:card][:billingAddress][:stateOrProvince]
     assert_equal @options[:billing_address][:zip], post[:card][:billingAddress][:postalCode]
     assert_equal @options[:billing_address][:city], post[:card][:billingAddress][:city]
-    assert_equal @options[:billing_address][:state], post[:card][:billingAddress][:stateOrProvince]
     assert_equal @options[:billing_address][:country], post[:card][:billingAddress][:country]
   end
 


### PR DESCRIPTION
Sends N/A if state field is not populated. Resolves validation errors from sending blank state field.

ECS-102

Remote:
39 tests, 100 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
26 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed