### PR TITLE
Use null@cybersource.com when option[:email] is an empty string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Adyen: Add gateway specific field for splits [leila-alderman] #3448
 * Adyen: Add `unstore` and `storeToken` actions with '/Recurring' endpoint [deedeelavinder][davidsantoso] #3438
 * Barclaycard Smartpay: Add functionality to set 3DS exemptions via API [britth] #3457
+* Use null@cybersource.com when option[:email] is an empty string [pi3r] #3462
 
 == Version 1.102.0 (Nov 14, 2019)
 * Quickbooks: Make token refresh optional with allow_refresh flag [britth] #3419

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -469,7 +469,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'company',               address[:company]                 unless address[:company].blank?
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
           xml.tag! 'phoneNumber',           address[:phone]                   unless address[:phone].blank?
-          xml.tag! 'email',                 options[:email] || 'null@cybersource.com'
+          xml.tag! 'email',                 options[:email].presence || 'null@cybersource.com'
           xml.tag! 'ipAddress',             options[:ip]                      unless options[:ip].blank? || shipTo
           xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
           xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -717,6 +717,14 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_address_email_has_a_default_when_email_option_is_empty
+    stub_comms do
+      @gateway.authorize(100, @credit_card, email: '')
+    end.check_request do |endpoint, data, headers|
+      assert_match('<email>null@cybersource.com</email>', data)
+    end.respond_with(successful_capture_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
We've had some cases where email ends up being sent as empty string and it causes the following error `missingField: c:billTo/c:email`. The current logic only checks for its existence, not for its value.
We should use `null@cybersource.com` for both `nil` and `""`.