### PR TITLE
Braintree Blue: Adding 3DS2 passthru support

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -647,26 +647,23 @@ module ActiveMerchant #:nodoc:
 
       def add_3ds_info(parameters, three_d_secure_opts)
         return if empty?(three_d_secure_opts)
+        pass_thru = {}
 
-        parameters[:three_d_secure_pass_thru] = {
-          three_d_secure_version: three_d_secure_opts[:version],
-          eci_flag: three_d_secure_opts[:eci],
-          cavv_algorithm: three_d_secure_opts[:cavv_algorithm],
-          cavv: three_d_secure_opts[:cavv],
-          directory_response: three_d_secure_opts[:directory_response_status],
-          authentication_response: three_d_secure_opts[:authentication_response_status],
-        }.merge(xid_or_ds_trans_id(three_d_secure_opts))
+        pass_thru[:three_d_secure_version] = three_d_secure_opts[:version] if three_d_secure_opts[:version]
+        pass_thru[:eci_flag] = three_d_secure_opts[:eci] if three_d_secure_opts[:eci]
+        pass_thru[:cavv_algorithm] = three_d_secure_opts[:cavv_algorithm] if three_d_secure_opts[:cavv_algorithm]
+        pass_thru[:cavv] = three_d_secure_opts[:cavv] if three_d_secure_opts[:cavv]
+        pass_thru[:directory_response] = three_d_secure_opts[:directory_response_status] if three_d_secure_opts[:directory_response_status]
+        pass_thru[:authentication_response] = three_d_secure_opts[:authentication_response_status] if three_d_secure_opts[:authentication_response_status]
+
+        parameters[:three_d_secure_pass_thru] = pass_thru.merge(xid_or_ds_trans_id(three_d_secure_opts))
       end
 
       def xid_or_ds_trans_id(three_d_secure_opts)
-        if three_d_secure_opts[:vesion] =~ /^2/
-          {
-            ds_transaction_id: three_d_secure_opts[:ds_transaction_id],
-          }
+        if three_d_secure_opts[:version].to_f >= 2
+          { ds_transaction_id: three_d_secure_opts[:ds_transaction_id] }
         else
-          {
-            xid: three_d_secure_opts[:xid],
-          }
+          { xid: three_d_secure_opts[:xid] }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -630,13 +630,7 @@ module ActiveMerchant #:nodoc:
           }
         end
 
-        if options[:three_d_secure]
-          parameters[:three_d_secure_pass_thru] = {
-            cavv: options[:three_d_secure][:cavv],
-            eci_flag: options[:three_d_secure][:eci],
-            xid: options[:three_d_secure][:xid],
-          }
-        end
+        add_3ds_info(parameters, options[:three_d_secure])
 
         parameters[:tax_amount] = options[:tax_amount] if options[:tax_amount]
         parameters[:tax_exempt] = options[:tax_exempt] if options[:tax_exempt]
@@ -649,6 +643,31 @@ module ActiveMerchant #:nodoc:
         parameters[:line_items] = options[:line_items] if options[:line_items]
 
         parameters
+      end
+
+      def add_3ds_info(parameters, three_d_secure_opts)
+        return if empty?(three_d_secure_opts)
+
+        parameters[:three_d_secure_pass_thru] = {
+          three_d_secure_version: three_d_secure_opts[:version],
+          eci_flag: three_d_secure_opts[:eci],
+          cavv_algorithm: three_d_secure_opts[:cavv_algorithm],
+          cavv: three_d_secure_opts[:cavv],
+          directory_response: three_d_secure_opts[:directory_response_status],
+          authentication_response: three_d_secure_opts[:authentication_response_status],
+        }.merge(xid_or_ds_trans_id(three_d_secure_opts))
+      end
+
+      def xid_or_ds_trans_id(three_d_secure_opts)
+        if three_d_secure_opts[:vesion] =~ /^2/
+          {
+            ds_transaction_id: three_d_secure_opts[:ds_transaction_id],
+          }
+        else
+          {
+            xid: three_d_secure_opts[:xid],
+          }
+        end
       end
 
       def add_stored_credential_data(parameters, credit_card_or_vault_id, options)

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -937,5 +937,4 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success response
     assert_equal expected_avs_code, response.avs_result['code']
   end
-
 end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -538,8 +538,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_three_d_secure_pass_thru
-    three_d_secure_params = { eci: '05', cavv: 'cavv', xid: 'xid' }
-    assert response = @gateway.purchase(@amount, @credit_card,
+    three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
+    response = @gateway.purchase(@amount, @credit_card,
+      three_d_secure: three_d_secure_params
+    )
+    assert_success response
+  end
+
+  def test_successful_purchase_with_some_three_d_secure_pass_thru_fields
+    three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id' }
+    response = @gateway.purchase(@amount, @credit_card,
       three_d_secure: three_d_secure_params
     )
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -647,11 +647,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.
       any_instance.
       expects(:sale).
-      with(has_entries(three_d_secure_pass_thru: {
+      with(has_entries(three_d_secure_pass_thru: has_entries(
         cavv: 'cavv',
         eci_flag: 'eci',
         xid: 'xid',
-      })).
+      ))).
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {cavv: 'cavv', eci: 'eci', xid: 'xid'})

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -643,18 +643,51 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), :customer => {:first_name => 'Longbob', :last_name => 'Longsen'})
   end
 
-  def test_three_d_secure_pass_thru_handling
+  def test_three_d_secure_pass_thru_handling_version_1
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(has_entries(three_d_secure_pass_thru: {
+        cavv: 'cavv',
+        eci_flag: 'eci',
+        xid: 'xid',
+      })).
+      returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {cavv: 'cavv', eci: 'eci', xid: 'xid'})
+  end
+
+  def test_three_d_secure_pass_thru_handling_version_2
     Braintree::TransactionGateway.
       any_instance.
       expects(:sale).
       with(has_entries(three_d_secure_pass_thru: has_entries(
+        three_d_secure_version: '2.0',
         cavv: 'cavv',
         eci_flag: 'eci',
-        xid: 'xid',
+        ds_transaction_id: 'trans_id',
+        cavv_algorithm: 'algorithm',
+        directory_response: 'directory',
+        authentication_response: 'auth'
       ))).
       returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {cavv: 'cavv', eci: 'eci', xid: 'xid'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth'})
+  end
+
+  def test_three_d_secure_pass_thru_some_fields
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(has_entries(three_d_secure_pass_thru: has_entries(
+        three_d_secure_version: '2.0',
+        cavv: 'cavv',
+        eci_flag: 'eci',
+        ds_transaction_id: 'trans_id'
+      ))).
+      returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id'})
   end
 
   def test_passes_recurring_flag


### PR DESCRIPTION
Continued from #3312 

Unit:
74 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
80 tests, 435 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed