### PR TITLE
Realex: Fix an error that occurs when the rebate_secret or refund_secret is nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Braintree Blue: Support for stored credentials [hdeters] #3286
 * Realex: Re-implement credit as general credit [leila-alderman] #3280
 * Paymill: Add currency and amount to store requests [jasonxp] #3289
+* Realex: Prevent error calculating `refund_hash` or `credit_hash` when the secret is nil [jasonxp] #3291
 
 == Version 1.96.0 (Jul 26, 2019)
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -42,8 +42,8 @@ module ActiveMerchant
 
       def initialize(options = {})
         requires!(options, :login, :password)
-        options[:refund_hash] = Digest::SHA1.hexdigest(options[:rebate_secret]) if options.has_key?(:rebate_secret)
-        options[:credit_hash] = Digest::SHA1.hexdigest(options[:refund_secret]) if options.has_key?(:refund_secret)
+        options[:refund_hash] = Digest::SHA1.hexdigest(options[:rebate_secret]) if options[:rebate_secret].present?
+        options[:credit_hash] = Digest::SHA1.hexdigest(options[:refund_secret]) if options[:refund_secret].present?
         super
       end
 

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -51,6 +51,43 @@ class RealexTest < Test::Unit::TestCase
     @amount = 100
   end
 
+  def test_initialize_sets_refund_and_credit_hashes
+    refund_secret = 'refund'
+    rebate_secret = 'rebate'
+
+    gateway = RealexGateway.new(
+      login: @login,
+      password: @password,
+      rebate_secret: rebate_secret,
+      refund_secret: refund_secret
+    )
+
+    assert gateway.options[:refund_hash] == Digest::SHA1.hexdigest(rebate_secret)
+    assert gateway.options[:credit_hash] == Digest::SHA1.hexdigest(refund_secret)
+  end
+
+  def test_initialize_with_nil_refund_and_rebate_secrets
+    gateway = RealexGateway.new(
+      login: @login,
+      password: @password,
+      rebate_secret: nil,
+      refund_secret: nil
+    )
+
+    assert_false gateway.options.key?(:refund_hash)
+    assert_false gateway.options.key?(:credit_hash)
+  end
+
+  def test_initialize_without_refund_and_rebate_secrets
+    gateway = RealexGateway.new(
+      login: @login,
+      password: @password
+    )
+
+    assert_false gateway.options.key?(:refund_hash)
+    assert_false gateway.options.key?(:credit_hash)
+  end
+
   def test_hash
     gateway = RealexGateway.new(
       :login => 'thestore',


### PR DESCRIPTION
Fix an error that occurs when the ```rebate_secret``` or ```refund_secret``` option is set to ```nil```. In that case, the Realex gateway initializer attempts to calculate the refund hash or credit hash, passing ```nil``` to ```Digest::SHA1.hexdigest```, causing a type error. The fix is to only compute each hash if its secret has actually been provided.