### PR TITLE
CE-136: Ixopay purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w(AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW)
       self.default_currency = 'EUR'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
 
       self.homepage_url = 'https://www.ixopay.com'
       self.display_name = 'Ixopay'
@@ -23,18 +23,22 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, payment_method, options={})
         # todo
+        # commit('authorize', build_authorize_request(money, payment_method, options), options)
       end
 
       def capture(money, authorization, options={})
         # todo
+        # commit('capture', build_capture_request(money, payment_method, options), options)
       end
 
       def refund(money, authorization, options={})
         # todo
+        # commit('refund', build_refund_request(money, payment_method, options), options)
       end
 
       def void(authorization, options={})
         # todo
+        # commit('void', build_void_request(money, payment_method, options), options)
       end
 
       def verify(credit_card, options={})

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -82,6 +82,7 @@ module ActiveMerchant #:nodoc:
         parse_element({:action => action}, REXML::Document.new(xml))
       end
 
+      # todo
       # This generic method appears in a number of gateways that parse XML.
       # In the future, we should investigate finding a library method to
       # drop in, or factoring it out to a module or base class.
@@ -235,7 +236,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
-        response[:reference_id] ? response[:reference_id] + '|' + response[:purchase_id] : nil
+        response[:reference_id] ? "#{response[:reference_id]}|#{response[:purchase_id]}" : nil
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -104,18 +104,6 @@ module ActiveMerchant #:nodoc:
         builder.to_xml
       end
 
-      def build_purchase_request(money, payment_method, options)
-        xml = Builder::XmlMarkup.new(indent: 2)
-
-        xml.transactionWithCard 'xmlns' => 'http://secure.ixopay.com/Schema/V2/TransactionWithCard' do
-          xml.username @options[:username]
-          xml.password Digest::SHA1.hexdigest(@options[:password])
-
-          add_card_data(xml, payment_method)
-          add_debit(xml, money, options)
-        end
-      end
-
       def add_card_data(xml, payment_method)
         xml.cardData do
           xml.cardHolder      payment_method.name

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -107,86 +107,85 @@ module ActiveMerchant #:nodoc:
       def build_purchase_request(money, payment_method, options)
         xml = Builder::XmlMarkup.new(indent: 2)
 
-        xml.instruct! :xml
+        xml.transactionWithCard 'xmlns' => 'http://secure.ixopay.com/Schema/V2/TransactionWithCard' do
+          xml.username @options[:username]
+          xml.password Digest::SHA1.hexdigest(@options[:password])
 
-        xml.tag! 'transactionWithCard', 'xmlns' => 'http://secure.ixopay.com/Schema/V2/TransactionWithCard' do
-          xml.tag! 'username', @options[:username]
-          xml.tag! 'password', Digest::SHA1.hexdigest(@options[:password])
           add_card_data(xml, payment_method)
           add_debit(xml, money, options)
         end
-
-        xml.target!
       end
 
       def add_card_data(xml, payment_method)
-        xml.tag! 'cardData' do
-          xml.tag! 'cardHolder', payment_method.name
-          xml.tag! 'pan', payment_method.number
-          xml.tag! 'cvv', payment_method.verification_value
-          xml.tag! 'expirationMonth', format(payment_method.month, :two_digits)
-          xml.tag! 'expirationYear', format(payment_method.year, :four_digits)
+        xml.cardData do
+          xml.cardHolder      payment_method.name
+          xml.pan             payment_method.number
+          xml.cvv             payment_method.verification_value
+          xml.expirationMonth format(payment_method.month, :two_digits)
+          xml.expirationYear  format(payment_method.year, :four_digits)
         end
       end
 
       def add_debit(xml, money, options)
-        currency = options[:currency] || currency(money)
+        currency    = options[:currency] || currency(money)
         description = options[:description].blank? ? 'Purchase' : options[:description]
 
-        xml.tag! 'debit' do
-          xml.tag! 'transactionId', new_transaction_id
+        xml.debit do
+          xml.transactionId new_transaction_id
+
           add_customer_data(xml, options)
-          xml.tag! 'amount', money
-          xml.tag! 'currency', currency
-          xml.tag! 'description', description
-          xml.tag! 'callbackUrl', options[:callback_url] || 'http://example.com'
+
+          xml.amount      money
+          xml.currency    currency
+          xml.description description
+          xml.callbackUrl(options[:callback_url] || 'http://example.com')
         end
       end
 
       def add_customer_data(xml, options)
         # Ixopay returns an error if the elements are not added in the order used here.
-        xml.tag! 'customer' do
+        xml.customer do
           add_billing_address(xml,  options[:billing_address])  if options[:billing_address]
           add_shipping_address(xml, options[:shipping_address]) if options[:shipping_address]
 
           if options.dig(:billing_address, :company)
-            xml.tag! 'company', options[:billing_address][:company]
+            xml.company options[:billing_address][:company]
           end
 
-          xml.tag! 'email', options[:email]
-          xml.tag! 'ipAddress', options[:ip] || '127.0.0.1'
+          xml.email options[:email]
+          xml.ipAddress(options[:ip] || '127.0.0.1')
         end
       end
 
       def add_billing_address(xml, address)
         if address[:name]
-          xml.tag! 'firstName', split_names(address[:name])[0]
-          xml.tag! 'lastName',  split_names(address[:name])[1]
+          xml.firstName split_names(address[:name])[0]
+          xml.lastName  split_names(address[:name])[1]
         end
 
-        xml.tag! 'billingAddress1', address[:address1]
-        xml.tag! 'billingAddress2', address[:address2]
-        xml.tag! 'billingCity',     address[:city]
-        xml.tag! 'billingPostcode', address[:zip]
-        xml.tag! 'billingState',    address[:state]
-        xml.tag! 'billingCountry',  address[:country]
-        xml.tag! 'billingPhone',    address[:phone]
+        xml.billingAddress1 address[:address1]
+        xml.billingAddress2 address[:address2]
+        xml.billingCity     address[:city]
+        xml.billingPostcode address[:zip]
+        xml.billingState    address[:state]
+        xml.billingCountry  address[:country]
+        xml.billingPhone    address[:phone]
       end
 
       def add_shipping_address(xml, address)
         if address[:name]
-          xml.tag! 'shippingFirstName', split_names(address[:name])[0]
-          xml.tag! 'shippingLastName',  split_names(address[:name])[1]
+          xml.shippingFirstName split_names(address[:name])[0]
+          xml.shippingLastName  split_names(address[:name])[1]
         end
 
-        xml.tag! 'shippingCompany',   address[:company]
-        xml.tag! 'shippingAddress1',  address[:address1]
-        xml.tag! 'shippingAddress2',  address[:address2]
-        xml.tag! 'shippingCity',      address[:city]
-        xml.tag! 'shippingPostcode',  address[:zip]
-        xml.tag! 'shippingState',     address[:state]
-        xml.tag! 'shippingCountry',   address[:country]
-        xml.tag! 'shippingPhone',     address[:phone]
+        xml.shippingCompany   address[:company]
+        xml.shippingAddress1  address[:address1]
+        xml.shippingAddress2  address[:address2]
+        xml.shippingCity      address[:city]
+        xml.shippingPostcode  address[:zip]
+        xml.shippingState     address[:state]
+        xml.shippingCountry   address[:country]
+        xml.shippingPhone     address[:phone]
       end
 
       def new_transaction_id

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -71,14 +71,11 @@ module ActiveMerchant #:nodoc:
 
       def generate_signature(http_method, xml, timestamp)
         content_type = 'text/xml; charset=utf-8'
-
-        message = http_method + "\n" + Digest::MD5.hexdigest(xml) + "\n" + content_type + "\n" \
-          + timestamp + "\n\n" + '/transaction'
-
+        message = "#{http_method}\n#{Digest::MD5.hexdigest(xml)}\n#{content_type}\n#{timestamp}\n\n/transaction"
         digest = OpenSSL::Digest.new('sha512')
         hmac = OpenSSL::HMAC.digest(digest, @secret, message)
 
-        Base64.encode64(hmac).split.join
+        Base64.encode64(hmac).delete("\n")
       end
 
       def parse(action, xml)
@@ -110,7 +107,7 @@ module ActiveMerchant #:nodoc:
       def build_purchase_request(money, payment_method, options)
         xml = Builder::XmlMarkup.new(indent: 2)
 
-        xml.instruct! :xml, encoding: 'utf-8'
+        xml.instruct! :xml
 
         xml.tag! 'transactionWithCard', 'xmlns' => 'http://secure.ixopay.com/Schema/V2/TransactionWithCard' do
           xml.tag! 'username', @options[:username]

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -214,7 +214,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_from_request_error(action, error)
-        puts "*** Error"
         response = parse(action, error.response.body)
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -1,31 +1,28 @@
+require 'pp'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class IxopayGateway < Gateway
-      self.test_url = 'https://example.com/test'
-      self.live_url = 'https://example.com/live'
+      self.test_url = 'https://secure.ixopay.com/transaction'
+      self.live_url = 'https://secure.ixopay.com/transaction'
 
       self.supported_countries = ['US']
-      self.default_currency = 'USD'
+      self.default_currency = 'EUR'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
-      self.homepage_url = 'http://www.example.net/'
-      self.display_name = 'New Gateway'
+      self.homepage_url = 'https://www.ixopay.com'
+      self.display_name = 'Ixopay'
 
       STANDARD_ERROR_CODE_MAPPING = {}
 
       def initialize(options={})
-        requires!(options, :some_credential, :another_credential)
+        requires!(options, :username, :password, :secret)
+        @secret = options[:secret]
         super
       end
 
-      def purchase(money, payment, options={})
-        post = {}
-        add_invoice(post, money, options)
-        add_payment(post, payment)
-        add_address(post, payment, options)
-        add_customer_data(post, options)
-
-        commit('sale', post)
+      def purchase(money, payment_method, options={})
+        commit('purchase', build_purchase_request(money, payment_method, options), options)
       end
 
       def authorize(money, payment, options={})
@@ -67,7 +64,26 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def add_customer_data(post, options)
+      def headers(xml)
+        timestamp = Time.now.httpdate
+
+        signature = generate_signature('POST', xml, timestamp)
+
+        {
+          'Authorization' => "Gateway #{options[:api_key]}:#{signature}",
+          'Date' => timestamp,
+          'Content-Type' => 'text/xml; charset=utf-8'
+        }
+      end
+
+      def generate_signature(http_method, xml, timestamp)
+        content_type = 'text/xml; charset=utf-8'
+        message = http_method + "\n" + Digest::MD5.hexdigest(xml) + "\n" + content_type + "\n" + timestamp + "\n\n" + '/transaction'
+
+        digest = OpenSSL::Digest.new('sha512')
+        hmac = OpenSSL::HMAC.digest(digest, @secret, message)
+
+        Base64.encode64(hmac).split.join
       end
 
       def add_address(post, creditcard, options)
@@ -81,41 +97,129 @@ module ActiveMerchant #:nodoc:
       def add_payment(post, payment)
       end
 
-      def parse(body)
-        {}
+      def parse(action, xml)
+        parse_element({:action => action}, REXML::Document.new(xml))
       end
 
-      def commit(action, parameters)
+      def parse_element(raw, node)
+        node_name = node.name.underscore
+        node.attributes.each do |k, v|
+          raw["#{node_name}_#{k.underscore}".to_sym] = v
+        end
+        if node.has_elements?
+          raw[node_name.to_sym] = true unless node.name.blank?
+          node.elements.each { |e| parse_element(raw, e) }
+        elsif node.children.count > 1
+          raw[node_name.to_sym] = node.children.join(' ').strip
+        else
+          raw[node_name.to_sym] = node.text unless node.text.nil?
+        end
+        raw
+      end
+
+      def build_purchase_request(money, payment_method, options)
+        xml = Builder::XmlMarkup.new(indent: 2)
+
+        xml.instruct! :xml, encoding: 'utf-8'
+
+        xml.tag! 'transactionWithCard', 'xmlns' => "http://secure.ixopay.com/Schema/V2/TransactionWithCard" do
+          xml.tag! 'username', @options[:username]
+          xml.tag! 'password', Digest::SHA1.hexdigest(@options[:password])
+          add_card_data(xml, payment_method)
+          add_debit(xml, money, options)
+        end
+
+        xml.target!
+      end
+
+      def add_card_data(xml, payment_method)
+        xml.tag! 'cardData' do
+          xml.tag! 'cardHolder', payment_method.name
+          xml.tag! 'pan', payment_method.number
+          xml.tag! 'cvv', payment_method.verification_value
+          xml.tag! 'expirationMonth', format(payment_method.month, :two_digits)
+          xml.tag! 'expirationYear', format(payment_method.year, :four_digits)
+        end
+      end
+
+      def add_debit(xml, money, options)
+        currency = options[:currency] || currency(money)
+        description = options[:description].blank? ? 'Purchase' : options[:description]
+
+        xml.tag! 'debit' do
+          xml.tag! 'transactionId', new_transaction_id
+          add_customer_data(xml, options)
+          xml.tag! 'amount', money
+          xml.tag! 'currency', currency
+          xml.tag! 'description', description
+          xml.tag! 'successUrl', 'http://example.com'
+          xml.tag! 'callbackUrl', options[:callback_url] || 'http://example.com'
+        end
+      end
+
+      def add_customer_data(xml, options)
+        xml.tag! 'customer' do
+          options[:customer].each do |attribute, value|
+            xml.tag! attribute.to_s.camelize(:lower), value
+          end
+
+          #xml.tag! 'ipAddress', '127.0.0.1'
+        end
+      end
+
+      def new_transaction_id
+        SecureRandom.uuid
+      end
+
+      def commit(action, request, options={})
         url = (test? ? test_url : live_url)
-        response = parse(ssl_post(url, post_data(action, parameters)))
+
+        begin
+          raw_response = ssl_post(url, request, headers(request))
+        rescue StandardError => e
+          return response_from_request_error(action, e)
+        end
+
+        response = parse(action, raw_response)
 
         Response.new(
           success_from(response),
           message_from(response),
           response,
           authorization: authorization_from(response),
-          avs_result: AVSResult.new(code: response["some_avs_response_key"]),
-          cvv_result: CVVResult.new(response["some_cvv_response_key"]),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def response_from_request_error(action, e)
+        response = parse(action, e.response.body)
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
           test: test?,
           error_code: error_code_from(response)
         )
       end
 
       def success_from(response)
+        response[:success] == 'true'
       end
 
       def message_from(response)
+        response[:message] || response[:return_type]
       end
 
       def authorization_from(response)
-      end
-
-      def post_data(action, parameters = {})
+        response[:reference_id] ? response[:reference_id] + '|' + response[:purchase_id] : nil
       end
 
       def error_code_from(response)
         unless success_from(response)
-          # TODO: lookup error code for this response
+          response[:code]
         end
       end
     end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -444,8 +444,10 @@ iveri:
   app_id: d10a603d-4ade-405b-93f1-826dfc0181e8
 
 ixopay:
-  some_credential: SOMECREDENTIAL
-  another_credential: ANOTHERCREDENTIAL
+  username: USERNAME
+  api_key: API_KEY
+  password: PASSWORD
+  secret: SHARED_SECRET
 
 jetpay:
   login: TESTTERMINAL

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -41,7 +41,6 @@ class RemoteIxopayTest < Test::Unit::TestCase
 
     assert_failure response
     assert_equal 'The transaction was declined', response.message
-    assert_equal '2003', response.params['code']
     assert_equal '2003', response.error_code
   end
 

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -22,10 +22,10 @@ class RemoteIxopayTest < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'FINISHED', response.message
-    assert_match /[0-9a-zA-Z]+(|[0-9a-zA-Z]+)*/, response.authorization
+    assert_match(/[0-9a-zA-Z]+(|[0-9a-zA-Z]+)*/, response.authorization)
 
     assert_equal @credit_card.name,           response.params['card_holder']
-    assert_equal "%02d" % @credit_card.month, response.params['expiry_month']
+    assert_equal '%02d' % @credit_card.month, response.params['expiry_month']
     assert_equal @credit_card.year.to_s,      response.params['expiry_year']
     assert_equal @credit_card.number[0..5],   response.params['first_six_digits']
     assert_equal 'FINISHED',                  response.params['return_type']

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -45,6 +45,8 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture
+    omit "Not yet implemented"
+
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
@@ -54,12 +56,16 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
+    omit "Not yet implemented"
+
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'REPLACE WITH FAILED AUTHORIZE MESSAGE', response.message
   end
 
   def test_partial_capture
+    omit "Not yet implemented"
+
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
@@ -68,12 +74,16 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
+    omit "Not yet implemented"
+
     response = @gateway.capture(@amount, '')
     assert_failure response
     assert_equal 'REPLACE WITH FAILED CAPTURE MESSAGE', response.message
   end
 
   def test_successful_refund
+    omit "Not yet implemented"
+
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
@@ -83,6 +93,8 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_partial_refund
+    omit "Not yet implemented"
+
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
@@ -91,12 +103,16 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
+    omit "Not yet implemented"
+
     response = @gateway.refund(@amount, '')
     assert_failure response
     assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
   end
 
   def test_successful_void
+    omit "Not yet implemented"
+
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
@@ -106,24 +122,32 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_void
+    omit "Not yet implemented"
+
     response = @gateway.void('')
     assert_failure response
     assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
   end
 
   def test_successful_verify
+    omit "Not yet implemented"
+
     response = @gateway.verify(@credit_card, @options)
     assert_success response
     assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
   end
 
   def test_failed_verify
+    omit "Not yet implemented"
+
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
     assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
   end
 
   def test_invalid_login
+    omit "Not yet implemented"
+
     gateway = IxopayGateway.new(login: '', password: '')
 
     response = gateway.purchase(@amount, @credit_card, @options)
@@ -132,6 +156,8 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_dump_transcript
+    omit "Not yet implemented"
+
     # This test will run a purchase transaction on your gateway
     # and dump a transcript of the HTTP conversation so that
     # you can use that transcript as a reference while
@@ -141,6 +167,8 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
+    omit "Not yet implemented"
+
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)
     end

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -24,13 +24,12 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_equal 'FINISHED', response.message
     assert_match(/[0-9a-zA-Z]+(|[0-9a-zA-Z]+)*/, response.authorization)
 
-    assert_equal @credit_card.name,           response.params['card_holder']
-    assert_equal '%02d' % @credit_card.month, response.params['expiry_month']
-    assert_equal @credit_card.year.to_s,      response.params['expiry_year']
-    assert_equal @credit_card.number[0..5],   response.params['first_six_digits']
+    assert_equal @credit_card.name,           response.params.dig('return_data', 'creditcard_data', 'card_holder')
+    assert_equal '%02d' % @credit_card.month, response.params.dig('return_data', 'creditcard_data', 'expiry_month')
+    assert_equal @credit_card.year.to_s,      response.params.dig('return_data', 'creditcard_data', 'expiry_year')
+    assert_equal @credit_card.number[0..5],   response.params.dig('return_data', 'creditcard_data', 'first_six_digits')
+    assert_equal @credit_card.number.split(//).last(4).join, response.params.dig('return_data', 'creditcard_data', 'last_four_digits')
     assert_equal 'FINISHED',                  response.params['return_type']
-
-    assert_equal @credit_card.number.split(//).last(4).join, response.params['last_four_digits']
 
     assert_not_nil response.params['purchase_id']
     assert_not_nil response.params['reference_id']

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -42,10 +42,11 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'The transaction was declined', response.message
     assert_equal '2003', response.params['code']
+    assert_equal '2003', response.error_code
   end
 
   def test_successful_authorize_and_capture
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
@@ -56,7 +57,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
@@ -64,7 +65,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_partial_capture
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
@@ -74,7 +75,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.capture(@amount, '')
     assert_failure response
@@ -82,7 +83,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -93,7 +94,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_partial_refund
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -103,7 +104,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.refund(@amount, '')
     assert_failure response
@@ -111,7 +112,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
@@ -122,7 +123,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.void('')
     assert_failure response
@@ -130,7 +131,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.verify(@credit_card, @options)
     assert_success response
@@ -138,7 +139,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
@@ -146,7 +147,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     gateway = IxopayGateway.new(login: '', password: '')
 
@@ -156,7 +157,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_dump_transcript
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     # This test will run a purchase transaction on your gateway
     # and dump a transcript of the HTTP conversation so that
@@ -167,7 +168,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    omit "Not yet implemented"
+    omit 'Not yet implemented'
 
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -72,7 +72,7 @@ class IxopayTest < Test::Unit::TestCase
 
   def test_scrub
     assert @gateway.supports_scrubbing?
-    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+    # assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
   private

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -37,38 +37,27 @@ class IxopayTest < Test::Unit::TestCase
     assert_equal '2003', response.error_code
   end
 
-  def test_successful_authorize
-  end
+  def test_successful_authorize; end
 
-  def test_failed_authorize
-  end
+  def test_failed_authorize; end
 
-  def test_successful_capture
-  end
+  def test_successful_capture; end
 
-  def test_failed_capture
-  end
+  def test_failed_capture; end
 
-  def test_successful_refund
-  end
+  def test_successful_refund; end
 
-  def test_failed_refund
-  end
+  def test_failed_refund; end
 
-  def test_successful_void
-  end
+  def test_successful_void; end
 
-  def test_failed_void
-  end
+  def test_failed_void; end
 
-  def test_successful_verify
-  end
+  def test_successful_verify; end
 
-  def test_successful_verify_with_failed_void
-  end
+  def test_successful_verify_with_failed_void; end
 
-  def test_failed_verify
-  end
+  def test_failed_verify; end
 
   def test_scrub
     assert @gateway.supports_scrubbing?
@@ -78,19 +67,19 @@ class IxopayTest < Test::Unit::TestCase
   private
 
   def pre_scrubbed
-    %q(
-      Run the remote tests for this gateway, and then put the contents of transcript.log here.
-    )
+    #  %q(
+    #    Run the remote tests for this gateway, and then put the contents of transcript.log here.
+    #  )
   end
 
   def post_scrubbed
-    %q(
-      Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
-      Things to scrub:
-        - Credit card number
-        - CVV
-        - Sensitive authentication details
-    )
+    #  %q(
+    #    Put the scrubbed contents of transcript.log here after implementing your scrubbing function.
+    #    Things to scrub:
+    #      - Credit card number
+    #      - CVV
+    #      - Sensitive authentication details
+    #  )
   end
 
   def successful_purchase_response
@@ -148,27 +137,19 @@ class IxopayTest < Test::Unit::TestCase
     XML
   end
 
-  def successful_authorize_response
-  end
+  def successful_authorize_response; end
 
-  def failed_authorize_response
-  end
+  def failed_authorize_response; end
 
-  def successful_capture_response
-  end
+  def successful_capture_response; end
 
-  def failed_capture_response
-  end
+  def failed_capture_response; end
 
-  def successful_refund_response
-  end
+  def successful_refund_response; end
 
-  def failed_refund_response
-  end
+  def failed_refund_response; end
 
-  def successful_void_response
-  end
+  def successful_void_response; end
 
-  def failed_void_response
-  end
+  def failed_void_response; end
 end


### PR DESCRIPTION
This pull request implements the Ixopay purchase action. It also includes skeleton code for additional work.

What's working:
* ```ruby -I test test/remote/gateways/remote_ixopay_test.rb -n test_successful_purchase```
* ```ruby -I test test/remote/gateways/remote_ixopay_test.rb -n test_failed_purchase```
* ```ruby -I test test/unit/gateways/ixopay_test.rb -n test_successful_purchase```
* ```ruby -I test test/unit/gateways/ixopay_test.rb -n test_failed_purchase```

The diff displayed here is relative to the initial code provided by running ```script/generate gateway ixopay```.

I'm planning a live review session for this code, but am opening the PR now for visibility.

Baseline: https://github.com/activemerchant/active_merchant/compare/ixopay_integration#diff-51a89ecca18e8620ad6cb8e059787833
