### PR TITLE
Card Connect: Handle 401s as responses

### DIFF
--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -281,6 +281,9 @@ module ActiveMerchant #:nodoc:
           test: test?,
           error_code: error_code_from(response)
         )
+      rescue ResponseError => e
+        return Response.new(false, 'Unable to authenticate.  Please check your credentials.', {}, :test => test?) if e.response.code == '401'
+        raise
       end
 
       def success_from(response)

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -201,9 +201,10 @@ class RemoteCardConnectTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = CardConnectGateway.new(username: '', password: '', merchant_id: '')
-    assert_raises(ActiveMerchant::ResponseError) do
-      gateway.purchase(@amount, @credit_card, @options)
-    end
+    response = gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_match %r{Unable to authenticate.  Please check your credentials.}, response.message
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
Remote (1 unrelated failure for echeck related to amount):
23 tests, 54 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.6522% passed

Unit:
21 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed