### PR TITLE
Ebanx: Update capture method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Ingenico GlobalCollect: support `airline_data` and related GSFs [therufs] #3461
 * Add UnionPay card type [leila-alderman] #3464
 * Braintree: Fix add_credit_card_to_customer in Store [molbrown] #3466
+* EBANX: Default to not send amount on capture [chinhle23] #3463
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_integration_key(post)
         post[:hash] = authorization
-        post[:amount] = amount(money)
+        post[:amount] = amount(money) if options[:include_capture_amount].to_s == 'true'
 
         commit(:capture, post)
       end

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -77,7 +77,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Sandbox - Test credit card, transaction declined reason insufficientFunds', response.message
+    assert_equal 'Invalid card or card type', response.message
     assert_equal 'NOK', response.error_code
   end
 
@@ -86,7 +86,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Accepted', auth.message
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'Accepted', capture.message
   end
@@ -94,16 +94,26 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Sandbox - Test credit card, transaction declined reason insufficientFunds', response.message
+    assert_equal 'Invalid card or card type', response.message
     assert_equal 'NOK', response.error_code
   end
 
-  def test_partial_capture
+  def test_successful_partial_capture_when_include_capture_amount_is_not_passed
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount-1, auth.authorization)
     assert_success capture
+  end
+
+  # Partial capture is only available in Brazil and the EBANX Integration Team must be contacted to enable
+  def test_failed_partial_capture_when_include_capture_amount_is_passed
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount-1, auth.authorization, @options.merge(include_capture_amount: true))
+    assert_failure capture
+    assert_equal 'Partial capture not available', capture.message
   end
 
   def test_failed_capture
@@ -149,7 +159,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'Parameter hash not informed', response.message
+    assert_equal 'Parameters hash or merchant_payment_code not informed', response.message
   end
 
   def test_successful_store_and_purchase
@@ -193,7 +203,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{Accepted}, response.message
+    assert_match %r{Invalid card or card type}, response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -54,9 +54,18 @@ class EbanxTest < Test::Unit::TestCase
 
     response = @gateway.capture(@amount, 'authorization', @options)
     assert_success response
-
-    assert_equal 'Sandbox - Test credit card, transaction captured', response.message
+    assert_equal '5dee94502bd59660b801c441ad5a703f2c4123f5fc892ccb', response.authorization
+    assert_equal 'Accepted', response.message
     assert response.test?
+  end
+
+  def test_failed_partial_capture
+    @gateway.expects(:ssl_request).returns(failed_partial_capture_response)
+
+    response = @gateway.capture(@amount, 'authorization', @options.merge(include_capture_amount: true))
+    assert_failure response
+    assert_equal 'BP-CAP-11', response.error_code
+    assert_equal 'Partial capture not available', response.message
   end
 
   def test_failed_capture
@@ -193,7 +202,13 @@ class EbanxTest < Test::Unit::TestCase
 
   def successful_capture_response
     %(
-      {"payment":{"hash":"592dd65824427e4f5f50564c118f399869637bfb30d54f5b","pin":"081043654","merchant_payment_code":"8424e3000d64d056fbd58639957dc1c4","order_number":null,"status":"CO","status_date":"2017-05-30 17:30:16","open_date":"2017-05-30 17:30:15","confirm_date":"2017-05-30 17:30:16","transfer_date":null,"amount_br":"3.31","amount_ext":"1.00","amount_iof":"0.01","currency_rate":"3.3000","currency_ext":"USD","due_date":"2017-06-02","instalments":"1","payment_type_code":"visa","transaction_status":{"acquirer":"EBANX","code":"OK","description":"Sandbox - Test credit card, transaction captured"},"pre_approved":true,"capture_available":false,"customer":{"document":"85351346893","email":"unspecified@example.com","name":"LONGBOB LONGSEN","birth_date":null}},"status":"SUCCESS"}
+      {"payment":{"hash":"5dee94502bd59660b801c441ad5a703f2c4123f5fc892ccb","pin":"675968133","country":"br","merchant_payment_code":"b98b2892b80771b9dadf2ebc482cb65d","order_number":null,"status":"CO","status_date":"2019-12-09 18:37:05","open_date":"2019-12-09 18:37:04","confirm_date":"2019-12-09 18:37:05","transfer_date":null,"amount_br":"4.19","amount_ext":"1.00","amount_iof":"0.02","currency_rate":"4.1700","currency_ext":"USD","due_date":"2019-12-12","instalments":"1","payment_type_code":"visa","details":{"billing_descriptor":"DEMONSTRATION"},"transaction_status":{"acquirer":"EBANX","code":"OK","description":"Accepted"},"pre_approved":true,"capture_available":false,"customer":{"document":"85351346893","email":"unspecified@example.com","name":"LONGBOB LONGSEN","birth_date":null}},"status":"SUCCESS"}
+    )
+  end
+
+  def failed_partial_capture_response
+    %(
+      {"status":"ERROR", "status_code":"BP-CAP-11", "status_message":"Partial capture not available"}
     )
   end
 


### PR DESCRIPTION
ECS-872/ECS-929
 
https://developers.ebanx.com/api-reference/ebanx-payment-api/payment-reference/reference-capture-operation/
Per Ebanx documentation: “You can make only one partial capture per authorized
payment and this feature is only available in Brazil. If you want to enable
this feature, please contact our Integration Team.”
 
 1. Ebanx will capture full amount authorized if no amount is included in
    the capture request. Adds a flag for including the amount only in the
    case of partial capture.
 
 2. Update tests for new error messages and handling of partial capture
 
Unit:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
 
Remote:
22 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed