### PR TITLE
Refactor Ixopay methods

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -195,19 +195,6 @@ module ActiveMerchant #:nodoc:
         Base64.encode64(hmac).delete("\n")
       end
 
-      def response_from_request_error(action, error)
-        response = parse(action, error.response.body)
-
-        Response.new(
-          success_from(response),
-          message_from(response),
-          response,
-          authorization: authorization_from(response),
-          test: test?,
-          error_code: error_code_from(response)
-        )
-      end
-
       def success_from(response)
         response[:success] == 'true'
       end

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         request = build_xml_request do |xml|
           add_card_data(xml, payment_method)
           add_debit(xml, money, options)
-	end
+	      end
         commit(request)
       end
 
@@ -66,9 +66,9 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         xml = Nokogiri::XML(body)
-	response = Hash.from_xml(xml.to_s)["result"]
-	response.deep_transform_keys { |key| key.underscore }
-	  .transform_keys { |key| key.to_sym }
+	      response = Hash.from_xml(xml.to_s)["result"]
+	      response.deep_transform_keys(&:underscore)
+	      .transform_keys(&:to_sym)
       end
 
       def build_xml_request

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         request = build_xml_request do |xml|
           add_card_data(xml, payment_method)
           add_debit(xml, money, options)
-	      end
+        end
         commit(request)
       end
 
@@ -66,16 +66,16 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         xml = Nokogiri::XML(body)
-	      response = Hash.from_xml(xml.to_s)["result"]
-	      response.deep_transform_keys(&:underscore)
-	      .transform_keys(&:to_sym)
+        response = Hash.from_xml(xml.to_s)['result']
+        response.deep_transform_keys(&:underscore)
+        .transform_keys(&:to_sym)
       end
 
       def build_xml_request
         builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           xml.transactionWithCard 'xmlns' => 'http://secure.ixopay.com/Schema/V2/TransactionWithCard' do
-          xml.username @options[:username]
-          xml.password Digest::SHA1.hexdigest(@options[:password])
+            xml.username @options[:username]
+            xml.password Digest::SHA1.hexdigest(@options[:password])
             yield(xml)
           end
         end

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -24,13 +24,12 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_equal 'FINISHED', response.message
     assert_match(/[0-9a-zA-Z]+(|[0-9a-zA-Z]+)*/, response.authorization)
 
-    assert_equal @credit_card.name,           response.params['card_holder']
-    assert_equal '%02d' % @credit_card.month, response.params['expiry_month']
-    assert_equal @credit_card.year.to_s,      response.params['expiry_year']
-    assert_equal @credit_card.number[0..5],   response.params['first_six_digits']
+    assert_equal @credit_card.name,           response.params.dig('return_data', 'creditcard_data', 'card_holder')
+    assert_equal '%02d' % @credit_card.month, response.params.dig('return_data', 'creditcard_data', 'expiry_month')
+    assert_equal @credit_card.year.to_s,      response.params.dig('return_data', 'creditcard_data', 'expiry_year')
+    assert_equal @credit_card.number[0..5],   response.params.dig('return_data', 'creditcard_data', 'first_six_digits')
+    assert_equal @credit_card.number.split(//).last(4).join, response.params.dig('return_data', 'creditcard_data', 'last_four_digits')
     assert_equal 'FINISHED',                  response.params['return_type']
-
-    assert_equal @credit_card.number.split(//).last(4).join, response.params['last_four_digits']
 
     assert_not_nil response.params['purchase_id']
     assert_not_nil response.params['reference_id']
@@ -41,7 +40,6 @@ class RemoteIxopayTest < Test::Unit::TestCase
 
     assert_failure response
     assert_equal 'The transaction was declined', response.message
-    assert_equal '2003', response.params['code']
     assert_equal '2003', response.error_code
   end
 


### PR DESCRIPTION
Refactored the foundational methods for the new Ixopay gateway.

Greatly simplified the `parse` and `parse_elements` methods by relying
on built-in Rails functionality.

Refactored the specific `build_purchase_request` into a more general
`build_xml_request` method that can be reused by the other transaction
types.