### PR TITLE
Braintree: Adds support for transaction_source

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Openpay: Fix for marking successful transaction(s) as failed [jknipp] #3121
-* Orbital: Support for stored credentials framework [jknipp] #3117
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
 * Worldpay: Add AVS and CVC Mapping [nfarve] #3107
 * Paymentez: Fixes extra_params field [molbrown] #3108
@@ -12,6 +10,9 @@
 * Adyen: Handles blank state address field [molbrown] #3113
 * Braintree: Send all country fields [curiousepic] #3112
 * Braintree: Account for empty string countries [curiousepic] #3115
+* Orbital: Support for stored credentials framework [jknipp] #3117
+* Openpay: Fix for marking successful transaction(s) as failed [jknipp] #3121
+* Braintree: Adds support for transaction_source [molbrown] #3120
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -585,7 +585,9 @@ module ActiveMerchant #:nodoc:
           parameters[:merchant_account_id] = merchant_account_id
         end
 
-        if options[:recurring]
+        if options[:transaction_source]
+          parameters[:transaction_source] = options[:transaction_source]
+        elsif options[:recurring]
           parameters[:recurring] = true
         end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -426,6 +426,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '510510', @braintree_backend.customer.find(response.params['customer_vault_id']).credit_cards[0].bin
   end
 
+  def test_purchase_with_transaction_source
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    customer_vault_id = response.params['customer_vault_id']
+
+    assert response = @gateway.purchase(@amount, customer_vault_id, @options.merge(:transaction_source => 'unscheduled'))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+  end
+
   def test_purchase_using_specified_payment_method_token
     assert response = @gateway.store(
       credit_card('4111111111111111',

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -678,6 +678,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'))
   end
 
+  def test_passes_transaction_source
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:transaction_source] == 'recurring')
+      (params[:recurring] == nil)
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card('41111111111111111111'), :transaction_source => 'recurring', :recurring => true)
+  end
+
   def test_configured_logger_has_a_default
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not


### PR DESCRIPTION
Braintree has deprecated the recurring field in lieu of the transaction_source parameter which allows a 'recurring' value. For now, Braintree still allows both fields to be sent.

ECS-97

Remote:
69 tests, 389 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
58 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed