### PR TITLE
Global Collect: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * BlueSnap: add standardized 3DS 2 auth fields [bayprogrammer] #3318
 * Barclaycard Smartpay: Add app based 3DS requests for auth and purchase [britth] #3327
 * Stripe Payment Intents, Checkout V2: Add support for `MOTO` flagging [britth] #3323
+* Global Collect: Add Cabal card [leila-alderman] #3310
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AD', 'AE', 'AG', 'AI', 'AL', 'AM', 'AO', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC', 'EE', 'EG', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY', 'HK', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE', 'IL', 'IM', 'IN', 'IS', 'IT', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PL', 'PN', 'PS', 'PT', 'PW', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SR', 'ST', 'SV', 'SZ', 'TC', 'TD', 'TG', 'TH', 'TJ', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'US', 'UY', 'UZ', 'VC', 'VE', 'VG', 'VI', 'VN', 'WF', 'WS', 'ZA', 'ZM', 'ZW']
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :naranja, :cabal]
 
       def initialize(options={})
         requires!(options, :merchant_id, :api_key_id, :secret_api_key)


### PR DESCRIPTION
Adds the Cabal card to the Global Collect gateway (also known as the
Ingenico gateway).

The Ingenico gateway docs do not include a test card number for Cabal,
and sending card numbers that follow the Luhn algorithm and fall within
the Cabal card range results in error messages of "Rejected".
Therefore, no additional remote or unit tests were added to the Global
Collect gateway to test the implementation of the Cabal card type.

CE-94 / CE-97

Unit:
20 tests, 88 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
17 tests, 40 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed