### PR TITLE
WorldPay - use ds_transaction_id for 3DS 2.x

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -301,15 +301,22 @@ module ActiveMerchant #:nodoc:
             end
 
             if three_d_secure = options[:three_d_secure]
-              xml.tag! 'info3DSecure' do
-                xml.tag! 'threeDSVersion', three_d_secure[:version]
-                xid_tag = three_d_secure[:version] =~ /^2/ ? 'dsTransactionId' : 'xid'
-                xml.tag! xid_tag, three_d_secure[:xid]
-                xml.tag! 'cavv', three_d_secure[:cavv]
-                xml.tag! 'eci', three_d_secure[:eci]
-              end
+              add_three_d_secure(three_d_secure, xml)
             end
           end
+        end
+      end
+
+      def add_three_d_secure(three_d_secure, xml)
+        xml.tag! 'info3DSecure' do
+          xml.tag! 'threeDSVersion', three_d_secure[:version]
+          if three_d_secure[:version] =~ /^2/
+            xml.tag! 'dsTransactionId', three_d_secure[:ds_transaction_id]
+          else
+            xml.tag! 'xid', three_d_secure[:xid]
+          end
+          xml.tag! 'cavv', three_d_secure[:cavv]
+          xml.tag! 'eci', three_d_secure[:eci]
         end
       end
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -602,7 +602,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_3ds_version_1_request
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option('1.0.2')))
+      @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option(version: '1.0.2', xid: 'xid')))
     end.check_request do |endpoint, data, headers|
       assert_match %r{<paymentService version="1.4" merchantCode="testlogin">}, data
       assert_match %r{<eci>eci</eci>}, data
@@ -614,12 +614,12 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_3ds_version_2_request
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option('2.1.0')))
+      @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option(version: '2.1.0', ds_transaction_id: 'ds_transaction_id')))
     end.check_request do |endpoint, data, headers|
       assert_match %r{<paymentService version="1.4" merchantCode="testlogin">}, data
       assert_match %r{<eci>eci</eci>}, data
       assert_match %r{<cavv>cavv</cavv>}, data
-      assert_match %r{<dsTransactionId>xid</dsTransactionId>}, data
+      assert_match %r{<dsTransactionId>ds_transaction_id</dsTransactionId>}, data
       assert_match %r{<threeDSVersion>2.1.0</threeDSVersion>}, data
     end.respond_with(successful_authorize_response)
   end
@@ -835,13 +835,14 @@ class WorldpayTest < Test::Unit::TestCase
     end
   end
 
-  def three_d_secure_option(version)
+  def three_d_secure_option(version:, xid: nil, ds_transaction_id: nil)
     {
       three_d_secure: {
         eci: 'eci',
         cavv: 'cavv',
-        xid: 'xid',
-        version: version
+        xid: xid,
+        ds_transaction_id: ds_transaction_id,
+        version: version,
       }
     }
   end


### PR DESCRIPTION
### Problem
For 3DS version 2.x, the value of the 3DS DS transaction ID is retrieved from `three_d_secure [xid]` but the value is in `three_d_secure[:ds_transaction_id]`

### Fix 
Retrieve the 3DS DS transaction ID from `three_d_secure[:ds_transaction_id]`