### PR TITLE
BlueSnap: Send amount in capture requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@
 * Credorax: Update supported countries [molbrown] #3260
 * Kushki: Update supported countries [molbrown] #3260
 * Paypal: Update supported countries [molbrown] #3260
+* BlueSnap: Send amount in capture requests [jknipp] #3262
+
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -95,6 +95,7 @@ module ActiveMerchant
         commit(:capture, :put) do |doc|
           add_authorization(doc, authorization)
           add_order(doc, options)
+          add_amount(doc, money, options)
         end
       end
 

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -176,6 +176,15 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_equal 'Success', capture.message
   end
 
+  def test_successful_authorize_and_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount - 1, auth.authorization)
+    assert_success capture
+    assert_equal 'Success', capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -91,9 +91,13 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_successful_capture
-    @gateway.expects(:raw_ssl_request).returns(successful_capture_response)
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.capture(@amount, @credit_card, @options)
+    end.check_request do |method, url, data|
+      assert_match(/<amount>1.00<\/amount>/, data)
+      assert_match(/<currency>USD<\/currency>/, data)
+    end.respond_with(successful_capture_response)
 
-    response = @gateway.capture(@amount, 'Authorization')
     assert_success response
     assert_equal '1012082881', response.authorization
   end


### PR DESCRIPTION
ECS-430

Unit:
26 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed