### PR TITLE
Stripe: Remove outdated 'customer options' deprecation

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -516,10 +516,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer(post, payment, options)
-        if options[:customer] && !payment.respond_to?(:number)
-          ActiveMerchant.deprecated 'Passing the customer in the options is deprecated. Just use the response.authorization instead.'
-          post[:customer] = options[:customer]
-        end
+        post[:customer] = options[:customer] if options[:customer] && !payment.respond_to?(:number)
       end
 
       def add_flags(post, options)


### PR DESCRIPTION
This is no longer deprecated; in fact it's actually required.

From the Stripe docs:

**source**: A payment source to be charged. This can be the ID of a card
(i.e., credit or debit card), a bank account, a source, a token, or a
connected account.  For certain sources—namely, cards, bank accounts,
and attached sources—**you must also pass the ID of the associated customer.**

https://stripe.com/docs/api/charges/create#create_charge-source

Closes #2421 (and removes a ton of of deprecation notices from log files
all across the world)