### PR TITLE
Worldpay: Add 3DS2 Support

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -339,7 +339,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'date', 'month' => format(payment_method.month, :two_digits), 'year' => format(payment_method.year, :four_digits)
         end
 
-        xml.tag! 'cardHolderName', options[:execute_threed] && (options[:three_ds_version] =~ /[^2]/).nil? ? '3D' : payment_method.name
+        three_ds_version = options[:three_ds_version] || options[:three_d_secure][:version]
+        xml.tag! 'cardHolderName', options[:execute_threed] && (three_ds_version =~ /[^2]/).nil? ? '3D' : payment_method.name
         xml.tag! 'cvc', payment_method.verification_value
 
         add_address(xml, (options[:billing_address] || options[:address]))


### PR DESCRIPTION
Adds 3DS support to worldpay gateway. Two remote tests failing that are
unlreated.

Loaded suite test/remote/gateways/remote_worldpay_test
.................................................
51 tests, 221 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.0784% passed

Loaded suite test/unit/gateways/worldpay_test
Started
...................................................................

67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed