### PR TITLE
Worldpay: Allow multiple refunds per authorization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Stripe Payment Intents: Set application fee or transfer amount on capture  [britth] #3340
 * TNS: Support Europe endpoint [curiousepic] #3346
 * Redsys: Add 3DS support to gateway [britth] #3336
+* Worldpay: Allow multiple refunds per authorization [jknipp] #3349
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         authorization = order_id_from_authorization(authorization.to_s)
         response = MultiResponse.run do |r|
-          r.process { inquire_request(authorization, options, 'CAPTURED', 'SETTLED', 'SETTLED_BY_MERCHANT') }
+          r.process { inquire_request(authorization, options, 'CAPTURED', 'SETTLED', 'SETTLED_BY_MERCHANT') } unless options[:authorization_validated]
           r.process { refund_request(money, authorization, options) }
         end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -492,12 +492,30 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   #   puts 'auth: ' + response.authorization
   # end
   #
-  # def test_refund
-  #   refund = @gateway.refund(@amount, '39270fd70be13aab55f84e28be45cad3')
-  #   assert_success refund
-  #   assert_equal 'SUCCESS', refund.message
-  # end
-  #
+  def test_refund
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert response.authorization
+
+    refund = @gateway.refund(@amount, response.authorization, authorization_validated: true)
+    assert_success refund
+    assert_equal 'SUCCESS', refund.message
+  end
+
+  def test_multiple_refunds
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert_equal 'SUCCESS', purchase.message
+
+    partial_amount = @amount - 1
+    assert_success refund1 = @gateway.refund(partial_amount, purchase.authorization, authorization_validated: true)
+    assert_equal 'SUCCESS', refund1.message
+
+    assert_success refund2 = @gateway.refund(@amount - partial_amount, purchase.authorization, authorization_validated: true)
+    assert_equal 'SUCCESS', refund2.message
+  end
+
   # def test_void_fails_unless_status_is_authorised
   #   response = @gateway.void('replace_with_authorization') # existing transaction in CAPTURED state
   #   assert_failure response


### PR DESCRIPTION
Remove the restriction to perform refunds only if a payment is in a
certain set of states.

ECS-344

Unit:
66 tests, 392 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
2 Unrelated test failures

53 tests, 232 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2264% passed