### PR TITLE
Stripe Payment Intents - Add new gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Stripe Payment Intents: Add new gateway [britth] #3290
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('thor')
+  s.add_development_dependency('pry')
 end

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -1,0 +1,239 @@
+require 'active_support/core_ext/hash/slice'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
+    # For the legacy API, see the Stripe gateway
+    class StripePaymentIntentsGateway < StripeGateway
+      ALLOWED_METHOD_STATES = %w[automatic manual].freeze
+      ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
+      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method]
+      CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
+      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage]
+      DEFAULT_API_VERSION = '2019-05-16'
+
+      def create_intent(money, payment_method, options = {})
+        post = {}
+        add_amount(post, money, options, true)
+        add_capture_method(post, options)
+        add_confirmation_method(post, options)
+        add_customer(post, options)
+        add_payment_method_token(post, payment_method, options)
+        add_metadata(post, options)
+        add_return_url(post, options)
+        add_connected_account(post, options)
+        add_shipping_address(post, options)
+        setup_future_usage(post, options)
+
+        CREATE_INTENT_ATTRIBUTES.each do |attribute|
+          add_whitelisted_attribute(post, options, attribute)
+        end
+
+        commit(:post, 'payment_intents', post, options)
+      end
+
+      def show_intent(intent_id, options)
+        commit(:get, "payment_intents/#{intent_id}", nil, options)
+      end
+
+      def confirm_intent(intent_id, payment_method, options = {})
+        post = {}
+        add_payment_method_token(post, payment_method, options)
+        CONFIRM_INTENT_ATTRIBUTES.each do |attribute|
+          add_whitelisted_attribute(post, options, attribute)
+        end
+
+        commit(:post, "payment_intents/#{intent_id}/confirm", post, options)
+      end
+
+      def create_payment_method(payment_method, options = {})
+        post = {}
+        post[:type] = 'card'
+        post[:card] = {}
+        post[:card][:number] = payment_method.number
+        post[:card][:exp_month] = payment_method.month
+        post[:card][:exp_year] = payment_method.year
+        post[:card][:cvc] = payment_method.verification_value if payment_method.verification_value
+
+        commit(:post, 'payment_methods', post, options)
+      end
+
+      def update_intent(money, intent_id, payment_method, options = {})
+        post = {}
+        post[:amount] = money if money
+
+        add_payment_method_token(post, payment_method, options)
+        add_payment_method_types(post, options)
+        add_customer(post, options)
+        add_metadata(post, options)
+        add_shipping_address(post, options)
+        add_connected_account(post, options)
+
+        UPDATE_INTENT_ATTRIBUTES.each do |attribute|
+          add_whitelisted_attribute(post, options, attribute)
+        end
+
+        commit(:post, "payment_intents/#{intent_id}", post, options)
+      end
+
+      def authorize(money, payment_method, options = {})
+        create_intent(money, payment_method, options.merge!(confirm: true, capture_method: 'manual'))
+      end
+
+      def purchase(money, payment_method, options = {})
+        create_intent(money, payment_method, options.merge!(confirm: true, capture_method: 'automatic'))
+      end
+
+      def capture(money, intent_id, options = {})
+        post = {}
+        post[:amount_to_capture] = money
+        add_connected_account(post, options)
+        commit(:post, "payment_intents/#{intent_id}/capture", post, options)
+      end
+
+      def void(intent_id, options = {})
+        post = {}
+        post[:cancellation_reason] = options[:cancellation_reason] if ALLOWED_CANCELLATION_REASONS.include?(options[:cancellation_reason])
+        commit(:post, "payment_intents/#{intent_id}/cancel", post, options)
+      end
+
+      def refund(money, intent_id, options = {})
+        intent = commit(:get, "payment_intents/#{intent_id}", nil, options)
+        charge_id = intent.params.dig('charges', 'data')[0].dig('id')
+        super(money, charge_id, options)
+      end
+
+      # Note: Not all payment methods are currently supported by the {Payment Methods API}[https://stripe.com/docs/payments/payment-methods]
+      # Current implementation will create a PaymentMethod object if the method is a token or credit card
+      # All other types will default to legacy Stripe store
+      def store(payment_method, options = {})
+        params = {}
+        post = {}
+
+        # If customer option is provided, create a payment method and attach to customer id
+        # Otherwise, create a customer, then attach
+        if payment_method.is_a?(StripePaymentToken) || payment_method.is_a?(ActiveMerchant::Billing::CreditCard)
+          add_payment_method_token(params, payment_method, options)
+          if options[:customer]
+            customer_id = options[:customer]
+          else
+            post[:validate] = options[:validate] unless options[:validate].nil?
+            post[:description] = options[:description] if options[:description]
+            post[:email] = options[:email] if options[:email]
+            customer = commit(:post, 'customers', post, options)
+            customer_id = customer.params['id']
+          end
+          commit(:post, "payment_methods/#{params[:payment_method]}/attach", { customer: customer_id }, options)
+        else
+          super(payment, options)
+        end
+      end
+
+      def unstore(identification, options = {}, deprecated_options = {})
+        if identification.include?('pm_')
+          _, payment_method = identification.split('|')
+          commit(:post, "payment_methods/#{payment_method}/detach", nil, options)
+        else
+          super(identification, options, deprecated_options)
+        end
+      end
+
+      private
+
+      def add_whitelisted_attribute(post, options, attribute)
+        post[attribute] = options[attribute] if options[attribute]
+        post
+      end
+
+      def add_capture_method(post, options)
+        capture_method = options[:capture_method].to_s
+        post[:capture_method] = capture_method if ALLOWED_METHOD_STATES.include?(capture_method)
+        post
+      end
+
+      def add_confirmation_method(post, options)
+        confirmation_method = options[:confirmation_method].to_s
+        post[:confirmation_method] = confirmation_method if ALLOWED_METHOD_STATES.include?(confirmation_method)
+        post
+      end
+
+      def add_customer(post, options)
+        customer = options[:customer].to_s
+        post[:customer] = customer if customer.start_with?('cus_')
+        post
+      end
+
+      def add_return_url(post, options)
+        return unless options[:confirm]
+        post[:confirm] = options[:confirm]
+        post[:return_url] = options[:return_url] if options[:return_url]
+        post
+      end
+
+      def add_payment_method_token(post, payment_method, options)
+        return if payment_method.nil?
+
+        if payment_method.is_a?(ActiveMerchant::Billing::CreditCard)
+          p = create_payment_method(payment_method, options)
+          payment_method = p.params['id']
+        end
+
+        if payment_method.is_a?(StripePaymentToken)
+          post[:payment_method] = payment_method.payment_data['id']
+        elsif payment_method.is_a?(String)
+          if payment_method.include?('|')
+            customer_id, payment_method_id = payment_method.split('|')
+            token = payment_method_id
+            post[:customer] = customer_id
+          else
+            token = payment_method
+          end
+          post[:payment_method] = token
+        end
+      end
+
+      def add_payment_method_types(post, options)
+        payment_method_types = options[:payment_method_types] if options[:payment_method_types]
+        return if payment_method_types.nil?
+
+        post[:payment_method_types] = Array(payment_method_types)
+        post
+      end
+
+      def setup_future_usage(post, options = {})
+        post[:setup_future_usage] = options[:setup_future_usage] if %w( on_session off_session ).include?(options[:setup_future_usage])
+        post[:off_session] = options[:off_session] if options[:off_session] && options[:confirm] == true
+        post
+      end
+
+      def add_connected_account(post, options = {})
+        return unless transfer_data = options[:transfer_data]
+        post[:transfer_data] = {}
+        post[:transfer_data][:destination] = transfer_data[:destination] if transfer_data[:destination]
+        post[:transfer_data][:amount] = transfer_data[:amount] if transfer_data[:amount]
+        post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
+        post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
+        post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
+        post
+      end
+
+      def add_shipping_address(post, options = {})
+        return unless shipping = options[:shipping]
+        post[:shipping] = {}
+        post[:shipping][:address] = {}
+        post[:shipping][:address][:line1] = shipping[:address][:line1]
+        post[:shipping][:address][:city] = shipping[:address][:city] if shipping[:address][:city]
+        post[:shipping][:address][:country] = shipping[:address][:country] if shipping[:address][:country]
+        post[:shipping][:address][:line2] = shipping[:address][:line2] if shipping[:address][:line2]
+        post[:shipping][:address][:postal_code] = shipping[:address][:postal_code] if shipping[:address][:postal_code]
+        post[:shipping][:address][:state] = shipping[:address][:state] if shipping[:address][:state]
+
+        post[:shipping][:name] = shipping[:name]
+        post[:shipping][:carrier] = shipping[:carrier] if shipping[:carrier]
+        post[:shipping][:phone] = shipping[:phone] if shipping[:phone]
+        post[:shipping][:tracking_number] = shipping[:tracking_number] if shipping[:tracking_number]
+        post
+      end
+    end
+  end
+end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1,0 +1,389 @@
+require 'test_helper'
+
+class RemoteStripeIntentsTest < Test::Unit::TestCase
+  def setup
+    @gateway = StripePaymentIntentsGateway.new(fixtures(:stripe))
+    @customer = fixtures(:stripe)[:customer_id]
+    @amount = 2000
+    @three_ds_payment_method = 'pm_card_threeDSecure2Required'
+    @visa_payment_method = 'pm_card_visa'
+    @declined_payment_method = 'pm_card_chargeDeclined'
+    @three_ds_credit_card = credit_card('4000000000003220',
+      verification_value: '737',
+      month: 10,
+      year: 2020
+    )
+    @visa_card = credit_card('4242424242424242',
+      verification_value: '737',
+      month: 10,
+      year: 2020
+    )
+    @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
+  end
+
+  def test_authorization_and_void
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+    }
+    assert authorization = @gateway.authorize(@amount, @visa_payment_method, options)
+
+    assert_equal 'requires_capture', authorization.params['status']
+    refute authorization.params.dig('charges', 'data')[0]['captured']
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
+  def test_successful_purchase
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+    }
+    assert purchase = @gateway.purchase(@amount, @visa_payment_method, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_unsuccessful_purchase
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+    }
+    assert purchase = @gateway.purchase(@amount, @declined_payment_method, options)
+
+    assert_equal 'Your card was declined.', purchase.message
+    refute purchase.params.dig('error', 'payment_intent', 'charges', 'data')[0]['captured']
+  end
+
+  def test_create_payment_intent_manual_capture_method
+    options = {
+      currency: 'USD',
+      capture_method: 'manual'
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+
+    assert_success response
+    assert_equal 'payment_intent', response.params['object']
+    assert_equal 'manual', response.params['capture_method']
+  end
+
+  def test_create_payment_intent_manual_confimation_method
+    options = {
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      confirmation_method: 'manual'
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+
+    assert_success response
+    assert_equal 'payment_intent', response.params['object']
+    assert_equal 'manual', response.params['confirmation_method']
+  end
+
+  def test_create_payment_intent_with_customer
+    options = {
+      currency: 'USD',
+      customer: @customer || 'set customer in fixtures'
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+
+    assert_success response
+    assert_equal 'payment_intent', response.params['object']
+    assert_equal @customer, response.params['customer']
+  end
+
+  def test_create_payment_intent_with_credit_card
+    options = {
+      currency: 'USD',
+      customer: @customer,
+    }
+
+    assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
+
+    assert_success response
+    assert_equal 'payment_intent', response.params['object']
+  end
+
+  def test_create_payment_intent_with_return_url
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      confirm: true,
+      return_url: 'https://www.example.com'
+    }
+
+    assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
+
+    assert_success response
+    assert_equal 'https://www.example.com', response.params['next_action']['redirect_to_url']['return_url']
+  end
+
+  def test_create_payment_intent_with_metadata
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      description: 'ActiveMerchant Test Purchase',
+      receipt_email: 'test@example.com',
+      statement_descriptor: 'Statement Descriptor',
+      metadata: { key_1: 'value_1', key_2: 'value_2' }
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+
+    assert_success response
+    assert_equal 'value_1', response.params['metadata']['key_1']
+    assert_equal 'ActiveMerchant Test Purchase', response.params['description']
+    assert_equal 'test@example.com', response.params['receipt_email']
+    assert_equal 'Statement Descriptor', response.params['statement_descriptor']
+  end
+
+  def test_create_payment_intent_that_saves_payment_method
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      save_payment_method: true
+    }
+
+    assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
+    assert_success response
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+    assert_failure response
+    assert_equal 'A payment method must be provided or already '\
+                 'attached to the PaymentIntent when `save_payment_method=true`.', response.message
+
+    options.delete(:customer)
+    assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
+    assert_failure response
+    assert_equal 'A valid `customer` must be provided when `save_payment_method=true`.', response.message
+  end
+
+  def test_create_payment_intent_with_setup_future_usage
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      setup_future_usage: 'on_session'
+    }
+
+    assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
+    assert_success response
+    assert_equal 'on_session', response.params['setup_future_usage']
+  end
+
+  def test_3ds_unauthenticated_authorize_with_off_session
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      off_session: true,
+    }
+
+    assert response = @gateway.authorize(@amount, @three_ds_credit_card, options)
+    assert_failure response
+  end
+
+  def test_create_payment_intent_with_shipping_address
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      shipping: {
+        address: {
+          line1: '1 Test Ln',
+          city: 'Durham'
+        },
+        name: 'John Doe',
+        tracking_number: '123456789'
+      }
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+    assert_success response
+    assert response.params['shipping']['address']
+    assert_equal 'John Doe', response.params['shipping']['name']
+  end
+
+  def test_create_payment_intent_with_connected_account
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      application_fee: 100,
+      transfer_data: {destination: @destination_account}
+    }
+
+    assert response = @gateway.create_intent(@amount, nil, options)
+
+    assert_success response
+    assert_equal 100, response.params['application_fee_amount']
+    assert_equal @destination_account, response.params.dig('transfer_data', 'destination')
+  end
+
+  def test_create_a_payment_intent_and_confirm
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      return_url: 'https://www.example.com',
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+    }
+    assert create_response = @gateway.create_intent(@amount, @three_ds_payment_method, options)
+    assert_equal 'requires_confirmation', create_response.params['status']
+    intent_id = create_response.params['id']
+
+    assert get_response = @gateway.show_intent(intent_id, options)
+    assert_equal 'requires_confirmation', get_response.params['status']
+
+    assert confirm_response = @gateway.confirm_intent(intent_id, nil, return_url: 'https://example.com/return-to-me')
+    assert_equal 'redirect_to_url', confirm_response.params.dig('next_action', 'type')
+  end
+
+  def test_create_a_payment_intent_and_manually_capture
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    intent_id = create_response.params['id']
+    assert_equal 'requires_capture', create_response.params['status']
+
+    assert capture_response = @gateway.capture(@amount, intent_id, options)
+    assert_equal 'succeeded', capture_response.params['status']
+    assert_equal 'Payment complete.', capture_response.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
+  end
+
+  def test_create_a_payment_intent_and_automatically_capture
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    assert_nil create_response.params['next_action']
+    assert_equal 'succeeded', create_response.params['status']
+    assert_equal 'Payment complete.', create_response.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
+  end
+
+  def test_failed_capture_after_creation
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, 'pm_card_chargeDeclined', options)
+    assert_equal 'requires_payment_method', create_response.params.dig('error', 'payment_intent', 'status')
+    assert_equal false, create_response.params.dig('error', 'payment_intent', 'charges', 'data')[0].dig('captured')
+  end
+
+  def test_create_a_payment_intent_and_update
+    update_amount = 2050
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    intent_id = create_response.params['id']
+    assert_equal @amount, create_response.params['amount']
+
+    assert update_response = @gateway.update_intent(update_amount, intent_id, nil, options.merge(payment_method_types: 'card'))
+    assert_equal update_amount, update_response.params['amount']
+    assert_equal 'requires_confirmation', update_response.params['status']
+  end
+
+  def test_create_a_payment_intent_and_void
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    intent_id = create_response.params['id']
+
+    assert cancel_response = @gateway.void(intent_id, cancellation_reason: 'requested_by_customer')
+    assert_equal @amount, cancel_response.params.dig('charges', 'data')[0].dig('amount_refunded')
+    assert_equal 'canceled', cancel_response.params['status']
+    assert_equal 'requested_by_customer', cancel_response.params['cancellation_reason']
+  end
+
+  def test_failed_void_after_capture
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    assert_equal 'succeeded', create_response.params['status']
+    intent_id = create_response.params['id']
+
+    assert cancel_response = @gateway.void(intent_id, cancellation_reason: 'requested_by_customer')
+    assert_equal 'You cannot cancel this PaymentIntent because ' \
+      'it has a status of succeeded. Only a PaymentIntent with ' \
+      'one of the following statuses may be canceled: ' \
+      'requires_payment_method, requires_capture, requires_confirmation, requires_action.', cancel_response.message
+  end
+
+  def test_refund_a_payment_intent
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      confirm: true
+    }
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    intent_id = create_response.params['id']
+
+    assert @gateway.capture(@amount, intent_id, options)
+
+    assert refund = @gateway.refund(@amount - 20, intent_id)
+    assert_equal @amount - 20, refund.params['charge']['amount_refunded']
+    assert_equal true, refund.params['charge']['captured']
+    refund_id = refund.params['id']
+    assert_equal refund.authorization, refund_id
+  end
+
+  def test_successful_store_purchase_and_unstore
+    options = {
+      currency: 'GBP',
+    }
+    assert store = @gateway.store(@visa_card, options)
+    assert store.params['customer'].start_with?('cus_')
+
+    assert purchase = @gateway.purchase(@amount, store.authorization, options)
+    assert 'succeeded', purchase.params['status']
+
+    assert unstore = @gateway.unstore(store.authorization)
+    assert_nil unstore.params['customer']
+  end
+
+  def test_transcript_scrubbing
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      return_url: 'https://www.example.com/return',
+      confirm: true
+    }
+    transcript = capture_transcript(@gateway) do
+      @gateway.create_intent(@amount, @three_ds_credit_card, options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@three_ds_credit_card.number, transcript)
+    assert_scrubbed(@three_ds_credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:login], transcript)
+  end
+end

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -1,0 +1,266 @@
+require 'test_helper'
+
+class StripePaymentIntentsTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = StripePaymentIntentsGateway.new(:login => 'login')
+
+    @credit_card = credit_card()
+    @threeds_2_card = credit_card('4000000000003220')
+    @visa_token = 'pm_card_visa'
+    @amount = 2020
+    @update_amount = 2050
+
+    @options = {
+      currency: 'GBP',
+      confirmation_method: 'manual',
+    }
+  end
+
+  def test_successful_create_and_confirm_intent
+    @gateway.expects(:ssl_request).times(3).returns(successful_create_3ds2_payment_method, successful_create_3ds2_intent_response, successful_confirm_3ds2_intent_response)
+
+    assert create = @gateway.create_intent(@amount, @threeds_2_card, @options.merge(return_url: 'https://www.example.com', capture_method: 'manual'))
+    assert_instance_of Response, create
+    assert_success create
+
+    assert_equal 'pi_1F1wpFAWOtgoysog8nTulYGk', create.authorization
+    assert_equal 'requires_confirmation', create.params['status']
+    assert create.test?
+
+    assert confirm = @gateway.confirm_intent(create.params['id'], nil, return_url: 'https://example.com/return-to-me')
+    assert_equal 'redirect_to_url', confirm.params.dig('next_action', 'type')
+  end
+
+  def test_successful_create_and_capture_intent
+    options = @options.merge(capture_method: 'manual', confirm: true)
+    @gateway.expects(:ssl_request).twice.returns(successful_create_intent_response, successful_capture_response)
+    assert create = @gateway.create_intent(@amount, @visa_token, options)
+    assert_success create
+    assert_equal 'requires_capture', create.params['status']
+
+    assert capture = @gateway.capture(@amount, create.params['id'], options)
+    assert_success capture
+    assert_equal 'succeeded', capture.params['status']
+    assert_equal 'Payment complete.', capture.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
+  end
+
+  def test_successful_create_and_update_intent
+    @gateway.expects(:ssl_request).twice.returns(successful_create_intent_response, successful_update_intent_response)
+    assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(capture_method: 'manual'))
+
+    assert update = @gateway.update_intent(@update_amount, create.params['id'], nil, @options.merge(capture_method: 'manual'))
+    assert_equal @update_amount, update.params['amount']
+    assert_equal 'requires_confirmation', update.params['status']
+  end
+
+  def test_successful_create_and_void_intent
+    @gateway.expects(:ssl_request).twice.returns(successful_create_intent_response, successful_void_response)
+    assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(capture_method: 'manual', confirm: true))
+
+    assert cancel = @gateway.void(create.params['id'])
+    assert_equal @amount, cancel.params.dig('charges', 'data')[0].dig('amount_refunded')
+    assert_equal 'canceled', cancel.params['status']
+  end
+
+  def test_failed_capture_after_creation
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    assert create = @gateway.create_intent(@amount, 'pm_card_chargeDeclined', @options.merge(confirm: true))
+    assert_equal 'requires_payment_method', create.params.dig('error', 'payment_intent', 'status')
+    assert_equal false, create.params.dig('error', 'payment_intent', 'charges', 'data')[0].dig('captured')
+  end
+
+  def test_failed_void_after_capture
+    @gateway.expects(:ssl_request).twice.returns(successful_capture_response, failed_cancel_response)
+    assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(confirm: true))
+    assert_equal 'succeeded', create.params['status']
+    intent_id = create.params['id']
+
+    assert cancel = @gateway.void(intent_id, cancellation_reason: 'requested_by_customer')
+    assert_equal 'You cannot cancel this PaymentIntent because ' \
+      'it has a status of succeeded. Only a PaymentIntent with ' \
+      'one of the following statuses may be canceled: ' \
+      'requires_payment_method, requires_capture, requires_confirmation, requires_action.', cancel.message
+  end
+
+  private
+
+  def successful_create_intent_response
+    <<-RESPONSE
+      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":2020,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_capture","transfer_data":null,"transfer_group":null}
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":2020,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1F1xawAWOtgoysog27xGBjM6","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":true,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+      {"id":"pi_1F1yBVAWOtgoysogearamRvl","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":1564504103,"cancellation_reason":"requested_by_customer","capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1yBWAWOtgoysog1MQfDpJH","object":"charge","amount":2020,"amount_refunded":2020,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564504102,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":46,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1yBVAWOtgoysogearamRvl","payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1yBWAWOtgoysog1MQfDpJH/rcpt_FX2Go3YHBqAYQPJuKGMeab3nyCU0Kks","refunded":true,"refunds":{"object":"list","data":[{"id":"re_1F1yBXAWOtgoysog0PU371Yz","object":"refund","amount":2020,"balance_transaction":null,"charge":"ch_1F1yBWAWOtgoysog1MQfDpJH","created":1564504103,"currency":"gbp","metadata":{},"reason":"requested_by_customer","receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null}],"has_more":false,"total_count":1,"url":"/v1/charges/ch_1F1yBWAWOtgoysog1MQfDpJH/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1yBVAWOtgoysogearamRvl"},"client_secret":"pi_1F1yBVAWOtgoysogearamRvl_secret_oCnlR2t0GPclqACgHt2rst4gM","confirmation_method":"manual","created":1564504101,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"canceled","transfer_data":null,"transfer_group":null}
+    RESPONSE
+  end
+
+  def successful_update_intent_response
+    <<-RESPONSE
+      {"id":"pi_1F1yBbAWOtgoysog52J88BuO","object":"payment_intent","amount":2050,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges?payment_intent=pi_1F1yBbAWOtgoysog52J88BuO"},"client_secret":"pi_1F1yBbAWOtgoysog52J88BuO_secret_olw5rmbtm7cd72S9JfbKjTJJv","confirmation_method":"manual","created":1564504107,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1yBbAWOtgoysoguJQsDdYj","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_confirmation","transfer_data":null,"transfer_group":null}
+    RESPONSE
+  end
+
+  def successful_create_3ds2_payment_method
+    <<-RESPONSE
+      {
+        "id": "pm_1F1xK0AWOtgoysogfPuRKN1d",
+        "object": "payment_method",
+        "billing_details": {
+          "address": {"city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null},
+          "email": null,
+          "name": null,
+          "phone": null},
+        "card": {
+          "brand": "visa",
+          "checks": {"address_line1_check": null,
+            "address_postal_code_check": null,
+            "cvc_check": "unchecked"},
+          "country": null,
+          "exp_month": 10,
+          "exp_year": 2020,
+          "fingerprint": "l3J0NJaGgv0jAGLV",
+          "funding": "credit",
+          "generated_from": null,
+          "last4": "3220",
+          "three_d_secure_usage": {"supported": true},
+          "wallet": null},
+        "created": 1564500784,
+        "customer": null,
+        "livemode": false,
+        "metadata": {},
+        "type": "card"
+      }
+    RESPONSE
+  end
+
+  def successful_create_3ds2_intent_response
+    <<-RESPONSE
+      {
+        "id": "pi_1F1wpFAWOtgoysog8nTulYGk",
+        "object": "payment_intent",
+        "amount": 2020,
+        "amount_capturable": 0,
+        "amount_received": 0,
+        "application": null,
+        "application_fee_amount": null,
+        "canceled_at": null,
+        "cancellation_reason": null,
+        "capture_method": "manual",
+        "charges": {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges?payment_intent=pi_1F1wpFAWOtgoysog8nTulYGk"
+          },
+        "client_secret": "pi_1F1wpFAWOtgoysog8nTulYGk_secret_75qf7rjBDsTTz279LfS1feXUj",
+        "confirmation_method": "manual",
+        "created": 1564498877,
+        "currency": "gbp",
+        "customer": "cus_7s22nNueP2Hjj6",
+        "description": null,
+        "invoice": null,
+        "last_payment_error": null,
+        "livemode": false,
+        "metadata": {},
+        "next_action": null,
+        "on_behalf_of": null,
+        "payment_method": "pm_1F1wpFAWOtgoysogJ8zQ8K07",
+        "payment_method_options": {
+          "card": {"request_three_d_secure": "automatic"}
+          },
+        "payment_method_types": ["card"],
+        "receipt_email": null,
+        "review": null,
+        "setup_future_usage": null,
+        "shipping": null,
+        "source": null,
+        "statement_descriptor": null,
+        "status": "requires_confirmation",
+        "transfer_data": null,
+        "transfer_group": null
+      }
+    RESPONSE
+  end
+
+  def successful_confirm_3ds2_intent_response
+    <<-RESPONSE
+      {
+        "id": "pi_1F1wpFAWOtgoysog8nTulYGk",
+        "object": "payment_intent",
+        "amount": 2020,
+        "amount_capturable": 0,
+        "amount_received": 0,
+        "application": null,
+        "application_fee_amount": null,
+        "canceled_at": null,
+        "cancellation_reason": null,
+        "capture_method": "manual",
+        "charges": {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges?payment_intent=pi_1F1wpFAWOtgoysog8nTulYGk"},
+          "client_secret": "pi_1F1wpFAWOtgoysog8nTulYGk_secret_75qf7rjBDsTTz279LfS1feXUj",
+          "confirmation_method": "manual",
+          "created": 1564498877,
+          "currency": "gbp",
+          "customer": "cus_7s22nNueP2Hjj6",
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "livemode": false,
+          "metadata": {},
+          "next_action": {
+            "redirect_to_url": {
+              "return_url": "https://example.com/return-to-me",
+              "url": "https://hooks.stripe.com/3d_secure_2_eap/begin_test/src_1F1wpGAWOtgoysog4f00umCp/src_client_secret_FX0qk3uQ04woFWgdJbN3pnHD"},
+            "type": "redirect_to_url"},
+          "on_behalf_of": null,
+          "payment_method": "pm_1F1wpFAWOtgoysogJ8zQ8K07",
+          "payment_method_options": {
+            "card": {"request_three_d_secure": "automatic"}
+            },
+          "payment_method_types": ["card"],
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "status": "requires_action",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+    RESPONSE
+  end
+
+  def failed_capture_response
+    <<-RESPONSE
+      {"error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_intent":{"id":"pi_1F2MB5AWOtgoysogCMt8BaxR","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","charges":{"object":"list","data":[{"id":"ch_1F2MB6AWOtgoysogAIvNV32Z","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564596332,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":"card_declined","failure_message":"Your card was declined.","fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"declined_by_network","reason":"generic_decline","risk_level":"normal","risk_score":41,"seller_message":"The bank did not return any further details with this decline.","type":"issuer_declined"},"paid":false,"payment_intent":"pi_1F2MB5AWOtgoysogCMt8BaxR","payment_method":"pm_1F2MB5AWOtgoysogq3yXZ98h","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","last4":"0002","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2MB6AWOtgoysogAIvNV32Z/rcpt_FXR3PjBGluHmHsnLmp0S2KQiHl3yg6W","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2MB6AWOtgoysogAIvNV32Z/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"failed","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2MB5AWOtgoysogCMt8BaxR"},"client_secret":"pi_1F2MB5AWOtgoysogCMt8BaxR_secret_fOHryjtjBE4gACiHTcREraXSQ","confirmation_method":"manual","created":1564596331,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"},"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":null,"payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_payment_method","transfer_data":null,"transfer_group":null},"payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"}}
+    RESPONSE
+  end
+
+  def failed_cancel_response
+    <<-RESPONSE
+      {"error":{"code":"payment_intent_unexpected_state","doc_url":"https://stripe.com/docs/error-codes/payment-intent-unexpected-state","message":"You cannot cancel this PaymentIntent because it has a status of succeeded. Only a PaymentIntent with one of the following statuses may be canceled: requires_payment_method, requires_capture, requires_confirmation, requires_action.","payment_intent":{"id":"pi_1F2McmAWOtgoysoglFLDRWab","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":2020,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","charges":{"object":"list","data":[{"id":"ch_1F2McmAWOtgoysogQgUS1YtH","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1F2McmAWOtgoysog8uxBEJ30","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":true,"created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":53,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F2McmAWOtgoysoglFLDRWab","payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2McmAWOtgoysogQgUS1YtH/rcpt_FXRVzyFnf7aCS1r13N3uym1u8AaboOJ","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2McmAWOtgoysogQgUS1YtH/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2McmAWOtgoysoglFLDRWab"},"client_secret":"pi_1F2McmAWOtgoysoglFLDRWab_secret_z4faDF0Cv0JZJ6pxK3bdIodkD","confirmation_method":"manual","created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null},"type":"invalid_request_error"}}
+    RESPONSE
+  end
+end


### PR DESCRIPTION
In preparation for Stripe 3DS2 support, this PR adds support for Stripe Payment Intents.
Stripe Payment Intents is added as a gateway, with functionality to create new PaymentIntents 
and Stripe PaymentMethods. PaymentIntents can also be confirmed, captured, cancelled, and 
updated. This gateway is implemented as a subclass of the Stripe gateway. To take advantage of 
the latest features, the API for this gateway is bumped up to the latest version, `2019-05-16`.

Remote:
23 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

===

_Confirming that original Stripe tests also passing:_
_Remote:_
_67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications_
_100% passed_

_Unit:_
_135 tests, 722 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications_
_100% passed_