### PR TITLE
Paymentez: Adds Elo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Mercado Pago: Adds Elo card type [deedeelavinder] #3156
 * Litle: Add support for stored credentials [bayprogrammer] #3155
 * Adyen: Correctly process risk_data option [bayprogrammer] #3161
+* Paymentez: Adds Elo card type [deedeelavinder] #3162
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[MX EC VE CO BR CL]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express diners_club]
+      self.supported_cardtypes = %i[visa master american_express diners_club elo]
 
       self.homepage_url = 'https://secure.paymentez.com/'
       self.display_name = 'Paymentez'
@@ -38,7 +38,8 @@ module ActiveMerchant #:nodoc:
         'visa' => 'vi',
         'master' => 'mc',
         'american_express' => 'ax',
-        'diners_club' => 'di'
+        'diners_club' => 'di',
+        'elo' => 'el'
       }.freeze
 
       def initialize(options = {})


### PR DESCRIPTION
Adds Elo card type.

Unit Tests:
23 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote Tests:
26 tests, 60 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
92.3077% passed

(Both of these failures are unrelated to the changes included. They have
to do with `capture` and succeed when run individually.)