### PR TITLE
Implement Worldpay store

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,14 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Bluesnap: Omit state codes for unsupported countries [therufs] #3229
+* Adyen: Pass updateShopperStatement, industryUsage [curiousepic] #3233
+* TransFirst Transaction Express: Fix blank address2 values [britth] #3231
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228
 * Qvalent: Adds support for standard stored credential framework [molbrown] #3227
 * Cybersource: Send tokenization data when card is :master [pi3r] #3230
-* Bluesnap: Omit state codes for unsupported countries [therufs] #3229
-* Adyen: Pass updateShopperStatement, industryUsage [curiousepic] #3233
-* TransFirst Transaction Express: Fix blank address2 values [britth] #3231
 
 == Version 1.94.0 (May 21, 2019)
 * Mundipagg: Fix number lengths for both VR and Sodexo [dtykocki] #3195

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229
 * Adyen: Pass updateShopperStatement, industryUsage [curiousepic] #3233
 * TransFirst Transaction Express: Fix blank address2 values [britth] #3231
+* WorldPay: Add support for store method [bayprogrammer] #3232
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228


### PR DESCRIPTION
We are only supporting shopper-scoped tokens right now, and not
implementing delete/unstore, saving a token along with an authorize or
purchase call, overriding token details on use, or setting the token
lifetime.

The design of the opaque token authorization string we return from
`store` has been intentionally designed to be flexible enough to extend
in a backwards-compatible way should any of the above features need to
be implemented.

Unit:
59 tests, 329 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
50 tests, 219 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96% passed

The two failing remote tests are concerning 3DS parameter pass through
which the test credentials I'm using does not have permission to use
presently.

ECS-347