### PR TITLE
Worldpay: Raise appropriate error when parsing

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -457,7 +457,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(action, xml)
-        doc = Nokogiri::XML(xml)
+        xml = xml.strip.gsub(/\&/, '&amp;')
+        begin
+          doc = Nokogiri::XML(xml, &:strict)
+        rescue Nokogiri::XML::SyntaxError => e
+          raise InvalidResponseError, "There was an error parsing the response: #{e} | The original response body was: #{xml}"
+        end
         doc.remove_namespaces!
         resp_params = {:action => action}
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -836,6 +836,14 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
   end
 
+  def test_parsing_error
+    assert_raise ActiveMerchant::InvalidResponseError do
+      stub_comms do
+        @gateway.authorize(@amount, @credit_card, @options)
+      end.respond_with('string')
+    end
+  end
+
   private
 
   def assert_tag_with_attributes(tag, attributes, string)


### PR DESCRIPTION
We have experienced instances of Worldpay responses consisting of a
plain text string, which threw a NoMethodError when attempting to parse.
It will now throw an InvalidResponseError with details.
This also replaces the problematic & character in responses.

Remote (3 unrelated failures):
54 tests, 235 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.4444% passed

Unit:
68 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed