### PR TITLE
Bambora Online ePay 3DS support

### DIFF
--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -5,23 +5,22 @@ class RemoteEpayTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = EpayGateway.new(fixtures(:epay))
-
     @credit_card = credit_card('3333333333333000')
     @credit_card_declined = credit_card('3333333333333102')
-
     @amount = 100
-    @options = {order_id: '1'}
+    @options_xid = {order_id: '1', three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: nil }}
+    @options_ds_transaction_id = {order_id: '1', three_d_secure: { eci: '7', xid: nil, cavv: '456', version: '2', ds_transaction_id: '798' }}
   end
 
-  def test_successful_purchase
-    response = @gateway.purchase(@amount, @credit_card, @options)
+  def test_successful_purchase_xid
+    response = @gateway.purchase(@amount, @credit_card, @options_xid)
     assert_success response
     assert !response.authorization.blank?
     assert response.test?
   end
 
-  def test_successful_authorize_and_capture
-    response = @gateway.authorize(@amount, @credit_card, @options)
+  def test_successful_authorize_and_capture_xid
+    response = @gateway.authorize(@amount, @credit_card, @options_xid)
     assert_success response
     assert !response.authorization.blank?
 
@@ -29,14 +28,72 @@ class RemoteEpayTest < Test::Unit::TestCase
     assert_success capture_response
   end
 
-  def test_failed_authorization
-    response = @gateway.authorize(@amount, @credit_card_declined, @options)
+  def test_failed_authorization_xid
+    response = @gateway.authorize(@amount, @credit_card_declined, @options_xid)
     assert_failure response
   end
 
-  def test_failed_purchase
-    response = @gateway.purchase(@amount, @credit_card_declined, @options)
+  def test_failed_purchase_xid
+    response = @gateway.purchase(@amount, @credit_card_declined, @options_xid)
     assert_failure response
+  end
+
+  def test_successful_refund_xid
+    response = @gateway.purchase(@amount, @credit_card, @options_xid)
+    assert_success response
+
+    refund_response = @gateway.refund(@amount, response.authorization)
+    assert_success refund_response
+  end
+
+  def test_successful_void_xid
+    response = @gateway.authorize(@amount, @credit_card, @options_xid)
+    assert_success response
+
+    void_response = @gateway.void(response.authorization)
+    assert_success void_response
+  end
+
+  def test_successful_purchase_ds_transaction_id
+    response = @gateway.purchase(@amount, @credit_card, @options_ds_transaction_id)
+    assert_success response
+    assert !response.authorization.blank?
+    assert response.test?
+  end
+
+  def test_successful_authorize_and_capture_ds_transaction_id
+    response = @gateway.authorize(@amount, @credit_card, @options_ds_transaction_id)
+    assert_success response
+    assert !response.authorization.blank?
+
+    capture_response = @gateway.capture(@amount, response.authorization)
+    assert_success capture_response
+  end
+
+  def test_failed_authorization_ds_transaction_id
+    response = @gateway.authorize(@amount, @credit_card_declined, @options_ds_transaction_id)
+    assert_failure response
+  end
+
+  def test_failed_purchase_ds_transaction_id
+    response = @gateway.purchase(@amount, @credit_card_declined, @options_ds_transaction_id)
+    assert_failure response
+  end
+
+  def test_successful_refund_ds_transaction_id
+    response = @gateway.purchase(@amount, @credit_card, @options_ds_transaction_id)
+    assert_success response
+
+    refund_response = @gateway.refund(@amount, response.authorization)
+    assert_success refund_response
+  end
+
+  def test_successful_void_ds_transaction_id
+    response = @gateway.authorize(@amount, @credit_card, @options_ds_transaction_id)
+    assert_success response
+
+    void_response = @gateway.void(response.authorization)
+    assert_success void_response
   end
 
   def test_failed_capture
@@ -44,29 +101,14 @@ class RemoteEpayTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_successful_refund
-    response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success response
-
-    refund_response = @gateway.refund(@amount, response.authorization)
-    assert_success refund_response
-  end
-
   def test_failed_refund
     response = @gateway.refund(@amount, 0)
     assert_failure response
-  end
-
-  def test_successful_void
-    response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_success response
-
-    void_response = @gateway.void(response.authorization)
-    assert_success void_response
   end
 
   def test_failed_void
     response = @gateway.void(0)
     assert_failure response
   end
+
 end


### PR DESCRIPTION
Adds 3DS support to the epay payment method.
---- Unit Test ----
Loaded suite test/unit/gateways/epay_test.rb
16 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---- Remote Test ----
Loaded suite test/remote/gateways/remote_epay_test.rb
9 tests, 15 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
