### PR TITLE
Adyen: Add normalized hash of 3DS 2.0 data fields from web browsers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Adyen: Correct formatting of Billing Address [nfarve] #3200
 * Stripe: Stripe: Show payment source [jknipp] #3202
 * Checkout V2: Checkout V2: Correct success criteria [curiousepic] #3205
+* Adyen: Add normalized hash of 3DS 2.0 data fields from web browsers [davidsantoso] #3207
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -308,9 +308,31 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3ds(post, options)
-        return unless options[:execute_threed] || options[:threed_dynamic]
-        post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
-        post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
+        if three_ds_2_options = options[:three_ds_2]
+          if browser_info = three_ds_2_options[:browser_info]
+            post[:browserInfo] = {
+              acceptHeader: browser_info[:accept_header],
+              colorDepth: browser_info[:depth],
+              javaEnabled: browser_info[:java],
+              language: browser_info[:language],
+              screenHeight: browser_info[:height],
+              screenWidth: browser_info[:width],
+              timeZoneOffset: browser_info[:timezone],
+              userAgent: browser_info[:user_agent]
+            }
+
+            if device_channel = three_ds_2_options[:channel]
+              post[:threeDS2RequestData] = {
+                deviceChannel: device_channel,
+                notificationURL: three_ds_2_options[:notification_url] || 'https://example.com/notification'
+              }
+            end
+          end
+        else
+          return unless options[:execute_threed] || options[:threed_dynamic]
+          post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
+          post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
+        end
       end
 
       def parse(body)


### PR DESCRIPTION
In an effort to begin supporting the intiation of 3DS 2.0 transactions,
this introduces another normalized hash for web browser data that can be
mapped to the fields a gateway is expecting. Similarly to stored
credentials, this hash should be used across all gateways in which 3DS
2.0 browser data is meant to be submitted so there is a single interface
for the client/device data.

Eventually I suspect this hash should also support mobile app information
by changing out the "channel" field and doing additional logic around that,
but for now we're starting with web browsers only.

The structure of the hash is as follows:

```ruby
three_ds_2: {
  channel: "browser",
  browser_info: {
    accept_header: "unknown",
    depth: 100,
    java: false,
    language: "US",
    height: 1000,
    width: 500,
    timezone: "-120",
    user_agent: "unknown"
  }
}
```

This should be all of the data gateways are expecting, however as with
all payment gateways I imagine there are some that will accept or
require additional data. In those cases I suspect we can add that data
to this additional hash for a specific gateways needs.