### PR TITLE
Adyen: Set 3DS exemptions via API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Adyen: Add functionality to set 3DS exemptions via API [britth] #3331
+
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290
 * Stripe: Send cardholder name and address when creating sources for 3DS 1.0 [jknipp] #3300

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -336,6 +336,11 @@ module ActiveMerchant #:nodoc:
             add_browser_info(three_ds_2_options[:browser_info], post)
             post[:threeDS2RequestData] = { deviceChannel: device_channel, notificationURL: three_ds_2_options[:notification_url] }
           end
+
+          if options.has_key?(:execute_threed)
+            post[:additionalData][:executeThreeD] = options[:execute_threed]
+            post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
+          end
         else
           return unless options[:execute_threed] || options[:threed_dynamic]
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }


### PR DESCRIPTION
There are a few different ways to [request exemptions via Adyen](https://docs.adyen.com/payments-essentials/psd2-sca-compliance-and-implementation-guide?query=additionalData.executeThreeD#managingpsd2scacompliance).
Users can let Adyen handle compliance by default, they can
configure specific rules using dynamic 3dsecure, or they can set
exemption flags via the API. This PR updates the Adyen gateway to
allow users to set specific exemptions using the sca_exemption
field, used in conjunction with the execute_threed field. Users
can also now set execute_threed to false if they want to bypass
3DS on a transaction.

Remote:
64 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
39 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed