### PR TITLE
ECS-217_braintree_stored_credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* CardConnect: Move domain from gateway spefici to gateway field
+* CardConnect: Move domain from gateway specific to gateway field [hdeters] #3283
+* Braintree Blue: Support for stored credentials [hdeters] #3286
 
 == Version 1.96.0 (Jul 26, 2019)
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -874,7 +874,62 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
+  def test_successful_merchant_purchase_initial
+    creds_options = stored_credential_options(:merchant, :recurring, :initial)
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+  end
+
+  def test_successful_subsequent_merchant_unscheduled_transaction
+    creds_options = stored_credential_options(:merchant, :unscheduled, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_subsequent_merchant_recurring_transaction
+    creds_options = stored_credential_options(:cardholder, :recurring, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_cardholder_purchase_initial
+    creds_options = stored_credential_options(:cardholder, :recurring, :initial)
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_cardholder_purchase_recurring
+    creds_options = stored_credential_options(:cardholder, :recurring, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_cardholder_purchase_unscheduled
+    creds_options = stored_credential_options(:cardholder, :unscheduled, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
   private
+
+  def stored_credential_options(*args, id: nil)
+    stored_credential(*args, id: id)
+  end
 
   def assert_avs(address1, zip, expected_avs_code)
     response = @gateway.purchase(@amount, @credit_card, billing_address: {address1: address1, zip: zip})

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -932,6 +932,169 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert response.success?
   end
 
+  def test_stored_credential_recurring_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, :initial)})
+  end
+
+  def test_stored_credential_recurring_cit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC')})
+  end
+
+  def test_stored_credential_recurring_mit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => 'recurring'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, :initial)})
+  end
+
+  def test_stored_credential_recurring_mit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'},
+          :transaction_source => 'recurring'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC')})
+  end
+
+  def test_stored_credential_installment_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, :initial)})
+  end
+
+  def test_stored_credential_installment_cit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, id: '123ABC')})
+  end
+
+  def test_stored_credential_installment_mit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => 'recurring'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, :initial)})
+  end
+
+  def test_stored_credential_installment_mit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'},
+          :transaction_source => 'recurring'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, id: '123ABC')})
+  end
+
+  def test_stored_credential_unscheduled_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, :initial)})
+  end
+
+  def test_stored_credential_unscheduled_cit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'},
+          :transaction_source => ''
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, id: '123ABC')})
+  end
+
+  def test_stored_credential_unscheduled_mit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'will_vault'},
+          :transaction_source => 'unscheduled'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, :initial)})
+  end
+
+  def test_stored_credential_unscheduled_mit_used
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          :external_vault => {
+            :status => 'vaulted',
+            :previous_network_transaction_id => '123ABC'
+        },
+          :transaction_source => 'unscheduled'
+        })
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, id: '123ABC')})
+  end
+
   private
 
   def braintree_result(options = {})
@@ -953,5 +1116,23 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
     # Reset the Braintree logger
     Braintree::Configuration.logger = nil
+  end
+
+  def standard_purchase_params
+    {
+    :amount => '1.00',
+      :order_id => '1',
+      :customer => {:id => nil, :email => nil, :phone => nil,
+                    :first_name => 'Longbob', :last_name => 'Longsen'},
+      :options => {:store_in_vault => false, :submit_for_settlement => true, :hold_in_escrow => nil},
+      :custom_fields => nil,
+      :credit_card => {
+        :number => '41111111111111111111',
+        :cvv => '123',
+        :expiration_month => '09',
+        :expiration_year => '2020',
+        :cardholder_name => 'Longbob Longsen',
+      }
+    }
   end
 end


### PR DESCRIPTION
Implement stored credentials framework for Braintree

Unit:
73 tests, 174 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
79 tests, 435 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed