### PR TITLE
Adyen: Support for additional AVS code mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Adyen: Pass updateShopperStatement, industryUsage [curiousepic] #3233
 * TransFirst Transaction Express: Fix blank address2 values [britth] #3231
 * WorldPay: Add support for store method [bayprogrammer] #3232
+* Adyen: Support for additional AVS code mapping [jknipp] #3236
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -3,11 +3,10 @@
 module ActiveMerchant
   module Billing
     # Implements the Address Verification System
-    # https://www.wellsfargo.com/downloads/pdf/biz/merchant/visa_avs.pdf
+    # https://www.cybersource.com/developers/other_resources/quick_references/avs_results/.
     # http://en.wikipedia.org/wiki/Address_Verification_System
-    # http://apps.cybersource.com/library/documentation/dev_guides/CC_Svcs_IG/html/app_avs_cvn_codes.htm#app_AVS_CVN_codes_7891_48375
-    # http://imgserver.skipjack.com/imgServer/5293710/AVS%20and%20CVV2.pdf
     # http://www.emsecommerce.net/avs_cvv2_response_codes.htm
+    # https://www.cardfellow.com/blog/address-verification-service-avs/
     class AVSResult
       MESSAGES = {
         'A' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
@@ -23,7 +22,7 @@ module ActiveMerchant
         'K' => 'Card member\'s name matches but billing address and billing postal code do not match.',
         'L' => 'Card member\'s name and billing postal code match, but billing address does not match.',
         'M' => 'Street address and postal code match.',
-        'N' => 'Street address and postal code do not match.',
+        'N' => 'Street address and postal code do not match. For American Express: Card member\'s name, street address and postal code do not match.',
         'O' => 'Card member\'s name and billing address match, but billing postal code does not match.',
         'P' => 'Postal code matches, but street address not verified.',
         'Q' => 'Card member\'s name, billing address, and postal code match. Shipping information verified but chargeback protection not guaranteed.',

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -140,10 +140,14 @@ module ActiveMerchant #:nodoc:
         '16' => 'N',  # Postal code doesn't match, address unknown
         '17' => 'U',  # Postal code doesn't match, address not checked
         '18' => 'I',  # Neither postal code nor address were checked
+        '19' => 'L',  # Name and postal code matches.
         '20' => 'V',  # Name, address and postal code matches.
+        '21' => 'O',  # Name and address matches.
+        '22' => 'K',  # Name matches.
         '23' => 'F',  # Postal code matches, name doesn't match.
         '24' => 'H',  # Both postal code and address matches, name doesn't match.
-        '25' => 'T'  # Address matches, name doesn't match.
+        '25' => 'T',  # Address matches, name doesn't match.
+        '26' => 'N'   # Neither postal code, address nor name matches.
       }
 
       CVC_MAPPING = {

--- a/test/unit/gateways/global_transport_test.rb
+++ b/test/unit/gateways/global_transport_test.rb
@@ -21,7 +21,7 @@ class GlobalTransportTest < Test::Unit::TestCase
     assert_equal '3648838', response.authorization
     assert response.test?
     assert_equal 'CVV matches', response.cvv_result['message']
-    assert_equal 'Street address and postal code do not match.', response.avs_result['message']
+    assert_equal 'Street address and postal code do not match. For American Express: Card member\'s name, street address and postal code do not match.', response.avs_result['message']
   end
 
   def test_failed_purchase


### PR DESCRIPTION
Map additional Adyen AVS result codes to Active Merchant AVS result
codes.

ECS-301

Unit:

37 tests, 179 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

60 tests, 187 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed