### PR TITLE
Adyen: Adds Unstore

### DIFF
--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -607,6 +607,39 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Authorised', response.message
   end
 
+  def test_successful_unstore
+    assert response = @gateway.store(@credit_card, @options)
+
+    assert !response.authorization.split('#')[2].nil?
+    assert_equal 'Authorised', response.message
+
+    shopper_reference = response.params['additionalData']['recurring.shopperReference']
+    recurring_detail_reference = response.params['additionalData']['recurring.recurringDetailReference']
+
+    assert response = @gateway.unstore(shopper_reference: shopper_reference,
+                                       recurring_detail_reference: recurring_detail_reference)
+
+    assert_equal '[detail-successfully-disabled]', response.message
+  end
+
+  def test_failed_unstore
+    assert response = @gateway.store(@credit_card, @options)
+
+    assert !response.authorization.split('#')[2].nil?
+    assert_equal 'Authorised', response.message
+
+    shopper_reference = response.params['additionalData']['recurring.shopperReference']
+    recurring_detail_reference = response.params['additionalData']['recurring.recurringDetailReference']
+
+    assert response = @gateway.unstore(shopper_reference: 'random_reference',
+                                       recurring_detail_reference: recurring_detail_reference)
+    assert_equal 'Contract not found', response.message
+
+    assert response = @gateway.unstore(shopper_reference: shopper_reference,
+                                       recurring_detail_reference: 'random_reference')
+    assert_equal 'PaymentDetail not found', response.message
+  end
+
   def test_successful_store_with_elo_card
     assert response = @gateway.store(@elo_credit_card, @options)
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -551,6 +551,22 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal 'Refused', response.message
   end
 
+  def test_successful_unstore
+    response = stub_comms do
+      @gateway.unstore(shopper_reference: 'shopper_reference',
+                       recurring_detail_reference: 'detail_reference')
+    end.respond_with(successful_unstore_response)
+    assert_equal '[detail-successfully-disabled]', response.message
+  end
+
+  def test_failed_unstore
+    @gateway.expects(:ssl_post).returns(failed_unstore_response)
+    response = @gateway.unstore(shopper_reference: 'random_reference',
+                                recurring_detail_reference: 'detail_reference')
+    assert_failure response
+    assert_equal 'Contract not found', response.message
+  end
+
   def test_successful_verify
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
@@ -983,6 +999,18 @@ class AdyenTest < Test::Unit::TestCase
   def failed_store_response
     <<-RESPONSE
     {"pspReference":"8835205393394754","refusalReason":"Refused","resultCode":"Refused"}
+    RESPONSE
+  end
+
+  def successful_unstore_response
+    <<-RESPONSE
+    {"response":"[detail-successfully-disabled]"}
+    RESPONSE
+  end
+
+  def failed_unstore_response
+    <<-RESPONSE
+    {"status":422,"errorCode":"800","message":"Contract not found","errorType":"validation"}
     RESPONSE
   end
 


### PR DESCRIPTION
This adds an `unstore` method using the `disable` action. Adyen provides
a different API for `disable` and so this also adjusts the url to
use `/Recurring`, instead of `/Payment`, when `disable` is called. It
also adds separate versioning for each, as recommended by Adyen's support team.

In addition to `merchantAccount`, there are two additional fields
required for this action: `shopperReference` and
`recurringDetailReference`.

This also pulls in `davidsantoso`'s work from #3451 which adds the `storeToken` action. 

Unit tests:
54 tests, 254 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
75 tests, 248 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3333% passed

(These two failing tests are unrelated to the proposed changes. They
both fail on master. They are the tests ending with
`threeds1_standalone` and `threeds2_standalone`.)