### PR TITLE
Update AVS result message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * TransFirst Transaction Express: Fix blank address2 values [britth] #3231
 * WorldPay: Add support for store method [bayprogrammer] #3232
 * Adyen: Support for additional AVS code mapping [jknipp] #3236
+* Update message for AVS result code 'A' to generically cover postal code mismatches [jknipp] #3237
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -9,7 +9,7 @@ module ActiveMerchant
     # https://www.cardfellow.com/blog/address-verification-service-avs/
     class AVSResult
       MESSAGES = {
-        'A' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+        'A' => 'Street address matches, but postal code does not match.',
         'B' => 'Street address matches, but postal code not verified.',
         'C' => 'Street address and postal code do not match.',
         'D' => 'Street address and postal code match.',

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -149,7 +149,7 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
     }
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_equal 'A', response.avs_result['code']
-    assert_equal 'Street address matches, but 5-digit and 9-digit postal code do not match.', response.avs_result['message']
+    assert_equal 'Street address matches, but postal code does not match.', response.avs_result['message']
     assert_equal 'Y', response.avs_result['street_match']
     assert_equal 'N', response.avs_result['postal_match']
   end

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -262,7 +262,7 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert_success response
     assert_equal(response.avs_result, {
         'code' => 'A',
-        'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+        'message' => 'Street address matches, but postal code does not match.',
         'street_match' => 'Y',
         'postal_match' => 'N'
     })

--- a/test/remote/gateways/remote_moneris_us_test.rb
+++ b/test/remote/gateways/remote_moneris_us_test.rb
@@ -217,7 +217,7 @@ class MonerisUsRemoteTest < Test::Unit::TestCase
     assert_success response
     assert_equal(response.avs_result, {
       'code' => 'A',
-      'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+      'message' => 'Street address matches, but postal code does not match.',
       'street_match' => 'Y',
       'postal_match' => 'N'
     })

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -990,7 +990,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(no_match_avs_response)
-    assert_equal 'Street address matches, but 5-digit and 9-digit postal code do not match.', response.message
+    assert_equal 'Street address matches, but postal code does not match.', response.message
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -208,7 +208,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_message_from
     assert_equal 'CVV does not match', @gateway.send(:parse, 'STATUS=2&CVV2=N&AVS=A&MESSAGE=FAILURE').message
-    assert_equal 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+    assert_equal 'Street address matches, but postal code does not match.',
       @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
   end
 

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -122,7 +122,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response + '&avs_result=A')
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal response.avs_result['code'], 'A'
-    assert_equal response.avs_result['message'], 'Street address matches, but 5-digit and 9-digit postal code do not match.'
+    assert_equal response.avs_result['message'], 'Street address matches, but postal code does not match.'
     assert_equal response.avs_result['street_match'], 'Y'
     assert_equal response.avs_result['postal_match'], 'N'
   end

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -197,7 +197,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
     assert_equal 'CVV does not match', @gateway.message_from(result)
 
     result[:card_code] = 'M'
-    assert_equal 'Street address matches, but 5-digit and 9-digit postal code do not match.', @gateway.message_from(result)
+    assert_equal 'Street address matches, but postal code does not match.', @gateway.message_from(result)
 
     result[:response_reason_code] = '22'
     assert_equal 'Failure', @gateway.message_from(result)

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -349,7 +349,7 @@ class MonerisTest < Test::Unit::TestCase
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_equal(response.avs_result, {
       'code' => 'A',
-      'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+      'message' => 'Street address matches, but postal code does not match.',
       'street_match' => 'Y',
       'postal_match' => 'N'
     })

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -300,7 +300,7 @@ class MonerisUsTest < Test::Unit::TestCase
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_equal(response.avs_result, {
       'code' => 'A',
-      'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+      'message' => 'Street address matches, but postal code does not match.',
       'street_match' => 'Y',
       'postal_match' => 'N'
     })


### PR DESCRIPTION
Update AVS result message for alpha code 'A' to be more generic. The
previous message was causing confusion for merchants processing Canadien
cards with 6 digit postal codes.

ECS-56

Unit:

Authorize.net
96 tests, 565 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Blue Pay
26 tests, 125 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Merchant eSolutions
20 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Metrics Global
22 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Moneris
37 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Moneris US
34 tests, 169 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

Merchant eSolutions
18 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Moneris
31 tests, 123 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Moneris US
30 tests, 118 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6667% passed
- One Unrelated test failure

ECS-56