### PR TITLE
Trans First Express: Don't pass blank name field

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -532,7 +532,7 @@ module ActiveMerchant #:nodoc:
 
       def add_contact(doc, fullname, options)
         doc['v1'].contact do
-          doc['v1'].fullName fullname
+          doc['v1'].fullName fullname unless fullname.blank?
           doc['v1'].coName options[:company_name] if options[:company_name]
           doc['v1'].title options[:title] if options[:title]
 
@@ -557,7 +557,7 @@ module ActiveMerchant #:nodoc:
 
           if (shipping_address = options[:shipping_address])
             doc['v1'].ship do
-              doc['v1'].fullName fullname
+              doc['v1'].fullName fullname unless fullname.blank?
               doc['v1'].addrLn1 shipping_address[:address1] if shipping_address[:address1]
               doc['v1'].addrLn2 shipping_address[:address2] if shipping_address[:address2]
               doc['v1'].city shipping_address[:city] if shipping_address[:city]
@@ -572,7 +572,7 @@ module ActiveMerchant #:nodoc:
 
       def add_name(doc, payment_method)
         doc['v1'].contact do
-          doc['v1'].fullName payment_method.name
+          doc['v1'].fullName payment_method.name unless payment_method.name.blank?
         end
       end
 

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -109,6 +109,32 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_without_name
+    credit_card_opts = {
+      :number => 4485896261017708,
+      :month => Date.new((Time.now.year + 1), 9, 30).month,
+      :year => Date.new((Time.now.year + 1), 9, 30).year,
+      :first_name => '',
+      :last_name => ''
+    }
+
+    credit_card = CreditCard.new(credit_card_opts)
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+
+    credit_card_opts = {
+      :number => 4485896261017708,
+      :month => Date.new((Time.now.year + 1), 9, 30).month,
+      :year => Date.new((Time.now.year + 1), 9, 30).year
+    }
+
+    credit_card = CreditCard.new(credit_card_opts)
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_echeck
     assert response = @gateway.purchase(@amount, @check, @options)
     assert_success response


### PR DESCRIPTION
Remote (Failures probably due to changes to sandbox, relevant remote
test does pass):
32 tests, 83 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
71.875% passed

Unit:
21 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed