### PR TITLE
Blue Snap: Supports Level 2/3 data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Braintree: Adds support for transaction_source [molbrown] #3120
 * Moneris: Remove redundant card on file guard clause [davidsantoso] #3123
 * Switch order of Romania country codes [molbrown] #3125
+* Blue Snap: Supports Level 2/3 data [molbrown] #3126
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -191,6 +191,7 @@ module ActiveMerchant
         doc.send('merchant-transaction-id', truncate(options[:order_id], 50)) if options[:order_id]
         doc.send('soft-descriptor', options[:soft_descriptor]) if options[:soft_descriptor]
         add_description(doc, options[:description]) if options[:description]
+        add_level_3_data(doc, options)
       end
 
       def add_address(doc, options)
@@ -202,6 +203,41 @@ module ActiveMerchant
         doc.address(address[:address]) if address[:address]
         doc.city(address[:city]) if address[:city]
         doc.zip(address[:zip]) if address[:zip]
+      end
+
+      def add_level_3_data(doc, options)
+        return unless options[:customer_reference_number]
+        doc.send('level-3-data') do
+          send_when_present(doc, :customer_reference_number, options)
+          send_when_present(doc, :sales_tax_amount, options)
+          send_when_present(doc, :freight_amount, options)
+          send_when_present(doc, :duty_amount, options)
+          send_when_present(doc, :destination_zip_code, options)
+          send_when_present(doc, :destination_country_code, options)
+          send_when_present(doc, :ship_from_zip_code, options)
+          send_when_present(doc, :discount_amount, options)
+          send_when_present(doc, :tax_amount, options)
+          send_when_present(doc, :tax_rate, options)
+          add_level_3_data_items(doc, options[:level_3_data_items]) if options[:level_3_data_items]
+        end
+      end
+
+      def send_when_present(doc, options_key, options, xml_element_name = nil)
+        return unless options[options_key]
+        xml_element_name ||= options_key.to_s
+
+        doc.send(xml_element_name.dasherize, options[options_key])
+      end
+
+      def add_level_3_data_items(doc, items)
+        items.each do |item|
+          doc.send('level-3-data-item') do
+            item.each do |key, value|
+              key = key.to_s.dasherize
+              doc.send(key, value)
+            end
+          end
+        end
       end
 
       def add_authorization(doc, authorization)

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -44,6 +44,58 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_equal 'CAD', response.params['currency']
   end
 
+  def test_successful_purchase_with_level3_data
+    l_three_visa = credit_card('4111111111111111', month: 2, year: 2023)
+    options = @options.merge({
+      customer_reference_number: '1234A',
+      sales_tax_amount: 0.6,
+      freight_amount: 0,
+      duty_amount: 0,
+      destination_zip_code: 12345,
+      destination_country_code: 'us',
+      ship_from_zip_code: 12345,
+      discount_amount: 0,
+      tax_amount: 0.6,
+      tax_rate: 6.0,
+      level_3_data_items: [
+        {
+          line_item_total: 9.00,
+          description: 'test_desc',
+          product_code: 'test_code',
+          item_quantity: 1.0,
+          tax_rate: 6.0,
+          tax_amount: 0.60,
+          unit_of_measure: 'lb',
+          commodity_code: 123,
+          discount_indicator: 'Y',
+          gross_net_indicator: 'Y',
+          tax_type: 'test',
+          unit_cost: 10.00
+        },
+        {
+          line_item_total: 9.00,
+          description: 'test_2',
+          product_code: 'test_2',
+          item_quantity: 1.0,
+          tax_rate: 7.0,
+          tax_amount: 0.70,
+          unit_of_measure: 'lb',
+          commodity_code: 123,
+          discount_indicator: 'Y',
+          gross_net_indicator: 'Y',
+          tax_type: 'test',
+          unit_cost: 14.00
+        }
+      ]
+    })
+    response = @gateway.purchase(@amount, l_three_visa, options)
+
+    assert_success response
+    assert_equal 'Success', response.message
+    assert_equal '1234A', response.params['customer-reference-number']
+    assert_equal '9', response.params['line-item-total']
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -150,6 +150,15 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_equal '<xml>You are not authorized to perform this request due to inappropriate role permissions.</xml>', response.message
   end
 
+  def test_does_not_send_level_3_when_empty
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |type, endpoint, data, headers|
+      assert_not_match(/level-3-data/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
Adds fields to enable Level 2/ Level 3 data, with existing
Nokogiri-Builder request structure for this gateway.

ECS-61

Unit:
20 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 76 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.3077% passed
Unrelated failures, caused by updated error messages and store functionality.