### PR TITLE
Update Braintree

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'rubocop', '~> 0.60.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.93.0'
+  gem 'braintree', '>= 2.98.0'
   gem 'mechanize'
 end


### PR DESCRIPTION
Update to latest gem version to allow supporting 3DS2 fields.
https://github.com/braintree/braintree_ruby/blob/master/CHANGELOG.md

Unit:
6 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Blue Remote:
79 tests, 435 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Blue Unit:
73 tests, 174 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Orange Remote:
21 tests, 91 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Orange Unit:
18 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed