### PR TITLE
Stripe Payment Intents: Successfully set application fee on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331
 * Adyen: Send "NA" instead of "N/A" [leila-alderman] #3339
+* Stripe Payment Intents: Set application fee or transfer amount on capture  [britth] #3340
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -92,7 +92,11 @@ module ActiveMerchant #:nodoc:
       def capture(money, intent_id, options = {})
         post = {}
         post[:amount_to_capture] = money
-        add_connected_account(post, options)
+        if options[:transfer_amount]
+          post[:transfer_data] = {}
+          post[:transfer_data][:amount] = options[:transfer_amount]
+        end
+        post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
         commit(:post, "payment_intents/#{intent_id}/capture", post, options)
       end
 


### PR DESCRIPTION
You do not need to pass the transfer destination in a capture request,
and in fact the request will fail if you try to post that data.
However, before this PR, we were requiring that a destination account
be present before setting the associated fee/transfer amount. This PR
updates the logic to set only the application fee or transfer amount
on capture requests when present.

Remote:
29 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed