### PR TITLE
CyberSource: Use 3DS hash for enrolled field

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -552,7 +552,7 @@ module ActiveMerchant #:nodoc:
         xml.tag!('commerceIndicator', options[:commerce_indicator]) if options[:commerce_indicator]
         xml.tag!('eciRaw', threeds_2_options[:eci]) if threeds_2_options[:eci]
         xml.tag!('xid', threeds_2_options[:xid]) if threeds_2_options[:xid]
-        xml.tag!('veresEnrolled', options[:veres_enrolled]) if options[:veres_enrolled]
+        xml.tag!('veresEnrolled', threeds_2_options[:enrolled]) if threeds_2_options[:enrolled]
         xml.tag!('paresStatus', threeds_2_options[:authentication_response_status]) if threeds_2_options[:authentication_response_status]
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -511,9 +511,9 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
         xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
         ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
         cavv_algorithm: 1,
+        enrolled: 'Y',
         authentication_response_status: 'Y'
       },
-      veres_enrolled: 'N',
       commerce_indicator: 'vbv'
     )
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -626,7 +626,7 @@ class CyberSourceTest < Test::Unit::TestCase
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     commerce_indicator = 'vbv'
     authentication_response_status = 'Y'
-    veres_enrolled = 'N'
+    enrolled = 'Y'
     options_with_normalized_3ds = @options.merge(
       three_d_secure: {
         version: version,
@@ -634,9 +634,9 @@ class CyberSourceTest < Test::Unit::TestCase
         cavv: cavv,
         ds_transaction_id: ds_transaction_id,
         cavv_algorithm: cavv_algorithm,
+        enrolled: enrolled,
         authentication_response_status: authentication_response_status
       },
-      veres_enrolled: veres_enrolled,
       commerce_indicator: commerce_indicator
     )
 
@@ -650,7 +650,7 @@ class CyberSourceTest < Test::Unit::TestCase
       assert_match(/<paresStatus\>#{authentication_response_status}/, data)
       assert_match(/<cavvAlgorithm\>#{cavv_algorithm}/, data)
       assert_match(/<commerceIndicator\>#{commerce_indicator}/, data)
-      assert_match(/<veresEnrolled\>#{veres_enrolled}/, data)
+      assert_match(/<veresEnrolled\>#{enrolled}/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Remote (5 unrelated failures):
63 tests, 267 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.0635% passed

Unit:
63 tests, 307 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed