### PR TITLE
[3DS] Update status to accept the correct field in payflow integration

### DIFF
--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -262,20 +262,32 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'NameOnCard', credit_card.first_name
           xml.tag! 'CVNum', credit_card.verification_value if credit_card.verification_value?
 
-          if options[:three_d_secure]
-            three_d_secure = options[:three_d_secure]
-            xml.tag! 'BuyerAuthResult' do
-              xml.tag! 'Status', three_d_secure[:status] unless three_d_secure[:status].blank?
-              xml.tag! 'AuthenticationId', three_d_secure[:authentication_id] unless three_d_secure[:authentication_id].blank?
-              xml.tag! 'PAReq', three_d_secure[:pareq] unless three_d_secure[:pareq].blank?
-              xml.tag! 'ACSUrl', three_d_secure[:acs_url] unless three_d_secure[:acs_url].blank?
-              xml.tag! 'ECI', three_d_secure[:eci] unless three_d_secure[:eci].blank?
-              xml.tag! 'CAVV', three_d_secure[:cavv] unless three_d_secure[:cavv].blank?
-              xml.tag! 'XID', three_d_secure[:xid] unless three_d_secure[:xid].blank?
-            end
-          end
+          add_three_d_secure(options, xml)
 
           xml.tag! 'ExtData', 'Name' => 'LASTNAME', 'Value' =>  credit_card.last_name
+        end
+      end
+
+      def add_three_d_secure(options, xml)
+        if options[:three_d_secure]
+          three_d_secure = options[:three_d_secure]
+          xml.tag! 'BuyerAuthResult' do
+            authentication_status(three_d_secure, xml)
+            xml.tag! 'AuthenticationId', three_d_secure[:authentication_id] unless three_d_secure[:authentication_id].blank?
+            xml.tag! 'PAReq', three_d_secure[:pareq] unless three_d_secure[:pareq].blank?
+            xml.tag! 'ACSUrl', three_d_secure[:acs_url] unless three_d_secure[:acs_url].blank?
+            xml.tag! 'ECI', three_d_secure[:eci] unless three_d_secure[:eci].blank?
+            xml.tag! 'CAVV', three_d_secure[:cavv] unless three_d_secure[:cavv].blank?
+            xml.tag! 'XID', three_d_secure[:xid] unless three_d_secure[:xid].blank?
+          end
+        end
+      end
+
+      def authentication_status(three_d_secure, xml)
+        if three_d_secure[:authentication_response_status].present?
+          xml.tag! 'Status', three_d_secure[:authentication_response_status]
+        elsif three_d_secure[:directory_response_status].present?
+          xml.tag! 'Status', three_d_secure[:directory_response_status]
         end
       end
 

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -456,8 +456,8 @@ class RemotePayflowTest < Test::Unit::TestCase
   def three_d_secure_option
     {
         :three_d_secure => {
-            :status => 'Y',
             :authentication_id => 'QvDbSAxSiaQs241899E0',
+            :authentication_response_status => 'Y',
             :eci => '02',
             :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
             :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -442,6 +442,17 @@ class PayflowTest < Test::Unit::TestCase
     assert_three_d_secure REXML::Document.new(xml.target!), '/Card/BuyerAuthResult'
   end
 
+  def test_add_credit_card_with_three_d_secure_frictionless
+    xml = Builder::XmlMarkup.new
+    credit_card = credit_card(
+      '5641820000000005',
+      :brand => 'maestro'
+    )
+
+    @gateway.send(:add_credit_card, xml, credit_card, @options.merge(three_d_secure_option_frictionless))
+    assert_three_d_secure_frictionless REXML::Document.new(xml.target!), '/Card/BuyerAuthResult'
+  end
+
   def test_duplicate_response_flag
     @gateway.expects(:ssl_post).returns(successful_duplicate_response)
 
@@ -876,6 +887,16 @@ Conn close
     assert_equal 'UXZEYlNBeFNpYVFzMjQxODk5RTA=', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/XID").text
   end
 
+  def assert_three_d_secure_frictionless(xml_doc, buyer_auth_result_path)
+    assert_equal 'C', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/Status").text
+    assert_equal 'QvDbSAxSiaQs241899E0', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/AuthenticationId").text
+    assert_equal 'pareq block', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/PAReq").text
+    assert_equal 'https://bankacs.bank.com/ascurl', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/ACSUrl").text
+    assert_equal '02', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/ECI").text
+    assert_equal 'jGvQIvG/5UhjAREALGYa6Vu/hto=', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/CAVV").text
+    assert_equal 'UXZEYlNBeFNpYVFzMjQxODk5RTA=', REXML::XPath.first(xml_doc, "#{buyer_auth_result_path}/XID").text
+  end
+
   def authorize_buyer_auth_result_path
     '/XMLPayRequest/RequestData/Transactions/Transaction/Authorization/PayData/Tender/Card/BuyerAuthResult'
   end
@@ -887,8 +908,22 @@ Conn close
   def three_d_secure_option
     {
         :three_d_secure => {
-            :status => 'Y',
             :authentication_id => 'QvDbSAxSiaQs241899E0',
+            :authentication_response_status => 'Y',
+            :pareq => 'pareq block',
+            :acs_url => 'https://bankacs.bank.com/ascurl',
+            :eci => '02',
+            :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+            :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+        }
+    }
+  end
+
+  def three_d_secure_option_frictionless
+    {
+        :three_d_secure => {
+            :authentication_id => 'QvDbSAxSiaQs241899E0',
+            :directory_response_status => 'C',
             :pareq => 'pareq block',
             :acs_url => 'https://bankacs.bank.com/ascurl',
             :eci => '02',


### PR DESCRIPTION
Due to missing information, we've been getting 3DS errors from payflow_uk:
`Field format error: 12000-Transaction is not compliant due to missing or invalid 3D-secure authentication values`
This PR adds the missing fields following [this documentation](https://developer.paypal.com/docs/classic/payflow/3d-secure-mpi/#how-to-send-3-d-secure-authentication-data)