### PR TITLE
Credorax: Add A Mandatory 3DS field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Stripe Payment Intents: Add supported countries [therufs] #3359
 * Mundipagg: Append error messages to the message response field [jasonxp] #3353
 * Redsys: Add ability to pass sca_exemption and moto fields to request exemptions [britth] #3354
+* Credorax: Add A Mandatory 3DS field [nfarve] #3360
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -278,7 +278,9 @@ module ActiveMerchant #:nodoc:
           post[:'3ds_channel'] = '02'
           post[:'3ds_redirect_url'] = three_ds_2_options[:notification_url]
           post[:'3ds_challengewindowsize'] = options[:three_ds_challenge_window_size] || '03'
+          post[:'3ds_version'] = options[:three_ds_version] if options[:three_ds_version]
           post[:d5] = browser_info[:user_agent]
+          post[:'3ds_transtype'] = options[:transaction_type] || '01'
           post[:'3ds_browsertz'] = browser_info[:timezone]
           post[:'3ds_browserscreenwidth'] = browser_info[:width]
           post[:'3ds_browserscreenheight'] = browser_info[:height]

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -24,6 +24,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       shipping_address: address(),
       order_id: '123',
       execute_threed: true,
+      three_ds_version: '2',
       three_ds_challenge_window_size: '01',
       stored_credential: {reason_type: 'unscheduled'},
       three_ds_2: {
@@ -79,7 +80,8 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   def test_successful_purchase_with_3ds2_fields
     options = @options.merge(@normalized_3ds_2_options)
     response = @gateway.purchase(@amount, @three_ds_card, options)
-    assert_equal 'Transaction pending cardholder authentication.', response.message
+    assert_success response
+    assert_equal 'Succeeded', response.message
   end
 
   def test_successful_purchase_with_auth_data_via_normalized_3ds2_options

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -208,6 +208,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
     end.check_request do |endpoint, data, headers|
       assert_match(/3ds_channel=02/, data)
+      assert_match(/3ds_transtype=01/, data)
       assert_match(/3ds_redirect_url=www.example.com/, data)
       assert_match(/3ds_challengewindowsize=01/, data)
       assert_match(/d5=unknown/, data)


### PR DESCRIPTION
Credorax now requires `3ds_transtype` is required. This passes a default
value if none is passed. Also passes optional field `3ds_version`.

Loaded suite test/unit/gateways/credorax_test
Started
.......................

Finished in 0.020239 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 125 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed