### PR TITLE
Map AVS codes for Adyen

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -110,24 +110,28 @@ module ActiveMerchant #:nodoc:
 
       AVS_MAPPING = {
         '0'  => 'R',  # Unknown
-        '1'  => 'A',	# Address matches, postal code doesn't
-        '2'  => 'N',	# Neither postal code nor address match
-        '3'  => 'R',	# AVS unavailable
-        '4'  => 'E',	# AVS not supported for this card type
-        '5'  => 'U',	# No AVS data provided
-        '6'  => 'Z',	# Postal code matches, address doesn't match
-        '7'  => 'D',	# Both postal code and address match
-        '8'  => 'U',	# Address not checked, postal code unknown
-        '9'  => 'B',	# Address matches, postal code unknown
-        '10' => 'N',	# Address doesn't match, postal code unknown
-        '11' => 'U',	# Postal code not checked, address unknown
-        '12' => 'B',	# Address matches, postal code not checked
-        '13' => 'U',	# Address doesn't match, postal code not checked
-        '14' => 'P',	# Postal code matches, address unknown
-        '15' => 'P',	# Postal code matches, address not checked
-        '16' => 'N',	# Postal code doesn't match, address unknown
+        '1'  => 'A',  # Address matches, postal code doesn't
+        '2'  => 'N',  # Neither postal code nor address match
+        '3'  => 'R',  # AVS unavailable
+        '4'  => 'E',  # AVS not supported for this card type
+        '5'  => 'U',  # No AVS data provided
+        '6'  => 'Z',  # Postal code matches, address doesn't match
+        '7'  => 'D',  # Both postal code and address match
+        '8'  => 'U',  # Address not checked, postal code unknown
+        '9'  => 'B',  # Address matches, postal code unknown
+        '10' => 'N',  # Address doesn't match, postal code unknown
+        '11' => 'U',  # Postal code not checked, address unknown
+        '12' => 'B',  # Address matches, postal code not checked
+        '13' => 'U',  # Address doesn't match, postal code not checked
+        '14' => 'P',  # Postal code matches, address unknown
+        '15' => 'P',  # Postal code matches, address not checked
+        '16' => 'N',  # Postal code doesn't match, address unknown
         '17' => 'U',  # Postal code doesn't match, address not checked
-        '18' => 'I'	  # Neither postal code nor address were checked
+        '18' => 'I',  # Neither postal code nor address were checked
+        '20' => 'V',  # Name, address and postal code matches.
+        '23' => 'F',  # Postal code matches, name doesn't match.
+        '24' => 'H',  # Both postal code and address matches, name doesn't match.
+        '25' => 'T'  # Address matches, name doesn't match.
       }
 
       CVC_MAPPING = {

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -295,6 +295,13 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_extended_avs_response
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(extended_avs_response)
+    assert_equal 'Card member\'s name, billing address, and billing postal code match.', response.avs_result['message']
+  end
+
   private
 
   def pre_scrubbed
@@ -565,6 +572,12 @@ class AdyenTest < Test::Unit::TestCase
   def failed_store_response
     <<-RESPONSE
     {"pspReference":"8835205393394754","refusalReason":"Refused","resultCode":"Refused"}
+    RESPONSE
+  end
+
+  def extended_avs_response
+    <<-RESPONSE
+    {\"additionalData\":{\"cvcResult\":\"1 Matches\",\"cvcResultRaw\":\"Y\",\"avsResult\":\"20 Name, address and zip match\",\"avsResultRaw\":\"M\"}}
     RESPONSE
   end
 end


### PR DESCRIPTION
Adding more mappings to AVSResult makes me a little ⁉️but it didn't look like there were good explicit corresponding options for the codes Adyen is returning. 