### PR TITLE
Stripe: Show payment source

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Stripe: Support show and list webhook endpoints [jknipp] #3196
 * CardConnect: Add frontendid parameter to requests [gcatlin] #3198
 * Adyen: Correct formatting of Billing Address [nfarve] #3200
+* Stripe: Stripe: Show payment source [jknipp] #3202
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -309,6 +309,10 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'sources', post, options)
       end
 
+      def show_source(source_id, options)
+        commit(:get, "sources/#{source_id}", nil, options)
+      end
+
       def create_webhook_endpoint(options, events)
         post = {}
         post[:url] = options[:callback_url]

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -49,6 +49,18 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_equal false, response.params['three_d_secure']['authenticated']
   end
 
+  def test_show_3ds_source
+    card_source  = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
+    assert three_d_secure_source = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure',  @options)
+    assert_success three_d_secure_source
+
+    assert response = @gateway.send(:show_source, three_d_secure_source.params['id'], @options)
+    assert_equal 'source', response.params['object']
+    assert_equal 'pending', response.params['status']
+    assert_equal 'three_d_secure', response.params['type']
+    assert_equal false, response.params['three_d_secure']['authenticated']
+  end
+
   def test_create_webhook_endpoint
     response = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
     assert_includes response.params['enabled_events'], 'source.chargeable'


### PR DESCRIPTION
@activemerchant/spreedly-connect This code change is to support charging a 3DS source in the `redirect` step of the Stripe 3DS 1.0 workflow. The existing approach attempts to charge a source even if the source is not `chargeable`, which would ultimately fail a transaction if the source is not yet chargeable, i.e. `pending`. Instead, we will use `show_source` to check if the source can be charged, and only attempt the charge if it is chargeable.

Add support for showing a payment source such as a card or 3DS payment
source.

Unit:

134 tests, 718 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Stripe 3DS:

11 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-289