### PR TITLE
Beanstream: update void authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -93,12 +93,15 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         reference, amount, type = split_auth(authorization)
-
-        post = {}
-        add_reference(post, reference)
-        add_original_amount(post, amount)
-        add_transaction_type(post, void_action(type))
-        commit(post)
+        if type == TRANSACTIONS[:authorization]
+          capture(0, authorization, options)
+        else
+          post = {}
+          add_reference(post, reference)
+          add_original_amount(post, amount)
+          add_transaction_type(post, void_action(type))
+          commit(post)
+        end
       end
 
       def verify(source, options={})

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -317,7 +317,7 @@ module ActiveMerchant #:nodoc:
         post[:status] = options[:status]
 
         billing_address = options[:billing_address] || options[:address]
-        post[:trnCardOwner] = billing_address[:name]
+        post[:trnCardOwner] = billing_address ? billing_address[:name] : nil
       end
 
       def add_recurring_amount(post, money)

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -187,6 +187,16 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert_match %r{Invalid shipping country id}, response.message
   end
 
+  def test_authorize_and_void
+    assert auth = @gateway.authorize(@amount, @visa, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert_false auth.authorization.blank?
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
   def test_authorize_and_capture
     assert auth = @gateway.authorize(@amount, @visa, @options)
     assert_success auth


### PR DESCRIPTION
Change the void action for authorization transactions to capture a 0 amount, per Beanstream's recommendation.

ECS-514 #close

Unit:
23 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
43 tests, 195 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.3488% passed

NOTE: Failing tests also failing in current master as of time of this
run.