### PR TITLE
Elavon: Send ssl_transaction_currency if not USD

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Checkout V2: Checkout V2: Correct success criteria [curiousepic] #3205
 * Adyen: Add normalized hash of 3DS 2.0 data fields from web browsers [davidsantoso] #3207
 * Stripe: Do not attempt application fee refund if refund was not successful [jasonwebster] #3206
+* Elavon: Send transaction_currency if currency is provided [gcatlin] #3201
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -42,6 +42,7 @@ module ActiveMerchant #:nodoc:
         else
           add_creditcard(form, payment_method)
         end
+        add_currency(form, money, options)
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
@@ -54,6 +55,7 @@ module ActiveMerchant #:nodoc:
         add_salestax(form, options)
         add_invoice(form, options)
         add_creditcard(form, creditcard)
+        add_currency(form, money, options)
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
@@ -69,6 +71,7 @@ module ActiveMerchant #:nodoc:
           add_approval_code(form, authorization)
           add_invoice(form, options)
           add_creditcard(form, options[:credit_card])
+          add_currency(form, money, options)
           add_customer_data(form, options)
           add_test_mode(form, options)
         else
@@ -102,6 +105,7 @@ module ActiveMerchant #:nodoc:
         form = {}
         add_invoice(form, options)
         add_creditcard(form, creditcard)
+        add_currency(form, money, options)
         add_address(form, options)
         add_customer_data(form, options)
         add_test_mode(form, options)
@@ -176,6 +180,10 @@ module ActiveMerchant #:nodoc:
 
         form[:first_name] = truncate(creditcard.first_name, 20)
         form[:last_name] = truncate(creditcard.last_name, 30)
+      end
+
+      def add_currency(form, money, options)
+        form[:transaction_currency] = options[:currency] if options[:currency]
       end
 
       def add_token(form, token)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -276,9 +276,9 @@ efsnet:
 
 # Provided for url update test
 elavon:
-  login: "000127"
-  user: ssltest
-  password: "IERAOBEE5V0D6Q3Q6R51TG89XAIVGEQ3LGLKMKCKCVQBGGGAU7FN627GPA54P5HR"
+  login: "009006"
+  user: "devportal"
+  password: "XWJS3QTFCH40HW0QGHJKXAYADCTDH0TXXAKXAEZCGCCJ29CFNPCZT4KA9D5KQMDA"
 
 element:
   account_id: "1013963"

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -205,6 +205,15 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_currency
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'JPY'))
+
+    assert_success response
+    assert response.test?
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Elavon returns an error for any API request that includes a currency
UNLESS the merchant's terminal is setup for multi-currency. Previously
we NEVER sent the currency, so only the default currency worked. Now, we
only send the `ssl_transaction_currency` field if the currency is not
the default currency (USD).

Elavon Multi-Currency Conversion (MCC) documentation:
https://developer.elavon.com/#/api/eb6e9106-0172-4305-bc5a-b3ebe832f823.rcosoomi/documents?converge-integration-guide/book/processing_options/../../book/processing_options/mcc.html

ECS-272

Closes #3201 

Unit:
29 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
24 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed