### PR TITLE
BluePay: Add IP address to all requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Pin Payments: Concatenate card and customer tokens when storing card [therufs] #3144
 * Update Discover regex to allow card numbers longer than 16 digits [prashcr] #3146
 * Merrco partial refunds fix [payfirma1] #3141
+* BluePay: Send customer IP address when provided [jknipp] #3149
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
         'REBID' => :rebid,
         'TRANS_TYPE' => :trans_type,
         'PAYMENT_ACCOUNT_MASK' => :acct_mask,
-        'CARD_TYPE' => :card_type,
+        'CARD_TYPE' => :card_type
       }
 
       REBILL_FIELD_MAP = {
@@ -41,6 +41,7 @@ module ActiveMerchant #:nodoc:
         'REB_AMOUNT' => :rebill_amount,
         'NEXT_AMOUNT' => :next_amount,
         'USUAL_DATE' => :undoc_usual_date, # Not found in the bp20rebadmin API doc.
+        'CUST_TOKEN' => :cust_token
       }
 
       self.supported_countries = ['US', 'CA']
@@ -84,7 +85,7 @@ module ActiveMerchant #:nodoc:
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
         post[:TRANS_TYPE]  = 'AUTH'
-        commit('AUTH_ONLY', money, post)
+        commit('AUTH_ONLY', money, post, options)
       end
 
       # Perform a purchase, which is essentially an authorization and capture in a single operation.
@@ -107,7 +108,7 @@ module ActiveMerchant #:nodoc:
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
         post[:TRANS_TYPE]  = 'SALE'
-        commit('AUTH_CAPTURE', money, post)
+        commit('AUTH_CAPTURE', money, post, options)
       end
 
       # Captures the funds from an authorize transaction.
@@ -123,7 +124,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         post[:MASTER_ID] = identification
         post[:TRANS_TYPE] = 'CAPTURE'
-        commit('PRIOR_AUTH_CAPTURE', money, post)
+        commit('PRIOR_AUTH_CAPTURE', money, post, options)
       end
 
       # Void a previous transaction
@@ -136,7 +137,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:MASTER_ID] = identification
         post[:TRANS_TYPE] = 'VOID'
-        commit('VOID', nil, post)
+        commit('VOID', nil, post, options)
       end
 
       # Performs a credit.
@@ -169,7 +170,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, options)
         add_address(post, options)
         add_customer_data(post, options)
-        commit('CREDIT', money, post)
+        commit('CREDIT', money, post, options)
       end
 
       def credit(money, payment_object, options = {})
@@ -189,7 +190,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, options)
         add_address(post, options)
         add_customer_data(post, options)
-        commit('CREDIT', money, post)
+        commit('CREDIT', money, post, options)
       end
 
       # Create a new recurring payment.
@@ -313,10 +314,11 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def commit(action, money, fields)
+      def commit(action, money, fields, options = {})
         fields[:AMOUNT] = amount(money) unless(fields[:TRANS_TYPE] == 'VOID' || action == 'rebill')
         fields[:MODE] = (test? ? 'TEST' : 'LIVE')
         fields[:ACCOUNT_ID] = @options[:login]
+        fields[:CUSTOMER_IP] = options[:ip] if options[:ip]
 
         if action == 'rebill'
           url = rebilling_url

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -10,7 +10,8 @@ class BluePayTest < Test::Unit::TestCase
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,
-      :description => 'Store purchase'
+      :description => 'Store purchase',
+      :ip => '192.168.0.1'
     }
 
     @recurring_options = {
@@ -36,7 +37,7 @@ class BluePayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, check, @options.merge(:email=>'foo@example.com'))
     assert_success response
     assert response.test?
-    assert_equal 'This transaction has been approved', response.message
+    assert_equal 'App ACH Sale', response.message
     assert response.authorization
   end
 

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -20,29 +20,43 @@ class BluePayTest < Test::Unit::TestCase
     @credit_card = credit_card
     @rebill_id = '100096219669'
     @rebill_status = 'active'
+    @options = {ip: '192.168.0.1'}
   end
 
   def test_successful_authorization
-    @gateway.expects(:ssl_post).returns(RSP[:approved_auth])
-    assert response = @gateway.authorize(@amount, @credit_card)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/CUSTOMER_IP=192.168.0.1/, data)
+    end.respond_with(RSP[:approved_auth])
+
+    assert response
     assert_instance_of Response, response
     assert_success response
     assert_equal '100134203758', response.authorization
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(RSP[:approved_purchase])
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/CUSTOMER_IP=192.168.0.1/, data)
+    end.respond_with(RSP[:approved_purchase])
 
-    assert response = @gateway.purchase(@amount, @credit_card)
+    assert response
     assert_instance_of Response, response
     assert_success response
     assert_equal '100134203767', response.authorization
   end
 
   def test_failed_authorization
-    @gateway.expects(:ssl_post).returns(RSP[:declined])
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/CUSTOMER_IP=192.168.0.1/, data)
+    end.respond_with(RSP[:declined])
 
-    assert response = @gateway.authorize(@amount, @credit_card)
+    assert response
     assert_instance_of Response, response
     assert_failure response
     assert_equal '100000000150', response.authorization
@@ -105,26 +119,38 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    @gateway.expects(:ssl_post).returns(successful_refund_response)
-    assert response = @gateway.refund(@amount, '100134230412', :card_number => @credit_card.number)
+    response = stub_comms do
+      @gateway.refund(@amount, '100134230412', @options.merge({:card_number => @credit_card.number}))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
+    end.respond_with(successful_refund_response)
+
+    assert response
     assert_success response
     assert_equal 'This transaction has been approved', response.message
   end
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', :card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345')
+      @gateway.refund(50, '123456789', @options.merge({:card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/NAME1=Bob/, data)
       assert_match(/NAME2=Smith/, data)
       assert_match(/ZIP=12345/, data)
+      assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(successful_purchase_response)
+
     assert_success response
   end
 
   def test_failed_refund
-    @gateway.expects(:ssl_post).returns(failed_refund_response)
-    assert response = @gateway.refund(@amount, '123456789', :card_number => @credit_card.number)
+    response = stub_comms do
+      @gateway.refund(@amount, '123456789', @options.merge({:card_number => @credit_card.number}))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
+    end.respond_with(failed_refund_response)
+
+    assert response
     assert_failure response
     assert_equal 'The referenced transaction does not meet the criteria for issuing a credit', response.message
   end
@@ -132,7 +158,13 @@ class BluePayTest < Test::Unit::TestCase
   def test_deprecated_credit
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning('credit should only be used to credit a payment method') do
-      assert response = @gateway.credit(@amount, '123456789', :card_number => @credit_card.number)
+      response = stub_comms do
+        @gateway.credit(@amount, '123456789', @options.merge({:card_number => @credit_card.number}))
+      end.check_request do |endpoint, data, headers|
+        assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
+      end.respond_with(failed_refund_response)
+
+      assert response
       assert_success response
       assert_equal 'This transaction has been approved', response.message
     end


### PR DESCRIPTION
@activemerchant/spreedly-connect I did not add the IP address to recurring billing requests because they are marked as `deprecated`. I can add them if the team feels it's worthwhile.

Add the IP address to all Blue Pay requests when available.

ECS-165

Unit:
26 tests, 125 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
15 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed