### PR TITLE
Decidir: Add remote tests for Cabal and Naranja

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Credorax: Enable selecting a processor [leila-alderman] #3302
 * WorldPay: Revert "Worldpay: Switch to Nokogiri" [dtykocki] #3372
 * Adyen: Add Cabal card [leila-alderman] #3361
+* Decidir: Add remote tests for Cabal and Naranja [leila-alderman] #3337
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -106,7 +106,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_auth_purchase_params(post, money, credit_card, options)
-        post[:payment_method_id] =  options[:payment_method_id] ? options[:payment_method_id].to_i : 1
+        post[:payment_method_id] = add_payment_method_id(credit_card)
         post[:site_transaction_id] = options[:order_id]
         post[:bin] = credit_card.number[0..5]
         post[:payment_type] = options[:payment_type] || 'single'
@@ -117,6 +117,18 @@ module ActiveMerchant #:nodoc:
 
         add_invoice(post, money, options)
         add_payment(post, credit_card, options)
+      end
+
+      def add_payment_method_id(credit_card)
+        if options[:payment_method_id]
+          options[:payment_method_id].to_i
+        elsif CreditCard.brand?(credit_card.number) == 'cabal'
+          63
+        elsif CreditCard.brand?(credit_card.number) == 'naranja'
+          24
+        else
+          1
+        end
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -7,6 +7,8 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4507990000004905')
+    @cabal_credit_card = credit_card('5896570000000008')
+    @naranja_credit_card = credit_card('5895627823453005')
     @declined_card = credit_card('4000300011112220')
     @options = {
       order_id: SecureRandom.uuid,
@@ -17,6 +19,20 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_cabal
+    response = @gateway_for_purchase.purchase(@amount, @cabal_credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_naranja
+    response = @gateway_for_purchase.purchase(@amount, @naranja_credit_card, @options)
     assert_success response
     assert_equal 'approved', response.message
     assert response.authorization

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -240,6 +240,26 @@ class DecidirTest < Test::Unit::TestCase
     assert_equal @gateway_for_purchase.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_payment_method_id_with_visa
+    post = {}
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, @credit_card, @options)
+    assert_equal 1, post[:payment_method_id]
+  end
+
+  def test_payment_method_id_with_cabal
+    post = {}
+    credit_card = credit_card('5896570000000008')
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, credit_card, @options)
+    assert_equal 63, post[:payment_method_id]
+  end
+
+  def test_payment_method_id_with_naranja
+    post = {}
+    credit_card = credit_card('5895627823453005')
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, credit_card, @options)
+    assert_equal 24, post[:payment_method_id]
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Added remote tests for the new card types Cabal and Naranja now that
the Decidir test gateway has been updated to accept these card types.

In addition, added new logic to determine the correct
`payment_method_id` based on the card type.

With the update of the test gateway, some of the error messages changed,
so those were also updated in the remote tests.

CE-94 / CE-110

Unit:
22 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
19 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed