### PR TITLE
OPP (Acapture): Update test cards' expirations

### DIFF
--- a/test/remote/gateways/remote_opp_test.rb
+++ b/test/remote/gateways/remote_opp_test.rb
@@ -6,9 +6,9 @@ class RemoteOppTest < Test::Unit::TestCase
     @gateway = OppGateway.new(fixtures(:opp))
     @amount = 100
 
-    @valid_card = credit_card('4200000000000000', month: 05, year: 2018)
-    @invalid_card = credit_card('4444444444444444', month: 05, year: 2018)
-    @amex_card = credit_card('377777777777770 ', month: 05, year: 2018, brand: 'amex', verification_value: '1234')
+    @valid_card = credit_card('4200000000000000', month: 05, year: Date.today.year + 2)
+    @invalid_card = credit_card('4444444444444444', month: 05, year: Date.today.year + 2)
+    @amex_card = credit_card('377777777777770 ', month: 05, year: Date.today.year + 2, brand: 'amex', verification_value: '1234')
 
     request_type = 'complete' # 'minimal' || 'complete'
     time = Time.now.to_i

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -7,8 +7,8 @@ class OppTest < Test::Unit::TestCase
     @gateway = OppGateway.new(fixtures(:opp))
     @amount = 100
 
-    @valid_card = credit_card('4200000000000000', month: 05, year: 2018, verification_value: '123')
-    @invalid_card = credit_card('4444444444444444', month: 05, year: 2018, verification_value: '123')
+    @valid_card = credit_card('4200000000000000', month: 05, year: Date.today.year + 2, verification_value: '123')
+    @invalid_card = credit_card('4444444444444444', month: 05, year: Date.today.year + 2, verification_value: '123')
 
     request_type = 'complete' # 'minimal' || 'complete'
     time = Time.now.to_i


### PR DESCRIPTION
This change is required for remote tests to pass

ECS-825

Unit:
14 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
15 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed