### PR TITLE
Adyen: Support idempotency on purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * FirstData e4 v27: Support v28 url and stored creds [curiousepic] #3165
 * WorldPay: Fix element order for 3DS + stored cred [bayprogrammer] #3172
 * Braintree: Add risk data to returned response [jknipp] #3169
+* Adyen: Support idempotency on purchase [molbrown] #3168
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -161,6 +161,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_idempotency_key
+    options = @options.merge(idempotency_key: 'testkey45678')
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+    first_auth = response.authorization
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal response.authorization, first_auth
+  end
+
   def test_successful_purchase_with_apple_pay
     response = @gateway.purchase(@amount, @apple_pay_card, @options)
     assert_success response

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -346,16 +346,6 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_optional_idempotency_key_header_excluded_on_purchase
-    options = @options.merge(:idempotency_key => 'test123')
-    response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
-      refute headers['Idempotency-Key']
-    end.respond_with(successful_authorize_response, successful_capture_response)
-    assert_success response
-  end
-
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Adding capability to send Idempotency-Key on the MultiResponse purchase
action. Modifies a single key so it can be re-used for the capture
request. User can safely re-try `purchase` with the original key since
both requests are idempotent and the key is modified in a fixed way.

Unit:
30 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
50 tests, 146 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-198