### PR TITLE
DLocal: Updates for version 2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447
 * Credorax: Add referral CFT transactions [leila-alderman] #3432
+* DLocal: Updates for version 2.1 [molbrown] #3449
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options={})
         post = {}
-        post[:payment_id] = authorization
+        post[:authorization_id] = authorization
         add_invoice(post, money, options) if money
         commit('capture', post, options)
       end
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options={})
         post = {}
-        post[:payment_id] = authorization
+        post[:authorization_id] = authorization
         commit('void', post, options)
       end
 
@@ -193,9 +193,9 @@ module ActiveMerchant #:nodoc:
         when 'refund'
           'refunds'
         when 'capture'
-          "payments/#{parameters[:payment_id]}/capture"
+          'payments'
         when 'void'
-          "payments/#{parameters[:payment_id]}/cancel"
+          "payments/#{parameters[:authorization_id]}/cancel"
         end
       end
 

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -194,15 +194,9 @@ class RemoteDLocalTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-    auth = @gateway.authorize(@amount, @credit_card, @options)
-    assert_success auth
-
-    assert capture = @gateway.capture(@amount, auth.authorization, @options)
-    assert_success capture
-
-    response = @gateway.void(auth.authorization)
+    response = @gateway.void('')
     assert_failure response
-    assert_match 'Invalid transaction status', response.message
+    assert_match 'Invalid request', response.message
   end
 
   def test_successful_verify


### PR DESCRIPTION
DLocal has updated its Auth/Capture flow, now accepting captures at a
new endpoint. It has also changed to use an authorization_id parameter
for referencing Authorize transactions (needed in capture and void
requests).

Remote:
26 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
17 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-565