### PR TITLE
Auth.net: Ensure proper parsing when quotes in direct_response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Merchant Warrior: Add void operation [leila-alderman] #3474
 * Decidir: Update payment method IDs [leila-alderman] #3476
 * Adyen: Add delivery address [leila-alderman] #3477
+* Authorize.net: Correctly parse direct_response field with quotation marks [britth] #3479
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -1007,7 +1007,7 @@ module ActiveMerchant
       end
 
       def parse_direct_response_elements(response, options)
-        params = response[:direct_response]
+        params = response[:direct_response]&.tr('"', '')
         return {} unless params
 
         parts = params.split(options[:delimiter] || ',')


### PR DESCRIPTION
Some transactions are getting marked as failures due to improper
parsing when there are quotes in direct_response field. PR removes
extra quotes from `direct_response` field so that separate delimited
fields can be correctly parsed.

Unit:
97 tests, 575 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
69 tests, 238 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed