### PR TITLE
Stripe Payment Intents - Update transfer_data option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * PayU Latam: Add support for the `merchant_buyer_id` field in the `options` and `buyer` hashes [jasonxp] #3308
 * Fat Zebra: Send metadata for purchase and authorize [montdidier] #3101
 * TrustCommerce: Add support for custom fields [jasonxp] #3313
+* Stripe Payment Intents: Support option fields `transfer_destination` and `transfer_amount` and remove `transfer_data` hash [britth] #3317
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -207,10 +207,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_connected_account(post, options = {})
-        return unless transfer_data = options[:transfer_data]
+        return unless options[:transfer_destination]
         post[:transfer_data] = {}
-        post[:transfer_data][:destination] = transfer_data[:destination] if transfer_data[:destination]
-        post[:transfer_data][:amount] = transfer_data[:amount] if transfer_data[:amount]
+        post[:transfer_data][:destination] = options[:transfer_destination]
+        post[:transfer_data][:amount] = options[:transfer_amount] if options[:transfer_amount]
         post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
         post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
         post[:application_fee_amount] = options[:application_fee] if options[:application_fee]

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -211,7 +211,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'USD',
       customer: @customer,
       application_fee: 100,
-      transfer_data: {destination: @destination_account}
+      transfer_destination: @destination_account
     }
 
     assert response = @gateway.create_intent(@amount, nil, options)


### PR DESCRIPTION
Rather than requiring a user to send in a hash with transfer data, this PR changes
to use individual `transfer_destination` and `transfer_amount` fields instead.

Remote:
24 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed