### PR TITLE
Decidir: Add debit card payment method IDs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Decidir: Update payment method IDs [leila-alderman] #3476
 * Adyen: Add delivery address [leila-alderman] #3477
 * Authorize.net: Correctly parse direct_response field with quotation marks [britth] #3479
+* Decidir: Add debit card payment method IDs [leila-alderman] #3480
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -106,7 +106,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_auth_purchase_params(post, money, credit_card, options)
-        post[:payment_method_id] = add_payment_method_id(credit_card)
+        post[:payment_method_id] = add_payment_method_id(credit_card, options)
         post[:site_transaction_id] = options[:order_id]
         post[:bin] = credit_card.number[0..5]
         post[:payment_type] = options[:payment_type] || 'single'
@@ -119,9 +119,19 @@ module ActiveMerchant #:nodoc:
         add_payment(post, credit_card, options)
       end
 
-      def add_payment_method_id(credit_card)
+      def add_payment_method_id(credit_card, options)
         if options[:payment_method_id]
           options[:payment_method_id].to_i
+        elsif options[:debit]
+          if CreditCard.brand?(credit_card.number) == 'visa'
+            31
+          elsif CreditCard.brand?(credit_card.number) == 'master'
+            105
+          elsif CreditCard.brand?(credit_card.number) == 'maestro'
+            106
+          elsif CreditCard.brand?(credit_card.number) == 'cabal'
+            108
+          end
         elsif CreditCard.brand?(credit_card.number) == 'master'
           104
         elsif CreditCard.brand?(credit_card.number) == 'american_express'

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1174,7 +1174,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
         :number => '41111111111111111111',
         :cvv => '123',
         :expiration_month => '09',
-        :expiration_year => '2020',
+        :expiration_year => (Time.now.year + 1).to_s,
         :cardholder_name => 'Longbob Longsen',
       }
     }

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -278,6 +278,53 @@ class DecidirTest < Test::Unit::TestCase
     assert_equal 24, post[:payment_method_id]
   end
 
+  def test_payment_method_id_with_visa_debit
+    visa_debit_card = credit_card('4517721004856075')
+    debit_options = @options.merge(debit: true)
+
+    stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, visa_debit_card, debit_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"payment_method_id":31/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_payment_method_id_with_mastercard_debit
+    # currently lacking a valid MasterCard debit card number, so using the MasterCard credit card number
+    mastercard = credit_card('5299910010000015')
+    debit_options = @options.merge(debit: true)
+
+    stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, mastercard, debit_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"payment_method_id":105/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_payment_method_id_with_maestro_debit
+    # currently lacking a valid Maestro debit card number, so using a generated test card number
+    maestro_card = credit_card('6759649826438453')
+    debit_options = @options.merge(debit: true)
+
+    stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, maestro_card, debit_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"payment_method_id":106/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_payment_method_id_with_cabal_debit
+    # currently lacking a valid Cabal debit card number, so using the Cabal credit card number
+    cabal_card = credit_card('5896570000000008')
+    debit_options = @options.merge(debit: true)
+
+    stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, cabal_card, debit_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"payment_method_id":108/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Adds the correct `payment_method_id` value for the four debit cards that
Decidir supports. These are selected by passing the new `debit` GSF.

CE-308

Unit:
32 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
21 tests, 70 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
95.2381% passed

The `test_successful_purchase_with_amex` remote test is failing with a
gateway timeout error.