### PR TITLE
BluePay: Allow setting DOC_TYPE in refund, credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * WorldPay: Add Cabal and Naranja remote tests [leila-alderman] #3378
 * Rubocop: Indentions [nfarve] #3383
 * Worldpay: Handle parse errors gracefully [curiousepic] #3380
+* BluePay: Add ability to pass doc_type in refunds and credits [britth] #3386
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -164,6 +164,7 @@ module ActiveMerchant #:nodoc:
         post[:PAYMENT_ACCOUNT] = ''
         post[:MASTER_ID]  = identification
         post[:TRANS_TYPE] = 'REFUND'
+        post[:DOC_TYPE] = options[:doc_type] if options[:doc_type]
         post[:NAME1] = options[:first_name] || ''
         post[:NAME2] = options[:last_name] if options[:last_name]
         post[:ZIP] = options[:zip] if options[:zip]
@@ -183,6 +184,7 @@ module ActiveMerchant #:nodoc:
         post[:PAYMENT_ACCOUNT] = ''
         add_payment_method(post, payment_object)
         post[:TRANS_TYPE] = 'CREDIT'
+        post[:DOC_TYPE] = options[:doc_type] if options[:doc_type]
 
         post[:NAME1] = options[:first_name] || ''
         post[:NAME2] = options[:last_name] if options[:last_name]

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -171,6 +171,24 @@ class BluePayTest < Test::Unit::TestCase
     ActiveMerchant::Billing::BluePayGateway.application_id = nil
   end
 
+  def test_successful_refund_with_check
+    assert response = @gateway.purchase(@amount, check, @options.merge(:email=>'foo@example.com'))
+    assert_success response
+    assert response.test?
+    assert_equal 'App ACH Sale', response.message
+    assert response.authorization
+
+    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(:doc_type=>'PPD'))
+    assert_success refund
+    assert_equal 'App ACH Void', refund.message
+  end
+
+  def test_successful_credit_with_check
+    assert credit = @gateway.credit(@amount, check, @options.merge(:doc_type=>'PPD'))
+    assert_success credit
+    assert_equal 'App ACH Credit', credit.message
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -18,6 +18,7 @@ class BluePayTest < Test::Unit::TestCase
     )
     @amount = 100
     @credit_card = credit_card
+    @check = check
     @rebill_id = '100096219669'
     @rebill_status = 'active'
     @options = {ip: '192.168.0.1'}
@@ -132,12 +133,13 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', @options.merge({:card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345'}))
+      @gateway.refund(50, '123456789', @options.merge({:card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345', :doc_type => 'WEB'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/NAME1=Bob/, data)
       assert_match(/NAME2=Smith/, data)
       assert_match(/ZIP=12345/, data)
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
+      assert_match(/DOC_TYPE=WEB/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -168,6 +170,16 @@ class BluePayTest < Test::Unit::TestCase
       assert_success response
       assert_equal 'This transaction has been approved', response.message
     end
+  end
+
+  def test_successful_credit_with_check
+    response = stub_comms do
+      @gateway.credit(50, @check, @options.merge({:doc_type => 'PPD'}))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/DOC_TYPE=PPD/, data)
+    end.respond_with(successful_credit_response)
+
+    assert_success response
   end
 
   def test_supported_countries
@@ -322,6 +334,10 @@ class BluePayTest < Test::Unit::TestCase
 
   def successful_status_recurring_response
     'last_date=2012-04-13%2009%3A49%3A27&usual_date=2012-04-13%2000%3A00%3A00&template_id=100096219668&status=active&account_id=100096218902&rebill_id=100096219669&reb_amount=2.00&creation_date=2012-04-13%2009%3A49%3A19&sched_expr=1%20DAY&next_date=2012-04-13%2000%3A00%3A00&next_amount=&user_id=100096218903&cycles_remain=4'
+  end
+
+  def successful_credit_response
+    'REBID=&AVS=_&TRANS_TYPE=CREDIT&STATUS=1&PAYMENT_ACCOUNT_MASK=C%3A244183602%3Axxxx8535&AUTH_CODE=&CARD_TYPE=ACH&MESSAGE=App%20ACH%20Credit&CVV2=_&TRANS_ID=100786598799'
   end
 
   def transcript


### PR DESCRIPTION
ACH refunds and credits [require DOC_TYPE to be set to PPD or CCD](https://www.bluepay.com/sites/default/files/documentation/BluePay_bp20post/Bluepay20post.txt)
to be processed successfully. This PR adds the ability to pass in
a specific DOC_TYPE in the request.

Remote:
17 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
27 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed