### PR TITLE
CyberSource: Add issuer data+MDD to credit & void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Adyen: Add delivery address [leila-alderman] #3477
 * Authorize.net: Correctly parse direct_response field with quotation marks [britth] #3479
 * Decidir: Add debit card payment method IDs [leila-alderman] #3480
+* CyberSource: Add issuer data+MDD to credit & void [leila-alderman] #3481
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -321,11 +321,14 @@ module ActiveMerchant #:nodoc:
 
         xml = Builder::XmlMarkup.new :indent => 2
         if action == 'capture'
+          add_mdd_fields(xml, options)
           add_void_service(xml, request_id, request_token)
         else
           add_purchase_data(xml, money, true, options.merge(:currency => currency || default_currency))
+          add_mdd_fields(xml, options)
           add_auth_reversal_service(xml, request_id, request_token)
         end
+        add_issuer_additional_data(xml, options)
         xml.target!
       end
 
@@ -344,7 +347,9 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
 
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
+        add_mdd_fields(xml, options)
         add_credit_service(xml)
+        add_issuer_additional_data(xml, options)
 
         xml.target!
       end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -168,6 +168,24 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(void)
   end
 
+  def test_void_with_issuer_additional_data
+    @options[:issuer_additional_data] = @issuer_additional_data
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_successful_response(void)
+  end
+
+  def test_void_with_mdd_fields
+    (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_successful_response(void)
+  end
+
   def test_successful_tax_calculation
     assert response = @gateway.calculate_tax(@credit_card, @options)
     assert response.params['totalTaxAmount']
@@ -392,6 +410,18 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_standalone_credit_to_card_with_merchant_descriptor
     @options[:merchant_descriptor] = 'Spreedly'
+    assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_standalone_credit_to_card_with_issuer_additional_data
+    @options[:issuer_additional_data] = @issuer_additional_data
+    assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_standalone_credit_to_card_with_mdd_fields
+    (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
     assert response = @gateway.credit(@amount, @credit_card, @options)
     assert_successful_response(response)
   end


### PR DESCRIPTION
Added the existing `issuer_additional_data` and `merchantDefinedData`
gateway specific fields in the CyberSource gateway to `credit` and
`void` transactions.

CE-293

Unit:
74 tests, 340 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
74 tests, 377 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
93.2432% passed

Unrelated and existing failing remote tests:
 - `test_successful_3ds_validate_authorize_request`
 - `test_successful_3ds_validate_purchase_request`
 - `test_successful_pinless_debit_card_puchase`
 - `test_successful_validate_pinless_debit_card`
 - `test_successful_tax_calculation`