### PR TITLE
TNS: Update verison and support pay mode

### DIFF
--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -5,14 +5,16 @@ module ActiveMerchant
 
       class_attribute :live_na_url, :live_ap_url, :live_eu_url, :test_na_url, :test_ap_url, :test_eu_url
 
-      self.live_na_url = 'https://secure.na.tnspayments.com/api/rest/version/36/'
-      self.test_na_url = 'https://secure.na.tnspayments.com/api/rest/version/36/'
+      VERSION = '52'
 
-      self.live_ap_url = 'https://secure.ap.tnspayments.com/api/rest/version/36/'
-      self.test_ap_url = 'https://secure.ap.tnspayments.com/api/rest/version/36/'
+      self.live_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.test_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{VERSION}/"
 
-      self.live_eu_url = 'https://secure.eu.tnspayments.com/api/rest/version/36/'
-      self.test_eu_url = 'https://secure.eu.tnspayments.com/api/rest/version/36/'
+      self.live_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.test_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{VERSION}/"
+
+      self.live_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.test_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{VERSION}/"
 
       self.display_name = 'TNS'
       self.homepage_url = 'http://www.tnsi.com/'

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1184,9 +1184,14 @@ tns:
   userid: TESTSPREEDLY01
   password: 3f34fe50334fbe6cbe04c283411a5860
 
+# This account seem to have expired
 tns_ap:
   userid: TESTUNISOLMAA01
   password: b7f8119fda3bd27c17656badb52c95bb
+
+tns_pay_mode:
+  userid: USERID
+  password: password
 
 trans_first:
   login: 45567

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -7,9 +7,9 @@ class RemoteTnsTest < Test::Unit::TestCase
     @gateway = TnsGateway.new(fixtures(:tns))
 
     @amount = 100
-    @credit_card = credit_card('5123456789012346')
-    @ap_credit_card = credit_card('5424180279791732', month: 05, year: 2017, verification_value: 222)
-    @declined_card = credit_card('4000300011112220')
+    @credit_card = credit_card('5123456789012346', month: 05, year: 2021)
+    @ap_credit_card = credit_card('5424180279791732', month: 05, year: 2021)
+    @declined_card = credit_card('5123456789012346', month: 01, year: 2028)
 
     @options = {
       order_id: generate_unique_id,
@@ -43,6 +43,18 @@ class RemoteTnsTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(more_options))
     assert_success response
     assert_equal 'Succeeded', response.message
+  end
+
+  # This requires a test account flagged for pay/purchase mode.
+  # The primary test account (TESTSPREEDLY01) is not flagged for this mode.
+  # This was initially tested with a private account.
+  def test_successful_purchase_in_pay_mode
+    gateway = TnsGateway.new(fixtures(:tns_pay_mode).merge(region: 'europe'))
+
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(currency: 'GBP', pay_mode: true))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'CAPTURED', response.params['order']['status']
   end
 
   def test_successful_purchase_with_region


### PR DESCRIPTION
This is an account-level flag that allows single-step purchases.
Test cards were updated to use expiry date to invoke response codes
according to https://na-gateway.mastercard.com/api/documentation/integrationGuidelines/supportedFeatures/testAndGoLive.html?locale=en_US

Remote (1 unrelated failure due to regional test account):
14 tests, 48 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.8571% passed

Unit:
17 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed