### PR TITLE
Worldpay: Handle parse errors gracefully

### DIFF
--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -836,6 +836,14 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
   end
 
+  def test_handles_plain_text_response
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.respond_with('Temporary Failure, please Retry')
+    assert_failure response
+    assert_match "Unparsable response received from Worldpay. Please contact Worldpay if you continue to receive this message. \(The raw response returned by the API was: \"Temporary Failure, please Retry\"\)", response.message
+  end
+
   private
 
   def assert_tag_with_attributes(tag, attributes, string)


### PR DESCRIPTION
We have experienced instances of Worldpay responses consisting of a
plain text string, which threw a NoMethodError when attempting to parse.
It will now return a falilure response with the relevant parsing error.
This also replaces the problematic & character in responses.

Remote (6 unrelated failures):
54 tests, 231 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.8889% passed

Unit:
68 tests, 401 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed