### PR TITLE
Realex: Implement credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * CardConnect: Move domain from gateway specific to gateway field [hdeters] #3283
 * Braintree Blue: Support for stored credentials [hdeters] #3286
+* Realex: Re-implement credit as general credit [leila-alderman] #3280
 
 == Version 1.96.0 (Jul 26, 2019)
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229


### PR DESCRIPTION
Implemented support for `credit` (also known as `general_credit` in
Spreedly parlance) for the Realex gateway, including remote and unit
tests.

CE-52 / CE-58

Unit:
27 tests, 844 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
26 tests, 135 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed