### PR TITLE
Adyen: Add support for non-fractional currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Spreedly: Consolidate API requests and support bank accounts [lancecarlson] #3105
 * BPoint: Hook up merchant_reference and CRN fields [curiousepic] #3249
 * Barclaycard Smartpay: Add support for 3DS2 [britth] #3251
+* Adyen: Add support for non-fractional currencies [molbrown] #3257
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228


### PR DESCRIPTION
Adds localized_amount to determine amount, to allow correct handling of
non-fractional currencies.

Includes a what_amount method which will protect customers already transacting on
Adyen from a sudden change in their transaction amounts. what_amount
will be removed after coordinating.

ECS-420

Unit:
40 tests, 189 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
60 tests, 187 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed
Failures due to error message change, unrelated