### PR TITLE
WorldPay: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Barclaycard Smartpay: Add app based 3DS requests for auth and purchase [britth] #3327
 * Stripe Payment Intents, Checkout V2: Add support for `MOTO` flagging [britth] #3323
 * Global Collect: Add Cabal card [leila-alderman] #3310
+* WorldPay: Add Cabal card [leila-alderman] #3316
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'GBP'
       self.money_format = :cents
       self.supported_countries = %w(HK GB AU AD AR BE BR CA CH CN CO CR CY CZ DE DK ES FI FR GI GR HU IE IN IT JP LI LU MC MT MY MX NL NO NZ PA PE PL PT SE SG SI SM TR UM VA)
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :elo, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :elo, :naranja, :cabal]
       self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
       self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.homepage_url = 'http://www.worldpay.com/'
@@ -23,6 +23,7 @@ module ActiveMerchant #:nodoc:
         'diners_club'      => 'DINERS-SSL',
         'elo'              => 'ELO-SSL',
         'naranja'          => 'NARANJA-SSL',
+        'cabal'            => 'CABAL-SSL',
         'unknown'          => 'CARD-SSL'
       }
 


### PR DESCRIPTION
Adds the ability to use the newly added Cabal card to the WorldPay
gateway.

Although the WorldPay gateway documentation includes a test card number
for Cabal, the current gateway integration is not set up to accept Cabal
cards and results in error messages of `"Payment Method CABAL-SSL is
unknown; The Payment Method is not available."`. Therefore, no
additional remote or unit tests were added to the WorldPay gateway to
test the implementation of the Cabal card type.

CE-94 / CE-98

Unit:
66 tests, 392 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
50 tests, 215 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
90% passed

Two of the failing tests are for 3DS parameter pass-through, which are
known to fail with the current test credentials. (See
https://github.com/activemerchant/active_merchant/commit/1243289c2e700e666a634a86611cd6fa8da0ae05#diff-5b1b45d9c385decf3c649a4e3e8ebbc5)

The other three failing tests are all related to `credit`:
 - `test_successful_credit_using_token`
 - `test_successful_mastercard_credit_on_cft_gateway`
 - `test_successful_visa_credit_on_cft_gateway`
These tests all result in error messages of `"Security violation"`, so
it's possible that the current credentials are not allowed to run
`credit` transactions.