### PR TITLE
Mundipagg: Add Alelo card support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,7 +25,7 @@
 * Kushki: Update supported countries [molbrown] #3260
 * Paypal: Update supported countries [molbrown] #3260
 * BlueSnap: Send amount in capture requests [jknipp] #3262
-
+* Adds Elo card type in general, and specifically to Mundipagg [jasonxp] #3255
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -19,6 +19,7 @@ module ActiveMerchant #:nodoc:
     # * Maestro
     # * Forbrugsforeningen
     # * Elo
+    # * Alelo
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -90,6 +91,7 @@ module ActiveMerchant #:nodoc:
       # * +'maestro'+
       # * +'forbrugsforeningen'+
       # * +'elo'+
+      # * +'alelo'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -6,6 +6,7 @@ module ActiveMerchant #:nodoc:
         'visa'               => ->(num) { num =~ /^4\d{12}(\d{3})?(\d{3})?$/ },
         'master'             => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), MASTERCARD_RANGES) },
         'elo'                => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ELO_RANGES) },
+        'alelo'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ALELO_RANGES) },
         'discover'           => ->(num) { num =~ /^(6011|65\d{2}|64[4-9]\d)\d{12,15}|(62\d{14,17})$/ },
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11}$/ },
@@ -77,6 +78,19 @@ module ActiveMerchant #:nodoc:
         650439..650439, 650485..650504, 650506..650530, 650577..650580, 650582..650591, 650721..650727, 650901..650922,
         650928..650928, 650938..650939, 650946..650948, 650954..650955, 650962..650963, 650967..650967, 650971..650971,
         651652..651667, 651675..651678, 655000..655010, 655012..655015, 655051..655052, 655056..655057
+      ]
+
+      # Alelo provides BIN ranges by e-mailing them out periodically.
+      # The BINs beginning with the digit 4 overlap with Visa's range of valid card numbers.
+      # By placing the 'alelo' entry in CARD_COMPANY_DETECTORS below the 'visa' entry, we
+      # identify these cards as Visa. This works because transactions with such cards will
+      # run on Visa rails.
+      ALELO_RANGES = [
+        402588..402588, 404347..404347, 405876..405876, 405882..405882, 405884..405884,
+        405886..405886, 430471..430471, 438061..438061, 438064..438064, 470063..470066,
+        496067..496067, 506699..506704, 506706..506706, 506713..506714, 506716..506716,
+        506749..506750, 506752..506752, 506754..506756, 506758..506762, 506764..506767,
+        506770..506771, 509015..509019, 509880..509882, 509884..509885, 509987..509988
       ]
 
       def self.included(base)

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :alelo]
 
       self.homepage_url = 'https://www.mundipagg.com/'
       self.display_name = 'Mundipagg'

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -138,6 +138,23 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'elo', CreditCard.brand?('6509550000000000')
   end
 
+  def test_should_detect_alelo_card
+    assert_equal 'alelo', CreditCard.brand?('5067490000000010')
+    assert_equal 'alelo', CreditCard.brand?('5067700000000028')
+    assert_equal 'alelo', CreditCard.brand?('5067600000000036')
+    assert_equal 'alelo', CreditCard.brand?('5067600000000044')
+  end
+
+  # Alelo BINs beginning with the digit 4 overlap with Visa's range of valid card numbers.
+  # We intentionally misidentify these cards as Visa, which works because transactions with
+  # such cards will run on Visa rails.
+  def test_should_detect_alelo_number_beginning_with_4_as_visa
+    assert_equal 'visa', CreditCard.brand?('4025880000000010')
+    assert_equal 'visa', CreditCard.brand?('4025880000000028')
+    assert_equal 'visa', CreditCard.brand?('4025880000000036')
+    assert_equal 'visa', CreditCard.brand?('4025880000000044')
+  end
+
   def test_should_detect_when_an_argument_brand_does_not_match_calculated_brand
     assert CreditCard.matching_brand?('4175001000000000', 'visa')
     assert_false CreditCard.matching_brand?('4175001000000000', 'master')

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -3,8 +3,33 @@ require 'test_helper'
 class MundipaggTest < Test::Unit::TestCase
   include CommStub
   def setup
-    @gateway = MundipaggGateway.new(api_key: 'my_api_key')
     @credit_card = credit_card
+
+    @alelo_card = credit_card(
+      '5067700000000028',
+      {
+        month: 10,
+        year: 2032,
+        first_name: 'John',
+        last_name: 'Smith',
+        verification_value: '737',
+        brand: 'alelo'
+      }
+    )
+
+    @alelo_visa_card = credit_card(
+      '4025880000000010',
+      {
+        month: 10,
+        year: 2032,
+        first_name: 'John',
+        last_name: 'Smith',
+        verification_value: '737',
+        brand: 'alelo'
+      }
+    )
+
+    @gateway = MundipaggGateway.new(api_key: 'my_api_key')
     @amount = 100
 
     @options = {
@@ -16,13 +41,15 @@ class MundipaggTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    test_successful_purchase_with(@credit_card)
+  end
 
-    response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success response
+  def test_successful_purchase_with_alelo_card
+    test_successful_purchase_with(@alelo_card)
+  end
 
-    assert_equal 'ch_90Vjq8TrwfP74XJO', response.authorization
-    assert response.test?
+  def test_successful_purchase_with_alelo_number_beginning_with_4
+    test_successful_purchase_with(@alelo_visa_card)
   end
 
   def test_successful_purchase_with_holder_document
@@ -189,6 +216,16 @@ class MundipaggTest < Test::Unit::TestCase
   end
 
   private
+
+  def test_successful_purchase_with(card)
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, card, @options)
+    assert_success response
+
+    assert_equal 'ch_90Vjq8TrwfP74XJO', response.authorization
+    assert response.test?
+  end
 
   def pre_scrubbed
     %q(


### PR DESCRIPTION
This change set adds support for the Alelo voucher card, including a Mundipagg implementation. Adyen Support has indicated that Alelo will be supported using elodebit rails for merchants that have a Cielo agreement. However, Adyen does not provide any Alelo test cards, and will not recognize generated cards as Alelo, so no Adyen-specific code has been added.

Some refactoring has been done in the Mundipagg remote tests to keep the code DRY now that a new card type is being tested.