### PR TITLE
Adyen: Correct formatting of Billing Address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195
 * Stripe: Support show and list webhook endpoints [jknipp] #3196
 * CardConnect: Add frontendid parameter to requests [gcatlin] #3198
+* Adyen: Correct formatting of Billing Address [nfarve] #3200
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -214,13 +214,13 @@ module ActiveMerchant #:nodoc:
       def add_address(post, options)
         return unless post[:card]&.kind_of?(Hash)
         if (address = options[:billing_address] || options[:address]) && address[:country]
-          post[:card][:billingAddress] = {}
-          post[:card][:billingAddress][:street] = address[:address1] || 'N/A'
-          post[:card][:billingAddress][:houseNumberOrName] = address[:address2] || 'N/A'
-          post[:card][:billingAddress][:postalCode] = address[:zip] if address[:zip]
-          post[:card][:billingAddress][:city] = address[:city] || 'N/A'
-          post[:card][:billingAddress][:stateOrProvince] = address[:state] || 'N/A'
-          post[:card][:billingAddress][:country] = address[:country] if address[:country]
+          post[:billingAddress] = {}
+          post[:billingAddress][:street] = address[:address1] || 'N/A'
+          post[:billingAddress][:houseNumberOrName] = address[:address2] || 'N/A'
+          post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
+          post[:billingAddress][:city] = address[:city] || 'N/A'
+          post[:billingAddress][:stateOrProvince] = address[:state] || 'N/A'
+          post[:billingAddress][:country] = address[:country] if address[:country]
         end
       end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -346,12 +346,12 @@ class AdyenTest < Test::Unit::TestCase
     @options[:billing_address].delete(:address2)
     @options[:billing_address].delete(:state)
     @gateway.send(:add_address, post, @options)
-    assert_equal 'N/A', post[:card][:billingAddress][:street]
-    assert_equal 'N/A', post[:card][:billingAddress][:houseNumberOrName]
-    assert_equal 'N/A', post[:card][:billingAddress][:stateOrProvince]
-    assert_equal @options[:billing_address][:zip], post[:card][:billingAddress][:postalCode]
-    assert_equal @options[:billing_address][:city], post[:card][:billingAddress][:city]
-    assert_equal @options[:billing_address][:country], post[:card][:billingAddress][:country]
+    assert_equal 'N/A', post[:billingAddress][:street]
+    assert_equal 'N/A', post[:billingAddress][:houseNumberOrName]
+    assert_equal 'N/A', post[:billingAddress][:stateOrProvince]
+    assert_equal @options[:billing_address][:zip], post[:billingAddress][:postalCode]
+    assert_equal @options[:billing_address][:city], post[:billingAddress][:city]
+    assert_equal @options[:billing_address][:country], post[:billingAddress][:country]
   end
 
   def test_authorize_with_network_tokenization_credit_card_no_name


### PR DESCRIPTION
With the upgrade of Adyen to version 40, the billing address was removed
from the card object. This corrects the format and returns the two tests
that fail when you pass an incorrect country or state. In order to see
AVS results you may need to make some configuration changes to your
account.

https://docs.adyen.com/developers/api-reference/payments-api#paymentresultadditionaldata

Loaded suite test/remote/gateways/remote_adyen_test
........................................................

56 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/adyen_test
Started
..................................

34 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed