### PR TITLE
CyberSource: Send issuer data on capture

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -290,6 +290,7 @@ module ActiveMerchant #:nodoc:
         add_purchase_data(xml, money, true, options)
         add_capture_service(xml, request_id, request_token)
         add_business_rules_data(xml, authorization, options)
+        add_issuer_additional_data(xml, options)
         xml.target!
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -256,6 +256,16 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_capture_with_issuer_additional_data
+    @options[:issuer_additional_data] = @issuer_additional_data
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert response = @gateway.capture(@amount, auth.authorization)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_authorization_and_failed_capture
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
The `issuer_additional_data` gateway specific field was previously
passed in auth and purchase requests. These fields can now also be
passed as part of capture requests.

CE-184

Unit:
63 tests, 307 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
64 tests, 272 assertions, 4 failures, 1 errors, 0 pendings, 0 omissions,
0 notifications
92.1875% passed

The 4 failures are unrelated to this change and appear to be persistent
throughout previous commits. The error is a timeout error that appears
to happen sporadically to random remote tests.