### PR TITLE
Deleted landing_page param to allow Paypal use their logic

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -146,9 +146,6 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'n2:cpp-payflow-color', options[:background_color] unless options[:background_color].blank?
               if options[:allow_guest_checkout]
                 xml.tag! 'n2:SolutionType', 'Sole'
-                unless options[:paypal_chooses_landing_page]
-                  xml.tag! 'n2:LandingPage', options[:landing_page] || 'Billing'
-                end
               end
               xml.tag! 'n2:BuyerEmail', options[:email] unless options[:email].blank?
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -642,13 +642,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
 
-  def test_paypal_chooses_landing_page
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_guest_checkout => true, :paypal_chooses_landing_page=> true}))
-
-    assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
-    assert_nil REXML::XPath.first(xml, '//n2:LandingPage')
-  end
-
   def test_not_adds_brand_name_if_not_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -639,7 +639,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_guest_checkout => true}))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
-    assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
 
   def test_not_adds_brand_name_if_not_specified


### PR DESCRIPTION
Refer to this pull request: https://github.com/activemerchant/active_merchant/pull/3176

Paypal wants us to remove `landing_page` to be able to use their own logic - determine whether directing users to login or guest checkout page. 

The empty `landing_page` was sent previously, now it will be removed entirely.

The deletion includes:
- ` LandingPage` tag with `:paypal_chooses_landing_page` option
- Corresponding test `test_paypal_chooses_landing_page`
- assert `LandingPage` tag in `test_allow_guest_checkout`