### PR TITLE
Worldpay: Adjust use of normalized stored credentials hash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Qvalent: Map CVV Result to responses [curiousepic] #3135
 * Card Connect: Handle 401s as responses [curiousepic] #3137
 * Worldpay: Introduce normalized stored credential options [davidsantoso] #3134
+* Worldpay: Adjust use of normalized stored credentials hash [davidsantoso] #3139
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -285,7 +285,11 @@ module ActiveMerchant #:nodoc:
         if options[:stored_credential][:initial_transaction]
           xml.tag! 'storedCredentials', 'usage' => 'FIRST'
         else
-          reason = options[:stored_credential][:recurring] ? 'RECURRING' : 'UNSCHEDULED'
+          reason = case options[:stored_credential][:reason_type]
+                   when 'installment' then 'INSTALMENT'
+                   when 'recurring' then 'RECURRING'
+                   when 'unscheduled' then 'UNSCHEDULED'
+                   end
 
           xml.tag! 'storedCredentials', 'usage' => 'USED', 'merchantInitiatedReason' => reason do
             xml.tag! 'schemeTransactionIdentifier', options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id]

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -127,7 +127,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   def test_successful_auth_and_capture_with_normalized_stored_credential
     stored_credential_params = {
       initial_transaction: true,
-      recurring: false,
+      reason_type: 'unscheduled',
       initiator: 'merchant',
       network_transaction_id: nil
     }
@@ -144,7 +144,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @options[:order_id] = generate_unique_id
     @options[:stored_credential] = {
       initial_transaction: false,
-      recurring: false,
+      reason_type: 'installment',
       initiator: 'merchant',
       network_transaction_id: auth.params['transaction_identifier']
     }


### PR DESCRIPTION
Previously the new/beta normalized stored credential hash was using a
boolean value to indicate if a transaction was part of a recurring
transaction or not. However, this did not allow for the case of gateways
(like Worldpay) to take into account transactions that are part of an
installment. This adjusts the previously "recurring" field to use the
name "transaction_type" which accepts a string of either:

- "installment"
- "recurring"
- "unscheduled"

This should allow more flexibility to for other gateways that also have
the notion of a payment that is part of an installment.

Note that this normalized hash is still in "beta" use. The hash
structure itself may change and until there is solid use around it
across multiple gateways, it will likely be a defined-yet-not-enforced
hash rather than an object which provides guarantees around field
values.