### PR TITLE
CyberSource: Send MDD on capture

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -291,6 +291,7 @@ module ActiveMerchant #:nodoc:
         add_capture_service(xml, request_id, request_token)
         add_business_rules_data(xml, authorization, options)
         add_issuer_additional_data(xml, options)
+        add_mdd_fields(xml, options)
         xml.target!
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -337,6 +337,15 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_capture_with_mdd_fields
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+  end
+
   def test_successful_authorize_with_nonfractional_currency
     assert response = @gateway.authorize(100, @credit_card, @options.merge(:currency => 'JPY'))
     assert_equal '1', response.params['amount']

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -273,6 +273,14 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response_capture.test?
   end
 
+  def test_capture_includes_mdd_fields
+    stub_comms do
+      @gateway.capture(100, '1846925324700976124593', order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_successful_credit_card_purchase_request
     @gateway.stubs(:ssl_post).returns(successful_capture_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
The merchant defined data gateway specific fields are now able to be
sent on capture requests in addition to the previously available
purchase and authorize requests.

CE-234

Unit:
64 tests, 310 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
65 tests, 278 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
92.3077% passed

The 5 remote failures seem to be previously existing and unrelated:
 - test_successful_3ds_validate_authorize_request
 - test_successful_3ds_validate_purchase_request
 - test_successful_pinless_debit_card_puchase
 - test_successful_tax_calculation
 - test_successful_validate_pinless_debit_card