### PR TITLE
VisaNet Peru: Always include DSC_COD_ACCION

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Adyen: Fix adding phone from billing address [curiousepic] #3179
 * Fix partial or missing address exceptions [molbrown] #3180
 * Adyen: Update to support normalized stored credential fields [molbrown] #3182
+* VisaNet Peru: Always include DSC_COD_ACCION [bayprogrammer] #3174
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/test/remote/gateways/remote_visanet_peru_test.rb
+++ b/test/remote/gateways/remote_visanet_peru_test.rb
@@ -73,17 +73,21 @@ class RemoteVisanetPeruTest < Test::Unit::TestCase
     assert_equal '1.99', response.params['data']['IMP_AUTORIZADO']
   end
 
-  def test_failed_authorize
+  def test_failed_authorize_declined_card
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 400, response.error_code
     assert_equal 'Operacion Denegada.', response.message
+  end
 
+  def test_failed_authorize_bad_email
     @options[:email] = 'cybersource@reject.com'
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 400, response.error_code
-    assert_equal 'REJECT', response.message
+
+    # this also exercises message joining for errorMessage and DSC_COD_ACCION when both are present
+    assert_equal 'REJECT | Operacion denegada', response.message
   end
 
   def test_failed_capture

--- a/test/unit/gateways/visanet_peru_test.rb
+++ b/test/unit/gateways/visanet_peru_test.rb
@@ -60,7 +60,7 @@ class VisanetPeruTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 400, response.error_code
-    assert_equal 'REJECT', response.message
+    assert_equal 'REJECT | Operacion denegada', response.message
   end
 
   def test_successful_capture
@@ -102,6 +102,27 @@ class VisanetPeruTest < Test::Unit::TestCase
     assert_failure response
     assert_match(/No se realizo la anulacion del deposito/, response.message)
     assert_equal 400, response.error_code
+  end
+
+  def test_failed_full_refund_when_unsettled
+    @gateway.expects(:ssl_request).with(:put, any_parameters).returns(failed_refund_response)
+    @gateway.expects(:ssl_request).with(:post, any_parameters).returns(failed_refund_with_action_code_response)
+    response = @gateway.refund(@amount, '122333444|444333221', force_full_refund_if_unsettled: true)
+    assert_failure response
+    assert_equal("Operacion Denegada. | [ 'NUMORDEN 122333444 no se encuentra registrado', 'No se realizo la anulacion del deposito' ]", response.message)
+    assert_equal 400, response.error_code
+  end
+
+  def test_failed_full_refund_when_unsettled_additional_message_concatenation
+    @gateway.expects(:ssl_request).with(:put, any_parameters).returns(failed_refund_with_message_and_action_code_response)
+    @gateway.expects(:ssl_request).with(:post, any_parameters).returns(failed_refund_with_message_and_action_code_response_2)
+    first_msg = 'No se realizo la anulacion del deposito'
+    first_dsc = 'Operacion Denegada.'
+    second_msg = 'Mal funcionamiento de la inteligencia artificial'
+    second_dsc = 'Lo siento Dave, me temo que no puedo hacer eso.'
+
+    response = @gateway.refund(@amount, '122333444|444333221', force_full_refund_if_unsettled: true)
+    assert_equal("#{second_msg} | #{second_dsc} | #{first_msg} | #{first_dsc}", response.message)
   end
 
   def test_successful_void
@@ -446,4 +467,56 @@ class VisanetPeruTest < Test::Unit::TestCase
     }
     RESPONSE
   end
+
+  def failed_refund_with_action_code_response
+    <<-RESPONSE
+    {
+      "errorCode": 400,
+      "errorMessage": "[ ]",
+      "data": {
+        "ESTADO": "",
+        "RESPUESTA": "2",
+        "DSC_COD_ACCION": "Operacion Denegada."
+      },
+      "transactionLog": {
+
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_refund_with_message_and_action_code_response
+    <<-RESPONSE
+    {
+      "errorCode": 400,
+      "errorMessage": "No se realizo la anulacion del deposito",
+      "data": {
+        "ESTADO": "",
+        "RESPUESTA": "2",
+        "DSC_COD_ACCION": "Operacion Denegada."
+      },
+      "transactionLog": {
+
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_refund_with_message_and_action_code_response_2
+    <<-RESPONSE
+    {
+      "errorCode": 400,
+      "errorMessage": "Mal funcionamiento de la inteligencia artificial",
+      "data": {
+        "ESTADO": "",
+        "RESPUESTA": "2",
+        "DSC_COD_ACCION": "Lo siento Dave, me temo que no puedo hacer eso."
+      },
+      "transactionLog": {
+
+      }
+    }
+    RESPONSE
+  end
+
 end


### PR DESCRIPTION
@nfarve could you check my thinking on this draft pull request? I'm working on a ticket (ECS-173) where I need to modify this adapter to add extra information to messages, but the existing message extraction logic is a bit tricky and I can't quite tell if it was doing what we expected or not.

-----

**VisaNet Peru: Ensure msg kept on bad cancelDeposit**

Looking at:

https://github.com/activemerchant/active_merchant/pull/2772#discussion_r174914253

It seems our intent is to stash the errorMessage in options so it can be added
to a follow up request if the follow up request fails (this would only happen
when the user has opted to force a full refund for an unsettled refund, if I'm
understanding the logic correctly).

However, when I went to add a test ensuring my understanding is correct it
seems we may have been checking for the wrong action for this "keep error
message before retrying full refund" logic, and it wasn't getting saved in the
option hash as I expected.

I've added a test that works the way I *expect* it to, then modified the
`message_from` implementation to make the test pass. I don't know for sure
whether this is correct, but I need to make sure the logic is correct here
before I can proceed with the fix for ECS-173 (where I'm going to add extra
information to the message).

ECS-173

Units:
14 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remotes:
17 tests, 25 assertions, 15 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
11.7647% passed

(Most of the remote tests are failing because our test credentials are bad and
we've not been able to get new ones yet).