### PR TITLE
Redsys: Add exemptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Stripe: Add supported countries [therufs] #3358
 * Stripe Payment Intents: Add supported countries [therufs] #3359
 * Mundipagg: Append error messages to the message response field [jasonxp] #3353
+* Redsys: Add ability to pass sca_exemption and moto fields to request exemptions [britth] #3354
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -200,6 +200,7 @@ module ActiveMerchant #:nodoc:
         add_threeds(data, options) if options[:execute_threed]
         data[:description] = options[:description]
         data[:store_in_vault] = options[:store]
+        data[:sca_exemption] = options[:sca_exemption]
 
         commit data, options
       end
@@ -215,6 +216,7 @@ module ActiveMerchant #:nodoc:
         add_threeds(data, options) if options[:execute_threed]
         data[:description] = options[:description]
         data[:store_in_vault] = options[:store]
+        data[:sca_exemption] = options[:sca_exemption]
 
         commit data, options
       end
@@ -428,6 +430,7 @@ module ActiveMerchant #:nodoc:
           xml.DS_MERCHANT_TERMINAL           options[:terminal] || @options[:terminal]
           xml.DS_MERCHANT_MERCHANTCODE       @options[:login]
           xml.DS_MERCHANT_MERCHANTSIGNATURE  build_signature(data) unless sha256_authentication?
+          xml.DS_MERCHANT_EXCEP_SCA          data[:sca_exemption] if data[:sca_exemption]
 
           # Only when card is present
           if data[:card]
@@ -439,6 +442,12 @@ module ActiveMerchant #:nodoc:
           elsif data[:credit_card_token]
             xml.DS_MERCHANT_IDENTIFIER data[:credit_card_token]
             xml.DS_MERCHANT_DIRECTPAYMENT 'true'
+          end
+
+          # Set moto flag only if explicitly requested via moto field
+          # Requires account configuration to be able to use
+          if options.dig(:moto) && options.dig(:metadata, :manual_entry)
+            xml.DS_MERCHANT_DIRECTPAYMENT 'moto'
           end
 
           if data[:threeds]

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -36,6 +36,21 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert_equal 'CardConfiguration', response.message
   end
 
+  # Requires account configuration to allow setting moto flag
+  def test_purchase_with_moto_flag
+    response = @gateway.purchase(100, @credit_card, @options.merge(moto: true, metadata: { manual_entry: true }))
+    assert_equal 'SIS0488 ERROR', response.message
+  end
+
+  def test_successful_3ds_authorize_with_exemption
+    options = @options.merge(execute_threed: true, terminal: 12)
+    response = @gateway.authorize(100, @credit_card, options.merge(sca_exemption: 'LWV'))
+    assert_success response
+    assert response.params['ds_emv3ds']
+    assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+    assert_equal 'CardConfiguration', response.message
+  end
+
   def test_purchase_with_invalid_order_id
     response = @gateway.purchase(100, @credit_card, order_id: "a%4#{generate_order_id}")
     assert_success response


### PR DESCRIPTION
Sets sca_exemption when available for 3ds transactions. Also sets
moto flag when requested.

Remote:
22 tests, 68 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
36 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed