### PR TITLE
Credorax: Enable selecting a processor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * CyberSource: Support 3DS2 pass-through fields [curiousepic] #3363
 * Worldpay: Switch to Nokogiri [nfarve] #3364
 * Credorax: Add support for MOTO flagging [britth] #3366
+* Credorax: Enable selecting a processor [leila-alderman] #3302
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -135,6 +135,7 @@ module ActiveMerchant #:nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_transaction_type(post, options)
+        add_processor(post, options)
 
         commit(:purchase, post)
       end
@@ -149,6 +150,7 @@ module ActiveMerchant #:nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_transaction_type(post, options)
+        add_processor(post, options)
 
         commit(:authorize, post)
       end
@@ -160,6 +162,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_echo(post, options)
         add_submerchant_id(post, options)
+        add_processor(post, options)
 
         commit(:capture, post)
       end
@@ -171,6 +174,7 @@ module ActiveMerchant #:nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         post[:a1] = generate_unique_id
+        add_processor(post, options)
 
         commit(:void, post, reference_action)
       end
@@ -182,6 +186,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_echo(post, options)
         add_submerchant_id(post, options)
+        add_processor(post, options)
 
         commit(:refund, post)
       end
@@ -195,6 +200,7 @@ module ActiveMerchant #:nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_transaction_type(post, options)
+        add_processor(post, options)
 
         commit(:credit, post)
       end
@@ -303,7 +309,6 @@ module ActiveMerchant #:nodoc:
 
       def add_3d_secure_1_data(post, options)
         post[:i8] = build_i8(options[:eci], options[:cavv], options[:xid])
-        post[:r1] = 'CREDORAX'
       end
 
       def add_normalized_3d_secure_2_data(post, options)
@@ -315,7 +320,6 @@ module ActiveMerchant #:nodoc:
         )
         post[:'3ds_version'] = three_d_secure_options[:version]
         post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
-        post[:r1] = 'CREDORAX'
       end
 
       def build_i8(eci, cavv=nil, xid=nil)
@@ -335,6 +339,11 @@ module ActiveMerchant #:nodoc:
       def add_transaction_type(post, options)
         post[:a9] = options[:transaction_type] if options[:transaction_type]
         post[:a2] = '3' if options.dig(:metadata, :manual_entry)
+      end
+
+      def add_processor(post, options)
+        post[:r1] = options[:processor] || 'CREDORAX'
+        post[:r2] = options[:processor_merchant_id] if options[:processor_merchant_id]
       end
 
       ACTIONS = {

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -311,6 +311,17 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_cvv_scrubbed(clean_transcript)
   end
 
+  def test_purchase_passes_processor
+    # returns a successful response when a valid processor parameter is sent
+    assert good_response = @gateway.purchase(@amount, @credit_card, @options.merge(fixtures(:credorax_with_processor)))
+    assert_success good_response
+    assert_equal 'Succeeded', good_response.message
+
+    # returns a failed response when an invalid tx_source parameter is sent
+    assert bad_response = @gateway.purchase(@amount, @credit_card, @options.merge(processor: 'invalid'))
+    assert_failure bad_response
+  end
+
   # #########################################################################
   # # CERTIFICATION SPECIFIC REMOTE TESTS
   # #########################################################################


### PR DESCRIPTION
Adds gateway specific fields to the Credorax gateway to enable the user
to select a different processor, including adding a unit test and a
(failing) remote test.

Gateway specific fields added:
 - R1: processor name
 - R2: processor merchant ID

CE-35

Unit:
23 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
26 tests, 37 assertions, 21 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
19.2308% passed

The Credorax gateway integration was recently updated, and now many of
the remote tests that were previously passing are failing. It is
currently unknown why these tests are all failing. We have reached
out to Credorax to inquire about this new behavior.