### PR TITLE
Mundipagg: Make gateway_affiliation_id an option

### DIFF
--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -155,7 +155,8 @@ module ActiveMerchant #:nodoc:
         post[:customer][:name] = payment.name if post[:customer]
         post[:customer_id] = parse_auth(payment)[0] if payment.is_a?(String)
         post[:payment] = {}
-        post[:payment][:gateway_affiliation_id] = @options[:gateway_id] if @options[:gateway_id]
+        affiliation = options[:gateway_affiliation_id] || @options[:gateway_id]
+        post[:payment][:gateway_affiliation_id] = affiliation if affiliation
         post[:payment][:metadata] = { mundipagg_payment_method_code: '1' } if test?
         if voucher?(payment)
           add_voucher(post, payment, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -550,6 +550,8 @@ money_movers:
 
 mundipagg:
   api_key: api_key
+  gateway_affiliation_id: gateway_affiliation_id
+  # left for backward-compatibility
   gateway_id: gateway_id
 
 # Working credentials, no need to replace

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -13,6 +13,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     # See https://docs.mundipagg.com/docs/simulador-de-voucher.
     @vr_voucher = credit_card('4000000000000010', brand: 'vr')
     @options = {
+      gateway_affiliation_id: fixtures(:mundipagg)[:gateway_affiliation_id],
       billing_address: address({neighborhood: 'Sesame Street'}),
       description: 'Store Purchase'
     }
@@ -185,6 +186,16 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match %r{Invalid API key; Authorization has been denied for this request.}, response.message
+  end
+
+  def test_gateway_id_fallback
+    gateway = MundipaggGateway.new(api_key: fixtures(:mundipagg)[:api_key], gateway_id: fixtures(:mundipagg)[:gateway_id])
+    options = {
+      billing_address: address({neighborhood: 'Sesame Street'}),
+      description: 'Store Purchase'
+    }
+    response = gateway.purchase(@amount, @credit_card, options)
+    assert_success response
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -8,6 +8,7 @@ class MundipaggTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
+      gateway_affiliation_id: 'abc123',
       order_id: '1',
       billing_address: address,
       description: 'Store Purchase'
@@ -166,6 +167,20 @@ class MundipaggTest < Test::Unit::TestCase
 
     assert_equal 'cus_N70xAX6S65cMnokB|card_51ElNwYSVJFpRe0g', response.authorization
     assert response.test?
+  end
+
+  def test_gateway_id_fallback
+    gateway = MundipaggGateway.new(api_key: 'my_api_key', gateway_id: 'abc123')
+    options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+    stub_comms do
+      gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"gateway_affiliation_id":"abc123"/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_scrub


### PR DESCRIPTION
gateway_affiliation_id was originally implemented as a gateway-level
credential (named gateway_id). However, this field makes more sense as a
transaction-level field.

Remote:
23 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
17 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed