### PR TITLE
BlueSnap: Support ACH/ECP payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * Worldpay: Adjust use of normalized stored credentials hash [davidsantoso] #3139
 * Adyen: Enable Dynamic 3DS [molbrown] #3138
 * Fat Zebra: Support voids [curiousepic] #3142
+* Blue Snap: Support ACH/ECP payments [jknipp] #3143
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * Adyen: Enable Dynamic 3DS [molbrown] #3138
 * Fat Zebra: Support voids [curiousepic] #3142
 * Blue Snap: Support ACH/ECP payments [jknipp] #3143
+* Blue Snap: Fix Card-on-File field typo [jknipp] #3143
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -170,7 +170,7 @@ module ActiveMerchant
       def add_auth_purchase(doc, money, payment_method, options)
         doc.send('recurring-transaction', options[:recurring] ? 'RECURRING' : 'ECOMMERCE')
         add_order(doc, options)
-        doc.send('storeCard', options[:store_card] || false)
+        doc.send('store-card', options[:store_card] || false)
         add_amount(doc, money, options)
         add_fraud_info(doc, options)
 

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -136,7 +136,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert card = @gateway.store(@credit_card)
 
     assert_success card
-    assert_false card.authorization == nil
+    assert_not_nil card.authorization
   end
 
   def test_purchase_with_token

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -6,8 +6,19 @@ class BlueSnapTest < Test::Unit::TestCase
   def setup
     @gateway = BlueSnapGateway.new(api_username: 'login', api_password: 'password')
     @credit_card = credit_card
+    @check = check
     @amount = 100
     @options = { order_id: '1', personal_identification_number: 'CNPJ' }
+    @valid_check_options = {
+      billing_address: {
+        address1: '123 Street',
+        address2: 'Apt 1',
+        city: 'Happy City',
+        state: 'CA',
+        zip: '94901'
+      },
+      authorized_by_shopper: true
+    }
   end
 
   def test_successful_purchase
@@ -18,12 +29,28 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_equal '1012082839', response.authorization
   end
 
+  def test_successful_echeck_purchase
+    @gateway.expects(:raw_ssl_request).returns(successful_echeck_purchase_response)
+
+    response = @gateway.purchase(@amount, @check, @options.merge(@valid_check_options))
+    assert_success response
+    assert_equal '1019803029', response.authorization
+  end
+
   def test_failed_purchase
     @gateway.expects(:raw_ssl_request).returns(failed_purchase_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal '14002', response.error_code
+  end
+
+  def test_failed_echeck_purchase
+    @gateway.expects(:raw_ssl_request).returns(failed_echeck_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '16004', response.error_code
   end
 
   def test_successful_authorize
@@ -117,12 +144,28 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_equal '20936441', response.authorization
   end
 
+  def test_successful_echeck_store
+    @gateway.expects(:raw_ssl_request).returns(successful_echeck_store_response)
+
+    response = @gateway.store(@check, @options)
+    assert_success response
+    assert_equal '23844081|check', response.authorization
+  end
+
   def test_failed_store
     @gateway.expects(:raw_ssl_request).returns(failed_store_response)
 
     response = @gateway.store(@credit_card, @options)
     assert_failure response
     assert_equal '14002', response.error_code
+  end
+
+  def test_failed_echeck_store
+    @gateway.expects(:raw_ssl_request).returns(failed_echeck_store_response)
+
+    response = @gateway.store(@check, @options)
+    assert_failure response
+    assert_equal '10001', response.error_code
   end
 
   def test_currency_added_correctly
@@ -165,6 +208,11 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_echeck_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed_echeck), post_scrubbed_echeck
+  end
+
   private
 
   def pre_scrubbed
@@ -181,6 +229,20 @@ class BlueSnapTest < Test::Unit::TestCase
     }
   end
 
+  def pre_scrubbed_echeck
+    %q{
+        opening connection to sandbox.bluesnap.com:443...
+        opened
+        starting SSL for sandbox.bluesnap.com:443...
+        SSL established
+        <- "POST /services/2/alt-transactions HTTP/1.1\r\nContent-Type: application/xml\r\nAuthorization: Basic QVBJXzE0NjExNzM3MTY2NTc2NzM0MDQyMzpuZll3VHg4ZkZBdkpxQlhjeHF3Qzg=\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: sandbox.bluesnap.com\r\nContent-Length: 973\r\n\r\n"
+        <- "<alt-transaction xmlns=\"http://ws.plimus.com\">\n  <amount>1.00</amount>\n  <currency>USD</currency>\n  <payer-info>\n    <first-name>Jim</first-name>\n    <last-name>Smith</last-name>\n    <state>CA</state>\n    <city>Happy City</city>\n    <zip>94901</zip>\n    <company-name>Jim Smith</company-name>\n  </payer-info>\n  <ecp-transaction>\n    <account-number>15378535</account-number>\n    <routing-number>244183602</routing-number>\n    <account-type>CORPORATE_CHECKING</account-type>\n  </ecp-transaction>\n  <authorized-by-shopper>true</authorized-by-shopper>\n  <transaction-fraud-info/>\n  </alt-transaction>"
+        -> "HTTP/1.1 200 200\r\n"
+        -> "Set-Cookie: JSESSIONID=65D503B9785EA6641D4757EA568A6532; Path=/services; Secure; HttpOnly\r\n"
+        -> "Connection: close\r\n"
+    }
+  end
+
   def post_scrubbed
     %q{
         opening connection to sandbox.bluesnap.com:443...
@@ -192,6 +254,20 @@ class BlueSnapTest < Test::Unit::TestCase
         -> "Content-Encoding: gzip\r\n"
         -> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03mS]\x8F\xDA0\x10|\xCF\xAF@\xA9\xD47c\xA0\x1F:Z\xE3\x13\xCD\xD1\x16\xF5\xC4U\x81\xF4\xB52\xB1\xE1,%v\xE4u\xB8K"
         Conn close
+    }
+  end
+
+  def post_scrubbed_echeck
+    %q{
+        opening connection to sandbox.bluesnap.com:443...
+        opened
+        starting SSL for sandbox.bluesnap.com:443...
+        SSL established
+        <- "POST /services/2/alt-transactions HTTP/1.1\r\nContent-Type: application/xml\r\nAuthorization: Basic [FILTERED]=\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: sandbox.bluesnap.com\r\nContent-Length: 973\r\n\r\n"
+        <- "<alt-transaction xmlns=\"http://ws.plimus.com\">\n  <amount>1.00</amount>\n  <currency>USD</currency>\n  <payer-info>\n    <first-name>Jim</first-name>\n    <last-name>Smith</last-name>\n    <state>CA</state>\n    <city>Happy City</city>\n    <zip>94901</zip>\n    <company-name>Jim Smith</company-name>\n  </payer-info>\n  <ecp-transaction>\n    <account-number>[FILTERED]</account-number>\n    <routing-number>[FILTERED]</routing-number>\n    <account-type>CORPORATE_CHECKING</account-type>\n  </ecp-transaction>\n  <authorized-by-shopper>true</authorized-by-shopper>\n  <transaction-fraud-info/>\n  </alt-transaction>"
+        -> "HTTP/1.1 200 200\r\n"
+        -> "Set-Cookie: JSESSIONID=65D503B9785EA6641D4757EA568A6532; Path=/services; Secure; HttpOnly\r\n"
+        -> "Connection: close\r\n"
     }
   end
 
@@ -230,6 +306,33 @@ class BlueSnapTest < Test::Unit::TestCase
     XML
   end
 
+  def successful_echeck_purchase_response
+    MockResponse.succeeded <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <alt-transaction xmlns="http://ws.plimus.com">
+        <transaction-id>1019803029</transaction-id>
+        <amount>1.00</amount>
+        <currency>USD</currency>
+        <payer-info>
+          <first-name>Jim</first-name>
+          <last-name>Smith</last-name>
+          <state>CA</state>
+          <city>Happy City</city>
+          <zip>94901</zip>
+          <company-name>Jim Smith</company-name>
+        </payer-info>
+        <ecp-transaction>
+          <account-number>15378535</account-number>
+          <routing-number>244183602</routing-number>
+          <account-type>CORPORATE_CHECKING</account-type>
+        </ecp-transaction>
+        <processing-info>
+          <processing-status>PENDING</processing-status>
+        </processing-info>
+      </alt-transaction>
+    XML
+  end
+
   def failed_purchase_response
     body = <<-XML
       <?xml version="1.0" encoding="UTF-8"?>
@@ -238,6 +341,21 @@ class BlueSnapTest < Test::Unit::TestCase
           <error-name>INCORRECT_INFORMATION</error-name>
           <code>14002</code>
           <description>Transaction failed  because of payment processing failure.: 430285 - Authorization has failed for this transaction. Please try again or contact your bank for assistance</description>
+        </message>
+      </messages>
+    XML
+
+    MockResponse.failed(body, 400)
+  end
+
+  def failed_echeck_purchase_response
+    body = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <messages xmlns="http://ws.plimus.com">
+        <message>
+          <error-name>PAYMENT_NOT_AUTHORIZED_BY_SHOPPER</error-name>
+          <code>16004</code>
+          <description>The payment was not authorized by shopper. Missing/Invalid 'authorized-by-shopper' element.</description>
         </message>
       </messages>
     XML
@@ -529,6 +647,39 @@ class BlueSnapTest < Test::Unit::TestCase
     response
   end
 
+  def successful_echeck_store_response
+    response = MockResponse.succeeded <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <vaulted-shopper xmlns="http://ws.plimus.com">
+        <vaulted-shopper-id>23844081</vaulted-shopper-id>
+        <first-name>Jim</first-name>
+        <last-name>Smith</last-name>
+        <city>Happy City</city>
+        <zip>94901</zip>
+        <company-name>Jim Smith</company-name>
+        <shopper-currency>USD</shopper-currency>
+        <payment-sources>
+          <ecp-info>
+            <billing-contact-info>
+              <first-name>Jim</first-name>
+              <last-name>Smith</last-name>
+              <city></city>
+              <company-name>Jim Smith</company-name>
+            </billing-contact-info>
+            <ecp>
+              <account-number>15378535</account-number>
+              <routing-number>244183602</routing-number>
+              <account-type>CORPORATE_CHECKING</account-type>
+            </ecp>
+          </ecp-info>
+        </payment-sources>
+      </vaulted-shopper>
+    XML
+
+    response.headers = { 'content-location' => 'https://sandbox.bluesnap.com/services/2/vaulted-shoppers/23844081' }
+    response
+  end
+
   def failed_store_response
     body =  <<-XML
       <?xml version="1.0" encoding="UTF-8"?>
@@ -537,6 +688,20 @@ class BlueSnapTest < Test::Unit::TestCase
           <error-name>INCORRECT_INFORMATION</error-name>
           <code>14002</code>
           <description>Transaction failed  because of payment processing failure.: 430285 - Authorization has failed for this transaction. Please try again or contact your bank for assistance</description>
+        </message>
+      </messages>
+    XML
+    MockResponse.failed(body, 400)
+  end
+
+  def failed_echeck_store_response
+    body =  <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <messages xmlns="http://ws.plimus.com">
+        <message>
+          <error-name>VALIDATION_GENERAL_FAILURE</error-name>
+          <code>10001</code>
+          <description>ECP data validity check failed</description>
         </message>
       </messages>
     XML

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -57,7 +57,7 @@ class BlueSnapTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
     end.check_request do |type, endpoint, data, headers|
-      assert_match '<storeCard>false</storeCard>', data
+      assert_match '<store-card>false</store-card>', data
       assert_match '<personal-identification-number>CNPJ</personal-identification-number>', data
     end.respond_with(successful_authorize_response)
     assert_success response


### PR DESCRIPTION
Add support for ACH/ECP/echeck payments. We only support vaulting and using 1 ACH account per customer (<= v2.0). Support for multiple ACH accounts (v3.0) was not included at this time.

ECS-60

Unit:
33 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed