### PR TITLE
CyberSource: Pass commerce indicator if present

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -530,19 +530,14 @@ module ActiveMerchant #:nodoc:
           add_auth_network_tokenization(xml, payment_method, options)
         else
           xml.tag! 'ccAuthService', {'run' => 'true'} do
-            check_for_stored_cred_commerce_indicator(xml, options)
+            indicator = options[:commerce_indicator] || stored_credential_commerce_indicator(options)
+            xml.tag!('commerceIndicator', indicator) if indicator
           end
         end
       end
 
-      def check_for_stored_cred_commerce_indicator(xml, options)
+      def stored_credential_commerce_indicator(options)
         return unless options[:stored_credential]
-        if commerce_indicator(options)
-          xml.tag!('commerceIndicator', commerce_indicator(options))
-        end
-      end
-
-      def commerce_indicator(options)
         return if options[:stored_credential][:initial_transaction]
         case options[:stored_credential][:reason_type]
         when 'installment' then 'install'

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -55,7 +55,8 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       ],
       :currency => 'USD',
       :ignore_avs => 'true',
-      :ignore_cvv => 'true'
+      :ignore_cvv => 'true',
+      :commerce_indicator => 'internet'
     }
 
     @subscription_options = {

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -118,6 +118,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_authorize_includes_commerce_indicator
+    stub_comms do
+      @gateway.authorize(100, @credit_card, commerce_indicator: 'internet')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<commerceIndicator>internet<\/commerceIndicator>/m, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_successful_check_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
Remote (5 unrelated failures also on master):
59 tests, 259 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.5254% passed

Unit:
61 tests, 288 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed