### PR TITLE
Adyen: Update to support normalized stored credential fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Adyen: Pass phone, statement, device_fingerprint [curiousepic] #3178
 * Adyen: Fix adding phone from billing address [curiousepic] #3179
 * Fix partial or missing address exceptions [molbrown] #3180
+Adyen: Update to support normalized stored credential fields [molbrown] #3182
 
 == Version 1.91.0 (February 22, 2019)
 * WorldPay: Pull CVC and AVS Result from Response [nfarve] #3106

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -61,7 +61,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      recurring_processing_model: 'CardOnFile'
+      stored_credential: {reason_type: 'unscheduled'}
     }
   end
 


### PR DESCRIPTION
Adapter already supports defining shopperInteraction and
recurringProcessingModel directly. Adding ability to define these fields
using the normalized hash (which can be overidden by passing the fields
directly). Maintains using verification value or Network Tokenization
cards to define shopperInteraction.

ECS-213

Unit:
32 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
52 tests, 149 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed