### PR TITLE
CardConnect: Add frontendid parameter to requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195
 * Stripe: Support show and list webhook endpoints [jknipp] #3196
+* CardConnect: Add frontendid parameter to requests [gcatlin] #3198
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -267,6 +267,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters, verb: :put, path: '')
+        parameters[:frontendid] = application_id
         parameters[:merchid] = @options[:merchant_id]
         url = url(action, path)
         response = parse(ssl_request(verb, url, post_data(parameters), headers))

--- a/test/unit/gateways/card_connect_test.rb
+++ b/test/unit/gateways/card_connect_test.rb
@@ -199,6 +199,17 @@ class CardConnectTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_frontendid_is_added_to_post_data_parameters
+    @gateway.class.application_id = 'my_app'
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_, _, body|
+      assert_equal 'my_app', JSON.parse(body)['frontendid']
+    end.respond_with(successful_purchase_response)
+  ensure
+    @gateway.class.application_id = nil
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Add `frontendid` parameter to request bodies using the gateway's
application_id as the value. This enables CardConnect to internally
account for their costs by attributing transactions to the originating
application / platform associated with the frontendid.

ECS-287

Closes #3198 

Unit:
22 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
23 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed