### PR TITLE
Checkout.com V2: Perform purchase in a single request

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -17,20 +17,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(amount, payment_method, options={})
-        multi = MultiResponse.run do |r|
-          r.process { authorize(amount, payment_method, options) }
-          r.process { capture(amount, r.authorization, options) }
-        end
-
-        merged_params = multi.responses.map(&:params).reduce({}, :merge)
-        succeeded = success_from(merged_params)
-
-        response(:purchase, succeeded, merged_params)
+        options[:capture] = true
+        authorize(amount, payment_method, options)
       end
 
       def authorize(amount, payment_method, options={})
         post = {}
-        post[:capture] = false
+        post[:capture] = options[:capture] || false
+
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
         add_customer_data(post, options)


### PR DESCRIPTION
There are currently 2 requests happening when you call `purchase`, `authorize` and `capture`. As stated in the [API docs](https://api-reference.checkout.com/#tag/Payments/paths/~1payments/post), you can simply pass `capture: true` when authorizing and the payment will be captured.

Note: In both cases, both before and after this change captures are asynchronous and you need to use webhooks to be notified of the result.