### PR TITLE
Default usaepay errors to processing_error & handle a couple more codes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Adyen: Support for additional AVS code mapping [jknipp] #3236
 * Update message for AVS result code 'A' to generically cover postal code mismatches [jknipp] #3237
 * CyberSource: Update CyberSource SOAP documentation link [vince-smith] #3204
+* USAePay: Handle additional error codes and add default error code [estelendur] #3167
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -6,6 +6,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
     @credit_card_with_track_data = credit_card_with_track_data('4000100011112224')
+    @invalid_transaction_card = credit_card('4000300511112225')
     @check = check
     @options = { :billing_address => address(:zip => '27614', :state => 'NC'), :shipping_address => address }
     @amount = 100
@@ -252,5 +253,11 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
 
     assert_scrubbed(@check.account_number, transcript)
     assert_scrubbed(@gateway.options[:login], transcript)
+  end
+
+  def test_processing_error
+    assert response = @gateway.purchase(@amount, @invalid_transaction_card, @options)
+    assert_equal 'processing_error', response.error_code
+    assert_failure response
   end
 end


### PR DESCRIPTION
USAePay returns a ton of different error codes and currently the usaepay support in active merchant returns a nil for all of the error codes not specifically mapped, which is not useful. So we are defaulting to processing_error for any errors not defined in the standard_error_code_mapping.