### PR TITLE
Quickbooks: Add OAuth 2.0 support, support void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * CyberSource: Send issuer data on capture [leila-alderman] #3404
 * Rubocop: Layout/RescueEnsureAlignment fix [leila-alderman] #3411
 * Credorax: Stop always sending r1 parameter [molbrown] #3415
+* Quickbooks: Add OAuth 2.0 support and void action [britth] #3397
 
 == Version 1.100.0 (Oct 16, 2019)
 * Stripe: Restore non-auto capture behaviour for card present transactions [PatrickFang] #3258

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -10,13 +10,10 @@ module ActiveMerchant #:nodoc:
 
       self.homepage_url = 'http://payments.intuit.com'
       self.display_name = 'QuickBooks Payments'
-      ENDPOINT =  '/quickbooks/v4/payments/charges'
-      OAUTH_ENDPOINTS = {
-        site: 'https://oauth.intuit.com',
-        request_token_path: '/oauth/v1/get_request_token',
-        authorize_url: 'https://appcenter.intuit.com/Connect/Begin',
-        access_token_path: '/oauth/v1/get_access_token'
-      }
+      BASE = '/quickbooks/v4/payments'
+      ENDPOINT =  "#{BASE}/charges"
+      VOID_ENDPOINT = "#{BASE}/txn-requests"
+      REFRESH_URI = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
 
       # https://developer.intuit.com/docs/0150_payments/0300_developer_guides/error_handling
 
@@ -51,7 +48,15 @@ module ActiveMerchant #:nodoc:
       FRAUD_WARNING_CODES = ['PMT-1000', 'PMT-1001', 'PMT-1002', 'PMT-1003']
 
       def initialize(options = {})
-        requires!(options, :consumer_key, :consumer_secret, :access_token, :token_secret, :realm)
+        # Quickbooks is deprecating OAuth 1.0 on December 17, 2019.
+        # OAuth 2.0 requires a client_id, client_secret, access_token, and refresh_token
+        # To maintain backwards compatibility, check for the presence of a refresh_token (only specified for OAuth 2.0)
+        # When present, validate that all OAuth 2.0 options are present
+        if options[:refresh_token]
+          requires!(options, :client_id, :client_secret, :access_token, :refresh_token)
+        else
+          requires!(options, :consumer_key, :consumer_secret, :access_token, :token_secret, :realm)
+        end
         @options = options
         super
       end
@@ -62,7 +67,8 @@ module ActiveMerchant #:nodoc:
         add_charge_data(post, payment, options)
         post[:capture] = 'true'
 
-        commit(ENDPOINT, post)
+        response = commit(ENDPOINT, post)
+        check_token_response(response, ENDPOINT, post)
       end
 
       def authorize(money, payment, options = {})
@@ -71,24 +77,35 @@ module ActiveMerchant #:nodoc:
         add_charge_data(post, payment, options)
         post[:capture] = 'false'
 
-        commit(ENDPOINT, post)
+        response = commit(ENDPOINT, post)
+        check_token_response(response, ENDPOINT, post)
       end
 
       def capture(money, authorization, options = {})
         post = {}
-        capture_uri = "#{ENDPOINT}/#{CGI.escape(authorization)}/capture"
+        authorization, _ = split_authorization(authorization)
         post[:amount] = localized_amount(money, currency(money))
         add_context(post, options)
 
-        commit(capture_uri, post)
+        response = commit(capture_uri(authorization), post)
+        check_token_response(response, capture_uri(authorization), post)
       end
 
       def refund(money, authorization, options = {})
         post = {}
         post[:amount] = localized_amount(money, currency(money))
         add_context(post, options)
+        authorization, _ = split_authorization(authorization)
 
-        commit(refund_uri(authorization), post)
+        response = commit(refund_uri(authorization), post)
+        check_token_response(response, refund_uri(authorization), post)
+      end
+
+      def void(authorization, options = {})
+        _, request_id = split_authorization(authorization)
+
+        response = commit(void_uri(request_id))
+        check_token_response(response, void_uri(request_id))
       end
 
       def verify(credit_card, options = {})
@@ -107,7 +124,12 @@ module ActiveMerchant #:nodoc:
           gsub(%r((oauth_signature=\")[a-zA-Z%0-9]+), '\1[FILTERED]').
           gsub(%r((oauth_token=\")\w+), '\1[FILTERED]').
           gsub(%r((number\D+)\d{16}), '\1[FILTERED]').
-          gsub(%r((cvc\D+)\d{3}), '\1[FILTERED]')
+          gsub(%r((cvc\D+)\d{3}), '\1[FILTERED]').
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((access_token\\?":\\?")[\w\-\.]+)i, '\1[FILTERED]').
+          gsub(%r((refresh_token\\?":\\?")\w+), '\1[FILTERED]').
+          gsub(%r((refresh_token=)\w+), '\1[FILTERED]').
+          gsub(%r((Authorization: Bearer )[\w\-\.]+)i, '\1[FILTERED]\2')
       end
 
       private
@@ -170,31 +192,30 @@ module ActiveMerchant #:nodoc:
         # The QuickBooks API returns HTTP 4xx on failed transactions, which causes a
         # ResponseError raise, so we have to inspect the response and discern between
         # a legitimate HTTP error and an actual gateway transactional error.
+        headers = {}
         response =
           begin
-            case method
-            when :post
-              ssl_post(endpoint, post_data(body), headers(:post, endpoint))
-            when :get
-              ssl_request(:get, endpoint, nil, headers(:get, endpoint))
-            else
-              raise ArgumentError, "Invalid HTTP method: #{method}. Valid methods are :post and :get"
-            end
+            headers = headers(method, endpoint)
+            method == :post ? ssl_post(endpoint, post_data(body), headers) : ssl_request(:get, endpoint, nil, headers)
           rescue ResponseError => e
             extract_response_body_or_raise(e)
           end
 
-        response_object(response)
+        response_object(response, headers)
       end
 
-      def response_object(raw_response)
+      def response_object(raw_response, headers = {})
         parsed_response = parse(raw_response)
+
+        # Include access_token and refresh_token in params for OAuth 2.0
+        parsed_response['access_token'] = @options[:access_token] if @options[:refresh_token]
+        parsed_response['refresh_token'] = @options[:refresh_token] if @options[:refresh_token]
 
         Response.new(
           success?(parsed_response),
           message_from(parsed_response),
           parsed_response,
-          authorization: authorization_from(parsed_response),
+          authorization: authorization_from(parsed_response, headers),
           test: test?,
           cvv_result: cvv_code_from(parsed_response),
           error_code: errors_from(parsed_response),
@@ -211,6 +232,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers(method, uri)
+        return oauth_v2_headers if @options[:refresh_token]
+
         raise ArgumentError, "Invalid HTTP method: #{method}. Valid methods are :post and :get" unless [:post, :get].include?(method)
         request_uri = URI.parse(uri)
 
@@ -244,6 +267,42 @@ module ActiveMerchant #:nodoc:
         }
       end
 
+      def oauth_v2_headers
+        {
+          'Content-Type'      => 'application/json',
+          'Request-Id'        => generate_unique_id,
+          'Accept'            => 'application/json',
+          'Authorization'     => "Bearer #{@options[:access_token]}"
+        }
+      end
+
+      def check_token_response(response, endpoint, body = {})
+        return response unless @options[:refresh_token]
+        return response unless response.params['code'] == 'AuthenticationFailed'
+        refresh_access_token
+        commit(endpoint, body)
+      end
+
+      def refresh_access_token
+        post = {}
+        post[:grant_type] = 'refresh_token'
+        post[:refresh_token] = @options[:refresh_token]
+        data = post.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+
+        basic_auth = Base64.strict_encode64("#{@options[:client_id]}:#{@options[:client_secret]}")
+        headers = {
+          'Content-Type'      => 'application/x-www-form-urlencoded',
+          'Accept'            => 'application/json',
+          'Authorization'     => "Basic #{basic_auth}"
+        }
+
+        response = ssl_post(REFRESH_URI, data, headers)
+        response = JSON.parse(response)
+
+        @options[:access_token] = response['access_token'] if response['access_token']
+        @options[:refresh_token] = response['refresh_token'] if response['refresh_token']
+      end
+
       def cvv_code_from(response)
         if response['errors'].present?
           FRAUD_WARNING_CODES.include?(response['errors'].first['code']) ? 'I' : ''
@@ -266,8 +325,13 @@ module ActiveMerchant #:nodoc:
         response['errors'].present? ? STANDARD_ERROR_CODE_MAPPING[response['errors'].first['code']] : ''
       end
 
-      def authorization_from(response)
-        response['id']
+      def authorization_from(response, headers = {})
+        [response['id'], headers['Request-Id']].join('|')
+      end
+
+      def split_authorization(authorization)
+        authorization, request_id = authorization.split('|')
+        [authorization, request_id]
       end
 
       def fraud_review_status_from(response)
@@ -284,7 +348,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund_uri(authorization)
-        "#{ENDPOINT}/#{CGI.escape(authorization)}/refunds"
+        "#{ENDPOINT}/#{CGI.escape(authorization.to_s)}/refunds"
+      end
+
+      def capture_uri(authorization)
+        "#{ENDPOINT}/#{CGI.escape(authorization.to_s)}/capture"
+      end
+
+      def void_uri(request_id)
+        "#{VOID_ENDPOINT}/#{CGI.escape(request_id.to_s)}/void"
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -875,8 +875,17 @@ quantum:
   password: Y
 
 # You will need to create a developer sandbox at https://developer.intuit.com/ and
-# successfully generate an OAuth 1.0a access token and token secret.
+# successfully generate an OAuth 2.0 access token and refresh_token. Access token
+# expires every 60 minutes
 quickbooks:
+  client_id:
+  client_secret:
+  refresh_token:
+  access_token:
+
+# You will need to create a developer sandbox at https://developer.intuit.com/ and
+# successfully generate an OAuth 1.0a access token and token secret.
+quickbooks_oauth_1:
   consumer_key:
   consumer_secret:
   access_token:

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -22,12 +22,14 @@ class RemoteTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'CAPTURED', response.message
+    assert_equal @gateway.options[:access_token], response.params['access_token']
+    assert_equal @gateway.options[:refresh_token], response.params['refresh_token']
   end
 
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'cardNumber is invalid.', response.message
+    assert_equal 'card.number is invalid.', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -88,7 +90,7 @@ class RemoteTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{cardNumber is invalid.}, response.message
+    assert_match %r{card.number is invalid.}, response.message
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
   end
 
@@ -105,7 +107,24 @@ class RemoteTest < Test::Unit::TestCase
     end
   end
 
-  def test_dump_transcript
-    # See quickbooks_test.rb for an example of a scrubbed transcript
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'ISSUED', void.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:access_token], transcript)
+    assert_scrubbed(@gateway.options[:refresh_token], transcript)
   end
 end

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -4,12 +4,19 @@ class QuickBooksTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = QuickbooksGateway.new(
+    @oauth_1_gateway = QuickbooksGateway.new(
       consumer_key: 'consumer_key',
       consumer_secret: 'consumer_secret',
       access_token: 'access_token',
       token_secret: 'token_secret',
       realm: 'realm_ID'
+    )
+
+    @oauth_2_gateway = QuickbooksGateway.new(
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      access_token: 'access_token',
+      refresh_token: 'refresh_token'
     )
 
     @credit_card = credit_card
@@ -21,105 +28,223 @@ class QuickBooksTest < Test::Unit::TestCase
       description: 'Store Purchase'
     }
 
-    @authorization = 'ECZ7U0SO423E'
+    @authorization = 'ECZ7U0SO423E|d40f8a8007ba1af90a656d7f6371f641'
+    @authorization_no_request_id = 'ECZ7U0SO423E'
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success response
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_purchase_response)
+      response = gateway.purchase(@amount, @credit_card, @options)
+      assert_success response
 
-    assert_equal 'EF1IQ9GGXS2D', response.authorization
-    assert response.test?
+      assert_match(/EF1IQ9GGXS2D|/, response.authorization)
+      assert response.test?
+    end
   end
 
   def test_failed_purchase
-    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(failed_purchase_response)
 
-    response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+      response = gateway.purchase(@amount, @credit_card, @options)
+      assert_failure response
+      assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+    end
   end
 
   def test_successful_authorize
-    @gateway.expects(:ssl_post).returns(successful_authorize_response)
-    response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_success response
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_authorize_response)
+      response = gateway.authorize(@amount, @credit_card, @options)
+      assert_success response
 
-    assert_equal @authorization, response.authorization
-    assert response.test?
+      assert_match(/ECZ7U0SO423E|/, response.authorization)
+      assert response.test?
+    end
   end
 
   def test_failed_authorize
-    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(failed_authorize_response)
 
-    response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_failure response
-    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+      response = gateway.authorize(@amount, @credit_card, @options)
+      assert_failure response
+      assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    end
   end
 
   def test_successful_capture
-    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_capture_response)
 
-    response = @gateway.capture(@amount, @authorization)
-    assert_success response
+      response = gateway.capture(@amount, @authorization)
+      assert_success response
+    end
+  end
+
+  def test_successful_capture_when_authorization_does_not_include_request_id
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_capture_response)
+
+      response = gateway.capture(@amount, @authorization_no_request_id)
+      assert_success response
+    end
   end
 
   def test_failed_capture
-    @gateway.expects(:ssl_post).returns(failed_capture_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(failed_capture_response)
 
-    response = @gateway.capture(@amount, @authorization)
-    assert_failure response
+      response = gateway.capture(@amount, @authorization)
+      assert_failure response
+    end
   end
 
   def test_successful_refund
-    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_refund_response)
 
-    response = @gateway.refund(@amount, @authorization)
-    assert_success response
+      response = gateway.refund(@amount, @authorization)
+      assert_success response
+    end
+  end
+
+  def test_successful_refund_when_authorization_does_not_include_request_id
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(successful_refund_response)
+
+      response = gateway.refund(@amount, @authorization_no_request_id)
+      assert_success response
+    end
   end
 
   def test_failed_refund
-    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      gateway.expects(:ssl_post).returns(failed_refund_response)
 
-    response = @gateway.refund(@amount, @authorization)
-    assert_failure response
+      response = gateway.refund(@amount, @authorization)
+      assert_failure response
+    end
   end
 
   def test_successful_verify
-    response = stub_comms do
-      @gateway.verify(@credit_card)
-    end.respond_with(successful_authorize_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      response = stub_comms(gateway) do
+        gateway.verify(@credit_card)
+      end.respond_with(successful_authorize_response)
 
-    assert_success response
+      assert_success response
+    end
   end
 
   def test_failed_verify
-    response = stub_comms do
-      @gateway.verify(@credit_card, @options)
-    end.respond_with(failed_authorize_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      response = stub_comms(gateway) do
+        gateway.verify(@credit_card, @options)
+      end.respond_with(failed_authorize_response)
 
-    assert_failure response
-    assert_not_nil response.message
+      assert_failure response
+      assert_not_nil response.message
+    end
   end
 
-  def test_scrub
-    assert @gateway.supports_scrubbing?
-    assert_equal @gateway.send(:scrub, pre_scrubbed), post_scrubbed
+  def test_successful_void
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      response = stub_comms(gateway) do
+        gateway.void(@authorization)
+      end.respond_with(successful_void_response)
+
+      assert_success response
+    end
+  end
+
+  def test_failed_void
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      response = stub_comms(gateway) do
+        gateway.void(@authorization)
+      end.respond_with(failed_void_response)
+
+      assert_failure response
+    end
+  end
+
+  def test_scrub_oauth_1
+    assert @oauth_1_gateway.supports_scrubbing?
+    assert_equal @oauth_1_gateway.send(:scrub, pre_scrubbed), post_scrubbed
+  end
+
+  def test_scrub_oauth_2
+    assert @oauth_2_gateway.supports_scrubbing?
+    assert_equal @oauth_2_gateway.send(:scrub, pre_scrubbed_oauth_2), post_scrubbed_oauth_2
   end
 
   def test_scrub_with_small_json
-    assert_equal @gateway.scrub(pre_scrubbed_small_json), post_scrubbed_small_json
+    assert_equal @oauth_1_gateway.scrub(pre_scrubbed_small_json), post_scrubbed_small_json
   end
 
   def test_default_context
-    stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |_endpoint, data, _headers|
-      json = JSON.parse(data)
-      refute json.fetch('context').fetch('mobile')
-      assert json.fetch('context').fetch('isEcommerce')
-    end.respond_with(successful_purchase_response)
+    [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
+      stub_comms(gateway) do
+        gateway.purchase(@amount, @credit_card, @options)
+      end.check_request do |_endpoint, data, _headers|
+        json = JSON.parse(data)
+        refute json.fetch('context').fetch('mobile')
+        assert json.fetch('context').fetch('isEcommerce')
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
+  def test_refresh_does_not_occur_for_oauth_1
+    @oauth_1_gateway.expects(:ssl_post).with(
+      anything,
+      Not(regexp_matches(%r{grant_type=refresh_token})),
+      anything
+    ).returns(successful_purchase_response)
+
+    response = @oauth_1_gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+
+    assert_match(/EF1IQ9GGXS2D|/, response.authorization)
+    assert response.test?
+  end
+
+  def test_refresh_does_not_occur_when_token_valid_for_oauth_2
+    @oauth_2_gateway.expects(:ssl_post).with(
+      anything,
+      Not(regexp_matches(%r{grant_type=refresh_token})),
+      has_entries('Authorization' => 'Bearer access_token')
+    ).returns(successful_purchase_response)
+
+    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_refresh_does_occur_when_token_invalid_for_oauth_2
+    @oauth_2_gateway.expects(:ssl_post).with(
+      anything,
+      anything,
+      has_entries('Authorization' => 'Bearer access_token')
+    ).returns(authentication_failed_oauth_2_response)
+
+    @oauth_2_gateway.expects(:ssl_post).with(
+      anything,
+      all_of(regexp_matches(%r{grant_type=refresh_token})),
+      anything
+    ).returns(successful_refresh_token_response)
+
+    @oauth_2_gateway.expects(:ssl_post).with(
+      anything,
+      anything,
+      has_entries('Authorization' => 'Bearer new_access_token')
+    ).returns(successful_purchase_response)
+
+    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_match(/EF1IQ9GGXS2D|/, response.authorization)
+    assert response.test?
   end
 
   private
@@ -333,6 +458,30 @@ class QuickBooksTest < Test::Unit::TestCase
     RESPONSE
   end
 
+  def authentication_failed_oauth_2_response
+    <<-RESPONSE
+      {
+         "code": "AuthenticationFailed",
+         "type": "INPUT",
+         "message": null,
+         "detail": null,
+         "moreInfo": null
+      }
+    RESPONSE
+  end
+
+  def successful_refresh_token_response
+    <<-RESPONSE
+      {
+        "x_refresh_token_expires_in": 8719040,
+        "refresh_token": "refresh_token",
+        "access_token": "new_access_token",
+        "token_type": "bearer",
+        "expires_in": 3600
+      }
+    RESPONSE
+  end
+
   def pre_scrubbed
     <<-PRE_SCRUBBED
       opening connection to sandbox.api.intuit.com:443...
@@ -393,5 +542,151 @@ class QuickBooksTest < Test::Unit::TestCase
       -> "\r\n"
       Conn close
     POST_SCRUBBED
+  end
+
+  def pre_scrubbed_oauth_2
+    %q(
+      opening connection to sandbox.api.intuit.com:443...
+      opened
+      starting SSL for sandbox.api.intuit.com:443...
+      SSL established
+      <- "POST /quickbooks/v4/payments/charges HTTP/1.1\r\nContent-Type: application/json\r\nRequest-Id: 3b098cc41f53562ec0f36a0fc7071ff8\r\nAccept: application/json\r\nAuthorization: Bearer eyabcd9ewjie0w9fj9jkewjaiojfiew0..rEVIND9few90zsg.CyFO4k9gR-t5yJsc0lxGrPPLGeO-JRa_5MZ_vG_H5AMlObrPpfhBRK51jUukhh0QOUjgkGm2jJb8c_haieKnkb3nY_W7giZyIG6d5g5XPqRZLhDnMCVVFHZyLIbBT_TDvZWROeOGY10xrDnUY5O05LYnOZc8gq7k_VTHHDrrmyeon3EmerAGjDUhnpp1DJRvR7SLUWgZQOuR997OuaP31_ZesKACzdVSw5QBJAhBeRqGl8LaNjjveQMo1c20CjWr_-c0EWbp0frMAA_UYaxtuzgRRs_opnMr4_PD7axQQevAzftSR1cQfUDAu_uybV5lyiUTfX80B3NBlLihWLiqCD9yWiYmup4TpNbapTL4x9CQz_WobicwWbhIJ7P1IrnxeJh2pW3ijjrBhbgLCCZ-6tcNUsD697ywn3YknT-iTSH-BIpGE_43bEOHyUtwZcIZIeb-6KtZIjQ_fjHfkRz66IrpP0V-XZ7_N5hJ7UIuQ34gOiuxdFJtbiMSUW1GnanJ9aRH8Fbzk_UzrWyuSs.XnsOxzQ\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox.api.intuit.com\r\nContent-Length: 310\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"4000100011112224\",\"expMonth\":\"09\",\"expYear\":2020,\"cvc\":\"123\",\"name\":\"Longbob Longsen\",\"address\":{\"streetAddress\":\"456 My Street\",\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"postalCode\":90210}},\"context\":{\"mobile\":false,\"isEcommerce\":true},\"capture\":\"true\"}"
+      -> "HTTP/1.1 401 Unauthorized\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:43 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 91\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "intuit_tid: adca0516-0af2-48cd-a704-095529fe615c\r\n"
+      -> "WWW-Authenticate: Bearer realm=\"Intuit\", error=\"invalid_token\"\r\n"
+      -> "\r\n"
+      reading 91 bytes...
+      -> "{\"code\":\"AuthenticationFailed\",\"type\":\"INPUT\",\"message\":null,\"detail\":null,\"moreInfo\":null}"
+      read 91 bytes
+      Conn close
+      opening connection to oauth.platform.intuit.com:443...
+      opened
+      starting SSL for oauth.platform.intuit.com:443...
+      SSL established
+      <- "POST /oauth2/v1/tokens/bearer HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic QUI3QWFkWGZYRWZyRE1WN0k2a3RFYXoyT2hCeHdhVkdtZUU5N3pmeGdjSllPUU40Qmo6ZEVJcms2bHozclVvQ05wRXFSbFV6bFd6STBYRUtyeDBYcDdoYVd3RQ==\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: oauth.platform.intuit.com\r\nContent-Length: 89\r\n\r\n"
+      <- "grant_type=refresh_token&refresh_token=DE123456780s7AvBrjWjfiowji9IIKDU4zE237CmbGO"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:43 GMT\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Content-Length: 1007\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "Strict-Transport-Security: max-age=15552000\r\n"
+      -> "intuit_tid: c9aff174-410e-4683-8a35-2591c659550f\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "\r\n"
+      reading 1007 bytes...
+      -> "{\"x_refresh_token_expires_in\":8719040,\"refresh_token\":\"DE987654s7AvBrjWOCJYWsifjewaifjeiowja4zE237CmbGO\",\"access_token\":\"abcifejwiajJJJIDJFIEJQ0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..DIoIqgR5MP51jw.SK_1VawNWV1SC9ZSRu278imQXb-Fsn4K6gJK_IuEcG2p5xf9bj5fO6p8M8cN2HOw8D9TNuqR3u4POypw-QR4xfjiewjaifeDzc_L1D9cR_Zypcss0CWlk3Wl5Sm-Yel6Ej6DZPdMRYDVzFQIy-ugvlcbBMs_TBhPWuidiL7Gdy61iMW-CUG80iy0VN8TrOTTxI7oRlrsKeVF_htYbwfafeYxUnMIMnjz8BxsWHCj2Dj3Osx1d1RScHPlrzQhO8t9s0MpGbpO0Ygiu5H3-E5KC5ihnDtgTFeyyHFx8hPiG_ScbdnYgXQPqJiJIJ47Us9Jv0kXA1YxQr35-vL2IGHa6haofByqLJjXIKlYi-suu1Xl6wlCCZufXvELBcfhdkG4iCKGO3KXOozUkZOav9IqPM7qjGskTzbmR4zMzCmf0ypQbmk-4NXQT3N1Z_mxTX4ebCfjF7h0LjX3sgFcwYtNKS_iLsygU8mPZScCthBH67bO2ce35ZjHr2kHYKKxAYS-wXmiMpFM7NvEkVjoWJarrMF-Q4DB7eLKezmEKuRMDr6Q6_gDEbeyHqqCauEczBriq61LnWlDuqJtySL-amSrADFU7SU8fmD4DhgxU.f0o4123vdcxH_zvzfaewa7Q\",\"token_type\":\"bearer\",\"expires_in\":3600}"
+      read 1007 bytes
+      Conn close
+      opening connection to sandbox.api.intuit.com:443...
+      opened
+      starting SSL for sandbox.api.intuit.com:443...
+      SSL established
+      <- "POST /quickbooks/v4/payments/charges HTTP/1.1\r\nContent-Type: application/json\r\nRequest-Id: da14d01c3608a0a036c4e7298cb5d56a\r\nAccept: application/json\r\nAuthorization: Bearer abcifejwiajJJJIDJFIEJQ0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..DIoIqgR5MP51jw.SK_1VawNWV1SC9ZSRu278imQXb-Fsn4K6gJK_IuEcG2p5xf9bj5fO6p8M8cN2HOw8D9TNuqR3u4POypw-QR4xfjiewjaifeDzc_L1D9cR_Zypcss0CWlk3Wl5Sm-Yel6Ej6DZPdMRYDVzFQIy-ugvlcbBMs_TBhPWuidiL7Gdy61iMW-CUG80iy0VN8TrOTTxI7oRlrsKeVF_htYbwfafeYxUnMIMnjz8BxsWHCj2Dj3Osx1d1RScHPlrzQhO8t9s0MpGbpO0Ygiu5H3-E5KC5ihnDtgTFeyyHFx8hPiG_ScbdnYgXQPqJiJIJ47Us9Jv0kXA1YxQr35-vL2IGHa6haofByqLJjXIKlYi-suu1Xl6wlCCZufXvELBcfhdkG4iCKGO3KXOozUkZOav9IqPM7qjGskTzbmR4zMzCmf0ypQbmk-4NXQT3N1Z_mxTX4ebCfjF7h0LjX3sgFcwYtNKS_iLsygU8mPZScCthBH67bO2ce35ZjHr2kHYKKxAYS-wXmiMpFM7NvEkVjoWJarrMF-Q4DB7eLKezmEKuRMDr6Q6_gDEbeyHqqCauEczBriq61LnWlDuqJtySL-amSrADFU7SU8fmD4DhgxU.f0o4123vdcxH_zvzfaewa7Q\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox.api.intuit.com\r\nContent-Length: 310\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"4000100011112224\",\"expMonth\":\"09\",\"expYear\":2020,\"cvc\":\"123\",\"name\":\"Longbob Longsen\",\"address\":{\"streetAddress\":\"456 My Street\",\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"postalCode\":90210}},\"context\":{\"mobile\":false,\"isEcommerce\":true},\"capture\":\"true\"}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:44 GMT\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "Strict-Transport-Security: max-age=15552000\r\n"
+      -> "intuit_tid: 09ce7b7f-e19a-4567-8d7f-cf6ce81a9c75\r\n"
+      -> "\r\n"
+      -> "213\r\n"
+      reading 531 bytes...
+      -> "{\"created\":\"2019-10-17T15:40:44Z\",\"status\":\"CAPTURED\",\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"xxxxxxxxxxxx2224\",\"name\":\"Longbob Longsen\",\"address\":{\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"streetAddress\":\"456 My Street\",\"postalCode\":\"90210\"},\"cardType\":\"Visa\",\"expMonth\":\"09\",\"expYear\":\"2020\",\"cvc\":\"xxx\"},\"capture\":true,\"avsStreet\":\"Pass\",\"avsZip\":\"Pass\",\"cardSecurityCodeMatch\":\"NotAvailable\",\"id\":\"ES2Q849Y8KQ9\",\"context\":{\"mobile\":false,\"deviceInfo\":{},\"recurring\":false,\"isEcommerce\":true},\"authCode\":\"574943\"}"
+      read 531 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    )
+  end
+
+  def post_scrubbed_oauth_2
+    %q(
+      opening connection to sandbox.api.intuit.com:443...
+      opened
+      starting SSL for sandbox.api.intuit.com:443...
+      SSL established
+      <- "POST /quickbooks/v4/payments/charges HTTP/1.1\r\nContent-Type: application/json\r\nRequest-Id: 3b098cc41f53562ec0f36a0fc7071ff8\r\nAccept: application/json\r\nAuthorization: Bearer [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox.api.intuit.com\r\nContent-Length: 310\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"[FILTERED]\",\"expMonth\":\"09\",\"expYear\":2020,\"cvc\":\"[FILTERED]\",\"name\":\"Longbob Longsen\",\"address\":{\"streetAddress\":\"456 My Street\",\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"postalCode\":90210}},\"context\":{\"mobile\":false,\"isEcommerce\":true},\"capture\":\"true\"}"
+      -> "HTTP/1.1 401 Unauthorized\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:43 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 91\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "intuit_tid: adca0516-0af2-48cd-a704-095529fe615c\r\n"
+      -> "WWW-Authenticate: Bearer realm=\"Intuit\", error=\"invalid_token\"\r\n"
+      -> "\r\n"
+      reading 91 bytes...
+      -> "{\"code\":\"AuthenticationFailed\",\"type\":\"INPUT\",\"message\":null,\"detail\":null,\"moreInfo\":null}"
+      read 91 bytes
+      Conn close
+      opening connection to oauth.platform.intuit.com:443...
+      opened
+      starting SSL for oauth.platform.intuit.com:443...
+      SSL established
+      <- "POST /oauth2/v1/tokens/bearer HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic [FILTERED]==\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: oauth.platform.intuit.com\r\nContent-Length: 89\r\n\r\n"
+      <- "grant_type=refresh_token&refresh_token=[FILTERED]"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:43 GMT\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Content-Length: 1007\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "Strict-Transport-Security: max-age=15552000\r\n"
+      -> "intuit_tid: c9aff174-410e-4683-8a35-2591c659550f\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "\r\n"
+      reading 1007 bytes...
+      -> "{\"x_refresh_token_expires_in\":8719040,\"refresh_token\":\"[FILTERED]\",\"access_token\":\"[FILTERED]\",\"token_type\":\"bearer\",\"expires_in\":3600}"
+      read 1007 bytes
+      Conn close
+      opening connection to sandbox.api.intuit.com:443...
+      opened
+      starting SSL for sandbox.api.intuit.com:443...
+      SSL established
+      <- "POST /quickbooks/v4/payments/charges HTTP/1.1\r\nContent-Type: application/json\r\nRequest-Id: da14d01c3608a0a036c4e7298cb5d56a\r\nAccept: application/json\r\nAuthorization: Bearer [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox.api.intuit.com\r\nContent-Length: 310\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"[FILTERED]\",\"expMonth\":\"09\",\"expYear\":2020,\"cvc\":\"[FILTERED]\",\"name\":\"Longbob Longsen\",\"address\":{\"streetAddress\":\"456 My Street\",\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"postalCode\":90210}},\"context\":{\"mobile\":false,\"isEcommerce\":true},\"capture\":\"true\"}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Date: Thu, 17 Oct 2019 15:40:44 GMT\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Server: nginx\r\n"
+      -> "Strict-Transport-Security: max-age=15552000\r\n"
+      -> "intuit_tid: 09ce7b7f-e19a-4567-8d7f-cf6ce81a9c75\r\n"
+      -> "\r\n"
+      -> "213\r\n"
+      reading 531 bytes...
+      -> "{\"created\":\"2019-10-17T15:40:44Z\",\"status\":\"CAPTURED\",\"amount\":\"1.00\",\"currency\":\"USD\",\"card\":{\"number\":\"xxxxxxxxxxxx2224\",\"name\":\"Longbob Longsen\",\"address\":{\"city\":\"Ottawa\",\"region\":\"CA\",\"country\":\"US\",\"streetAddress\":\"456 My Street\",\"postalCode\":\"90210\"},\"cardType\":\"Visa\",\"expMonth\":\"09\",\"expYear\":\"2020\",\"cvc\":\"xxx\"},\"capture\":true,\"avsStreet\":\"Pass\",\"avsZip\":\"Pass\",\"cardSecurityCodeMatch\":\"NotAvailable\",\"id\":\"ES2Q849Y8KQ9\",\"context\":{\"mobile\":false,\"deviceInfo\":{},\"recurring\":false,\"isEcommerce\":true},\"authCode\":\"574943\"}"
+      read 531 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    )
   end
 end


### PR DESCRIPTION
Quickbooks is deprecating OAuth 1.0 support, and requiring OAuth
2.0 no later than December 17, 2019. This PR adds support for
OAuth 2.0, requiring the `access_token`, `refresh_token`, `client_id`
and `client_secret` when creating a gateway. When refresh_token is
present, OAuth 2.0 authentication will be attempted. If not
included, OAuth 1.0 will be attempted and should still work until
the deprecation date.

In the Quickbooks implementation, the access_token expires every
60 minutes and you must use the refresh_token to generate a new
one. There's no way to proactively check if the token is still
valid; you'll just see that the request fails with an
`AuthenticationFailed` error. This PR adds logic to each action to
check for this error, and attempt to refresh the token and reissue
the request when it happens.

This gateway also did not previously implement the void method;
support is added here. It required a change to authorization_from
method to include the request-id since that is needed in the void
request. The authorization value is split appropriately to parse out
the value needed for a given method.

Remote:
14 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
15 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed