### PR TITLE
Adyen: Add capture_delay_hours GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Revert "Revert "Worldpay: Switch to Nokogiri"" [curiousepic] #3373
 * Adyen: Fix `authorise3d` message for refusals [jeremywrowe] #3374
 * Redsys: Set authorization field for 3DS transactions [britth] #3377
+* Adyen: Add capture_delay_hours GSF [therufs] #3376
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -186,6 +186,7 @@ module ActiveMerchant #:nodoc:
         post[:selectedBrand] ||= NETWORK_TOKENIZATION_CARD_SOURCE[payment.source.to_s] if payment.is_a?(NetworkTokenizationCreditCard)
         post[:deliveryDate] = options[:delivery_date] if options[:delivery_date]
         post[:merchantOrderReference] = options[:merchant_order_reference] if options[:merchant_order_reference]
+        post[:captureDelayHours] = options[:capture_delay_hours] if options[:capture_delay_hours]
         post[:additionalData] ||= {}
         post[:additionalData][:overwriteBrand] = normalize(options[:overwrite_brand]) if options[:overwrite_brand]
         post[:additionalData][:customRoutingFlag] = options[:custom_routing_flag] if options[:custom_routing_flag]

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -337,7 +337,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
-    options = @options.merge!(fraudOffset: '1', installments: 2, shopper_statement: 'statement note', device_fingerprint: 'm7Cmrf++0cW4P6XfF7m/rA')
+    options = @options.merge!(
+      fraudOffset: '1',
+      installments: 2,
+      shopper_statement: 'statement note',
+      device_fingerprint: 'm7Cmrf++0cW4P6XfF7m/rA',
+      capture_delay_hours: 4)
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal '[capture-received]', response.message

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -296,6 +296,14 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_capture_delay_hours_sent
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({capture_delay_hours: 4}))
+    end.check_request do |endpoint, data, headers|
+      assert_equal 4, JSON.parse(data)['captureDelayHours']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_custom_routing_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({custom_routing_flag: 'abcdefg'}))


### PR DESCRIPTION
Unit: 
48 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 
66 tests, 213 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed. Both failures involve the `liabilityShift` 3DS field.

CE-133