### PR TITLE
Orbital: Pass normalized stored credential fields

### DIFF
--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -157,6 +157,54 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_normalized_mit_stored_credentials
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        initiator: 'merchant',
+        reason_type: 'unscheduled',
+        network_transaction_id: 'abcdefg12345678'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_normalized_cit_stored_credentials
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: true,
+        initiator: 'customer',
+        reason_type: 'unscheduled'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_overridden_normalized_stored_credentials
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        initiator: 'merchant',
+        reason_type: 'unscheduled',
+        network_transaction_id: 'abcdefg12345678'
+      },
+      mit_msg_type: 'MRSB'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   # Amounts of x.01 will fail
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(101, @declined_card, @options)


### PR DESCRIPTION
Remote: 27 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 72 tests, 432 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

I'd particularly appreciate @jknipp and @davidsantoso's eyes on this one. Orbital's expectations for message/reason type are not straightforward https://www.dropbox.com/s/532uhzsx5mhydb5/OrbitalGatewayXMLInterfaceSpecification%207.7.pdf?dl=0 (section 3.3)