### PR TITLE
WorldPay: Add Cabal and Naranja remote tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Adyen: Add capture_delay_hours GSF [therufs] #3376
 * Credorax: Add support for stored credentials [chinhle23] #3375
 * BlueSnap: Add remote tests for Cabal and Naranja [leila-alderman] #3382
+* WorldPay: Add Cabal and Naranja remote tests [leila-alderman] #3378
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -16,6 +16,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       :verification_value => '737',
       :brand => 'elo'
     )
+    @cabal_card = credit_card('6035220000000006')
+    @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
     @declined_card = credit_card('4111111111111111', :first_name => nil, :last_name => 'REFUSED')
     @threeDS_card = credit_card('4111111111111111', :first_name => nil, :last_name => '3D')
@@ -40,6 +42,18 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_elo
     assert response = @gateway.purchase(@amount, @elo_credit_card, @options.merge(currency: 'BRL'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_cabal
+    response = @gateway.purchase(@amount, @cabal_card, @options.merge(currency: 'ARS'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_naranja
+    response = @gateway.purchase(@amount, @naranja_card, @options.merge(currency: 'ARS'))
     assert_success response
     assert_equal 'SUCCESS', response.message
   end


### PR DESCRIPTION
Adds remote tests for both of the newly implemented card types:
 - Cabal
 - Naranja

The test card numbers for the new card types were taken directly from
WorldPay's
[documentation](https://beta.developer.worldpay.com/docs/wpg/latinamericaintegration/test).

CE-94 / CE-109

Unit:
67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
56 tests, 235 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
91.0714% passed

Failing remote tests:
 - test_3ds_version_1_parameters_pass_thru
 - test_3ds_version_2_parameters_pass_thru
 - test_successful_credit_using_token
 - test_successful_mastercard_credit_on_cft_gateway
 - test_successful_visa_credit_on_cft_gateway

The first two failing tests are associated with pass-through
parameters, which were already known to not work.

The other three failing tests are all associated with the CTF gateway,
which is currently failing for unknown reasons.