### PR TITLE
FirstdataE4: Rename to FirstdataE4V11

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4_v11.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v11.rb
@@ -1,6 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
-    class FirstdataE4Gateway < Gateway
+    class FirstdataE4V11Gateway < Gateway
       # TransArmor support requires v11 or lower
       self.test_url = 'https://api.demo.globalgatewaye4.firstdata.com/transaction/v11'
       self.live_url = 'https://api.globalgatewaye4.firstdata.com/transaction/v11'
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['CA', 'US']
       self.default_currency = 'USD'
       self.homepage_url = 'http://www.firstdata.com'
-      self.display_name = 'FirstData Global Gateway e4'
+      self.display_name = 'FirstData Global Gateway e4 v11'
 
       STANDARD_ERROR_CODE_MAPPING = {
         # Bank error codes: https://firstdata.zendesk.com/entries/471297-First-Data-Global-Gateway-e4-Bank-Response-Codes
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         '42' => STANDARD_ERROR_CODE[:processing_error]
       }
 
-      # Create a new FirstdataE4Gateway
+      # Create a new FirstdataE4V11Gateway
       #
       # The gateway requires that a valid login and password be passed
       # in the +options+ hash.

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -343,7 +343,7 @@ first_pay:
   transaction_center_id: 1264
   gateway_id: "a91c38c3-7d7f-4d29-acc7-927b4dca0dbe"
 
-firstdata_e4:
+firstdata_e4_v11:
   login: SD8821-67
   password: T6bxSywbcccbJ19eDXNIGaCDOBg1W7T8
 

--- a/test/remote/gateways/remote_firstdata_e4_v11_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v11_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class RemoteFirstdataE4Test < Test::Unit::TestCase
+class RemoteFirstdataE4V11Test < Test::Unit::TestCase
   def setup
-    @gateway = FirstdataE4Gateway.new(fixtures(:firstdata_e4))
+    @gateway = FirstdataE4V11Gateway.new(fixtures(:firstdata_e4_v11))
     @credit_card = credit_card
     @bad_credit_card = credit_card('4111111111111113')
     @credit_card_with_track_data = credit_card_with_track_data('4003000123456781')
@@ -178,7 +178,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = FirstdataE4Gateway.new(:login    => 'NotARealUser',
+    gateway = FirstdataE4V11Gateway.new(:login    => 'NotARealUser',
                                      :password => 'NotARealPassword')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match %r{Unauthorized Request}, response.message
@@ -231,9 +231,9 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   def test_verify_credentials
     assert @gateway.verify_credentials
 
-    gateway = FirstdataE4Gateway.new(login: 'unknown', password: 'unknown')
+    gateway = FirstdataE4V11Gateway.new(login: 'unknown', password: 'unknown')
     assert !gateway.verify_credentials
-    gateway = FirstdataE4Gateway.new(login: fixtures(:firstdata_e4)[:login], password: 'unknown')
+    gateway = FirstdataE4V11Gateway.new(login: fixtures(:firstdata_e4_v11)[:login], password: 'unknown')
     assert !gateway.verify_credentials
   end
 

--- a/test/unit/gateways/firstdata_e4_v11_test.rb
+++ b/test/unit/gateways/firstdata_e4_v11_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 require 'nokogiri'
 require 'yaml'
 
-class FirstdataE4Test < Test::Unit::TestCase
+class FirstdataE4V11Test < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = FirstdataE4Gateway.new(
+    @gateway = FirstdataE4V11Gateway.new(
       :login    => 'A00427-01',
       :password => 'testus'
     )
@@ -38,7 +38,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Transaction Normal - Approved', response.message
 
-    FirstdataE4Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
+    FirstdataE4V11Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_purchase_with_specified_currency
@@ -51,7 +51,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert_equal 'Transaction Normal - Approved', response.message
     assert_equal 'GBP', response.params['currency']
 
-    FirstdataE4Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
+    FirstdataE4V11Gateway::SENSITIVE_FIELDS.each { |f| assert !response.params.has_key?(f.to_s) }
   end
 
   def test_successful_purchase_with_token
@@ -136,11 +136,11 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['CA', 'US'], FirstdataE4Gateway.supported_countries
+    assert_equal ['CA', 'US'], FirstdataE4V11Gateway.supported_countries
   end
 
   def test_supported_cardtypes
-    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4V11Gateway.supported_cardtypes
   end
 
   def test_avs_result


### PR DESCRIPTION
In preparation to rename FirstdataE4V27 to FirstdataE4, making the names
accurately refer to the support gateway versions.

Unit:
32 tests, 157 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
No currently working test creds.