### PR TITLE
Stripe: Support show and list webhook endpoints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195
+* Stripe: Support show and list webhook endpoints [jknipp] #3196
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -322,6 +322,18 @@ module ActiveMerchant #:nodoc:
         commit(:delete, "webhook_endpoints/#{options[:webhook_id]}", {}, options)
       end
 
+      def show_webhook_endpoint(options)
+        options.delete(:stripe_account)
+        commit(:get, "webhook_endpoints/#{options[:webhook_id]}", nil, options)
+      end
+
+      def list_webhook_endpoints(options)
+        params = {}
+        params[:limit] = options[:limit] if options[:limit]
+        options.delete(:stripe_account)
+        commit(:get, "webhook_endpoints?#{post_data(params)}", nil, options)
+      end
+
       def create_post_for_auth_or_purchase(money, payment, options)
         post = {}
 

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -53,12 +53,22 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     response = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
+    assert_equal 'enabled', response.params['status']
+    assert_nil response.params['application']
+
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    assert_equal true, deleted_response.params['deleted']
   end
 
   def test_create_webhook_endpoint_on_connected_account
     response = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
+    assert_equal 'enabled', response.params['status']
+    assert_not_nil response.params['application']
+
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    assert_equal true, deleted_response.params['deleted']
   end
 
   def test_delete_webhook_endpoint
@@ -74,4 +84,49 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_equal response.params['id'], webhook.params['id']
     assert_equal true, response.params['deleted']
   end
+
+  def test_show_webhook_endpoint
+    webhook = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
+    response = @gateway.send(:show_webhook_endpoint,  @options.merge(:webhook_id => webhook.params['id']))
+    assert_includes response.params['enabled_events'], 'source.chargeable'
+    assert_equal @options[:callback_url], response.params['url']
+    assert_equal 'enabled', response.params['status']
+    assert_nil response.params['application']
+
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    assert_equal true, deleted_response.params['deleted']
+  end
+
+  def test_show_webhook_endpoint_on_connected_account
+    webhook = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
+    response = @gateway.send(:show_webhook_endpoint,  @options.merge({:webhook_id => webhook.params['id'], stripe_account: @stripe_account}))
+
+    assert_includes response.params['enabled_events'], 'source.chargeable'
+    assert_equal @options[:callback_url], response.params['url']
+    assert_equal 'enabled', response.params['status']
+    assert_not_nil response.params['application']
+
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    assert_equal true, deleted_response.params['deleted']
+  end
+
+  def test_list_webhook_endpoints
+    webhook1 = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
+    webhook2 = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
+    assert_nil webhook1.params['application']
+    assert_not_nil webhook2.params['application']
+
+    response = @gateway.send(:list_webhook_endpoints,  @options.merge({limit: 100}))
+    assert_not_nil response.params
+    assert_equal 'list', response.params['object']
+    assert response.params['data'].size >= 2
+    webhook_id_set = Set.new(response.params['data'].map { |webhook| webhook['id'] }.uniq)
+    assert Set[webhook1.params['id'], webhook2.params['id']].subset?(webhook_id_set)
+
+    deleted_response1 = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook1.params['id']))
+    deleted_response2 = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook2.params['id']))
+    assert_equal true, deleted_response1.params['deleted']
+    assert_equal true, deleted_response2.params['deleted']
+  end
+
 end


### PR DESCRIPTION
Add support for listing and showing webhook endpoints.

ECS-289

Unit:

134 tests, 718 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Stripe 3DS:

10 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed