### PR TITLE
Authnet: Parse card_type from response

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -887,6 +887,10 @@ module ActiveMerchant
                                       (empty?(element.content) ? nil : element.content[-4..-1])
         end
 
+        response[:card_type] = if(element = doc.at_xpath('//accountType'))
+                                 (empty?(element.content) ? nil : element.content)
+        end
+
         response[:test_request] = if(element = doc.at_xpath('//testRequest'))
                                     (empty?(element.content) ? nil : element.content)
         end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -567,6 +567,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       authorization_code
       avs_result_code
       card_code
+      card_type
       cardholder_authentication_code
       full_response_code
       response_code

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -286,6 +286,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'M', response.cvv_result['code']
     assert_equal 'CVV matches', response.cvv_result['message']
     assert_equal 'I00001', response.params['full_response_code']
+    assert_equal  '0015', response.params['account_number']
+    assert_equal  'MasterCard', response.params['card_type']
 
     assert_equal '508141794', response.authorization.split('#')[0]
     assert response.test?


### PR DESCRIPTION
When creating a new `ActiveMerchant::Billing::Response`, the `AuthorizeNetGateway` does not populate `params` with all of the data that is returned in Authorize.net's XML response.

One of the missing fields is `card_type`. This PR follows the convention in `AuthorizeNetGateway` to add that value.

```
% rake test:units
Finished in 9.844451 seconds.
------------------------------------------------------------------------------------------------------------------------
4056 tests, 69070 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------
412.01 tests/s, 7016.14 assertions/s
```
```
% rake test:remote TEST=test/remote/gateways/remote_authorize_net_test.rb
Finished in 61.416603 seconds.
------------------------------------------------------------------------------------------------------------------------
69 tests, 238 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------
1.12 tests/s, 3.88 assertions/s
```
