### PR TITLE
PayU Latam: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Global Collect: Add Cabal card [leila-alderman] #3310
 * WorldPay: Add Cabal card [leila-alderman] #3316
 * Decidir: Add Cabal card [leila-alderman] #3322
+* PayU Latam: Add Cabal card [leila-alderman] #3324
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -12,14 +12,15 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PA', 'PE']
       self.default_currency = 'USD'
       self.money_format = :dollars
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja, :cabal]
 
       BRAND_MAP = {
         'visa' => 'VISA',
         'master' => 'MASTERCARD',
         'american_express' => 'AMEX',
         'diners_club' => 'DINERS',
-        'naranja' => 'NARANJA'
+        'naranja' => 'NARANJA',
+        'cabal' => 'CABAL'
       }
 
       MINIMUMS = {

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -9,6 +9,8 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     @declined_card = credit_card('4097440000000004', verification_value: '444', first_name: 'REJECTED', last_name: '')
     @pending_card = credit_card('4097440000000004', verification_value: '444', first_name: 'PENDING', last_name: '')
     @naranja_credit_card = credit_card('5895620000000002', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'naranja')
+    @cabal_credit_card = credit_card('5896570000000004', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
+    @invalid_cabal_card = credit_card('6271700000000000', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
 
     @options = {
       dni_number: '5415668464654',
@@ -53,6 +55,13 @@ class RemotePayuLatamTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_naranja_card
     response = @gateway.purchase(@amount, @naranja_credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_cabal_card
+    response = @gateway.purchase(@amount, @cabal_credit_card, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
     assert response.test?
@@ -221,6 +230,12 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_equal 'DECLINED', response.params['transactionResponse']['state']
   end
 
+  def test_failed_purchase_with_cabal_card
+    response = @gateway.purchase(@amount, @invalid_cabal_card, @options)
+    assert_failure response
+    assert_equal 'DECLINED', response.params['transactionResponse']['state']
+  end
+
   def test_failed_purchase_with_no_options
     response = @gateway.purchase(@amount, @declined_card, {})
     assert_failure response
@@ -243,6 +258,13 @@ class RemotePayuLatamTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_naranja_card
     response = @gateway.authorize(@amount, @naranja_credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert_match %r(^\d+\|(\w|-)+$), response.authorization
+  end
+
+  def test_successful_authorize_with_cabal_card
+    response = @gateway.authorize(@amount, @cabal_credit_card, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
     assert_match %r(^\d+\|(\w|-)+$), response.authorization

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -12,6 +12,7 @@ class PayuLatamTest < Test::Unit::TestCase
     @pending_card = credit_card('4097440000000004', verification_value: '222', first_name: 'PENDING', last_name: '')
     @no_cvv_visa_card = credit_card('4097440000000004', verification_value: ' ')
     @no_cvv_amex_card = credit_card('4097440000000004', verification_value: ' ', brand: 'american_express')
+    @cabal_credit_card = credit_card('5896570000000004', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
 
     @options = {
       dni_number: '5415668464654',
@@ -57,6 +58,15 @@ class PayuLatamTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_cabal_card
+    @gateway.expects(:ssl_post).returns(successful_purchase_with_cabal_response)
+
+    response = @gateway.purchase(@amount, @cabal_credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert response.test?
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 
@@ -81,6 +91,15 @@ class PayuLatamTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_authorize_with_cabal_card
+    @gateway.expects(:ssl_post).returns(successful_authorize_with_cabal_response)
+
+    response = @gateway.authorize(@amount, @cabal_credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert_match %r(^\d+\|(\w|-)+$), response.authorization
   end
 
   def test_failed_authorize
@@ -461,6 +480,37 @@ class PayuLatamTest < Test::Unit::TestCase
     RESPONSE
   end
 
+  def successful_purchase_with_cabal_response
+    <<-RESPONSE
+    {
+    	"code":"SUCCESS",
+    	"error":null,
+    	"transactionResponse": {
+    	  "orderId":846449068,
+	  "transactionId":"34fa1616-f16c-4474-98dc-6163cb05f6d1",
+    	  "state":"APPROVED",
+	  "paymentNetworkResponseCode":null,
+	  "paymentNetworkResponseErrorMessage":null,
+	  "trazabilityCode":"00000000",
+	  "authorizationCode":"00000000",
+	  "pendingReason":null,
+	  "responseCode":"APPROVED",
+	  "errorCode":null,
+	  "responseMessage":null,
+	  "transactionDate":null,
+	  "transactionTime":null,
+	  "operationDate":1567524354749,
+	  "referenceQuestionnaire":null,
+	  "extraParameters": {
+	    "PAYMENT_WAY_ID":"28",
+	    "BANK_REFERENCED_CODE":"DEBIT"
+	    },
+	  "additionalInfo":null
+	}
+    }
+    RESPONSE
+  end
+
   def failed_purchase_response
     <<-RESPONSE
     {
@@ -511,6 +561,38 @@ class PayuLatamTest < Test::Unit::TestCase
           "extraParameters": null
        }
     }
+    RESPONSE
+  end
+
+  def successful_authorize_with_cabal_response
+    <<-RESPONSE
+    {
+    	"code":"SUCCESS",
+    	"error":null,
+    	"transactionResponse": {
+    	  "orderId":846449155,
+    	  "transactionId":"c15e6015-87c2-4db9-9100-894bf5564330",
+    	  "state":"APPROVED",
+	  "paymentNetworkResponseCode":null,
+	  "paymentNetworkResponseErrorMessage":null,
+	  "trazabilityCode":"00000000",
+	  "authorizationCode":"00000000",
+	  "pendingReason":null,
+	  "responseCode":"APPROVED",
+	  "errorCode":null,
+	  "responseMessage":null,
+	  "transactionDate":null,
+	  "transactionTime":null,
+	  "operationDate":1567524806987,
+	  "referenceQuestionnaire":null,
+	  "extraParameters": {
+	    "PAYMENT_WAY_ID":"28",
+	    "BANK_REFERENCED_CODE":"DEBIT"
+	  },
+	  "additionalInfo":null
+	}
+    }
+
     RESPONSE
   end
 


### PR DESCRIPTION
Adds the Cabal card to the PayU Latam gateway, including adding new
remote and unit tests.

CE-94 / CE-101

Unit:
31 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
33 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed