### PR TITLE
BlueSnap: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Decidir: Add Cabal card [leila-alderman] #3322
 * PayU Latam: Add Cabal card [leila-alderman] #3324
 * dLocal: Add Cabal card [leila-alderman] #3325
+* BlueSnap: Add Cabal card [leila-alderman] #3326
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -8,7 +8,7 @@ module ActiveMerchant
       self.supported_countries = %w(US CA GB AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE AR BO BR BZ CL CO CR DO EC GF GP GT HN HT MF MQ MX NI PA PE PR PY SV UY VE)
 
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club, :maestro, :naranja, :cabal]
 
       self.homepage_url = 'https://home.bluesnap.com/'
       self.display_name = 'BlueSnap'

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -6,10 +6,12 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4263982640269299')
+    @cabal_credit_card = credit_card('6271701225979642')
     @declined_card = credit_card('4917484589897107', month: 1, year: 2023)
     @invalid_card = credit_card('4917484589897106', month: 1, year: 2023)
     @three_ds_visa_card = credit_card('4000000000001091', month: 1)
     @three_ds_master_card = credit_card('5200000000001096', month: 1)
+    @invalid_cabal_card = credit_card('5896 5700 0000 0000', month: 1, year: 2023)
 
     @options = { billing_address: address }
     @options_3ds2 = @options.merge(
@@ -155,6 +157,13 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_failure response
     assert_match(/Authorization has failed for this transaction/, response.message)
     assert_equal '14002', response.error_code
+  end
+
+  def test_failed_purchase_with_invalid_cabal_card
+    response = @gateway.purchase(@amount, @invalid_cabal_card, @options)
+    assert_failure response
+    assert_match(/'Card Number' should be a valid Credit Card/, response.message)
+    assert_equal '10001', response.error_code
   end
 
   def test_cvv_result


### PR DESCRIPTION
Adds the Cabal card type to the BlueSnap gateway.

I have been able to successfully add a remote test for a failed purchase
transaction made with an invalid Cabal card; however, when I try to run
a remote test for a successful purchase with a Cabal card, I receive the
error message "Transaction failed because there are no available
processors." (error code 14016). According to the [BlueSnap documentation](https://developers.bluesnap.com/v8976-JSON/docs/card-transaction-errors),
resolving this error requires contacting BlueSnap Support.

BlueSnap provides a [Cabal test card number](https://developers.bluesnap.com/docs/test-credit-cards)
in their docs, so it seems that Cabal needs to enabled on our test
gateway in order to test Cabal on this gateway.

CE-94 / CE-103

Unit:
27 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
36 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed