### PR TITLE
TransFirst Express: Fix blank address2 values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Cybersource: Send tokenization data when card is :master [pi3r] #3230
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229
 * Adyen: Pass updateShopperStatement, industryUsage [curiousepic] #3233
+* TransFirst Transaction Express: Fix blank address2 values [britth] #3231
 
 == Version 1.94.0 (May 21, 2019)
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -544,7 +544,7 @@ module ActiveMerchant #:nodoc:
               end
             end
             doc['v1'].addrLn1 billing_address[:address1] if billing_address[:address1]
-            doc['v1'].addrLn2 billing_address[:address2] if billing_address[:address2]
+            doc['v1'].addrLn2 billing_address[:address2] unless billing_address[:address2].blank?
             doc['v1'].city billing_address[:city] if billing_address[:city]
             doc['v1'].state billing_address[:state] if billing_address[:state]
             doc['v1'].zipCode billing_address[:zip] if billing_address[:zip]
@@ -559,7 +559,7 @@ module ActiveMerchant #:nodoc:
             doc['v1'].ship do
               doc['v1'].fullName fullname unless fullname.blank?
               doc['v1'].addrLn1 shipping_address[:address1] if shipping_address[:address1]
-              doc['v1'].addrLn2 shipping_address[:address2] if shipping_address[:address2]
+              doc['v1'].addrLn2 shipping_address[:address2] unless shipping_address[:address2].blank?
               doc['v1'].city shipping_address[:city] if shipping_address[:city]
               doc['v1'].state shipping_address[:state] if shipping_address[:state]
               doc['v1'].zipCode shipping_address[:zip] if shipping_address[:zip]

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -7,7 +7,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
 
     @amount = 100
     @declined_amount = 21
-    @credit_card = credit_card('4485896261017708')
+    @credit_card = credit_card('4485896261017708', verification_value: 999)
     @check = check
 
     billing_address = address({
@@ -74,6 +74,26 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_not_nil response.cvv_result
     assert_equal 'Street address does not match, but 5-digit postal code matches.', response.avs_result['message']
     assert_equal 'CVV matches', response.cvv_result['message']
+  end
+
+  def test_successful_purchase_without_address2
+    # Test that empty string in `address2` doesn't cause transaction failure
+    options = @options.dup
+    options[:shipping_address] = {
+      address1: '450 Main',
+      address2: '',
+      zip: '85284',
+    }
+
+    options[:billing_address] = {
+      address1: '450 Main',
+      address2: '',
+      zip: '85284',
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
   end
 
   def test_successful_purchase_without_cvv


### PR DESCRIPTION
If a user passes in an empty string for the address2 field, their 
transaction will fail on this gateway. This PR ensures that address2 
only gets passed through if it is present and not blank. Additionally 
it cleans up some remote test failures. test_successful_verify still 
fails in the remote tests, but failure is unrelated to change.

Unit:
21 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
33 tests, 107 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed