### PR TITLE
Worldpay: Exemption flagging (MOTO)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * PayU Latam: Add Cabal card [leila-alderman] #3324
 * dLocal: Add Cabal card [leila-alderman] #3325
 * BlueSnap: Add Cabal card [leila-alderman] #3326
+* Worldpay: Add support for MOTO flagging [britth] #3329
 
 == Version 1.97.0 (Aug 15, 2019)
 * CyberSource: Add issuer `additionalData` gateway-specific field [jasonxp] #3296

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -207,6 +207,7 @@ module ActiveMerchant #:nodoc:
               if options[:instalments]
                 add_instalments_data(xml, options)
               end
+              add_moto_flag(xml, options) if options.dig(:metadata, :manual_entry)
             end
           end
         end
@@ -421,6 +422,10 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'instalments', options[:instalments]
           xml.tag! 'cpf', options[:cpf] if options[:cpf]
         end
+      end
+
+      def add_moto_flag(xml, options)
+        xml.tag! 'dynamicInteractionType', 'type' => 'MOTO'
       end
 
       def address_with_defaults(address)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -144,6 +144,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     refute first_message.params['session_id'].blank?
   end
 
+  # Requires additional account configuration to proceed successfully
+  def test_marking_3ds_purchase_as_moto
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { manual_entry: true }))
+    assert_equal 'AllowDynamicInteractionType property is disabled for this merchant', response.message
+  end
+
   def test_successful_auth_and_capture_with_normalized_stored_credential
     stored_credential_params = {
       initial_transaction: true,


### PR DESCRIPTION
This PR adds the necessary fields to mark transactions as MOTO 
by setting `dynamicInteractionType` to `MOTO` when the 
payment is marked as a manual entry ([requires configuration on 
the account level to be able to use](http://support.worldpay.com/support/kb/gg/corporate-gateway-guide-beta/content/directintegration/paymentrequests.htm#Flexible)).


Remote:
51 tests, 217 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.1961% passed

Unit:
66 tests, 392 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed