### PR TITLE
Quickbooks: Mark AuthorizationFailed responses as failures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * RuboCop: Fix Layout/MultilineOperationIndentation [leila-alderman] #3439
 * Worldpay: Update logic to set cardholderName for 3DS transactions [britth] #3444
 * Adopt new enrolled key for 3DS1 transactions. enrolled contains the 3… #3442
+* Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447
 
 == Version 1.101.0 (Nov 4, 2019)
 * Add UYI to list of currencies without fractions [curiousepic] #3416

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -321,7 +321,7 @@ module ActiveMerchant #:nodoc:
       def success?(response)
         return FRAUD_WARNING_CODES.concat(['0']).include?(response['errors'].first['code']) if response['errors']
 
-        !['DECLINED', 'CANCELLED'].include?(response['status']) && !['AuthenticationFailed'].include?(response['code'])
+        !['DECLINED', 'CANCELLED'].include?(response['status']) && !['AuthenticationFailed', 'AuthorizationFailed'].include?(response['code'])
       end
 
       def message_from(response)
@@ -329,7 +329,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def errors_from(response)
-        response['errors'].present? ? STANDARD_ERROR_CODE_MAPPING[response['errors'].first['code']] : ''
+        if ['AuthenticationFailed', 'AuthorizationFailed'].include?(response['code'])
+          response['code']
+        else
+          response['errors'].present? ? STANDARD_ERROR_CODE_MAPPING[response['errors'].first['code']] : ''
+        end
       end
 
       def authorization_from(response, headers = {})

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -247,6 +247,15 @@ class QuickBooksTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_authorization_failed_code_results_in_failure
+    @oauth_2_gateway.expects(:ssl_post).returns(authorization_failed_oauth_2_response)
+
+    response = @oauth_2_gateway.authorize(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal 'AuthorizationFailed', response.error_code
+  end
+
   private
 
   def pre_scrubbed_small_json
@@ -462,6 +471,18 @@ class QuickBooksTest < Test::Unit::TestCase
     <<-RESPONSE
       {
          "code": "AuthenticationFailed",
+         "type": "INPUT",
+         "message": null,
+         "detail": null,
+         "moreInfo": null
+      }
+    RESPONSE
+  end
+
+  def authorization_failed_oauth_2_response
+    <<-RESPONSE
+      {
+         "code": "AuthorizationFailed",
          "type": "INPUT",
          "message": null,
          "detail": null,


### PR DESCRIPTION
When an access_token has insufficient scope, a merchant will
receive the code `AuthorizationFailed`, rather than
`AuthenticationFailed`. This update checks for this error code
and marks such transactions as failures.

Unit:
22 tests, 118 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
17 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed