### PR TITLE
Revert "Worldpay: Switch to Nokogiri"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Worldpay: Switch to Nokogiri [nfarve] #3364
 * Credorax: Add support for MOTO flagging [britth] #3366
 * Credorax: Enable selecting a processor [leila-alderman] #3302
+* WorldPay: Revert "Worldpay: Switch to Nokogiri" [dtykocki] #3372
 
 == Version 1.98.0 (Sep 9, 2019)
 * Stripe Payment Intents: Add new gateway [britth] #3290

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1393,7 +1393,6 @@ class WorldpayTest < Test::Unit::TestCase
                 <cardBrand>VISA</cardBrand>
                 <cardSubBrand>VISA_CREDIT</cardSubBrand>
                 <issuerCountryCode>N/A</issuerCountryCode>
-                <issuerName>TARGOBANK AG & CO. KGAA</issuerName>
                 <obfuscatedPAN>4111********1111</obfuscatedPAN>
               </derived>
             </cardDetails>


### PR DESCRIPTION
This reverts 0735e8977affbd929e1605e5ded9e7d3567096a9 due XML parse
exceptions that we observed with production traffic.

Unit Tests:
67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
All failed because " Failed with 503 Service Unavailable" at the time of
this change