### PR TITLE
Payflow: Explicitly parse XML passed in L2/L3 fields

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
         fields.each do |k, v|
           if v.is_a? String
             new_node = Nokogiri::XML::Node.new(k, xml_doc)
-            new_node.add_child(v)
+            new_node.add_child(check_child(v))
             xml_doc.at_css(parent).add_child(new_node)
           else
             check_subparent_before_continuing(parent, k, xml_doc)
@@ -213,6 +213,10 @@ module ActiveMerchant #:nodoc:
           end
         end
         xml_doc
+      end
+
+      def check_child(child)
+        Nokogiri::XML.parse(child).root || child
       end
 
       def check_subparent_before_continuing(parent, subparent, xml_doc)

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -40,7 +40,7 @@ class RemotePayflowTest < Test::Unit::TestCase
         }
       }'
 
-    @l3_json = '{
+    @xml_json = '{
         "Invoice": {
           "Date": "20190104",
           "Level3Invoice": {
@@ -99,8 +99,8 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_not_nil response.authorization
   end
 
-  def test_successful_purchase_with_l3_fields
-    options = @options.merge(level_three_fields: @l3_json)
+  def test_successful_purchase_with_xml_fields
+    options = @options.merge(level_three_fields: @xml_json)
 
     assert response = @gateway.purchase(100000, @credit_card, options)
     assert_equal 'Approved', response.message
@@ -109,8 +109,8 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_not_nil response.authorization
   end
 
-  def test_successful_purchase_with_l2_l3_fields
-    options = @options.merge(level_two_fields: @l2_json).merge(level_three_fields: @l3_json)
+  def test_successful_purchase_with_l2_and_xml_fields
+    options = @options.merge(level_two_fields: @l2_json).merge(level_three_fields: @xml_json)
 
     assert response = @gateway.purchase(100000, @credit_card, options)
     assert_equal 'Approved', response.message

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -25,13 +25,15 @@ class PayflowTest < Test::Unit::TestCase
       }
     }'
 
-    @l3_json = '{
+    @xml_json = '{
       "Invoice": {
         "Date": "20190104",
         "Level3Invoice": {
           "CountyTax": {"Amount": "3.23"}
         }
-      }
+      },
+      "Items":
+        "<Item Number=\"1\"><SKU>1111</SKU><UPC>9999</UPC><Description>Widget</Description><Quantity>2</Quantity><UnitOfMeasurement>INQ</UnitOfMeasurement><UnitPrice>49.99</UnitPrice><DiscountAmt>9.98</DiscountAmt><FreightAmt>3.00</FreightAmt><HandlingAmt>8.00</HandlingAmt><TotalAmt>101.00</TotalAmt><PickUp>  <Address>  <Street>500 Main St.</Street><City>Anytown</City><State>NY</State><Zip>67890</Zip><Country>US</Country></Address><Time>15:30</Time><Date>20030630</Date><RecordNumber>24680</RecordNumber></PickUp><TrackingNumber>ABC0123</TrackingNumber><Delivery><Date>20030714</Date><Time>12:00</Time></Delivery><UNSPSCCode>54.10.15.05</UNSPSCCode></Item><Item Number=\"2\"><SKU>2222</SKU><UPC>8888</UPC><Description>Gizmo</Description><Quantity>5</Quantity><UnitOfMeasurement>INQ</UnitOfMeasurement><UnitPrice>9.99</UnitPrice><DiscountAmt>2.50</DiscountAmt><FreightAmt>3.00</FreightAmt><HandlingAmt>2.50</HandlingAmt><TotalAmt>52.95</TotalAmt><PickUp>  <Address>    <Street>500 Main St.</Street><City>Anytown</City><State>NY</State><Zip>67890</Zip><Country>US</Country></Address><Time>09:00</Time><Date>20030628</Date><RecordNumber>13579</RecordNumber></PickUp><TrackingNumber>XYZ7890</TrackingNumber><Delivery><Date>20030711</Date><Time>09:00</Time></Delivery><UNSPSCCode>54.10.16.05</UNSPSCCode></Item>"
     }'
   end
 
@@ -131,7 +133,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_level_3_fields
-    options = @options.merge(level_three_fields: @l3_json)
+    options = @options.merge(level_three_fields: @xml_json)
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
@@ -147,7 +149,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_level_2_3_fields
-    options = @options.merge(level_two_fields: @l2_json).merge(level_three_fields: @l3_json)
+    options = @options.merge(level_two_fields: @l2_json).merge(level_three_fields: @xml_json)
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
Unit tests: 48 tests, 234 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed 

Remote tests: 35 tests, 152 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
74.2857% passed 
Same failures as were in previous PR for this ticket (https://github.com/activemerchant/active_merchant/pull/3272#issuecomment-511455793)