### PR TITLE
Append error messages to Cecabank response

### DIFF
--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -173,11 +173,22 @@ module ActiveMerchant #:nodoc:
         response = parse(xml)
         Response.new(
           response[:success],
-          response[:message],
+          message_from(response),
           response,
           :test => test?,
-          :authorization => build_authorization(response)
+          :authorization => build_authorization(response),
+          :error_code => response[:error_code]
         )
+      end
+
+      def message_from(response)
+        if response[:message] == 'ERROR' && response[:error_message]
+          response[:error_message]
+        elsif response[:error_message]
+          "#{response[:message]} #{response[:error_message]}"
+        else
+          response[:message]
+        end
       end
 
       def post_data(params)

--- a/test/unit/gateways/cecabank_test.rb
+++ b/test/unit/gateways/cecabank_test.rb
@@ -53,6 +53,7 @@ class CecabankTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
+    assert_match(/Formato CVV2\/CVC2 no valido/, response.message)
     assert response.test?
   end
 


### PR DESCRIPTION
Pursuant to [ECS-96](https://spreedly.atlassian.net/browse/ECS-96) and in lieu of https://github.com/spreedly/core/pull/3527. 