### PR TITLE
Openpay: Fix successful transaction(s) marked as failed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Openpay: Fix for marking successful transaction(s) as failed [jknipp] #3121
 * Orbital: Support for stored credentials framework [jknipp] #3117
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
 * Worldpay: Add AVS and CVC Mapping [nfarve] #3107

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def error?(response)
-        response.key?('error_code')
+        response['error_code'] && !response['error_code'].blank?
       end
 
       def response_error(raw_response)

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -311,7 +311,8 @@ class OpenpayTest < Test::Unit::TestCase
     "creation_date": "2014-01-20T17:08:43-06:00",
     "description": "Store Purchase",
     "error_message": null,
-    "order_id": null
+    "order_id": null,
+    "error_code": null
 }
     RESPONSE
   end
@@ -345,7 +346,8 @@ class OpenpayTest < Test::Unit::TestCase
     "creation_date": "2014-01-18T21:01:10-06:00",
     "description": "Store Purchase",
     "error_message": null,
-    "order_id": null
+    "order_id": null,
+    "error_code": null
 }
     RESPONSE
   end
@@ -379,7 +381,8 @@ class OpenpayTest < Test::Unit::TestCase
     "creation_date": "2014-01-18T21:01:10-06:00",
     "description": "Store Purchase",
     "error_message": null,
-    "order_id": null
+    "order_id": null,
+    "error_code": null
 }
       RESPONSE
   end
@@ -421,7 +424,8 @@ class OpenpayTest < Test::Unit::TestCase
     "creation_date": "2014-01-18T21:49:38-06:00",
     "description": "Store Purchase",
     "error_message": null,
-    "order_id": null
+    "order_id": null,
+    "error_code": null
 }
     RESPONSE
   end


### PR DESCRIPTION
Some Openpay transaction response objects are including an error_code
field that was previously only present in error responses. Now we will
check for the existence of the error_code field and a non-nil/blank
error code.

ECS-97

Remote:
24 tests, 80 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
83.3333% passed

Unit:
20 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

@activemerchant/spreedly-connect 4 Remote tests are failing for unrelated reasons.
* `test_successful_purchase_with_card_stored` fails due to invalid source_id
*  Failures due to a different response message (I believe this was triggered by multiple test runs): 
    * `test_unsuccessful_authorize`
    * `test_unsuccessful_purchase`
    * `test_unsuccessful_verify`
