### PR TITLE
Revert "Revert "Worldpay: Switch to Nokogiri""

### DIFF
--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1393,6 +1393,7 @@ class WorldpayTest < Test::Unit::TestCase
                 <cardBrand>VISA</cardBrand>
                 <cardSubBrand>VISA_CREDIT</cardSubBrand>
                 <issuerCountryCode>N/A</issuerCountryCode>
+                <issuerName>TARGOBANK AG & CO. KGAA</issuerName>
                 <obfuscatedPAN>4111********1111</obfuscatedPAN>
               </derived>
             </cardDetails>


### PR DESCRIPTION
This reverts commit 59472b102db3668e9363f1a41668355ce1ac4033.

This change was found not to have cause the previously mentioned issues.

Remote (5 unrelated failures):
54 tests, 231 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.7407% passed

Unit:
67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed