### PR TITLE
OPP: Adds support for store

### DIFF
--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -125,6 +125,9 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options={})
         # debit
+        if payment.is_a?(String)
+          options[:registrationId] = payment
+        end
         execute_dbpa(options[:risk_workflow] ? 'PA.CP': 'DB',
           money, payment, options)
       end
@@ -156,6 +159,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def store(credit_card, options = {})
+        execute_store(credit_card, options.merge(store: true))
+      end
+
       def supports_scrubbing?
         true
       end
@@ -168,6 +175,15 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def execute_store(payment, options)
+        post = {}
+        add_payment_method(post, payment, options)
+        add_address(post, options)
+        add_options(post, options)
+        add_3d_secure(post, options)
+        commit(post, nil, options)
+      end
 
       def execute_dbpa(txtype, money, payment, options)
         post = {}
@@ -243,6 +259,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment, options)
+        return if payment.is_a?(String)
         if options[:registrationId]
           post[:card] = {
             cvv: payment.verification_value,
@@ -278,7 +295,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_url(url, authorization, options)
-        if options[:registrationId]
+        if options[:store]
+          url.gsub(/payments/, 'registrations'
+        elsif options[:registrationId]
           "#{url.gsub(/payments/, 'registrations')}/#{options[:registrationId]}/payments"
         elsif authorization
           "#{url}/#{authorization}"

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -296,7 +296,7 @@ module ActiveMerchant #:nodoc:
 
       def build_url(url, authorization, options)
         if options[:store]
-          url.gsub(/payments/, 'registrations'
+          url.gsub(/payments/, 'registrations')
         elsif options[:registrationId]
           "#{url.gsub(/payments/, 'registrations')}/#{options[:registrationId]}/payments"
         elsif authorization

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -228,7 +228,7 @@ class OppTest < Test::Unit::TestCase
 
   def failed_store_response(id, code='100.100.101')
     OppMockResponse.new(400,
-      JSON.generate({'id' => id, 'result' => {'code' => code, "description" => 'invalid creditcard, bank account number or bank name'},
+      JSON.generate({'id' => id, 'result' => {'code' => code, 'description' => 'invalid creditcard, bank account number or bank name'},
                      'card' => {'bin' => '444444', 'last4Digits' => '4444', 'holder' => 'Longbob Longsen', 'expiryMonth' => '05', 'expiryYear' => '2018'},
                      'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage', 'timestamp' => '2015-06-20 20:40:26+0000', 'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'})
     )

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -203,34 +203,96 @@ class OppTest < Test::Unit::TestCase
 
   def successful_response(type, id)
     OppMockResponse.new(200,
-      JSON.generate({'id' => id, 'paymentType' => type, 'paymentBrand' => 'VISA', 'amount' => '1.00', 'currency' => 'EUR', "des
-      criptor" => '5410.9959.0306 OPP_Channel ', 'result' => {'code' => '000.100.110', 'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"}, 'card' => {"bin
-      " => '420000', 'last4Digits' => '0000', 'holder' => 'Longbob Longsen', 'expiryMonth' => '05', 'expiryYear' => '2018'}, 'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage', "time
-      stamp" => '2015-06-20 19:31:01+0000', 'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'})
+      JSON.generate({
+        'id' => id,
+        'paymentType' => type,
+        'paymentBrand' => 'VISA',
+        'amount' => '1.00',
+        'currency' => 'EUR',
+        'descriptor' => '5410.9959.0306 OPP_Channel',
+        'result' => {
+          'code' => '000.100.110',
+          'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
+        },
+        'card' => {
+          'bin' => '420000',
+          'last4Digits' => '0000',
+          'holder' => 'Longbob Longsen',
+          'expiryMonth' => '05',
+          'expiryYear' => '2018'
+        },
+        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+        'timestamp' => '2015-06-20 19:31:01+0000',
+        'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
+      })
     )
   end
 
   def successful_store_response(id)
     OppMockResponse.new(200,
-      JSON.generate({'id' => id, 'result' => {'code' => '000.100.110', 'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"}, 'card' => {"bin
-      " => '420000', 'last4Digits' => '0000', 'holder' => 'Longbob Longsen', 'expiryMonth' => '05', 'expiryYear' => '2018'}, 'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage', "time
-      stamp" => '2015-06-20 19:31:01+0000', 'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'})
+      JSON.generate({
+        'id' => id,
+        'result' => {
+          'code' => '000.100.110',
+          'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
+        },
+        'card' => {
+          'bin' => '420000',
+          'last4Digits' => '0000',
+          'holder' => 'Longbob Longsen',
+          'expiryMonth' => '05',
+          'expiryYear' => '2018'
+        },
+        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+        'timestamp' => '2015-06-20 19:31:01+0000',
+        'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
+      })
     )
   end
 
   def failed_response(type, id, code='100.100.101')
     OppMockResponse.new(400,
-      JSON.generate({'id' => id, 'paymentType' => type, 'paymentBrand' => 'VISA', 'result' => {'code' => code, "des
-        cription" => 'invalid creditcard, bank account number or bank name'}, 'card' => {'bin' => '444444', 'last4Digits' => '4444', 'holder' => 'Longbob Longsen', 'expiryMonth' => '05', 'expiryYear' => '2018'},
-                     'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage', 'timestamp' => '2015-06-20 20:40:26+0000', 'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'})
+      JSON.generate({
+        'id' => id,
+        'paymentType' => type,
+        'paymentBrand' => 'VISA',
+        'result' => {
+          'code' => code,
+          'description' => 'invalid creditcard, bank account number or bank name'
+        },
+        'card' => {
+          'bin' => '444444',
+          'last4Digits' => '4444',
+          'holder' => 'Longbob Longsen',
+          'expiryMonth' => '05',
+          'expiryYear' => '2018'
+        },
+        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+        'timestamp' => '2015-06-20 20:40:26+0000',
+        'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
+      })
     )
   end
 
   def failed_store_response(id, code='100.100.101')
     OppMockResponse.new(400,
-      JSON.generate({'id' => id, 'result' => {'code' => code, 'description' => 'invalid creditcard, bank account number or bank name'},
-                     'card' => {'bin' => '444444', 'last4Digits' => '4444', 'holder' => 'Longbob Longsen', 'expiryMonth' => '05', 'expiryYear' => '2018'},
-                     'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage', 'timestamp' => '2015-06-20 20:40:26+0000', 'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'})
+      JSON.generate({
+        'id' => id,
+        'result' => {
+          'code' => code,
+          'description' => 'invalid creditcard, bank account number or bank name'
+        },
+        'card' => {
+          'bin' => '444444',
+          'last4Digits' => '4444',
+          'holder' => 'Longbob Longsen',
+          'expiryMonth' => '05',
+          'expiryYear' => '2018'
+        },
+        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+        'timestamp' => '2015-06-20 20:40:26+0000',
+        'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
+      })
     )
   end
 


### PR DESCRIPTION
This adds support for tokenizing cards in the Open Payments Platform Gateway.

Documentation for tokenization can be found here: https://docs.oppwa.com/tutorials/server-to-server/tokenisation

Added functionality:
- ability to pass a token to `purchase` to pay with a previously stored card
- ability to `store` a credit card