### PR TITLE
Checkout.com V2: Fetch payment by ID or session ID support

### DIFF
--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -8,6 +8,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @credit_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2025')
     @expired_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2010')
     @declined_card = credit_card('42424242424242424', verification_value: '234', month: '6', year: '2025')
+    @invalid_payment_id = '1111'
 
     @options = {
       order_id: '1',
@@ -218,4 +219,10 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'request_invalid: card_expired', response.message
     assert_equal 'request_invalid: card_expired', response.error_code
   end
+
+  def test_failed_get_payment
+    response = @gateway.get_payment(@invalid_payment_id)
+    assert_failure response
+  end
+
 end


### PR DESCRIPTION
This is necessary to complete the 3D Secure flow with Checkout, a checkout session ID must be verified using their API. This is necessary if one wants to store 3DS-secured credit cards.

Other changes:

- Some slight refactoring for `commit` to now rely on an `api_request` method which makes requests and parses responses.
- Have all Checkout V2 requests happen via `ssl_request` rather than `ssl_post`, because we now have a GET request in this PR.
- Stub ssl_request instead of ssl_post in checkout_v2 unit test.
- Update signature of `check_request` block params in checkout_v2 unit test.


If this PR is merged, all open PRs for Checkout.com V2 will need the modifications for the unit tests to stub `ssl_request` instead of `ssl_post` and update the signature of `check_request` or their tests will be failing.