### PR TITLE
Worldpay: Switch to Nokogiri

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Redsys: Add ability to pass sca_exemption and moto fields to request exemptions [britth] #3354
 * Credorax: Add A Mandatory 3DS field [nfarve] #3360
 * CyberSource: Support 3DS2 pass-through fields [curiousepic] #3363
+* Worldpay: Switch to Nokogiri [nfarve] #3364
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1393,6 +1393,7 @@ class WorldpayTest < Test::Unit::TestCase
                 <cardBrand>VISA</cardBrand>
                 <cardSubBrand>VISA_CREDIT</cardSubBrand>
                 <issuerCountryCode>N/A</issuerCountryCode>
+                <issuerName>TARGOBANK AG & CO. KGAA</issuerName>
                 <obfuscatedPAN>4111********1111</obfuscatedPAN>
               </derived>
             </cardDetails>


### PR DESCRIPTION
The `&` symbol was causing issues when parsing responses from worldpay.
This updates the parsing method to Nokogiri so these special characters
no longer cause an issue.

2 remotes tests failing for unrelated reasons.

Loaded suite test/unit/gateways/worldpay_test
...................................................................

67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_worldpay_test
....................................................

54 tests, 235 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2963% passed