### PR TITLE
PaymentExpress: Support client_info field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * Blue Snap: Fix Card-on-File field typo [jknipp] #3143
 * Add Bambora gateway [InfraRuby] #3145
 * Bambora Asia-Pacific: Updates Gateway [molbrown] #3145
+* PaymentExpress: Support ClientInfo field [jknipp] #3131
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -241,7 +241,8 @@ module ActiveMerchant #:nodoc:
       #       :client_type => :web, # Possible values are: :web, :ivr, :moto, :unattended, :internet, or :recurring
       #       :txn_data1 => "String up to 255 characters",
       #       :txn_data2 => "String up to 255 characters",
-      #       :txn_data3 => "String up to 255 characters"
+      #       :txn_data3 => "String up to 255 characters",
+      #       :client_info => "String up to 15 characters. The IP address of the user who processed the transaction."
       #     }
       #
       # +:client_type+, while not documented for PxPost, will be sent as
@@ -277,6 +278,8 @@ module ActiveMerchant #:nodoc:
         xml.add_element('TxnData1').text = options[:txn_data1].to_s.slice(0, 255) unless options[:txn_data1].blank?
         xml.add_element('TxnData2').text = options[:txn_data2].to_s.slice(0, 255) unless options[:txn_data2].blank?
         xml.add_element('TxnData3').text = options[:txn_data3].to_s.slice(0, 255) unless options[:txn_data3].blank?
+
+        xml.add_element('ClientInfo').text = options[:client_info] if options[:client_info]
       end
 
       def new_transaction

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -31,6 +31,13 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
     assert_not_nil response.authorization
   end
 
+  def test_successful_purchase_with_client_info
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:client_info => '192.168.0.1'))
+    assert_success response
+    assert_equal 'The Transaction was approved', response.message
+    assert_not_nil response.authorization
+  end
+
   def test_declined_purchase
     assert response = @gateway.purchase(@amount, credit_card('5431111111111228'), @options)
     assert_match %r{declined}i, response.message

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -242,6 +242,14 @@ class PaymentExpressTest < Test::Unit::TestCase
     end
   end
 
+  def test_pass_client_info
+    options = {:client_info => '192.168.0.1'}
+
+    perform_each_transaction_type_with_request_body_assertions(options) do |body|
+      assert_match(/<ClientInfo>192.168.0.1<\/ClientInfo>/, body)
+    end
+  end
+
   def test_purchase_truncates_order_id_to_16_chars
     stub_comms do
       @gateway.purchase(@amount, @visa, {:order_id => '16chars---------EXTRA'})


### PR DESCRIPTION
Adds support for the ClientInfo field used to send the IP address.

ECS-124

Unit:
34 tests, 249 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
15 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed