### PR TITLE
NMI: Add customer id to authorization on store

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method, options)
         if(payment_method.is_a?(String))
-          post[:customer_vault_id] = payment_method
+          post[:customer_vault_id] = split_authorization(payment_method)[0]
         elsif payment_method.is_a?(NetworkTokenizationCreditCard)
           post[:ccnumber] = payment_method.number
           post[:ccexp] = exp_date(payment_method)
@@ -236,15 +236,16 @@ module ActiveMerchant #:nodoc:
           succeeded,
           message_from(succeeded, response),
           response,
-          authorization: authorization_from(response, params[:payment]),
+          authorization: authorization_from(response, params[:payment], action),
           avs_result: AVSResult.new(code: response[:avsresponse]),
           cvv_result: CVVResult.new(response[:cvvresponse]),
           test: test?
         )
       end
 
-      def authorization_from(response, payment_type)
-        [ response[:transactionid], payment_type ].join('#')
+      def authorization_from(response, payment_type, action)
+        authorization = (action == 'add_customer' ? response[:customer_vault_id] : response[:transactionid])
+        [ authorization, payment_type ].join('#')
       end
 
       def split_authorization(authorization)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -202,39 +202,38 @@ class RemoteNmiTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
-    assert response.params['customer_vault_id']
+    assert response.authorization.include?(response.params['customer_vault_id'])
   end
 
   def test_failed_store
     card = credit_card(year: 2010)
     response = @gateway.store(card, @options)
     assert_failure response
-    assert_nil response.params['customer_vault_id']
   end
 
   def test_successful_store_with_echeck
     response = @gateway.store(@check, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
-    assert response.params['customer_vault_id']
+    assert response.authorization.include?(response.params['customer_vault_id'])
   end
 
   def test_successful_store_and_purchase
-    vault_id = @gateway.store(@credit_card, @options).params['customer_vault_id']
+    vault_id = @gateway.store(@credit_card, @options).authorization
     purchase = @gateway.purchase(@amount, vault_id, @options)
     assert_success purchase
     assert_equal 'Succeeded', purchase.message
   end
 
   def test_successful_store_and_auth
-    vault_id = @gateway.store(@credit_card, @options).params['customer_vault_id']
+    vault_id = @gateway.store(@credit_card, @options).authorization
     auth = @gateway.authorize(@amount, vault_id, @options)
     assert_success auth
     assert_equal 'Succeeded', auth.message
   end
 
   def test_successful_store_and_credit
-    vault_id = @gateway.store(@credit_card, @options).params['customer_vault_id']
+    vault_id = @gateway.store(@credit_card, @options).authorization
     credit = @gateway.credit(@amount, vault_id, @options)
     assert_success credit
     assert_equal 'Succeeded', credit.message

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -272,6 +272,7 @@ class NmiTest < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Succeeded', response.message
     assert response.params['customer_vault_id']
+    assert response.authorization.include?(response.params['customer_vault_id'])
   end
 
   def test_failed_store
@@ -303,7 +304,7 @@ class NmiTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
     assert_equal 'Succeeded', response.message
-    assert response.params['customer_vault_id']
+    assert response.authorization.include?(response.params['customer_vault_id'])
   end
 
   def test_avs_result


### PR DESCRIPTION
Previously authorizations for the store action were empty. Now we return
the relevant customer_vault_id as the authorization to use in subsequent
transactions.

Remote:
34 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
27 tests, 195 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed