### PR TITLE
Adyen: Add Cabal card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Credorax: Add support for MOTO flagging [britth] #3366
 * Credorax: Enable selecting a processor [leila-alderman] #3302
 * WorldPay: Revert "Worldpay: Switch to Nokogiri" [dtykocki] #3372
+* Adyen: Add Cabal card [leila-alderman] #3361
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -28,6 +28,15 @@ class AdyenTest < Test::Unit::TestCase
       :brand => 'elo'
     )
 
+    @cabal_credit_card = credit_card('6035 2277 1642 7021',
+      :month => 10,
+      :year => 2020,
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :verification_value => '737',
+      :brand => 'cabal'
+    )
+
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
@@ -227,6 +236,15 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_with_elo_response, successful_capture_with_elo_repsonse)
     assert_success response
     assert_equal '8835511210681145#8835511210689965#', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_cabal_card
+    response = stub_comms do
+      @gateway.purchase(@amount, @cabal_credit_card, @options)
+    end.respond_with(successful_authorize_with_cabal_response, successful_capture_with_cabal_repsonse)
+    assert_success response
+    assert_equal '883567090118045A#883567090119063C#', response.authorization
     assert response.test?
   end
 
@@ -742,6 +760,25 @@ class AdyenTest < Test::Unit::TestCase
     <<-RESPONSE
     {
       "pspReference":"8835511210689965",
+      "response":"[capture-received]"
+    }
+    RESPONSE
+  end
+
+  def successful_authorize_with_cabal_response
+    <<-RESPONSE
+    {
+      "pspReference":"883567090118045A",
+      "resultCode":"Authorised",
+      "authCode":"77651"
+    }
+    RESPONSE
+  end
+
+  def successful_capture_with_cabal_repsonse
+    <<-RESPONSE
+    {
+      "pspReference":"883567090119063C",
       "response":"[capture-received]"
     }
     RESPONSE


### PR DESCRIPTION
Added the Cabal card to the Adyen gateway, including adding unit and
remote tests.

Currently, Adyen does not support recurring transactions for Cabal
cards, so additional logic was added to the `store` method to return an
error message when attempting to store a Cabal card. Since the `store`
method for Adyen uses the `authorise` action, even though Cabal cards
cannot be successfully stored, the response from the gateway is
successful and does not return any sort of error message.

CE-99

Unit:
40 tests, 193 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
68 tests, 214 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed