### PR TITLE
dLocal: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * WorldPay: Add Cabal card [leila-alderman] #3316
 * Decidir: Add Cabal card [leila-alderman] #3322
 * PayU Latam: Add Cabal card [leila-alderman] #3324
+* dLocal: Add Cabal card [leila-alderman] #3325
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY', 'TR']
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja, :cabal]
 
       self.homepage_url = 'https://dlocal.com/'
       self.display_name = 'dLocal'

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -7,6 +7,8 @@ class RemoteDLocalTest < Test::Unit::TestCase
     @amount = 200
     @credit_card = credit_card('4111111111111111')
     @credit_card_naranja = credit_card('5895627823453005')
+    @cabal_credit_card = credit_card('5896 5700 0000 0004')
+    @invalid_cabal_card = credit_card('6035 2277 0000 0000')
     # No test card numbers, all txns are approved by default,
     # but errors can be invoked directly with the `description` field
     @options = {
@@ -44,6 +46,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_purchase_naranja
     response = @gateway.purchase(@amount, @credit_card_naranja, @options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
+  def test_successful_purchase_cabal
+    response = @gateway.purchase(@amount, @cabal_credit_card, @options)
     assert_success response
     assert_match 'The payment was paid', response.message
   end
@@ -95,6 +103,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was rejected', response.message
   end
 
+  def test_failed_purchase_with_cabal
+    response = @gateway.purchase(@amount, @invalid_cabal_card, @options)
+    assert_failure response
+    assert_match 'Payment not found', response.message
+  end
+
   def test_failed_document_format
     response = @gateway.purchase(@amount, @credit_card, @options.merge(document: 'bad_document'))
     assert_failure response
@@ -103,6 +117,16 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_match 'The payment was authorized', auth.message
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+    assert_match 'The payment was paid', capture.message
+  end
+
+  def test_successful_authorize_and_capture_with_cabal
+    auth = @gateway.authorize(@amount, @cabal_credit_card, @options)
     assert_success auth
     assert_match 'The payment was authorized', auth.message
 
@@ -183,6 +207,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{The payment was authorized}, response.message
+  end
+
+  def test_successful_verify_with_cabal
+    response = @gateway.verify(@cabal_credit_card, @options)
     assert_success response
     assert_match %r{The payment was authorized}, response.message
   end


### PR DESCRIPTION
Adds the Cabal card type to the dLocal gateway, including adding remote
tests to confirm that Cabal cards work on this gateway. The remote tests
include a failed purchase test to ensure that dLocal is validating the
test card.

CE-94 / CE-102

Unit:
17 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
26 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed