### PR TITLE
Merchant Warrior: Add void operation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Adyen: add `recurring_contract_type` GSF to auth [therufs] #3471
 * Stripe Payment Intents: Use localized_amount on capture [molbrown] #3475
 * Add support for dLocal installments [kdelemme] #3456
+* Merchant Warrior: Add void operation [leila-alderman] #3474
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -58,6 +58,13 @@ module ActiveMerchant #:nodoc:
         commit('refundCard', post)
       end
 
+      def void(money, identification, options = {})
+        post = {}
+        add_amount(post, money, options)
+        add_transaction(post, identification)
+        commit('processVoid', post)
+      end
+
       def store(creditcard, options = {})
         post = {
           'cardName' => scrub_name(creditcard.name),

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -8,11 +8,19 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     @failure_amount = 205
 
     @credit_card = credit_card(
-      '5123456789012346',
-      :month => 5,
-      :year => Time.now.year + 2,
-      :verification_value => '123',
-      :brand => 'master'
+      '4564710000000004',
+      :month => '2',
+      :year => '29',
+      :verification_value => '847',
+      :brand => 'visa'
+    )
+
+    @expired_card = credit_card(
+      '4564710000000012',
+      :month => '2',
+      :year => '05',
+      :verification_value => '963',
+      :brand => 'visa'
     )
 
     @options = {
@@ -44,15 +52,15 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
 
   def test_successful_purchase
     assert purchase = @gateway.purchase(@success_amount, @credit_card, @options)
-    assert_equal 'Transaction approved', purchase.message
     assert_success purchase
+    assert_equal 'Transaction approved', purchase.message
     assert_not_nil purchase.params['transaction_id']
     assert_equal purchase.params['transaction_id'], purchase.authorization
   end
 
   def test_failed_purchase
-    assert purchase = @gateway.purchase(@failure_amount, @credit_card, @options)
-    assert_equal 'Transaction declined', purchase.message
+    assert purchase = @gateway.purchase(@success_amount, @expired_card, @options)
+    assert_match 'Card has expired', purchase.message
     assert_failure purchase
     assert_not_nil purchase.params['transaction_id']
     assert_equal purchase.params['transaction_id'], purchase.authorization
@@ -68,8 +76,23 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
 
   def test_failed_refund
     assert refund = @gateway.refund(@success_amount, 'invalid-transaction-id')
-    assert_match %r{Invalid transactionID}, refund.message
+    assert_match %r{'transactionID' not found}, refund.message
     assert_failure refund
+  end
+
+  def test_successful_void
+    assert purchase = @gateway.purchase(@success_amount, @credit_card, @options)
+    assert_success purchase
+
+    assert void = @gateway.void(@success_amount, purchase.authorization)
+    assert_success void
+    assert_equal 'Transaction approved', void.message
+  end
+
+  def test_failed_void
+    assert void = @gateway.void(@success_amount, 'invalid-transaction-id')
+    assert_match %r{'transactionID' not found}, void.message
+    assert_failure void
   end
 
   def test_capture_too_much

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -61,6 +61,26 @@ class MerchantWarriorTest < Test::Unit::TestCase
     assert_nil response.authorization
   end
 
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    assert response = @gateway.void(@success_amount, @transaction_id, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert response.test?
+    assert_equal '30-d4d19f4-db17-11df-9322-0022198101cd', response.authorization
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    assert response = @gateway.void(@success_amount, @transaction_id)
+    assert_failure response
+    assert_equal 'MW -016:transactionID has already been reversed', response.message
+    assert response.test?
+    assert_nil response.authorization
+  end
+
   def test_successful_store
     @credit_card.month = '2'
     @credit_card.year = '2005'


### PR DESCRIPTION
This addes the `void` operation to the Merchant Warrior gateway along
with unit and remote tests.

Adding support for this operation required switching to a new provider,
which required new test card numbers to be used.

CE-294

Unit:
12 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
13 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed