### PR TITLE
CyberSource: Fix XML error on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * DLocal: Updates for version 2.1 [molbrown] #3449
 * CyberSource: Send MDD on capture [leila-alderman] #3453
 * Ixopay: Include extra_data gateway specific field [therufs] #3450
+* CyberSource: Fix XML error on capture [leila-alderman] #3454
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -288,10 +288,10 @@ module ActiveMerchant #:nodoc:
 
         xml = Builder::XmlMarkup.new :indent => 2
         add_purchase_data(xml, money, true, options)
+        add_mdd_fields(xml, options)
         add_capture_service(xml, request_id, request_token)
         add_business_rules_data(xml, authorization, options)
         add_issuer_additional_data(xml, options)
-        add_mdd_fields(xml, options)
         xml.target!
       end
 


### PR DESCRIPTION
Fixes an XML parsing error in `capture` requests on CyberSource.

In [a previous commit](https://github.com/activemerchant/active_merchant/commit/35b5dd95db0252c7b98d8411fd3adb50fc266eb8),
the `add_mdd_fields` method was added to `capture` transaction requests.
However, these fields are required to be passed in a specific location
within the XML request sent to the CyberSource gateway.

This commit moves the `add_mdd_fields` method within `capture` to the
correct location for XML parsing by the CyberSource gateway.

CE-234

Unit:
64 tests, 310 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
65 tests, 278 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
92.3077% passed

The 5 remote failures are previously existing and unrelated:

 - test_successful_3ds_validate_authorize_request
 - test_successful_3ds_validate_purchase_request
 - test_successful_pinless_debit_card_puchase
 - test_successful_tax_calculation
 - test_successful_validate_pinless_debit_card