### PR TITLE
Add 3dsecure options for securionpay

### DIFF
--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -137,6 +137,9 @@ module ActiveMerchant #:nodoc:
           post[:metadata] = {}
           post[:metadata][:email] = options[:email]
         end
+        if options[:three_d_secure]
+          add_3d_secure_options(post, options)
+        end
         post
       end
 
@@ -173,6 +176,22 @@ module ActiveMerchant #:nodoc:
           post[:card][:addressZip] = address[:zip] if address[:zip]
           post[:card][:addressState] = address[:state] if address[:state]
           post[:card][:addressCity] = address[:city] if address[:city]
+        end
+      end
+
+      def add_3d_secure_options(post, options)
+        three_d_secure = options[:three_d_secure]
+        post[:threeDSecure] = {}
+
+        unless three_d_secure[:require_attempt].nil?
+          post[:threeDSecure][:requireAttempt] = three_d_secure[:require_attempt]
+        end
+        unless three_d_secure[:require_enrolled_card].nil?
+          post[:threeDSecure][:requireEnrolledCard] = three_d_secure[:require_enrolled_card]
+        end
+        unless three_d_secure[:require_successful_liability_shift_for_enrolled_card].nil?
+          post[:threeDSecure][:requireSuccessfulLiabilityShiftForEnrolledCard] =
+            three_d_secure[:require_successful_liability_shift_for_enrolled_card]
         end
       end
 
@@ -213,11 +232,11 @@ module ActiveMerchant #:nodoc:
         return nil unless params
 
         params.map do |key, value|
-          next if value.blank?
+          next if value.to_s.blank?
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|
-              h["#{key}[#{k}]"] = v unless v.blank?
+              h["#{key}[#{k}]"] = v unless v.to_s.blank?
             end
             post_data(h)
           elsif value.is_a?(Array)

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -86,7 +86,18 @@ class SecurionPayTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({ description: 'test charge', ip: '127.127.127.127', user_agent: 'browser XXX', referrer: 'http://www.foobar.com', email: 'foo@bar.com' })
+      updated_options = @options.merge({
+        description: 'test charge',
+        ip: '127.127.127.127',
+        user_agent: 'browser XXX',
+        referrer: 'http://www.foobar.com',
+        email: 'foo@bar.com',
+        three_d_secure: {
+          require_attempt: true,
+          require_enrolled_card: true,
+          require_successful_liability_shift_for_enrolled_card: false
+        }
+      })
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/description=test\+charge/, data)
@@ -94,6 +105,9 @@ class SecurionPayTest < Test::Unit::TestCase
       assert_match(/user_agent=browser\+XXX/, data)
       assert_match(/referrer=http\%3A\%2F\%2Fwww\.foobar\.com/, data)
       assert_match(/metadata\[email\]=foo\%40bar\.com/, data)
+      assert_match(/threeDSecure\[requireAttempt\]=true/, data)
+      assert_match(/threeDSecure\[requireEnrolledCard\]=true/, data)
+      assert_match(/threeDSecure\[requireSuccessfulLiabilityShiftForEnrolledCard\]=false/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
- Add SecurionPay threeDSecure options in charge action.
DOCS => https://securionpay.com/docs/api#charge-create

- allow pass boolean options values. post_data(params) method was skipping options with boolean values
