### PR TITLE
Stripe Payment Intents: Add billing_details to payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * TrustCommerce: Add support for custom fields [jasonxp] #3313
 * Stripe Payment Intents: Support option fields `transfer_destination` and `transfer_amount` and remove `transfer_data` hash [britth] #3317
 * Barclaycard Smartpay: Add support for `shopperStatement` gateway-specific field [jasonxp] #3319
+* Stripe Payment Intents: Add support for billing_details on payment methods [britth] #3320
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -54,6 +54,7 @@ module ActiveMerchant #:nodoc:
         post[:card][:exp_month] = payment_method.month
         post[:card][:exp_year] = payment_method.year
         post[:card][:cvc] = payment_method.verification_value if payment_method.verification_value
+        add_billing_address(post, options)
 
         commit(:post, 'payment_methods', post, options)
       end
@@ -214,6 +215,22 @@ module ActiveMerchant #:nodoc:
         post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
         post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
         post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
+        post
+      end
+
+      def add_billing_address(post, options = {})
+        return unless billing = options[:billing_address] || options[:address]
+        post[:billing_details] = {}
+        post[:billing_details][:address] = {}
+        post[:billing_details][:address][:city] = billing[:city] if billing[:city]
+        post[:billing_details][:address][:country] = billing[:country] if billing[:country]
+        post[:billing_details][:address][:line1] = billing[:address1] if billing[:address1]
+        post[:billing_details][:address][:line2] = billing[:address2] if billing[:address2]
+        post[:billing_details][:address][:postal_code] = billing[:zip] if billing[:zip]
+        post[:billing_details][:address][:state] = billing[:state] if billing[:state]
+        post[:billing_details][:email] = billing[:email] if billing[:email]
+        post[:billing_details][:name] = billing[:name] if billing[:name]
+        post[:billing_details][:phone] = billing[:phone] if billing[:phone]
         post
       end
 

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -206,6 +206,20 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'John Doe', response.params['shipping']['name']
   end
 
+  def test_create_payment_intent_with_billing_address
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      billing_address: address,
+      confirm: true
+    }
+
+    assert response = @gateway.create_intent(@amount, @visa_card, options)
+    assert_success response
+    assert billing = response.params.dig('charges', 'data')[0].dig('billing_details', 'address')
+    assert_equal 'Ottawa', billing['city']
+  end
+
   def test_create_payment_intent_with_connected_account
     options = {
       currency: 'USD',


### PR DESCRIPTION
Saves billing details (address, name, email, phone) to payment methods.

Remote:
25 tests, 107 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed