### PR TITLE
Adyen: Enable Dynamic 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * Card Connect: Handle 401s as responses [curiousepic] #3137
 * Worldpay: Introduce normalized stored credential options [davidsantoso] #3134
 * Worldpay: Adjust use of normalized stored credentials hash [davidsantoso] #3139
+* Adyen: Enable Dynamic 3DS [molbrown] #3138
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -33,7 +33,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, payment, options={})
-        if options[:execute_threed]
+        if options[:execute_threed] || options[:threed_dynamic]
           authorize(money, payment, options)
         else
           MultiResponse.run do |r|
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         add_shopper_interaction(post, payment, options)
         add_address(post, options)
         add_installments(post, options) if options[:installments]
-        add_3ds(post, options) if options[:execute_threed]
+        add_3ds(post, options)
         commit('authorise', post)
       end
 
@@ -276,8 +276,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3ds(post, options)
-        post[:additionalData] = { executeThreeD: 'true' }
+        return unless options[:execute_threed] || options[:threed_dynamic]
         post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
+        post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
       end
 
       def parse(body)


### PR DESCRIPTION
Allows for initiating Dynamic 3DS by passing browserInfo without
executeThreeD. Merchant account must be set up for Dynamic 3DS.

ECS-131

Unit:
27 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
41 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed