### PR TITLE
Add Redsys SCA_EXCEPTION indicator.

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -199,6 +199,7 @@ module ActiveMerchant #:nodoc:
         add_payment(data, payment)
         add_threeds(data, options) if options[:execute_threed]
         data[:description] = options[:description]
+        data[:sca_exception] = options[:sca_exception] if options[:sca_exception]
         data[:store_in_vault] = options[:store]
 
         commit data, options
@@ -214,6 +215,7 @@ module ActiveMerchant #:nodoc:
         add_payment(data, payment)
         add_threeds(data, options) if options[:execute_threed]
         data[:description] = options[:description]
+        data[:sca_exception] = options[:sca_exception] if options[:sca_exception]
         data[:store_in_vault] = options[:store]
 
         commit data, options
@@ -425,6 +427,7 @@ module ActiveMerchant #:nodoc:
           xml.DS_MERCHANT_ORDER              data[:order_id]
           xml.DS_MERCHANT_TRANSACTIONTYPE    data[:action]
           xml.DS_MERCHANT_PRODUCTDESCRIPTION data[:description]
+          xml.DS_MERCHANT_EXCEP_SCA          data[:sca_exception] if data[:sca_exception]
           xml.DS_MERCHANT_TERMINAL           options[:terminal] || @options[:terminal]
           xml.DS_MERCHANT_MERCHANTCODE       @options[:login]
           xml.DS_MERCHANT_MERCHANTSIGNATURE  build_signature(data) unless sha256_authentication?

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -7,6 +7,7 @@ class RemoteRedsysTest < Test::Unit::TestCase
     @declined_card = credit_card
     @options = {
       order_id: generate_order_id,
+      sca_exception: 'MIT',
       description: 'Test Description'
     }
     @amount = 100


### PR DESCRIPTION
To quote the Sep 2019 Virtual Plus POS manual (I only have the Spanish version):

> De acuerdo a la normativa que entra en vigor el 14 de septiembre de 2019, en general, todas las operaciones de comercio electrónico dentro de la EEA (European Economic Area) deberán utilizar autenticación reforzada (SCA – Strong Customer Authentication / Autenticación Reforzada), si bien se contemplan algunos escenarios para los cuales se exime de esta obligatoriedad (exenciones).

I am told going forward merchant initiated transactions will need to be flagged with SCA_EXCEPTION='MIT', which this PR enables.

See also #3314
