### PR TITLE
Qvalent: Adds support for standard stored credential framework

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 
 == HEAD
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228
-
+* Qvalent: Adds support for standard stored credential framework [molbrown] #3227
 
 == Version 1.94.0 (May 21, 2019)
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -27,6 +27,7 @@ module ActiveMerchant #:nodoc:
         add_order_number(post, options)
         add_payment_method(post, payment_method)
         add_verification_value(post, payment_method)
+        add_stored_credential_data(post, payment_method, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
 
@@ -39,6 +40,7 @@ module ActiveMerchant #:nodoc:
         add_order_number(post, options)
         add_payment_method(post, payment_method)
         add_verification_value(post, payment_method)
+        add_stored_credential_data(post, payment_method, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
 
@@ -61,6 +63,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        post['order.ECI'] = options[:eci] || 'SSL'
 
         commit('refund', post)
       end
@@ -124,7 +127,6 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, money, options)
         post['order.amount'] = amount(money)
         post['card.currency'] = CURRENCY_CODES[options[:currency] || currency(money)]
-        post['order.ECI'] = options[:eci] || 'SSL'
       end
 
       def add_payment_method(post, payment_method)
@@ -132,6 +134,46 @@ module ActiveMerchant #:nodoc:
         post['card.PAN'] = payment_method.number
         post['card.expiryYear'] = format(payment_method.year, :two_digits)
         post['card.expiryMonth'] = format(payment_method.month, :two_digits)
+      end
+
+      def add_stored_credential_data(post, payment_method, options)
+        post['order.ECI'] = options[:eci] || eci(options)
+        if (stored_credential = options[:stored_credential]) && %w(visa master).include?(payment_method.brand)
+          post['card.posEntryMode'] = stored_credential[:initial_transaction] ? 'MANUAL' : 'STORED_CREDENTIAL'
+          stored_credential_usage(post, payment_method, options) unless stored_credential[:initiator] && stored_credential[:initiator] == 'cardholder'
+          post['order.authTraceId'] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
+        end
+      end
+
+      def stored_credential_usage(post, payment_method, options)
+        return unless payment_method.brand == 'visa'
+        stored_credential = options[:stored_credential]
+        if stored_credential[:initial_transaction]
+          post['card.storedCredentialUsage'] = 'INITIAL_STORAGE'
+        elsif stored_credential[:reason_type] == ('recurring' || 'installment')
+          post['card.storedCredentialUsage'] = 'RECURRING'
+        elsif stored_credential[:reason_type] == 'unscheduled'
+          post['card.storedCredentialUsage'] = 'UNSCHEDULED'
+        end
+      end
+
+      def eci(options)
+        if options.dig(:stored_credential, :initial_transaction)
+          'SSL'
+        elsif options.dig(:stored_credential, :initiator) && options[:stored_credential][:initiator] == 'cardholder'
+          'MTO'
+        elsif options.dig(:stored_credential, :reason_type)
+          case options[:stored_credential][:reason_type]
+          when 'recurring'
+            'REC'
+          when 'installment'
+            'INS'
+          when 'unscheduled'
+            'MTO'
+          end
+        else
+          'SSL'
+        end
       end
 
       def add_verification_value(post, payment_method)

--- a/test/remote/gateways/remote_qvalent_test.rb
+++ b/test/remote/gateways/remote_qvalent_test.rb
@@ -5,7 +5,8 @@ class RemoteQvalentTest < Test::Unit::TestCase
     @gateway = QvalentGateway.new(fixtures(:qvalent))
 
     @amount = 100
-    @credit_card = credit_card('4000100011112224')
+    @credit_card = credit_card('4242424242424242')
+    @mastercard = credit_card('5163200000000008', brand: 'master')
     @declined_card = credit_card('4000000000000000')
     @expired_card = credit_card('4111111113444494')
 
@@ -189,4 +190,53 @@ class RemoteQvalentTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, clean_transcript)
     assert_scrubbed(@gateway.options[:password], clean_transcript)
   end
+
+  def test_successful_purchase_initial
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: true,
+        initiator: 'merchant',
+        reason_type: 'unscheduled'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_not_nil response.params['response.authTraceId']
+  end
+
+  def test_successful_purchase_cardholder
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        initiator: 'cardholder',
+        reason_type: 'unscheduled',
+        network_transaction_id: 'qwerty7890'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_mastercard
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        initiator: 'merchant',
+        reason_type: 'recurring',
+        network_transaction_id: 'qwerty7890'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @mastercard, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
 end


### PR DESCRIPTION
Includes ECI, posEntryMode, storedCredentialUsage, and authTraceID fields,
for Qvalent's requirements for use of stored Visa and Mastercards.
Mastercard will not accept all fields required by Visa.

Unit:
23 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-174