### PR TITLE
Do not attempt application fee refund if refund was not successful

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Adyen: Correct formatting of Billing Address [nfarve] #3200
 * Stripe: Stripe: Show payment source [jknipp] #3202
 * Checkout V2: Checkout V2: Correct success criteria [curiousepic] #3205
+* Stripe: Do not attempt application fee refund if refund was not successful [jasonwebster] #3206
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
 
         response = commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options)
 
-        if options[:refund_fee_amount] && options[:refund_fee_amount].to_s != '0'
+        if response.success? && options[:refund_fee_amount] && options[:refund_fee_amount].to_s != '0'
           charge = api_request(:get, "charges/#{CGI.escape(identification)}", nil, options)
 
           if application_fee = charge['application_fee']

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -685,7 +685,6 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
   end
 
-  # What is the significance of this??? it's to test that the first response is used as primary. so identical to above with an extra assertion
   def test_refund_with_fee_response_responds_with_the_refund_authorization
     s = sequence('request')
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)
@@ -714,6 +713,14 @@ class StripeTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
     assert_success response
+  end
+
+  def test_unsuccessful_refund_does_not_refund_fee
+    s = sequence('request')
+    @gateway.expects(:ssl_request).returns(generic_error_response).in_sequence(s)
+
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert_failure response
   end
 
   def test_successful_verify


### PR DESCRIPTION
This was a regression made in adc5a88c485e8de8cf30c064233fbe7bc927bf86
which was trying to make the App Fee refunds not impact the overall
status of the Refund response. That was achieved, but it also made the
unintentional change of always trying to refund the application fee
regardless of the refund succeeding or not. There was previously no test
coverage of this behaviour.