### PR TITLE
Redsys: Check for non-3DS response before attempting 3DS parse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Rubocop: Layout/MultilineHashBraceLayout [nfarve] #3385
 * CardConnect: Always include additional_data in purchase [therufs] #3387
 * CardConnect: Add user_fields GSF [therufs] #3388
+* Redsys: Updates to parse method for non-3DS responses [britth] #3391
 
 == Version 1.99.0 (Sep 26, 2019)
 * Adyen: Add functionality to set 3DS exemptions via API [britth] #3331


### PR DESCRIPTION
Based on the Redsys docs, it seems that when you attempt 3DS but
3DS is not available, you will receive a direct response to your
request. Currently, we look under specific namespaces related to
the 3DS action step when performing 3DS, which would cause an error
if the service returned a direct response. This PR updates the
parse method to first look for the path //RETORNOXML/OPERACION
and if present (and successful), tries to parse the response.
Otherwise, we proceed to the 3DS specific parsing, or error
message if there was an issue.

Unfortunately, there's no way to test this in the Redsys sandbox,
but existing functionality appears in tact with this change.

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
36 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed