### PR TITLE
PaymentExpress: Use ip field for client_info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* BluePay: Send customer IP address when provided [jknipp] #3149
+* PaymentExpress: Use ip field for client_info field [jknipp] #3150
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106
@@ -38,7 +40,6 @@
 * Pin Payments: Concatenate card and customer tokens when storing card [therufs] #3144
 * Update Discover regex to allow card numbers longer than 16 digits [prashcr] #3146
 * Merrco partial refunds fix [payfirma1] #3141
-* BluePay: Send customer IP address when provided [jknipp] #3149
 
 == Version 1.90.0 (January 8, 2019)
 * Mercado Pago: Support "gateway" processing mode [curiousepic] #3087

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -153,6 +153,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(result, options)
         add_address_verification_data(result, options)
         add_optional_elements(result, options)
+        add_ip(result, options)
         result
       end
 
@@ -163,6 +164,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(result, options)
         add_reference(result, identification)
         add_optional_elements(result, options)
+        add_ip(result, options)
         result
       end
 
@@ -172,6 +174,7 @@ module ActiveMerchant #:nodoc:
         add_amount(result, 100, options) # need to make an auth request for $1
         add_token_request(result, options)
         add_optional_elements(result, options)
+        add_ip(result, options)
         result
       end
 
@@ -233,6 +236,10 @@ module ActiveMerchant #:nodoc:
         xml.add_element('AvsPostCode').text = address[:zip]
       end
 
+      def add_ip(xml, options)
+        xml.add_element('ClientInfo').text = options[:ip] if options[:ip]
+      end
+
       # The options hash may contain optional data which will be passed
       # through the specialized optional fields at PaymentExpress
       # as follows:
@@ -241,8 +248,7 @@ module ActiveMerchant #:nodoc:
       #       :client_type => :web, # Possible values are: :web, :ivr, :moto, :unattended, :internet, or :recurring
       #       :txn_data1 => "String up to 255 characters",
       #       :txn_data2 => "String up to 255 characters",
-      #       :txn_data3 => "String up to 255 characters",
-      #       :client_info => "String up to 15 characters. The IP address of the user who processed the transaction."
+      #       :txn_data3 => "String up to 255 characters"
       #     }
       #
       # +:client_type+, while not documented for PxPost, will be sent as
@@ -278,8 +284,6 @@ module ActiveMerchant #:nodoc:
         xml.add_element('TxnData1').text = options[:txn_data1].to_s.slice(0, 255) unless options[:txn_data1].blank?
         xml.add_element('TxnData2').text = options[:txn_data2].to_s.slice(0, 255) unless options[:txn_data2].blank?
         xml.add_element('TxnData3').text = options[:txn_data3].to_s.slice(0, 255) unless options[:txn_data3].blank?
-
-        xml.add_element('ClientInfo').text = options[:client_info] if options[:client_info]
       end
 
       def new_transaction

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -31,8 +31,8 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
     assert_not_nil response.authorization
   end
 
-  def test_successful_purchase_with_client_info
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:client_info => '192.168.0.1'))
+  def test_successful_purchase_with_ip
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:ip => '192.168.0.1'))
     assert_success response
     assert_equal 'The Transaction was approved', response.message
     assert_not_nil response.authorization

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -242,8 +242,8 @@ class PaymentExpressTest < Test::Unit::TestCase
     end
   end
 
-  def test_pass_client_info
-    options = {:client_info => '192.168.0.1'}
+  def test_pass_ip_as_client_info
+    options = {:ip => '192.168.0.1'}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientInfo>192.168.0.1<\/ClientInfo>/, body)


### PR DESCRIPTION
Use the built in ip field instead of a gateway specific field for
sending the ip address with requests.

ECS-124

Unit:
34 tests, 249 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
15 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed