### PR TITLE
NMI: Add support for stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * NAB Transact: Update periodic test url [mengqing] #3177
 * NMI: Add level 3 gateway-specific fields tax, shipping, and ponumber [jasonxp] #3239
 * Checkout V2: Update stored card flag [curiousepic] #3247
+* NMI: Add support for stored credentials [bayprogrammer] #3243
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
+        add_stored_credential(post, options)
         add_customer_data(post, options)
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
@@ -43,6 +44,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
+        add_stored_credential(post, options)
         add_customer_data(post, options)
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
@@ -175,6 +177,34 @@ module ActiveMerchant #:nodoc:
           post[:ccnumber] = payment_method.number
           post[:cvv] = payment_method.verification_value unless empty?(payment_method.verification_value)
           post[:ccexp] = exp_date(payment_method)
+        end
+      end
+
+      def add_stored_credential(post, options)
+        return unless (stored_credential = options[:stored_credential])
+
+        if stored_credential[:initiator] == 'cardholder'
+          post[:initiated_by] = 'customer'
+        else
+          post[:initiated_by] = 'merchant'
+        end
+
+        # :reason_type, when provided, overrides anything previously set in
+        # post[:billing_method] (see `add_invoice` and the :recurring) option
+        case stored_credential[:reason_type]
+        when 'recurring'
+          post[:billing_method] = 'recurring'
+        when 'installment'
+          post[:billing_method] = 'installment'
+        when 'unscheduled'
+          post.delete(:billing_method)
+        end
+
+        if stored_credential[:initial_transaction]
+          post[:stored_credential_indicator] = 'stored'
+        else
+          post[:stored_credential_indicator] = 'used'
+          post[:initial_transaction_id] = stored_credential[:network_transaction_id]
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -245,6 +245,26 @@ module ActiveMerchant
       }.update(options)
     end
 
+    def stored_credential(*args, **options)
+      id = options.delete(:id) || options.delete(:network_transaction_id)
+
+      stored_credential = {
+        network_transaction_id: id,
+        initial_transaction: false
+      }
+
+      stored_credential[:initial_transaction] = true if args.include?(:initial)
+
+      stored_credential[:reason_type] = 'recurring' if args.include?(:recurring)
+      stored_credential[:reason_type] = 'unscheduled' if args.include?(:unscheduled)
+      stored_credential[:reason_type] = 'installment' if args.include?(:installment)
+
+      stored_credential[:initiator] = 'cardholder' if args.include?(:cardholder)
+      stored_credential[:initiator] = 'merchant' if args.include?(:merchant)
+
+      stored_credential
+    end
+
     def generate_unique_id
       SecureRandom.hex(16)
     end

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -382,6 +382,216 @@ class NmiTest < Test::Unit::TestCase
     end
   end
 
+  def test_stored_credential_recurring_cit_initial
+    options = stored_credential_options(:cardholder, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      assert_match(/billing_method=recurring/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_cit_used
+    options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=recurring/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_initial
+    options = stored_credential_options(:merchant, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      assert_match(/billing_method=recurring/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_used
+    options = stored_credential_options(:merchant, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=recurring/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_initial
+    options = stored_credential_options(:cardholder, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      assert_match(/billing_method=installment/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_used
+    options = stored_credential_options(:cardholder, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=installment/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_initial
+    options = stored_credential_options(:merchant, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      assert_match(/billing_method=installment/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_used
+    options = stored_credential_options(:merchant, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=installment/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_initial
+    options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      refute_match(/billing_method/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_used
+    options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      refute_match(/billing_method/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_initial
+    options = stored_credential_options(:merchant, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+      refute_match(/billing_method/, data)
+      refute_match(/initial_transaction_id/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_used
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      refute_match(/billing_method/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_purchase_with_stored_credential
+    options = stored_credential_options(:merchant, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=installment/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_takes_precedence_over_recurring_option
+    options = stored_credential_options(:merchant, :installment, id: 'abc123').merge(recurring: true)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      assert_match(/billing_method=installment/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_takes_precedence_over_recurring_option
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(recurring: true)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+      refute_match(/billing_method/, data)
+      assert_match(/initial_transaction_id=abc123/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
   private
 
   def test_verify(options = {})
@@ -419,6 +629,20 @@ class NmiTest < Test::Unit::TestCase
     assert_match(/customer_id=123/, data)
 
     test_level3_options(data)
+  end
+
+  def stored_credential_options(*args, id: nil)
+    {
+      order_id: '#1001',
+      description: 'AM test',
+      currency: 'GBP',
+      dup_seconds: 15,
+      customer: '123',
+      tax: 5.25,
+      shipping: 10.51,
+      ponumber: 1002,
+      stored_credential: stored_credential(*args, id: id)
+    }
   end
 
   def successful_purchase_response


### PR DESCRIPTION
Unit:
45 tests, 342 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
41 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-258

Closes #3243