### PR TITLE
[Realex] Add 3DS support through external MPI

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -290,7 +290,7 @@ module ActiveMerchant
 
       def add_three_d_secure(xml, options)
         return unless three_d_secure = options[:three_d_secure]
-        version = three_d_secure.fetch(:version, "")
+        version = three_d_secure.fetch(:version, '')
         xml.tag! 'mpi' do
           if version =~ /^2/
             xml.tag! 'authentication_value', three_d_secure[:cavv]

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -289,12 +289,18 @@ module ActiveMerchant
       end
 
       def add_three_d_secure(xml, options)
-        if options[:three_d_secure]
-          xml.tag! 'mpi' do
-            xml.tag! 'cavv', options[:three_d_secure][:cavv]
-            xml.tag! 'eci', options[:three_d_secure][:eci]
-            xml.tag! 'xid', options[:three_d_secure][:xid]
+        return unless three_d_secure = options[:three_d_secure]
+        version = three_d_secure.fetch(:version, "")
+        xml.tag! 'mpi' do
+          if version =~ /^2/
+            xml.tag! 'authentication_value', three_d_secure[:cavv]
+            xml.tag! 'ds_trans_id', three_d_secure[:ds_transaction_id]
+          else
+            xml.tag! 'cavv', three_d_secure[:cavv]
+            xml.tag! 'xid', three_d_secure[:xid]
           end
+          xml.tag! 'eci', three_d_secure[:eci]
+          xml.tag! 'message_version', version
         end
       end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1051,6 +1051,12 @@ realex_visa:
   year: '2020'
   verification_value: '123'
 
+realex_visa_3ds_enrolled:
+  number: '4012001037141112'
+  month: '9'
+  year: '2021'
+  verification_value: '123'
+
 realex_visa_coms_error:
   number: '4009830000001985'
   month: '6'

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -115,12 +115,27 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_match %r{DECLINED}i, response.message
   end
 
-  def test_realex_purchase_with_three_d_secure
+  def test_realex_purchase_with_three_d_secure_1
     response = @gateway.purchase(
       1000,
       @visa,
       three_d_secure: {
-        eci: '05', xid: '05', cavv: '05'
+        eci: '05', xid: '05', cavv: '05', version: '1.0.2'
+      },
+      :order_id => generate_unique_id,
+      :description => 'Test Realex with 3DS'
+    )
+    assert_success response
+    assert response.test?
+    assert_equal 'Successful', response.message
+  end
+
+  def test_realex_purchase_with_three_d_secure_2
+    response = @gateway.purchase(
+      1000,
+      @visa,
+      three_d_secure: {
+        eci: '05', ds_transaction_id: '05', cavv: '05', version: '2.1.0'
       },
       :order_id => generate_unique_id,
       :description => 'Test Realex with 3DS'

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -3,14 +3,15 @@ require 'test_helper'
 class RemoteRealexTest < Test::Unit::TestCase
 
   def setup
-    @gateway = RealexGateway.new(fixtures(:realex))
+    @gateway = RealexGateway.new(fixtures(:realex_with_account))
 
     # Replace the card numbers with the test account numbers from Realex
-    @visa            = card_fixtures(:realex_visa)
-    @visa_declined   = card_fixtures(:realex_visa_declined)
-    @visa_referral_b = card_fixtures(:realex_visa_referral_b)
-    @visa_referral_a = card_fixtures(:realex_visa_referral_a)
-    @visa_coms_error = card_fixtures(:realex_visa_coms_error)
+    @visa              = card_fixtures(:realex_visa)
+    @visa_declined     = card_fixtures(:realex_visa_declined)
+    @visa_referral_b   = card_fixtures(:realex_visa_referral_b)
+    @visa_referral_a   = card_fixtures(:realex_visa_referral_a)
+    @visa_coms_error   = card_fixtures(:realex_visa_coms_error)
+    @visa_3ds_enrolled = card_fixtures(:realex_visa_3ds_enrolled)
 
     @mastercard            = card_fixtures(:realex_mastercard)
     @mastercard_declined   = card_fixtures(:realex_mastercard_declined)
@@ -118,9 +119,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_with_three_d_secure_1
     response = @gateway.purchase(
       1000,
-      @visa,
+      @visa_3ds_enrolled,
       three_d_secure: {
-        eci: '05', xid: '05', cavv: '05', version: '1.0.2'
+        eci: '05',
+        cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+        xid: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY=',
+        version: '1.0.2',
       },
       :order_id => generate_unique_id,
       :description => 'Test Realex with 3DS'
@@ -133,9 +137,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_with_three_d_secure_2
     response = @gateway.purchase(
       1000,
-      @visa,
+      @visa_3ds_enrolled,
       three_d_secure: {
-        eci: '05', ds_transaction_id: '05', cavv: '05', version: '2.1.0'
+        eci: '05',
+        cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+        ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
+        version: '2.1.0',
       },
       :order_id => generate_unique_id,
       :description => 'Test Realex with 3DS'
@@ -178,7 +185,6 @@ class RemoteRealexTest < Test::Unit::TestCase
         :order_id => generate_unique_id,
         :description => 'Test Realex coms error'
       )
-
       assert_not_nil response
       assert_failure response
 

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -339,15 +339,16 @@ SRC
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
-  def test_three_d_secure
+  def test_three_d_secure_1
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
     options = {
-      :order_id => '1',
-      :three_d_secure => {
-        :cavv => '1234',
-        :eci => '1234',
-        :xid => '1234'
+      order_id: '1',
+      three_d_secure: {
+        cavv: '1234',
+        eci: '1234',
+        xid: '1234',
+        version: '1.0.2',
       }
     }
 
@@ -355,13 +356,14 @@ SRC
     assert_equal 'M', response.cvv_result['code']
   end
 
-  def test_auth_xml_with_three_d_secure
+  def test_auth_xml_with_three_d_secure_1
     options = {
-      :order_id => '1',
-      :three_d_secure => {
-        :cavv => '1234',
-        :eci => '1234',
-        :xid => '1234'
+      order_id: '1',
+      three_d_secure: {
+        cavv: '1234',
+        eci: '1234',
+        xid: '1234',
+        version: '1.0.2',
       }
     }
 
@@ -388,8 +390,53 @@ SRC
   <sha1hash>3499d7bc8dbacdcfba2286bd74916d026bae630f</sha1hash>
   <mpi>
     <cavv>1234</cavv>
-    <eci>1234</eci>
     <xid>1234</xid>
+    <eci>1234</eci>
+    <message_version>1.0.2</message_version>
+  </mpi>
+</request>
+SRC
+
+    assert_xml_equal valid_auth_request_xml, @gateway.build_purchase_or_authorization_request(:authorization, @amount, @credit_card, options)
+  end
+
+  def test_auth_xml_with_three_d_secure_2
+    options = {
+      order_id: '1',
+      three_d_secure: {
+        cavv: '1234',
+        eci: '1234',
+        ds_transaction_id: '1234',
+        version: '2.1.0',
+      }
+    }
+
+    @gateway.expects(:new_timestamp).returns('20090824160201')
+
+    valid_auth_request_xml = <<-SRC
+<request timestamp="20090824160201" type="auth">
+  <merchantid>your_merchant_id</merchantid>
+  <account>your_account</account>
+  <orderid>1</orderid>
+  <amount currency=\"EUR\">100</amount>
+  <card>
+    <number>4263971921001307</number>
+    <expdate>0808</expdate>
+    <chname>Longbob Longsen</chname>
+    <type>VISA</type>
+    <issueno></issueno>
+    <cvn>
+      <number></number>
+      <presind></presind>
+    </cvn>
+  </card>
+  <autosettle flag="0"/>
+  <sha1hash>3499d7bc8dbacdcfba2286bd74916d026bae630f</sha1hash>
+  <mpi>
+    <authentication_value>1234</authentication_value>
+    <ds_trans_id>1234</ds_trans_id>
+    <eci>1234</eci>
+    <message_version>2.1.0</message_version>
   </mpi>
 </request>
 SRC


### PR DESCRIPTION
A few sample request we got from Realex contacts

```
<mpi>
  <cavv>AAACBllleHchZTBWIGV4AAAAAAA=</cavv>
  <xid>crqAeMwkEL9r4POdxpByWJ1/wYg=</xid>
  <eci>5</eci>
  <message_version>1</message_version>
</mpi>
```

And

```
<mpi>
  <eci>5</eci>
  <ds_trans_id>c272b04f-6e7b-43a2-bb78-90f4fb94aa25</ds_trans_id>
  <authentication_value>ODQzNjgwNjU0ZjM3N2JmYTg0NTM=</authentication_value>
  <message_version>2.1.0</message_version>
</mpi>
```

New card comes from: https://developer.globalpay.com/#!/resources/test-card-numbers