### PR TITLE
Added MOTO support for Adyen & Eway Rapid

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -205,7 +205,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_shopper_interaction(post, payment, options={})
-        if options.dig(:stored_credential, :initial_transaction) || (payment.respond_to?(:verification_value) && payment.verification_value) || payment.is_a?(NetworkTokenizationCreditCard)
+        if options.dig(:metadata, :manual_entry)
+          shopper_interaction = 'Moto'
+        elsif options.dig(:stored_credential, :initial_transaction) || (payment.respond_to?(:verification_value) && payment.verification_value) || payment.is_a?(NetworkTokenizationCreditCard)
           shopper_interaction = 'Ecommerce'
         else
           shopper_interaction = 'ContAuth'

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -189,7 +189,7 @@ module ActiveMerchant #:nodoc:
       def add_metadata(params, options)
         params['RedirectUrl'] = options[:redirect_url] || 'http://example.com'
         params['CustomerIP'] = options[:ip] if options[:ip]
-        params['TransactionType'] = options[:transaction_type] || 'Purchase'
+        params['TransactionType'] = transaction_type(options)
         params['DeviceID'] = options[:application_id] || application_id
         if partner = options[:partner_id] || partner_id
           params['PartnerID'] = truncate(partner, 50)
@@ -376,6 +376,13 @@ module ActiveMerchant #:nodoc:
         else
           'P'
         end
+      end
+
+      def transaction_type(options)
+        moto = if options.dig(:metadata, :manual_entry)
+                 'MOTO'
+               end
+        options[:transaction_type] || moto || 'Purchase'
       end
 
       MESSAGES = {

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -104,6 +104,17 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Authorised', response.message
   end
 
+  def test_successful_authorize_moto
+    options = @options.merge({
+      metadata: {
+        manual_entry: true,
+      }
+    })
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
   def test_successful_authorize_avs
     # Account configuration may need to be done: https://docs.adyen.com/developers/api-reference/payments-api#paymentresultadditionaldata
     options = @options.update({

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -358,6 +358,12 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
     assert_equal 'Transaction Approved Successful', response.message
   end
 
+  def test_successful_purchase_with_moto
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { manual_entry: true }))
+    assert_success response
+    assert_equal 'Transaction Approved Successful', response.message
+  end
+
   def test_invalid_login
     gateway = EwayRapidGateway.new(
       login: 'bogus',

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -545,6 +545,25 @@ class EwayRapidTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_moto_transaction
+    options = {
+      metadata: {
+        manual_entry: true,
+      }
+    }
+    response = stub_comms do
+      @gateway.purchase(100, 'the_customer_token', options)
+    end.check_request do |endpoint, data, headers|
+      assert_match '"Method":"TokenPayment"', data
+      assert_match '"TransactionType":"MOTO"', data
+    end.respond_with(successful_store_purchase_response)
+
+    assert_success response
+    assert_equal 'Transaction Approved Successful', response.message
+    assert_equal 10440234, response.authorization
+    assert response.test?
+  end
+
   def test_verification_results
     response = stub_comms do
       @gateway.purchase(100, @credit_card)


### PR DESCRIPTION
This PR add support for MOTO (Mail Order / Telephone Order) transactions for the following gateways:
- Adyen
- Eway Rapid

This is required to exempt those transactions from SCA when 3DS 2.0 is in place.