### PR TITLE
TransFirst TrExp: Remove hyphens from zip

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * CardStream: use localized_amount to correctly support zero-decimal currencies [britth] #3473
 * EBANX: Add additional data in post [Ruanito] #3482
 * Credorax: Omit phone when nil [leila-alderman] #3490
+* TransFirst TrExp: Remove hyphens from zip [leila-alderman] #3483
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -548,7 +548,7 @@ module ActiveMerchant #:nodoc:
             doc['v1'].addrLn2 billing_address[:address2] unless billing_address[:address2].blank?
             doc['v1'].city billing_address[:city] if billing_address[:city]
             doc['v1'].state billing_address[:state] if billing_address[:state]
-            doc['v1'].zipCode billing_address[:zip] if billing_address[:zip]
+            doc['v1'].zipCode billing_address[:zip].delete('-') if billing_address[:zip]
             doc['v1'].ctry 'US'
           end
 
@@ -563,7 +563,7 @@ module ActiveMerchant #:nodoc:
               doc['v1'].addrLn2 shipping_address[:address2] unless shipping_address[:address2].blank?
               doc['v1'].city shipping_address[:city] if shipping_address[:city]
               doc['v1'].state shipping_address[:state] if shipping_address[:state]
-              doc['v1'].zipCode shipping_address[:zip] if shipping_address[:zip]
+              doc['v1'].zipCode shipping_address[:zip].delete('-') if shipping_address[:zip]
               doc['v1'].phone shipping_address[:phone].gsub(/\D/, '') if shipping_address[:phone]
               doc['v1'].email shipping_address[:email] if shipping_address[:email]
             end

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -26,6 +26,25 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_strip_hyphens_from_zip
+    options = {
+      :billing_address => {
+        :name => 'John & Mary Smith',
+        :address1 => '1 Main St.',
+        :city => 'Burlington',
+        :state => 'MA',
+        :zip => '01803-3747',
+        :country => 'US'
+      }
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/018033747/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@declined_amount, @credit_card)


### PR DESCRIPTION
The TransFirst Transaction Express gateway cannot handle hyphens
included in the zip code. This change strips any hyphens from the zip
code before sending it to the gateway.

[CE-328](https://spreedly.atlassian.net/browse/CE-328)

Unit:
22 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
33 tests, 107 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
96.9697% passed

Seemingly unrelated failing test: `test_successful_verify`

All unit tests:
4409 tests, 71312 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed