### PR TITLE
Cybersource: add GSFs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Braintree: Fix add_credit_card_to_customer in Store [molbrown] #3466
 * EBANX: Default to not send amount on capture [chinhle23] #3463
 * Latitude19: Convert money format to dollars [molbrown] #3468
+* CyberSource: add several GSFs [therufs] #3465
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447


### PR DESCRIPTION
Adds:
invoiceHeader.merchantDescriptor, available for auth, capture, and credit
installment.totalCount, available for auth
othertax.localTaxAmount
othertax.nationalTaxAmount, available for capture

I'm not super happy with what's happening to `add_payment_method_or_subscription` but don't have great ideas for an obvious refactor. 

CE-263