### PR TITLE
Stripe Payment Intents: add supported countries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Credorax: Add 3DS 2.0 [nfarve] #3342
 * TNS: Update verison and support pay mode [curiousepic] #3355
 * Stripe: Add supported countries [therufs] #3358
+* Stripe Payment Intents: Add supported countries [therufs] #3359
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
     # For the legacy API, see the Stripe gateway
     class StripePaymentIntentsGateway < StripeGateway
 
-      self.supported_countries = %w(AT AU BE BR CA CH DE DK ES FI FR GB HK IE IT JP LU MX NL NO NZ PT SE SG US)
+      self.supported_countries = %w(AT AU BE BR CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MX NL NO NZ PL PT SE SG SI SK US)
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze


### PR DESCRIPTION
[CE-123](https://spreedly.atlassian.net/browse/CE-123)

Unit tests:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
29 tests, 118 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed 
Invalid request error generating failure on `test_create_payment_intent_that_saves_payment_method`: "A valid `customer` must be provided when `save_payment_method=true`". 