### PR TITLE
Decidir: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Stripe Payment Intents, Checkout V2: Add support for `MOTO` flagging [britth] #3323
 * Global Collect: Add Cabal card [leila-alderman] #3310
 * WorldPay: Add Cabal card [leila-alderman] #3316
+* Decidir: Add Cabal card [leila-alderman] #3322
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AR']
       self.money_format = :cents
       self.default_currency = 'ARS'
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja, :cabal]
 
       self.homepage_url = 'http://www.decidir.com'
       self.display_name = 'Decidir'


### PR DESCRIPTION
Adds the Cabal card type to the Decidir gateway.

With our current test gateway implementation, it does not seem possible
to test Cabal cards. When attempting to run a remote test with a Cabal
test card number, the error message states that the request contains an
invalid BIN (first 6 digits of the card number). Therefore, the addition
of Cabal cards has not been tested on the Decidir gateway.

CE-94 / CE-100

Unit:
22 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
17 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed