### PR TITLE
BlueSnap: Support personal_identification_number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Moneris: Remove redundant card on file guard clause [davidsantoso] #3123
 * Switch order of Romania country codes [molbrown] #3125
 * Blue Snap: Supports Level 2/3 data [molbrown] #3126
+* Blue Snap: Support personal_identification_number [jknipp] #3128
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -5,7 +5,7 @@ module ActiveMerchant
     class BlueSnapGateway < Gateway
       self.test_url = 'https://sandbox.bluesnap.com/services/2'
       self.live_url = 'https://ws.bluesnap.com/services/2'
-      self.supported_countries = %w(US CA GB AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE)
+      self.supported_countries = %w(US CA GB AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE AR BO BR BZ CL CO CR DO EC GF GP GT HN HT MF MQ MX NI PA PE PR PY SV UY VE)
 
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro]
@@ -164,6 +164,7 @@ module ActiveMerchant
       def add_personal_info(doc, credit_card, options)
         doc.send('first-name', credit_card.first_name)
         doc.send('last-name', credit_card.last_name)
+        doc.send('personal-identification-number', options[:personal_identification_number]) if options[:personal_identification_number]
         doc.email(options[:email]) if options[:email]
         add_address(doc, options)
       end

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -7,7 +7,7 @@ class BlueSnapTest < Test::Unit::TestCase
     @gateway = BlueSnapGateway.new(api_username: 'login', api_password: 'password')
     @credit_card = credit_card
     @amount = 100
-    @options = { order_id: '1' }
+    @options = { order_id: '1', personal_identification_number: 'CNPJ' }
   end
 
   def test_successful_purchase
@@ -31,6 +31,7 @@ class BlueSnapTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, @options)
     end.check_request do |type, endpoint, data, headers|
       assert_match '<storeCard>false</storeCard>', data
+      assert_match '<personal-identification-number>CNPJ</personal-identification-number>', data
     end.respond_with(successful_authorize_response)
     assert_success response
     assert_equal '1012082893', response.authorization
@@ -211,6 +212,7 @@ class BlueSnapTest < Test::Unit::TestCase
           <state>ON</state>
           <city>Ottawa</city>
           <zip>K1C2N6</zip>
+          <personal-identification-number>CNPJ</personal-identification-number>
       </card-holder-info>
       <credit-card>
           <card-last-four-digits>9299</card-last-four-digits>
@@ -260,6 +262,7 @@ class BlueSnapTest < Test::Unit::TestCase
           <state>ON</state>
           <city>Ottawa</city>
           <zip>K1C2N6</zip>
+          <personal-identification-number>CNPJ</personal-identification-number>
       </card-holder-info>
       <credit-card>
           <card-last-four-digits>9299</card-last-four-digits>
@@ -308,6 +311,7 @@ class BlueSnapTest < Test::Unit::TestCase
           <state>ON</state>
           <city>Ottawa</city>
           <zip>K1C2N6</zip>
+          <personal-identification-number>CNPJ</personal-identification-number>
       </card-holder-info>
       <credit-card>
           <card-last-four-digits>9299</card-last-four-digits>
@@ -356,6 +360,7 @@ class BlueSnapTest < Test::Unit::TestCase
             <state>ON</state>
             <city>Ottawa</city>
             <zip>K1C2N6</zip>
+            <personal-identification-number>CNPJ</personal-identification-number>
          </card-holder-info>
          <credit-card>
             <card-last-four-digits>9299</card-last-four-digits>
@@ -404,6 +409,7 @@ class BlueSnapTest < Test::Unit::TestCase
             <state>ON</state>
             <city>Ottawa</city>
             <zip>K1C2N6</zip>
+            <personal-identification-number>CNPJ</personal-identification-number>
          </card-holder-info>
          <credit-card>
             <card-last-four-digits>9299</card-last-four-digits>
@@ -452,6 +458,7 @@ class BlueSnapTest < Test::Unit::TestCase
           <state>ON</state>
           <city>Ottawa</city>
           <zip>K1C2N6</zip>
+          <personal-identification-number>CNPJ</personal-identification-number>
         </card-holder-info>
         <credit-card>
           <card-last-four-digits>9299</card-last-four-digits>
@@ -493,6 +500,7 @@ class BlueSnapTest < Test::Unit::TestCase
         <state>ON</state>
         <city>Ottawa</city>
         <zip>K1C2N6</zip>
+        <personal-identification-number>CNPJ</personal-identification-number>
         <shopper-currency>USD</shopper-currency>
         <payment-sources>
           <credit-card-info>


### PR DESCRIPTION
Add support for GSF personal_identification_number, which is required
for transactions in Brazil.

Expand supported countries to include LATAM countries supported by Blue
Snap.

ECS-110

Unit:
19 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed