### PR TITLE
Do not consider a refund unsuccessful if only refunding the fee failed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 == HEAD
 
+* Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188
+
 == Version 1.91.0 (April 8, 2019)
 * BluePay: Send customer IP address when provided [jknipp] #3149
 * PaymentExpress: Use ip field for client_info field [jknipp] #3150

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -686,7 +686,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   # What is the significance of this??? it's to test that the first response is used as primary. so identical to above with an extra assertion
-  def test_refund_with_fee_response_gives_a_charge_authorization
+  def test_refund_with_fee_response_responds_with_the_refund_authorization
     s = sequence('request')
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(successful_fetch_application_fee_response).in_sequence(s)
@@ -697,24 +697,23 @@ class StripeTest < Test::Unit::TestCase
     assert_equal 're_test_refund', response.authorization
   end
 
-  def test_unsuccessful_refund_with_refund_fee_amount_when_application_fee_id_not_found
+  def test_successful_refund_with_failed_fee_refund_fetch
     s = sequence('request')
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(unsuccessful_fetch_application_fee_response).in_sequence(s)
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
-    assert_failure response
-    assert_match(/^Application fee id could not be retrieved/, response.message)
+    assert_success response
   end
 
-  def test_unsuccessful_refund_with_refund_fee_amount_when_refunding_application_fee
+  def test_successful_refund_with_failed_fee_refund
     s = sequence('request')
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(successful_fetch_application_fee_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(generic_error_response).in_sequence(s)
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
-    assert_failure response
+    assert_success response
   end
 
   def test_successful_verify


### PR DESCRIPTION
Fixes https://github.com/activemerchant/active_merchant/issues/3116

When specifying the `refund_fee_amount` on a Refund using the Stripe
gateway, Active Merchant makes three different API requests:

1. Issue the actual refund against the charge
2. Fetch the charge to get the application fee identifier
3. Issue the application fee refund against the original application fee

Currently, if either 2 or 3 fail while 1 succeeds, the `#refund`
method's response is a failure, which is not true. This process is not
transactional. The refund had succeeded and is not rolled back, which
isn't possible to do anyway.

This addresses this problem by always responding with the status
of the refund, regardless of what happened with the fee refund.
There is no way to make this process transactional. You may send
complaints to Stripe 😉 