### PR TITLE
Add UnionPay card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * EBANX: Include Peru in supported countries [Ruanito] #3443
 * Bluesnap: include fraud data in response message [therufs] #3459
 * Ingenico GlobalCollect: support `airline_data` and related GSFs [therufs] #3461
+* Add UnionPay card type [leila-alderman] #3464
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -22,6 +22,7 @@ module ActiveMerchant #:nodoc:
     # * Alelo
     # * Cabal
     # * Naranja
+    # * UnionPay
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -96,6 +97,7 @@ module ActiveMerchant #:nodoc:
       # * +'alelo'+
       # * +'cabal'+
       # * +'naranja'+
+      # * +'union_pay'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -18,6 +18,7 @@ module ActiveMerchant #:nodoc:
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
         'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
         'cabal'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 8), CABAL_RANGES) },
+        'unionpay'           => ->(num) { (16..19).cover?(num&.size) && in_bin_range?(num.slice(0, 8), UNIONPAY_RANGES) },
         'carnet'             => lambda { |num|
           num&.size == 16 && (
             in_bin_range?(num.slice(0, 6), CARNET_RANGES) ||
@@ -121,6 +122,14 @@ module ActiveMerchant #:nodoc:
 
       NARANJA_RANGES = [
         589562..589562
+      ]
+
+      # In addition to the BIN ranges listed here that all begin with 81, UnionPay cards
+      # include many ranges that start with 62.
+      # Prior to adding UnionPay, cards that start with 62 were all classified as Discover.
+      # Because UnionPay cards are able to run on Discover rails, this was kept the same.
+      UNIONPAY_RANGES = [
+        81000000..81099999, 81100000..81319999, 81320000..81519999, 81520000..81639999, 81640000..81719999
       ]
 
       def self.included(base)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AT AU BE BG BR CH CY CZ DE DK EE ES FI FR GB GI GR HK HU IE IS IT LI LT LU LV MC MT MX NL NO PL PT RO SE SG SK SI US)
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(CVE DJF GNF IDR JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro, :discover, :elo, :naranja, :cabal]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro, :discover, :elo, :naranja, :cabal, :unionpay]
 
       self.money_format = :cents
 

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
       self.money_format        = :cents
 
       # Not all card types may be activated by the bank!
-      self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :diners_club]
+      self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :diners_club, :unionpay]
       self.homepage_url        = 'http://www.redsys.es/'
       self.display_name        = 'Redsys'
 

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteRedsysSHA256Test < Test::Unit::TestCase
   def setup
     @gateway = RedsysGateway.new(fixtures(:redsys_sha256))
+    @amount = 100
     @credit_card = credit_card('4548812049400004')
     @declined_card = credit_card
     @threeds2_credit_card = credit_card('4918019199883839')
@@ -12,14 +13,14 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(100, @credit_card, @options)
+    response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Approved', response.message
   end
 
   def test_successful_authorize_3ds
     options = @options.merge(execute_threed: true, terminal: 12)
-    response = @gateway.authorize(100, @credit_card, options)
+    response = @gateway.authorize(@amount, @credit_card, options)
     assert_success response
     assert response.params['ds_emv3ds']
     assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
@@ -29,7 +30,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
 
   def test_successful_purchase_3ds
     options = @options.merge(execute_threed: true, terminal: 12)
-    response = @gateway.purchase(100, @threeds2_credit_card, options)
+    response = @gateway.purchase(@amount, @threeds2_credit_card, options)
     assert_success response
     assert three_ds_data = JSON.parse(response.params['ds_emv3ds'])
     assert_equal '2.1.0', three_ds_data['protocolVersion']
@@ -40,13 +41,13 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
 
   # Requires account configuration to allow setting moto flag
   def test_purchase_with_moto_flag
-    response = @gateway.purchase(100, @credit_card, @options.merge(moto: true, metadata: { manual_entry: true }))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(moto: true, metadata: { manual_entry: true }))
     assert_equal 'SIS0488 ERROR', response.message
   end
 
   def test_successful_3ds_authorize_with_exemption
     options = @options.merge(execute_threed: true, terminal: 12)
-    response = @gateway.authorize(100, @credit_card, options.merge(sca_exemption: 'LWV'))
+    response = @gateway.authorize(@amount, @credit_card, options.merge(sca_exemption: 'LWV'))
     assert_success response
     assert response.params['ds_emv3ds']
     assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
@@ -54,13 +55,13 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_purchase_with_invalid_order_id
-    response = @gateway.purchase(100, @credit_card, order_id: "a%4#{generate_order_id}")
+    response = @gateway.purchase(@amount, @credit_card, order_id: "a%4#{generate_order_id}")
     assert_success response
     assert_equal 'Transaction Approved', response.message
   end
 
   def test_successful_purchase_using_vault_id
-    response = @gateway.purchase(100, @credit_card, @options.merge(store: true))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(store: true))
     assert_success response
     assert_equal 'Transaction Approved', response.message
 
@@ -68,21 +69,21 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert_not_nil credit_card_token
 
     @options[:order_id] = generate_order_id
-    response = @gateway.purchase(100, credit_card_token, @options)
+    response = @gateway.purchase(@amount, credit_card_token, @options)
     assert_success response
     assert_equal 'Transaction Approved', response.message
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(100, @declined_card, @options)
+    response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'SIS0093 ERROR', response.message
   end
 
   def test_purchase_and_refund
-    purchase = @gateway.purchase(100, @credit_card, @options)
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
-    refund = @gateway.refund(100, purchase.authorization)
+    refund = @gateway.refund(@amount, purchase.authorization)
     assert_success refund
   end
 
@@ -94,18 +95,18 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_successful_authorise_and_capture
-    authorize = @gateway.authorize(100, @credit_card, @options)
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
     assert_equal 'Transaction Approved', authorize.message
     assert_not_nil authorize.authorization
 
-    capture = @gateway.capture(100, authorize.authorization)
+    capture = @gateway.capture(@amount, authorize.authorization)
     assert_success capture
     assert_match(/Refund.*approved/, capture.message)
   end
 
   def test_successful_authorise_using_vault_id
-    authorize = @gateway.authorize(100, @credit_card, @options.merge(store: true))
+    authorize = @gateway.authorize(@amount, @credit_card, @options.merge(store: true))
     assert_success authorize
     assert_equal 'Transaction Approved', authorize.message
     assert_not_nil authorize.authorization
@@ -114,20 +115,20 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert_not_nil credit_card_token
 
     @options[:order_id] = generate_order_id
-    authorize = @gateway.authorize(100, credit_card_token, @options)
+    authorize = @gateway.authorize(@amount, credit_card_token, @options)
     assert_success authorize
     assert_equal 'Transaction Approved', authorize.message
     assert_not_nil authorize.authorization
   end
 
   def test_failed_authorize
-    response = @gateway.authorize(100, @declined_card, @options)
+    response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'SIS0093 ERROR', response.message
   end
 
   def test_successful_void
-    authorize = @gateway.authorize(100, @credit_card, @options)
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
 
     void = @gateway.void(authorize.authorization)
@@ -137,7 +138,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_failed_void
-    authorize = @gateway.authorize(100, @credit_card, @options)
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize
 
     void = @gateway.void(authorize.authorization)

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -137,6 +137,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_should_detect_elo_card
     assert_equal 'elo', CreditCard.brand?('5090510000000000')
     assert_equal 'elo', CreditCard.brand?('5067530000000000')
+    assert_equal 'elo', CreditCard.brand?('6277800000000000')
     assert_equal 'elo', CreditCard.brand?('6509550000000000')
   end
 
@@ -169,6 +170,23 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'cabal', CreditCard.brand?('6035224400000000')
   end
 
+  # UnionPay BINs beginning with 62 overlap with Discover's range of valid card numbers.
+  # We intentionally misidentify these cards as Discover, which works because transactions with
+  # UnionPay cards will run on Discover rails.
+  def test_should_detect_unionpay_cards_beginning_with_62_as_discover
+    assert_equal 'discover', CreditCard.brand?('6212345678901265')
+    assert_equal 'discover', CreditCard.brand?('6221260000000000')
+    assert_equal 'discover', CreditCard.brand?('6250941006528599')
+    assert_equal 'discover', CreditCard.brand?('6212345678900000003')
+  end
+
+  def test_should_detect_unionpay_card
+    assert_equal 'unionpay', CreditCard.brand?('8100000000000000')
+    assert_equal 'unionpay', CreditCard.brand?('814400000000000000')
+    assert_equal 'unionpay', CreditCard.brand?('8171999927660000')
+    assert_equal 'unionpay', CreditCard.brand?('8171999900000000021')
+  end
+
   def test_should_detect_when_an_argument_brand_does_not_match_calculated_brand
     assert CreditCard.matching_brand?('4175001000000000', 'visa')
     assert_false CreditCard.matching_brand?('4175001000000000', 'master')
@@ -194,7 +212,6 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_matching_discover_card
     assert_equal 'discover', CreditCard.brand?('6011000000000000')
     assert_equal 'discover', CreditCard.brand?('6500000000000000')
-    assert_equal 'discover', CreditCard.brand?('6221260000000000')
     assert_equal 'discover', CreditCard.brand?('6450000000000000')
 
     assert_not_equal 'discover', CreditCard.brand?('6010000000000000')

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -37,6 +37,15 @@ class AdyenTest < Test::Unit::TestCase
       :brand => 'cabal'
     )
 
+    @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
+      :month => 10,
+      :year => 2030,
+      :first_name => 'John',
+      :last_name => 'Smith',
+      :verification_value => '737',
+      :brand => 'unionpay'
+    )
+
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
@@ -242,7 +251,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_purchase_with_elo_card
     response = stub_comms do
       @gateway.purchase(@amount, @elo_credit_card, @options)
-    end.respond_with(successful_authorize_with_elo_response, successful_capture_with_elo_repsonse)
+    end.respond_with(simple_successful_authorize_response, simple_successful_capture_repsonse)
     assert_success response
     assert_equal '8835511210681145#8835511210689965#', response.authorization
     assert response.test?
@@ -251,9 +260,18 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_purchase_with_cabal_card
     response = stub_comms do
       @gateway.purchase(@amount, @cabal_credit_card, @options)
-    end.respond_with(successful_authorize_with_cabal_response, successful_capture_with_cabal_repsonse)
+    end.respond_with(simple_successful_authorize_response, simple_successful_capture_repsonse)
     assert_success response
-    assert_equal '883567090118045A#883567090119063C#', response.authorization
+    assert_equal '8835511210681145#8835511210689965#', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_unionpay_card
+    response = stub_comms do
+      @gateway.purchase(@amount, @unionpay_credit_card, @options)
+    end.respond_with(simple_successful_authorize_response, simple_successful_capture_repsonse)
+    assert_success response
+    assert_equal '8835511210681145#8835511210689965#', response.authorization
     assert response.test?
   end
 
@@ -823,7 +841,7 @@ class AdyenTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def successful_authorize_with_elo_response
+  def simple_successful_authorize_response
     <<-RESPONSE
     {
       "pspReference":"8835511210681145",
@@ -833,29 +851,10 @@ class AdyenTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def successful_capture_with_elo_repsonse
+  def simple_successful_capture_repsonse
     <<-RESPONSE
     {
       "pspReference":"8835511210689965",
-      "response":"[capture-received]"
-    }
-    RESPONSE
-  end
-
-  def successful_authorize_with_cabal_response
-    <<-RESPONSE
-    {
-      "pspReference":"883567090118045A",
-      "resultCode":"Authorised",
-      "authCode":"77651"
-    }
-    RESPONSE
-  end
-
-  def successful_capture_with_cabal_repsonse
-    <<-RESPONSE
-    {
-      "pspReference":"883567090119063C",
       "response":"[capture-received]"
     }
     RESPONSE

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -237,7 +237,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_supported_cardtypes
-    assert_equal [:visa, :master, :american_express, :jcb, :diners_club], RedsysGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :diners_club, :unionpay], RedsysGateway.supported_cardtypes
   end
 
   def test_using_test_mode

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -199,7 +199,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_supported_cardtypes
-    assert_equal [:visa, :master, :american_express, :jcb, :diners_club], RedsysGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :diners_club, :unionpay], RedsysGateway.supported_cardtypes
   end
 
   def test_using_test_mode


### PR DESCRIPTION
Added the UnionPay card type with support on Adyen and Redsys gateways.

Prior to adding UnionPay, cards that start with 62 were all classified
as Discover. Because UnionPay cards are able to run on Discover rails,
this was kept the same.

Unit and remote tests were added for UnionPay card numbers on Adyen.

UnionPay test card numbers aren't available for Redsys, so the new card
type hasn't yet been tested on this gateway. The changes made to the
Redsys remote test are simple cleanup to add a missing instance
variable.

CE-279 / CE-262

All unit tests:
4382 tests, 71190 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed

Adyen unit tests:
56 tests, 263 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Redsys SHA1 unit tests:
32 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Redsys SHA256 unit tests:
36 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Adyen remote tests:
81 tests, 268 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
97.5309% passed

The 2 failures were previously existing and are unrelated:
 - test_successful_purchase_with_auth_data_via_threeds1_standalone
 - test_successful_purchase_with_auth_data_via_threeds2_standalone

Redsys SHA1 remote tests:
18 tests, 51 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
88.8889% passed

The 2 failures seem unrelated (perhaps related to the two different SHA
versions of the Redsys gateway?)
 - test_successful_purchase_using_vault_id
 - test_successful_authorise_using_vault_id
Error message: "The signature sent is not correct."

Redsys SHA256 remote tests:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed