### PR TITLE
Ixopay: Implement verify action

### DIFF
--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -132,19 +132,15 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    omit 'Not yet implemented'
-
     response = @gateway.verify(@credit_card, @options)
     assert_success response
-    assert_match %r{REPLACE WITH SUCCESS MESSAGE}, response.message
+    assert_match %r{FINISHED}, response.message
   end
 
   def test_failed_verify
-    omit 'Not yet implemented'
-
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{REPLACE WITH FAILED PURCHASE MESSAGE}, response.message
+    assert_match %r{The transaction was declined}, response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -113,11 +113,27 @@ class IxopayTest < Test::Unit::TestCase
     assert_equal 'Transaction of type "void" requires a referenceTransactionId', response.message
   end
 
-  def test_successful_verify; end
+  def test_successful_verify
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, successful_void_response)
+    response = @gateway.verify(credit_card('4111111111111111'), @options)
 
-  def test_successful_verify_with_failed_void; end
+    assert_success response
+    assert_equal 'FINISHED', response.message
+  end
 
-  def test_failed_verify; end
+  def test_successful_verify_with_failed_void
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, failed_void_response)
+
+    response = @gateway.verify(credit_card('4111111111111111'), @options)
+    assert_success response
+  end
+
+  def test_failed_verify
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+  end
 
   def test_scrub
     assert @gateway.supports_scrubbing?


### PR DESCRIPTION
Implement the `verify` action for the new Ixopay gateway, including
remote and unit tests.

CE-135 / CE-141

Unit:
15 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 3 omissions,
0 notifications
100% passed