### PR TITLE
Fixes checkout v2 integration

### DIFF
--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -93,19 +93,6 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
-  def test_successful_authorize_with_sanitized_phone_number
-    stub_comms do
-      options = {
-        billing_address: {
-          phone: "'12345*)",
-        },
-      }
-      @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
-      assert_match(/\"phone\":{\"number\":\"12345\"/, data)
-    end.respond_with(successful_authorize_response)
-  end
-
   def test_successful_authorize_and_capture_with_additional_options
     response = stub_comms do
       options = {


### PR DESCRIPTION
Formatting + 2 fixes

- Card on File: the way we were sending that value was wrong/misplaced.
- Phone numbers: Checkout.com does not support non-digit chars for the `source: { phone: { number: '' }}}` field