### PR TITLE
Braintree: Account for empty string countries

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -328,7 +328,9 @@ module ActiveMerchant #:nodoc:
         mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2]) if address[:country] || address[:country_code_alpha2]
         mapped[:country_name] = address[:country_name] if address[:country_name]
         mapped[:country_code_alpha3] = address[:country_code_alpha3] if address[:country_code_alpha3]
-        mapped[:country_code_alpha3] ||= Country.find(address[:country]).code(:alpha3).value if address[:country]
+        unless address[:country].blank?
+          mapped[:country_code_alpha3] ||= Country.find(address[:country]).code(:alpha3).value
+        end
         mapped[:country_code_numeric] = address[:country_code_numeric] if address[:country_code_numeric]
 
         mapped

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -38,7 +38,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'authorized', response.params['braintree_transaction']['status']
   end
 
-  def test_successful_authorize_with_nil_billing_address_options
+  def test_successful_authorize_with_nil_and_empty_billing_address_options
     credit_card = credit_card('5105105105105100')
     options = {
       :billing_address => {
@@ -50,7 +50,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
         :city => nil,
         :state => nil,
         :zip => nil,
-        :country_name => nil
+        :country => ''
       }
     }
     assert response = @gateway.authorize(@amount, credit_card, options)


### PR DESCRIPTION
The prior change using the Country module didn't guard against empty
string country fields.

Remote:
68 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
57 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed