### PR TITLE
Add 3DS2 Support to Netbanx

### DIFF
--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -132,6 +132,11 @@ module ActiveMerchant #:nodoc:
         if options[:billing_address]
           post[:card][:billingAddress]  = map_address(options[:billing_address])
         end
+
+        if options[:authentication]
+          post[:authentication]  = map_3ds(options[:authentication]) if options[:authentication]
+        end
+
       end
 
       def add_invoice(post, money, options)
@@ -151,6 +156,7 @@ module ActiveMerchant #:nodoc:
 
         post[:currencyCode] = options[:currency] if options[:currency]
         post[:billingDetails]  = map_address(options[:billing_address]) if options[:billing_address]
+        post[:authentication]  = map_3ds(options[:authentication]) if options[:authentication]
       end
 
       def expdate(credit_card)
@@ -175,6 +181,18 @@ module ActiveMerchant #:nodoc:
           :state  => address[:state],
         }
         mapped[:country] = country.code(:alpha2).value unless country.blank?
+
+        mapped
+      end
+
+      def map_3ds(three_d_secure_options)
+        mapped = {
+          :eci => three_d_secure_options[:eci],
+          :cavv => three_d_secure_options[:cavv],
+          :threeDResult => three_d_secure_options[:threeDResult],
+          :threeDSecureVersion => three_d_secure_options[:threeDSecureVersion],
+          :directoryServerTransactionId => three_d_secure_options[:directoryServerTransactionId]
+        }
 
         mapped
       end

--- a/test/remote/gateways/remote_netbanx_test.rb
+++ b/test/remote/gateways/remote_netbanx_test.rb
@@ -11,6 +11,17 @@ class RemoteNetbanxTest < Test::Unit::TestCase
       description: 'Store Purchase',
       currency: 'CAD'
     }
+
+    @options_3ds2 = @options.merge(
+      authentication: {
+        eci: '05',
+        cavv: 'AAABCIEjYgAAAAAAlCNiENiWiV+=',
+        threeDResult: "Y",
+        threeDSecureVersion: '2.1.0',
+        directoryServerTransactionId: 'a3a721f3-b6fa-4cb5-84ea-c7b5c39890a2'
+      }
+    )
+
   end
 
   def test_successful_purchase
@@ -29,6 +40,13 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)
+    assert_equal 'OK', response.message
+    assert_equal response.authorization, response.params['id']
+  end
+
+  def test_successful_purchase_with_3ds2_auth
+    assert response = @gateway.purchase(@amount, @credit_card, @options_3ds2)
+    assert_success response
     assert_equal 'OK', response.message
     assert_equal response.authorization, response.params['id']
   end
@@ -71,6 +89,15 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     response = @gateway.capture(@amount, SecureRandom.uuid)
     assert_failure response
     assert_equal 'The authorization ID included in this settlement request could not be found.', response.message
+  end
+
+  def test_successful_authorize_and_capture_with_3ds2_auth
+    auth = @gateway.authorize(@amount, @credit_card, @options_3ds2)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options_3ds2)
+    assert_success capture
+    assert_equal 'OK', capture.message
   end
 
   # def test_successful_refund
@@ -202,4 +229,5 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'OK', response.message
   end
+
 end


### PR DESCRIPTION

Adds Netbanx threeDSecure options to _add payment_ and _add credit card,_ as per request from Paysafe. 
