### PR TITLE
BlueSnap: Default to not send amount on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * CardConnect: Fix parsing of level 3 fields [hdeters] #3273
 * TrustCommerce: Support void after purchase [jknipp] #3265
 * Payflow: Support arbitrary level 2 + level 3 fields [therufs] #3272
+* BlueSnap: Default to not send amount on capture [molbrown] #3270
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -95,7 +95,7 @@ module ActiveMerchant
         commit(:capture, :put) do |doc|
           add_authorization(doc, authorization)
           add_order(doc, options)
-          add_amount(doc, money, options)
+          add_amount(doc, money, options) if options[:include_capture_amount] == true
         end
       end
 

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -94,6 +94,18 @@ class BlueSnapTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.capture(@amount, @credit_card, @options)
     end.check_request do |method, url, data|
+      assert_not_match(/<amount>1.00<\/amount>/, data)
+      assert_not_match(/<currency>USD<\/currency>/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success response
+    assert_equal '1012082881', response.authorization
+  end
+
+  def test_successful_partial_capture
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.capture(@amount, @credit_card, @options.merge(include_capture_amount: true))
+    end.check_request do |method, url, data|
       assert_match(/<amount>1.00<\/amount>/, data)
       assert_match(/<currency>USD<\/currency>/, data)
     end.respond_with(successful_capture_response)


### PR DESCRIPTION
Including an amount on capture can cause an issue if attempting to
capture full amount authorized and there are slight differences in
amount requested and amount actually authorized due to currency
exchange. BlueSnap will capture full amount authorized if no amount is
included in the capture request. Adds a flag for including the amount
only in the case of partial capture.

Continues ECS-454
Relates to ECS-430

Unit:
27 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed