### PR TITLE
Fix ENV based configuration of Net::Http for proxies (again)

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -17,6 +17,7 @@ module ActiveMerchant
     MIN_VERSION = :TLS1_1
     RETRY_SAFE = false
     RUBY_184_POST_HEADERS = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+    PROXY_ADDRESS = :ENV
 
     attr_accessor :endpoint
     attr_accessor :open_timeout
@@ -56,7 +57,7 @@ module ActiveMerchant
         @max_version = nil
       end
       @ssl_connection = {}
-      @proxy_address = :ENV
+      @proxy_address = PROXY_ADDRESS
       @proxy_port = nil
     end
 

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -29,6 +29,8 @@ module ActiveMerchant #:nodoc:
       base.class_attribute :wiredump_device
 
       base.class_attribute :proxy_address
+      base.proxy_address = Connection::PROXY_ADDRESS
+
       base.class_attribute :proxy_port
     end
 

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -79,4 +79,21 @@ class PostsDataTests < Test::Unit::TestCase
       @gateway.ssl_post(@url, '')
     end
   end
+
+  def test_respecting_environment_proxy_settings
+    # use rfc5737 test PI range && expect Errno::ENETUNREACH
+    url = 'http://192.0.2.0'
+
+    # mock result
+    http = Net::HTTP.new('192.0.2.0', 80)
+    
+    # ensure clean proxy config
+    gw_class = Class.new(ActiveMerchant::Billing::Gateway)
+    gateway = gw_class.new
+
+    Net::HTTP.stubs(:new).with('192.0.2.0', 80, :ENV, nil).returns(http, http)
+    assert_raises(Errno::ENETUNREACH) do
+      gateway.ssl_post(url, '')
+    end
+  end
 end


### PR DESCRIPTION
Proxy configuration from environment variables is broken again (previous incarnations #2372 / #2800). This time at gateway level - ActiveMerchant::PostsData unconditionally assigns gateway class level proxy_address (defalu nil) to connection.proxy_address (default :ENV) changing the default from "Use environment" to "Disable proxy".
The proposed fix is to initialize both default values with :ENV