### PR TITLE
Adyen: Remove temporary amount modification for non-fractional currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Paypal: Update supported countries [molbrown] #3260
 * BlueSnap: Send amount in capture requests [jknipp] #3262
 * Adds Elo card type in general, and specifically to Mundipagg [jasonxp] #3255
+* Adyen: Remove temporary amount modification for non-fractional currencies [molbrown] #3263
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -239,7 +239,6 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         currency = options[:currency] || currency(money)
-        money = calculate_amount(money, options)
         amount = {
           value: localized_amount(money, currency),
           currency: currency
@@ -249,24 +248,11 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice_for_modification(post, money, options)
         currency = options[:currency] || currency(money)
-        money = calculate_amount(money, options)
         amount = {
           value: localized_amount(money, currency),
           currency: currency
         }
         post[:modificationAmount] = amount
-      end
-
-      # temporary method in place to support Spreedly customers switching
-      # over to sending multiplied amounts for non-fractional currency transactions,
-      # as now required for localized_amount. To avoid amount manipulation, send
-      # opt_out_multiply_amount with any non-fractional currency transaction.
-      def calculate_amount(money, options)
-        currency = options[:currency] || currency(money)
-        if non_fractional_currency?(currency)
-          money *=100 unless options[:opt_out_multiply_amount]
-        end
-        money
       end
 
       def add_payment(post, payment)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -196,7 +196,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_purchase
@@ -274,7 +274,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -452,7 +452,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.store(@declined_card, @options)
 
     assert_failure response
-    assert_equal 'Refused', response.message
+    assert_equal 'CVC Declined', response.message
   end
 
   def test_successful_purchase_using_stored_card
@@ -491,7 +491,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match 'Refused', response.message
+    assert_match 'CVC Declined', response.message
   end
 
   def test_verify_with_idempotency_key

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -271,17 +271,9 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
-  def test_nonfractional_currency_handling_with_amount_modification
+  def test_nonfractional_currency_handling
     stub_comms do
-      @gateway.authorize(1, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
-      assert_match(/"amount\":{\"value\":\"1\",\"currency\":\"JPY\"}/, data)
-    end.respond_with(successful_authorize_response)
-  end
-
-  def test_nonfractional_currency_handling_without_amount_modification
-    stub_comms do
-      @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY', opt_out_multiply_amount: true))
+      @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
     end.check_request do |endpoint, data, headers|
       assert_match(/"amount\":{\"value\":\"2\",\"currency\":\"JPY\"}/, data)
     end.respond_with(successful_authorize_response)


### PR DESCRIPTION
After safe switchover is coordinated with customer who needed
transition step during update of Adyen to use localized_amount.

Unit:
39 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
60 tests, 187 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Continues ECS-420