### PR TITLE
Fix number lengths for both VR and Sodexo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195
+
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188
 * Stripe: Fix webhook creation for connected account [jknipp] #3193

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -13,8 +13,8 @@ module ActiveMerchant #:nodoc:
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
         'maestro'            => ->(num) { (12..19).cover?(num&.size) && in_bin_range?(num.slice(0, 6), MAESTRO_RANGES) },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
-        'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{8}$/ },
-        'vr'                 => ->(num) { num =~ /^(627416|637036)\d{8}$/ },
+        'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
+        'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
         'carnet'             => lambda { |num|
           num&.size == 16 && (
             in_bin_range?(num.slice(0, 6), CARNET_RANGES) ||

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -7,7 +7,11 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
-    @voucher = credit_card('60607044957644', brand: 'sodexo')
+    @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
+    # Mundipagg only allows certain card numbers for success and failure scenarios.
+    # As such, we cannot use a card number with a BIN belonging to VR.
+    # See https://docs.mundipagg.com/docs/simulador-de-voucher.
+    @vr_voucher = credit_card('4000000000000010', brand: 'vr')
     @options = {
       billing_address: address({neighborhood: 'Sesame Street'}),
       description: 'Store Purchase'
@@ -39,9 +43,16 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_successful_purchase_with_voucher
+  def test_successful_purchase_with_sodexo_voucher
     @options.update(holder_document: '93095135270')
-    response = @gateway.purchase(@amount, @voucher, @options)
+    response = @gateway.purchase(@amount, @sodexo_voucher, @options)
+    assert_success response
+    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+  end
+
+  def test_successful_purchase_with_vr_voucher
+    @options.update(holder_document: '93095135270')
+    response = @gateway.purchase(@amount, @vr_voucher, @options)
     assert_success response
     assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
   end
@@ -111,18 +122,36 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     assert_success void
   end
 
-  def test_successful_void_with_voucher
+  def test_successful_void_with_sodexo_voucher
     @options.update(holder_document: '93095135270')
-    auth = @gateway.purchase(@amount, @voucher, @options)
+    auth = @gateway.purchase(@amount, @sodexo_voucher, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
   end
 
-  def test_successful_refund_with_voucher
+  def test_successful_void_with_vr_voucher
     @options.update(holder_document: '93095135270')
-    auth = @gateway.purchase(@amount, @voucher, @options)
+    auth = @gateway.purchase(@amount, @vr_voucher, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_refund_with_sodexo_voucher
+    @options.update(holder_document: '93095135270')
+    auth = @gateway.purchase(@amount, @sodexo_voucher, @options)
+    assert_success auth
+
+    assert void = @gateway.refund(1, auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_refund_with_vr_voucher
+    @options.update(holder_document: '93095135270')
+    auth = @gateway.purchase(@amount, @vr_voucher, @options)
     assert_success auth
 
     assert void = @gateway.refund(1, auth.authorization)

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -125,11 +125,11 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   end
 
   def test_should_detect_sodexo_card
-    assert_equal 'sodexo', CreditCard.brand?('60606944957644')
+    assert_equal 'sodexo', CreditCard.brand?('6060694495764400')
   end
 
   def test_should_detect_vr_card
-    assert_equal 'vr', CreditCard.brand?('63703644957644')
+    assert_equal 'vr', CreditCard.brand?('6370364495764400')
   end
 
   def test_should_detect_elo_card


### PR DESCRIPTION
When first implemented, we were under the impression that these card
types only supported 14 digits. After some production usage and confirmation
from the card issuers, it turns out they only support 16 digits. This
modifies the brand detection mechanism ensure 16 digit numbers are
supported.

Unit:
4044 tests, 69009 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed

Mundipagg Remote:
23 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed