### PR TITLE
Quickbooks: Make refresh optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419
+
 == Version 1.101.0 (Nov 4, 2019)
 * Add UYI to list of currencies without fractions [curiousepic] #3416
 * Quickbooks: Add OAuth 2.0 support and void action [britth] #3397

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -127,4 +127,23 @@ class RemoteTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:access_token], transcript)
     assert_scrubbed(@gateway.options[:refresh_token], transcript)
   end
+
+  def test_failed_purchase_with_expired_token
+    @gateway.options[:access_token] = 'not_a_valid_token'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'AuthenticationFailed', response.params['code']
+  end
+
+  def test_successful_purchase_with_expired_token
+    @gateway.options[:access_token] = 'not_a_valid_token'
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(allow_refresh: true))
+    assert_success response
+  end
+
+  def test_refresh
+    response = @gateway.refresh
+    assert_success response
+    assert response.params['access_token']
+  end
 end

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -202,7 +202,7 @@ class QuickBooksTest < Test::Unit::TestCase
       anything
     ).returns(successful_purchase_response)
 
-    response = @oauth_1_gateway.purchase(@amount, @credit_card, @options)
+    response = @oauth_1_gateway.purchase(@amount, @credit_card, @options.merge(allow_refresh: true))
 
     assert_success response
 
@@ -217,7 +217,7 @@ class QuickBooksTest < Test::Unit::TestCase
       has_entries('Authorization' => 'Bearer access_token')
     ).returns(successful_purchase_response)
 
-    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options)
+    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options.merge(allow_refresh: true))
     assert_success response
   end
 
@@ -240,7 +240,7 @@ class QuickBooksTest < Test::Unit::TestCase
       has_entries('Authorization' => 'Bearer new_access_token')
     ).returns(successful_purchase_response)
 
-    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options)
+    response = @oauth_2_gateway.purchase(@amount, @credit_card, @options.merge(allow_refresh: true))
     assert_success response
 
     assert_match(/EF1IQ9GGXS2D|/, response.authorization)


### PR DESCRIPTION
While access_tokens expire every hour, there are potential
complications in refreshing them in certain workflows. Adds a flag,
`allow_refresh` to optionally refresh the access_token after making
a request. Also marks as a failure if authentication failed.

Remote:
16 tests, 40 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
21 tests, 114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed