### PR TITLE
VisaNet Peru: Pass amount in capture requests

### DIFF
--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(amount, authorization, options={})
         params = {}
+        params[:amount] = amount(amount) if amount
         options[:id_unico] = split_authorization(authorization)[1]
         add_auth_order_id(params, authorization, options)
         commit('deposit', params, options)

--- a/test/remote/gateways/remote_visanet_peru_test.rb
+++ b/test/remote/gateways/remote_visanet_peru_test.rb
@@ -65,6 +65,23 @@ class RemoteVisanetPeruTest < Test::Unit::TestCase
     assert_equal @options[:order_id], capture.params['externalTransactionId']
   end
 
+  def test_successful_authorize_and_partial_capture
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'OK', response.message
+    assert response.authorization
+    assert_equal @options[:order_id], response.params['externalTransactionId']
+    assert_equal '1.00', response.params['data']['IMP_AUTORIZADO']
+
+    first_capture = @gateway.capture(@amount-1, response.authorization, @options)
+    assert_success first_capture
+    assert_equal 'OK', first_capture.message
+
+    second_capture = @gateway.capture(1, response.authorization, @options)
+    assert_success second_capture
+    assert_equal 'OK', second_capture.message
+  end
+
   def test_successful_authorize_fractional_amount
     amount = 199
     response = @gateway.authorize(amount, @credit_card)


### PR DESCRIPTION
Passing amounts in capture requests will allow for partial captures.

Remote: Current test credentials are expired so this will need to be
confirmed in production environment and any issues soon addressed.

Unit:
15 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed