### PR TITLE
RuboCop: Layout/SpaceInsidePercentLiteralDelimiter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,11 +105,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
-# Offense count: 115
-# Cop supports --auto-correct.
-Layout/SpaceInsidePercentLiteralDelimiters:
-  Enabled: false
-
 # Offense count: 150
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * Credorax: Omit phone when nil [leila-alderman] #3490
 * TransFirst TrExp: Remove hyphens from zip [leila-alderman] #3483
 * RuboCop: Layout/SpaceInsideArrayPercentLiteral fix [leila-alderman] #3484
+* RuboCop: Layout/SpaceInsidePercentLiteralDelimiter [leila-alderman] #3485
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -39,10 +39,10 @@ module ActiveMerchant
 
       # Map vendor's AVS result code to a postal match code
       POSTAL_MATCH_CODE = {
-        'Y' => %w( D H F H J L M P Q V W X Y Z ),
-        'N' => %w( A C K N O ),
-        'X' => %w( G S ),
-        nil => %w( B E I R T U )
+        'Y' => %w(D H F H J L M P Q V W X Y Z),
+        'N' => %w(A C K N O),
+        'X' => %w(G S),
+        nil => %w(B E I R T U)
       }.inject({}) do |map, (type, codes)|
         codes.each { |code| map[code] = type }
         map
@@ -50,10 +50,10 @@ module ActiveMerchant
 
       # Map vendor's AVS result code to a street match code
       STREET_MATCH_CODE = {
-        'Y' => %w( A B D H J M O Q T V X Y ),
-        'N' => %w( C K L N W Z ),
-        'X' => %w( G S ),
-        nil => %w( E F I P R U )
+        'Y' => %w(A B D H J M O Q T V X Y),
+        'N' => %w(C K L N W Z),
+        'X' => %w(G S),
+        nil => %w(E F I P R U)
       }.inject({}) do |map, (type, codes)|
         codes.each { |code| map[code] = type }
         map

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -10,8 +10,8 @@ module ActiveMerchant #:nodoc:
 
       self.ignore_http_status = true
 
-      CARD_CODE_ERRORS = %w( N S )
-      AVS_ERRORS = %w( A E N R W Z )
+      CARD_CODE_ERRORS = %w(N S)
+      AVS_ERRORS = %w(A E N R W Z)
       AVS_REASON_CODES = %w(27 45)
 
       FIELD_MAP = {

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
         ACTIONS
       end
 
-      CREDIT_CARD_FIELDS = %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber )
+      CREDIT_CARD_FIELDS = %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber)
 
       ACTIONS = {
            :credit_card_authorize       => CREDIT_CARD_FIELDS,

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -265,7 +265,7 @@ module ActiveMerchant #:nodoc:
 
       def default_customer_fields
         hash={}
-        %w( CustomerRef Title FirstName LastName Company JobDesc Email Address Suburb State PostCode Country Phone Mobile Fax URL Comments CCNumber CCNameOnCard CCExpiryMonth CCExpiryYear ).each do |field|
+        %w(CustomerRef Title FirstName LastName Company JobDesc Email Address Suburb State PostCode Country Phone Mobile Fax URL Comments CCNumber CCNameOnCard CCExpiryMonth CCExpiryYear).each do |field|
           hash[field.to_sym]=''
         end
         return hash
@@ -273,7 +273,7 @@ module ActiveMerchant #:nodoc:
 
       def default_payment_fields
         hash={}
-        %w( managedCustomerID amount invoiceReference invoiceDescription ).each do |field|
+        %w(managedCustomerID amount invoiceReference invoiceDescription).each do |field|
           hash[field.to_sym]=''
         end
         return hash

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -35,8 +35,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.metricsglobal.com'
       self.display_name = 'Metrics Global'
 
-      CARD_CODE_ERRORS = %w( N S )
-      AVS_ERRORS = %w( A E N R W Z )
+      CARD_CODE_ERRORS = %w(N S)
+      AVS_ERRORS = %w(A E N R W Z)
       AVS_REASON_CODES = %w(27 45)
 
       # Creates a new MetricsGlobalGateway

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
 
       # Country supported by Omise
       # * Thailand
-      self.supported_countries = %w( TH JP )
+      self.supported_countries = %w(TH JP)
 
       # Credit cards supported by Omise
       # * VISA

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -455,7 +455,7 @@ module ActiveMerchant #:nodoc:
         # - http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf
         unless creditcard.nil?
           if creditcard.verification_value?
-            xml.tag! :CardSecValInd, '1' if %w( visa discover ).include?(creditcard.brand)
+            xml.tag! :CardSecValInd, '1' if %w(visa discover).include?(creditcard.brand)
             xml.tag! :CardSecVal, creditcard.verification_value
           end
         end
@@ -938,10 +938,10 @@ module ActiveMerchant #:nodoc:
 
         # Map vendor's AVS result code to a postal match code
         ORBITAL_POSTAL_MATCH_CODE = {
-            'Y' => %w( 9 A B C H JA JD M2 M3 M5 N5 N8 N9 X Z ),
-            'N' => %w( D E F G M8 ),
-            'X' => %w( 4 J R ),
-            nil => %w( 1 2 3 5 6 7 8 JB JC M1 M4 M6 M7 N3 N4 N6 N7 UK )
+            'Y' => %w(9 A B C H JA JD M2 M3 M5 N5 N8 N9 X Z),
+            'N' => %w(D E F G M8),
+            'X' => %w(4 J R),
+            nil => %w(1 2 3 5 6 7 8 JB JC M1 M4 M6 M7 N3 N4 N6 N7 UK)
         }.inject({}) do |map, (type, codes)|
           codes.each { |code| map[code] = type }
           map
@@ -949,10 +949,10 @@ module ActiveMerchant #:nodoc:
 
         # Map vendor's AVS result code to a street match code
         ORBITAL_STREET_MATCH_CODE = {
-            'Y' => %w( 9 B D F H JA JB M2 M4 M5 M6 M7 N3 N5 N7 N8 N9 X ),
-            'N' => %w( A C E G M8 Z ),
-            'X' => %w( 4 J R ),
-            nil => %w( 1 2 3 5 6 7 8 JC JD M1 M3 N4 N6 UK )
+            'Y' => %w(9 B D F H JA JB M2 M4 M5 M6 M7 N3 N5 N7 N8 N9 X),
+            'N' => %w(A C E G M8 Z),
+            'X' => %w(4 J R),
+            nil => %w(1 2 3 5 6 7 8 JC JD M1 M3 N4 N6 UK)
         }.inject({}) do |map, (type, codes)|
           codes.each { |code| map[code] = type }
           map

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -143,7 +143,7 @@ module ActiveMerchant #:nodoc:
         990028  => 'Transaction cancelled' # Customer clicks the 'Cancel' button on the payment page
       }
 
-      SUCCESS_CODES = %w( 990004 990005 990017 990012 990018 990031 )
+      SUCCESS_CODES = %w(990004 990005 990017 990012 990018 990031)
 
       TRANSACTION_CODES = {
         0 => 'Not Done',

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
       # However, regular accounts with DPS only support VISA and Mastercard
       self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb ]
 
-      self.supported_countries = %w[ AU FJ GB HK IE MY NZ PG SG US ]
+      self.supported_countries = %w[AU FJ GB HK IE MY NZ PG SG US]
 
       self.homepage_url = 'http://www.paymentexpress.com/'
       self.display_name = 'PaymentExpress'

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -16,7 +16,7 @@ module ActiveMerchant
         'U' => 'Issuer was not certified for card verification'
       }
 
-      CARD_CODE_ERRORS = %w( N S )
+      CARD_CODE_ERRORS = %w(N S)
 
       AVS_MESSAGES = {
         'A' => 'Street address matches billing information, zip/postal code does not',
@@ -34,7 +34,7 @@ module ActiveMerchant
         'Z' => '5-digit zip/postal code matches billing information, street address does not',
       }
 
-      AVS_ERRORS = %w( A E N R W Z )
+      AVS_ERRORS = %w(A E N R W Z)
 
       PAYMENT_GATEWAY_RESPONSES = {
         'P01' => 'AVS Mismatch Failure',

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
@@ -140,11 +140,11 @@ module QuickpayCommon
     10 => {
       :authorize => %w(mobile_number acquirer autofee customer_id extras
                        zero_auth customer_ip),
-      :capture   => %w( extras ),
-      :cancel    => %w( extras ),
-      :refund    => %w( extras ),
-      :subscribe => %w( variables branding_id),
-      :authorize_subscription => %w( mobile_number acquirer customer_ip),
+      :capture   => %w(extras),
+      :cancel    => %w(extras),
+      :refund    => %w(extras),
+      :subscribe => %w(variables branding_id),
+      :authorize_subscription => %w(mobile_number acquirer customer_ip),
       :recurring => %w(auto_capture autofee zero_auth)
     }
   }

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -28,8 +28,8 @@ module ActiveMerchant #:nodoc:
 
       APPROVED, DECLINED = 1, 2
 
-      CARD_CODE_ERRORS = %w( N S )
-      AVS_ERRORS = %w( A E N R W Z )
+      CARD_CODE_ERRORS = %w(N S)
+      AVS_ERRORS = %w(A E N R W Z)
 
       def initialize(options = {})
         requires!(options, :login, :password)

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -21,8 +21,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.securepay.com/'
       self.display_name = 'SecurePay'
 
-      CARD_CODE_ERRORS = %w( N S )
-      AVS_ERRORS = %w( A E N R W Z )
+      CARD_CODE_ERRORS = %w(N S)
+      AVS_ERRORS = %w(A E N R W Z)
       AVS_REASON_CODES = %w(27 45)
       TRANSACTION_ALREADY_ACTIONED = %w(310 311)
 

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
 
       MONETARY_CHANGE_STATUSES = ['SETTLE', 'AUTHORIZE', 'AUTHORIZE ADDITIONAL', 'CREDIT', 'SPLITSETTLE']
 
-      CARD_CODE_ERRORS = %w( N S "" )
+      CARD_CODE_ERRORS = %w(N S "")
 
       CARD_CODE_MESSAGES = {
         'M' => 'Card verification number matched',
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         '' => 'Transaction failed because incorrect card verification number was entered or no number was entered'
       }
 
-      AVS_ERRORS = %w( A B C E I N O P R W Z )
+      AVS_ERRORS = %w(A B C E I N O P R W Z)
 
       AVS_MESSAGES = {
         'A' => 'Street address matches billing information, zip/postal code does not',

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -218,7 +218,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def setup_future_usage(post, options = {})
-        post[:setup_future_usage] = options[:setup_future_usage] if %w( on_session off_session ).include?(options[:setup_future_usage])
+        post[:setup_future_usage] = options[:setup_future_usage] if %w(on_session off_session).include?(options[:setup_future_usage])
         post[:off_session] = options[:off_session] if options[:off_session] && options[:confirm] == true
         post
       end

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
 
       TRANSACTION_API = '/createShopifyTransaction.php'
 
-      self.supported_countries = %w[ NZ CA ]
+      self.supported_countries = %w[NZ CA]
       self.default_currency = 'NZD'
       self.supported_cardtypes = [:visa, :master]
       self.homepage_url = 'https://www.swipehq.com/checkout'

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -230,21 +230,21 @@ module ActiveMerchant #:nodoc:
       } #:nodoc:
 
       AVS_RESULTS = {
-        'Y' => %w( YYY Y YYA YYD ),
-        'Z' => %w( NYZ Z ),
-        'A' => %w( YNA A YNY ),
-        'N' => %w( NNN N NN ),
-        'X' => %w( YYX X ),
-        'W' => %w( NYW W ),
-        'XXW' => %w( XXW ),
-        'XXU' => %w( XXU ),
-        'R' => %w( XXR R U E ),
-        'S' => %w( XXS S ),
-        'XXE' => %w( XXE ),
-        'G' => %w( XXG G C I ),
-        'B' => %w( YYG B M ),
-        'D' => %w( GGG D ),
-        'P' => %w( YGG P )
+        'Y' => %w(YYY Y YYA YYD),
+        'Z' => %w(NYZ Z),
+        'A' => %w(YNA A YNY),
+        'N' => %w(NNN N NN),
+        'X' => %w(YYX X),
+        'W' => %w(NYW W),
+        'XXW' => %w(XXW),
+        'XXU' => %w(XXU),
+        'R' => %w(XXR R U E),
+        'S' => %w(XXS S),
+        'XXE' => %w(XXE),
+        'G' => %w(XXG G C I),
+        'B' => %w(YYG B M),
+        'D' => %w(GGG D),
+        'P' => %w(YGG P)
       }.inject({}) do |map, (type, codes)|
         codes.each { |code| map[code] = type }
         map

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -13,9 +13,9 @@ module ActiveMerchant #:nodoc:
         'xsi:noNamespaceSchemaLocation' => 'wirecard.xsd'
       }
 
-      PERMITTED_TRANSACTIONS = %w[ PREAUTHORIZATION CAPTURE PURCHASE ]
+      PERMITTED_TRANSACTIONS = %w[PREAUTHORIZATION CAPTURE PURCHASE]
 
-      RETURN_CODES = %w[ ACK NOK ]
+      RETURN_CODES = %w[ACK NOK]
 
       # Wirecard only allows phone numbers with a format like this: +xxx(yyy)zzz-zzzz-ppp, where:
       #   xxx = Country code

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -23,7 +23,7 @@ class OmiseTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal @gateway.supported_countries, %w( TH JP )
+    assert_equal @gateway.supported_countries, %w(TH JP)
   end
 
   def test_supported_cardtypes


### PR DESCRIPTION
Fixes the RuboCop todo item that enforces no extra spaces inside the
delimeters of `%i`, `%w`, and `%x` literals.

All unit tests:
4408 tests, 71309 assertions, 0 failures, 0 errors, 0 pendings,
2 omissions, 0 notifications
100% passed