### PR TITLE
Adyen: add recurring_contract_type GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Adyen: Add `unstore` and `storeToken` actions with '/Recurring' endpoint [deedeelavinder][davidsantoso] #3438
 * Barclaycard Smartpay: Add functionality to set 3DS exemptions via API [britth] #3457
 * Use null@cybersource.com when option[:email] is an empty string [pi3r] #3462
+* Adyen: add `recurring_contract_type` GSF [therufs] #3460
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -367,8 +367,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_recurring_contract(post, options = {})
+        recurring_contract_type = options[:recurring_contract_type] || 'RECURRING'
         recurring = {
-          contract: 'RECURRING'
+          contract: recurring_contract_type
         }
 
         post[:recurring] = recurring

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -548,9 +548,18 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.store(@credit_card, @options)
     end.check_request do |endpoint, data, headers|
       assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
+      assert_equal 'RECURRING', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_store_response)
     assert_success response
     assert_equal '#8835205392522157#8315202663743702', response.authorization
+  end
+
+  def test_successful_store_with_recurring_contract_type
+    stub_comms do
+      @gateway.store(@credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))
+    end.check_request do |endpoint, data, headers|
+      assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
+    end.respond_with(successful_store_response)
   end
 
   def test_failed_store


### PR DESCRIPTION
CE-233

Unit: 55 tests, 259 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 75 tests, 248 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3333% passed 

Remote failures: 
test_successful_purchase_with_auth_data_via_threeds2_standalone
test_successful_purchase_with_auth_data_via_threeds1_standalone

Both fail on `assert_equal 'true', auth.params['additionalData']['liabilityShift']` with `<"true"> expected but was <nil>`, which I think is a familiar behavior. 