### PR TITLE
Credorax: Add MOTO support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Credorax: Add A Mandatory 3DS field [nfarve] #3360
 * CyberSource: Support 3DS2 pass-through fields [curiousepic] #3363
 * Worldpay: Switch to Nokogiri [nfarve] #3364
+* Credorax: Add support for MOTO flagging [britth] #3366
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -334,6 +334,7 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction_type(post, options)
         post[:a9] = options[:transaction_type] if options[:transaction_type]
+        post[:a2] = '3' if options.dig(:metadata, :manual_entry)
       end
 
       ACTIONS = {

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -84,6 +84,14 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_moto_purchase
+    response = @gateway.purchase(@amount, @three_ds_card, @options.merge(metadata: { manual_entry: true }))
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal '3', response.params['A2']
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_auth_data_via_normalized_3ds2_options
     version = '2.0'
     eci = '02'

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -326,6 +326,15 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_adds_moto_a2_field
+    @options[:metadata] = { manual_entry: true }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/a2=3/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_supports_billing_descriptor
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do


### PR DESCRIPTION
Credorax uses the field `a2` to mark payment source type. Possible 
values for this field are:

2 - Online Order (default value) 
3 - Telephone Order 
4 - Mail Order 
5 - Virtual Terminal

This PR sets the value to 3 when the manual entry flag is set. 

Unit:
24 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
27 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed