### PR TITLE
Braintree: Fix add_credit_card_to_customer in Store

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Bluesnap: include fraud data in response message [therufs] #3459
 * Ingenico GlobalCollect: support `airline_data` and related GSFs [therufs] #3461
 * Add UnionPay card type [leila-alderman] #3464
+* Braintree: Fix add_credit_card_to_customer in Store [molbrown] #3466
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -260,7 +260,7 @@ module ActiveMerchant #:nodoc:
           }
           if options[:billing_address]
             address = map_address(options[:billing_address])
-            parameters[:credit_card][:billing_address] = address unless address.all? { |_k, v| empty?(v) }
+            parameters[:billing_address] = address unless address.all? { |_k, v| empty?(v) }
           end
 
           result = @braintree_gateway.credit_card.create(parameters)

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -292,11 +292,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_store_with_existing_customer_id
     credit_card = credit_card('5105105105105100')
     customer_id = generate_unique_id
-    assert response = @gateway.store(credit_card, customer: customer_id)
+    assert response = @gateway.store(credit_card, @options.merge(customer: customer_id))
     assert_success response
     assert_equal 1, @braintree_backend.customer.find(customer_id).credit_cards.size
 
-    assert response = @gateway.store(credit_card, customer: customer_id)
+    credit_card = credit_card('4111111111111111')
+    assert response = @gateway.store(credit_card, @options.merge(customer: customer_id))
     assert_success response
     assert_equal 2, @braintree_backend.customer.find(customer_id).credit_cards.size
     assert_equal customer_id, response.params['customer_vault_id']


### PR DESCRIPTION
add_credit_card_to_customer method was assigning billing_address to
credit_card before credit_card existed. This issue was exposed through a
customer bug, and tests never actually tested the if options[:billing_address]
scenario.

Unit:
75 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
80 tests, 435 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-910