### PR TITLE
StripePaymentIntents: Fix backwards compatibility for Refund

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, intent_id, options = {})
-        if intent_id.include?("pi_")
+        if intent_id.include?('pi_')
           intent = commit(:get, "payment_intents/#{intent_id}", nil, options)
           charge_id = intent.params.dig('charges', 'data')[0].dig('id')
         else

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -107,8 +107,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, intent_id, options = {})
-        intent = commit(:get, "payment_intents/#{intent_id}", nil, options)
-        charge_id = intent.params.dig('charges', 'data')[0].dig('id')
+        if intent_id.include?("pi_")
+          intent = commit(:get, "payment_intents/#{intent_id}", nil, options)
+          charge_id = intent.params.dig('charges', 'data')[0].dig('id')
+        else
+          charge_id = intent_id
+        end
         super(money, charge_id, options)
       end
 


### PR DESCRIPTION
Don't try to get the payment intent object if the parameter passed is not actually an `intent_id`, it can be already a `charge_id` when the purchase was made with `StripeGateway` then attempt to refund with `StripePaymentIntentsGateway`.