### PR TITLE
Update stripe_payment_intents.rb

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -130,7 +130,7 @@ module ActiveMerchant #:nodoc:
           end
           commit(:post, "payment_methods/#{params[:payment_method]}/attach", { customer: customer_id }, options)
         else
-          super(payment, options)
+          super(payment_method, options)
         end
       end
 


### PR DESCRIPTION
A bug on Stripe Payment Intents gateway file preventing from storing a customer credit card