### PR TITLE
Adyen: Set response success for unstore

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -512,6 +512,8 @@ module ActiveMerchant #:nodoc:
           response['response'] == 'Authorised' || response['response'] == '[adjustAuthorisation-received]'
         when 'storeToken'
           response['result'] == 'Success'
+        when 'disable'
+          response['response'] == '[detail-successfully-disabled]'
         else
           false
         end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -676,6 +676,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.unstore(shopper_reference: shopper_reference,
                                        recurring_detail_reference: recurring_detail_reference)
 
+    assert_success response
     assert_equal '[detail-successfully-disabled]', response.message
   end
 
@@ -690,10 +691,14 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     assert response = @gateway.unstore(shopper_reference: 'random_reference',
                                        recurring_detail_reference: recurring_detail_reference)
+
+    assert_failure response
     assert_equal 'Contract not found', response.message
 
     assert response = @gateway.unstore(shopper_reference: shopper_reference,
                                        recurring_detail_reference: 'random_reference')
+
+    assert_failure response
     assert_equal 'PaymentDetail not found', response.message
   end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -592,6 +592,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.unstore(shopper_reference: 'shopper_reference',
                        recurring_detail_reference: 'detail_reference')
     end.respond_with(successful_unstore_response)
+    assert_success response
     assert_equal '[detail-successfully-disabled]', response.message
   end
 


### PR DESCRIPTION
Update so that Response responds correctly to success? when an unstore (disable) is performed successfully.

Unit tests:
56 tests, 264 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
81 tests, 271 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5309% passed
_(2 failures were pre-existing:  test_successful_purchase_with_auth_data_via_threeds1_standalone, test_successful_purchase_with_auth_data_via_threeds2_standalone)_
