### PR TITLE
CECAbank: Update encryption to SHA2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Payflow: Support arbitrary level 2 + level 3 fields [therufs] #3272
 * BlueSnap: Default to not send amount on capture [molbrown] #3270
 * Spreedly: extra fields, remove extraneous check [montdidier] #3102 #3281
+* Cecabank: Update encryption to SHA2 [leila-alderman] #3278
 
 == Version 1.95.0 (May 23, 2019)
 * Adyen: Constantize version to fix subdomains [curiousepic] #3228

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -1,7 +1,7 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class CecabankGateway < Gateway
-      self.test_url = 'http://tpv.ceca.es:8000'
+      self.test_url = 'https://tpv.ceca.es'
       self.live_url = 'https://pgw.ceca.es'
 
       self.supported_countries = ['ES']
@@ -13,14 +13,14 @@ module ActiveMerchant #:nodoc:
 
       #### CECA's MAGIC NUMBERS
       CECA_NOTIFICATIONS_URL = 'NONE'
-      CECA_ENCRIPTION = 'SHA1'
+      CECA_ENCRIPTION = 'SHA2'
       CECA_DECIMALS = '2'
       CECA_MODE = 'SSL'
       CECA_UI_LESS_LANGUAGE = 'XML'
       CECA_UI_LESS_LANGUAGE_REFUND = '1'
       CECA_UI_LESS_REFUND_PAGE = 'anulacion_xml'
-      CECA_ACTION_REFUND   = 'tpvanularparcialmente' # use partial refund's URL to avoid time frame limitations and decision logic on client side
-      CECA_ACTION_PURCHASE = 'tpv'
+      CECA_ACTION_REFUND   = 'anulaciones/anularParcial' # use partial refund's URL to avoid time frame limitations and decision logic on client side
+      CECA_ACTION_PURCHASE = 'tpv/compra'
       CECA_CURRENCIES_DICTIONARY = {'EUR' => 978, 'USD' => 840, 'GBP' => 826}
 
       # Creates a new CecabankGateway
@@ -168,8 +168,8 @@ module ActiveMerchant #:nodoc:
           'AcquirerBIN' => options[:acquirer_bin],
           'TerminalID' => options[:terminal_id]
         )
-        url = (test? ? self.test_url : self.live_url) + "/cgi-bin/#{action}"
-        xml = ssl_post(url, post_data(parameters))
+        url = (test? ? self.test_url : self.live_url) + "/tpvweb/#{action}.action"
+        xml = ssl_post("#{url}?", post_data(parameters))
         response = parse(xml)
         Response.new(
           response[:success],
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
           CECA_NOTIFICATIONS_URL +
           CECA_NOTIFICATIONS_URL
         end
-        Digest::SHA1.hexdigest(signature_fields)
+        Digest::SHA2.hexdigest(signature_fields)
       end
     end
   end

--- a/test/remote/gateways/remote_cecabank_test.rb
+++ b/test/remote/gateways/remote_cecabank_test.rb
@@ -23,7 +23,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'ERROR', response.message
+    assert_match 'ERROR', response.message
   end
 
   def test_successful_refund
@@ -36,20 +36,19 @@ class RemoteCecabankTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_refund
-    assert response = @gateway.refund(@amount, 'wrongreference', @options)
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert response = @gateway.refund(@amount, purchase.authorization, @options.merge(currency: 'USD'))
     assert_failure response
-    assert_equal 'ERROR', response.message
+    assert_match 'ERROR', response.message
   end
 
   def test_invalid_login
-    gateway = CecabankGateway.new(
-      :merchant_id => '',
-      :acquirer_bin => '',
-      :terminal_id => '',
-      :key => ''
-    )
+    gateway = CecabankGateway.new(fixtures(:cecabank).merge(key: 'invalid'))
+
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'ERROR', response.message
+    assert_match 'ERROR', response.message
   end
 end


### PR DESCRIPTION
Updated the encryption method for the CECAbank gateway from SHA1 to
SHA2. This change also included updating the URLs for the gateway and
revising the remote tests.

CE-23

Unit:
7 tests, 36 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
5 tests, 17 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed