### PR TITLE
CardConnect: Fix level 3 field parse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * NMI: Correct password scrubber to scrub symbols [hdeters] #3267
 * Global Collect: Only add name if present [curiousepic] #3268
 * HPS: Add Apple Pay raw cryptogram support [slogsdon] #3209
+* CardConnect: Fix parsing of level 3 fields [hdeters] #3273
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -233,6 +233,7 @@ module ActiveMerchant #:nodoc:
             item.each_pair do |k, v|
               updated.merge!(k.to_s.gsub(/_/, '') => v)
             end
+            updated
           end
         end
       end

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -34,28 +34,28 @@ class RemoteCardConnectTest < Test::Unit::TestCase
       ship_from_date: '20877',
       items: [
         {
-          line_no: '1',
+          lineno: '1',
           material: 'MATERIAL-1',
           description: 'DESCRIPTION-1',
           upc: 'UPC-1',
           quantity: '1000',
           uom: 'CS',
-          unit_cost: '900',
-          net_amnt: '150',
-          tax_amnt: '117',
-          disc_amnt: '0'
+          unitcost: '900',
+          netamnt: '150',
+          taxamnt: '117',
+          discamnt: '0'
         },
         {
-          line_no: '2',
+          lineno: '2',
           material: 'MATERIAL-2',
           description: 'DESCRIPTION-2',
           upc: 'UPC-1',
           quantity: '2000',
           uom: 'CS',
-          unit_cost: '450',
-          net_amnt: '300',
-          tax_amnt: '117',
-          disc_amnt: '0'
+          unitcost: '450',
+          netamnt: '300',
+          taxamnt: '117',
+          discamnt: '0'
         }
       ]
     }


### PR DESCRIPTION
Remove underscores from level 3 gateway specific fields. This functionality existed but wasn't working correctly -- this PR fixes it. 

ECS-397

Unit:
22 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
23 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed