### PR TITLE
Moneris: Add support for temporary vault storage

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -140,12 +140,21 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      # When passing a :duration option (time in seconds) you can create a
+      # temporary vault record to avoid incurring Moneris vault storage fees
+      #
+      # https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Vault#vaulttokenadd
       def store(credit_card, options = {})
         post = {}
         post[:pan] = credit_card.number
         post[:expdate] = expdate(credit_card)
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
-        commit('res_add_cc', post)
+        if options[:duration]
+          post[:duration] = options[:duration]
+          commit('res_temp_add', post)
+        else
+          commit('res_add_cc', post)
+        end
       end
 
       def unstore(data_key, options = {})
@@ -408,6 +417,7 @@ module ActiveMerchant #:nodoc:
             'opentotals' => [:ecr_number],
             'batchclose' => [:ecr_number],
             'res_add_cc' => [:pan, :expdate, :crypt_type, :cof_info],
+            'res_temp_add' => [:pan, :expdate, :crypt_type, :duration],
             'res_delete' => [:data_key],
             'res_update_cc' => [:data_key, :pan, :expdate, :crypt_type],
             'res_purchase_cc' => [:data_key, :order_id, :cust_id, :amount, :crypt_type, :cof_info],

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -199,6 +199,14 @@ class MonerisRemoteTest < Test::Unit::TestCase
     @data_key = response.params['data_key']
   end
 
+  def test_successful_store_with_duration
+    assert response = @gateway.store(@credit_card, duration: 600)
+    assert_success response
+    assert_equal 'Successfully registered cc details', response.message
+    assert response.params['data_key'].present?
+    @data_key = response.params['data_key']
+  end
+
   def test_successful_unstore
     test_successful_store
     assert response = @gateway.unstore(@data_key)

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -200,6 +200,15 @@ class MonerisTest < Test::Unit::TestCase
     @data_key = response.params['data_key']
   end
 
+  def test_successful_store_with_duration
+    @gateway.expects(:ssl_post).returns(successful_store_with_duration_response)
+    assert response = @gateway.store(@credit_card, duration: 600)
+    assert_success response
+    assert_equal 'Successfully registered cc details', response.message
+    assert response.params['data_key'].present?
+    @data_key = response.params['data_key']
+  end
+
   def test_successful_unstore
     @gateway.expects(:ssl_post).returns(successful_unstore_response)
     test_successful_store
@@ -834,6 +843,41 @@ class MonerisTest < Test::Unit::TestCase
     <ResponseCode>027</ResponseCode>
     <Complete>true</Complete>
     <Message>Successfully registered cc details * =</Message>
+  </receipt>
+</response>
+    RESPONSE
+  end
+
+  def successful_store_with_duration_response
+    <<-RESPONSE
+<?xml version="1.0"?>
+<response>
+  <receipt>
+    <DataKey>1234567890</DataKey>
+    <ReceiptId>null</ReceiptId>
+    <ReferenceNum>null</ReferenceNum>
+    <ResponseCode>001</ResponseCode>
+    <ISO>null</ISO>
+    <AuthCode>null</AuthCode>
+    <Message>Successfully registered CC details.</Message>
+    <TransType>null</TransType>
+    <Complete>true</Complete>
+    <TransAmount>null</TransAmount>
+    <CardType>null</CardType>
+    <TransID>null</TransID>
+    <TimedOut>false</TimedOut>
+    <CorporateCard>null</CorporateCard>
+    <RecurSuccess>null</RecurSuccess>
+    <AvsResultCode>null</AvsResultCode>
+    <CvdResultCode>null</CvdResultCode>
+    <ResSuccess>true</ResSuccess>
+    <PaymentType>cc</PaymentType>
+    <IsVisaDebit>null</IsVisaDebit>
+    <ResolveData>
+      <anc1/>
+      <masked_pan>4242***4242</masked_pan>
+      <expdate>2010</expdate>
+    </ResolveData>
   </receipt>
 </response>
     RESPONSE


### PR DESCRIPTION
Temporary vault storage is useful for one-off card tokenization without
incurring Moneris' monthly vault storage fees.

Docs at https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Vault#vaulttokenadd

----

4333 tests, 70892 assertions, 1 failures, 7 errors, 0 pendings, 0 omissions, 0 notifications
99.8154% passed
(all test fails are from an unrelated gateway: so_easy_pay_test)