### PR TITLE
[3DS] Paypal 2.0 integration

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
         xml.tag! transaction_type + 'Req', 'xmlns' => PAYPAL_NAMESPACE do
           xml.tag! transaction_type + 'Request', 'xmlns:n2' => EBAY_NAMESPACE do
-            xml.tag! 'n2:Version', API_VERSION
+            xml.tag! 'n2:Version', api_version(options)
             xml.tag! 'n2:' + transaction_type + 'RequestDetails' do
               xml.tag! 'n2:ReferenceID', reference_id if transaction_type == 'DoReferenceTransaction'
               xml.tag! 'n2:PaymentAction', action
@@ -71,6 +71,11 @@ module ActiveMerchant #:nodoc:
         end
 
         xml.target!
+      end
+
+      def api_version(options)
+        return API_VERSION_3DS2 if options.dig(:three_d_secure, :version) =~ /^2/
+        API_VERSION
       end
 
       def add_credit_card(xml, credit_card, address, options)
@@ -108,6 +113,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Cavv', three_d_secure[:cavv] unless three_d_secure[:cavv].blank?
           xml.tag! 'Eci3ds', three_d_secure[:eci] unless three_d_secure[:eci].blank?
           xml.tag! 'Xid', three_d_secure[:xid] unless three_d_secure[:xid].blank?
+          xml.tag! 'ThreeDSVersion', three_d_secure[:version] unless three_d_secure[:version].blank?
+          xml.tag! 'DSTransactionId', three_d_secure[:ds_transaction_id] unless three_d_secure[:ds_transaction_id].blank?
         end
       end
 

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -5,6 +5,7 @@ module ActiveMerchant #:nodoc:
       include Empty
 
       API_VERSION = '124'
+      API_VERSION_3DS2 = '214.0'
 
       URLS = {
         :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -269,4 +269,19 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
     assert response.params['transaction_id']
   end
+
+  def test_successful_purchase_with_3ds_version_2
+    params = @params.merge!({
+      three_d_secure: {
+          trans_status: 'Y',
+          eci: '05',
+          cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+          ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
+          version: '2.1.0'
+      }
+    })
+    response = @gateway.purchase(@amount, @credit_card, params)
+    assert_success response
+    assert response.params['transaction_id']
+  end
 end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -613,13 +613,26 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_3ds_version_1_request
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option))
+      @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option(version: '1.0.2', xid: 'xid')))
     end.check_request do |endpoint, data, headers|
       assert_match %r{<n2:Version>124</n2:Version>}, data
       assert_match %r{<AuthStatus3ds>Y</AuthStatus3ds>}, data
       assert_match %r{<Cavv>cavv</Cavv>}, data
       assert_match %r{<Eci3ds>eci</Eci3ds>}, data
       assert_match %r{<Xid>xid</Xid>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_3ds_version_2_request
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option(version: '2.1.0', ds_transaction_id: 'ds_transaction_id')))
+    end.check_request do |endpoint, data, headers|
+      assert_match %r{<n2:Version>214.0</n2:Version>}, data
+      assert_match %r{<AuthStatus3ds>Y</AuthStatus3ds>}, data
+      assert_match %r{<Cavv>cavv</Cavv>}, data
+      assert_match %r{<Eci3ds>eci</Eci3ds>}, data
+      assert_match %r{<ThreeDSVersion>2.1.0</ThreeDSVersion>}, data
+      assert_match %r{<DSTransactionId>ds_transaction_id</DSTransactionId>}, data
     end.respond_with(successful_purchase_response)
   end
 
@@ -1429,13 +1442,15 @@ class PaypalTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def three_d_secure_option
+  def three_d_secure_option(version:, xid: nil, ds_transaction_id: nil)
     {
         three_d_secure: {
             trans_status: 'Y',
             eci: 'eci',
             cavv: 'cavv',
-            xid: 'xid'
+            xid: xid,
+            ds_transaction_id: ds_transaction_id,
+            version: version
         }
     }
   end


### PR DESCRIPTION
Follows this [PR](https://github.com/activemerchant/active_merchant/pull/3279)

Currently Paypal is not ready to support 2.0, this PR does the preparation work for when they do support it we can ship directly then.

Example usage from the Paypal [documentation](https://developer.paypal.com/docs/classic/paypal-payments-pro/integration-guide/3d-secure/) for 2.0

```
<Version>214.0</Version>
.
.
.
<ThreeDSecureRequest>
    <MpiVendor3ds>Y</MpiVendor3ds>
    <AuthStatus3ds>Y</AuthStatus3ds>
    <Cavv>jMKEKlqlJGiJARAbxMDZ5+fnFeg=</Cavv>
    <Eci3ds>02</Eci3ds>
    <Xid>TTVmdlFxbERYVXo5R1hrVUY5bjY=</Xid>
    <ThreeDSVersion>2.1.0</ThreeDSVersion>
    <DSTransactionId>f38e6948-5388-41a6-bca4-b49723c19437</DSTransactionId>
</ThreeDSecureRequest>
```