### PR TITLE
Worldpay: Update cardholder name logic based on 3DS version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * RuboCop: Fix Layout/EndAlignment [leila-alderman] #3427
 * RuboCop: Fix Layout/ExtraSpacing [leila-alderman] #3429
 * RuboCop: Fix Layout/MultilineOperationIndentation [leila-alderman] #3439
+* Worldpay: Update logic to set cardholderName for 3DS transactions [britth] #3444
 
 == Version 1.101.0 (Nov 4, 2019)
 * Add UYI to list of currencies without fractions [curiousepic] #3416

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -335,7 +335,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'date', 'month' => format(payment_method.month, :two_digits), 'year' => format(payment_method.year, :four_digits)
         end
 
-        xml.tag! 'cardHolderName', options[:execute_threed] && (options[:three_ds_version] =~ /[^2]/).nil? ? '3D' : payment_method.name
+        xml.tag! 'cardHolderName', options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
         xml.tag! 'cvc', payment_method.verification_value
 
         add_address(xml, (options[:billing_address] || options[:address]))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -606,6 +606,39 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_3ds_name_coersion_based_on_version
+    @options[:execute_threed] = true
+    @options[:three_ds_version] = '2.0'
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if /<submit>/ =~ data
+        assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data
+      end
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+
+    @options[:three_ds_version] = '2'
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if /<submit>/ =~ data
+        assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data
+      end
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+
+    @options[:three_ds_version] = '1.0.2'
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      if /<submit>/ =~ data
+        assert_match %r{<cardHolderName>3D</cardHolderName>}, data
+      end
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
In testing with Worldpay, there was some unexpected behavior when
the 3DS version was 2. The existing regex match didn't capture the
value of `2` as being equivalent to a 3DS2 version, and so the
cardholder name was getting set to '3D'. This update uses
`start_with?` to capture any version value that starts with `2`,
including `2`. Unit tests have also been updated to test various
permutations of 3DS2 version values.

Remote:
56 tests, 240 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4286% passed
(pre-existing failures)

Unit:
69 tests, 411 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed