### PR TITLE
Moneris: Add support for stored credentials

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
         post[:order_id] = options[:order_id]
         post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
-        add_cof(post, options)
+        add_stored_credential(post, options)
         action = if post[:cavv]
                    'cavv_preauth'
                  elsif post[:data_key].blank?
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         post[:order_id] = options[:order_id]
         post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
-        add_cof(post, options)
+        add_stored_credential(post, options)
         action = if post[:cavv]
                    'cavv_purchase'
                  elsif post[:data_key].blank?
@@ -206,6 +206,48 @@ module ActiveMerchant #:nodoc:
         post[:issuer_id] = options[:issuer_id] if options[:issuer_id]
         post[:payment_indicator] = options[:payment_indicator] if options[:payment_indicator]
         post[:payment_information] = options[:payment_information] if options[:payment_information]
+      end
+
+      def add_stored_credential(post, options)
+        add_cof(post, options)
+        # if any of :issuer_id, :payment_information, or :payment_indicator is not passed,
+        # then check for :stored credential options
+        return unless (stored_credential = options[:stored_credential]) && !cof_details_present?(options)
+        if stored_credential[:initial_transaction]
+          add_stored_credential_initial(post, options)
+        else
+          add_stored_credential_used(post, options)
+        end
+      end
+
+      def add_stored_credential_initial(post, options)
+        post[:payment_information] ||= '0'
+        post[:issuer_id] ||= ''
+        if options[:stored_credential][:initiator] == 'merchant'
+          case options[:stored_credential][:reason_type]
+          when 'recurring', 'installment'
+            post[:payment_indicator] ||= 'R'
+          when 'unscheduled'
+            post[:payment_indicator] ||= 'C'
+          end
+        else
+          post[:payment_indicator] ||= 'C'
+        end
+      end
+
+      def add_stored_credential_used(post, options)
+        post[:payment_information] ||= '2'
+        post[:issuer_id] = options[:stored_credential][:network_transaction_id] if options[:issuer_id].blank?
+        if options[:stored_credential][:initiator] == 'merchant'
+          case options[:stored_credential][:reason_type]
+          when 'recurring', 'installment'
+            post[:payment_indicator] ||= 'R'
+          when '', 'unscheduled'
+            post[:payment_indicator] ||= 'U'
+          end
+        else
+          post[:payment_indicator] ||= 'Z'
+        end
       end
 
       # Common params used amongst the +credit+, +void+ and +capture+ methods

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -390,7 +390,187 @@ class MonerisTest < Test::Unit::TestCase
     assert @gateway.supports_scrubbing?
   end
 
+  def test_stored_credential_recurring_cit_initial
+    options = stored_credential_options(:cardholder, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_cit_used
+    options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_initial
+    options = stored_credential_options(:merchant, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_used
+    options = stored_credential_options(:merchant, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_initial
+    options = stored_credential_options(:cardholder, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_used
+    options = stored_credential_options(:cardholder, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_initial
+    options = stored_credential_options(:merchant, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_used
+    options = stored_credential_options(:merchant, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_initial
+    options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_used
+    options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_initial
+    options = stored_credential_options(:merchant, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_used
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>U<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_add_cof_overrides_stored_credential_option
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(issuer_id: 'xyz987', payment_indicator: 'R', payment_information: '0')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>xyz987<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
   private
+
+  def stored_credential_options(*args, id: nil)
+    {
+      order_id: '#1001',
+      description: 'AM test',
+      currency: 'CAD',
+      customer: '123',
+      stored_credential: stored_credential(*args, id: id),
+      issuer_id: ''
+    }
+  end
 
   def successful_purchase_response
     <<-RESPONSE


### PR DESCRIPTION
https://usa.visa.com/dam/VCOM/global/support-legal/documents/stored-credential-transaction-framework-vbs-10-may-17.pdf
https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Purchase

This change allows for the standardization of utilizing the stored credentials framework

1. VISA's stored credential transaction framework does not support 'recurring' nor 'installment' transactions
   for cardholder-initiated, thus passing the ':cardholder' option will default ':payment_indicator' to 'C' for
   initial transactions and to 'Z' for subsequent transactions.

2. The ':issuer_id', ':payment_indicator', and ':payment_information' options can still be passed directly and
   will override any values set by the ':stored_credential' options.

Unit:
50 tests, 266 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 199 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-422/ECS-780