### PR TITLE
Braintree: Add risk data fields to response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Adyen: Idempotency for non-purchase requests [molbrown] #3164
 * FirstData e4 v27: Support v28 url and stored creds [curiousepic] #3165
 * WorldPay: Fix element order for 3DS + stored cred [bayprogrammer] #3172
+* Braintree: Add risk data to returned response [jknipp] #3169
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -543,6 +543,17 @@ module ActiveMerchant #:nodoc:
           'token'               => transaction.credit_card_details.token
         }
 
+        if transaction.risk_data
+          risk_data = {
+            'id'                      => transaction.risk_data.id,
+            'decision'                => transaction.risk_data.decision,
+            'device_data_captured'    => transaction.risk_data.device_data_captured,
+            'fraud_service_provider'  => transaction.risk_data.fraud_service_provider
+          }
+        else
+          risk_data = nil
+        end
+
         {
           'order_id'                => transaction.order_id,
           'amount'                  => transaction.amount.to_s,
@@ -553,6 +564,7 @@ module ActiveMerchant #:nodoc:
           'shipping_details'        => shipping_details,
           'vault_customer'          => vault_customer,
           'merchant_account_id'     => transaction.merchant_account_id,
+          'risk_data'               => risk_data,
           'processor_response_code' => response_code_from_result(result)
         }
       end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -179,6 +179,20 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_match %r{number is not an accepted test number}, response.message
   end
 
+  def test_successful_verify_with_device_data
+    # Requires Advanced Fraud Tools to be enabled
+    assert response = @gateway.verify(@credit_card, @options.merge({device_data: 'device data for verify'}))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+
+    assert transaction = response.params['braintree_transaction']
+    assert transaction['risk_data']
+    assert transaction['risk_data']['id']
+    assert_equal 'Approve', transaction['risk_data']['decision']
+    assert_equal false, transaction['risk_data']['device_data_captured']
+    assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
+  end
+
   def test_successful_validate_on_store
     card = credit_card('4111111111111111', :verification_value => '101')
     assert response = @gateway.store(card, :verify_card => true)
@@ -401,6 +415,20 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_purchase_with_device_data
+    # Requires Advanced Fraud Tools to be enabled
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(device_data: 'device data for purchase'))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+
+    assert transaction = response.params['braintree_transaction']
+    assert transaction['risk_data']
+    assert transaction['risk_data']['id']
+    assert_equal 'Approve', transaction['risk_data']['decision']
+    assert_equal false, transaction['risk_data']['device_data_captured']
+    assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
   end
 
   def test_purchase_with_store_using_random_customer_id

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -754,6 +754,21 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), descriptor_name: 'wow*productname', descriptor_phone: '4443331112', descriptor_url: 'wow.com')
   end
 
+  def test_successful_purchase_with_device_data
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:device_data] == 'device data string')
+    end.returns(braintree_result({risk_data: {id: 123456, decision: 'Decline', device_data_captured: true, fraud_service_provider: 'kount'}}))
+
+    response = @gateway.purchase(100, credit_card('41111111111111111111'), device_data: 'device data string')
+
+    assert transaction = response.params['braintree_transaction']
+    assert transaction['risk_data']
+    assert_equal 123456, transaction['risk_data']['id']
+    assert_equal 'Decline', transaction['risk_data']['decision']
+    assert_equal true, transaction['risk_data']['device_data_captured']
+    assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
+  end
+
   def test_apple_pay_card
     Braintree::TransactionGateway.any_instance.expects(:sale).
       with(


### PR DESCRIPTION
Explicitly add the risk data fields to the active merchant response, if
they are provided.

ECS-210

Unit:
59 tests, 158 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
71 tests, 407 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed