### PR TITLE
Adyen: Idempotency for non-purchase requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Bambora Asia-Pacific: Adds Store [molbrown] #3147
 * Orbital: Pass normalized stored credential fields [curiousepic] #3148
 * Adds Elo card type in general and specifically to Adyen [deedeelavinder] #3153
+* Adyen: Idempotency for non-purchase requests [molbrown] #3157
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -71,6 +71,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Authorised', response.message
   end
 
+  def test_successful_authorize_with_idempotency_key
+    options = @options.merge(idempotency_key: 'test123')
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+    first_auth = response.authorization
+
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_equal response.authorization, first_auth
+  end
+
   def test_successful_authorize_with_3ds
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: true))
     assert response.test?
@@ -110,7 +122,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_purchase
@@ -176,7 +188,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -287,7 +299,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.store(@declined_card, @options)
 
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_purchase_using_stored_card
@@ -326,7 +338,22 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match 'Refused', response.message
+    assert_match 'CVC Declined', response.message
+  end
+
+  def test_verify_with_idempotency_key
+    options = @options.merge(idempotency_key: 'test123')
+    response = @gateway.authorize(0, @credit_card, options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+    first_auth = response.authorization
+
+    response = @gateway.verify(@credit_card, options)
+    assert_success response
+    assert_equal response.authorization, first_auth
+
+    response = @gateway.void(first_auth, @options)
+    assert_success response
   end
 
   def test_invalid_login

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -320,6 +320,26 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal 'Card member\'s name, billing address, and billing postal code match.', response.avs_result['message']
   end
 
+  def test_optional_idempotency_key_header
+    options = @options.merge(:idempotency_key => 'test123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert headers['Idempotency-Key']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_optional_idempotency_key_header_excluded_on_purchase
+    options = @options.merge(:idempotency_key => 'test123')
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      refute headers['Idempotency-Key']
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Support of Idempotency-Key for all actions except purchase, due to
multi-key requirement (design still pending).

ECS-166

Unit:
29 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
43 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed