### PR TITLE
Stripe Payment Intents: Use localized_amount on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Adyen: Fix response success for unstore [kheang] #3470
 * CyberSource: add several GSFs [therufs] #3465
 * Adyen: add `recurring_contract_type` GSF to auth [therufs] #3471
+* Stripe Payment Intents: Use localized_amount on capture [molbrown] #3475
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
 
       def update_intent(money, intent_id, payment_method, options = {})
         post = {}
-        post[:amount] = money if money
+        add_amount(post, money, options)
 
         add_payment_method_token(post, payment_method, options)
         add_payment_method_types(post, options)
@@ -91,7 +91,8 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, intent_id, options = {})
         post = {}
-        post[:amount_to_capture] = money
+        currency = options[:currency] || currency(money)
+        post[:amount_to_capture] = localized_amount(money, currency)
         if options[:transfer_amount]
           post[:transfer_data] = {}
           post[:transfer_data][:amount] = options[:transfer_amount]


### PR DESCRIPTION
localized_amount method for formatting non-fractional currencies was
used on authorize, but not capture, leading to capture requests for
larger amounts than authorized.

Unit:
6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 123 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-939