### PR TITLE
Use current Mastercard URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wiki
 * [Conekta](https://conekta.io) - MX
 * [CyberSource](http://www.cybersource.com) - US, BR, CA, CN, DK, FI, FR, DE, JP, MX, NO, SE, GB, SG
 * [DIBS](http://www.dibspayment.com/) - US, FI, NO, SE, GB
-* [DataCash](http://www.datacash.com/) - GB
 * [Efsnet](http://www.concordefsnet.com/) - US
 * [Elavon MyVirtualMerchant](http://www.elavon.com/) - US, CA
 * [ePay](http://epay.dk/) - DK, SE, NO
@@ -148,6 +147,7 @@ The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wiki
 * [Komoju](http://www.komoju.com/) - JP
 * [LinkPoint](http://www.linkpoint.com/) - US
 * [Litle & Co.](http://www.litle.com/) - US
+* [Mastercard (formerly DataCash, MiGS and TNSPay)](https://www.mastercard.com/gateway.html) - AU, AE, BD, BN, EG, HK, ID, IN, JO, KW, LB, LK, MU, MV, MY, NZ, OM, PH, QA, SA, SG, TT, VN
 * [maxiPago!](http://www.maxipago.com/) - BR
 * [Merchant e-Solutions](http://www.merchante-solutions.com/) - US
 * [Merchant One Gateway](http://merchantone.com/) - US
@@ -155,7 +155,6 @@ The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wiki
 * [MerchantWarrior](http://www.merchantwarrior.com/) - AU
 * [Mercury](http://www.mercurypay.com) - US, CA
 * [Metrics Global](http://www.metricsglobal.com) - US
-* [MasterCard Internet Gateway Service (MiGS)](http://mastercard.com/mastercardsps) - AU, AE, BD, BN, EG, HK, ID, IN, JO, KW, LB, LK, MU, MV, MY, NZ, OM, PH, QA, SA, SG, TT, VN
 * [Modern Payments](http://www.modpay.com) - US
 * [MONEI](http://www.monei.net/) - AD, AT, BE, BG, CA, CH, CY, CZ, DE, DK, EE, ES, FI, FO, FR, GB, GI, GR, HU, IE, IL, IS, IT, LI, LT, LU, LV, MT, NL, NO, PL, PT, RO, SE, SI, SK, TR, US, VA
 * [Moneris](http://www.moneris.com/) - CA
@@ -221,7 +220,6 @@ The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wiki
 * [Spreedly](https://spreedly.com) - AD, AE, AT, AU, BD, BE, BG, BN, CA, CH, CY, CZ, DE, DK, EE, EG, ES, FI, FR, GB, GI, GR, HK, HU, ID, IE, IL, IM, IN, IS, IT, JO, KW, LB, LI, LK, LT, LU, LV, MC, MT, MU, MV, MX, MY, NL, NO, NZ, OM, PH, PL, PT, QA, RO, SA, SE, SG, SI, SK, SM, TR, TT, UM, US, VA, VN, ZA
 * [Stripe](https://stripe.com/) - AT, AU, BE, CA, CH, DE, DK, ES, FI, FR, GB, IE, IT, LU, NL, NO, SE, SG, US
 * [Swipe](https://www.swipehq.com/checkout) - CA, NZ
-* [TNS](http://www.tnsi.com/) - AR, AU, BR, FR, DE, HK, MX, NZ, SG, GB, US
 * [Transact Pro](https://www.transactpro.lv/business/online-payments-acceptance) - US
 * [TransFirst](http://www.transfirst.com/) - US
 * [Transnational](http://www.tnbci.com/) - US

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
       #
       # Below are links from the card providers with their requirements
       # visa:             http://usa.visa.com/personal/security/3-digit-security-code.jsp
-      # master:           http://www.mastercard.com/ca/merchant/en/getstarted/Anatomy_MasterCard.html
+      # master:           https://www.mastercard.us/en-us/merchants/get-support/merchant-learning-center/glossary.html#c
       # jcb:              http://www.jcbcard.com/security/info.html
       # diners_club:      http://www.dinersclub.com/assets/DinersClub_card_ID_features.pdf
       # discover:         https://www.discover.com/credit-cards/help-center/glossary.html

--- a/lib/active_merchant/billing/gateways/citrus_pay.rb
+++ b/lib/active_merchant/billing/gateways/citrus_pay.rb
@@ -5,8 +5,8 @@ module ActiveMerchant
 
       class_attribute :live_na_url, :live_ap_url, :test_na_url, :test_ap_url
 
-      self.test_na_url = 'https://test-gateway.mastercard.com/api/rest/version/39/'
-      self.test_ap_url = 'https://test-gateway.mastercard.com/api/rest/version/39/'
+      self.test_na_url = 'https://na-gateway.mastercard.com/api/rest/version/39/'
+      self.test_ap_url = 'https://ap-gateway.mastercard.com/api/rest/version/39/'
 
       self.live_na_url = 'https://na-gateway.mastercard.com/api/rest/version/39/'
       self.live_ap_url = 'https://ap-gateway.mastercard.com/api/rest/version/39/'

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -8,8 +8,8 @@ module ActiveMerchant
 
       self.supported_cardtypes = [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro ]
 
-      self.homepage_url = 'http://www.datacash.com/'
-      self.display_name = 'DataCash'
+      self.homepage_url = 'https://www.mastercard.com/gateway.html'
+      self.display_name = 'Mastercard (DataCash)'
 
       self.test_url = 'https://testserver.datacash.com/Transaction'
       self.live_url = 'https://mars.transaction.datacash.com/Transaction'

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -7,17 +7,17 @@ module ActiveMerchant
 
       VERSION = '52'
 
-      self.live_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{VERSION}/"
-      self.test_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.live_na_url = "https://na-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_na_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
-      self.live_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{VERSION}/"
-      self.test_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.live_ap_url = "https://ap-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_ap_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
-      self.live_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{VERSION}/"
-      self.test_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.live_eu_url = "https://eu-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_eu_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
-      self.display_name = 'TNS'
-      self.homepage_url = 'http://www.tnsi.com/'
+      self.display_name = 'Mastercard (formerly TNSPay)'
+      self.homepage_url = 'https://www.mastercard.com/gateway.html'
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -8,13 +8,13 @@ module ActiveMerchant
       VERSION = '52'
 
       self.live_na_url = "https://na-gateway.mastercard.com/api/rest/version/#{VERSION}/"
-      self.test_na_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_na_url = "https://na-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
       self.live_ap_url = "https://ap-gateway.mastercard.com/api/rest/version/#{VERSION}/"
-      self.test_ap_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_ap_url = "https://ap-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
       self.live_eu_url = "https://eu-gateway.mastercard.com/api/rest/version/#{VERSION}/"
-      self.test_eu_url = "https://test-gateway.mastercard.com/api/rest/version/#{VERSION}/"
+      self.test_eu_url = "https://eu-gateway.mastercard.com/api/rest/version/#{VERSION}/"
 
       self.display_name = 'Mastercard (formerly TNSPay)'
       self.homepage_url = 'https://www.mastercard.com/gateway.html'

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -167,7 +167,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/na-gateway.mastercard.com/, endpoint)
+      assert_match(/test-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/ap-gateway.mastercard.com/, endpoint)
+      assert_match(/test-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -167,7 +167,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/secure.na.tnspayments.com/, endpoint)
+      assert_match(/na-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/secure.ap.tnspayments.com/, endpoint)
+      assert_match(/ap-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -167,7 +167,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/test-gateway.mastercard.com/, endpoint)
+      assert_match(/na-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class CitrusPayTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/test-gateway.mastercard.com/, endpoint)
+      assert_match(/ap-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -167,7 +167,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/secure.na.tnspayments.com/, endpoint)
+      assert_match(/na-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/secure.ap.tnspayments.com/, endpoint)
+      assert_match(/ap-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -199,7 +199,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/secure.eu.tnspayments.com/, endpoint)
+      assert_match(/eu-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -167,7 +167,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/na-gateway.mastercard.com/, endpoint)
+      assert_match(/test-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/ap-gateway.mastercard.com/, endpoint)
+      assert_match(/test-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -199,7 +199,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/eu-gateway.mastercard.com/, endpoint)
+      assert_match(/test-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -167,7 +167,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/test-gateway.mastercard.com/, endpoint)
+      assert_match(/na-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -183,7 +183,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/test-gateway.mastercard.com/, endpoint)
+      assert_match(/ap-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response
@@ -199,7 +199,7 @@ class TnsTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/test-gateway.mastercard.com/, endpoint)
+      assert_match(/eu-gateway.mastercard.com/, endpoint)
     end.respond_with(successful_capture_response)
 
     assert_success response


### PR DESCRIPTION
- MiGS, TNSPay and DataCash are all now under Mastercard Payment Gateway umbrella
- *.tnspayments.com is deprecated in favour of *-gateway.mastercard.com