### PR TITLE
Add Kosovo to the list of countries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Spreedly: extra fields, remove extraneous check [montdidier] #3102 #3281
 * Cecabank: Update encryption to SHA2 [leila-alderman] #3278
 * Credorax: add 3DS2 MPI auth data support [bayprogrammer] #3274
+* Add Kosovo to the list of countries [AnotherJoSmith] #3226
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -183,6 +183,7 @@ module ActiveMerchant #:nodoc:
       { alpha2: 'KI', name: 'Kiribati', alpha3: 'KIR', numeric: '296' },
       { alpha2: 'KP', name: 'Korea, Democratic People\'s Republic of', alpha3: 'PRK', numeric: '408' },
       { alpha2: 'KR', name: 'Korea, Republic of', alpha3: 'KOR', numeric: '410' },
+      { alpha2: 'XK', name: 'Kosovo', alpha3: 'XKX', numeric: '900' },
       { alpha2: 'KW', name: 'Kuwait', alpha3: 'KWT', numeric: '414' },
       { alpha2: 'KG', name: 'Kyrgyzstan', alpha3: 'KGZ', numeric: '417' },
       { alpha2: 'LA', name: 'Lao People\'s Democratic Republic', alpha3: 'LAO', numeric: '418' },


### PR DESCRIPTION
Although these codes are not officially in the ISO standard, they are
used by the European Commission, and we're seeing some buyers use them.
The numeric code, which is almost never used by the provider, is one of
the reserved codes that will never be assigned to an actual country. If
Kosovo is added to the ISO standard, we can correct it at that time.