### PR TITLE
Adyen: Add delivery address

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -282,6 +282,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
+        if address = options[:shipping_address]
+          post[:deliveryAddress] = {}
+          post[:deliveryAddress][:street] = address[:address1] || 'NA'
+          post[:deliveryAddress][:houseNumberOrName] = address[:address2] || 'NA'
+          post[:deliveryAddress][:postalCode] = address[:zip] if address[:zip]
+          post[:deliveryAddress][:city] = address[:city] || 'NA'
+          post[:deliveryAddress][:stateOrProvince] = get_state(address)
+          post[:deliveryAddress][:country] = address[:country] if address[:country]
+        end
         return unless post[:card]&.kind_of?(Hash)
         if (address = options[:billing_address] || options[:address]) && address[:country]
           post[:billingAddress] = {}

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -60,6 +60,7 @@ class AdyenTest < Test::Unit::TestCase
 
     @options = {
       billing_address: address(),
+      shipping_address: address(),
       shopper_reference: 'John Smith',
       order_id: '345123',
       installments: 2,
@@ -662,13 +663,22 @@ class AdyenTest < Test::Unit::TestCase
     @options[:billing_address].delete(:address1)
     @options[:billing_address].delete(:address2)
     @options[:billing_address].delete(:state)
+    @options[:shipping_address].delete(:state)
     @gateway.send(:add_address, post, @options)
+    # Billing Address
     assert_equal 'NA', post[:billingAddress][:street]
     assert_equal 'NA', post[:billingAddress][:houseNumberOrName]
     assert_equal 'NA', post[:billingAddress][:stateOrProvince]
     assert_equal @options[:billing_address][:zip], post[:billingAddress][:postalCode]
     assert_equal @options[:billing_address][:city], post[:billingAddress][:city]
     assert_equal @options[:billing_address][:country], post[:billingAddress][:country]
+    # Shipping Address
+    assert_equal 'NA', post[:deliveryAddress][:stateOrProvince]
+    assert_equal @options[:shipping_address][:address1], post[:deliveryAddress][:street]
+    assert_equal @options[:shipping_address][:address2], post[:deliveryAddress][:houseNumberOrName]
+    assert_equal @options[:shipping_address][:zip], post[:deliveryAddress][:postalCode]
+    assert_equal @options[:shipping_address][:city], post[:deliveryAddress][:city]
+    assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
   end
 
   def test_authorize_with_network_tokenization_credit_card_no_name


### PR DESCRIPTION
Added the `deliveryAddress` hash to the Adyen gateway using the existing
Active Merchant standard `shipping_address` hash.

Expanded an exising unit test to include tests for `deliveryAddress` in
a request; no additional remote tests were added since the delivery
address is not a required field and is not included in responses.

CE-295

Unit:
56 tests, 270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
81 tests, 271 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
97.5309% passed

All unit tests:
4391 tests, 71246 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed

RuboCop:
695 files inspected, no offenses detected