### PR TITLE
Decidir: Update payment method IDs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Stripe Payment Intents: Use localized_amount on capture [molbrown] #3475
 * Add support for dLocal installments [kdelemme] #3456
 * Merchant Warrior: Add void operation [leila-alderman] #3474
+* Decidir: Update payment method IDs [leila-alderman] #3476
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -122,6 +122,12 @@ module ActiveMerchant #:nodoc:
       def add_payment_method_id(credit_card)
         if options[:payment_method_id]
           options[:payment_method_id].to_i
+        elsif CreditCard.brand?(credit_card.number) == 'master'
+          104
+        elsif CreditCard.brand?(credit_card.number) == 'american_express'
+          65
+        elsif CreditCard.brand?(credit_card.number) == 'diners_club'
+          8
         elsif CreditCard.brand?(credit_card.number) == 'cabal'
           63
         elsif CreditCard.brand?(credit_card.number) == 'naranja'

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -7,6 +7,9 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4507990000004905')
+    @master_card_credit_card = credit_card('5299910010000015')
+    @amex_credit_card = credit_card('373953192351004')
+    @diners_club_credit_card = credit_card('36463664750005')
     @cabal_credit_card = credit_card('5896570000000008')
     @naranja_credit_card = credit_card('5895627823453005')
     @declined_card = credit_card('4000300011112220')
@@ -23,6 +26,30 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_equal 'approved', response.message
     assert response.authorization
   end
+
+  def test_successful_purchase_with_master_card
+    response = @gateway_for_purchase.purchase(@amount, @master_card_credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_amex
+    response = @gateway_for_purchase.purchase(@amount, @amex_credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  # This test is currently failing.
+  # Decidir hasn't been able to provide a valid Diners Club test card number.
+  #
+  # def test_successful_purchase_with_diners_club
+  #   response = @gateway_for_purchase.purchase(@amount, @diners_club_credit_card, @options)
+  #   assert_success response
+  #   assert_equal 'approved', response.message
+  #   assert response.authorization
+  # end
 
   def test_successful_purchase_with_cabal
     response = @gateway_for_purchase.purchase(@amount, @cabal_credit_card, @options)

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -246,6 +246,24 @@ class DecidirTest < Test::Unit::TestCase
     assert_equal 1, post[:payment_method_id]
   end
 
+  def test_payment_method_id_with_mastercard
+    post = {}
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, credit_card('5299910010000015'), @options)
+    assert_equal 104, post[:payment_method_id]
+  end
+
+  def test_payment_method_id_with_amex
+    post = {}
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, credit_card('373953192351004'), @options)
+    assert_equal 65, post[:payment_method_id]
+  end
+
+  def test_payment_method_id_with_diners
+    post = {}
+    @gateway_for_purchase.send(:add_auth_purchase_params, post, @amount, credit_card('36463664750005'), @options)
+    assert_equal 8, post[:payment_method_id]
+  end
+
   def test_payment_method_id_with_cabal
     post = {}
     credit_card = credit_card('5896570000000008')


### PR DESCRIPTION
Fixed a bug in which existing supported card types were not assigned the
correct payment method ID.

CE-315

Unit:
28 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
21 tests, 70 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
95.2381% passed

The remote failure is a `504 Gateway Timeout` error. This doesn't seem
like an issue, although it is consistently happening for the same remote
test: `test_successful_purchase_with_amex`.

All unit tests:
4385 tests, 71204 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed

695 files inspected, no offenses detected