### PR TITLE
add MONEI 3d secure support

### DIFF
--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -235,8 +235,8 @@ module ActiveMerchant #:nodoc:
       # 02 = MASTER_3D_SUCCESS
       # 05 = VISA_3D_SUCCESS
       # 06 = VISA_3D_ATTEMPT
-      # 07 = DEFAULT_E_COMMERCE 
-      def eci_to_result_indicator(eci) 
+      # 07 = DEFAULT_E_COMMERCE
+      def eci_to_result_indicator(eci)
         case eci
         when '02', '05'
           return eci
@@ -249,7 +249,7 @@ module ActiveMerchant #:nodoc:
       def add_three_d_secure(xml, options)
         if options[:three_d_secure]
           xml.Authentication(:type => '3DSecure') do
-            xml.ResultIndicator eci_to_result_indicator options[:three_d_secure][:eci] 
+            xml.ResultIndicator eci_to_result_indicator options[:three_d_secure][:eci]
             xml.Parameter(:name => 'VERIFICATION_ID') { xml.text options[:three_d_secure][:cavv] }
             xml.Parameter(:name => 'XID') { xml.text options[:three_d_secure][:xid] }
           end

--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -133,6 +133,7 @@ module ActiveMerchant #:nodoc:
           add_payment(xml, action, money, options)
           add_account(xml, credit_card)
           add_customer(xml, credit_card, options)
+          add_three_d_secure(xml, options)
         end
 
         commit(request)
@@ -221,6 +222,36 @@ module ActiveMerchant #:nodoc:
           xml.Contact do
             xml.Email options[:email] || 'noemail@monei.net'
             xml.Ip options[:ip] || '0.0.0.0'
+          end
+        end
+      end
+
+      # Private : Convert ECI to ResultIndicator
+      # Possible ECI values:
+      # 02 or 05 - Fully Authenticated Transaction
+      # 00 or 07 - Non 3D Secure Transaction
+      # Possible ResultIndicator values:
+      # 01 = MASTER_3D_ATTEMPT
+      # 02 = MASTER_3D_SUCCESS
+      # 05 = VISA_3D_SUCCESS
+      # 06 = VISA_3D_ATTEMPT
+      # 07 = DEFAULT_E_COMMERCE 
+      def eci_to_result_indicator(eci) 
+        case eci
+        when '02', '05'
+          return eci
+        else
+          return '07'
+        end
+      end
+
+      # Private : Add the 3DSecure infos to XML
+      def add_three_d_secure(xml, options)
+        if options[:three_d_secure]
+          xml.Authentication(:type => '3DSecure') do
+            xml.ResultIndicator eci_to_result_indicator options[:three_d_secure][:eci] 
+            xml.Parameter(:name => 'VERIFICATION_ID') { xml.text options[:three_d_secure][:cavv] }
+            xml.Parameter(:name => 'XID') { xml.text options[:three_d_secure][:xid] }
           end
         end
       end

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -13,12 +13,7 @@ class RemoteMoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase',
-      three_d_secure: {
-        eci: '05',
-        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
-        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
-      }
+      description: 'Store Purchase'
     }
   end
 
@@ -29,10 +24,37 @@ class RemoteMoneiTest < Test::Unit::TestCase
     assert_equal 'Request successfully processed in \'Merchant in Connector Test Mode\'', response.message
   end
 
+  def test_successful_purchase_with_3ds
+    options = @options.merge!({
+      three_d_secure: {
+        eci: '05',
+        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+      }
+    })
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal 'Request successfully processed in \'Merchant in Connector Test Mode\'', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'invalid cc number/brand combination', response.message
+  end
+
+  def test_failed_purchase_with_3ds
+    options = @options.merge!({
+      three_d_secure: {
+        eci: '05',
+        cavv: 'INVALID_Verification_ID',
+        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+      }
+    })
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_failure response
+    assert_equal 'Invalid 3DSecure Verification_ID. Must have Base64 encoding a Length of 28 digits', response.message
   end
 
   def test_successful_authorize_and_capture

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -13,7 +13,12 @@ class RemoteMoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      three_d_secure: {
+        eci: '05',
+        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+      }
     }
   end
 

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -5,10 +5,7 @@ class MoneiTest < Test::Unit::TestCase
 
   def setup
     @gateway = MoneiGateway.new(
-      :sender_id => 'mother',
-      :channel_id => 'there is no other',
-      :login => 'like mother',
-      :pwd => 'so treat Her right'
+      fixtures(:monei)
     )
 
     @credit_card = credit_card
@@ -17,7 +14,12 @@ class MoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      three_d_secure: {
+        eci: '05',
+        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+      }
     }
   end
 

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -14,12 +14,7 @@ class MoneiTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase',
-      three_d_secure: {
-        eci: '05',
-        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
-        xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
-      }
+      description: 'Store Purchase'
     }
   end
 
@@ -130,6 +125,26 @@ class MoneiTest < Test::Unit::TestCase
       @gateway.verify(@credit_card, @options)
     end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
+  end
+
+  def test_3ds_request
+    three_d_secure_options = {
+      eci: '05',
+      cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+      xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+    }
+    options = @options.merge!({
+      three_d_secure: three_d_secure_options
+    })
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      body = CGI.unescape data
+      assert_match %r{<Authentication type="3DSecure">}, body
+      assert_match %r{<ResultIndicator>05</ResultIndicator>}, body
+      assert_match %r{<Parameter name="VERIFICATION_ID">#{three_d_secure_options[:cavv]}</Parameter>}, body
+      assert_match %r{<Parameter name="XID">#{three_d_secure_options[:xid]}</Parameter>}, body
+    end.respond_with(successful_purchase_response)
   end
 
   private


### PR DESCRIPTION
This PR adds 3d secure support for [MONEI gateway](https://monei.net/)

Full MONEI XML API documentation can be found in [XML_Transactions_3_4_4.pdf](https://github.com/activemerchant/active_merchant/files/3461045/XML_Transactions_3_4_4.pdf)

Remote test result:

```
rake test TEST=test/remote/gateways/remote_monei_test.rb
/Users/dmitriy/.rvm/rubies/ruby-2.5.5/bin/ruby -w -I"lib:test" -I"/Users/dmitriy/.rvm/gems/ruby-2.5.5/gems/rake-12.3.3/lib" "/Users/dmitriy/.rvm/gems/ruby-2.5.5/gems/rake-12.3.3/lib/rake/rake_test_loader.rb" "test/remote/gateways/remote_monei_test.rb" 
Loaded suite /Users/dmitriy/.rvm/gems/ruby-2.5.5/gems/rake-12.3.3/lib/rake/rake_test_loader
Started
................
Finished in 18.328891 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------
16 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------
0.87 tests/s, 2.07 assertions/s
```
