### PR TITLE
Ixopay: Implement void action

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -51,8 +51,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(authorization, options={})
-        # todo
-        # commit('void', build_void_request(money, payment_method, options), options)
+        request = build_xml_request do |xml|
+          add_void(xml, authorization)
+        end
+
+        commit(request)
       end
 
       def verify(credit_card, options={})
@@ -147,15 +150,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_refund(xml, money, authorization)
-        xml.refund do
-          xml.transactionId           new_transaction_id
-          xml.referenceTransactionId  authorization&.split('|')&.first
-          xml.amount                  money
-          xml.currency                options[:currency] || currency(money)
-        end
-      end
-
       def add_preauth(xml, money, options)
         description  = options[:description].blank? ? 'Preauthorize' : options[:description]
         currency     = options[:currency] || currency(money)
@@ -170,6 +164,22 @@ module ActiveMerchant #:nodoc:
           xml.currency    currency
           xml.description description
           xml.callbackUrl callback_url
+        end
+      end
+
+      def add_refund(xml, money, authorization)
+        xml.refund do
+          xml.transactionId           new_transaction_id
+          xml.referenceTransactionId  authorization&.split('|')&.first
+          xml.amount                  money
+          xml.currency                options[:currency] || currency(money)
+        end
+      end
+
+      def add_void(xml, authorization)
+        xml.void do
+          xml.transactionId           new_transaction_id
+          xml.referenceTransactionId  authorization&.split('|')&.first
         end
       end
 

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -117,22 +117,18 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    omit 'Not yet implemented'
-
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
-    assert_equal 'REPLACE WITH SUCCESSFUL VOID MESSAGE', void.message
+    assert_equal 'FINISHED', void.message
   end
 
   def test_failed_void
-    omit 'Not yet implemented'
-
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'REPLACE WITH FAILED VOID MESSAGE', response.message
+    assert_equal 'Transaction of type "void" requires a referenceTransactionId', response.message
   end
 
   def test_successful_verify

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -97,9 +97,21 @@ class IxopayTest < Test::Unit::TestCase
     assert_equal 'Transaction of type "refund" requires a referenceTransactionId', response.message
   end
 
-  def test_successful_void; end
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+    response = @gateway.void('eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe')
 
-  def test_failed_void; end
+    assert_success response
+    assert_equal 'FINISHED', response.message
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+    response = @gateway.void(nil)
+
+    assert_failure response
+    assert_equal 'Transaction of type "void" requires a referenceTransactionId', response.message
+  end
 
   def test_successful_verify; end
 
@@ -359,7 +371,30 @@ class IxopayTest < Test::Unit::TestCase
     XML
   end
 
-  def successful_void_response; end
+  def successful_void_response
+    <<-XML
+    <result xmlns="http://secure.ixopay.com/Schema/V2/Result">
+      <success>true</success>
+      <referenceId>cb656bd5286e77501b2e</referenceId>
+      <purchaseId>20191031-b1f9f7991766cf933659</purchaseId>
+      <returnType>FINISHED</returnType>
+      <paymentMethod>Creditcard</paymentMethod>
+    </result>
+    XML
+  end
 
-  def failed_void_response; end
+  def failed_void_response
+    <<-XML
+    <result xmlns="http://secure.ixopay.com/Schema/V2/Result">
+      <success>false</success>
+      <returnType>ERROR</returnType>
+      <errors>
+        <error>
+          <message>Transaction of type "void" requires a referenceTransactionId</message>
+          <code>9999</code>
+        </error>
+      </errors>
+    </result>
+    XML
+  end
 end


### PR DESCRIPTION
Implements the void transaction type for the new Ixopay gateway,
including unit and remote tests.

CE-135 / CE-139

Unit:
15 tests, 52 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
16 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 5 omissions,
0 notifications
100% passed