### PR TITLE
Add support for dLocal installments

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -129,6 +129,8 @@ module ActiveMerchant #:nodoc:
         post[:card][:cvv] = card.verification_value
         post[:card][:descriptor] = options[:dynamic_descriptor] if options[:dynamic_descriptor]
         post[:card][:capture] = (action == 'purchase')
+        post[:card][:installments] = options[:installments] if options[:installments]
+        post[:card][:installments_id] = options[:installments_id] if options[:installments_id]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -26,6 +26,13 @@ class RemoteDLocalTest < Test::Unit::TestCase
       document: '10563145',
       currency: 'ARS'
     }
+    @options_argentina_installments = {
+      billing_address: address(country: 'Argentina'),
+      document: '10563145',
+      currency: 'ARS',
+      installments: '3',
+      installments_id: 'INS54434'
+    }
     @options_mexico = {
       billing_address: address(country: 'Mexico'),
       document: '128475869794933',
@@ -40,6 +47,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
+  def test_successful_purchase_with_installments
+    response = @gateway.purchase(@amount, @credit_card, @options_argentina_installments)
     assert_success response
     assert_match 'The payment was paid', response.message
   end

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -32,6 +32,18 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal '300', response.error_code
   end
 
+  def test_purchase_with_installments
+    installments = '6'
+    installments_id = 'INS54434'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(installments: installments, installments_id: installments_id))
+    end.check_request do |endpoint, data, headers|
+      assert_equal installments, JSON.parse(data)['card']['installments']
+      assert_equal installments_id, JSON.parse(data)['card']['installments_id']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -200,6 +212,10 @@ class DLocalTest < Test::Unit::TestCase
 
   def successful_purchase_response
     '{"id":"D-15104-05b0ec0c-5a1e-470a-b342-eb5f20758ef7","amount":1.00,"currency":"BRL","payment_method_id":"CARD","payment_method_type":"CARD","payment_method_flow":"DIRECT","country":"BR","card":{"holder_name":"Longbob Longsen","expiration_month":9,"expiration_year":2019,"brand":"VI","last4":"1111","card_id":"CV-993903e4-0b33-48fd-8d9b-99fd6c3f0d1a"},"created_date":"2018-12-06T20:20:41.000+0000","approved_date":"2018-12-06T20:20:42.000+0000","status":"PAID","status_detail":"The payment was paid","status_code":"200","order_id":"15940ef43d39331bc64f31341f8ccd93"}'
+  end
+
+  def successful_purchase_with_installments_response
+    '{"id":"D-4-e2227981-8ec8-48fd-8e9a-19fedb08d73a","amount":1000,"currency":"BRL","payment_method_id":"CARD","payment_method_type":"CARD","payment_method_flow":"DIRECT","country":"BR","card":{"holder_name":"Thiago Gabriel","expiration_month":10,"expiration_year":2040,"brand":"VI","last4":"1111"},"created_date":"2019-02-06T21:04:43.000+0000","approved_date":"2019-02-06T21:04:44.000+0000","status":"PAID","status_detail":"The payment was paid.","status_code":"200","order_id":"657434343","notification_url":"http://merchant.com/notifications"}'
   end
 
   def failed_purchase_response


### PR DESCRIPTION
**when applied this will**
Add support for creating a payment with installments with dLocal

```
remote tests
27 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

unit tests
18 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```