### PR TITLE
WorldPay: Fix element order for 3DS + stored cred

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * WorldPay: Adds Elo card type [deedeelavinder] #3163
 * Adyen: Idempotency for non-purchase requests [molbrown] #3164
 * FirstData e4 v27: Support v28 url and stored creds [curiousepic] #3165
+* WorldPay: Fix element order for 3DS + stored cred [bayprogrammer] #3172
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -263,13 +263,13 @@ module ActiveMerchant #:nodoc:
 
               add_address(xml, (options[:billing_address] || options[:address]))
             end
+            add_stored_credential_options(xml, options)
             if options[:ip] && options[:session_id]
               xml.tag! 'session', 'shopperIPAddress' => options[:ip], 'id' => options[:session_id]
             else
               xml.tag! 'session', 'shopperIPAddress' => options[:ip] if options[:ip]
               xml.tag! 'session', 'id' => options[:session_id] if options[:session_id]
             end
-            add_stored_credential_options(xml, options)
           end
         end
       end


### PR DESCRIPTION
WorldPay's XML DTD requires that the `session` comes after
`storedCredentials`. When using stored credential options with a 3DS
request we were ending up with the elements being generated in the wrong
order. This fixes the issue and ensures `storedCredentials` precede
`session` when both are to be included in the request document.

ECS-219

Unit:
44 tests, 242 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
35 tests, 154 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed