### PR TITLE
Worldpay: Update test with MOTO enabled account

### DIFF
--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -152,10 +152,11 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     refute first_message.params['session_id'].blank?
   end
 
-  # Requires additional account configuration to proceed successfully
+  # Ensure the account is configured to use this feature to proceed successfully
   def test_marking_3ds_purchase_as_moto
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { manual_entry: true }))
-    assert_equal 'AllowDynamicInteractionType property is disabled for this merchant', response.message
+    assert_success response
+    assert_equal 'SUCCESS', response.message
   end
 
   def test_successful_auth_and_capture_with_normalized_stored_credential


### PR DESCRIPTION
MOTO is now enabled on the test account used in Worldpay remote
testing. Updates test to actually check that purchase is successful
when flagged as MOTO.

Remote:
54 tests, 232 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.7407% passed
(5 preexisting, unrelated errors)

Unit:
67 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed