### PR TITLE
Adyen: Add gateway specific field for splits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * CyberSource: Send MDD on capture [leila-alderman] #3453
 * Ixopay: Include extra_data gateway specific field [therufs] #3450
 * CyberSource: Fix XML error on capture [leila-alderman] #3454
+* Adyen: Add gateway specific field for splits [leila-alderman] #3448
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -312,6 +312,32 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_splits_sent
+    split_data = [{
+      'amount' => {
+        'currency' => 'USD',
+        'value' => 50
+        },
+      'type' => 'MarketPlace',
+      'account' => '163298747',
+      'reference' => 'QXhlbFN0b2x0ZW5iZXJnCg'
+    }, {
+      'amount' => {
+        'currency' => 'USD',
+        'value' => 50
+        },
+      'type' => 'Commission',
+      'reference' => 'THVjYXNCbGVkc29lCg'
+    }]
+
+    options = @options.merge({ splits: split_data })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_equal split_data, JSON.parse(data)['splits']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({execute_threed: false}))


### PR DESCRIPTION
Added the `splits` gateway specific field to the Adyen gateway.

For more details, see the Adyen documentation:
[Adyen API Reference](https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v50/payments__reqParam_splits)
[Adyen MarketPlace information about splits](https://docs.adyen.com/marketpay/processing-payments#providing-split-information)

CE-220

Unit:
51 tests, 243 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
73 tests, 234 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
97.2603% passed

The two failing remote tests are
 - `test_successful_purchase_with_auth_data_via_threeds1_standalone`
 - `test_successful_purchase_with_auth_data_via_threeds2_standalone`
These have been failing for a while and are unrelated.