### PR TITLE
Checkout.com V2: Let Checkout API handle verification

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -61,11 +61,8 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post, authorization)
       end
 
-      def verify(credit_card, options={})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+      def verify(payment_method, options={})
+        authorize(0, payment_method, options)
       end
 
       def supports_scrubbing?


### PR DESCRIPTION
Based on https://api-reference.checkout.com/#tag/Payments/paths/~1payments/post

which says
> Omitting the amount or providing 0 will perform a card verification.

Authorizing with an amount of 0 will make Checkout verify the card themselves. This is more advantageous because they can do retries with different amounts, and they will take care of voiding the charge, meaning this is one less thing active_merchant has to worry about.

This works for both credit cards and tokenized credit cards.