### PR TITLE
Credorax: add 3DS2 MPI auth data support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * BlueSnap: Default to not send amount on capture [molbrown] #3270
 * Spreedly: extra fields, remove extraneous check [montdidier] #3102 #3281
 * Cecabank: Update encryption to SHA2 [leila-alderman] #3278
+* Credorax: add 3DS2 MPI auth data support [bayprogrammer] #3274
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ end
 For more in-depth documentation and tutorials, see [GettingStarted.md](GettingStarted.md) and the
 [API documentation](http://www.rubydoc.info/github/activemerchant/active_merchant/).
 
+Emerging ActiveMerchant 3DS conventions are documented in the [Contributing](https://github.com/activemerchant/active_merchant/wiki/Contributing#3ds-options)
+guide and [Standardized 3DS Fields](https://github.com/activemerchant/active_merchant/wiki/Standardized-3DS-Fields) guide of the wiki.
+
 ## Supported Payment Gateways
 
 The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wikis) contains a [table of features supported by each gateway](https://github.com/activemerchant/active_merchant/wiki/Gateway-Feature-Matrix).

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -6,6 +6,10 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Credorax Gateway'
       self.homepage_url = 'https://www.credorax.com/'
 
+      # NOTE: the IP address you run the remote tests from will need to be
+      # whitelisted by Credorax; contact support@credorax.com as necessary to
+      # request your IP address be added to the whitelist for your test
+      # account.
       self.test_url = 'https://intconsole.credorax.com/intenv/service/gateway'
 
       # The live URL is assigned on a per merchant basis once certification has passed
@@ -264,8 +268,30 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3d_secure(post, options)
-        return unless options[:eci] && options[:xid]
-        post[:i8] = "#{options[:eci]}:#{(options[:cavv] || "none")}:#{options[:xid]}"
+        if options[:eci] && options[:xid]
+          add_3d_secure_1_data(post, options)
+        elsif options[:three_d_secure]
+          add_normalized_3d_secure_2_data(post, options)
+        end
+      end
+
+      def add_3d_secure_1_data(post, options)
+        post[:i8] = build_i8(options[:eci], options[:cavv], options[:xid])
+      end
+
+      def add_normalized_3d_secure_2_data(post, options)
+        three_d_secure_options = options[:three_d_secure]
+
+        post[:i8] = build_i8(
+          three_d_secure_options[:eci],
+          three_d_secure_options[:cavv]
+        )
+        post[:'3ds_version'] = three_d_secure_options[:version]
+        post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
+      end
+
+      def build_i8(eci, cavv=nil, xid=nil)
+        "#{eci}:#{cavv || 'none'}:#{xid || 'none'}"
       end
 
       def add_echo(post, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -220,6 +220,9 @@ creditcall:
   terminal_id: '99961426'
   transaction_key: '9drdRU9wJ65SNRw3'
 
+# NOTE: the IP address you run the remote tests from will need to be
+# whitelisted by Credorax; contact support@credorax.com as necessary to request
+# your IP address be added to the whitelist for your test account.
 credorax:
   merchant_id: 'merchant_id'
   cipher_key: 'cipher_key'


### PR DESCRIPTION
Credorax: add 3DS2 MPI auth data support

Unit:
22 tests, 102 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 45 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
60% passed

NOTE: Failing tests also failing in current master as of time of this run (and these same 10 were passing only a couple hours ago). The Credorax test infrastructure with respect to the test Visa credentials seems very unstable (and possibly depenedent on the time of day the transactions are attempted), see:

https://github.com/activemerchant/active_merchant/pull/3040#issuecomment-437146298

Today, it seemed like they passed before 17:00 London time, and started failing with "Transaction has been declined." at or around 17:00 London time. Shuffling card numbers is futile, just leaving these failures in place since there is no predictable and reliable way to ensure they always pass.

ECS-382

Closes #3274