### PR TITLE
Adyen: Support adjust action

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -76,6 +76,13 @@ module ActiveMerchant #:nodoc:
         commit('cancel', post, options)
       end
 
+      def adjust(money, authorization, options={})
+        post = init_post(options)
+        add_invoice_for_modification(post, money, options)
+        add_reference(post, authorization, options)
+        commit('adjustAuthorisation', post, options)
+      end
+
       def store(credit_card, options={})
         requires!(options, :order_id)
         post = init_post(options)
@@ -367,7 +374,7 @@ module ActiveMerchant #:nodoc:
         case action.to_s
         when 'authorise', 'authorise3d'
           ['Authorised', 'Received', 'RedirectShopper'].include?(response['resultCode'])
-        when 'capture', 'refund', 'cancel'
+        when 'capture', 'refund', 'cancel', 'adjustAuthorisation'
           response['response'] == "[#{action}-received]"
         else
           false

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -305,6 +305,36 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Original pspReference required for this operation', response.message
   end
 
+  def test_successful_adjust
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    assert adjust = @gateway.adjust(200, authorize.authorization)
+    assert_success adjust
+    assert_equal '[adjustAuthorisation-received]', adjust.message
+  end
+
+  def test_successful_adjust_and_capture
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    assert adjust = @gateway.adjust(200, authorize.authorization)
+    assert_success adjust
+    assert_equal '[adjustAuthorisation-received]', adjust.message
+
+    assert capture = @gateway.capture(200, authorize.authorization)
+    assert_success capture
+  end
+
+  def test_failed_adjust
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert response = @gateway.adjust(200, '')
+    assert_failure response
+    assert_equal 'Original pspReference required for this operation', response.message
+  end
+
   def test_successful_store
     assert response = @gateway.store(@credit_card, @options)
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -270,6 +270,21 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_adjust
+    @gateway.expects(:ssl_post).returns(successful_adjust_response)
+    response = @gateway.adjust(200, '8835544088660594')
+    assert_equal '8835544088660594#8835544088660594#', response.authorization
+    assert_equal '[adjustAuthorisation-received]', response.message
+    assert response.test?
+  end
+
+  def test_failed_adjust
+    @gateway.expects(:ssl_post).returns(failed_adjust_response)
+    response = @gateway.adjust(200, '')
+    assert_equal 'Original pspReference required for this operation', response.message
+    assert_failure response
+  end
+
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
@@ -623,6 +638,26 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def failed_void_response
+    <<-RESPONSE
+    {
+      "status":422,
+      "errorCode":"167",
+      "message":"Original pspReference required for this operation",
+      "errorType":"validation"
+    }
+    RESPONSE
+  end
+
+  def successful_adjust_response
+    <<-RESPONSE
+    {
+      "pspReference": "8835544088660594",
+      "response": "[adjustAuthorisation-received]"
+    }
+    RESPONSE
+  end
+
+  def failed_adjust_response
     <<-RESPONSE
     {
       "status":422,


### PR DESCRIPTION
This adds support for Adyen's adjustAuthorization action, which can
change the amount of a prior authorization, either increasing or
decreasing the amount and extending the auth period. There is no other
precedent for this type of action in ActiveMerchant, but it seems very
straightforward and simple to support, similar to other followup actions
like refunds and voids.

Remote:
55 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
34 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed