### PR TITLE
Quickpay: Remove testmode flag from v4-v7 platform

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -29,7 +29,6 @@ module ActiveMerchant #:nodoc:
         add_creditcard_or_reference(post, credit_card_or_reference, options)
         add_autocapture(post, false)
         add_fraud_parameters(post, options) if action.eql?(:authorize)
-        add_testmode(post)
 
         commit(action, post)
       end
@@ -87,7 +86,6 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, options)
         add_description(post, options)
         add_fraud_parameters(post, options)
-        add_testmode(post)
 
         commit(:subscribe, post)
       end
@@ -137,11 +135,6 @@ module ActiveMerchant #:nodoc:
 
       def add_description(post, options)
         post[:description] = options[:description] || 'Description'
-      end
-
-      def add_testmode(post)
-        return if post[:transaction].present?
-        post[:testmode] = test? ? '1' : '0'
       end
 
       def add_fraud_parameters(post, options)


### PR DESCRIPTION
According to Quickpay support, the testmode flag is no longer supported on the old platform.