### PR TITLE
[Orbital] Add support for 3DS 2.0

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
     class OrbitalGateway < Gateway
       include Empty
 
-      API_VERSION = '7.7'
+      API_VERSION = '7.9'
 
       POST_HEADERS = {
         'MIME-Version' => '1.1',

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -521,6 +521,24 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:PymtBrandProgramCode, 'ASK')
       end
 
+      def add_mc_program_protocol(xml, creditcard, three_d_secure)
+        return unless three_d_secure && creditcard.brand == 'master'
+
+        xml.tag!(:MCProgramProtocol, three_d_secure[:version].to_i) if three_d_secure[:version]
+      end
+
+      def add_mc_directory_trans_id(xml, creditcard, three_d_secure)
+        return unless three_d_secure && creditcard.brand == 'master'
+
+        xml.tag!(:MCDirectoryTransID, three_d_secure[:ds_transaction_id]) if three_d_secure[:ds_transaction_id]
+      end
+
+      def add_ucaf_ind(xml, creditcard, three_d_secure)
+        return unless three_d_secure && creditcard.brand == 'master'
+
+        xml.tag!(:UCAFInd, three_d_secure[:ucaf_collection_ind]) if three_d_secure[:ucaf_collection_ind]
+      end
+
       def add_refund(xml, currency=nil)
         xml.tag! :AccountNum, nil
 
@@ -716,6 +734,9 @@ module ActiveMerchant #:nodoc:
             add_level_2_purchase(xml, parameters)
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, creditcard, three_d_secure)
+            add_mc_program_protocol(xml, creditcard, three_d_secure)
+            add_mc_directory_trans_id(xml, creditcard, three_d_secure)
+            add_ucaf_ind(xml, creditcard, three_d_secure)
           end
         end
         xml.target!

--- a/test/schema/orbital/Request_PTI79.xsd
+++ b/test/schema/orbital/Request_PTI79.xsd
@@ -352,7 +352,21 @@
             <xs:element name="PinlessDebitMerchantUrl" type="xs:string" minOccurs="0"/>
             <xs:element name="RtauOptOutInd" type="xs:string" minOccurs="0"/>  
             <xs:element name="PymtBrandProgramCode" type="xs:string" minOccurs="0"/>
-		</xs:sequence>
+            <xs:element name="TokenTxnType" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCATrustedMerchant" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCASecureCorporatePayment" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCATransactionRiskAnalysis" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCALowValuePayment" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCAMerchantInitiatedTransaction" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCARecurringPayment" type="xs:string" minOccurs="0"/>
+            <xs:element name="SCADelegation" type="xs:string" minOccurs="0"/>
+            <xs:element name="DeferredAuth" type="xs:string" minOccurs="0"/>
+            <xs:element name="MCProgramProtocol" type="xs:string" minOccurs="0"/>
+            <xs:element name="MCDirectoryTransID" type="xs:string" minOccurs="0"/>
+            <xs:element name="UCAFInd" type="xs:string" minOccurs="0"/>
+            <!-- ?&AUTO_ADD_FIELD_NewOrder -->
+            <!-- DONOT TOUCH THE ABOVE LINE -->
+        </xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="PC3LineItemArray">
 		<xs:sequence>
@@ -425,7 +439,20 @@
 			<xs:element name="PCardDtlTaxAmount1" type="xs:string" minOccurs="0"/>
 			<xs:element name="PCardDtlTaxAmount2Ind" type="xs:string" minOccurs="0"/>
 			<xs:element name="PCardDtlTaxAmount2" type="xs:string" minOccurs="0"/>
-			<xs:element name="PinlessDebitTotalShpmnt" type="xs:string" minOccurs="0"/>
+			<xs:element name="PinlessDebitTotalShpmnt" type="xs:string" minOccurs="0"/>			
+			<xs:element name="AuthenticationECIInd" type="xs:string" minOccurs="0"/>
+			<xs:element name="DigitalTokenCryptogram" type="xs:string" minOccurs="0"/>
+			<xs:element name="XID" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCATrustedMerchant" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCASecureCorporatePayment" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCATransactionRiskAnalysis" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCALowValuePayment" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCAMerchantInitiatedTransaction" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCARecurringPayment" type="xs:string" minOccurs="0"/>
+			<xs:element name="SCADelegation" type="xs:string" minOccurs="0"/>
+			<xs:element name="MCProgramProtocol" type="xs:string" minOccurs="0"/>
+			<xs:element name="MCDirectoryTransID" type="xs:string" minOccurs="0"/>
+			<xs:element name="UCAFInd" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="reversalType">
@@ -543,6 +570,7 @@
 			<xs:element name="MITSubmittedTransactionID" type="xs:string" minOccurs="0"/>
 			<xs:element name="PinlessDebitTxnType" type="xs:string" minOccurs="0"/>
             <xs:element name="PinlessDebitMerchantUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="CardBrand" type="valid-card-brands" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="flexCacheType">
@@ -934,17 +962,22 @@
 					</xs:enumeration>
 					<xs:enumeration value="CZ">
 						<xs:annotation>
-							<xs:documentation>International Maestro</xs:documentation>
+							<xs:documentation>Chasenet Credit</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="CR">
 						<xs:annotation>
-							<xs:documentation>International Maestro</xs:documentation>
+							<xs:documentation>Chasenet Signature Debit</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="AA">
 						<xs:annotation>
-							<xs:documentation>International Maestro</xs:documentation>
+							<xs:documentation>Auto Assign</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="TK">
+						<xs:annotation>
+							<xs:documentation>Use Token as Account Number</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -57,6 +57,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
         cavv: 'TESTCAVV',
       }
     }
+    @three_d_secure_2_options = {
+      three_d_secure: {
+        eci: '5',
+        cavv: 'TESTCAVV',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        ucaf_collection_ind: '1',
+        version: '2.1.0',
+      }
+    }
   end
 
   def test_successful_purchase
@@ -99,7 +108,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_visa_purchase
+  def test_three_d_secure_1_data_on_visa_purchase
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|
@@ -109,7 +118,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_visa_authorization
+  def test_three_d_secure_1_data_on_visa_authorization
     stub_comms do
       @gateway.authorize(50, credit_card, @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|
@@ -120,7 +129,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_master_purchase
+  def test_three_d_secure_2_data_on_visa_purchase
+    stub_comms do
+      @gateway.purchase(50, credit_card, @options.merge(@three_d_secure_2_options))
+    end.check_request do |endpoint, data, headers|
+      assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
+      assert_match %{<CAVV>TESTCAVV</CAVV>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_2_data_on_visa_authorization
+    stub_comms do
+      @gateway.authorize(50, credit_card, @options.merge(@three_d_secure_2_options))
+    end.check_request do |endpoint, data, headers|
+      assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
+      assert_match %{<CAVV>TESTCAVV</CAVV>}, data
+      assert_xml_valid_to_xsd(data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_1_data_on_master_purchase
     stub_comms do
       @gateway.purchase(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|
@@ -129,7 +157,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_master_authorization
+  def test_three_d_secure_1_data_on_master_authorization
     stub_comms do
       @gateway.authorize(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|
@@ -139,7 +167,32 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_american_express_purchase
+  def test_three_d_secure_2_data_on_master_purchase
+    stub_comms do
+      @gateway.purchase(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_2_options))
+    end.check_request do |endpoint, data, headers|
+      assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
+      assert_match %{<AAV>TESTCAVV</AAV>}, data
+      assert_match %{<MCProgramProtocol>2</MCProgramProtocol>}, data
+      assert_match %{<MCDirectoryTransID>97267598-FAE6-48F2-8083-C23433990FBC</MCDirectoryTransID>}, data
+      assert_match %{<UCAFInd>1</UCAFInd>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_2_data_on_master_authorization
+    stub_comms do
+      @gateway.authorize(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_2_options))
+    end.check_request do |endpoint, data, headers|
+      assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
+      assert_match %{<AAV>TESTCAVV</AAV>}, data
+      assert_match %{<MCProgramProtocol>2</MCProgramProtocol>}, data
+      assert_match %{<MCDirectoryTransID>97267598-FAE6-48F2-8083-C23433990FBC</MCDirectoryTransID>}, data
+      assert_match %{<UCAFInd>1</UCAFInd>}, data
+      assert_xml_valid_to_xsd(data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_1_data_on_american_express_purchase
     stub_comms do
       @gateway.purchase(50, credit_card(nil, brand: 'american_express'), @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|
@@ -149,7 +202,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_american_express_authorization
+  def test_three_d_secure_1_data_on_american_express_authorization
     stub_comms do
       @gateway.authorize(50, credit_card(nil, brand: 'american_express'), @options.merge(@three_d_secure_options))
     end.check_request do |endpoint, data, headers|


### PR DESCRIPTION
The `version` and `ds_trasactioni_id` fields are [standardized](https://github.com/activemerchant/active_merchant/wiki/Standardized-3DS-Fields). The `ucaf_collection_ind` field is supported as a top-level option by the `MerchantESolutionsGateway` class, which hasn't been updated to support the `:three_d_secure` options hash.