### PR TITLE
Credorax: Don't pass 3ds_version in initial 3ds request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Barclaycard Smartpay: Add functionality to set 3DS exemptions via API [britth] #3457
 * Use null@cybersource.com when option[:email] is an empty string [pi3r] #3462
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460
+* Credorax: Only pass `3ds_version` parameter when required [britth] #3458
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -305,7 +305,6 @@ module ActiveMerchant #:nodoc:
           options.dig(:stored_credential, :initiator) == 'merchant' ? post[:'3ds_channel'] = '03' : post[:'3ds_channel'] = '02'
           post[:'3ds_redirect_url'] = three_ds_2_options[:notification_url]
           post[:'3ds_challengewindowsize'] = options[:three_ds_challenge_window_size] || '03'
-          post[:'3ds_version'] = options[:three_ds_version] if options[:three_ds_version]
           post[:d5] = browser_info[:user_agent]
           post[:'3ds_transtype'] = options[:transaction_type] || '01'
           post[:'3ds_browsertz'] = browser_info[:timezone]
@@ -330,6 +329,7 @@ module ActiveMerchant #:nodoc:
 
       def add_3d_secure_1_data(post, options)
         post[:i8] = build_i8(options[:eci], options[:cavv], options[:xid])
+        post[:'3ds_version'] = options[:three_ds_version].nil? || options[:three_ds_version] == '1' ? '1.0' : options[:three_ds_version]
       end
 
       def add_normalized_3d_secure_2_data(post, options)
@@ -339,7 +339,7 @@ module ActiveMerchant #:nodoc:
           three_d_secure_options[:eci],
           three_d_secure_options[:cavv]
         )
-        post[:'3ds_version'] = three_d_secure_options[:version]
+        post[:'3ds_version'] = three_d_secure_options[:version] == '2' ? '2.0' : three_d_secure_options[:version]
         post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
       end
 

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -8,7 +8,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     @credit_card = credit_card('4176661000001015', verification_value: '281', month: '12', year: '2022')
     @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12', year: '2025')
     @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12', year: '2022')
-    @three_ds_card = credit_card('5185520050000010', verification_value: '737', month: '12', year: '2022')
+    @three_ds_card = credit_card('5455330200000016', verification_value: '737', month: '12', year: '2022')
     @options = {
       order_id: '1',
       currency: 'EUR',
@@ -71,6 +71,22 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       xid: '00000000000000000501',
       # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without a r1 (processor) parameter.
       processor: 'CREDORAX'
+    )
+
+    response = @gateway.purchase(@amount, @fully_auth_card, options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_auth_data_via_3ds1_fields_passing_3ds_version
+    options = @options.merge(
+      eci: '02',
+      cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+      xid: '00000000000000000501',
+      # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without a r1 (processor) parameter.
+      processor: 'CREDORAX',
+      three_ds_version: '1.0'
     )
 
     response = @gateway.purchase(@amount, @fully_auth_card, options)


### PR DESCRIPTION
Credorax 3DS requests are erroring with the message "At least 
one of input parameters is malformed. Parameter 3ds_version is
invalid.". We've been informed that you should not pass
`3ds_version` as part of the original transaction request, and
that the correct version will be returned in your response. You
only need to send it when a 92 needs to be triggered (three ds
completion) or when you're sending an i8 param in your original
request. This PR removes 3ds_version from the original request
where i8 is not passed.

Some updates to tests were also required. It appears that this
behavior is somewhat new, as the 3DS2 tests now fail without this
change. Additionally, the test card doesn't proceed to direct 
success as seemed to have been the case before based on the 
existing test; instead it returns a message that authentication is 
required.

Unit:
60 tests, 289 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed