### PR TITLE
Ixopay: Remove default callback URL

### DIFF
--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -149,14 +149,14 @@ module ActiveMerchant #:nodoc:
           xml.amount      localized_amount(money, currency)
           xml.currency    currency
           xml.description description
-          xml.callbackUrl(options[:callback_url] || 'http://example.com')
+          xml.callbackUrl(options[:callback_url])
         end
       end
 
       def add_preauth(xml, money, options)
         description  = options[:description].blank? ? 'Preauthorize' : options[:description]
         currency     = options[:currency] || currency(money)
-        callback_url = options[:callback_url] || 'http://example.com'
+        callback_url = options[:callback_url]
 
         xml.preauthorize do
           xml.transactionId new_transaction_id


### PR DESCRIPTION
The Ixopay adapter was previously passing in a default ```callback_url``` of ```http://www.example.com``` in the case that the option was not provided. This change removes the default. The value of not having a (useless) default is that if the URL is not provided when required for the particular connector being used with Ixopay, Ixopay will be able to return an error as such to the user.