### PR TITLE
Adds Naranja card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Realex: Prevent error calculating `refund_hash` or `credit_hash` when the secret is nil [jasonxp] #3291
 * MercadoPago: Add Cabal card type [leila-alderman] #3295
 * Adyen: Add app based 3DS requests for auth and purchase [jeremywrowe] #3298
+* PayU Latam: Add Naranja card type [hdeters] #3299
 
 == Version 1.96.0 (Jul 26, 2019)
 * Bluesnap: Omit state codes for unsupported countries [therufs] #3229

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
     # * Elo
     # * Alelo
     # * Cabal
+    # * Naranja
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -94,6 +95,7 @@ module ActiveMerchant #:nodoc:
       # * +'elo'+
       # * +'alelo'+
       # * +'cabal'+
+      # * +'naranja'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -9,6 +9,7 @@ module ActiveMerchant #:nodoc:
         'alelo'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ALELO_RANGES) },
         'discover'           => ->(num) { num =~ /^(6011|65\d{2}|64[4-9]\d)\d{12,15}|(62\d{14,17})$/ },
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
+        'naranja'            => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), NARANJA_RANGES) },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11}$/ },
         'jcb'                => ->(num) { num =~ /^35(28|29|[3-8]\d)\d{12}$/ },
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
@@ -100,6 +101,10 @@ module ActiveMerchant #:nodoc:
         60352200..60352299
       ]
 
+      NARANJA_RANGES = [
+        589562..589562
+      ]
+
       def self.included(base)
         base.extend(ClassMethods)
       end
@@ -175,7 +180,7 @@ module ActiveMerchant #:nodoc:
           valid_test_mode_card_number?(number) ||
             valid_card_number_length?(number) &&
             valid_card_number_characters?(number) &&
-            valid_checksum?(number)
+            valid_by_algorithm?(brand?(number), number)
         end
 
         def card_companies
@@ -249,6 +254,15 @@ module ActiveMerchant #:nodoc:
             %w[1 2 3 success failure error].include?(number)
         end
 
+        def valid_by_algorithm?(brand, numbers) #:nodoc:
+          case brand
+          when 'naranja'
+            valid_naranja_algo?(numbers)
+          else
+            valid_luhn?(numbers)
+          end
+        end
+
         ODD_LUHN_VALUE = {
           48 => 0,
           49 => 1,
@@ -279,7 +293,7 @@ module ActiveMerchant #:nodoc:
         # Checks the validity of a card number by use of the Luhn Algorithm.
         # Please see http://en.wikipedia.org/wiki/Luhn_algorithm for details.
         # This implementation is from the luhn_checksum gem, https://github.com/zendesk/luhn_checksum.
-        def valid_checksum?(numbers) #:nodoc:
+        def valid_luhn?(numbers) #:nodoc:
           sum = 0
 
           odd = true
@@ -294,6 +308,16 @@ module ActiveMerchant #:nodoc:
           end
 
           sum % 10 == 0
+        end
+
+        # Checks the validity of a card number by use of Naranja's specific algorithm.
+        def valid_naranja_algo?(numbers) #:nodoc:
+          num_array = numbers.to_s.chars.map(&:to_i)
+          multipliers = [4, 3, 2, 7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
+          num_sum = num_array[0..14].zip(multipliers).map { |a, b| a*b }.reduce(:+)
+          intermediate = 11 - (num_sum % 11)
+          final_num = intermediate > 9 ? 0 : intermediate
+          final_num == num_array[15]
         end
       end
     end

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AT', 'AU', 'BE', 'BG', 'BR', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GI', 'GR', 'HK', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'MT', 'MX', 'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SG', 'SK', 'SI', 'US']
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(CVE DJF GNF IDR JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro,  :discover, :elo]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro,  :discover, :elo, :naranja]
 
       self.money_format = :cents
 

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -8,7 +8,7 @@ module ActiveMerchant
       self.supported_countries = %w(US CA GB AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE AR BO BR BZ CL CO CR DO EC GF GP GT HN HT MF MQ MX NI PA PE PR PY SV UY VE)
 
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja]
 
       self.homepage_url = 'https://home.bluesnap.com/'
       self.display_name = 'BlueSnap'

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY', 'TR']
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja]
 
       self.homepage_url = 'https://dlocal.com/'
       self.display_name = 'dLocal'

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AD', 'AE', 'AG', 'AI', 'AL', 'AM', 'AO', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC', 'EE', 'EG', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY', 'HK', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE', 'IL', 'IM', 'IN', 'IS', 'IT', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PL', 'PN', 'PS', 'PT', 'PW', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SR', 'ST', 'SV', 'SZ', 'TC', 'TD', 'TG', 'TH', 'TJ', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'US', 'UY', 'UZ', 'VC', 'VE', 'VG', 'VI', 'VN', 'WF', 'WS', 'ZA', 'ZM', 'ZW']
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :naranja]
 
       def initialize(options={})
         requires!(options, :merchant_id, :api_key_id, :secret_api_key)

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.live_url = self.test_url = 'https://api.mercadopago.com/v1'
 
       self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY']
-      self.supported_cardtypes = [:visa, :master, :american_express, :elo, :cabal]
+      self.supported_cardtypes = [:visa, :master, :american_express, :elo, :cabal, :naranja]
 
       self.homepage_url = 'https://www.mercadopago.com/'
       self.display_name = 'Mercado Pago'

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -12,13 +12,14 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PA', 'PE']
       self.default_currency = 'USD'
       self.money_format = :dollars
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja]
 
       BRAND_MAP = {
         'visa' => 'VISA',
         'master' => 'MASTERCARD',
         'american_express' => 'AMEX',
-        'diners_club' => 'DINERS'
+        'diners_club' => 'DINERS',
+        'naranja' => 'NARANJA'
       }
 
       MINIMUMS = {

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'GBP'
       self.money_format = :cents
       self.supported_countries = %w(HK GB AU AD AR BE BR CA CH CN CO CR CY CZ DE DK ES FI FR GI GR HU IE IN IT JP LI LU MC MT MY MX NL NO NZ PA PE PL PT SE SG SI SM TR UM VA)
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :elo]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :elo, :naranja]
       self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
       self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.homepage_url = 'http://www.worldpay.com/'
@@ -22,6 +22,7 @@ module ActiveMerchant #:nodoc:
         'maestro'          => 'MAESTRO-SSL',
         'diners_club'      => 'DINERS-SSL',
         'elo'              => 'ELO-SSL',
+        'naranja'          => 'NARANJA-SSL',
         'unknown'          => 'CARD-SSL'
       }
 

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -4,8 +4,9 @@ class RemoteDLocalTest < Test::Unit::TestCase
   def setup
     @gateway = DLocalGateway.new(fixtures(:d_local))
 
-    @amount = 100
+    @amount = 200
     @credit_card = credit_card('4111111111111111')
+    @credit_card_naranja = credit_card('5895627823453005')
     # No test card numbers, all txns are approved by default,
     # but errors can be invoked directly with the `description` field
     @options = {
@@ -37,6 +38,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
+  def test_successful_purchase_naranja
+    response = @gateway.purchase(@amount, @credit_card_naranja, @options)
     assert_success response
     assert_match 'The payment was paid', response.message
   end

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -145,6 +145,12 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'alelo', CreditCard.brand?('5067600000000044')
   end
 
+  def test_should_detect_naranja_card
+    assert_equal 'naranja', CreditCard.brand?('5895627823453005')
+    assert_equal 'naranja', CreditCard.brand?('5895620000000002')
+    assert_equal 'naranja', CreditCard.brand?('5895626746595650')
+  end
+
   # Alelo BINs beginning with the digit 4 overlap with Visa's range of valid card numbers.
   # We intentionally misidentify these cards as Visa, which works because transactions with
   # such cards will run on Visa rails.
@@ -197,6 +203,12 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_nil CreditCard.brand?('XXXXXXXXXXXX0000')
     assert_false CreditCard.valid_number?('XXXXXXXXXXXX0000')
     assert_false CreditCard.valid_number?(nil)
+  end
+
+  def test_matching_valid_naranja
+    number = '5895627823453005'
+    assert_equal 'naranja', CreditCard.brand?(number)
+    assert CreditCard.valid_number?(number)
   end
 
   def test_16_digit_maestro_uk


### PR DESCRIPTION
This adds support for the Naranja card type along with the custom
card number validation logic they use. Naranja is added as a card
type to the following gateways: Bluesnap, dLocal, PayU Latam, Ingenico
ePayments, Mercado Pago, Worldpay, Adyen

There is a single BIN number for Naranja (589562) -- it is co-branded
with Visa, Mastercard, and Amex and will be identified as the co-brand
in those cases.

Added remote gateway test for dLocal and PayU Latam -- remaining
gateways either didn't have a Naranja test card available or needed
additional configuration for Naranja cards (card type or region enabled)

Removed two tests from PayU Latam because capture and void methods are
now supported in the sandbox.

Remote dLocal tests
Remote
22 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote PayU Latam tests
30 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Card method unit tests
36 tests, 234 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

EVS-171