### PR TITLE
Monei: Add 3DSecure

### DIFF
--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -133,6 +133,7 @@ module ActiveMerchant #:nodoc:
           add_payment(xml, action, money, options)
           add_account(xml, credit_card)
           add_customer(xml, credit_card, options)
+          add_three_d_secure(xml, options)
         end
 
         commit(request)
@@ -221,6 +222,17 @@ module ActiveMerchant #:nodoc:
           xml.Contact do
             xml.Email options[:email] || 'noemail@monei.net'
             xml.Ip options[:ip] || '0.0.0.0'
+          end
+        end
+      end
+
+      # Private : Add the 3DSecure infos to XML
+      def add_three_d_secure(xml, options)
+        if options[:three_d_secure]
+          xml.ThreeDSecure do
+            xml.eci options[:three_d_secure][:eci]
+            xml.verificationId options[:three_d_secure][:cavv]
+            xml.xid options[:three_d_secure][:xid]
           end
         end
       end

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -13,7 +13,12 @@ class RemoteMoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      three_d_secure: {
+        eci: '1234',
+        cavv: '1234',
+        xid: '1234'
+      }
     }
   end
 

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -17,7 +17,12 @@ class MoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      three_d_secure: {
+        eci: '1234',
+        cavv: '1234',
+        xid: '1234'
+      }
     }
   end
 


### PR DESCRIPTION
Add support for ECI, XID and CAVV on the XML request for 3D Secure. Following: https://docs.monei.net/reference/parameters#td-secure

