### PR TITLE
Braintree: Add skip_avs and skip_cvv fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Update message for AVS result code 'A' to generically cover postal code mismatches [jknipp] #3237
 * CyberSource: Update CyberSource SOAP documentation link [vince-smith] #3204
 * USAePay: Handle additional error codes and add default error code [estelendur] #3167
+* Braintree: Add `skip_avs` and `skip_cvv` gateway specific fields [leila-alderman] #3241
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -419,7 +419,9 @@ module ActiveMerchant #:nodoc:
           'street: A, zip: N' => 'C',
           'street: A, zip: U' => 'I',
           'street: A, zip: I' => 'I',
-          'street: A, zip: A' => 'I'
+          'street: A, zip: A' => 'I',
+
+          'street: B, zip: B' => 'B'
         }
       end
 
@@ -588,6 +590,14 @@ module ActiveMerchant #:nodoc:
 
         if options[:skip_advanced_fraud_checking]
           parameters[:options][:skip_advanced_fraud_checking] = options[:skip_advanced_fraud_checking]
+        end
+
+        if options[:skip_avs]
+          parameters[:options][:skip_avs] = options[:skip_avs]
+        end
+
+        if options[:skip_cvv]
+          parameters[:options][:skip_cvv] = options[:skip_cvv]
         end
 
         parameters[:custom_fields] = options[:custom_fields]

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -417,6 +417,20 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
   end
 
+  def test_successful_purchase_with_skip_avs
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(skip_avs: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'B', response.avs_result['code']
+  end
+
+  def test_successful_purchase_with_skip_cvv
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(skip_cvv: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'B', response.cvv_result['code']
+  end
+
   def test_successful_purchase_with_device_data
     # Requires Advanced Fraud Tools to be enabled
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(device_data: 'device data for purchase'))

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -686,6 +686,24 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), :transaction_source => 'recurring', :recurring => true)
   end
 
+  def test_passes_skip_avs
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:options][:skip_avs] == true)
+    end.returns(braintree_result(:avs_postal_code_response_code => 'B', :avs_street_address_response_code => 'B'))
+
+    response = @gateway.purchase(100, credit_card('41111111111111111111'), :skip_avs => true)
+    assert_equal 'B', response.avs_result['code']
+  end
+
+  def test_passes_skip_cvv
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:options][:skip_cvv] == true)
+    end.returns(braintree_result(:cvv_response_code => 'B'))
+
+    response = @gateway.purchase(100, credit_card('41111111111111111111'), :skip_cvv => true)
+    assert_equal 'B', response.cvv_result['code']
+  end
+
   def test_configured_logger_has_a_default
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not


### PR DESCRIPTION
Added `skip_avs` and `skip_cvv` gateway specific fields to the
Braintree gateway along with unit and remote tests.

ECS-328 / ECS-394

Remote:
73 tests, 415 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Unit:
61 tests, 162 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed