### PR TITLE
Ixopay: Add support for currency option to refund method

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options={})
         request = build_xml_request do |xml|
-          add_refund(xml, money, authorization)
+          add_refund(xml, money, authorization, options)
         end
 
         commit(request)
@@ -170,7 +170,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_refund(xml, money, authorization)
+      def add_refund(xml, money, authorization, options)
         currency = options[:currency] || currency(money)
 
         xml.refund do

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -98,10 +98,12 @@ class RemoteIxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    options = @options.update(currency: 'USD')
+
+    purchase = @gateway.purchase(@amount, @credit_card, options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert refund = @gateway.refund(@amount, purchase.authorization, options)
     assert_success refund
     assert_equal 'FINISHED', refund.message
   end

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -24,12 +24,10 @@ class IxopayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
-
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert match(/<description>.+<\/description>/, data)
+      assert_match(/<description>.+<\/description>/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -109,6 +107,16 @@ class IxopayTest < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'FINISHED', response.message
+  end
+
+  def test_refund_includes_currency_option
+    options = { currency: 'USD' }
+
+    stub_comms do
+      @gateway.refund(@amount, 'eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe', options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<currency>USD<\/currency>/, data)
+    end.respond_with(successful_refund_response)
   end
 
   def test_failed_refund


### PR DESCRIPTION
For refunds, the currency in the ```options``` hash was not passed to the ```refund``` method. This resulted in the default currency being used. I discovered the problem while testing with the new gateway in core. I specified USD for the currency for the purchase, but the credit (refund) defaulted to EUR, which caused a mismatch error at the gateway.

When I posted in Slack, I was under the impression that core was not passing the currency from the transaction for refunds. I was mistaken: the problem was just that we weren't propagating it to the ```add_refund``` helper in Active Merchant.

In Slack, we also spoke briefly about whether the latter part of the ```options[:currency] || currency(money)``` idiom was needed. I took a look and decided to leave that in for now, since the ```currency``` method on the gateway base class results in the default currency, and we're following that everywhere else. Some other non-Spreedly users of the gateway adapters might be passing in money objects that support the ```currency``` method, so there's potentially some value in maintaining consistency there.
