### PR TITLE
Add shipping info to Stripe purchases

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -540,27 +540,26 @@ module ActiveMerchant #:nodoc:
         post[:metadata] ||= {}
         post[:metadata][:card_read_method] = creditcard.read_method if creditcard.respond_to?(:read_method)
       end
-      
-      def add_shipping_info(post, options = {})
-        post[:shipping] = {}
 
-        if address = options[:shipping_address]
+      def add_shipping_info(post, options = {})
+        # address.line1 and name are required parameters for shipping
+        if (address = options[:shipping_address]) && address[:address1] && (name = address_name(address))
+          post[:shipping] = {}
+          post[:shipping][:name] = name
+
           address_params = {}
-          address_params[:line1] = address[:address1] if address[:address1]
+          address_params[:line1] = address[:address1]
           address_params[:line2] = address[:address2] if address[:address2]
           address_params[:city] = address[:city] if address[:city]
           address_params[:state] = address[:state] if address[:state]
           address_params[:postal_code] = address[:zip] if address[:zip]
           address_params[:country] = address[:country] if address[:country]
-          post[:shipping][:address] = address_params unless address_params.empty?
-          post[:shipping][:name] = address[:name] if address[:name]
+          post[:shipping][:address] = address_params
+
           post[:shipping][:phone] = address[:phone] if address[:phone]
+          post[:shipping][:carrier] = options[:carrier] if options[:carrier]
+          post[:shipping][:tracking_number] = options[:tracking_number] if options[:tracking_number]
         end
-
-        post[:shipping][:carrier] = options[:carrier] if options[:carrier]
-        post[:shipping][:tracking_number] = options[:tracking_number] if options[:tracking_number]
-
-        post.delete(:shipping) if post[:shipping].empty?
       end
 
       def add_source_owner(post, creditcard, options)
@@ -806,6 +805,14 @@ module ActiveMerchant #:nodoc:
             dest = dest[key]
           end
           dest[dest_path.last] = source
+        end
+      end
+
+      def address_name(address)
+        if address[:name]
+          address[:name]
+        elsif address[:first_name] && address[:last_name]
+          "#{address[:first_name]} #{address[:last_name]}"
         end
       end
     end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -371,6 +371,7 @@ module ActiveMerchant #:nodoc:
         end
 
         add_metadata(post, options)
+        add_shipping_info(post, options)
         add_application_fee(post, options)
         add_exchange_rate(post, options)
         add_destination(post, options)
@@ -538,6 +539,28 @@ module ActiveMerchant #:nodoc:
       def add_emv_metadata(post, creditcard)
         post[:metadata] ||= {}
         post[:metadata][:card_read_method] = creditcard.read_method if creditcard.respond_to?(:read_method)
+      end
+      
+      def add_shipping_info(post, options = {})
+        post[:shipping] = {}
+
+        if address = options[:shipping_address]
+          address_params = {}
+          address_params[:line1] = address[:address1] if address[:address1]
+          address_params[:line2] = address[:address2] if address[:address2]
+          address_params[:city] = address[:city] if address[:city]
+          address_params[:state] = address[:state] if address[:state]
+          address_params[:postal_code] = address[:zip] if address[:zip]
+          address_params[:country] = address[:country] if address[:country]
+          post[:shipping][:address] = address_params unless address_params.empty?
+          post[:shipping][:name] = address[:name] if address[:name]
+          post[:shipping][:phone] = address[:phone] if address[:phone]
+        end
+
+        post[:shipping][:carrier] = options[:carrier] if options[:carrier]
+        post[:shipping][:tracking_number] = options[:tracking_number] if options[:tracking_number]
+
+        post.delete(:shipping) if post[:shipping].empty?
       end
 
       def add_source_owner(post, creditcard, options)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -140,6 +140,15 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal custom_options[:tracking_number], response.params['shipping']['tracking_number']
   end
 
+  def test_successful_purchase_with_invalid_shipping_info
+    custom_options = @options.merge(:shipping_address => address(name: nil), :carrier => 'UPS', :tracking_number => '12345')
+    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
+    assert_success response
+    assert_equal 'charge', response.params['object']
+    assert response.params['paid']
+    assert_equal nil, response.params['shipping']
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -122,6 +122,24 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'wow@example.com', response.params['metadata']['email']
   end
 
+  def test_successful_purchase_with_shipping_info
+    custom_options = @options.merge(:shipping_address => address(), :carrier => 'UPS', :tracking_number => '12345')
+    assert response = @gateway.purchase(@amount, @credit_card, custom_options)
+    assert_success response
+    assert_equal 'charge', response.params['object']
+    assert response.params['paid']
+    assert_equal custom_options[:shipping_address][:name], response.params['shipping']['name']
+    assert_equal custom_options[:shipping_address][:address1], response.params['shipping']['address']['line1']
+    assert_equal custom_options[:shipping_address][:address2], response.params['shipping']['address']['line2']
+    assert_equal custom_options[:shipping_address][:city], response.params['shipping']['address']['city']
+    assert_equal custom_options[:shipping_address][:state], response.params['shipping']['address']['state']
+    assert_equal custom_options[:shipping_address][:zip], response.params['shipping']['address']['postal_code']
+    assert_equal custom_options[:shipping_address][:country], response.params['shipping']['address']['country']
+    assert_equal custom_options[:shipping_address][:phone], response.params['shipping']['phone']
+    assert_equal custom_options[:carrier], response.params['shipping']['carrier']
+    assert_equal custom_options[:tracking_number], response.params['shipping']['tracking_number']
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1100,6 +1100,31 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @options[:tracking_number], post[:shipping][:tracking_number]
   end
 
+  def test_add_shipping_info_requires_name
+    post = {}
+    @options[:shipping_address][:name] = nil
+
+    @gateway.send(:add_shipping_info, post, @options)
+    assert_equal nil, post[:shipping]
+  end
+
+  def test_add_shipping_info_requires_address1
+    post = {}
+    @options[:shipping_address][:address1] = nil
+
+    @gateway.send(:add_shipping_info, post, @options)
+    assert_equal nil, post[:shipping]
+  end
+
+  def test_add_shipping_info_city_is_optional
+    post = {}
+    @options[:shipping_address][:city] = nil
+
+    @gateway.send(:add_shipping_info, post, @options)
+    assert_equal nil, post[:shipping][:address][:city]
+    assert_equal @options[:shipping_address][:address1], post[:shipping][:address][:line1]
+  end
+
   def test_ensure_does_not_respond_to_credit
     assert !@gateway.respond_to?(:credit)
   end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -15,7 +15,10 @@ class StripeTest < Test::Unit::TestCase
     @options = {
       :billing_address => address(),
       :statement_address => statement_address(),
-      :description => 'Test Purchase'
+      :description => 'Test Purchase',
+      :shipping_address => address(),
+      :carrier => 'UPS',
+      :tracking_number => '12345'
     }
 
     @threeds_options = {
@@ -1080,6 +1083,21 @@ class StripeTest < Test::Unit::TestCase
 
       assert_equal nil, post[:statement_address]
     end
+  end
+
+  def test_add_shipping_info
+    post = {:card => {}}
+    @gateway.send(:add_shipping_info, post, @options)
+    assert_equal @options[:shipping_address][:zip], post[:shipping][:address][:postal_code]
+    assert_equal @options[:shipping_address][:state], post[:shipping][:address][:state]
+    assert_equal @options[:shipping_address][:address1], post[:shipping][:address][:line1]
+    assert_equal @options[:shipping_address][:address2], post[:shipping][:address][:line2]
+    assert_equal @options[:shipping_address][:country], post[:shipping][:address][:country]
+    assert_equal @options[:shipping_address][:city], post[:shipping][:address][:city]
+    assert_equal @options[:shipping_address][:name], post[:shipping][:name]
+    assert_equal @options[:shipping_address][:phone], post[:shipping][:phone]
+    assert_equal @options[:carrier], post[:shipping][:carrier]
+    assert_equal @options[:tracking_number], post[:shipping][:tracking_number]
   end
 
   def test_ensure_does_not_respond_to_credit


### PR DESCRIPTION
This builds upon the work done by @whitby3001 in https://github.com/activemerchant/active_merchant/pull/2379

That PR was reverted in 28eb2a8113653b8b0e0f283f95ede6e3f18c99f4 due to validation errors from Stripe with incomplete shipping information. I've added checks to ensure all required fields are present and added some test coverage for this case.

Stripe docs on required parameters: https://stripe.com/docs/api/charges/create#create_charge-shipping