### PR TITLE
Decidir: Add new gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * BPoint: Hook up merchant_reference and CRN fields [curiousepic] #3249
 * Barclaycard Smartpay: Add support for 3DS2 [britth] #3251
 * Adyen: Add support for non-fractional currencies [molbrown] #3257
+* Decidir: Add new gateway [jknipp] #3254
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -1,0 +1,232 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class DecidirGateway < Gateway
+      self.test_url = 'https://developers.decidir.com/api/v2'
+      self.live_url = 'https://live.decidir.com/api/v2'
+
+      self.supported_countries = ['AR']
+      self.money_format = :cents
+      self.default_currency = 'ARS'
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+
+      self.homepage_url = 'http://www.decidir.com'
+      self.display_name = 'Decidir'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        1 => STANDARD_ERROR_CODE[:call_issuer],
+        2 => STANDARD_ERROR_CODE[:call_issuer],
+        3 => STANDARD_ERROR_CODE[:config_error],
+        4 => STANDARD_ERROR_CODE[:pickup_card],
+        5 => STANDARD_ERROR_CODE[:card_declined],
+        7 => STANDARD_ERROR_CODE[:pickup_card],
+        12 => STANDARD_ERROR_CODE[:processing_error],
+        14 => STANDARD_ERROR_CODE[:invalid_number],
+        28 => STANDARD_ERROR_CODE[:processing_error],
+        38 => STANDARD_ERROR_CODE[:incorrect_pin],
+        39 => STANDARD_ERROR_CODE[:invalid_number],
+        43 => STANDARD_ERROR_CODE[:pickup_card],
+        45 => STANDARD_ERROR_CODE[:card_declined],
+        46 => STANDARD_ERROR_CODE[:invalid_number],
+        47 => STANDARD_ERROR_CODE[:card_declined],
+        48 => STANDARD_ERROR_CODE[:card_declined],
+        49 => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        51 => STANDARD_ERROR_CODE[:card_declined],
+        53 => STANDARD_ERROR_CODE[:card_declined],
+        54 => STANDARD_ERROR_CODE[:expired_card],
+        55 => STANDARD_ERROR_CODE[:incorrect_pin],
+        56 => STANDARD_ERROR_CODE[:card_declined],
+        57 => STANDARD_ERROR_CODE[:card_declined],
+        76 => STANDARD_ERROR_CODE[:call_issuer],
+        96 => STANDARD_ERROR_CODE[:processing_error],
+        97 => STANDARD_ERROR_CODE[:processing_error],
+      }
+
+      def initialize(options={})
+        requires!(options, :api_key)
+        super
+        @options[:preauth_mode] ||= false
+      end
+
+      def purchase(money, payment, options={})
+        raise ArgumentError, 'Purchase is not supported on Decidir gateways configured with the preauth_mode option' if @options[:preauth_mode]
+
+        post = {}
+        add_auth_purchase_params(post, money, payment, options)
+        commit(:post, 'payments', post)
+      end
+
+      def authorize(money, payment, options={})
+        raise ArgumentError, 'Authorize is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
+
+        post = {}
+        add_auth_purchase_params(post, money, payment, options)
+        commit(:post, 'payments', post)
+      end
+
+      def capture(money, authorization, options={})
+        raise ArgumentError, 'Capture is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
+
+        post = {}
+        add_amount(post, money, options)
+        commit(:put, "payments/#{authorization}", post)
+      end
+
+      def refund(money, authorization, options={})
+        post = {}
+        add_amount(post, money, options)
+        commit(:post, "payments/#{authorization}/refunds", post)
+      end
+
+      def void(authorization, options={})
+        post = {}
+        commit(:post, "payments/#{authorization}/refunds", post)
+      end
+
+      def verify(credit_card, options={})
+        raise ArgumentError, 'Verify is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
+
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((apikey: )\w+)i, '\1[FILTERED]').
+          gsub(%r((\"card_number\\\":\\\")\d+), '\1[FILTERED]').
+          gsub(%r((\"security_code\\\":\\\")\d+), '\1[FILTERED]')
+      end
+
+      private
+
+      def add_auth_purchase_params(post, money, credit_card, options)
+        post[:payment_method_id] =  options[:payment_method_id] ? options[:payment_method_id].to_i : 1
+        post[:site_transaction_id] = options[:order_id]
+        post[:bin] = credit_card.number[0..5]
+        post[:payment_type] = options[:payment_type] || 'single'
+        post[:installments] = options[:installments] ? options[:installments].to_i : 1
+        post[:description] = options[:description] if options[:description]
+        post[:email] = options[:email] if options[:email]
+        post[:sub_payments] = []
+
+        add_invoice(post, money, options)
+        add_payment(post, credit_card, options)
+      end
+
+      def add_invoice(post, money, options)
+        add_amount(post, money, options)
+        post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_amount(post, money, options)
+        currency = (options[:currency] || currency(money))
+        post[:amount] = localized_amount(money, currency).to_i
+      end
+
+      def add_payment(post, credit_card, options)
+        card_data = {}
+        card_data[:card_number] = credit_card.number
+        card_data[:card_expiration_month] = format(credit_card.month, :two_digits)
+        card_data[:card_expiration_year] = format(credit_card.year, :two_digits)
+        card_data[:security_code] = credit_card.verification_value if credit_card.verification_value?
+        card_data[:card_holder_name] = credit_card.name if credit_card.name
+
+        # additional data used for Visa transactions
+        card_data[:card_holder_door_number] = options[:card_holder_door_number].to_i if options[:card_holder_door_number]
+        card_data[:card_holder_birthday] = options[:card_holder_birthday] if options[:card_holder_birthday]
+
+        card_data[:card_holder_identification] = {}
+        card_data[:card_holder_identification][:type] = options[:card_holder_identification_type] if options[:card_holder_identification_type]
+        card_data[:card_holder_identification][:number] = options[:card_holder_identification_number] if options[:card_holder_identification_number]
+
+        post[:card_data] = card_data
+      end
+
+      def headers(options = {})
+        {
+          'apikey' => @options[:api_key],
+          'Content-type'  => 'application/json',
+          'Cache-Control' => 'no-cache'
+        }
+      end
+
+      def commit(method, endpoint, parameters, options={})
+        url = "#{(test? ? test_url : live_url)}/#{endpoint}"
+
+        begin
+          raw_response = ssl_request(method, url, post_data(parameters), headers(options))
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = parse(raw_response)
+        end
+
+        success = success_from(response)
+        Response.new(
+          success,
+          message_from(success, response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: success ? nil : error_code_from(response)
+        )
+      end
+
+      def post_data(parameters = {})
+        parameters.to_json
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      rescue JSON::ParserError
+        {
+          'message' => "A non-JSON response was received from Decidir where one was expected. The raw response was:\n\n#{body}"
+        }
+      end
+
+      def message_from(success, response)
+        return response['status'] if success
+        return response['message'] if response['message']
+
+        message = nil
+
+        if error = response.dig('status_details', 'error')
+          message = error.dig('reason', 'description')
+        elsif response['error_type']
+          if response['validation_errors']
+            message = response['validation_errors'].map { |errors| "#{errors['code']}: #{errors['param']}" }.join(', ')
+          end
+          message ||= response['error_type']
+        end
+
+        message
+      end
+
+      def success_from(response)
+        response['status'] == 'approved' || response['status'] == 'pre_approved'
+      end
+
+      def authorization_from(response)
+        response['id']
+      end
+
+      def error_code_from(response)
+        error_code = nil
+        if error = response.dig('status_details', 'error')
+          code = error.dig('reason', 'id')
+          error_code = STANDARD_ERROR_CODE_MAPPING[code]
+          error_code ||= error['type']
+        elsif response['error_type']
+          error_code = response['error_type'] if response['validation_errors']
+        end
+
+        error_code || STANDARD_ERROR_CODE[:processing_error]
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -253,6 +253,14 @@ data_cash:
   login: X
   password: Y
 
+# Working credentials, no need to replace
+decidir_authorize:
+  api_key: 5a15fbc227224edabdb6f2e8219e8b28
+  preauth_mode: true
+
+decidir_purchase:
+  api_key: 5df6b5764c3f4822aecdc82d56f26b9d
+
 # No working test credentials
 dibs:
   merchant_id: SOMECREDENTIAL

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -1,0 +1,168 @@
+require 'test_helper'
+
+class RemoteDecidirTest < Test::Unit::TestCase
+  def setup
+    @gateway_for_purchase = DecidirGateway.new(fixtures(:decidir_purchase))
+    @gateway_for_auth = DecidirGateway.new(fixtures(:decidir_authorize))
+
+    @amount = 100
+    @credit_card = credit_card('4507990000004905')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      order_id: SecureRandom.uuid,
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      card_holder_door_number: '1234',
+      card_holder_birthday: '01011980',
+      card_holder_identification_type: 'dni',
+      card_holder_identification_number: '123456',
+      installments: '12'
+    }
+
+    response = @gateway_for_purchase.purchase(@amount, credit_card('4509790112684851'), @options.merge(options))
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_failed_purchase
+    response = @gateway_for_purchase.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'TARJETA INVALIDA', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+  end
+
+  def test_failed_purchase_with_invalid_field
+    response = @gateway_for_purchase.purchase(@amount, @declined_card, @options.merge(installments: -1))
+    assert_failure response
+    assert_equal 'invalid_param: installments', response.message
+    assert_match 'invalid_request_error', response.error_code
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway_for_auth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'pre_approved', auth.message
+    assert auth.authorization
+
+    assert capture = @gateway_for_auth.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'approved', capture.message
+    assert capture.authorization
+  end
+
+  def test_failed_authorize
+    response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'TARJETA INVALIDA', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+  end
+
+  def test_failed_partial_capture
+    auth = @gateway_for_auth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway_for_auth.capture(1, auth.authorization)
+    assert_failure capture
+    assert_equal 'amount: Amount out of ranges: 100 - 100', capture.message
+    assert_equal 'invalid_request_error', capture.error_code
+    assert_nil capture.authorization
+  end
+
+  def test_failed_capture
+    response = @gateway_for_auth.capture(@amount, '')
+
+    assert_equal 'not_found_error', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
+  def test_successful_refund
+    purchase = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway_for_purchase.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'approved', refund.message
+    assert refund.authorization
+  end
+
+  def test_partial_refund
+    purchase = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway_for_purchase.refund(@amount-1, purchase.authorization)
+    assert_success refund
+    assert_equal 'approved', refund.message
+    assert refund.authorization
+  end
+
+  def test_failed_refund
+    response = @gateway_for_purchase.refund(@amount, '')
+    assert_failure response
+    assert_equal 'not_found_error', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
+  def test_successful_void
+    auth = @gateway_for_auth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway_for_auth.void(auth.authorization)
+    assert_success void
+    assert_equal 'approved', void.message
+    assert void.authorization
+  end
+
+  def test_failed_void
+    response = @gateway_for_auth.void('')
+    assert_failure response
+    assert_equal 'not_found_error', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
+  def test_successful_verify
+    response = @gateway_for_auth.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{pre_approved}, response.message
+  end
+
+  def test_failed_verify
+    response = @gateway_for_auth.verify(@declined_card, @options)
+    assert_failure response
+    assert_match %r{TARJETA INVALIDA}, response.message
+  end
+
+  def test_invalid_login
+    gateway = DecidirGateway.new(api_key: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid authentication credentials}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway_for_purchase) do
+      @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway_for_purchase.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway_for_purchase.options[:api_key], transcript)
+  end
+
+end

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -1,0 +1,371 @@
+require 'test_helper'
+
+class DecidirTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway_for_purchase = DecidirGateway.new(api_key: 'api_key')
+    @gateway_for_auth = DecidirGateway.new(api_key: 'api_key', preauth_mode: true)
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway_for_purchase.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 7719132, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_options
+    options = {
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      card_holder_door_number: '1234',
+      card_holder_birthday: '01011980',
+      card_holder_identification_type: 'dni',
+      card_holder_identification_number: '123456',
+      installments: 12
+    }
+
+    response = stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(options))
+    end.check_request do |method, endpoint, data, headers|
+      assert data =~ /card_holder_door_number/, '1234'
+      assert data =~ /card_holder_birthday/, '01011980'
+      assert data =~ /type/, 'dni'
+      assert data =~ /number/, '123456'
+    end.respond_with(successful_purchase_response)
+
+    assert_equal 7719132, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway_for_purchase.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'TARJETA INVALIDA', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+  end
+
+  def test_failed_purchase_with_invalid_field
+    @gateway_for_purchase.expects(:ssl_request).returns(failed_purchase_with_invalid_field_response)
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(installments: -1))
+    assert_failure response
+    assert_equal 'invalid_param: installments', response.message
+    assert_match 'invalid_request_error', response.error_code
+  end
+
+  def test_failed_purchase_with_preauth_mode
+    assert_raise(ArgumentError) do
+      @gateway_for_auth.purchase(@amount, @credit_card, @options)
+    end
+  end
+
+  def test_successful_authorize
+    @gateway_for_auth.expects(:ssl_request).returns(successful_authorize_response)
+
+    response = @gateway_for_auth.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 7720214, response.authorization
+    assert_equal 'pre_approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_authorize
+    @gateway_for_auth.expects(:ssl_request).returns(failed_authorize_response)
+
+    response = @gateway_for_auth.authorize(@amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal 7719358, response.authorization
+    assert_equal 'TARJETA INVALIDA', response.message
+    assert response.test?
+  end
+
+  def test_failed_authorize_without_preauth_mode
+    assert_raise(ArgumentError) do
+      @gateway_for_purchase.authorize(@amount, @credit_card, @options)
+    end
+  end
+
+  def test_successful_capture
+    @gateway_for_auth.expects(:ssl_request).returns(successful_capture_response)
+
+    response = @gateway_for_auth.capture(@amount, 7720214)
+    assert_success response
+
+    assert_equal 7720214, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_partial_capture
+    @gateway_for_auth.expects(:ssl_request).returns(failed_partial_capture_response)
+
+    response = @gateway_for_auth.capture(@amount, '')
+    assert_failure response
+
+    assert_nil response.authorization
+    assert_equal 'amount: Amount out of ranges: 100 - 100', response.message
+    assert_equal 'invalid_request_error', response.error_code
+    assert response.test?
+  end
+
+  def test_failed_capture
+    @gateway_for_auth.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway_for_auth.capture(@amount, '')
+    assert_failure response
+
+    assert_equal '', response.authorization
+    assert_equal 'not_found_error', response.message
+    assert response.test?
+  end
+
+  def test_failed_capture_without_preauth_mode
+    assert_raise(ArgumentError) do
+      @gateway_for_purchase.capture(@amount, @credit_card, @options)
+    end
+  end
+
+  def test_successful_refund
+    @gateway_for_purchase.expects(:ssl_request).returns(successful_refund_response)
+
+    response = @gateway_for_purchase.refund(@amount, 81931, @options)
+    assert_success response
+
+    assert_equal 81931, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_partial_refund
+    @gateway_for_purchase.expects(:ssl_request).returns(partial_refund_response)
+
+    response = @gateway_for_purchase.refund(@amount-1, 81932, @options)
+    assert_success response
+
+    assert_equal 81932, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_refund
+    @gateway_for_purchase.expects(:ssl_request).returns(failed_refund_response)
+
+    response = @gateway_for_purchase.refund(@amount, '')
+    assert_failure response
+
+    assert_equal '', response.authorization
+    assert_equal 'not_found_error', response.message
+    assert response.test?
+  end
+
+  def test_successful_void
+    @gateway_for_auth.expects(:ssl_request).returns(successful_void_response)
+
+    response = @gateway_for_auth.void(@amount, '')
+    assert_success response
+
+    assert_equal 82814, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_void
+    @gateway_for_auth.expects(:ssl_request).returns(failed_void_response)
+
+    response = @gateway_for_auth.void('')
+    assert_failure response
+
+    assert_equal '', response.authorization
+    assert_equal 'not_found_error', response.message
+    assert response.test?
+  end
+
+  def test_successful_verify
+    @gateway_for_auth.expects(:ssl_request).at_most(3).returns(successful_void_response)
+
+    response = @gateway_for_auth.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_successful_verify_with_failed_void
+    @gateway_for_auth.expects(:ssl_request).at_most(3).returns(failed_void_response)
+
+    response = @gateway_for_auth.verify(@credit_card, @options)
+    assert_failure response
+
+    assert_equal 'not_found_error', response.message
+    assert response.test?
+  end
+
+  def test_failed_verify
+    @gateway_for_auth.expects(:ssl_request).at_most(2).returns(failed_authorize_response)
+
+    response = @gateway_for_auth.verify(@credit_card, @options)
+    assert_failure response
+
+    assert_equal 'TARJETA INVALIDA', response.message
+    assert response.test?
+  end
+
+  def test_failed_verify_for_without_preauth_mode
+    assert_raise(ArgumentError) do
+      @gateway_for_purchase.verify(@amount, @credit_card, @options)
+    end
+  end
+
+  def test_scrub
+    assert @gateway_for_purchase.supports_scrubbing?
+    assert_equal @gateway_for_purchase.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      opening connection to developers.decidir.com:443...
+      opened
+      starting SSL for developers.decidir.com:443...
+      SSL established
+      <- "POST /api/v2/payments HTTP/1.1\r\nContent-Type: application/json\r\nApikey: 5df6b5764c3f4822aecdc82d56f26b9d\r\nCache-Control: no-cache\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: developers.decidir.com\r\nContent-Length: 414\r\n\r\n"
+      <- "{\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"bin\":\"450799\",\"payment_type\":\"single\",\"installments\":1,\"description\":\"Store Purchase\",\"sub_payments\":[],\"amount\":100,\"currency\":\"ARS\",\"card_data\":{\"card_number\":\"4507990000004905\",\"card_expiration_month\":\"09\",\"card_expiration_year\":\"20\",\"security_code\":\"123\",\"card_holder_name\":\"Longbob Longsen\",\"card_holder_identification\":{}}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Mon, 24 Jun 2019 18:38:42 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 659\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "X-Kong-Upstream-Latency: 159\r\n"
+      -> "X-Kong-Proxy-Latency: 0\r\n"
+      -> "Via: kong/0.8.3\r\n"
+      -> "\r\n"
+      reading 659 bytes...
+      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":null,\"aggregate_data\":null,\"establishment_name\":null,\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
+      read 659 bytes
+      Conn close
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      opening connection to developers.decidir.com:443...
+      opened
+      starting SSL for developers.decidir.com:443...
+      SSL established
+      <- "POST /api/v2/payments HTTP/1.1\r\nContent-Type: application/json\r\nApikey: [FILTERED]\r\nCache-Control: no-cache\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: developers.decidir.com\r\nContent-Length: 414\r\n\r\n"
+      <- "{\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"bin\":\"450799\",\"payment_type\":\"single\",\"installments\":1,\"description\":\"Store Purchase\",\"sub_payments\":[],\"amount\":100,\"currency\":\"ARS\",\"card_data\":{\"card_number\":\"[FILTERED]\",\"card_expiration_month\":\"09\",\"card_expiration_year\":\"20\",\"security_code\":\"[FILTERED]\",\"card_holder_name\":\"Longbob Longsen\",\"card_holder_identification\":{}}}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Mon, 24 Jun 2019 18:38:42 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 659\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "X-Kong-Upstream-Latency: 159\r\n"
+      -> "X-Kong-Proxy-Latency: 0\r\n"
+      -> "Via: kong/0.8.3\r\n"
+      -> "\r\n"
+      reading 659 bytes...
+      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":null,\"aggregate_data\":null,\"establishment_name\":null,\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
+      read 659 bytes
+      Conn close
+    )
+  end
+
+  def successful_purchase_response
+    %(
+      {"id":7719132,"site_transaction_id":"ebcb2db7-7aab-4f33-a7d1-6617a5749fce","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"approved","status_details":{"ticket":"7156","card_authorization_code":"174838","address_validation_code":"VTE0011","error":null},"date":"2019-06-21T17:48Z","customer":null,"bin":"450799","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999999","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"345425f15b2c7c4584e0044357b6394d7e","customer_token":null,"card_data":"/tokens/7719132"}
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      {"id":7719351,"site_transaction_id":"73e3ed66-37b1-4c97-8f69-f9cb96422383","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"rejected","status_details":{"ticket":"7162","card_authorization_code":"","address_validation_code":null,"error":{"type":"invalid_number","reason":{"id":14,"description":"TARJETA INVALIDA","additional_description":""}}},"date":"2019-06-21T17:57Z","customer":null,"bin":"400030","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999999","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"11b076fbc8fa6a55783b2f5d03f6938d8a","customer_token":null,"card_data":"/tokens/7719351"}
+    )
+  end
+
+  def failed_purchase_with_invalid_field_response
+    %(
+      {\"error_type\":\"invalid_request_error\",\"validation_errors\":[{\"code\":\"invalid_param\",\"param\":\"installments\"}]}    )
+  end
+
+  def successful_authorize_response
+    %(
+      {"id":7720214,"site_transaction_id":"0fcedc95-4fbc-4299-80dc-f77e9dd7f525","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"pre_approved","status_details":{"ticket":"8187","card_authorization_code":"180548","address_validation_code":"VTE0011","error":null},"date":"2019-06-21T18:05Z","customer":null,"bin":"450799","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999997","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"345425f15b2c7c4584e0044357b6394d7e","customer_token":null,"card_data":"/tokens/7720214"}
+    )
+  end
+
+  def failed_authorize_response
+    %(
+      {"id":7719358,"site_transaction_id":"ff1c12c1-fb6d-4c1a-bc20-2e77d4322c61","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"rejected","status_details":{"ticket":"8189","card_authorization_code":"","address_validation_code":null,"error":{"type":"invalid_number","reason":{"id":14,"description":"TARJETA INVALIDA","additional_description":""}}},"date":"2019-06-21T18:07Z","customer":null,"bin":"400030","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999997","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"11b076fbc8fa6a55783b2f5d03f6938d8a","customer_token":null,"card_data":"/tokens/7719358"}
+    )
+  end
+
+  def successful_capture_response
+    %(
+      {"id":7720214,"site_transaction_id":"0fcedc95-4fbc-4299-80dc-f77e9dd7f525","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"approved","status_details":{"ticket":"8187","card_authorization_code":"180548","address_validation_code":"VTE0011","error":null},"date":"2019-06-21T18:05Z","customer":null,"bin":"450799","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999997","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":{"id":78436,"origin_amount":100,"date":"2019-06-21T03:00Z"},"pan":"345425f15b2c7c4584e0044357b6394d7e","customer_token":null,"card_data":"/tokens/7720214"}
+    )
+  end
+
+  def failed_partial_capture_response
+    %(
+      {"error_type":"invalid_request_error","validation_errors":[{"code":"amount","param":"Amount out of ranges: 100 - 100"}]}
+    )
+  end
+
+  def failed_capture_response
+    %(
+      {"error_type":"not_found_error","entity_name":"","id":""}
+    )
+  end
+
+  def successful_refund_response
+    %(
+      {"id":81931,"amount":100,"sub_payments":null,"error":null,"status":"approved"}
+    )
+  end
+
+  def partial_refund_response
+    %(
+      {"id":81932,"amount":99,"sub_payments":null,"error":null,"status":"approved"}
+    )
+  end
+
+  def failed_refund_response
+    %(
+      {"error_type":"not_found_error","entity_name":"","id":""}
+    )
+  end
+
+  def successful_void_response
+    %(
+      {"id":82814,"amount":100,"sub_payments":null,"error":null,"status":"approved"}
+    )
+  end
+
+  def failed_void_response
+    %(
+      {"error_type":"not_found_error","entity_name":"","id":""}
+    )
+  end
+end


### PR DESCRIPTION
Add support for the Decidir gateway. This implementation sends card data
inline with purchase and authorize requests rather than creating payment
method tokens.

ECS-374

Unit:
18 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
17 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed