### PR TITLE
Realex: Add 3DS

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -145,7 +145,11 @@ module ActiveMerchant
           add_card(xml, credit_card)
           xml.tag! 'autosettle', 'flag' => auto_settle_flag(action)
           add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), amount(money), (options[:currency] || currency(money)), credit_card.number)
-          add_network_tokenization_card(xml, credit_card) if credit_card.is_a?(NetworkTokenizationCreditCard)
+          if credit_card.is_a?(NetworkTokenizationCreditCard)
+            add_network_tokenization_card(xml, credit_card)
+          else
+            add_three_d_secure(xml, options)
+          end
           add_comments(xml, options)
           add_address_and_customer_info(xml, options)
         end
@@ -280,6 +284,16 @@ module ActiveMerchant
         xml.tag! 'supplementarydata' do
           xml.tag! 'item', 'type' => 'mobile' do
             xml.tag! 'field01', payment.source.to_s.gsub('_', '-')
+          end
+        end
+      end
+
+      def add_three_d_secure(xml, options)
+        if options[:three_d_secure]
+          xml.tag! 'mpi' do
+            xml.tag! 'cavv', options[:three_d_secure][:cavv]
+            xml.tag! 'eci', options[:three_d_secure][:eci]
+            xml.tag! 'xid', options[:three_d_secure][:xid]
           end
         end
       end

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -115,6 +115,21 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_match %r{DECLINED}i, response.message
   end
 
+  def test_realex_purchase_with_three_d_secure
+    response = @gateway.purchase(
+      1000,
+      @visa,
+      three_d_secure: {
+        eci: '05', xid: '05', cavv: '05'
+      },
+      :order_id => generate_unique_id,
+      :description => 'Test Realex with 3DS'
+    )
+    assert_success response
+    assert response.test?
+    assert_equal 'Successful', response.message
+  end
+
   def test_realex_purchase_referral_b
     [ @visa_referral_b, @mastercard_referral_b ].each do |card|
       response = @gateway.purchase(@amount, card,


### PR DESCRIPTION
Add support for ECI, XID and CAVV on the XML request for 3D Secure. Following: https://developer.globalpay.com/#!/api/3d-secure-two#3ds2-authorization

```xml
  <mpi>
    <cavv>AAACBllleHchZTBWIGV4AAAAAAA=</cavv>
    <xid>crqAeMwkEL9r4POdxpByWJ1/wYg=</xid>
    <eci>5</eci>
  </mpi>
```

New remote test passes:
```
Loaded suite test/remote/gateways/remote_realex_test
Started
.
Finished in 0.991542 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 3 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.01 tests/s, 3.03 assertions/s
```