### PR TITLE
Adyen: Add support for non-fractional currencies

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -237,17 +237,19 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, money, options)
+        currency = options[:currency] || currency(money)
         amount = {
-          value: amount(money),
-          currency: options[:currency] || currency(money)
+          value: localized_amount(money, currency),
+          currency: currency
         }
         post[:amount] = amount
       end
 
       def add_invoice_for_modification(post, money, options)
+        currency = options[:currency] || currency(money)
         amount = {
-          value: amount(money),
-          currency: options[:currency] || currency(money)
+          value: localized_amount(money, currency),
+          currency: currency
         }
         post[:modificationAmount] = amount
       end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -271,6 +271,14 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_nonfractional_currency_handling
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"amount\":{\"value\":\"1\",\"currency\":\"JPY\"}/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Adds localized_amount to determine amount, to allow correct handling of non-fractional currencies.

ECS-420

Unit:
39 tests, 186 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
60 tests, 187 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed
Failures due to error message change, unrelated