### PR TITLE
Elavon: Multi-currency support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Adyen: Add normalized hash of 3DS 2.0 data fields from web browsers [davidsantoso] #3207
 * Stripe: Do not attempt application fee refund if refund was not successful [jasonwebster] #3206
 * Elavon: Send transaction_currency if currency is provided [gcatlin] #3201
+* Elavon: Multi-currency support [jknipp] #3210
 
 == Version 1.93.0 (April 18, 2019)
 * Stripe: Do not consider a refund unsuccessful if only refunding the fee failed [jasonwebster] #3188

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -183,7 +183,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_currency(form, money, options)
-        form[:transaction_currency] = options[:currency] if options[:currency]
+        currency = options[:currency] || currency(money)
+        form[:transaction_currency] = currency if currency && (@options[:multi_currency] || options[:multi_currency])
       end
 
       def add_token(form, token)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -275,10 +275,17 @@ efsnet:
   password: Y
 
 # Provided for url update test
+
 elavon:
+  login: "009005"
+  user: "devportal"
+  password: "BDDZY5KOUDCNPV4L3821K7PETO4Z7TPYOJB06TYBI1CW771IDHXBVBP51HZ6ZANJ"
+
+elavon_multi_currency:
   login: "009006"
   user: "devportal"
   password: "XWJS3QTFCH40HW0QGHJKXAYADCTDH0TXXAKXAEZCGCCJ29CFNPCZT4KA9D5KQMDA"
+  multi_currency: true
 
 element:
   account_id: "1013963"

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteElavonTest < Test::Unit::TestCase
   def setup
     @gateway = ElavonGateway.new(fixtures(:elavon))
+    @multi_currency_gateway = ElavonGateway.new(fixtures(:elavon_multi_currency))
 
     @credit_card = credit_card('4124939999999990')
     @bad_credit_card = credit_card('invalid')
@@ -205,8 +206,27 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response.authorization
   end
 
-  def test_successful_purchase_with_currency
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'JPY'))
+  def test_failed_purchase_with_multi_currency_terminal_setting_disabled
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'USD', multi_currency: true))
+
+    assert_failure response
+    assert response.test?
+    assert_equal 'Transaction currency is not allowed for this terminal.  Your terminal must be setup with Multi currency', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_multi_currency_gateway_setting
+    assert response = @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'JPY'))
+
+    assert_success response
+    assert response.test?
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_multi_currency_transaction_setting
+    @multi_currency_gateway.options.merge!(multi_currency: false)
+    assert response = @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'JPY', multi_currency: true))
 
     assert_success response
     assert response.test?


### PR DESCRIPTION
Send the currency in the ssl_transaction_currency field only if the
user has specified they are using multi-currency. The multi-currency
flag can be set with either a gateway or transaction level field.

Using multi-currency depends on the merchant's multi-currency terminal
setting at Elavon.

ECS-272

Unit:
31 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed