### PR TITLE
Mundipagg: Append errors to message response field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * TNS: Update verison and support pay mode [curiousepic] #3355
 * Stripe: Add supported countries [therufs] #3358
 * Stripe Payment Intents: Add supported countries [therufs] #3359
+* Mundipagg: Append error messages to the message response field [jasonxp] #3353
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -249,7 +249,8 @@ module ActiveMerchant #:nodoc:
           error_code: error_code_from(response)
         )
       rescue ResponseError => e
-        message = get_error_message(e)
+        message = get_error_messages(e)
+
         return Response.new(
           false,
           "#{STANDARD_ERROR_MESSAGE_MAPPING[e.response.code]} #{message}",
@@ -263,13 +264,39 @@ module ActiveMerchant #:nodoc:
         %w[pending paid processing canceled active].include? response['status']
       end
 
-      def get_error_message(error)
-        JSON.parse(error.response.body)['message']
-      end
-
       def message_from(response)
+        return gateway_response_errors(response) if gateway_response_errors?(response)
         return response['message'] if response['message']
         return response['last_transaction']['acquirer_message'] if response['last_transaction']
+      end
+
+      def get_error_messages(error)
+        parsed_response_body = parse(error.response.body)
+        message = parsed_response_body['message']
+
+        parsed_response_body['errors']&.each do |type, descriptions|
+          message += ' | '
+          message += descriptions.join(', ')
+        end
+
+        message
+      end
+
+      def gateway_response_errors?(response)
+        response.try(:[], 'last_transaction').try(:[], 'gateway_response').try(:[], 'errors').present?
+      end
+
+      def gateway_response_errors(response)
+        error_string = ''
+
+        response['last_transaction']['gateway_response']['errors']&.each do |error|
+          error.each do |key, value|
+            error_string += ' | ' unless error_string.blank?
+            error_string += value
+          end
+        end
+
+        error_string
       end
 
       def authorization_from(response, action)

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -21,6 +21,9 @@ class RemoteMundipaggTest < Test::Unit::TestCase
       billing_address: address({neighborhood: 'Sesame Street'}),
       description: 'Store Purchase'
     }
+
+    @excess_length_neighborhood = address({neighborhood: 'Super Long Neighborhood Name' * 5})
+    @neighborhood_length_error = 'Invalid parameters; The request is invalid. | The field neighborhood must be a string with a maximum length of 64.'
   end
 
   def test_successful_purchase
@@ -68,6 +71,15 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     test_failed_purchase_with(@declined_card)
   end
 
+  def test_failed_purchase_with_top_level_errors
+    @options[:billing_address] = @excess_length_neighborhood
+
+    response = @gateway.purchase(105200, @credit_card, @options)
+
+    assert_failure response
+    assert_equal @neighborhood_length_error, response.message
+  end
+
   def test_failed_purchase_with_alelo_card
     test_failed_purchase_with(@declined_alelo_voucher)
   end
@@ -86,6 +98,15 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
   def test_failed_authorize_with_alelo_card
     test_failed_authorize_with(@declined_alelo_voucher)
+  end
+
+  def test_failed_authorize_with_top_level_errors
+    @options[:billing_address] = @excess_length_neighborhood
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal @neighborhood_length_error, response.message
   end
 
   def test_partial_capture
@@ -188,6 +209,15 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
   def test_successful_store_and_purchase_with_alelo_card
     test_successful_store_and_purchase_with(@alelo_voucher)
+  end
+
+  def test_failed_store_with_top_level_errors
+    @options[:billing_address] = @excess_length_neighborhood
+
+    response = @gateway.store(@credit_card, @options)
+
+    assert_failure response
+    assert_equal @neighborhood_length_error, response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -38,6 +38,8 @@ class MundipaggTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+
+    @gateway_response_error = 'Esta loja n??o possui um meio de pagamento configurado para a bandeira VR'
   end
 
   def test_successful_purchase
@@ -81,6 +83,23 @@ class MundipaggTest < Test::Unit::TestCase
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
   end
 
+  def test_failed_purchase_with_top_level_errors
+    @gateway.expects(:ssl_post).raises(mock_response_error)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_invalid_parameter_errors(response)
+  end
+
+  def test_failed_purchase_with_gateway_response_errors
+    @gateway.expects(:ssl_post).returns(failed_response_with_gateway_response_errors)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal @gateway_response_error, response.message
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -111,6 +130,23 @@ class MundipaggTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
+  def test_failed_authorize_with_top_level_errors
+    @gateway.expects(:ssl_post).raises(mock_response_error)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_invalid_parameter_errors(response)
+  end
+
+  def test_failed_authorize_with_gateway_response_errors
+    @gateway.expects(:ssl_post).returns(failed_response_with_gateway_response_errors)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal @gateway_response_error, response.message
   end
 
   def test_successful_capture
@@ -196,6 +232,23 @@ class MundipaggTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_failed_store_with_top_level_errors
+    @gateway.expects(:ssl_post).times(2).raises(mock_response_error)
+
+    response = @gateway.store(@credit_card, @options)
+
+    assert_invalid_parameter_errors(response)
+  end
+
+  def test_failed_store_with_gateway_response_errors
+    @gateway.expects(:ssl_post).times(2).returns(failed_response_with_gateway_response_errors)
+
+    response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert_equal @gateway_response_error, response.message
+  end
+
   def test_gateway_id_fallback
     gateway = MundipaggGateway.new(api_key: 'my_api_key', gateway_id: 'abc123')
     options = {
@@ -225,6 +278,22 @@ class MundipaggTest < Test::Unit::TestCase
 
     assert_equal 'ch_90Vjq8TrwfP74XJO', response.authorization
     assert response.test?
+  end
+
+  def mock_response_error
+    mock_response = Net::HTTPUnprocessableEntity.new('1.1', '422', 'Unprocessable Entity')
+    mock_response.stubs(:body).returns(failed_response_with_top_level_errors)
+
+    ActiveMerchant::ResponseError.new(mock_response)
+  end
+
+  def assert_invalid_parameter_errors(response)
+    assert_failure response
+
+    assert_equal(
+      'Invalid parameters; The request is invalid. | The field neighborhood must be a string with a maximum length of 64. | The field line_1 must be a string with a maximum length of 256.',
+      response.message
+    )
   end
 
   def pre_scrubbed
@@ -412,6 +481,130 @@ class MundipaggTest < Test::Unit::TestCase
           "updated_at": "2018-02-01T18:42:44Z",
           "gateway_response": {
             "code": "201"
+          }
+        }
+      }
+    )
+  end
+
+  def failed_response_with_top_level_errors
+    %(
+      {
+        "message": "The request is invalid.",
+        "errors": {
+          "charge.payment.credit_card.card.billing_address.neighborhood": [
+            "The field neighborhood must be a string with a maximum length of 64."
+          ],
+          "charge.payment.credit_card.card.billing_address.line_1": [
+            "The field line_1 must be a string with a maximum length of 256."
+          ]
+        },
+        "request": {
+          "currency": "USD",
+          "amount": 100,
+          "customer": {
+            "name": "Longbob Longsen",
+            "phones": {},
+            "metadata": {}
+          },
+          "payment": {
+            "gateway_affiliation_id": "d76dffc8-c3e5-4d80-b9ee-dc8fb6c56c83",
+            "payment_method": "credit_card",
+            "credit_card": {
+              "installments": 1,
+              "capture": true,
+              "card": {
+                "last_four_digits": "2224",
+                "brand": "Visa",
+                "holder_name": "Longbob Longsen",
+                "exp_month": 9,
+                "exp_year": 2020,
+                "billing_address": {
+                  "street": "My Street",
+                  "number": "456",
+                  "zip_code": "K1C2N6",
+                  "neighborhood": "Sesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame Street",
+                  "city": "Ottawa",
+                  "state": "ON",
+                  "country": "CA",
+                  "line_1": "456, My Street, Sesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame StreetSesame Street"
+                },
+                "options": {}
+              }
+            },
+            "metadata": {
+              "mundipagg_payment_method_code": "1"
+            }
+          }
+        }
+      }
+    )
+  end
+
+  def failed_response_with_gateway_response_errors
+    %(
+      {
+        "id": "ch_90Vjq8TrwfP74XJO",
+        "code": "ME0KIN4A0O",
+        "gateway_id": "162bead8-23a0-4708-b687-078a69a1aa7c",
+        "amount": 100,
+        "paid_amount": 100,
+        "status": "paid",
+        "currency": "USD",
+        "payment_method": "credit_card",
+        "paid_at": "2018-02-01T18:41:05Z",
+        "created_at": "2018-02-01T18:41:04Z",
+        "updated_at": "2018-02-01T18:41:04Z",
+        "customer": {
+          "id": "cus_VxJX2NmTqyUnXgL9",
+          "name": "Longbob Longsen",
+          "email": "",
+          "delinquent": false,
+          "created_at": "2018-02-01T18:41:04Z",
+          "updated_at": "2018-02-01T18:41:04Z",
+          "phones": {}
+        },
+        "last_transaction": {
+          "id": "tran_JNzjzadcVZHlG8K2",
+          "transaction_type": "credit_card",
+          "gateway_id": "c579c8fa-53d7-41a8-b4cc-a03c712ebbb7",
+          "amount": 100,
+          "status": "captured",
+          "success": true,
+          "installments": 1,
+          "operation_type": "auth_and_capture",
+          "card": {
+            "id": "card_pD02Q6WtOTB7a3kE",
+            "first_six_digits": "400010",
+            "last_four_digits": "2224",
+            "brand": "Visa",
+            "holder_name": "Longbob Longsen",
+            "exp_month": 9,
+            "exp_year": 2019,
+            "status": "active",
+            "created_at": "2018-02-01T18:41:04Z",
+            "updated_at": "2018-02-01T18:41:04Z",
+            "billing_address": {
+              "street": "My Street",
+              "number": "456",
+              "zip_code": "K1C2N6",
+              "neighborhood": "Sesame Street",
+              "city": "Ottawa",
+              "state": "ON",
+              "country": "CA",
+              "line_1": "456, My Street, Sesame Street"
+            },
+            "type": "credit"
+          },
+          "created_at": "2018-02-01T18:41:04Z",
+          "updated_at": "2018-02-01T18:41:04Z",
+          "gateway_response": {
+            "code": "400",
+            "errors": [
+              {
+                "message": "Esta loja n??o possui um meio de pagamento configurado para a bandeira VR"
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
For ```purchase```, ```authorize```, and ```store```, extract any error messages from the gateway response and append them to the "message" response feld. Mundipagg can return errors at either the top level of the response object, or under the ```last_transaction``` ```gateway_response``` key.