### PR TITLE
Ixopay: Implement refund

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -39,8 +39,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options={})
-        # todo
-        # commit('refund', build_refund_request(money, payment_method, options), options)
+        request = build_xml_request do |xml|
+          add_refund(xml, money, authorization)
+        end
+
+        commit(request)
       end
 
       def void(authorization, options={})
@@ -127,6 +130,15 @@ module ActiveMerchant #:nodoc:
           xml.currency    currency
           xml.description description
           xml.callbackUrl(options[:callback_url] || 'http://example.com')
+        end
+      end
+
+      def add_refund(xml, money, authorization)
+        xml.refund do
+          xml.transactionId           new_transaction_id
+          xml.referenceTransactionId  authorization&.split('|')&.first
+          xml.amount                  money
+          xml.currency                options[:currency] || currency(money)
         end
       end
 

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -81,19 +81,15 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    omit 'Not yet implemented'
-
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_success refund
-    assert_equal 'REPLACE WITH SUCCESSFUL REFUND MESSAGE', refund.message
+    assert_equal 'FINISHED', refund.message
   end
 
   def test_partial_refund
-    omit 'Not yet implemented'
-
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
@@ -102,11 +98,9 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    omit 'Not yet implemented'
-
-    response = @gateway.refund(@amount, '')
+    response = @gateway.refund(@amount, nil)
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED REFUND MESSAGE', response.message
+    assert_equal 'Transaction of type "refund" requires a referenceTransactionId', response.message
   end
 
   def test_successful_void

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -45,9 +45,21 @@ class IxopayTest < Test::Unit::TestCase
 
   def test_failed_capture; end
 
-  def test_successful_refund; end
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    response = @gateway.refund(@amount, 'eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe')
 
-  def test_failed_refund; end
+    assert_success response
+    assert_equal 'FINISHED', response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    response = @gateway.refund(@amount, nil)
+
+    assert_failure response
+    assert_equal 'Transaction of type "refund" requires a referenceTransactionId', response.message
+  end
 
   def test_successful_void; end
 
@@ -145,9 +157,32 @@ class IxopayTest < Test::Unit::TestCase
 
   def failed_capture_response; end
 
-  def successful_refund_response; end
+  def successful_refund_response
+    <<-XML
+      <result xmlns="http://secure.ixopay.com/Schema/V2/Result">
+        <success>true</success>
+        <referenceId>21c47c977476d5a3b682</referenceId>
+        <purchaseId>20191028-c9e173c255d14f90816b</purchaseId>
+        <returnType>FINISHED</returnType>
+        <paymentMethod>Creditcard</paymentMethod>
+      </result>
+    XML
+  end
 
-  def failed_refund_response; end
+  def failed_refund_response
+    <<-XML
+      <result xmlns="http://secure.ixopay.com/Schema/V2/Result">
+        <success>false</success>
+        <returnType>ERROR</returnType>
+        <errors>
+          <error>
+            <message>Transaction of type "refund" requires a referenceTransactionId</message>
+            <code>9999</code>
+          </error>
+        </errors>
+      </result>
+    XML
+  end
 
   def successful_void_response; end
 


### PR DESCRIPTION
Implements the `refund` transaction type for the new Ixopay gateway.

CE-140

Unit:
14 tests, 16 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
16 tests, 23 assertions, 0 failures, 0 errors, 0 pendings, 11 omissions,
0 notifications
100% passed