### PR TITLE
Add tests for Ixopay exception handling

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -184,26 +184,12 @@ module ActiveMerchant #:nodoc:
         url = (test? ? test_url : live_url)
 
         # ssl_post raises an exception for any non-2xx HTTP status from the gateway
-        begin
-          raw_response = ssl_post(url, request, headers(request))
-        rescue StandardError => error
-          return response_from_request_error(error)
-        end
-
-        response = parse(raw_response)
-
-        Response.new(
-          success_from(response),
-          message_from(response),
-          response,
-          authorization: authorization_from(response),
-          test: test?,
-          error_code: error_code_from(response)
-        )
-      end
-
-      def response_from_request_error(error)
-        response = parse(error.response.body)
+        response =
+          begin
+            parse(ssl_post(url, request, headers(request)))
+          rescue StandardError => error
+            parse(error.response.body)
+          end
 
         Response.new(
           success_from(response),

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -183,6 +183,7 @@ module ActiveMerchant #:nodoc:
       def commit(request)
         url = (test? ? test_url : live_url)
 
+        # ssl_post raises an exception for any non-2xx HTTP status from the gateway
         begin
           raw_response = ssl_post(url, request, headers(request))
         rescue StandardError => error

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -43,6 +43,16 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_equal '2003', response.error_code
   end
 
+  def test_failed_authentication
+    gateway = IxopayGateway.new(username: 'baduser', password: 'badpass', secret: 'badsecret')
+    response = gateway.purchase(@amount, @credit_card, {})
+
+    assert_failure response
+
+    assert_equal 'Invalid Signature: Invalid authorization header', response.message
+    assert_equal '1004', response.error_code
+  end
+
   def test_successful_authorize_and_capture
     omit 'Not yet implemented'
 


### PR DESCRIPTION
The Active Merchant network methods raise an exception for any non-2xx status code returned from the gateway. There is exception handling in place in the Ixopay gateway to handle this. This pull request adds test coverage for that exception handling.