### PR TITLE
Allow to pass empty `landing_page` parameter

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -146,9 +146,9 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'n2:cpp-payflow-color', options[:background_color] unless options[:background_color].blank?
               if options[:allow_guest_checkout]
                 xml.tag! 'n2:SolutionType', 'Sole'
-                xml.tag! 'n2:LandingPage', options[:landing_page] || 'Billing'
-              elsif options[:paypal_chooses_landing_page]
-                xml.tag! 'n2:SolutionType', 'Sole'
+                unless options[:paypal_chooses_landing_page]
+                  xml.tag! 'n2:LandingPage', options[:landing_page] || 'Billing'
+                end
               end
               xml.tag! 'n2:BuyerEmail', options[:email] unless options[:email].blank?
 

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -147,6 +147,8 @@ module ActiveMerchant #:nodoc:
               if options[:allow_guest_checkout]
                 xml.tag! 'n2:SolutionType', 'Sole'
                 xml.tag! 'n2:LandingPage', options[:landing_page] || 'Billing'
+              elsif options[:paypal_chooses_landing_page]
+                xml.tag! 'n2:SolutionType', 'Sole'
               end
               xml.tag! 'n2:BuyerEmail', options[:email] unless options[:email].blank?
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -642,6 +642,13 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
 
+  def test_paypal_chooses_landing_page
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:paypal_chooses_landing_page=> true}))
+
+    assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
+    assert_nil REXML::XPath.first(xml, '//n2:LandingPage')
+  end
+
   def test_not_adds_brand_name_if_not_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -643,7 +643,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_paypal_chooses_landing_page
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:paypal_chooses_landing_page=> true}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_guest_checkout => true, :paypal_chooses_landing_page=> true}))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_nil REXML::XPath.first(xml, '//n2:LandingPage')


### PR DESCRIPTION
PayPal has logic in their javascript to determine if a visitor should see the sign-in page or the guest checkout page.

This kicks in only when the `landing_page` parameter is not sent and the logic is based off cookies.