### PR TITLE
Redsys: Set authorization for 3DS transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Revert "Revert "Worldpay: Switch to Nokogiri"" [curiousepic] #3373
 * Adyen: Fix `authorise3d` message for refusals [jeremywrowe] #3374
+* Redsys: Set authorization field for 3DS transactions [britth] #3377
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -473,6 +473,7 @@ module ActiveMerchant #:nodoc:
             params[element.name.downcase.to_sym] = element.text
           end
           message = response_text_3ds(xml, params)
+          options[:authorization] = build_authorization(params)
           success = params.size > 0 && is_success_response?(params[:ds_response])
         elsif code == '0'
           op = xml.xpath('//RETORNOXML/OPERACION')

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -24,6 +24,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert response.params['ds_emv3ds']
     assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
     assert_equal 'CardConfiguration', response.message
+    assert response.authorization
   end
 
   def test_successful_purchase_3ds
@@ -34,6 +35,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert_equal '2.1.0', three_ds_data['protocolVersion']
     assert_equal 'https://sis-d.redsys.es/sis-simulador-web/threeDsMethod.jsp', three_ds_data['threeDSMethodURL']
     assert_equal 'CardConfiguration', response.message
+    assert response.authorization
   end
 
   # Requires account configuration to allow setting moto flag

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -116,15 +116,16 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_successful_authorize_with_3ds
     @gateway.expects(:ssl_post).returns(successful_authorize_with_3ds_response)
-    response = @gateway.authorize(100, credit_card, { execute_threed: true, order_id: '156201452719' })
+    response = @gateway.authorize(100, credit_card, { execute_threed: true, order_id: '156270437866' })
     assert response.test?
     assert response.params['ds_emv3ds']
     assert_equal response.message, 'CardConfiguration'
+    assert_equal response.authorization, '156270437866||'
   end
 
   def test_3ds_data_passed
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(100, credit_card, { execute_threed: true, order_id: '156201452719', terminal: 12, sca_exemption: 'LWV' })
+      @gateway.authorize(100, credit_card, { execute_threed: true, order_id: '156270437866', terminal: 12, sca_exemption: 'LWV' })
     end.check_request do |method, endpoint, data, headers|
       assert_match(/iniciaPeticion/, data)
       assert_match(/<DS_MERCHANT_TERMINAL>12<\/DS_MERCHANT_TERMINAL>/, data)
@@ -135,7 +136,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_moto_flag_passed
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(100, credit_card, { order_id: '156201452719', moto: true, metadata: { manual_entry: true } })
+      @gateway.authorize(100, credit_card, { order_id: '156270437866', moto: true, metadata: { manual_entry: true } })
     end.check_request do |method, endpoint, data, headers|
       assert_match(/DS_MERCHANT_DIRECTPAYMENT%3Emoto%3C%2FDS_MERCHANT_DIRECTPAYMENT/, data)
     end.respond_with(successful_authorize_with_3ds_response)
@@ -143,7 +144,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_moto_flag_not_passed_if_not_explicitly_requested
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(100, credit_card, { order_id: '156201452719', metadata: { manual_entry: true } })
+      @gateway.authorize(100, credit_card, { order_id: '156270437866', metadata: { manual_entry: true } })
     end.check_request do |method, endpoint, data, headers|
       refute_match(/DS_MERCHANT_DIRECTPAYMENT%3Emoto%3C%2FDS_MERCHANT_DIRECTPAYMENT/, data)
     end.respond_with(successful_authorize_with_3ds_response)


### PR DESCRIPTION
Ensure that the authorization field is set when performing 3DS transactions.

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
36 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed