### PR TITLE
Moneris: include AVS and CoF fields when storing vault records

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -144,7 +144,9 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:pan] = credit_card.number
         post[:expdate] = expdate(credit_card)
+        post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
+        add_stored_credential(post, options)
         commit('res_add_cc', post)
       end
 
@@ -405,9 +407,9 @@ module ActiveMerchant #:nodoc:
             'Batchcloseall' => [],
             'opentotals' => [:ecr_number],
             'batchclose' => [:ecr_number],
-            'res_add_cc' => [:pan, :expdate, :crypt_type, :cof_info],
+            'res_add_cc' => [:pan, :expdate, :crypt_type, :avs_info, :cof_info],
             'res_delete' => [:data_key],
-            'res_update_cc' => [:data_key, :pan, :expdate, :crypt_type],
+            'res_update_cc' => [:data_key, :pan, :expdate, :crypt_type, :avs_info, :cof_info],
             'res_purchase_cc' => [:data_key, :order_id, :cust_id, :amount, :crypt_type, :cof_info],
             'res_preauth_cc' => [:data_key, :order_id, :cust_id, :amount, :crypt_type, :cof_info]
         }

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -199,6 +199,38 @@ class MonerisRemoteTest < Test::Unit::TestCase
     @data_key = response.params['data_key']
   end
 
+  # AVS result fields are stored in the vault and returned as part of the
+  # XML response under <Receipt//ResolveData> (which isn't parsed by ActiveMerchant so
+  # we can't test for it).
+  #
+  # Actual AVS results aren't returned processed until an actual transaction is made
+  # so we make a second purchase request.
+  def test_successful_store_and_purchase_with_avs
+    gateway = MonerisGateway.new(fixtures(:moneris).merge(avs_enabled: true))
+
+    # card number triggers AVS match
+    @credit_card = credit_card('4761739012345637', :verification_value => '012')
+    assert response = gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'Successfully registered cc details', response.message
+    assert response.params['data_key'].present?
+    data_key = response.params['data_key']
+
+    options_without_address = @options.dup
+    options_without_address.delete(:address)
+    assert response = @gateway.purchase(@amount, data_key, options_without_address)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+
+    assert_equal(response.avs_result, {
+        'code' => 'M',
+        'message' => 'Street address and postal code match.',
+        'street_match' => 'Y',
+        'postal_match' => 'Y'
+    })
+  end
+
   def test_successful_unstore
     test_successful_store
     assert response = @gateway.unstore(@data_key)


### PR DESCRIPTION
Moneris allows AVS and card-on-file information to optionally be passed
when creating and updating vault records. Note this doesn't apply
to temporary vault records.

https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Vault#vaultaddcreditcard
https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Vault#vaultupdatecreditcard