### PR TITLE
Adyen: Send "NA" instead of "N/A"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331
+* Adyen: Send "NA" instead of "N/A" [leila-alderman] #3339
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -229,17 +229,17 @@ module ActiveMerchant #:nodoc:
         return unless post[:card]&.kind_of?(Hash)
         if (address = options[:billing_address] || options[:address]) && address[:country]
           post[:billingAddress] = {}
-          post[:billingAddress][:street] = address[:address1] || 'N/A'
-          post[:billingAddress][:houseNumberOrName] = address[:address2] || 'N/A'
+          post[:billingAddress][:street] = address[:address1] || 'NA'
+          post[:billingAddress][:houseNumberOrName] = address[:address2] || 'NA'
           post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
-          post[:billingAddress][:city] = address[:city] || 'N/A'
+          post[:billingAddress][:city] = address[:city] || 'NA'
           post[:billingAddress][:stateOrProvince] = get_state(address)
           post[:billingAddress][:country] = address[:country] if address[:country]
         end
       end
 
       def get_state(address)
-        address[:state] && !address[:state].blank? ? address[:state] : 'N/A'
+        address[:state] && !address[:state].blank? ? address[:state] : 'NA'
       end
 
       def add_invoice(post, money, options)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -534,9 +534,9 @@ class AdyenTest < Test::Unit::TestCase
     @options[:billing_address].delete(:address2)
     @options[:billing_address].delete(:state)
     @gateway.send(:add_address, post, @options)
-    assert_equal 'N/A', post[:billingAddress][:street]
-    assert_equal 'N/A', post[:billingAddress][:houseNumberOrName]
-    assert_equal 'N/A', post[:billingAddress][:stateOrProvince]
+    assert_equal 'NA', post[:billingAddress][:street]
+    assert_equal 'NA', post[:billingAddress][:houseNumberOrName]
+    assert_equal 'NA', post[:billingAddress][:stateOrProvince]
     assert_equal @options[:billing_address][:zip], post[:billingAddress][:postalCode]
     assert_equal @options[:billing_address][:city], post[:billingAddress][:city]
     assert_equal @options[:billing_address][:country], post[:billingAddress][:country]


### PR DESCRIPTION
When an address field is not provided, the default will now be "NA"
instead of the previous "N/A". According to Adyen, this should improve
acceptance rates for transactions that do not include an address
provided by the customer.

CE-115

Unit:
47 tests, 228 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
66 tests, 213 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
96.9697% passed

The two tests that are failing:
 - test_successful_purchase_with_auth_data_via_threeds1_standalone
 - test_successful_purchase_with_auth_data_via_threeds2_standalone

These failures seem to be unrelated to the changes here as these
tests are also failing on the `master` branch.