### PR TITLE
Decidir: Add Naranja Card

### DIFF
--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AR']
       self.money_format = :cents
       self.default_currency = 'ARS'
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja]
 
       self.homepage_url = 'http://www.decidir.com'
       self.display_name = 'Decidir'
@@ -99,7 +99,8 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((apikey: )\w+)i, '\1[FILTERED]').
           gsub(%r((\"card_number\\\":\\\")\d+), '\1[FILTERED]').
-          gsub(%r((\"security_code\\\":\\\")\d+), '\1[FILTERED]')
+          gsub(%r((\"security_code\\\":\\\")\d+), '\1[FILTERED]').
+          gsub(%r((\"emv_issuer_data\\\":\\\")\d+), '\1[FILTERED]')
       end
 
       private

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -78,7 +78,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
     assert capture = @gateway_for_auth.capture(1, auth.authorization)
     assert_failure capture
-    assert_equal 'amount: Amount out of ranges: 100 - 100', capture.message
+    assert_equal 'amount: Amount out of ranges: 80 - 105', capture.message
     assert_equal 'invalid_request_error', capture.error_code
     assert_nil capture.authorization
   end


### PR DESCRIPTION
EVS-181

Adds Naranha card to Decidir gateway
Updated two tests to correspond to changed Decidir responses

Unit:
22 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
17 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed