### PR TITLE
Fix partial or missing address exceptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Adyen: Support idempotency on purchase [molbrown] #3168
 * Adyen: Pass phone, statement, device_fingerprint [curiousepic] #3178
 * Adyen: Fix adding phone from billing address [curiousepic] #3179
+* Fix partial or missing address exceptions [molbrown] #3180
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
         post[:payer][:name] = card.name
         post[:payer][:email] = options[:email] if options[:email]
         post[:payer][:birth_date] = options[:birth_date] if options[:birth_date]
-        post[:payer][:phone] = address[:phone] if address[:phone]
+        post[:payer][:phone] = address[:phone] if address && address[:phone]
         post[:payer][:document] = options[:document] if options[:document]
         post[:payer][:document2] = options[:document2] if options[:document2]
         post[:payer][:user_reference] = options[:user_reference] if options[:user_reference]

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -128,8 +128,8 @@ module ActiveMerchant #:nodoc:
       def add_shipping_address(post, options)
         if address = options[:shipping_address]
           post[:address] = {}
-          post[:address][:street] = address[:address1].match(/\D+/)[0].strip if address[:address1]
-          post[:address][:number] = address[:address1].match(/\d+/)[0] if address[:address1]
+          post[:address][:street] = address[:address1].match(/\D+/)[0].strip if address[:address1]&.match(/\D+/)
+          post[:address][:number] = address[:address1].match(/\d+/)[0] if address[:address1]&.match(/\d+/)
           post[:address][:compliment] = address[:address2] if address[:address2]
           post[:address][:city] = address[:city] if address[:city]
           post[:address][:state] = address[:state] if address[:state]

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -39,6 +39,15 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal 'D-15104-be03e883-3e6b-497d-840e-54c8b6209bc3', response.authorization
   end
 
+  def test_successful_authorize_without_address
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options.delete(:billing_address))
+    assert_success response
+
+    assert_equal 'D-15104-be03e883-3e6b-497d-840e-54c8b6209bc3', response.authorization
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
 

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -63,6 +63,20 @@ class MundipaggTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_authorize_with_partially_missing_address
+    shipping_address = {
+      country: 'BR',
+      address1: 'Foster St.'
+    }
+
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(shipping_address: shipping_address))
+    assert_success response
+
+    assert_equal 'ch_gm5wrlGMI2Fb0x6K', response.authorization
+    assert response.test?
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
 


### PR DESCRIPTION
NilClass errors noted in attempted transactions for DLocal and Mundipagg gateways,
due to absent objects. Made small fixes that will avoid this error.

Mundipagg Unit tests:
17 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

DLocal Unit tests:
16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed