### PR TITLE
Barclaycard Smartpay: 3DS2 Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * NMI: Add support for stored credentials [bayprogrammer] #3243
 * Spreedly: Consolidate API requests and support bank accounts [lancecarlson] #3105
 * BPoint: Hook up merchant_reference and CRN fields [curiousepic] #3249
+* Barclaycard Smartpay: Add support for 3DS2 [britth] #3251
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -112,6 +112,30 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
         zip:      '95014',
         country:  'US'
         })
+
+    @normalized_3ds_2_options = {
+      reference: '345123',
+      shopper_email: 'john.smith@test.com',
+      shopper_ip: '77.110.174.153',
+      shopper_reference: 'John Smith',
+      billing_address: address(),
+      order_id: '123',
+      stored_credential: {reason_type: 'unscheduled'},
+      three_ds_2: {
+        channel: 'browser',
+        browser_info: {
+          accept_header: 'unknown',
+          depth: 100,
+          java: false,
+          language: 'US',
+          height: 1000,
+          width: 500,
+          timezone: '-120',
+          user_agent: 'unknown'
+        },
+        notification_url: 'https://example.com/notification'
+      }
+    }
   end
 
   def teardown
@@ -174,6 +198,16 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     refute response.params['issuerUrl'].blank?
     refute response.params['md'].blank?
     refute response.params['paRequest'].blank?
+  end
+
+  def test_successful_authorize_with_3ds2_browser_client_data
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @normalized_3ds_2_options)
+    assert response.test?
+    refute response.authorization.blank?
+    assert_equal response.params['resultCode'], 'IdentifyShopper'
+    refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
+    refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
+    refute response.params['additionalData']['threeds2.threeDSMethodURL'].blank?
   end
 
   def test_successful_authorize_and_capture


### PR DESCRIPTION
This preps Barclaycard Smartpay for 3DS2 integration. The api version
is bumped up to 40 to get relevant 3DS2 functionality, and additional 
browser_info is captured. The parse method is also updated so that it 
can return a nested hash with an additionalData field for 3DS2.

Unit:
28 tests, 142 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
34 tests, 76 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.0588% passed
(failed `test_successful_third_party_payout` - unrelated invalid credentials error)