### PR TITLE
Credorax: Stop always sending r1 parameter

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -358,7 +358,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_processor(post, options)
-        post[:r1] = options[:processor] || 'CREDORAX'
+        post[:r1] = options[:processor] if options[:processor]
         post[:r2] = options[:processor_merchant_id] if options[:processor_merchant_id]
       end
 

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -64,11 +64,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without an r1 parameter.
   def test_successful_purchase_with_auth_data_via_3ds1_fields
     options = @options.merge(
       eci: '02',
       cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
-      xid: '00000000000000000501'
+      xid: '00000000000000000501',
+      processor: 'CREDORAX'
     )
 
     response = @gateway.purchase(@amount, @fully_auth_card, options)
@@ -92,6 +94,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without an r1 parameter.
   def test_successful_purchase_with_auth_data_via_normalized_3ds2_options
     version = '2.0'
     eci = '02'
@@ -103,7 +106,8 @@ class RemoteCredoraxTest < Test::Unit::TestCase
         eci: eci,
         cavv: cavv,
         ds_transaction_id: ds_transaction_id
-      }
+      },
+      processor: 'CREDORAX'
     )
 
     response = @gateway.purchase(@amount, @fully_auth_card, options)
@@ -162,11 +166,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', capture.message
   end
 
+  # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without an r1 parameter.
   def test_successful_authorize_with_auth_data_via_3ds1_fields
     options = @options.merge(
       eci: '02',
       cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
-      xid: '00000000000000000501'
+      xid: '00000000000000000501',
+      processor: 'CREDORAX'
     )
 
     response = @gateway.authorize(@amount, @fully_auth_card, options)
@@ -175,6 +181,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without an r1 parameter.
   def test_successful_authorize_with_auth_data_via_normalized_3ds2_options
     version = '2.0'
     eci = '02'
@@ -186,7 +193,8 @@ class RemoteCredoraxTest < Test::Unit::TestCase
         eci: eci,
         cavv: cavv,
         ds_transaction_id: ds_transaction_id
-      }
+      },
+      processor: 'CREDORAX'
     )
 
     response = @gateway.authorize(@amount, @fully_auth_card, options)


### PR DESCRIPTION
Credorax users must be enabled in their Credorax account to specify
their processor (via the r1 parameter). Maintains ability to pass in a
value for r1 via the processor option, and stops default sending it
with the value of CREDORAX when none is specified.

Necessary change due to an issue with a Spreedly customer having
rejected 3DS1 transactions due to inclusion of an r1 parameter in their
requests.

ECS-778

Unit:
58 tests, 264 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 128 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed