### PR TITLE
BPoint: Hook up merchant_reference and CRN fields

### DIFF
--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -163,10 +163,10 @@ module ActiveMerchant #:nodoc:
         xml.send('PaymentType', payment_type)
         xml.send('TxnType', 'WEB_SHOP')
         xml.send('BillerCode', options.fetch(:biller_code, ''))
-        xml.send('MerchantReference', '')
-        xml.send('CRN1', '')
-        xml.send('CRN2', '')
-        xml.send('CRN3', '')
+        xml.send('MerchantReference', options[:order_id]) if options[:order_id]
+        xml.send('CRN1', options[:crn1]) if options[:crn1]
+        xml.send('CRN2', options[:crn2]) if options[:crn2]
+        xml.send('CRN3', options[:crn3]) if options[:crn3]
         xml.send('Amount', amount)
       end
 

--- a/test/remote/gateways/remote_bpoint_test.rb
+++ b/test/remote/gateways/remote_bpoint_test.rb
@@ -40,6 +40,12 @@ class RemoteBpointTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_more_options
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ crn1: 'ref'}))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/bpoint_test.rb
+++ b/test/unit/gateways/bpoint_test.rb
@@ -130,6 +130,15 @@ class BpointTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_passing_reference_and_crn
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ crn1: 'ref' }))
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<MerchantReference>1</MerchantReference>)m, data)
+      assert_match(%r(<CRN1>ref</CRN1>)m, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
These fields were already implemented in the request structure but did
not actually get anything passed to them from options.

Unit:
18 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: No current test credentials, fairly confident the changes are
safe given that the fields are already present in requests, just without
a value.