### PR TITLE
TrustCommerce: Send full name on ACH transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,11 @@
 * Cecabank: Append error text to message [therufs] #3127
 * Adyen: Extend AVS code mappings [therufs] #3119
 * NMI: Add customer id to authorization on store [curiousepic] #3130
+<<<<<<< HEAD
 * Trans First Express: Don't pass blank name field [curiousepic] #3133
+=======
+* TrustCommerce: Send full name on ACH transactions [jknipp] #3132
+>>>>>>> TrustCommerce: Send full name on ACH transactions
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -333,6 +333,7 @@ module ActiveMerchant #:nodoc:
         params[:routing] = check.routing_number
         params[:account] = check.account_number
         params[:savings] = 'y' if check.account_type == 'savings'
+        params[:name] = check.name
       end
 
       def add_creditcard(params, creditcard)

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -37,6 +37,7 @@ class TrustCommerceTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @check)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{aggregator1}, data)
+      assert_match(%r{name=Jim\+Smith}, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Support sending full name for ACH transactions in require name field.

ECS-137

Unit:
10 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
16 tests, 59 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
81.25% passed

Unrelated remote test failures.