### PR TITLE
CardConnect: fix domain GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* CardConnect: Move domain from gateway spefici to gateway field
 
 == Version 1.96.0 (Jul 26, 2019)
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def require_valid_domain!(options, param)
-        if options.key?(param)
+        if options[param]
           raise ArgumentError.new('not a valid cardconnect domain') unless /\Dcardconnect.com:\d{1,}\D/ =~ options[param]
         end
       end


### PR DESCRIPTION
Retrieve domain from gateway specific fields rather than at the
top gateway level

ECS-448

Unit:
22 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
23 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed