### PR TITLE
Stripe Payment Intents, Checkout V2: MOTO flag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Stripe Payment Intents: Add support for billing_details on payment methods [britth] #3320
 * BlueSnap: add standardized 3DS 2 auth fields [bayprogrammer] #3318
 * Barclaycard Smartpay: Add app based 3DS requests for auth and purchase [britth] #3327
+* Stripe Payment Intents, Checkout V2: Add support for `MOTO` flagging [britth] #3323
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -128,6 +128,7 @@ module ActiveMerchant #:nodoc:
       def add_transaction_data(post, options = {})
         post[:payment_type] = 'Regular' if options[:transaction_indicator] == 1
         post[:payment_type] = 'Recurring' if options[:transaction_indicator] == 2
+        post[:payment_type] = 'MOTO' if options[:transaction_indicator] == 3
         post[:previous_payment_id] = options[:previous_charge_id] if options[:previous_charge_id]
       end
 

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -5,6 +5,9 @@ module ActiveMerchant #:nodoc:
     # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
     # For the legacy API, see the Stripe gateway
     class StripePaymentIntentsGateway < StripeGateway
+
+      self.supported_countries = %w(AT AU BE BR CA CH DE DK ES FI FR GB HK IE IT JP LU MX NL NO NZ PT SE SG US)
+
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
       CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method]
@@ -24,6 +27,7 @@ module ActiveMerchant #:nodoc:
         add_connected_account(post, options)
         add_shipping_address(post, options)
         setup_future_usage(post, options)
+        add_exemption(post, options)
 
         CREATE_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
@@ -199,6 +203,13 @@ module ActiveMerchant #:nodoc:
 
         post[:payment_method_types] = Array(payment_method_types)
         post
+      end
+
+      def add_exemption(post, options = {})
+        return unless options[:confirm]
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:moto] = true if options[:moto]
       end
 
       def setup_future_usage(post, options = {})

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -63,6 +63,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_moto_flag
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(transaction_indicator: 3))
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_includes_avs_result
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
This PR enables marking a transaction as MOTO on the Stripe Payment
Intents and Checkout V2 gateways. Note: For Stripe, accounts must
be configured to allow setting the [MOTO flag](https://stripe.com/guides/strong-customer-authentication#phone-sales). This PR also adds the list of 
supported countries for Stripe Payment Intents.

**Stripe Payment Intents**
Remote:
28 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

**Checkout V2**
Remote:
30 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
26 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed