### PR TITLE
Latitude19: Convert money format to dollars

### DIFF
--- a/lib/active_merchant/billing/gateways/latitude19.rb
+++ b/lib/active_merchant/billing/gateways/latitude19.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['US', 'CA']
       self.default_currency = 'USD'
-      self.money_format = :cents
+      self.money_format = :dollars
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb]
 
       RESPONSE_CODE_MAPPING = {

--- a/test/unit/gateways/latitude19_test.rb
+++ b/test/unit/gateways/latitude19_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Latitude19Test < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = Latitude19Gateway.new(fixtures(:latitude19))
 
@@ -29,18 +31,18 @@ class Latitude19Test < Test::Unit::TestCase
   # end
 
   def test_successful_authorize_and_capture
-    @gateway.expects(:ssl_post).returns(successful_authorize_response)
-    @gateway.expects(:ssl_post).returns(successful_token_response)
-    @gateway.expects(:ssl_post).returns(successful_session_response)
-
-    response = @gateway.authorize(@amount, @credit_card, @options)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.respond_with(successful_session_response, successful_token_response, successful_authorize_response)
     assert_success response
     assert_equal 'Approved', response.message
     assert_match %r(^auth\|\w+$), response.authorization
 
-    @gateway.expects(:ssl_post).returns(successful_capture_response)
-
-    capture = @gateway.capture(@amount, response.authorization, @options)
+    capture = stub_comms do
+      @gateway.capture(@amount, response.authorization, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"amount\":\"1.00\"/, data)
+    end.respond_with(successful_capture_response)
     assert_success capture
     assert_equal 'Approved', capture.message
   end


### PR DESCRIPTION
With feedback from the gateway, it expects amounts to come in dollar
format (includes a decimal). Issue exposed due to customer usage, which
may be the first use of this gateway adapter.

Unit:
9 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
10 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-908