### PR TITLE
Adyen: add recurring_contract_type to auth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Latitude19: Convert money format to dollars [molbrown] #3468
 * Adyen: Fix response success for unstore [kheang] #3470
 * CyberSource: add several GSFs [therufs] #3465
+* Adyen: add `recurring_contract_type` GSF to auth [therufs] #3471
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447


### PR DESCRIPTION
Unit: 
57 tests, 267 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
81 tests, 271 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5309% passed

Failures on 3DS (1 and 2) purchase_with_auth_data attempts. 