### PR TITLE
Cardstream: Localize zero-decimal currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Decidir: Add debit card payment method IDs [leila-alderman] #3480
 * CyberSource: Add issuer data+MDD to credit & void [leila-alderman] #3481
 * Credorax: add `authorization_type` and `multiple_capture_count` GSFs [therufs] #3478
+* CardStream: use localized_amount to correctly support zero-decimal currencies [britth] #3473
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -7,6 +7,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = self.live_url = 'https://gateway.cardstream.com/direct/'
       self.money_format = :cents
       self.default_currency = 'GBP'
+      self.currencies_without_fractions = %w(CVE ISK JPY UGX)
       self.supported_countries = ['GB', 'US', 'CH', 'SE', 'SG', 'NO', 'JP', 'IS', 'HK', 'NL', 'CZ', 'CA', 'AU']
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb, :maestro]
       self.homepage_url = 'http://www.cardstream.com/'
@@ -173,7 +174,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         post = {}
         add_pair(post, :xref, authorization)
-        add_pair(post, :amount, amount(money), :required => true)
+        add_pair(post, :amount, localized_amount(money, options[:currency] || currency(money)), :required => true)
         add_remote_address(post, options)
 
         commit('CAPTURE', post)
@@ -224,8 +225,9 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_amount(post, money, options)
-        add_pair(post, :amount, amount(money), :required => true)
-        add_pair(post, :currencyCode, currency_code(options[:currency] || currency(money)))
+        currency = options[:currency] || currency(money)
+        add_pair(post, :amount, localized_amount(money, currency), :required => true)
+        add_pair(post, :currencyCode, currency_code(currency))
       end
 
       def add_customer_data(post, options)
@@ -249,7 +251,7 @@ module ActiveMerchant #:nodoc:
           if ['american_express', 'diners_club'].include?(card_brand(credit_card_or_reference).to_s)
             add_pair(post, :item1Quantity, 1)
             add_pair(post, :item1Description, (options[:description] || options[:order_id]).slice(0, 15))
-            add_pair(post, :item1GrossValue, amount(money))
+            add_pair(post, :item1GrossValue, localized_amount(money, options[:currency] || currency(money)))
           end
         end
 

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -8,35 +8,35 @@ class RemoteCardStreamTest < Test::Unit::TestCase
 
     @amex = credit_card('374245455400001',
       :month => '12',
-      :year => '2014',
+      :year => Time.now.year + 1,
       :verification_value => '4887',
       :brand => :american_express
     )
 
     @mastercard = credit_card('5301250070000191',
       :month => '12',
-      :year => '2014',
+      :year => Time.now.year + 1,
       :verification_value => '419',
       :brand => :master
     )
 
     @visacreditcard = credit_card('4929421234600821',
       :month => '12',
-      :year => '2014',
+      :year => Time.now.year + 1,
       :verification_value => '356',
       :brand => :visa
     )
 
     @visadebitcard = credit_card('4539791001730106',
       :month => '12',
-      :year => '2014',
+      :year => Time.now.year + 1,
       :verification_value => '289',
       :brand => :visa
     )
 
     @declined_card = credit_card('4000300011112220',
       :month => '9',
-      :year => '2014'
+      :year => Time.now.year + 1
     )
 
     @amex_options = {
@@ -75,6 +75,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
         :zip => 'NN17 8YG',
         :country => 'GB'
       },
+      :order_id => generate_unique_id,
       :merchant_name => 'merchant',
       :dynamic_descriptor => 'product',
       :ip => '1.1.1.1',
@@ -166,7 +167,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
 
     assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visacredit_options)
     assert_failure responseRefund
-    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_equal 'Cannot REFUND this SALE transaction', responseRefund.message
     assert responseRefund.test?
   end
 
@@ -223,7 +224,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert !responsePurchase.authorization.blank?
 
     assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @visadebit_options)
-    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_equal 'Cannot REFUND this SALE transaction', responseRefund.message
     assert_failure responseRefund
     assert responseRefund.test?
   end
@@ -261,7 +262,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert !responsePurchase.authorization.blank?
 
     assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @amex_options)
-    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_equal 'Cannot REFUND this SALE transaction', responseRefund.message
     assert_failure responseRefund
     assert responseRefund.test?
   end
@@ -299,7 +300,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert !responsePurchase.authorization.blank?
 
     assert responseRefund = @gateway.refund(142, responsePurchase.authorization, @mastercard_options)
-    assert_equal 'Can not REFUND this SALE transaction', responseRefund.message
+    assert_equal 'Cannot REFUND this SALE transaction', responseRefund.message
     assert_failure responseRefund
     assert responseRefund.test?
   end
@@ -341,6 +342,13 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     assert response = @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(currency: 'CEO'))
     assert_failure response
     assert_match %r{MISSING_CURRENCYCODE}, response.message
+  end
+
+  def test_successful_purchase_and_amount_for_non_decimal_currency
+    assert response = @gateway.purchase(14200, @visacreditcard, @visacredit_options.merge(currency: 'JPY'))
+    assert_success response
+    assert_equal '392', response.params['currencyCode']
+    assert_equal '142', response.params['amount']
   end
 
   def test_successful_visadebitcard_purchase
@@ -393,7 +401,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @mastercard_options)
     assert_failure response
-    assert_match %r{INVALID_CARDNUMBER}, response.message
+    assert_match %r{Disallowed cardnumber}, response.message
   end
 
   def test_successful_3dsecure_purchase


### PR DESCRIPTION
Zero-decimal currencies were being handled in an unexpected way on
Cardstream compared to other gateways. For instance, whereas we
expect a merchant to pass in an amount like 100 to be charged 1
JPY, this gateway processes this as though it's a charge of 100 JPY. 
This PR uses localized_amount to divide the value by 100 before 
passing along to the gateway. The gateway does not support any 
three-decimal currencies, so this PR does not try to test those 
scenarios.

This gateway also had quite a few failing tests due to cc year,
updated error messages and some duplicate transaction handling.
These are also updated in this PR. The tests are still somewhat
temperamental in that you'll sometimes get a timeout, but that
does not appear to be related to these updates as it's a different
test or two each time (and sometimes none at all).

Remote:
31 tests, 204 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
26 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed