### PR TITLE
Trust Commerce: Support void after purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * Global Collect: Only add name if present [curiousepic] #3268
 * HPS: Add Apple Pay raw cryptogram support [slogsdon] #3209
 * CardConnect: Fix parsing of level 3 fields [hdeters] #3273
+* TrustCommerce: Support void after purchase [jknipp] #3265
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -104,6 +104,8 @@ module ActiveMerchant #:nodoc:
       TEST_LOGIN = 'TestMerchant'
       TEST_PASSWORD = 'password'
 
+      VOIDABLE_ACTIONS = %w(preauth sale postauth credit)
+
       self.money_format = :cents
       self.supported_cardtypes = [:visa, :master, :discover, :american_express, :diners_club, :jcb]
       self.supported_countries = ['US']
@@ -179,9 +181,10 @@ module ActiveMerchant #:nodoc:
       # postauth, we preserve active_merchant's nomenclature of capture() for consistency with the rest of the library. To process
       # a postauthorization with TC, you need an amount in cents or a money object, and a TC transid.
       def capture(money, authorization, options = {})
+        transaction_id, _ = split_authorization(authorization)
         parameters = {
           :amount => amount(money),
-          :transid => authorization,
+          :transid => transaction_id,
         }
         add_aggregator(parameters, options)
 
@@ -191,9 +194,10 @@ module ActiveMerchant #:nodoc:
       # refund() allows you to return money to a card that was previously billed. You need to supply the amount, in cents or a money object,
       # that you want to refund, and a TC transid for the transaction that you are refunding.
       def refund(money, identification, options = {})
+        transaction_id, _ = split_authorization(identification)
         parameters = {
           :amount => amount(money),
-          :transid => identification
+          :transid => transaction_id
         }
         add_aggregator(parameters, options)
 
@@ -214,18 +218,24 @@ module ActiveMerchant #:nodoc:
       # TrustCommerce to allow for reversal transactions before you can use this
       # method.
       #
+      # void() is also used to to cancel a capture (postauth), purchase (sale),
+      # or refund (credit) or a before it is sent for settlement.
+      #
       # NOTE: AMEX preauth's cannot be reversed. If you want to clear it more
       # quickly than the automatic expiration (7-10 days), you will have to
       # capture it and then immediately issue a credit for the same amount
       # which should clear the customers credit card with 48 hours according to
       # TC.
       def void(authorization, options = {})
+        transaction_id, original_action = split_authorization(authorization)
+        action = (VOIDABLE_ACTIONS - ['preauth']).include?(original_action) ? 'void' : 'reversal'
+
         parameters = {
-          :transid => authorization,
+          :transid => transaction_id,
         }
         add_aggregator(parameters, options)
 
-        commit('reversal', parameters)
+        commit(action, parameters)
       end
 
       # recurring() a TrustCommerce account that is activated for Citadel, TrustCommerce's
@@ -416,7 +426,7 @@ module ActiveMerchant #:nodoc:
         message = message_from(data)
         Response.new(success, message, data,
           :test => test?,
-          :authorization => data['transid'],
+          :authorization => authorization_from(action, data),
           :cvv_result => data['cvv'],
           :avs_result => { :code => data['avs'] }
         )
@@ -446,6 +456,15 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def authorization_from(action, data)
+        authorization = data['transid']
+        authorization = "#{authorization}|#{action}" if authorization && VOIDABLE_ACTIONS.include?(action)
+        authorization
+      end
+
+      def split_authorization(authorization)
+        authorization.split('|')
+      end
     end
   end
 end

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -84,6 +84,18 @@ class TrustCommerceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  # Requires enabling the setting: 'Allow voids to process or settle on processing node' in the Trust Commerce vault UI
+  def test_purchase_and_void
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    void = @gateway.void(purchase.authorization)
+    assert_success void
+    assert_equal 'The transaction was successful', void.message
+    assert_equal 'accepted', void.params['status']
+    assert void.params['transid']
+  end
+
   def test_successful_authorize_with_avs
     assert response = @gateway.authorize(@amount, @credit_card, :billing_address => @valid_address)
 


### PR DESCRIPTION
I was not able to test this remotely. I'm not sure if this functionality is enabled via settings or if it cannot be tested in the sandbox.

Trust Commerce allows voids on purchases, refunds and captures, and
preauths. Preauth uses the 'reversal' function, while purchase, refund,
and capture use the Trust Commerce 'void' function'.

Expand void support for additional transaction types by tracking the
original action associated with the authorization transaction
id. The action take at Trust Commerce (reversal or void) is based on the
original action.

ECS-356

Unit:
12 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
16 tests, 59 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
81.25% passed

Three unrelated, existing remote test failures.