### PR TITLE
Fat Zebra can use standardized 3ds fields

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -125,11 +125,13 @@ module ActiveMerchant #:nodoc:
       def add_extra_options(post, options)
         extra = {}
         extra[:ecm] = '32' if options[:recurring]
-        extra[:cavv] = options[:cavv] if options[:cavv]
-        extra[:xid] = options[:xid] if options[:xid]
-        extra[:sli] = options[:sli] if options[:sli]
+        extra[:cavv] = options[:cavv] || options.dig(:three_d_secure, :cavv) if options[:cavv] || options.dig(:three_d_secure, :cavv)
+        extra[:xid] = options[:xid] || options.dig(:three_d_secure, :xid) if options[:xid] || options.dig(:three_d_secure, :xid)
+        extra[:sli] = options[:sli] || options.dig(:three_d_secure, :eci) if options[:sli] || options.dig(:three_d_secure, :eci)
         extra[:name] = options[:merchant] if options[:merchant]
         extra[:location] = options[:merchant_location] if options[:merchant_location]
+        extra[:card_on_file] = options.dig(:extra, :card_on_file) if options.dig(:extra, :card_on_file)
+        extra[:auth_reason]  = options.dig(:extra, :auth_reason) if options.dig(:extra, :auth_reason)
         post[:extra] = extra if extra.any?
       end
 

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -188,6 +188,24 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert_match %r{Extra/cavv is required for SLI 05}, response.message
   end
 
+  def test_successful_purchase_with_3DS_information_using_standard_fields
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: { cavv: 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', xid: 'MGVmMmNlMzI4NjAyOWU2ZDgwNTQ=', eci: '05' }))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase_with_incomplete_3DS_information_using_standard_fields
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: { xid: 'MGVmMmNlMzI4NjAyOWU2ZDgwNTQ=', eci: '05' }))
+    assert_failure response
+    assert_match %r{Extra/cavv is required for SLI 05}, response.message
+  end
+
+  def test_successful_purchase_with_card_on_file_information
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(recurring: true, extra: { card_on_file: true, auth_reason: 'U' }))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_invalid_login
     gateway = FatZebraGateway.new(
       username: 'invalid',

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -15,7 +15,8 @@ class FatZebraTest < Test::Unit::TestCase
     @options = {
       order_id: rand(10000),
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      extra: { card_on_file: false }
     }
   end
 
@@ -81,7 +82,7 @@ class FatZebraTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(recurring: true))
     end.check_request do |method, endpoint, data, headers|
-      assert_match(%r("extra":{"ecm":"32"}), data)
+      assert_match(%r("extra":{"ecm":"32"), data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
The Fat Zebra adapter does not currently support the standard presentation of 3DS fields as documented [here](https://github.com/activemerchant/active_merchant/wiki/Standardized-3DS-Fields). 

This PR allows the adapter to pass on the standard fields at least for 3DS v1. FZ does not at this juncture support 3DS v2.

This PR also allows an extras field with additional keys and values to be passed in unmolested to support various other functions that might be available to the account holder.

~~This PR builds on https://github.com/activemerchant/active_merchant/pull/3407 and I would imagine be merged afterwards.~~