### PR TITLE
QuickPay v10: Add 3DS params

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -103,7 +103,7 @@ module ActiveMerchant
         post = {}
 
         add_amount(post, money, options)
-        add_credit_card_or_reference(post, credit_card_or_reference)
+        add_credit_card_or_reference(post, credit_card_or_reference, options)
         add_additional_params(:authorize, post, options)
 
         post
@@ -216,6 +216,12 @@ module ActiveMerchant
           post[:card][:cvd]        = credit_card_or_reference.verification_value
           post[:card][:expiration] = expdate(credit_card_or_reference)
           post[:card][:issued_to]  = credit_card_or_reference.name
+        end
+
+        if options[:three_d_secure]
+          post[:card][:cavv]= options.dig(:three_d_secure, :cavv)
+          post[:card][:eci] = options.dig(:three_d_secure, :eci)
+          post[:card][:xav] = options.dig(:three_d_secure, :xid)
         end
       end
 

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -95,6 +95,23 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert_equal 'OK', capture.message
   end
 
+  def test_successful_authorize_and_capture_with_3ds
+    options = @options.merge(
+      three_d_secure: {
+        cavv: '1234',
+        eci: '1234',
+        xid: '1234'
+      }
+    )
+    assert auth = @gateway.authorize(@amount, @valid_card, options)
+    assert_success auth
+    assert_equal 'OK', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'OK', capture.message
+  end
+
   def test_unsuccessful_authorize_and_capture
     assert auth = @gateway.authorize(@amount, @capture_rejected_card, @options)
     assert_success auth


### PR DESCRIPTION
Add support for 3DSecure for QuickPay v10. 

From the documentation : https://learn.quickpay.net/tech-talk/api/services/#POST-payments--id-authorize---format-

