### PR TITLE
RuboCop: Layout/SpaceInsideArrayLiteralBrackets

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,14 +89,6 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundOperators:
   Enabled: false
 
-# Offense count: 118
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBrackets: space, no_space
-Layout/SpaceInsideArrayLiteralBrackets:
-  Enabled: false
-
 # Offense count: 1186
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
 * TransFirst TrExp: Remove hyphens from zip [leila-alderman] #3483
 * RuboCop: Layout/SpaceInsideArrayPercentLiteral fix [leila-alderman] #3484
 * RuboCop: Layout/SpaceInsidePercentLiteralDelimiter [leila-alderman] #3485
+* RuboCop: Layout/SpaceInsideArrayLiteralBrackets [leila-alderman] #3486
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -256,7 +256,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def prepare_address_for_non_american_countries(options)
-        [ options[:billing_address], options[:shipping_address] ].compact.each do |address|
+        [options[:billing_address], options[:shipping_address]].compact.each do |address|
           next if empty?(address[:country])
           unless ['US', 'CA'].include?(address[:country])
             address[:state] = '--'

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://gatewaytest.borgun.is/ws/Heimir.pub.ws:Authorization'
       self.live_url = 'https://gateway01.borgun.is/ws/Heimir.pub.ws:Authorization'
 
-      self.supported_countries = ['IS', 'GB', 'HU', 'CZ', 'DE', 'DK', 'SE' ]
+      self.supported_countries = ['IS', 'GB', 'HU', 'CZ', 'DE', 'DK', 'SE']
       self.default_currency = 'ISK'
       self.money_format = :cents
       self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :discover, :jcb]

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -6,8 +6,8 @@ module ActiveMerchant #:nodoc:
 
       self.money_format = :cents
       self.default_currency = 'GBP'
-      self.supported_cardtypes = [ :visa, :maestro, :master, :american_express, :jcb ]
-      self.supported_countries = [ 'GB' ]
+      self.supported_cardtypes = [:visa, :maestro, :master, :american_express, :jcb]
+      self.supported_countries = ['GB']
       self.homepage_url = 'http://www.cardsave.net/'
       self.display_name = 'CardSave'
 

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def authorization_from(request, response)
-        [ response[:reference_number], request[:CardLastFourDigits], request[:Amount] ].join('|')
+        [response[:reference_number], request[:CardLastFourDigits], request[:Amount]].join('|')
       end
 
       def split_authorization(authorization)

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -6,7 +6,7 @@ module ActiveMerchant
       self.default_currency = 'GBP'
       self.supported_countries = ['GB']
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
 
       self.homepage_url = 'http://www.datacash.com/'
       self.display_name = 'DataCash'

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response, params)
-        [ response[:transaction_id], params[:transaction_amount] ].compact.join(';')
+        [response[:transaction_id], params[:transaction_amount]].compact.join(';')
       end
 
       def parse(xml)

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         if address = options[:billing_address] || options[:address]
-          post[:CustomerAddress]    = [ address[:address1], address[:address2], address[:city], address[:state], address[:country] ].compact.join(', ')
+          post[:CustomerAddress]    = [address[:address1], address[:address2], address[:city], address[:state], address[:country]].compact.join(', ')
           post[:CustomerPostcode]   = address[:zip]
         end
       end

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -5,8 +5,8 @@ module ActiveMerchant #:nodoc:
 
       API_VERSION = '8.5'
 
-      TEST_LOGINS = [ {:login => 'A00049-01', :password => 'test1'},
-                      {:login => 'A00427-01', :password => 'testus'} ]
+      TEST_LOGINS = [{:login => 'A00049-01', :password => 'test1'},
+                     {:login => 'A00427-01', :password => 'testus'}]
 
       TRANSACTIONS = { :sale          => '00',
                        :authorization => '01',
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
 
       SUCCESS = 'true'
 
-      SENSITIVE_FIELDS = [ :verification_str2, :expiry_date, :card_number ]
+      SENSITIVE_FIELDS = [:verification_str2, :expiry_date, :card_number]
 
       self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :discover]
       self.supported_countries = ['CA', 'US']

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -380,7 +380,7 @@ module ActiveMerchant #:nodoc:
 
         success = response[:transaction_result][:status_code] == '0'
         message = response[:transaction_result][:message]
-        authorization = success ? [ options[:order_id], response[:transaction_output_data][:cross_reference], response[:transaction_output_data][:auth_code] ].compact.join(';') : nil
+        authorization = success ? [options[:order_id], response[:transaction_output_data][:cross_reference], response[:transaction_output_data][:auth_code]].compact.join(';') : nil
 
         Response.new(success, message, response,
           :test => test?,

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -333,7 +333,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response, money, previous_token)
         original_amount = amount(money) if money
-        [ response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(';')
+        [response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(';')
       end
 
       def add_credit_card(xml, credit_card)

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -344,7 +344,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response, money, previous_token)
         original_amount = amount(money) if money
-        [ response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(';')
+        [response[:transaction_id], response[:approval], original_amount, (response[:token] || previous_token)].join(';')
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -308,7 +308,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
-        [ response['ReferenceID'], response['OrderNumber'] ].join(';') if response[:success]
+        [response['ReferenceID'], response['OrderNumber']].join(';') if response[:success]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -294,7 +294,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      SUCCESS_CODES = [ 'Approved', 'Success' ]
+      SUCCESS_CODES = ['Approved', 'Success']
 
       def commit(action, request)
         response = parse(action, ssl_post(endpoint_url, build_soap_request(request), build_header))

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
         :trigger   => 8
       }
 
-      SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
+      SUCCESS_CODES = ['00', '08', '11', '16', '77']
 
       def initialize(options = {})
         requires!(options, :login, :password)

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -24,7 +24,7 @@ module ActiveMerchant
     class NetRegistryGateway < Gateway
       self.live_url = self.test_url = 'https://paygate.ssllock.net/external2.pl'
 
-      FILTERED_PARAMS = [ 'card_no', 'card_expiry', 'receipt_array' ]
+      FILTERED_PARAMS = ['card_no', 'card_expiry', 'receipt_array']
 
       self.supported_countries = ['AU']
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         :quasi         => 'Q'
       }
 
-      SUCCESS_CODES = [ '1', 'T' ]
+      SUCCESS_CODES = ['1', 'T']
       SUCCESS_MESSAGE = 'The transaction was approved'
       FAILURE_MESSAGE = 'The transaction failed'
       TEST_LOGIN = '104901072025'

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -284,7 +284,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response, payment_type, action)
         authorization = (action == 'add_customer' ? response[:customer_vault_id] : response[:transactionid])
-        [ authorization, payment_type ].join('#')
+        [authorization, payment_type].join('#')
       end
 
       def split_authorization(authorization)

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
-        [ response[:authnum], response[:transid] ].compact.join(';')
+        [response[:authnum], response[:transid]].compact.join(';')
       end
 
       def test_response?(response)

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
       # VISA, Mastercard, Diners Club and Farmers cards are supported
       #
       # However, regular accounts with DPS only support VISA and Mastercard
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
 
       self.supported_countries = %w[AU FJ GB HK IE MY NZ PG SG US]
 

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -14,7 +14,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['NZ']
 
       # TODO: check this with paystation (amex and diners need to be enabled)
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
 
       self.homepage_url        = 'http://paystation.co.nz'
       self.display_name        = 'Paystation'

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -3,8 +3,8 @@ module ActiveMerchant
     class PaywayGateway < Gateway
       self.live_url = self.test_url = 'https://ccapi.client.qvalent.com/payway/ccapi'
 
-      self.supported_countries = [ 'AU' ]
-      self.supported_cardtypes = [ :visa, :master, :diners_club, :american_express, :bankcard ]
+      self.supported_countries = ['AU']
+      self.supported_cardtypes = [:visa, :master, :diners_club, :american_express, :bankcard]
       self.display_name        = 'Pay Way'
       self.homepage_url        = 'http://www.payway.com.au'
       self.default_currency    = 'AUD'

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -88,8 +88,8 @@ module ActiveMerchant
         :credit => 'newreturn'
       }
 
-      SUCCESS_CODES = [ 'pending', 'success' ]
-      FAILURE_CODES = [ 'badcard', 'fraud' ]
+      SUCCESS_CODES = ['pending', 'success']
+      FAILURE_CODES = ['badcard', 'fraud']
 
       self.default_currency = 'USD'
       self.supported_countries = ['US']

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -21,7 +21,7 @@ module ActiveMerchant
       # American Express, Diners Club, JCB, International Maestro,
       # Style, Clydesdale Financial Services, Other
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb, :maestro ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :maestro]
       self.homepage_url = 'http://www.paymentsolutionsltd.com/'
       self.display_name = 'PSL Payment Solutions'
 

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -11,8 +11,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://payments.intuit.com/'
       self.display_name = 'QuickBooks Merchant Services'
       self.default_currency = 'USD'
-      self.supported_cardtypes = [ :visa, :master, :discover, :american_express, :diners_club, :jcb ]
-      self.supported_countries = [ 'US' ]
+      self.supported_cardtypes = [:visa, :master, :discover, :american_express, :diners_club, :jcb]
+      self.supported_countries = ['US']
 
       TYPES = {
         :authorize => 'CustomerCreditCardAuth',

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -31,7 +31,7 @@ module ActiveMerchant
 
       self.money_format = :cents
       self.default_currency = 'EUR'
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
       self.supported_countries = %w(IE GB FR BE NL LU IT US CA ES)
       self.homepage_url = 'http://www.realexpayments.com/'
       self.display_name = 'Realex'

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -361,11 +361,11 @@ module ActiveMerchant #:nodoc:
         when :store
           response['Token']
         else
-          [ params[:VendorTxCode],
-            response['VPSTxId'] || params[:VPSTxId],
-            response['TxAuthNo'],
-            response['SecurityKey'] || params[:SecurityKey],
-            action ].join(';')
+          [params[:VendorTxCode],
+           response['VPSTxId'] || params[:VPSTxId],
+           response['TxAuthNo'],
+           response['SecurityKey'] || params[:SecurityKey],
+           action].join(';')
         end
       end
 
@@ -389,7 +389,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_simulator_url(action)
-        endpoint = [ :purchase, :authorization ].include?(action) ? 'VSPDirectGateway.asp' : "VSPServerGateway.asp?Service=Vendor#{TRANSACTIONS[action].capitalize}Tx"
+        endpoint = [:purchase, :authorization].include?(action) ? 'VSPDirectGateway.asp' : "VSPServerGateway.asp?Service=Vendor#{TRANSACTIONS[action].capitalize}Tx"
         "#{self.simulator_url}/#{endpoint}"
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
         :trigger          => nil
       }
 
-      SUCCESS_CODES = [ '00', '08', '11', '16', '77' ]
+      SUCCESS_CODES = ['00', '08', '11', '16', '77']
 
       def initialize(options = {})
         requires!(options, :login, :password)

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -2,7 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class SecurePayTechGateway < Gateway
       class SecurePayTechPostData < PostData
-        self.required_fields = [ :OrderReference, :CardNumber, :CardExpiry, :CardHolderName, :CardType, :MerchantID, :MerchantKey, :Amount, :Currency ]
+        self.required_fields = [:OrderReference, :CardNumber, :CardExpiry, :CardHolderName, :CardType, :MerchantID, :MerchantKey, :Amount, :Currency]
       end
 
       self.live_url = self.test_url = 'https://tx.securepaytech.com/web/HttpPostPurchase'

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -300,9 +300,9 @@ module ActiveMerchant #:nodoc:
         when :authorization
           parse_authorization_response(body)
         when :get_status
-          parse_status_response(body, [ :SerialNumber, :TransactionAmount, :TransactionStatusCode, :TransactionStatusMessage, :OrderNumber, :TransactionDateTime, :TransactionID, :ApprovalCode, :BatchNumber ])
+          parse_status_response(body, [:SerialNumber, :TransactionAmount, :TransactionStatusCode, :TransactionStatusMessage, :OrderNumber, :TransactionDateTime, :TransactionID, :ApprovalCode, :BatchNumber])
         else
-          parse_status_response(body, [ :SerialNumber, :TransactionAmount, :DesiredStatus, :StatusResponse, :StatusResponseMessage, :OrderNumber, :AuditID ])
+          parse_status_response(body, [:SerialNumber, :TransactionAmount, :DesiredStatus, :StatusResponse, :StatusResponseMessage, :OrderNumber, :AuditID])
         end
       end
 
@@ -329,7 +329,7 @@ module ActiveMerchant #:nodoc:
       def parse_status_response(body, response_keys)
         lines = split_lines(body)
 
-        keys = [ :szSerialNumber, :szErrorCode, :szNumberRecords]
+        keys = [:szSerialNumber, :szErrorCode, :szNumberRecords]
         values = split_line(lines[0])[0..2]
 
         result = Hash[*keys.zip(values).flatten]

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
       # number 5551234 within area code 202 (country code 1).
       VALID_PHONE_FORMAT = /\+\d{1,3}(\(?\d{3}\)?)?\d{3}-\d{4}-\d{3}/
 
-      self.supported_cardtypes = [ :visa, :master, :american_express, :diners_club, :jcb ]
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb]
       self.supported_countries = %w(AD CY GI IM MT RO CH AT DK GR IT MC SM TR BE EE HU LV NL SK GB BG FI IS LI NO SI VA FR IL LT PL ES CZ DE IE LU PT SE)
       self.homepage_url = 'http://www.wirecard.com'
       self.display_name = 'Wirecard'

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -40,7 +40,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase
-    [ @visa, @mastercard ].each do |card|
+    [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex Purchase',
@@ -95,7 +95,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_declined
-    [ @visa_declined, @mastercard_declined ].each do |card|
+    [@visa_declined, @mastercard_declined].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex purchase declined'
@@ -153,7 +153,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_referral_b
-    [ @visa_referral_b, @mastercard_referral_b ].each do |card|
+    [@visa_referral_b, @mastercard_referral_b].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex Referral B'
@@ -167,7 +167,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_referral_a
-    [ @visa_referral_a, @mastercard_referral_a ].each do |card|
+    [@visa_referral_a, @mastercard_referral_a].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex Rqeferral A'
@@ -180,7 +180,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_coms_error
-    [ @visa_coms_error, @mastercard_coms_error ].each do |card|
+    [@visa_coms_error, @mastercard_coms_error].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex coms error'
@@ -425,7 +425,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_maps_avs_and_cvv_response_codes
-    [ @visa, @mastercard ].each do |card|
+    [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
         :order_id => generate_unique_id,
         :description => 'Test Realex Purchase',

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -83,7 +83,7 @@ class DataCashTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro ], DataCashGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro], DataCashGateway.supported_cardtypes
   end
 
   def test_purchase_with_missing_order_id_option

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -49,8 +49,8 @@ class ExactTest < Test::Unit::TestCase
   end
 
   def test_expdate
-    assert_equal('%02d%s' % [ @credit_card.month,
-                              @credit_card.year.to_s[-2..-1] ],
+    assert_equal('%02d%s' % [@credit_card.month,
+                             @credit_card.year.to_s[-2..-1]],
       @gateway.send(:expdate, @credit_card))
   end
 

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -372,8 +372,7 @@ Conn close
         :standalone => false,
         :rrn => '000000000002',
       },
-      :errors => [
-      ],
+      :errors => [],
       :test => true
     }.to_json
   end

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -130,7 +130,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :diners_club, :jcb ], PaymentExpressGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :diners_club, :jcb], PaymentExpressGateway.supported_cardtypes
   end
 
   def test_avs_result_not_supported

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -47,7 +47,7 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
         :description       => 'Test Title',
         :return_url        => 'http://return.url',
         :cancel_return_url => 'http://cancel.url',
-        :items             => [ ])
+        :items             => [])
     end
 
     assert_raise ArgumentError do
@@ -56,7 +56,7 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
         :description       => 'Test Title',
         :return_url        => 'http://return.url',
         :cancel_return_url => 'http://cancel.url',
-        :items             => [ Hash.new ])
+        :items             => [Hash.new])
     end
 
     assert_raise ArgumentError do
@@ -65,12 +65,12 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
         :description       => 'Test Title',
         :return_url        => 'http://return.url',
         :cancel_return_url => 'http://cancel.url',
-        :items             => [ { :name => 'Charge',
+        :items             => [{ :name => 'Charge',
                                   :number => '1',
                                   :quantity => '1',
                                   :amount   => 100,
                                   :description => 'Description',
-                                  :category => 'Physical' } ])
+                                  :category => 'Physical' }])
     end
   end
 
@@ -82,12 +82,12 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
       :description       => 'Test Title',
       :return_url        => 'http://return.url',
       :cancel_return_url => 'http://cancel.url',
-      :items             => [ { :name => 'Charge',
+      :items             => [{ :name => 'Charge',
                                 :number => '1',
                                 :quantity => '1',
                                 :amount   => 100,
                                 :description => 'Description',
-                                :category => 'Digital' } ])
+                                :category => 'Digital' }])
   end
 
   private

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -36,7 +36,7 @@ class PslCardTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :diners_club, :jcb, :maestro ], PslCardGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :diners_club, :jcb, :maestro], PslCardGateway.supported_cardtypes
   end
 
   def test_avs_result

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -153,7 +153,7 @@ class QuickpayV10Test < Test::Unit::TestCase
 
   def test_supported_card_types
     klass = @gateway.class
-    assert_equal [:dankort, :forbrugsforeningen, :visa, :master, :american_express, :diners_club, :jcb, :maestro ], klass.supported_cardtypes
+    assert_equal [:dankort, :forbrugsforeningen, :visa, :master, :american_express, :diners_club, :jcb, :maestro], klass.supported_cardtypes
   end
 
   def test_successful_capture

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -129,7 +129,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
   def test_supported_card_types
     klass = @gateway.class
-    assert_equal [ :dankort, :forbrugsforeningen, :visa, :master, :american_express, :diners_club, :jcb, :maestro ], klass.supported_cardtypes
+    assert_equal [:dankort, :forbrugsforeningen, :visa, :master, :american_express, :diners_club, :jcb, :maestro], klass.supported_cardtypes
   end
 
   def test_add_testmode_does_not_add_testmode_if_transaction_id_present

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -141,7 +141,7 @@ class RealexTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal [ :visa, :master, :american_express, :diners_club ], RealexGateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :diners_club], RealexGateway.supported_cardtypes
   end
 
   def test_avs_result_not_supported

--- a/test/unit/post_data_test.rb
+++ b/test/unit/post_data_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class MyPost < ActiveMerchant::PostData
-  self.required_fields = [ :ccnumber, :ccexp, :firstname, :lastname, :username, :password, :order_id, :key, :time ]
+  self.required_fields = [:ccnumber, :ccexp, :firstname, :lastname, :username, :password, :order_id, :key, :time]
 end
 
 class PostDataTest < Test::Unit::TestCase
@@ -29,7 +29,7 @@ class PostDataTest < Test::Unit::TestCase
   end
 
   def test_dont_ignore_required_blank_fields
-    ActiveMerchant::PostData.required_fields = [ :name ]
+    ActiveMerchant::PostData.required_fields = [:name]
     post = ActiveMerchant::PostData.new
 
     assert_equal 0, post.keys.size
@@ -45,6 +45,6 @@ class PostDataTest < Test::Unit::TestCase
 
   def test_subclass
     post = MyPost.new
-    assert_equal [ :ccnumber, :ccexp, :firstname, :lastname, :username, :password, :order_id, :key, :time ], post.required_fields
+    assert_equal [:ccnumber, :ccexp, :firstname, :lastname, :username, :password, :order_id, :key, :time], post.required_fields
   end
 end


### PR DESCRIPTION
Fixes the RuboCop todo that enforces no surrounding spaces inside the
brackets of an array literal.

All unit tests:
4408 tests, 71309 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed