### PR TITLE
[Checkout.com] Using options[:metadata][:manual_entry] for Moto transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -128,7 +128,7 @@ module ActiveMerchant #:nodoc:
       def add_transaction_data(post, options = {})
         post[:payment_type] = 'Regular' if options[:transaction_indicator] == 1
         post[:payment_type] = 'Recurring' if options[:transaction_indicator] == 2
-        post[:payment_type] = 'MOTO' if options[:transaction_indicator] == 3
+        post[:payment_type] = 'MOTO' if options[:transaction_indicator] == 3 || options.dig(:metadata, :manual_entry)
         post[:previous_payment_id] = options[:previous_charge_id] if options[:previous_charge_id]
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -70,6 +70,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_manual_entry_flag
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(metadata: { manual_entry: true}))
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_includes_avs_result
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -117,6 +117,19 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_moto_transaction_is_properly_set
+    response = stub_comms do
+      options = {
+        metadata: { manual_entry: true}
+      }
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{"payment_type":"MOTO"}, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_3ds_passed
     response = stub_comms do
       options = {


### PR DESCRIPTION
##### Unit tests
```
...........................
Finished in 0.012471 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
27 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

##### Remote tests
```
...............................
Finished in 30.509284 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
31 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```