### PR TITLE
BlueSnap: Add remote tests for Cabal and Naranja

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Redsys: Set authorization field for 3DS transactions [britth] #3377
 * Adyen: Add capture_delay_hours GSF [therufs] #3376
 * Credorax: Add support for stored credentials [chinhle23] #3375
+* BlueSnap: Add remote tests for Cabal and Naranja [leila-alderman] #3382
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -6,7 +6,8 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4263982640269299')
-    @cabal_credit_card = credit_card('6271701225979642')
+    @cabal_card = credit_card('6271701225979642', month: 3, year: 2020)
+    @naranja_card = credit_card('5895626746595650', month: 11, year: 2020)
     @declined_card = credit_card('4917484589897107', month: 1, year: 2023)
     @invalid_card = credit_card('4917484589897106', month: 1, year: 2023)
     @three_ds_visa_card = credit_card('4000000000001091', month: 1)
@@ -40,6 +41,24 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_cabal_card
+    options = @options.merge({
+      email: 'joe@example.com'
+    })
+    response = @gateway.purchase(@amount, @cabal_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_naranja_card
+    options = @options.merge({
+      email: 'joe@example.com'
+    })
+    response = @gateway.purchase(@amount, @naranja_card, options)
     assert_success response
     assert_equal 'Success', response.message
   end


### PR DESCRIPTION
Added remote tests for the new Cabal and Naranja card types that were
previously enabled.

CE-94 / CE-111

Unit:
30 tests, 142 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
40 tests, 121 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
97.5% passed

`test_successful_purchase_with_3ds2_auth` is now failing with the error
message "Transaction failed  because of payment processing failure.:
400540 - Authorisation failed for request 2652197". It's not clear what
is causing this error, but it doesn't seem related to these changes.