### PR TITLE
[Gateways::Cybersource] Send tokenization data when card is :master

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -550,7 +550,7 @@ module ActiveMerchant #:nodoc:
             xml.tag!('commerceIndicator', 'vbv')
             xml.tag!('xid', payment_method.payment_cryptogram)
           end
-        when :mastercard
+        when :master
           xml.tag! 'ucaf' do
             xml.tag!('authenticationData', payment_method.payment_cryptogram)
             xml.tag!('collectionIndicator', '2')

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -462,7 +462,7 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     credit_card = network_tokenization_credit_card('5555555555554444',
-      :brand              => 'mastercard',
+      :brand              => 'master',
       :transaction_id     => '123',
       :eci                => '05',
       :payment_cryptogram => '111111111100cryptogram'


### PR DESCRIPTION
Currently it will send tokenization data for MasterCard when the card
type is `:mastercard` which is an invalid card type. This commit makes it
so it will send tokenization data when the card type is `:master` and not
`:mastercard`.

Right now, all tokenized mastercard are failing on Cybersource (at least for us).

Tests seem to only fail for the `SoEasyPay` which are unrelated to those changes
```
4069 tests, 69102 assertions, 1 failures, 7 errors, 0 pendings, 0 omissions, 0 notifications
99.8034% passed
```