### PR TITLE
Stripe: Fix webhook creation for connected account

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188
+* Stripe: Fix webhook creation for connected account [jknipp] #3193
 
 == Version 1.91.0 (April 8, 2019)
 * BluePay: Send customer IP address when provided [jknipp] #3149

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -313,6 +313,8 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:url] = options[:callback_url]
         post[:enabled_events] = events
+        post[:connect] = true if options[:stripe_account]
+        options.delete(:stripe_account)
         commit(:post, 'webhook_endpoints', post, options)
       end
 


### PR DESCRIPTION
Don't send the Stripe connect account id when creating webhooks. Instead
indicate the webhook should receive events from the connected
account, if the stripe account is present.

ECS-242

Unit:
134 tests, 719 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote 3DS Tests:
7 tests, 26 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Connect Tests:
4 tests, 14 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed