### PR TITLE
Rubocop: Layout/SpaceInsideArrayPercentLiteral fix

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,12 +97,6 @@ Layout/SpaceAroundOperators:
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 
-# Offense count: 12
-# Cop supports --auto-correct.
-Layout/SpaceInsideArrayPercentLiteral:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/migs/migs_codes.rb'
-
 # Offense count: 1186
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * EBANX: Add additional data in post [Ruanito] #3482
 * Credorax: Omit phone when nil [leila-alderman] #3490
 * TransFirst TrExp: Remove hyphens from zip [leila-alderman] #3483
+* RuboCop: Layout/SpaceInsideArrayPercentLiteral fix [leila-alderman] #3484
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/migs/migs_codes.rb
+++ b/lib/active_merchant/billing/gateways/migs/migs_codes.rb
@@ -85,13 +85,13 @@ module ActiveMerchant
         # migs_code: Used in response for purchase/authorize/status
         # migs_long_code: Used to pre-select card for server_purchase_url
         # name: The nice display name
-        %w(american_express AE Amex             American\ Express),
-        %w(diners_club      DC Dinersclub       Diners\ Club),
-        %w(jcb              JC JCB              JCB\ Card),
-        %w(maestro          MS Maestro          Maestro\ Card),
-        %w(master           MC Mastercard       MasterCard),
-        %w(na               PL PrivateLabelCard Private\ Label\ Card),
-        %w(visa             VC Visa             Visa\ Card')
+        %w(american_express AE Amex American\ Express),
+        %w(diners_club DC Dinersclub Diners\ Club),
+        %w(jcb JC JCB JCB\ Card),
+        %w(maestro MS Maestro Maestro\ Card),
+        %w(master MC Mastercard MasterCard),
+        %w(na PL PrivateLabelCard Private\ Label\ Card),
+        %w(visa VC Visa Visa\ Card)
       ].map do |am_code, migs_code, migs_long_code, name|
         CreditCardType.new(am_code, migs_code, migs_long_code, name)
       end


### PR DESCRIPTION
Fixes the Rubocop todo item that enforces spacing within arrays created
using percent literals.

All unit tests:
4408 tests, 71309 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed