### PR TITLE
RuboCop: Fix Layout/ExtraSpacing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,12 +35,6 @@ Layout/EmptyLineAfterGuardClause:
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-# Offense count: 174
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Enabled: false
-
 # Offense count: 105
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Paymentez: Update supported countries [curiousepic] #3425
 * Ixopay: Add new gateway [jasonxp] #3426
 * RuboCop: Fix Layout/EndAlignment [leila-alderman] #3427
+* RuboCop: Fix Layout/ExtraSpacing [leila-alderman] #3429
 
 == Version 1.101.0 (Nov 4, 2019)
 * Add UYI to list of currencies without fractions [curiousepic] #3416

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -336,7 +336,7 @@ module ActiveMerchant #:nodoc:
           if expired?
             errors << [:year,  'expired']
           else
-            errors << [:year,  'is not a valid year']  if !valid_expiry_year?(year)
+            errors << [:year,  'is not a valid year'] if !valid_expiry_year?(year)
           end
         end
 
@@ -347,7 +347,7 @@ module ActiveMerchant #:nodoc:
         errors = []
 
         if !empty?(brand)
-          errors << [:brand, 'is invalid']  if !CreditCard.card_companies.include?(brand)
+          errors << [:brand, 'is invalid'] if !CreditCard.card_companies.include?(brand)
         end
 
         if empty?(number)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AT', 'AU', 'BE', 'BG', 'BR', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GI', 'GR', 'HK', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'MT', 'MX', 'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SG', 'SK', 'SI', 'US']
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(CVE DJF GNF IDR JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro,  :discover, :elo, :naranja, :cabal]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro, :discover, :elo, :naranja, :cabal]
 
       self.money_format = :cents
 

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
           post[:city] = billing_address[:city]
           post[:state] = billing_address[:state]
           post[:countryId] = billing_address[:country]
-          post[:postalCode]    = billing_address[:zip]
+          post[:postalCode] = billing_address[:zip]
           post[:phone] = billing_address[:phone]
         end
       end

--- a/lib/active_merchant/billing/gateways/bank_frick.rb
+++ b/lib/active_merchant/billing/gateways/bank_frick.rb
@@ -97,7 +97,7 @@ module ActiveMerchant #:nodoc:
           post[:zip]     = address[:zip].to_s
           post[:city]    = address[:city].to_s
           post[:country] = address[:country].to_s
-          post[:state]   = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:state]   = address[:state].blank? ? 'n/a' : address[:state]
         end
       end
 
@@ -119,7 +119,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        results  = {}
+        results = {}
         xml = Nokogiri::XML(body)
         resp = xml.xpath('//Response/Transaction/Identification')
         resp.children.each do |element|

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -129,25 +129,25 @@ module ActiveMerchant #:nodoc:
       # Smartpay may return AVS codes not covered by standard AVSResult codes.
       # Smartpay's descriptions noted below.
       AVS_MAPPING = {
-        '0'  => 'R',  # Unknown
-        '1'  => 'A',	# Address matches, postal code doesn't
-        '2'  => 'N',	# Neither postal code nor address match
-        '3'  => 'R',	# AVS unavailable
-        '4'  => 'E',	# AVS not supported for this card type
-        '5'  => 'U',	# No AVS data provided
-        '6'  => 'Z',	# Postal code matches, address doesn't match
-        '7'  => 'D',	# Both postal code and address match
-        '8'  => 'U',	# Address not checked, postal code unknown
-        '9'  => 'B',	# Address matches, postal code unknown
-        '10' => 'N',	# Address doesn't match, postal code unknown
-        '11' => 'U',	# Postal code not checked, address unknown
-        '12' => 'B',	# Address matches, postal code not checked
-        '13' => 'U',	# Address doesn't match, postal code not checked
-        '14' => 'P',	# Postal code matches, address unknown
-        '15' => 'P',	# Postal code matches, address not checked
-        '16' => 'N',	# Postal code doesn't match, address unknown
-        '17' => 'U',  # Postal code doesn't match, address not checked
-        '18' => 'I'	  # Neither postal code nor address were checked
+        '0'  => 'R', # Unknown
+        '1'  => 'A', # Address matches, postal code doesn't
+        '2'  => 'N', # Neither postal code nor address match
+        '3'  => 'R', # AVS unavailable
+        '4'  => 'E', # AVS not supported for this card type
+        '5'  => 'U', # No AVS data provided
+        '6'  => 'Z', # Postal code matches, address doesn't match
+        '7'  => 'D', # Both postal code and address match
+        '8'  => 'U', # Address not checked, postal code unknown
+        '9'  => 'B', # Address matches, postal code unknown
+        '10' => 'N', # Address doesn't match, postal code unknown
+        '11' => 'U', # Postal code not checked, address unknown
+        '12' => 'B', # Address matches, postal code not checked
+        '13' => 'U', # Address doesn't match, postal code not checked
+        '14' => 'P', # Postal code matches, address unknown
+        '15' => 'P', # Postal code matches, address not checked
+        '16' => 'N', # Postal code doesn't match, address unknown
+        '17' => 'U', # Postal code doesn't match, address not checked
+        '18' => 'I'	 # Neither postal code nor address were checked
       }
 
       def commit(action, post, account = 'ws', password = @options[:password])

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
-        post[:TRANS_TYPE]  = 'AUTH'
+        post[:TRANS_TYPE] = 'AUTH'
         commit('AUTH_ONLY', money, post, options)
       end
 
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
-        post[:TRANS_TYPE]  = 'SALE'
+        post[:TRANS_TYPE] = 'SALE'
         commit('AUTH_CAPTURE', money, post, options)
       end
 
@@ -385,7 +385,7 @@ module ActiveMerchant #:nodoc:
         elsif message =~ /Approved/
           message = 'This transaction has been approved'
         elsif message =~  /Expired/
-          message =  'The credit card has expired'
+          message = 'The credit card has expired'
         end
         message
       end

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
           post[address_key(prefix, 'FirstName')] = address[:first_name]
           post[address_key(prefix, 'LastName')]  = address[:last_name]
         end
-        post[address_key(prefix, 'MiddleName')]  = address[:middle_name]
+        post[address_key(prefix, 'MiddleName')] = address[:middle_name]
 
         post[address_key(prefix, 'Company')]  = address[:company]
         post[address_key(prefix, 'Street')]   = address[:address1]

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -49,7 +49,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, identification, options = {})
         post = {}
-        post[:origtx]  = identification
+        post[:origtx] = identification
         add_invoice(post, options)
         add_customer_data(post, options)
         commit('REFUND', money, post)
@@ -107,8 +107,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, options)
-        post[:order_number]    = options[:order_id] if options[:order_id].present?
-        post[:itemcode]       = (options[:item_code] || @options[:default_item_code])
+        post[:order_number] = options[:order_id] if options[:order_id].present?
+        post[:itemcode] = (options[:item_code] || @options[:default_item_code])
       end
 
       def add_address(post, options)
@@ -121,8 +121,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        post[:email_g]  = options[:email]
-        post[:custcode]  = options[:custcode] unless empty?(options[:custcode])
+        post[:email_g] = options[:email]
+        post[:custcode] = options[:custcode] unless empty?(options[:custcode])
       end
 
       def expdate(creditcard)

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
       protected
 
       def build_sale_request(type, money, creditcard, options = {})
-        requires!(options,  :order_id)
+        requires!(options, :order_id)
 
         xml = Builder::XmlMarkup.new :indent => 2
 

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -130,7 +130,7 @@ module ActiveMerchant #:nodoc:
 
         if root.elements['OPERACION']
           response[:operation_type] = root.elements['OPERACION'].attributes['tipo']
-          response[:amount] =  root.elements['OPERACION/importe'].text.strip
+          response[:amount] = root.elements['OPERACION/importe'].text.strip
         end
 
         response[:description] = root.elements['OPERACION/descripcion'].text if root.elements['OPERACION/descripcion']

--- a/lib/active_merchant/billing/gateways/checkout.rb
+++ b/lib/active_merchant/billing/gateways/checkout.rb
@@ -198,7 +198,7 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def authorization_from(response, action,  amount, options)
+      def authorization_from(response, action, amount, options)
         currency = options[:currency] || currency(amount)
         [response[:tranid], response[:trackid], action, amount, currency].join('|')
       end

--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -177,8 +177,8 @@ module ActiveMerchant #:nodoc:
         return unless (options[:verify_zip].to_s == 'true') || (options[:verify_address].to_s == 'true')
         if address = options[:billing_address]
           xml.AdditionalVerification do
-            xml.Zip address[:zip] if options[:verify_zip].to_s  == 'true'
-            xml.Address address[:address1] if options[:verify_address].to_s  == 'true'
+            xml.Zip address[:zip] if options[:verify_zip].to_s == 'true'
+            xml.Address address[:address1] if options[:verify_address].to_s == 'true'
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -177,7 +177,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_invoice(post, money,  options)
+      def add_invoice(post, money, options)
         post[:CurrencyCode] = options[:currency] || (currency(money) if money)
         post[:InvoiceNumber] = options[:order_id].rjust(12, '0')
         post[:InputType] = 'I'
@@ -227,7 +227,7 @@ module ActiveMerchant #:nodoc:
             r.process { commit_raw(action, parameters) }
             r.process {
               split_auth = split_authorization(r.authorization)
-              auth =  (action.include?('recur')? split_auth[4] : split_auth[0])
+              auth = (action.include?('recur')? split_auth[4] : split_auth[0])
               action.include?('recur') ? commit_raw('recur/ack', {ID: auth}) : commit_raw('ack', {TransactionNumber: auth})
             }
           end

--- a/lib/active_merchant/billing/gateways/culqi.rb
+++ b/lib/active_merchant/billing/gateways/culqi.rb
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
           post[:city] = billing_address[:city]
           post[:state] = billing_address[:state]
           post[:countrycode] = billing_address[:country]
-          post[:zip]    = billing_address[:zip]
+          post[:zip] = billing_address[:zip]
           post[:telno] = billing_address[:phone]
           post[:telnocc] = options[:telephone_country_code] || '051'
         end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
       # This functionality is only supported by this particular gateway may
       # be changed at any time
       def calculate_tax(creditcard, options)
-        requires!(options,  :line_items)
+        requires!(options, :line_items)
         setup_address_hash(options)
         commit(build_tax_calculation_request(creditcard, options), :calculate_tax, nil, options)
       end
@@ -314,7 +314,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_void_request(identification, options)
-        order_id, request_id, request_token, action, money, currency  = identification.split(';')
+        order_id, request_id, request_token, action, money, currency = identification.split(';')
         options[:order_id] = order_id
 
         xml = Builder::XmlMarkup.new :indent => 2
@@ -444,23 +444,23 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'merchantID', @options[:login]
         xml.tag! 'merchantReferenceCode', options[:order_id] || generate_unique_id
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
-        xml.tag! 'clientLibraryVersion',  VERSION
+        xml.tag! 'clientLibraryVersion', VERSION
         xml.tag! 'clientEnvironment', RUBY_PLATFORM
       end
 
       def add_purchase_data(xml, money = 0, include_grand_total = false, options={})
         xml.tag! 'purchaseTotals' do
           xml.tag! 'currency', options[:currency] || currency(money)
-          xml.tag!('grandTotalAmount', localized_amount(money.to_i, options[:currency] || default_currency))  if include_grand_total
+          xml.tag!('grandTotalAmount', localized_amount(money.to_i, options[:currency] || default_currency)) if include_grand_total
         end
       end
 
       def add_address(xml, payment_method, address, options, shipTo = false)
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
-          xml.tag! 'firstName',             payment_method.first_name             if payment_method
-          xml.tag! 'lastName',              payment_method.last_name              if payment_method
+          xml.tag! 'firstName',             payment_method.first_name if payment_method
+          xml.tag! 'lastName',              payment_method.last_name if payment_method
           xml.tag! 'street1',               address[:address1]
-          xml.tag! 'street2',               address[:address2]                unless address[:address2].blank?
+          xml.tag! 'street2',               address[:address2] unless address[:address2].blank?
           xml.tag! 'city',                  address[:city]
           xml.tag! 'state',                 address[:state]
           xml.tag! 'postalCode',            address[:zip]
@@ -679,7 +679,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'subscriptionID',  subscription_id
           end
 
-          xml.tag! 'status',            options[:subscription][:status]                         if options[:subscription][:status]
+          xml.tag! 'status',            options[:subscription][:status] if options[:subscription][:status]
           xml.tag! 'amount',            localized_amount(options[:subscription][:amount].to_i, options[:currency] || default_currency) if options[:subscription][:amount]
           xml.tag! 'numberOfPayments',  options[:subscription][:occurrences]                    if options[:subscription][:occurrences]
           xml.tag! 'automaticRenew',    options[:subscription][:automatic_renew]                if options[:subscription][:automatic_renew]

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -111,35 +111,35 @@ module ActiveMerchant #:nodoc:
       def add_address(post, options)
         if address = options[:billing_address] || options[:address]
           if address[:address2]
-            post[:billing_address]    = address[:address1].to_s << ' ' <<  address[:address2].to_s
+            post[:billing_address]    = address[:address1].to_s << ' ' << address[:address2].to_s
           else
             post[:billing_address]    = address[:address1].to_s
           end
           post[:billing_city]         = address[:city].to_s
-          post[:billing_state]        = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:billing_state]        = address[:state].blank? ? 'n/a' : address[:state]
           post[:billing_postal_code]  = address[:zip].to_s
           post[:billing_country]      = address[:country].to_s
         end
 
         if address = options[:shipping_address]
           if address[:address2]
-            post[:shipping_address]   = address[:address1].to_s << ' ' <<  address[:address2].to_s
+            post[:shipping_address]   = address[:address1].to_s << ' ' << address[:address2].to_s
           else
             post[:shipping_address]   = address[:address1].to_s
           end
           post[:shipping_city]        = address[:city].to_s
-          post[:shipping_state]       = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:shipping_state]       = address[:state].blank? ? 'n/a' : address[:state]
           post[:shipping_postal_code] = address[:zip].to_s
           post[:shipping_country]     = address[:country].to_s
         end
       end
 
       def add_creditcard(post, creditcard)
-        post[:billing_name]  = creditcard.name if creditcard.name
-        post[:account_number]  = creditcard.number
+        post[:billing_name] = creditcard.name if creditcard.name
+        post[:account_number] = creditcard.number
         post[:card_verification_value] = creditcard.verification_value if creditcard.verification_value?
-        post[:expiration_month]  = sprintf('%.2i', creditcard.month)
-        post[:expiration_year]  = sprintf('%.4i', creditcard.year)[-2..-1]
+        post[:expiration_month] = sprintf('%.2i', creditcard.month)
+        post[:expiration_year] = sprintf('%.4i', creditcard.year)[-2..-1]
       end
 
       def commit(action, parameters)
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
         ACTIONS
       end
 
-      CREDIT_CARD_FIELDS =  %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber )
+      CREDIT_CARD_FIELDS = %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber )
 
       ACTIONS = {
            :credit_card_authorize       => CREDIT_CARD_FIELDS,

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_creditcard(post, creditcard)
-        post[:CardNumber]  = creditcard.number
+        post[:CardNumber] = creditcard.number
         post[:CardExpiryMonth]  = sprintf('%.2i', creditcard.month)
         post[:CardExpiryYear] = sprintf('%.4i', creditcard.year)[-2..-1]
         post[:CustomerFirstName] = creditcard.first_name

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
 
       # add credit card details to be stored by eway. NOTE eway requires "title" field
       def add_creditcard(post, creditcard)
-        post[:CCNumber]  = creditcard.number
+        post[:CCNumber] = creditcard.number
         post[:CCExpiryMonth]  = sprintf('%.2i', creditcard.month)
         post[:CCExpiryYear] = sprintf('%.4i', creditcard.year)[-2..-1]
         post[:CCNameOnCard] = creditcard.name

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response), message, response,
           :test => test?,
           :authorization => response['transactionid'],
-          :avs_result => {:code =>  response['avsresponse']},
+          :avs_result => {:code => response['avsresponse']},
           :cvv_result => response['cvvresponse']
         )
       end

--- a/lib/active_merchant/billing/gateways/finansbank.rb
+++ b/lib/active_merchant/billing/gateways/finansbank.rb
@@ -3,7 +3,7 @@ require 'active_merchant/billing/gateways/cc5'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class FinansbankGateway < CC5Gateway
-      self.live_url =  'https://www.fbwebpos.com/servlet/cc5ApiServer'
+      self.live_url = 'https://www.fbwebpos.com/servlet/cc5ApiServer'
       self.test_url = 'https://entegrasyon.asseco-see.com.tr/fim/api'
 
       # The countries the gateway supports merchants from as 2 digit ISO country codes

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, identifier, options = {})
         get = {}
         get[:transactionId] = identifier
-        get[:tranType]     = 'REFUNDREQUEST'
+        get[:tranType] = 'REFUNDREQUEST'
         commit('/transaction/refundrequest?' + encode(get))
       end
 

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
       def build_authorize_request(money, credit_card, options)
         build_xml_request(money, credit_card, options) do |xml|
           add_customer_data(xml, options)
-          add_order_data(xml, options)  do
+          add_order_data(xml, options) do
             add_addresses(xml, options)
           end
           add_credit_card(xml, credit_card)

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
       def add_payment(post, payment, options)
         year  = format(payment.year, :two_digits)
         month = format(payment.month, :two_digits)
-        expirydate =   "#{month}#{year}"
+        expirydate = "#{month}#{year}"
         pre_authorization = options[:pre_authorization] ? 'PRE_AUTHORIZATION' : 'FINAL_AUTHORIZATION'
 
         post['cardPaymentMethodSpecificInput'] = {

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -110,12 +110,12 @@ module ActiveMerchant #:nodoc:
         if address = options[:billing_address] || options[:address]
           post[:address1]    = address[:address1].to_s
           post[:address2]    = address[:address2].to_s unless address[:address2].blank?
-          post[:company]    = address[:company].to_s
-          post[:phone]      = address[:phone].to_s
-          post[:zip]        = address[:zip].to_s
-          post[:city]       = address[:city].to_s
-          post[:country]    = address[:country].to_s
-          post[:state]      = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:company]     = address[:company].to_s
+          post[:phone]       = address[:phone].to_s
+          post[:zip]         = address[:zip].to_s
+          post[:city]        = address[:city].to_s
+          post[:country]     = address[:country].to_s
+          post[:state]       = address[:state].blank? ? 'n/a' : address[:state]
         end
       end
 
@@ -141,9 +141,9 @@ module ActiveMerchant #:nodoc:
           post[:customer_vault] = 'add_customer'
           post[:customer_vault_id] = options[:store] unless options[:store] == true
         end
-        post[:ccnumber]  = creditcard.number
+        post[:ccnumber] = creditcard.number
         post[:cvv] = creditcard.verification_value if creditcard.verification_value?
-        post[:ccexp]  = expdate(creditcard)
+        post[:ccexp] = expdate(creditcard)
         post[:firstname] = creditcard.first_name
         post[:lastname]  = creditcard.last_name
       end
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, money, parameters)
-        parameters[:amount]  = amount(money) if money
+        parameters[:amount] = amount(money) if money
 
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
@@ -193,7 +193,7 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         post = {}
-        post[:username]      = @options[:login]
+        post[:username]   = @options[:login]
         post[:password]   = @options[:password]
         post[:type]       = action if action
 

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
 
       def verify_credentials
         void = void('', options)
-        return true if void.message ==  'Missing OriginalMerchantTrace'
+        return true if void.message == 'Missing OriginalMerchantTrace'
         false
       end
 

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -311,11 +311,11 @@ module ActiveMerchant #:nodoc:
               options_element = item_element.add_element('options')
               for option in value
                 opt_element = options_element.add_element('option')
-                opt_element.add_element('name').text =  option[:name]   unless option[:name].blank?
-                opt_element.add_element('value').text =  option[:value]   unless option[:value].blank?
+                opt_element.add_element('name').text = option[:name] unless option[:name].blank?
+                opt_element.add_element('value').text = option[:value] unless option[:value].blank?
               end
             else
-              item_element.add_element(key.to_s).text =  item[key].to_s unless item[key].blank?
+              item_element.add_element(key.to_s).text = item[key].to_s unless item[key].blank?
             end
           end
         end
@@ -340,7 +340,7 @@ module ActiveMerchant #:nodoc:
             :terminaltype => options[:terminaltype],
             :ip => options[:ip],
             :reference_number => options[:reference_number],
-            :recurring => options[:recurring] || 'NO',  # DO NOT USE if you are using the periodic billing option.
+            :recurring => options[:recurring] || 'NO', # DO NOT USE if you are using the periodic billing option.
             :tdate => options[:tdate]
           },
           :orderoptions => {
@@ -395,8 +395,8 @@ module ActiveMerchant #:nodoc:
           params[:billing][:zip]       = billing_address[:zip]      unless billing_address[:zip].blank?
           params[:billing][:country]   = billing_address[:country]  unless billing_address[:country].blank?
           params[:billing][:company]   = billing_address[:company]  unless billing_address[:company].blank?
-          params[:billing][:phone]     = billing_address[:phone]  unless billing_address[:phone].blank?
-          params[:billing][:email]     = options[:email] unless options[:email].blank?
+          params[:billing][:phone]     = billing_address[:phone]    unless billing_address[:phone].blank?
+          params[:billing][:email]     = options[:email]            unless options[:email].blank?
         end
 
         if shipping_address = options[:shipping_address]

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -193,7 +193,7 @@ module ActiveMerchant #:nodoc:
 
       def refund_type(payment)
         _, kind, _ = split_authorization(payment)
-        if check?(payment) || kind  == 'echeckSales'
+        if check?(payment) || kind == 'echeckSales'
           :echeckCredit
         else
           :credit

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -133,9 +133,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_creditcard(post, creditcard, options)
-        post[:card_number]  = creditcard.number
+        post[:card_number] = creditcard.number
         post[:cvv2] = creditcard.verification_value if creditcard.verification_value?
-        post[:card_exp_date]  = expdate(creditcard)
+        post[:card_exp_date] = expdate(creditcard)
       end
 
       def add_3dsecure_params(post, options)
@@ -156,13 +156,13 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, money, parameters)
         url = test? ? self.test_url : self.live_url
-        parameters[:transaction_amount]  = amount(money) if money unless action == 'V'
+        parameters[:transaction_amount] = amount(money) if money unless action == 'V'
 
         response =
           begin
             parse(ssl_post(url, post_data(action, parameters)))
           rescue ActiveMerchant::ResponseError => e
-            { 'error_code' => '404',  'auth_response_text' => e.to_s }
+            { 'error_code' => '404', 'auth_response_text' => e.to_s }
           end
 
         Response.new(response['error_code'] == '000', message_from(response), response,

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -97,7 +97,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(data)
-        responses =  CGI.parse(data).inject({}) { |h, (k, v)| h[k] = v.first; h }
+        responses = CGI.parse(data).inject({}) { |h, (k, v)| h[k] = v.first; h }
         Response.new(
           (responses['response'].to_i == 1),
           responses['responsetext'],

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
           post[:billcity] = billing_address[:city]
           post[:billstate] = billing_address[:state]
           post[:billcountry] = billing_address[:country]
-          post[:bilzip]    = billing_address[:zip]
+          post[:bilzip] = billing_address[:zip]
           post[:phone] = billing_address[:phone]
         end
       end

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -261,7 +261,7 @@ module ActiveMerchant #:nodoc:
           post[:zip]     = address[:zip].to_s
           post[:city]    = address[:city].to_s
           post[:country] = address[:country].to_s
-          post[:state]   = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:state]   = address[:state].blank? ? 'n/a' : address[:state]
         end
 
         if address = options[:shipping_address]
@@ -273,7 +273,7 @@ module ActiveMerchant #:nodoc:
           post[:ship_to_zip]     = address[:zip].to_s
           post[:ship_to_city]    = address[:city].to_s
           post[:ship_to_country] = address[:country].to_s
-          post[:ship_to_state]   = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:ship_to_state]   = address[:state].blank? ? 'n/a' : address[:state]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers
-        { 'Content-Type'  => 'application/x-www-form-urlencoded;charset=UTF-8' }
+        { 'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8' }
       end
 
       def post_data(action, params)

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_creditcard_type(post, card_type)
-        post[:Gateway]  = 'ssl'
+        post[:Gateway] = 'ssl'
         post[:card] = CARD_TYPES.detect { |ct| ct.am_code == card_type }.migs_long_code
       end
 

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -81,7 +81,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        post[:acctNum]   = options[:customer]
+        post[:acctNum] = options[:customer]
       end
 
       def add_address(post, options)

--- a/lib/active_merchant/billing/gateways/moneris_us.rb
+++ b/lib/active_merchant/billing/gateways/moneris_us.rb
@@ -191,7 +191,7 @@ module ActiveMerchant #:nodoc:
           if crypt_type = options[:crypt_type] || @options[:crypt_type]
             post[:crypt_type] = crypt_type
           end
-          post[:cust_id]    = options[:customer] || source.name
+          post[:cust_id] = options[:customer] || source.name
         end
       end
 

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response), message, response,
           :test => test?,
           :authorization => response['transactionid'],
-          :avs_result => {:code =>  response['avsresponse']},
+          :avs_result => {:code => response['avsresponse']},
           :cvv_result => response['cvvresponse']
         )
       end

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -130,8 +130,8 @@ module ActiveMerchant #:nodoc:
         post[:card][:cvv]        = credit_card.verification_value
         post[:card][:cardExpiry] = expdate(credit_card)
 
-        post[:authentication]  = map_3ds(options[:three_d_secure]) if options[:three_d_secure]
-        post[:card][:billingAddress]  = map_address(options[:billing_address]) if options[:billing_address]
+        post[:authentication] = map_3ds(options[:three_d_secure]) if options[:three_d_secure]
+        post[:card][:billingAddress] = map_address(options[:billing_address]) if options[:billing_address]
       end
 
       def add_invoice(post, money, options)

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -220,7 +220,7 @@ module ActiveMerchant #:nodoc:
           post[:city] = billing_address[:city]
           post[:state] = billing_address[:state]
           post[:country] = billing_address[:country]
-          post[:zip]    = billing_address[:zip]
+          post[:zip] = billing_address[:zip]
           post[:phone] = billing_address[:phone]
         end
 
@@ -231,7 +231,7 @@ module ActiveMerchant #:nodoc:
           post[:shipping_city] = shipping_address[:city]
           post[:shipping_state] = shipping_address[:state]
           post[:shipping_country] = shipping_address[:country]
-          post[:shipping_zip]    = shipping_address[:zip]
+          post[:shipping_zip] = shipping_address[:zip]
           post[:shipping_phone] = shipping_address[:phone]
         end
       end
@@ -292,7 +292,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers
-        { 'Content-Type'  => 'application/x-www-form-urlencoded;charset=UTF-8' }
+        { 'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8' }
       end
 
       def post_data(action, params)

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -291,7 +291,7 @@ module ActiveMerchant #:nodoc:
         add_pair post, 'DECLINEURL',      options[:decline_url]     if options[:decline_url]
         add_pair post, 'EXCEPTIONURL',    options[:exception_url]   if options[:exception_url]
         add_pair post, 'CANCELURL',       options[:cancel_url]      if options[:cancel_url]
-        add_pair post, 'PARAMVAR',        options[:paramvar]       if options[:paramvar]
+        add_pair post, 'PARAMVAR',        options[:paramvar]        if options[:paramvar]
         add_pair post, 'PARAMPLUS',       options[:paramplus]       if options[:paramplus]
         add_pair post, 'COMPLUS',         options[:complus]         if options[:complus]
         add_pair post, 'LANGUAGE',        options[:language]        if options[:language]

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -456,7 +456,7 @@ module ActiveMerchant #:nodoc:
         unless creditcard.nil?
           if creditcard.verification_value?
             xml.tag! :CardSecValInd, '1' if %w( visa discover ).include?(creditcard.brand)
-            xml.tag! :CardSecVal,  creditcard.verification_value
+            xml.tag! :CardSecVal, creditcard.verification_value
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
 
       def force_utf8(string)
         return nil unless string
-        binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?')   # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
+        binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?') # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
         binary.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
       end
 

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -106,7 +106,7 @@ module ActiveMerchant #:nodoc:
         900002  => 'Card Expired',
         900003  => 'Insufficient Funds',
         900004  => 'Invalid Card Number',
-        900005  => 'Bank Interface Timeout',  # indicates a communications failure between the banks systems
+        900005  => 'Bank Interface Timeout', # indicates a communications failure between the banks systems
         900006  => 'Invalid Card',
         900007  => 'Declined',
         900009  => 'Lost Card',
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
         900014  => 'Excessive Card Usage',
         900015  => 'Card Blacklisted',
 
-        900207  => 'Declined; authentication failed',  # indicates the cardholder did not enter their MasterCard SecureCode / Verified by Visa password correctly
+        900207  => 'Declined; authentication failed', # indicates the cardholder did not enter their MasterCard SecureCode / Verified by Visa password correctly
 
         990020  => 'Auth Declined',
 
@@ -135,12 +135,12 @@ module ActiveMerchant #:nodoc:
         990053  => 'Error processing transaction',
 
         # Miscellaneous - Unless otherwise noted, the TRANSACTION_STATUS will be 0.
-        900209  => 'Transaction verification failed (phase 2)',  # Indicates the verification data returned from MasterCard SecureCode / Verified by Visa has been altered
-        900210  => 'Authentication complete; transaction must be restarted',  # Indicates that the MasterCard SecuerCode / Verified by Visa transaction has already been completed.  Most likely caused by the customer clicking the refresh button
+        900209  => 'Transaction verification failed (phase 2)', # Indicates the verification data returned from MasterCard SecureCode / Verified by Visa has been altered
+        900210  => 'Authentication complete; transaction must be restarted', # Indicates that the MasterCard SecuerCode / Verified by Visa transaction has already been completed.  Most likely caused by the customer clicking the refresh button
 
         990024  => 'Duplicate Transaction Detected.  Please check before submitting',
 
-        990028  => 'Transaction cancelled'  # Customer clicks the 'Cancel' button on the payment page
+        990028  => 'Transaction cancelled' # Customer clicks the 'Cancel' button on the payment page
       }
 
       SUCCESS_CODES = %w( 990004 990005 990017 990012 990018 990031 )

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_amount(post, amount)
-        post[:amount] =  amount(amount)
+        post[:amount] = amount(amount)
       end
 
       def add_creditcard(post, creditcard)

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -97,7 +97,7 @@ module ActiveMerchant #:nodoc:
     # See example use above for address AVS fields
     # See #recurring for periodic transaction fields
     class PayJunctionGateway < Gateway
-      API_VERSION   = '1.2'
+      API_VERSION = '1.2'
 
       class_attribute :test_url, :live_url
 
@@ -319,7 +319,7 @@ module ActiveMerchant #:nodoc:
         address = options[:billing_address] || options[:address]
 
         if address
-          params[:address]  = address[:address1] unless address[:address1].blank?
+          params[:address]   = address[:address1] unless address[:address1].blank?
           params[:city]      = address[:city]     unless address[:city].blank?
           params[:state]     = address[:state]    unless address[:state].blank?
           params[:zipcode]   = address[:zip]      unless address[:zip].blank?

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
       # Used for capturing, which is currently not supported.
       def add_reference(post, identification)
         auth, trans_id = identification.split(';')
-        post[:authnum]    = auth
+        post[:authnum] = auth
         post[:transid] = trans_id
       end
 

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -171,7 +171,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        success?(response) ? SUCCESS_MESSAGE : (response[:commentaire]  || FAILURE_MESSAGE)
+        success?(response) ? SUCCESS_MESSAGE : (response[:commentaire] || FAILURE_MESSAGE)
       end
 
       def post_data(action, parameters = {})

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -150,7 +150,7 @@ module ActiveMerchant #:nodoc:
             end
             xml.tag! 'Tender' do
               xml.tag! 'Card' do
-                xml.tag! 'ExtData', 'Name' => 'ORIGID', 'Value' =>  reference
+                xml.tag! 'ExtData', 'Name' => 'ORIGID', 'Value' => reference
               end
             end
           end
@@ -264,7 +264,7 @@ module ActiveMerchant #:nodoc:
 
           add_three_d_secure(options, xml)
 
-          xml.tag! 'ExtData', 'Name' => 'LASTNAME', 'Value' =>  credit_card.last_name
+          xml.tag! 'ExtData', 'Name' => 'LASTNAME', 'Value' => credit_card.last_name
         end
       end
 

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
       #
       # Note, once stored, PaymentExpress does not support unstoring a stored card.
       def store(credit_card, options = {})
-        request  = build_token_request(credit_card, options)
+        request = build_token_request(credit_card, options)
         commit(:validate, request)
       end
 

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
         post['account.expiry.year'] = sprintf('%.4i', credit_card.year)
         post['account.verification'] = credit_card.verification_value
         post['account.email'] = (options[:email] || nil)
-        post['presentation.amount3D'] =  (options[:money] || nil)
+        post['presentation.amount3D'] = (options[:money] || nil)
         post['presentation.currency3D'] = (options[:currency] || currency(options[:money]))
       end
 

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
           post[:address1] = address[:address1].to_s
           post[:address2] = address[:address2].to_s
           post[:city]     = address[:city].to_s
-          post[:state]    = (address[:state].blank?  ? 'n/a' : address[:state])
+          post[:state]    = (address[:state].blank? ? 'n/a' : address[:state])
           post[:zip]      = address[:zip].to_s
           post[:country]  = address[:country].to_s
           post[:phone]    = address[:phone].to_s
@@ -78,7 +78,7 @@ module ActiveMerchant #:nodoc:
           post[:shipping_address2]  = address[:address2].to_s
           post[:shipping_city]      = address[:city].to_s
           post[:shipping_country]   = address[:country].to_s
-          post[:shipping_state]     = (address[:state].blank?  ? 'n/a' : address[:state])
+          post[:shipping_state]     = (address[:state].blank? ? 'n/a' : address[:state])
           post[:shipping_zip]       = address[:zip].to_s
           post[:shipping_email]     = address[:email].to_s
         end

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -128,7 +128,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_token(post, token)
-        post[:fp] = 't'    # turn on "future payments" - what paystation calls Token Billing
+        post[:fp] = 't' # turn on "future payments" - what paystation calls Token Billing
         post[:ft] = token
       end
 

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -219,7 +219,7 @@ module ActiveMerchant
 
       def add_customer_data(post, options)
         post[:email] = options[:email]
-        post[:dontsndmail]        = 'yes' unless options[:send_email_confirmation]
+        post[:dontsndmail] = 'yes' unless options[:send_email_confirmation]
         post[:ipaddress] = options[:ip]
       end
 
@@ -256,7 +256,7 @@ module ActiveMerchant
             post[:state] = shipping_address[:state]
           else
             post[:state] = 'ZZ'
-            post[:province]  = shipping_address[:state]
+            post[:province] = shipping_address[:state]
           end
 
           post[:country] = shipping_address[:country]

--- a/lib/active_merchant/billing/gateways/pro_pay.rb
+++ b/lib/active_merchant/billing/gateways/pro_pay.rb
@@ -253,7 +253,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        results  = {}
+        results = {}
         xml = Nokogiri::XML(body)
         resp = xml.xpath('//XMLResponse/XMLTrans')
         resp.children.each do |element|

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -211,7 +211,7 @@ module ActiveMerchant
 
       def add_purchase_details(post)
         post[:EchoAmount] = 'YES'
-        post[:SCBI] = 'YES'                   # Return information about the transaction
+        post[:SCBI] = 'YES' # Return information about the transaction
         post[:MessageType] = MESSAGE_TYPE
       end
 

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
 
       def build_purchase_request(money, creditcard, options)
         xml = Builder::XmlMarkup.new
-        add_common_credit_card_info(xml, @options[:ignore_avs] ||  @options[:ignore_cvv] ? 'SALES' : 'AUTH_CAPTURE')
+        add_common_credit_card_info(xml, @options[:ignore_avs] || @options[:ignore_cvv] ? 'SALES' : 'AUTH_CAPTURE')
         add_address(xml, creditcard, options[:billing_address], options)
         add_purchase_data(xml, money)
         add_creditcard(xml, creditcard)

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://payments.intuit.com'
       self.display_name = 'QuickBooks Payments'
       BASE = '/quickbooks/v4/payments'
-      ENDPOINT =  "#{BASE}/charges"
+      ENDPOINT = "#{BASE}/charges"
       VOID_ENDPOINT = "#{BASE}/txn-requests"
       REFRESH_URI = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
 
@@ -42,7 +42,7 @@ module ActiveMerchant #:nodoc:
         'PMT-5001' => STANDARD_ERROR_CODE[:card_declined],      # Merchant does not support given payment method
 
         # System Error
-        'PMT-6000' => STANDARD_ERROR_CODE[:processing_error],   # A temporary Issue prevented this request from being processed.
+        'PMT-6000' => STANDARD_ERROR_CODE[:processing_error], # A temporary Issue prevented this request from being processed.
       }
 
       FRAUD_WARNING_CODES = ['PMT-1000', 'PMT-1001', 'PMT-1002', 'PMT-1003']

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -204,7 +204,7 @@ module ActiveMerchant
       end
 
       def add_credit_card_or_reference(post, credit_card_or_reference, options = {})
-        post[:card]             ||= {}
+        post[:card] ||= {}
         if credit_card_or_reference.is_a?(String)
           post[:card][:token] = credit_card_or_reference
         else

--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        results  = {}
+        results = {}
         xml = Nokogiri::XML(body)
         resp = xml.xpath('//Response/Transaction/Identification')
         resp.children.each do |element|

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -146,9 +146,9 @@ module ActiveMerchant #:nodoc:
           post[:sg_Address] = address[:address1] if address[:address1]
           post[:sg_City] = address[:city] if address[:city]
           post[:sg_State] = address[:state]  if address[:state]
-          post[:sg_Zip] = address[:zip]  if address[:zip]
-          post[:sg_Country] = address[:country]  if address[:country]
-          post[:sg_Phone] = address[:phone]  if address[:phone]
+          post[:sg_Zip] = address[:zip] if address[:zip]
+          post[:sg_Country] = address[:country] if address[:country]
+          post[:sg_Phone] = address[:phone] if address[:phone]
         end
 
         post[:sg_Email] = options[:email]

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'Sage Payment Solutions'
       self.live_url = 'https://www.sagepayments.net/cgi-bin'
 
-      self.supported_countries =  ['US', 'CA']
+      self.supported_countries = ['US', 'CA']
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
 
       TRANSACTIONS = {
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       }
 
       SOURCE_CARD   = 'bankcard'
-      SOURCE_ECHECK =  'virtual_check'
+      SOURCE_ECHECK = 'virtual_check'
 
       def initialize(options = {})
         requires!(options, :login, :password)
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
       # use the same method as in pay_conex
       def force_utf8(string)
         return nil unless string
-        binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?')   # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
+        binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?') # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
         binary.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
       end
 
@@ -227,7 +227,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_addresses(post, options)
-        billing_address   = options[:billing_address] || options[:address] || {}
+        billing_address = options[:billing_address] || options[:address] || {}
 
         post[:C_address]    = billing_address[:address1]
         post[:C_city]       = billing_address[:city]

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -394,7 +394,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        response['Status'] == APPROVED ? 'Success' : (response['StatusDetail'] || 'Unspecified error')    # simonr 20080207 can't actually get non-nil blanks, so this is shorter
+        response['Status'] == APPROVED ? 'Success' : (response['StatusDetail'] || 'Unspecified error') # simonr 20080207 can't actually get non-nil blanks, so this is shorter
       end
 
       def post_data(action, parameters = {})

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'FIRSTNAME', creditcard.first_name
             xml.tag! 'LASTNAME', creditcard.last_name
             xml.tag! 'PHONE', address[:phone].to_s
-            xml.tag! 'STATE', address[:state].blank?  ? 'n/a' : address[:state]
+            xml.tag! 'STATE', address[:state].blank? ? 'n/a' : address[:state]
             xml.tag! 'ZIP', address[:zip].to_s
           end
         end
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'LASTNAME', address[:last_name].to_s
             end
 
-            xml.tag! 'STATE', address[:state].blank?  ? 'n/a' : address[:state]
+            xml.tag! 'STATE', address[:state].blank? ? 'n/a' : address[:state]
             xml.tag! 'ZIP', address[:zip].to_s
           end
         else

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -159,7 +159,7 @@ module ActiveMerchant #:nodoc:
           post[:zip]     = address[:zip].to_s
           post[:city]    = address[:city].to_s
           post[:country] = address[:country].to_s
-          post[:state]   = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:state]   = address[:state].blank? ? 'n/a' : address[:state]
         end
 
         if address = options[:shipping_address]
@@ -171,7 +171,7 @@ module ActiveMerchant #:nodoc:
           post[:ship_to_zip]     = address[:zip].to_s
           post[:ship_to_city]    = address[:city].to_s
           post[:ship_to_country] = address[:country].to_s
-          post[:ship_to_state]   = address[:state].blank?  ? 'n/a' : address[:state]
+          post[:ship_to_state]   = address[:state].blank? ? 'n/a' : address[:state]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -375,7 +375,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_creditcard(post, creditcard)
-        post[:AccountNumber]  = creditcard.number
+        post[:AccountNumber] = creditcard.number
         post[:Month] = creditcard.month
         post[:Year] = creditcard.year
         post[:CVV2] = creditcard.verification_value if creditcard.verification_value?

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
           post[prefix+'zip']        = address[:zip].to_s
           post[prefix+'city']       = address[:city].to_s
           post[prefix+'country']    = address[:country].to_s
-          post[prefix+'state']      = address[:state].blank?  ? 'n/a' : address[:state]
+          post[prefix+'state']      = address[:state].blank? ? 'n/a' : address[:state]
         end
       end
 
@@ -181,9 +181,9 @@ module ActiveMerchant #:nodoc:
           post[:customer_vault] = 'add_customer'
           post[:customer_vault_id] = options[:store] unless options[:store] == true
         end
-        post[:ccnumber]  = creditcard.number
+        post[:ccnumber] = creditcard.number
         post[:cvv] = creditcard.verification_value if creditcard.verification_value?
-        post[:ccexp]  = expdate(creditcard)
+        post[:ccexp] = expdate(creditcard)
         post[:firstname] = creditcard.first_name
         post[:lastname]  = creditcard.last_name
       end
@@ -225,7 +225,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, money, parameters)
-        parameters[:amount]  = localized_amount(money, parameters[:currency] || default_currency) if money
+        parameters[:amount] = localized_amount(money, parameters[:currency] || default_currency) if money
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
         Response.new(response['response'] == '1', message_from(response), response,
           :authorization => (response['transactionid'] || response['customer_vault_id']),
@@ -255,7 +255,7 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         post = {}
-        post[:username]      = @options[:login]
+        post[:username] = @options[:login]
         post[:password]   = @options[:password]
         post[:type]       = action if action
 

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
         post[:address] = "#{address[:address1]}, #{address[:address2]}"
         post[:city] = address[:city]
         post[:country] = address[:country]
-        post[:mobile] = address[:phone]     # API only has a "mobile" field, no "phone"
+        post[:mobile] = address[:phone] # API only has a "mobile" field, no "phone"
       end
 
       def add_invoice(post, options)

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
           post[:address]['address1'] = billing_address[:address1] if billing_address[:address1]
           post[:address]['city']     = billing_address[:city] if billing_address[:city]
           post[:address]['country']  = billing_address[:country]  if billing_address[:country]
-          post[:address]['region']   = billing_address[:state]  if billing_address[:state]
+          post[:address]['region']   = billing_address[:state] if billing_address[:state]
           post[:address]['postal_code'] = billing_address[:zip]
         end
 

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -1,7 +1,7 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class WorldpayOnlinePaymentsGateway < Gateway
-      self.live_url =  'https://api.worldpay.com/v1/'
+      self.live_url = 'https://api.worldpay.com/v1/'
 
       self.default_currency = 'GBP'
 

--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -110,8 +110,8 @@ module ActiveMerchant #:nodoc:
           post[:ci_shipaddr2] = shipping_address[:address2]
           post[:ci_shipcity] = shipping_address[:city]
           post[:ci_shipstate] = shipping_address[:state]
-          post[:ci_shipzip]    = shipping_address[:zip]
-          post[:ci_shipcountry]    = shipping_address[:country]
+          post[:ci_shipzip] = shipping_address[:zip]
+          post[:ci_shipcountry] = shipping_address[:country]
         end
       end
 

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant #:nodoc:
-  module PostsData  #:nodoc:
+  module PostsData #:nodoc:
     def self.included(base)
       base.class_attribute :ssl_strict
       base.ssl_strict = true

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -638,7 +638,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @check, @options)
     assert_success purchase
 
-    @options.update(transaction_id:  purchase.params['transaction_id'], test_request: true)
+    @options.update(transaction_id: purchase.params['transaction_id'], test_request: true)
     refund = @gateway.credit(@amount, @check, @options)
     assert_failure refund
     assert_match %r{The transaction cannot be found}, refund.message, 'Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise.'

--- a/test/remote/gateways/remote_checkout_test.rb
+++ b/test/remote/gateways/remote_checkout_test.rb
@@ -9,7 +9,7 @@ class RemoteCheckoutTest < Test::Unit::TestCase
       year: '2017',
       verification_value: '956'
     )
-    @declined_card  = credit_card(
+    @declined_card = credit_card(
       '4543474002249996',
       month: '06',
       year: '2018',

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -133,7 +133,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert response.test?
     assert_equal 'Invalid account number', response.message
-    assert_equal false,  response.success?
+    assert_equal false, response.success?
   end
 
   def test_authorize_and_void
@@ -273,7 +273,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount + 10, auth.authorization, @options)
     assert_failure capture
-    assert_equal 'The requested amount exceeds the originally authorized amount',  capture.message
+    assert_equal 'The requested amount exceeds the originally authorized amount', capture.message
   end
 
   def test_failed_capture_bad_auth_info
@@ -306,7 +306,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.validate_pinless_debit_card(@pinless_debit_card, @options)
     assert response.test?
     assert_equal 'Y', response.params['status']
-    assert_equal true,  response.success?
+    assert_equal true, response.success?
   end
 
   def test_network_tokenization_authorize_and_capture

--- a/test/remote/gateways/remote_data_cash_test.rb
+++ b/test/remote/gateways/remote_data_cash_test.rb
@@ -326,7 +326,7 @@ class RemoteDataCashTest < Test::Unit::TestCase
   end
 
   def test_order_id_that_is_too_long
-    @params[:order_id] =  "#{@params[:order_id]}1234356"
+    @params[:order_id] = "#{@params[:order_id]}1234356"
     response = @gateway.purchase(@amount, @mastercard, @params)
     assert_success response
     assert response.test?

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -71,7 +71,7 @@ class EwayTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    @credit_card_success.verification_value =  '431'
+    @credit_card_success.verification_value = '431'
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(100, @credit_card_success, @params)
     end

--- a/test/remote/gateways/remote_instapay_test.rb
+++ b/test/remote/gateways/remote_instapay_test.rb
@@ -24,12 +24,12 @@ class RemoteInstapayTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    assert response = @gateway.purchase(@amount,  @declined_card, @options)
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
   end
 
   def test_succesful_authorization
-    assert response = @gateway.authorize(@amount,  @credit_card, @options)
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal InstapayGateway::SUCCESS_MESSAGE, response.message
   end

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -29,7 +29,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_equal @credit_card.year.to_s,      response.params.dig('return_data', 'creditcard_data', 'expiry_year')
     assert_equal @credit_card.number[0..5],   response.params.dig('return_data', 'creditcard_data', 'first_six_digits')
     assert_equal @credit_card.number.split(//).last(4).join, response.params.dig('return_data', 'creditcard_data', 'last_four_digits')
-    assert_equal 'FINISHED',                  response.params['return_type']
+    assert_equal 'FINISHED', response.params['return_type']
 
     assert_not_nil response.params['purchase_id']
     assert_not_nil response.params['reference_id']

--- a/test/remote/gateways/remote_micropayment_test.rb
+++ b/test/remote/gateways/remote_micropayment_test.rb
@@ -89,7 +89,7 @@ class RemoteMicropaymentTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_and_refund
-    response = @gateway.authorize(@amount, @credit_card,  @options.merge(recurring: false))
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(recurring: false))
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_match %r(^\w+\|.+$), response.authorization

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -48,7 +48,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_refund
-    assert response = @gateway.refund(@amount, '1',  @options)
+    assert response = @gateway.refund(@amount, '1', @options)
     assert_failure response
     assert_not_nil response.message
   end

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -99,7 +99,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_failed_reauthorization
-    return if not @three_days_old_auth_id2  # was authed for $10, attempt $20
+    return if not @three_days_old_auth_id2 # was authed for $10, attempt $20
     auth = @gateway.reauthorize(2000, @three_days_old_auth_id2)
     assert_false auth?
     assert !auth.authorization

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -35,15 +35,15 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
   end
 
   def test_create_3ds_source
-    card_source  = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
-    assert response = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure',  @options)
+    card_source = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
+    assert response = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure', @options)
     assert_success response
     assert_three_ds_source(response)
   end
 
   def test_show_3ds_source
-    card_source  = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
-    assert three_d_secure_source = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure',  @options)
+    card_source = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
+    assert three_d_secure_source = @gateway.send(:create_source, @amount, card_source.params['id'], 'three_d_secure', @options)
     assert_success three_d_secure_source
     assert_three_ds_source(three_d_secure_source)
 
@@ -118,7 +118,7 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_nil webhook1.params['application']
     assert_not_nil webhook2.params['application']
 
-    response = @gateway.send(:list_webhook_endpoints,  @options.merge({limit: 100}))
+    response = @gateway.send(:list_webhook_endpoints, @options.merge({limit: 100}))
     assert_not_nil response.params
     assert_equal 'list', response.params['object']
     assert response.params['data'].size >= 2
@@ -135,7 +135,7 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     card_source_response = @gateway.send(:create_source, @amount, @credit_card, 'card', @options)
     assert_card_source(card_source_response)
 
-    assert three_ds_source_response = @gateway.send(:create_source, @amount, card_source_response.params['id'], 'three_d_secure',  @options)
+    assert three_ds_source_response = @gateway.send(:create_source, @amount, card_source_response.params['id'], 'three_d_secure', @options)
     assert_success three_ds_source_response
     assert_three_ds_source(three_ds_source_response)
 

--- a/test/remote/gateways/remote_swipe_checkout_test.rb
+++ b/test/remote/gateways/remote_swipe_checkout_test.rb
@@ -8,7 +8,7 @@ class RemoteSwipeCheckoutTest < Test::Unit::TestCase
     @accepted_card = credit_card('1234123412341234')
     @declined_card = credit_card('1111111111111111')
     @invalid_card  = credit_card('1000000000000000')
-    @empty_card  = credit_card('')
+    @empty_card = credit_card('')
 
     @options = {
       order_id: '1',

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -205,7 +205,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_transcript_scrubbing
     @credit_card.verification_value = @invalid_verification_value
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount, @credit_card,  @options)
+      @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
 

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -100,7 +100,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_line_items
     line_items = [
-      {sku:  'abc123', cost: 119, quantity: 1},
+      {sku: 'abc123', cost: 119, quantity: 1},
       {sku: 'def456', cost: 200, quantity: 2, name: 'an item' }
     ]
 

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -169,7 +169,7 @@ class RemoteWepayTest < Test::Unit::TestCase
     authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
 
-    sleep 30  # Wait for authorization to clear. Doesn't always work.
+    sleep 30 # Wait for authorization to clear. Doesn't always work.
     assert capture = @gateway.capture(nil, authorize.authorization)
     assert_success capture
   end

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -258,7 +258,7 @@ class RemoteWirecardTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount, @credit_card,  @options)
+      @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -477,7 +477,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount, @credit_card,  @options)
+      @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
 

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -150,11 +150,11 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_not_be_valid_for_edge_year_cases
-    @visa.year  = Time.now.year - 1
+    @visa.year = Time.now.year - 1
     errors = assert_not_valid @visa
     assert errors[:year]
 
-    @visa.year  = Time.now.year + 21
+    @visa.year = Time.now.year + 21
     errors = assert_not_valid @visa
     assert errors[:year]
   end

--- a/test/unit/gateways/axcessms_test.rb
+++ b/test/unit/gateways/axcessms_test.rb
@@ -106,7 +106,7 @@ class AxcessmsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_void_response)
     response = @gateway.refund(@amount - 30, 'authorization', @options)
     assert_failure response
-    assert_equal 'Reference Error - reversal needs at least one successful transaction of type (CP or DB or RB or PA)',  response.message
+    assert_equal 'Reference Error - reversal needs at least one successful transaction of type (CP or DB or RB or PA)', response.message
   end
 
   def test_authorize_using_reference_sets_proper_elements

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -374,7 +374,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'JPY'))
     end.check_request do |endpoint, data, headers|
       assert_match(/amount.value=1/, data)
-      assert_match(/amount.currency=JPY/,  data)
+      assert_match(/amount.currency=JPY/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response
@@ -385,7 +385,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'OMR'))
     end.check_request do |endpoint, data, headers|
       assert_match(/amount.value=100/, data)
-      assert_match(/amount.currency=OMR/,  data)
+      assert_match(/amount.currency=OMR/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -25,7 +25,7 @@ class BeanstreamTest < Test::Unit::TestCase
       transaction_id: 'transaction ID'
     )
 
-    @check       = check(
+    @check = check(
                      :institution_number => '001',
                      :transit_number     => '26729'
                    )

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -187,7 +187,7 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [:visa, :master, :american_express, :discover, :diners_club, :jcb],  BluePayGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :discover, :diners_club, :jcb], BluePayGateway.supported_cardtypes
   end
 
   def test_parser_extracts_exactly_the_keys_in_gateway_response

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -47,7 +47,7 @@ class BogusTest < Test::Unit::TestCase
   def test_capture
     assert  @gateway.capture(1000, '1337').success?
     assert  @gateway.capture(1000, @response.params['transid']).success?
-    response =  @gateway.capture(1000, CC_FAILURE_PLACEHOLDER)
+    response = @gateway.capture(1000, CC_FAILURE_PLACEHOLDER)
     refute response.success?
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     assert_raises(ActiveMerchant::Billing::Error) do
@@ -57,7 +57,7 @@ class BogusTest < Test::Unit::TestCase
 
   def test_credit
     assert @gateway.credit(1000, credit_card(CC_SUCCESS_PLACEHOLDER)).success?
-    response =  @gateway.credit(1000, credit_card(CC_FAILURE_PLACEHOLDER))
+    response = @gateway.credit(1000, credit_card(CC_FAILURE_PLACEHOLDER))
     refute response.success?
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -47,7 +47,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_processor
     result = {}
 
-    @gateway.send(:add_processor, result,   {:processor => 'ccprocessorb'})
+    @gateway.send(:add_processor, result, {:processor => 'ccprocessorb'})
     assert_equal ['processor_id'], result.stringify_keys.keys.sort
     assert_equal 'ccprocessorb', result[:processor_id]
   end
@@ -86,7 +86,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result,   {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
+    @gateway.send(:add_address, result, {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
     assert_equal ['address1', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result['state']
     assert_equal '164 Waverley Street', result['address1']
@@ -96,7 +96,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_shipping_address
     result = {}
 
-    @gateway.send(:add_address, result,   {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'}, 'shipping')
+    @gateway.send(:add_address, result, {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'}, 'shipping')
     assert_equal ['shipping_address1', 'shipping_city', 'shipping_company', 'shipping_country', 'shipping_phone', 'shipping_state', 'shipping_zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result['shipping_state']
     assert_equal '164 Waverley Street', result['shipping_address1']

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -55,7 +55,7 @@ class Cashnet < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [:visa, :master, :american_express, :discover, :diners_club, :jcb],  CashnetGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :discover, :diners_club, :jcb], CashnetGateway.supported_cardtypes
   end
 
   def test_add_invoice

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -5,8 +5,8 @@ class CheckoutTest < Test::Unit::TestCase
 
   def setup
     @gateway = ActiveMerchant::Billing::CheckoutGateway.new(
-      :merchant_id    => 'SBMTEST',    # Merchant Code
-      :password => 'Password1!'          # Processing Password
+      :merchant_id    => 'SBMTEST', # Merchant Code
+      :password => 'Password1!' # Processing Password
     )
     @options = {
       order_id: generate_unique_id

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -249,7 +249,7 @@ class ClearhausTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_signing_request_with_invalid_key
-    gateway = ClearhausGateway.new(api_key: 'test_key',  signing_key: @test_signing_key, private_key: 'foo')
+    gateway = ClearhausGateway.new(api_key: 'test_key', signing_key: @test_signing_key, private_key: 'foo')
 
     # stub actual network access, but this shouldn't be reached
     gateway.stubs(:ssl_post).returns(nil)

--- a/test/unit/gateways/flo2cash_simple_test.rb
+++ b/test/unit/gateways/flo2cash_simple_test.rb
@@ -67,7 +67,7 @@ class Flo2cashSimpleTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    transcript =  @gateway.scrub(successful_purchase_response)
+    transcript = @gateway.scrub(successful_purchase_response)
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)

--- a/test/unit/gateways/flo2cash_test.rb
+++ b/test/unit/gateways/flo2cash_test.rb
@@ -95,7 +95,7 @@ class Flo2cashTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    transcript =  @gateway.scrub(successful_authorize_response)
+    transcript = @gateway.scrub(successful_authorize_response)
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -59,7 +59,7 @@ class KomojuTest < Test::Unit::TestCase
     successful_response = successful_credit_card_refund_response
     @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
 
-    response = @gateway.refund(@amount,  '7e8c55a54256ce23e387f2838c', @options)
+    response = @gateway.refund(@amount, '7e8c55a54256ce23e387f2838c', @options)
     assert_success response
 
     assert_equal successful_response['id'], response.authorization

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -92,7 +92,7 @@ class MercuryTest < Test::Unit::TestCase
 
   def test_card_present_with_max_length_track_1_data
     track_data    = '%B373953192351004^CARDUSER/JOHN^200910100000019301000000877000000930001234567?'
-    stripped_data =  'B373953192351004^CARDUSER/JOHN^200910100000019301000000877000000930001234567'
+    stripped_data = 'B373953192351004^CARDUSER/JOHN^200910100000019301000000877000000930001234567'
     @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -73,7 +73,7 @@ class OmiseTest < Test::Unit::TestCase
 
   def test_error_code_from
     response = @gateway.send(:parse, invalid_security_code_response)
-    error_code  = @gateway.send(:error_code_from, response)
+    error_code = @gateway.send(:error_code_from, response)
     assert_equal 'invalid_security_code', error_code
   end
 
@@ -90,7 +90,7 @@ class OmiseTest < Test::Unit::TestCase
   end
 
   def test_card_declined
-    card_declined =  @gateway.send(:parse, failed_capture_response)
+    card_declined = @gateway.send(:parse, failed_capture_response)
     card_declined_code = @gateway.send(:standard_error_code_mapping, card_declined)
     assert_equal 'card_declined', card_declined_code
   end

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -23,7 +23,7 @@ class PayJunctionTest < Test::Unit::TestCase
   def test_detect_test_credentials_when_in_production
     Base.mode = :production
 
-    live_gw  = PayJunctionGateway.new(
+    live_gw = PayJunctionGateway.new(
                  :login      => 'l',
                  :password   => 'p'
                )

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -593,7 +593,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_reference_transaction
     @gateway.expects(:ssl_post).returns(successful_reference_transaction_response)
 
-    response = @gateway.reference_transaction(2000,  { :reference_id => 'ref_id' })
+    response = @gateway.reference_transaction(2000, { :reference_id => 'ref_id' })
 
     assert_equal 'Success', response.params['ack']
     assert_equal 'Success', response.message

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -92,7 +92,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_dont_send_fractional_amount_for_chinese_yen
-    @amount = 100_00  # 100 YEN
+    @amount = 100_00 # 100 YEN
     @options[:currency] = 'JPY'
 
     @gateway.expects(:add_pair).with({}, :Amount, '100', :required => true)


### PR DESCRIPTION
Fixes the RuboCop Layout/ExtraSpacing errors caused by extra spaces
throughout Active Merchant.

Unit:
4340 tests, 70985 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed

RuboCop:
692 files inspected, no offenses detected