### PR TITLE
Visanet Peru: Add amount argument to Capture

### DIFF
--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       def purchase(amount, payment_method, options={})
         MultiResponse.run() do |r|
           r.process { authorize(amount, payment_method, options) }
-          r.process { capture(r.authorization, options) }
+          r.process { capture(amount, r.authorization, options) }
         end
       end
 
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         commit('authorize', params, options)
       end
 
-      def capture(authorization, options={})
+      def capture(amount, authorization, options={})
         params = {}
         options[:id_unico] = split_authorization(authorization)[1]
         add_auth_order_id(params, authorization, options)

--- a/test/remote/gateways/remote_visanet_peru_test.rb
+++ b/test/remote/gateways/remote_visanet_peru_test.rb
@@ -58,7 +58,7 @@ class RemoteVisanetPeruTest < Test::Unit::TestCase
     assert_equal @options[:order_id], response.params['externalTransactionId']
     assert_equal '1.00', response.params['data']['IMP_AUTORIZADO']
 
-    capture = @gateway.capture(response.authorization, @options)
+    capture = @gateway.capture(@amount, response.authorization, @options)
     assert_success capture
     assert_equal 'OK', capture.message
     assert capture.authorization
@@ -91,7 +91,7 @@ class RemoteVisanetPeruTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = @gateway.capture('900000044')
+    response = @gateway.capture(@amount, '900000044')
     assert_failure response
     assert_match(/NUMORDEN 900000044 no se encuentra registrado/, response.message)
     assert_equal 400, response.error_code

--- a/test/unit/gateways/visanet_peru_test.rb
+++ b/test/unit/gateways/visanet_peru_test.rb
@@ -67,7 +67,7 @@ class VisanetPeruTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).with(:post, any_parameters).returns(successful_authorize_response)
     @gateway.expects(:ssl_request).with(:put, any_parameters).returns(successful_capture_response)
     response = @gateway.authorize(@amount, @credit_card, @options)
-    capture = @gateway.capture(response.authorization, @options)
+    capture = @gateway.capture(@amount, response.authorization, @options)
     assert_success capture
     assert_equal 'OK', capture.message
     assert_match %r(^[0-9]{9}|$), capture.authorization
@@ -78,7 +78,7 @@ class VisanetPeruTest < Test::Unit::TestCase
   def test_failed_capture
     @gateway.expects(:ssl_request).returns(failed_capture_response)
     invalid_purchase_number = '900000044'
-    response = @gateway.capture(invalid_purchase_number)
+    response = @gateway.capture(@amount, invalid_purchase_number)
     assert_failure response
     assert_equal '[ "NUMORDEN 900000044 no se encuentra registrado", "No se realizo el deposito" ]', response.message
     assert_equal 400, response.error_code


### PR DESCRIPTION
Capture was initially implemented without an amount argument, this adds
it for the sake of standardization.

Remote tests are causing 500s with our latest test credentials, but I'm
comfortable with only unit tests since this is a fix which doesn't have
any logic behind it (we're not actually adding the amount to the
request - later we can add it to support partial captures).

Unit:
15 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed