### PR TITLE
Barclaycard Smartpay: Allow direct exemption requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * CyberSource: Fix XML error on capture [leila-alderman] #3454
 * Adyen: Add gateway specific field for splits [leila-alderman] #3448
 * Adyen: Add `unstore` and `storeToken` actions with '/Recurring' endpoint [deedeelavinder][davidsantoso] #3438
+* Barclaycard Smartpay: Add functionality to set 3DS exemptions via API [britth] #3457
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -359,6 +359,12 @@ module ActiveMerchant #:nodoc:
             add_browser_info(three_ds_2_options[:browser_info], post)
             post[:threeDS2RequestData] = { deviceChannel: device_channel, notificationURL: three_ds_2_options[:notification_url] }
           end
+
+          if options.has_key?(:execute_threed)
+            post[:additionalData] ||= {}
+            post[:additionalData][:executeThreeD] = options[:execute_threed]
+            post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
+          end
         else
           return unless options[:execute_threed] || options[:threed_dynamic]
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -10,7 +10,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111', :month => 10, :year => 2020, :verification_value => 737)
     @declined_card = credit_card('4000300011112220', :month => 3, :year => 2030, :verification_value => 737)
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
-    @three_ds_2_enrolled_card = credit_card('4917610000000000', brand: :visa)
+    @three_ds_2_enrolled_card = credit_card('4917610000000000', month: 10, year: 2020, verification_value: '737', brand: :visa)
 
     @options = {
       order_id: '1',
@@ -218,6 +218,28 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @three_ds_2_enrolled_card, @normalized_3ds_2_options)
     assert response.test?
     refute response.authorization.blank?
+    assert_equal response.params['resultCode'], 'IdentifyShopper'
+    refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
+    refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
+    refute response.params['additionalData']['threeds2.threeDSMethodURL'].blank?
+  end
+
+  def test_successful_purchase_with_3ds2_exemption_requested_and_execute_threed_false
+    assert response = @gateway.authorize(@amount, @three_ds_2_enrolled_card, @normalized_3ds_2_options.merge(execute_threed: false, sca_exemption: 'lowValue'))
+    assert response.test?
+    refute response.authorization.blank?
+
+    assert_equal response.params['resultCode'], 'Authorised'
+  end
+
+  # According to Adyen documentation, if execute_threed is set to true and an exemption provided
+  # the gateway will apply and request for the specified exemption in the authentication request,
+  # after the device fingerprint is submitted to the issuer.
+  def test_successful_purchase_with_3ds2_exemption_requested_and_execute_threed_true
+    assert response = @gateway.authorize(@amount, @three_ds_2_enrolled_card, @normalized_3ds_2_options.merge(execute_threed: true, sca_exemption: 'lowValue'))
+    assert response.test?
+    refute response.authorization.blank?
+
     assert_equal response.params['resultCode'], 'IdentifyShopper'
     refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
     refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?


### PR DESCRIPTION
As a whitelabel of Adyen, Barclay also allows you to request
exemptions directly via the api. Updates the gateway to permit
`sca_exemption` option that will be populated for 3DS2 txns where
`execute_threed` option is passed.

Unit
34 tests, 167 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
38 tests, 98 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3684% passed
(unrelated preexisting failure: test_successful_third_party_payout)