### PR TITLE
Merrco partial refunds fix

### DIFF
--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -8,13 +8,13 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AF AX AL DZ AS AD AO AI AQ AG AR AM AW AU AT AZ BS BH BD BB BY BE BZ BJ BM BT BO BQ BA BW BV BR IO BN BG BF BI KH CM CA CV KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CW CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM HN HK HU IS IN ID IR IQ IE IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NC NZ NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF VC WS SM ST SA SN RS SC SL SG SX SK SI SB SO ZA GS SS ES LK PM SD SR SJ SZ SE CH SY TW TJ TZ TH NL TL TG TK TO TT TN TR TM TC TV UG UA AE GB US UM UY UZ VU VA VE VN VG VI WF EH YE ZM ZW)
       self.default_currency = 'CAD'
       self.supported_cardtypes = [
-        :american_express,
-        :diners_club,
-        :discover,
-        :jcb,
-        :master,
-        :maestro,
-        :visa
+          :american_express,
+          :diners_club,
+          :discover,
+          :jcb,
+          :master,
+          :maestro,
+          :visa
       ]
 
       self.money_format = :cents
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options={})
         post = {}
-        add_order_id(post, options)
+        add_order_id(post)
 
         commit(:post, "auths/#{authorization}/voidauths", post)
       end
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options={})
         post = {}
         add_payment(post, credit_card)
-        add_order_id(post, options)
+        add_order_id(post)
 
         commit(:post, 'verifications', post)
       end
@@ -103,9 +103,9 @@ module ActiveMerchant #:nodoc:
 
       def scrub(transcript)
         transcript.
-          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
-          gsub(%r(("card\\?":{\\?"cardNum\\?":\\?")\d+), '\1[FILTERED]').
-          gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
+            gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+            gsub(%r(("card\\?":{\\?"cardNum\\?":\\?")\d+), '\1[FILTERED]').
+            gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
       end
 
       private
@@ -132,7 +132,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:amount] = amount(money)
-        add_order_id(post, options)
+        add_order_id(post)
       end
 
       def add_payment(post, credit_card_or_reference, options = {})
@@ -157,18 +157,18 @@ module ActiveMerchant #:nodoc:
         { :month => month, :year => year }
       end
 
-      def add_order_id(post, options)
-        post[:merchantRefNum] = (options[:order_id] || SecureRandom.uuid)
+      def add_order_id(post)
+        post[:merchantRefNum] = (SecureRandom.uuid)
       end
 
       def map_address(address)
         return {} if address.nil?
         country = Country.find(address[:country]) if address[:country]
         mapped = {
-          :street => address[:address1],
-          :city   => address[:city],
-          :zip    => address[:zip],
-          :state  => address[:state],
+            :street => address[:address1],
+            :city   => address[:city],
+            :zip    => address[:zip],
+            :state  => address[:state],
         }
         mapped[:country] = country.code(:alpha2).value unless country.blank?
 
@@ -190,12 +190,12 @@ module ActiveMerchant #:nodoc:
 
         success = success_from(response)
         Response.new(
-          success,
-          message_from(success, response),
-          response,
-          :test => test?,
-          :error_code => error_code_from(response),
-          :authorization => authorization_from(success, get_url(uri), method, response)
+            success,
+            message_from(success, response),
+            response,
+            :test => test?,
+            :error_code => error_code_from(response),
+            :authorization => authorization_from(success, get_url(uri), method, response)
         )
       end
 
@@ -237,10 +237,10 @@ module ActiveMerchant #:nodoc:
       # Builds the auth and U-A headers for the request
       def headers
         {
-          'Accept'        => 'application/json',
-          'Content-type'  => 'application/json',
-          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}",
-          'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
+            'Accept'        => 'application/json',
+            'Content-type'  => 'application/json',
+            'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}",
+            'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
         }
       end
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -8,13 +8,13 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AF AX AL DZ AS AD AO AI AQ AG AR AM AW AU AT AZ BS BH BD BB BY BE BZ BJ BM BT BO BQ BA BW BV BR IO BN BG BF BI KH CM CA CV KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CW CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM HN HK HU IS IN ID IR IQ IE IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NC NZ NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF VC WS SM ST SA SN RS SC SL SG SX SK SI SB SO ZA GS SS ES LK PM SD SR SJ SZ SE CH SY TW TJ TZ TH NL TL TG TK TO TT TN TR TM TC TV UG UA AE GB US UM UY UZ VU VA VE VN VG VI WF EH YE ZM ZW)
       self.default_currency = 'CAD'
       self.supported_cardtypes = [
-          :american_express,
-          :diners_club,
-          :discover,
-          :jcb,
-          :master,
-          :maestro,
-          :visa
+        :american_express,
+        :diners_club,
+        :discover,
+        :jcb,
+        :master,
+        :maestro,
+        :visa
       ]
 
       self.money_format = :cents
@@ -103,9 +103,9 @@ module ActiveMerchant #:nodoc:
 
       def scrub(transcript)
         transcript.
-            gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
-            gsub(%r(("card\\?":{\\?"cardNum\\?":\\?")\d+), '\1[FILTERED]').
-            gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r(("card\\?":{\\?"cardNum\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
       end
 
       private
@@ -165,10 +165,10 @@ module ActiveMerchant #:nodoc:
         return {} if address.nil?
         country = Country.find(address[:country]) if address[:country]
         mapped = {
-            :street => address[:address1],
-            :city   => address[:city],
-            :zip    => address[:zip],
-            :state  => address[:state],
+          :street => address[:address1],
+          :city   => address[:city],
+          :zip    => address[:zip],
+          :state  => address[:state],
         }
         mapped[:country] = country.code(:alpha2).value unless country.blank?
 
@@ -190,12 +190,12 @@ module ActiveMerchant #:nodoc:
 
         success = success_from(response)
         Response.new(
-            success,
-            message_from(success, response),
-            response,
-            :test => test?,
-            :error_code => error_code_from(response),
-            :authorization => authorization_from(success, get_url(uri), method, response)
+          success,
+          message_from(success, response),
+          response,
+          :test => test?,
+          :error_code => error_code_from(response),
+          :authorization => authorization_from(success, get_url(uri), method, response)
         )
       end
 
@@ -237,10 +237,10 @@ module ActiveMerchant #:nodoc:
       # Builds the auth and U-A headers for the request
       def headers
         {
-            'Accept'        => 'application/json',
-            'Content-type'  => 'application/json',
-            'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}",
-            'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
+          'Accept'        => 'application/json',
+          'Content-type'  => 'application/json',
+          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}",
+          'User-Agent'    => "Netbanx-Paysafe v1.0/ActiveMerchant #{ActiveMerchant::VERSION}"
         }
       end
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options={})
         post = {}
-        add_order_id(post)
+        add_order_id(post, options)
 
         commit(:post, "auths/#{authorization}/voidauths", post)
       end
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options={})
         post = {}
         add_payment(post, credit_card)
-        add_order_id(post)
+        add_order_id(post, options)
 
         commit(:post, 'verifications', post)
       end
@@ -132,7 +132,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:amount] = amount(money)
-        add_order_id(post)
+        add_order_id(post, options)
       end
 
       def add_payment(post, credit_card_or_reference, options = {})
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
         { :month => month, :year => year }
       end
 
-      def add_order_id(post)
+      def add_order_id(post, options)
         post[:merchantRefNum] = SecureRandom.uuid
       end
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -55,6 +55,10 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, money, options)
 
+        # Setting merchantRefNumber to a unique id for each refund
+        # This is to support multiple partial refunds for the same order
+        post[:merchantRefNum] = SecureRandom.uuid
+
         commit(:post, "settlements/#{authorization}/refunds", post)
       end
 
@@ -158,7 +162,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_order_id(post, options)
-        post[:merchantRefNum] = SecureRandom.uuid
+        post[:merchantRefNum] = (options[:order_id] || SecureRandom.uuid)
       end
 
       def map_address(address)

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_order_id(post)
-        post[:merchantRefNum] = (SecureRandom.uuid)
+        post[:merchantRefNum] = SecureRandom.uuid
       end
 
       def map_address(address)


### PR DESCRIPTION
Changes made to the add_order_id method to send a uuid in place of order number. This is expected to fix the multiple partial refunds problem for Merrco payments.