### PR TITLE
add deviceFingerprintID to cybersource payment gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -669,7 +669,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         if payment_method_or_reference.is_a?(String)
-          add_line_item_data if options[:line_items]
+          add_line_item_data(xml, options) if options[:line_items]
           add_address(xml, payment_method_or_reference, options[:billing_address], options) if options[:billing_address]
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true) if options[:shipping_address]
           add_purchase_data(xml, money, true, options)
@@ -679,7 +679,7 @@ module ActiveMerchant #:nodoc:
           add_purchase_data(xml, money, true, options)
           add_check(xml, payment_method_or_reference)
         else
-          add_line_item_data if options[:line_items]
+          add_line_item_data(xml, options) if options[:line_items]
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true)
           add_purchase_data(xml, money, true, options)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -669,6 +669,9 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         if payment_method_or_reference.is_a?(String)
+          add_line_item_data if options[:line_items]
+          add_address(xml, payment_method_or_reference, options[:billing_address], options) if options[:billing_address]
+          add_address(xml, payment_method_or_reference, options[:shipping_address], options, true) if options[:shipping_address]
           add_purchase_data(xml, money, true, options)
           add_subscription(xml, options, payment_method_or_reference)
         elsif card_brand(payment_method_or_reference) == 'check'

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -300,6 +300,7 @@ module ActiveMerchant #:nodoc:
           add_payment_network_token(xml) if network_tokenization?(payment_method_or_reference)
           add_business_rules_data(xml, payment_method_or_reference, options) unless options[:pinless_debit_card]
         end
+        add_device_fingerprint_id(xml, options)
         xml.target!
       end
 
@@ -365,6 +366,7 @@ module ActiveMerchant #:nodoc:
         end
         add_subscription_create_service(xml, options)
         add_business_rules_data(xml, payment_method, options)
+        add_device_fingerprint_id(xml, options)
         xml.target!
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -260,6 +260,7 @@ module ActiveMerchant #:nodoc:
         add_threeds_services(xml, options)
         add_payment_network_token(xml) if network_tokenization?(creditcard_or_reference)
         add_business_rules_data(xml, creditcard_or_reference, options)
+        add_device_fingerprint_id(xml, options)
         add_stored_credential_options(xml, options)
         xml.target!
       end
@@ -707,6 +708,12 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
         else
           xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
+        end
+      end
+      
+      def add_device_fingerprint_id(xml, options={})
+        if options[:device_fingerprint_id]
+          xml.tag! 'deviceFingerprintID', options[:device_fingerprint_id]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -679,6 +679,7 @@ module ActiveMerchant #:nodoc:
           add_purchase_data(xml, money, true, options)
           add_check(xml, payment_method_or_reference)
         else
+          add_line_item_data if options[:line_items]
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true)
           add_purchase_data(xml, money, true, options)


### PR DESCRIPTION
Some countries require the deviceFingerprintID tag in order to get production keys