### PR TITLE
RuboCop: Layout/EmptyLinesAroundClassBody fix

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,13 +28,6 @@ Layout/AlignHash:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-# Offense count: 173
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines, beginning_only, ending_only
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
 # Offense count: 105
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * RuboCop: Layout/SpaceInsideArrayPercentLiteral fix [leila-alderman] #3484
 * RuboCop: Layout/SpaceInsidePercentLiteralDelimiter [leila-alderman] #3485
 * RuboCop: Layout/SpaceInsideArrayLiteralBrackets [leila-alderman] #3486
+* RuboCop: Layout/EmptyLinesAroundClassBody fix [leila-alderman] #3487
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/cvv_result.rb
+++ b/lib/active_merchant/billing/cvv_result.rb
@@ -4,7 +4,6 @@ module ActiveMerchant
     # http://www.bbbonline.org/eExport/doc/MerchantGuide_cvv2.pdf
     # Check additional codes from cybersource website
     class CVVResult
-
       MESSAGES = {
         'D'  =>  'CVV check flagged transaction as suspicious',
         'I'  =>  'CVV failed data validation check',

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class AdyenGateway < Gateway
-
       # we recommend setting up merchant-specific endpoints.
       # https://docs.adyen.com/developers/api-manual#apiendpoints
       self.test_url = 'https://pal-test.adyen.com/pal/servlet/'

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -199,7 +199,6 @@ module ActiveMerchant #:nodoc:
           response['message'] || 'Unable to read error message'
         end
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -1059,7 +1059,6 @@ module ActiveMerchant
           balance_on_card: parts[54] || '',
         }
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -240,7 +240,6 @@ module ActiveMerchant #:nodoc:
       end
 
       class ProcessPaymentResponse < BPointResponse
-
         private
 
         def authorization_key
@@ -257,7 +256,6 @@ module ActiveMerchant #:nodoc:
       end
 
       class AddTokenResponse < BPointResponse
-
         private
 
         def authorization_key

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -16,7 +16,6 @@ module ActiveMerchant #:nodoc:
         @test_url = 'https://gw1.cardsaveonlinepayments.com:4430/'
         @live_url = 'https://gw1.cardsaveonlinepayments.com:4430/'
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class CardStreamGateway < Gateway
-
       THREEDSECURE_REQUIRED_DEPRECATION_MESSAGE = 'Specifying the :threeDSRequired initialization option is deprecated. Please use the `:threeds_required => true` *transaction* option instead.'
 
       self.test_url = self.live_url = 'https://gateway.cardstream.com/direct/'
@@ -363,7 +362,6 @@ module ActiveMerchant #:nodoc:
       def add_pair(post, key, value, options = {})
         post[key] = value if !value.blank? || options[:required]
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/citrus_pay.rb
+++ b/lib/active_merchant/billing/gateways/citrus_pay.rb
@@ -16,7 +16,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -310,7 +310,6 @@ module ActiveMerchant #:nodoc:
         }
         resp
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -285,7 +285,6 @@ module ActiveMerchant #:nodoc:
           @params['CreateCustomerResult']
         end
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -251,7 +251,6 @@ module ActiveMerchant #:nodoc:
       def strip_invalid_xml_chars(xml)
         xml.gsub(/&(?!(?:[a-z]+|#[0-9]+|x[a-zA-Z0-9]+);)/, '&amp;')
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/global_transport.rb
+++ b/lib/active_merchant/billing/gateways/global_transport.rb
@@ -188,7 +188,6 @@ module ActiveMerchant #:nodoc:
           ExtData: ''
         }
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -3,7 +3,6 @@ require 'cgi'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MerchantOneGateway < Gateway
-
       class MerchantOneSslConnection < ActiveMerchant::Connection
         def configure_ssl(http)
           super(http)

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MicropaymentGateway < Gateway
-
       self.display_name = 'micropayment'
       self.homepage_url = 'https://www.micropayment.de/'
 

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -295,7 +295,6 @@ module ActiveMerchant #:nodoc:
       def request_timeout
         @options[:request_timeout] || 60
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -224,7 +224,6 @@ module ActiveMerchant #:nodoc:
 
         parameters.reject { |k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -318,7 +318,6 @@ module ActiveMerchant #:nodoc:
           response[:responsetext]
         end
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -318,7 +318,6 @@ module ActiveMerchant #:nodoc:
         post[:currency]    = (options[:currency] || currency(money))
         post[:description] = options[:description] if options.key?(:description)
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -323,7 +323,6 @@ module ActiveMerchant #:nodoc:
           'discover'        => 'DI',
           'diners_club'     => 'DC', }[key]
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PacNetRavenGateway < Gateway
-
       AVS_ADDRESS_CODES = {
         'avs_address_unavailable'   => 'X',
         'avs_address_not_checked'   => 'X',

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -237,7 +237,6 @@ module ActiveMerchant #:nodoc:
         message += " (The raw response returned by the API was #{raw_response.inspect})"
         return Response.new(false, message)
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -38,7 +38,6 @@ module ActiveMerchant #:nodoc:
 
         super
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PaystationGateway < Gateway
-
       self.live_url = self.test_url = 'https://www.paystation.co.nz/direct/paystation.dll'
 
       # an "error code" of "0" means "No error - transaction successful"
@@ -195,7 +194,6 @@ module ActiveMerchant #:nodoc:
       def format_date(month, year)
         "#{format(year, :two_digits)}#{format(month, :two_digits)}"
       end
-
     end
 
     class PaystationResponse < Response

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -270,7 +270,6 @@ module ActiveMerchant #:nodoc:
       def authorization_parts_from(authorization)
         authorization.split(/;/)
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -19,7 +19,6 @@ module ActiveMerchant #:nodoc:
           QuickpayV10Gateway.new(options)
         end
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -296,7 +296,6 @@ module ActiveMerchant #:nodoc:
       end
 
       class SageVault
-
         def initialize(options, gateway)
           @live_url = 'https://www.sagepayments.net/web_services/wsVault/wsVault.asmx'
           @options = options

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class SecureNetGateway < Gateway
-
       API_VERSION = '4.0'
 
       TRANSACTIONS = {
@@ -257,7 +256,6 @@ module ActiveMerchant #:nodoc:
       def build_authorization(response)
         [response[:transactionid], response[:transactionamount], response[:last4_digits]].join('|')
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -3,7 +3,6 @@ require File.join(File.dirname(__FILE__), '..', 'check.rb')
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class SmartPs < Gateway #:nodoc:
-
       ##
       # This is the base gateway for processors who use the smartPS processing system
 

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -189,7 +189,6 @@ module ActiveMerchant #:nodoc:
         end
         retval.target!
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -5,7 +5,6 @@ module ActiveMerchant #:nodoc:
     # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
     # For the legacy API, see the Stripe gateway
     class StripePaymentIntentsGateway < StripeGateway
-
       self.supported_countries = %w(AT AU BE BR CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MX NL NO NZ PL PT SE SG SI SK US)
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -21,7 +21,6 @@ module ActiveMerchant
       self.supported_countries = %w(AR AU BR FR DE HK MX NZ SG GB US)
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/transax.rb
+++ b/lib/active_merchant/billing/gateways/transax.rb
@@ -16,7 +16,6 @@ module ActiveMerchant #:nodoc:
 
       # The name of the gateway
       self.display_name = 'NELiX TransaX'
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/usa_epay.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay.rb
@@ -5,7 +5,6 @@ module ActiveMerchant #:nodoc:
     # depending on options passed to new.
     #
     class UsaEpayGateway < Gateway
-
       self.abstract_class = true
 
       ##

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -1607,7 +1607,6 @@ module ActiveMerchant #:nodoc:
 
         response
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/vanco.rb
+++ b/lib/active_merchant/billing/gateways/vanco.rb
@@ -288,7 +288,6 @@ module ActiveMerchant
           'Content-Type' => 'text/xml'
         }
       end
-
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -205,7 +205,6 @@ module ActiveMerchant #:nodoc:
       def handle_response(response)
         response.body
       end
-
     end
   end
 end

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -2,7 +2,6 @@ require 'active_merchant'
 require 'support/gateway_support'
 
 class SSLVerify
-
   def initialize
     @gateways = GatewaySupport.new.gateways
   end
@@ -86,5 +85,4 @@ class SSLVerify
   rescue Net::HTTPBadResponse, Errno::ETIMEDOUT, EOFError, SocketError, Errno::ECONNREFUSED, Timeout::Error => ex
     return :error, ex.inspect
   end
-
 end

--- a/lib/support/ssl_version.rb
+++ b/lib/support/ssl_version.rb
@@ -83,5 +83,4 @@ class SSLVersion
   rescue StandardError => ex
     return :error, ex.inspect
   end
-
 end

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -88,5 +88,4 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
       transaction_identifier: defaults[:transaction_identifier]
     )
   end
-
 end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -872,5 +872,4 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     return response
   end
-
 end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -743,5 +743,4 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     gateway = AuthorizeNetGateway.new(login: 'unknown_login', password: 'not_right')
     assert !gateway.verify_credentials
   end
-
 end

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -62,5 +62,4 @@ class RemoteBanwireTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
-
 end

--- a/test/remote/gateways/remote_beanstream_interac_test.rb
+++ b/test/remote/gateways/remote_beanstream_interac_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteBeanstreamInteracTest < Test::Unit::TestCase
-
   def setup
     @gateway = BeanstreamInteracGateway.new(fixtures(:beanstream_interac))
 

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 # only work the first time you run them since the profile, if created again, becomes a duplicate.  There is a setting in order settings which, when unchecked will allow the tests to be run any number
 # of times without needing the manual deletion step between test runs.  The setting is: Do not allow profile to be created with card data duplicated from an existing profile.
 class RemoteBeanstreamTest < Test::Unit::TestCase
-
   def setup
     @gateway = BeanstreamGateway.new(fixtures(:beanstream))
 

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -427,5 +427,4 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_scrubbed(@check.routing_number, transcript)
     assert_scrubbed(@gateway.options[:api_password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_card_save_test.rb
+++ b/test/remote/gateways/remote_card_save_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteCardSaveTest < Test::Unit::TestCase
-
   def setup
     @gateway = CardSaveGateway.new(fixtures(:card_save))
 

--- a/test/remote/gateways/remote_citrus_pay_test.rb
+++ b/test/remote/gateways/remote_citrus_pay_test.rb
@@ -130,5 +130,4 @@ class RemoteCitrusPayTest < Test::Unit::TestCase
     gateway = CitrusPayGateway.new(userid: 'unknown', password: 'unknown')
     assert !gateway.verify_credentials
   end
-
 end

--- a/test/remote/gateways/remote_ct_payment_certification_test.rb
+++ b/test/remote/gateways/remote_ct_payment_certification_test.rb
@@ -239,5 +239,4 @@ class RemoteCtPaymentCertificationTest < Test::Unit::TestCase
     puts "Test #{test_number} | transaction number: #{response.params['transactionNumber']}, invoice number #{response.params['invoiceNumber']}, timestamp: #{response.params['timeStamp']}, result: #{response.params['returnCode']}"
     puts response.inspect
   end
-
 end

--- a/test/remote/gateways/remote_ct_payment_test.rb
+++ b/test/remote/gateways/remote_ct_payment_test.rb
@@ -169,5 +169,4 @@ class RemoteCtPaymentTest < Test::Unit::TestCase
     assert_scrubbed(Base64.strict_encode64(@credit_card.number), transcript)
     assert_scrubbed(@gateway.options[:api_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -249,5 +249,4 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:trans_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_data_cash_test.rb
+++ b/test/remote/gateways/remote_data_cash_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteDataCashTest < Test::Unit::TestCase
-
   def setup
     # gateway to connect to Datacash
     @gateway = DataCashGateway.new(fixtures(:data_cash))

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -207,5 +207,4 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway_for_purchase.options[:api_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_digitzs_test.rb
+++ b/test/remote/gateways/remote_digitzs_test.rb
@@ -132,5 +132,4 @@ class RemoteDigitzsTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:api_key], transcript)
     assert_scrubbed(@gateway.options[:app_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -225,5 +225,4 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:integration_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_efsnet_test.rb
+++ b/test/remote/gateways/remote_efsnet_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteEfsnetTest < Test::Unit::TestCase
-
   def setup
     Base.mode = :test
 

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -244,5 +244,4 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -110,5 +110,4 @@ class RemoteEpayTest < Test::Unit::TestCase
     response = @gateway.void(0)
     assert_failure response
   end
-
 end

--- a/test/remote/gateways/remote_federated_canada_test.rb
+++ b/test/remote/gateways/remote_federated_canada_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteFederatedCanadaTest < Test::Unit::TestCase
-
   def setup
     @gateway = FederatedCanadaGateway.new(fixtures(:federated_canada))
 

--- a/test/remote/gateways/remote_first_giving_test.rb
+++ b/test/remote/gateways/remote_first_giving_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteFirstGivingTest < Test::Unit::TestCase
-
   def setup
     @gateway = FirstGivingGateway.new(fixtures(:first_giving))
 

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -248,5 +248,4 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert_scrubbed(cc_with_different_cvc.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -267,5 +267,4 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:password], transcript)
     assert_scrubbed(@gateway.options[:hmac_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -207,5 +207,4 @@ class RemoteForteTest < Test::Unit::TestCase
   def wait_for_authorization_to_clear
     sleep(10)
   end
-
 end

--- a/test/remote/gateways/remote_garanti_test.rb
+++ b/test/remote/gateways/remote_garanti_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 # NOTE: tests may fail randomly because Garanti returns random(!) responses for their test server
 class RemoteGarantiTest < Test::Unit::TestCase
-
   def setup
     @gateway = GarantiGateway.new(fixtures(:garanti))
 

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -220,5 +220,4 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:secret_api_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_global_transport_test.rb
+++ b/test/remote/gateways/remote_global_transport_test.rb
@@ -137,5 +137,4 @@ class RemoteGlobalTransportTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:global_password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -136,5 +136,4 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:agent_code], transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_instapay_test.rb
+++ b/test/remote/gateways/remote_instapay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteInstapayTest < Test::Unit::TestCase
-
   def setup
     @gateway = InstapayGateway.new(fixtures(:instapay))
 

--- a/test/remote/gateways/remote_itransact_test.rb
+++ b/test/remote/gateways/remote_itransact_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteItransactTest < Test::Unit::TestCase
-
   def setup
     @gateway = ItransactGateway.new(fixtures(:itransact))
 

--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -160,5 +160,4 @@ class RemoteIveriTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:cert_id], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -244,5 +244,4 @@ class RemoteIxopayTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_jetpay_test.rb
+++ b/test/remote/gateways/remote_jetpay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteJetpayTest < Test::Unit::TestCase
-
   def setup
     @gateway = JetpayGateway.new(fixtures(:jetpay))
 

--- a/test/remote/gateways/remote_jetpay_v2_certification_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_certification_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
-
   def setup
     @gateway = JetpayV2Gateway.new(fixtures(:jetpay_v2))
 
@@ -344,5 +343,4 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     assert_equal 'APPROVED', response.message
     @unique_id = response.params['unique_id']
   end
-
 end

--- a/test/remote/gateways/remote_jetpay_v2_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteJetpayV2Test < Test::Unit::TestCase
-
   def setup
     @gateway = JetpayV2Gateway.new(fixtures(:jetpay_v2))
 

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -280,5 +280,4 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:access_token], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteMerchantOneTest < Test::Unit::TestCase
-
   def setup
     @gateway = MerchantOneGateway.new(fixtures(:merchant_one))
 

--- a/test/remote/gateways/remote_modern_payments_cim_test.rb
+++ b/test/remote/gateways/remote_modern_payments_cim_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteModernPaymentsCimTest < Test::Unit::TestCase
-
   def setup
     @gateway = ModernPaymentsCimGateway.new(fixtures(:modern_payments))
 

--- a/test/remote/gateways/remote_modern_payments_test.rb
+++ b/test/remote/gateways/remote_modern_payments_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteModernPaymentTest < Test::Unit::TestCase
-
   def setup
     @gateway = ModernPaymentsGateway.new(fixtures(:modern_payments))
 

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -162,5 +162,4 @@ class RemoteMoneiTest < Test::Unit::TestCase
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end
-
 end

--- a/test/remote/gateways/remote_moneris_us_test.rb
+++ b/test/remote/gateways/remote_moneris_us_test.rb
@@ -257,5 +257,4 @@ class MonerisUsRemoteTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteNabTransactTest < Test::Unit::TestCase
-
   def setup
     @gateway = NabTransactGateway.new(fixtures(:nab_transact))
     @privileged_gateway = NabTransactGateway.new(fixtures(:nab_transact_privileged))
@@ -260,5 +259,4 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
-
 end

--- a/test/remote/gateways/remote_ncr_secure_pay_test.rb
+++ b/test/remote/gateways/remote_ncr_secure_pay_test.rb
@@ -118,5 +118,4 @@ class RemoteMonetraTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -10,7 +10,6 @@ require 'test_helper'
 # All purchases made in these tests are $1, so hopefully you won't be
 # sent broke if you forget...
 class NetRegistryTest < Test::Unit::TestCase
-
   def setup
     @gateway = NetRegistryGateway.new(fixtures(:net_registry))
 

--- a/test/remote/gateways/remote_netbanx_test.rb
+++ b/test/remote/gateways/remote_netbanx_test.rb
@@ -229,5 +229,4 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'OK', response.message
   end
-
 end

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class RemoteOgoneTest < Test::Unit::TestCase
-
   def setup
     @gateway = OgoneGateway.new(fixtures(:ogone))
     @amount = 100

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -99,5 +99,4 @@ class RemoteOmiseTest < Test::Unit::TestCase
     assert_success response
     assert_equal @amount-1000, response.params['amount']
   end
-
 end

--- a/test/remote/gateways/remote_opp_test.rb
+++ b/test/remote/gateways/remote_opp_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteOppTest < Test::Unit::TestCase
-
   def setup
     @gateway = OppGateway.new(fixtures(:opp))
     @amount = 100

--- a/test/remote/gateways/remote_pagarme_test.rb
+++ b/test/remote/gateways/remote_pagarme_test.rb
@@ -153,5 +153,4 @@ class RemotePagarmeTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:api_key], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_pay_secure_test.rb
+++ b/test/remote/gateways/remote_pay_secure_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemotePaySecureTest < Test::Unit::TestCase
-
   def setup
     @gateway = PaySecureGateway.new(fixtures(:pay_secure))
 

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class RemotePayboxDirectTest < Test::Unit::TestCase
-
   def setup
     @gateway = PayboxDirectGateway.new(fixtures(:paybox_direct))
 

--- a/test/remote/gateways/remote_payex_test.rb
+++ b/test/remote/gateways/remote_payex_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemotePayexTest < Test::Unit::TestCase
-
   def setup
     @gateway = PayexGateway.new(fixtures(:payex))
 

--- a/test/remote/gateways/remote_payflow_express_test.rb
+++ b/test/remote/gateways/remote_payflow_express_test.rb
@@ -133,7 +133,6 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
 end
 
 class RemotePayflowExpressUkTest < Test::Unit::TestCase
-
   def setup
     @gateway = PayflowExpressUkGateway.new(fixtures(:payflow_uk))
   end

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemotePaymentExpressTest < Test::Unit::TestCase
-
   def setup
     @gateway = PaymentExpressGateway.new(fixtures(:payment_express))
 
@@ -146,5 +145,4 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
     assert_scrubbed(@gateway.options[:password], clean_transcript)
   end
-
 end

--- a/test/remote/gateways/remote_paymill_test.rb
+++ b/test/remote/gateways/remote_paymill_test.rb
@@ -171,5 +171,4 @@ class RemotePaymillTest < Test::Unit::TestCase
     gateway = PaymillGateway.new(public_key: 'unknown_key', private_key: 'unknown_key')
     assert !gateway.verify_credentials
   end
-
 end

--- a/test/remote/gateways/remote_paystation_test.rb
+++ b/test/remote/gateways/remote_paystation_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemotePaystationTest < Test::Unit::TestCase
-
   def setup
     @gateway = PaystationGateway.new(fixtures(:paystation))
 

--- a/test/remote/gateways/remote_psigate_test.rb
+++ b/test/remote/gateways/remote_psigate_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PsigateRemoteTest < Test::Unit::TestCase
-
   def setup
     Base.mode = :test
     @gateway = PsigateGateway.new(fixtures(:psigate))

--- a/test/remote/gateways/remote_psl_card_test.rb
+++ b/test/remote/gateways/remote_psl_card_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemotePslCardTest < Test::Unit::TestCase
-
   def setup
     @gateway = PslCardGateway.new(fixtures(:psl_card))
 

--- a/test/remote/gateways/remote_quantum_test.rb
+++ b/test/remote/gateways/remote_quantum_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteQuantumTest < Test::Unit::TestCase
-
   def setup
     @gateway = QuantumGateway.new(fixtures(:quantum))
 

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteQuickPayV10Test < Test::Unit::TestCase
-
   def setup
     @gateway = QuickpayV10Gateway.new(fixtures(:quickpay_v10_api_key))
     @amount = 100
@@ -268,5 +267,4 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     assert_scrubbed(@valid_card.verification_value.to_s, clean_transcript)
     assert_scrubbed(@gateway.options[:api_key], clean_transcript)
   end
-
 end

--- a/test/remote/gateways/remote_qvalent_test.rb
+++ b/test/remote/gateways/remote_qvalent_test.rb
@@ -238,5 +238,4 @@ class RemoteQvalentTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded', response.message
   end
-
 end

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteRealexTest < Test::Unit::TestCase
-
   def setup
     @gateway = RealexGateway.new(fixtures(:realex_with_account))
 

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -230,5 +230,4 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:client_password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteSageTest < Test::Unit::TestCase
-
   def setup
     @gateway = SageGateway.new(fixtures(:sage))
 
@@ -231,5 +230,4 @@ class RemoteSageTest < Test::Unit::TestCase
     assert_scrubbed(@check.routing_number, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_secure_net_test.rb
+++ b/test/remote/gateways/remote_secure_net_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class SecureNetTest < Test::Unit::TestCase
-
   def setup
     Base.mode = :test
     @gateway = SecureNetGateway.new(fixtures(:secure_net))
@@ -135,5 +134,4 @@ class SecureNetTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
-
 end

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteSecurePayAuTest < Test::Unit::TestCase
-
   class MyCreditCard
     include ActiveMerchant::Billing::CreditCardMethods
     attr_accessor :number, :month, :year, :first_name, :last_name, :verification_value, :brand

--- a/test/remote/gateways/remote_secure_pay_test.rb
+++ b/test/remote/gateways/remote_secure_pay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteSecurePayTest < Test::Unit::TestCase
-
   def setup
     @gateway = SecurePayGateway.new(fixtures(:secure_pay))
 

--- a/test/remote/gateways/remote_so_easy_pay_test.rb
+++ b/test/remote/gateways/remote_so_easy_pay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteSoEasyPayTest < Test::Unit::TestCase
-
   def setup
     @gateway = SoEasyPayGateway.new(fixtures(:so_easy_pay))
 

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteSpreedlyCoreTest < Test::Unit::TestCase
-
   def setup
     @gateway = SpreedlyCoreGateway.new(fixtures(:spreedly_core))
 

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -190,5 +190,4 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_equal 'three_d_secure', response.params['type']
     assert_equal false, response.params['three_d_secure']['authenticated']
   end
-
 end

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -161,5 +161,4 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     assert_equal 'wow@example.com', response.params['metadata']['email']
     assert_match CHARGE_ID_REGEX, response.authorization
   end
-
 end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -665,5 +665,4 @@ class RemoteStripeTest < Test::Unit::TestCase
     gateway = StripeGateway.new(login: 'an_unknown_api_key')
     assert !gateway.verify_credentials
   end
-
 end

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteTnsTest < Test::Unit::TestCase
-
   def setup
     TnsGateway.ssl_strict = false # Sandbox has an improperly installed cert
     @gateway = TnsGateway.new(fixtures(:tns))

--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteTransFirstTest < Test::Unit::TestCase
-
   def setup
     @gateway = TransFirstGateway.new(fixtures(:trans_first))
 

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
-
   def setup
     @gateway = TransFirstTransactionExpressGateway.new(fixtures(:trans_first_transaction_express))
 

--- a/test/remote/gateways/remote_webpay_test.rb
+++ b/test/remote/gateways/remote_webpay_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class RemoteWebpayTest < Test::Unit::TestCase
-
   def setup
     @gateway = WebpayGateway.new(fixtures(:webpay))
 
@@ -134,5 +133,4 @@ class RemoteWebpayTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Invalid API key provided. Check your API key is correct.', response.message
   end
-
 end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class RemoteWorldpayTest < Test::Unit::TestCase
-
   def setup
     @gateway = WorldpayGateway.new(fixtures(:world_pay_gateway))
     @cftgateway = WorldpayGateway.new(fixtures(:world_pay_gateway_cft))

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class ConnectionTest < Test::Unit::TestCase
-
   def setup
     @ok = stub(:code => 200, :message => 'OK', :body => 'success')
 
@@ -244,5 +243,4 @@ class ConnectionTest < Test::Unit::TestCase
       @connection.wiredump_device = transcript
     end
   end
-
 end

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -652,5 +652,4 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     Conn close
     )
   end
-
 end

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -370,5 +370,4 @@ class BeanstreamTest < Test::Unit::TestCase
   def scrubbed_transcript
     'ref1=reference+one&trnCardOwner=Longbob+Longsen&trnCardNumber=[FILTERED]&trnExpMonth=09&trnExpYear=16&trnCardCvd=[FILTERED]&ordName=xiaobo+zzz&ordEmailAddress=xiaobozzz%40example.com&username=awesomesauce&password=[FILTERED]'
   end
-
 end

--- a/test/unit/gateways/braintree_test.rb
+++ b/test/unit/gateways/braintree_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class BraintreeTest < Test::Unit::TestCase
-
   def test_new_with_login_password_creates_braintree_orange
     gateway = BraintreeGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/card_save_test.rb
+++ b/test/unit/gateways/card_save_test.rb
@@ -273,5 +273,4 @@ class CardSaveTest < Test::Unit::TestCase
       </soap:Body>
     </soap:Envelope>)
   end
-
 end

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -470,5 +470,4 @@ Conn close
   def failed_ch_response
     { 'status' => { 'code' => 40000, 'message' => 'General input error' }}.to_json
   end
-
 end

--- a/test/unit/gateways/efsnet_test.rb
+++ b/test/unit/gateways/efsnet_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class EfsnetTest < Test::Unit::TestCase
-
   def setup
     @gateway = EfsnetGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/ezic_test.rb
+++ b/test/unit/gateways/ezic_test.rb
@@ -166,5 +166,4 @@ class EzicTest < Test::Unit::TestCase
   def successful_authorize_raw_response
     MockResponse.succeeded(successful_authorize_response)
   end
-
 end

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -981,5 +981,4 @@ read 1067 bytes
 Conn close
     }
   end
-
 end

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -341,5 +341,4 @@ class IridiumTest < Test::Unit::TestCase
   <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CardDetailsTransactionResponse xmlns="https://www.thepaymentgateway.net/"><CardDetailsTransactionResult AuthorisationAttempted="True"><StatusCode>0</StatusCode><Message>AuthCode: 608724</Message></CardDetailsTransactionResult><TransactionOutputData CrossReference="110428221508160201608724"><AuthCode>608724</AuthCode><AddressNumericCheckResult>PASSED</AddressNumericCheckResult><PostCodeCheckResult>PASSED</PostCodeCheckResult><CV2CheckResult>PASSED</CV2CheckResult><GatewayEntryPoints><GatewayEntryPoint EntryPointURL="https://gw1.iridiumcorp.net/" Metric="100" /><GatewayEntryPoint EntryPointURL="https://gw2.iridiumcorp.net/" Metric="200" /><GatewayEntryPoint EntryPointURL="https://gw3.iridiumcorp.net/" Metric="300" /></GatewayEntryPoints></TransactionOutputData></CardDetailsTransactionResponse></soap:Body></soap:Envelope>
     POST_SCRUBBED
   end
-
 end

--- a/test/unit/gateways/itransact_test.rb
+++ b/test/unit/gateways/itransact_test.rb
@@ -67,5 +67,4 @@ class ItransactTest < Test::Unit::TestCase
     "<?xml version=\"1.0\" standalone=\"yes\"?>
 <GatewayInterface><TransactionResponse><TransactionResult><Status>ok</Status><ErrorCategory></ErrorCategory><ErrorMessage></ErrorMessage><WarningMessage></WarningMessage><TimeStamp>20081216141214</TimeStamp><TestMode>TRUE</TestMode><Total>1.0</Total><XID>9999999999</XID><CustomerData><BillingAddress><Address1>1234 My Street</Address1><City>Ottawa</City><FirstName>Longbob</FirstName><LastName>Longsen</LastName><State>ON</State><Zip>K1C2N6</Zip><Country>CA</Country><Phone>(555)555-5555</Phone></BillingAddress><ShippingAddress><Address1></Address1><City></City><FirstName></FirstName><LastName></LastName><State></State><Zip></Zip><Country></Country><Phone></Phone></ShippingAddress></CustomerData></TransactionResult></TransactionResponse></GatewayInterface>"
   end
-
 end

--- a/test/unit/gateways/jetpay_v2_test.rb
+++ b/test/unit/gateways/jetpay_v2_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class JetpayV2Test < Test::Unit::TestCase
-
   def setup
     @gateway = JetpayV2Gateway.new(:login => 'login')
 

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -256,5 +256,4 @@ class LinkpointTest < Test::Unit::TestCase
   def scrubbed_transcript
     '</orderoptions><creditcard><cardnumber>[FILTERED]</cardnumber><cardexpmonth>9</cardexpmonth><cardexpyear>16</cardexpyear><cvmvalue>[FILTERED]</cvmvalue><cvmindicator>provided</cvmindicator></creditcard><billing><name>Jim Smith</name>'
   end
-
 end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -922,5 +922,4 @@ class LitleTest < Test::Unit::TestCase
       Conn close
     post_scrub
   end
-
 end

--- a/test/unit/gateways/merchant_one_test.rb
+++ b/test/unit/gateways/merchant_one_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class MerchantOneTest < Test::Unit::TestCase
-
   def setup
     @gateway = MerchantOneGateway.new(fixtures(:merchant_one))
     @credit_card = credit_card

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -216,5 +216,4 @@ Parameter name: strPAN</faultstring>
 </soap:Envelope>
     XML
   end
-
 end

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -645,5 +645,4 @@ read 659 bytes
 Conn close
   }
   end
-
 end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -456,5 +456,4 @@ Conn close
     </NABTransactMessage>
     XML
   end
-
 end

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class OgoneTest < Test::Unit::TestCase
-
   def setup
     @credentials = { :login => 'pspid',
                      :user => 'username',
@@ -806,5 +805,4 @@ read 152 bytes
 Conn close
     }
   end
-
 end

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -812,5 +812,4 @@ class OmiseTest < Test::Unit::TestCase
     }
     RESPONSE
   end
-
 end

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -304,5 +304,4 @@ class OppTest < Test::Unit::TestCase
       @body = body
     end
   end
-
 end

--- a/test/unit/gateways/pagarme_test.rb
+++ b/test/unit/gateways/pagarme_test.rb
@@ -974,5 +974,4 @@ class PagarmeTest < Test::Unit::TestCase
     }
     SUCCESS_RESPONSE
   end
-
 end

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -101,5 +101,4 @@ class PayGateTest < Test::Unit::TestCase
     </protocol>
     ENDOFXML
   end
-
 end

--- a/test/unit/gateways/pay_secure_test.rb
+++ b/test/unit/gateways/pay_secure_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PaySecureTest < Test::Unit::TestCase
-
   def setup
     @gateway = PaySecureGateway.new(
                  :login => 'login',

--- a/test/unit/gateways/paymill_test.rb
+++ b/test/unit/gateways/paymill_test.rb
@@ -776,5 +776,4 @@ class PaymillTest < Test::Unit::TestCase
   def scrubbed_transcript
     'connection_uri=https://test-token.paymill.com?account.number=[FILTERED]&account.expiry.month=09&account.expiry.year=2016&account.verification=[FILTERED]'
   end
-
 end

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -164,5 +164,4 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_equal 'id', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
     assert_equal '127.0.0.1', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text
   end
-
 end

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -118,5 +118,4 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
     		</SOAP-ENV:Body>
     	</SOAP-ENV:Envelope>"
   end
-
 end

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -425,5 +425,4 @@ class PaystationTest < Test::Unit::TestCase
   def post_scrubbed
     'pstn_pi=609035&pstn_gi=PUSHPAY&pstn_2p=t&pstn_nr=t&pstn_df=yymm&pstn_ms=a755b9c84a530aee91dc3077f57294b0&pstn_mo=Store+Purchase&pstn_mr=&pstn_am=&pstn_cu=NZD&pstn_cn=[FILTERED]&pstn_ct=visa&pstn_ex=1305&pstn_cc=[FILTERED]&pstn_tm=T&paystation=_empty'
   end
-
 end

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PaywayTest < Test::Unit::TestCase
-
   def setup
     @gateway = PaywayGateway.new(
       :username => '12341234',

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -543,5 +543,4 @@ class PinTest < Test::Unit::TestCase
       }
     }'
   end
-
 end

--- a/test/unit/gateways/plugnpay_test.rb
+++ b/test/unit/gateways/plugnpay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PlugnpayTest < Test::Unit::TestCase
-
   def setup
     Base.mode = :test
 

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PslCardTest < Test::Unit::TestCase
-
   def setup
     @gateway = PslCardGateway.new(
                  :login => 'LOGIN',

--- a/test/unit/gateways/quickpay_test.rb
+++ b/test/unit/gateways/quickpay_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class QuickpayTest < Test::Unit::TestCase
-
   def test_error_without_login_option
     assert_raise ArgumentError do
       QuickpayGateway.new
@@ -17,5 +16,4 @@ class QuickpayTest < Test::Unit::TestCase
     gateway = QuickpayGateway.new(:login => 100, :api_key => 'APIKEY')
     assert_instance_of QuickpayV10Gateway, gateway
   end
-
 end

--- a/test/unit/gateways/skip_jack_test.rb
+++ b/test/unit/gateways/skip_jack_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class SkipJackTest < Test::Unit::TestCase
-
   def setup
     Base.mode = :test
 

--- a/test/unit/gateways/so_easy_pay_test.rb
+++ b/test/unit/gateways/so_easy_pay_test.rb
@@ -220,5 +220,4 @@ class SoEasyPayTest < Test::Unit::TestCase
         </soap:Body>
       </soap:Envelope>)
   end
-
 end

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class SpreedlyCoreTest < Test::Unit::TestCase
-
   def setup
     @gateway = SpreedlyCoreGateway.new(:login => 'api_login', :password => 'api_secret', :gateway_token => 'token')
     @payment_method_token = 'E3eQGR3E0xiosj7FOJRtIKbF8Ch'

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class TransFirstTest < Test::Unit::TestCase
-
   def setup
     @gateway = TransFirstGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/trexle_test.rb
+++ b/test/unit/gateways/trexle_test.rb
@@ -440,5 +440,4 @@ class TrexleTest < Test::Unit::TestCase
       }
     }'
   end
-
 end

--- a/test/unit/gateways/usa_epay_test.rb
+++ b/test/unit/gateways/usa_epay_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'logger'
 
 class UsaEpayTest < Test::Unit::TestCase
-
   def test_transaction_gateway_created
     gateway = UsaEpayGateway.new(
       :login => 'X'

--- a/test/unit/gateways/vanco_test.rb
+++ b/test/unit/gateways/vanco_test.rb
@@ -180,5 +180,4 @@ class VancoTest < Test::Unit::TestCase
       <?xml version="1.0" encoding="UTF-8"  ?><VancoWS><Auth><RequestID>dc9a5e2b620eee5d248e1b33cc1f33</RequestID><RequestTime>2015-05-01 16:19:33 -0400</RequestTime><RequestType>EFTAddCredit</RequestType><Signature></Signature><SessionID>67a731057f821413155033bc23551aef3ba0b204</SessionID><Version>2</Version></Auth><Response><Errors><Error><ErrorCode>575</ErrorCode><ErrorDescription>Amount Cannot Be Greater Than $100.05</ErrorDescription></Error></Errors></Response></VancoWS>
      )
   end
-
 end

--- a/test/unit/gateways/viaklix_test.rb
+++ b/test/unit/gateways/viaklix_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class ViaklixTest < Test::Unit::TestCase
-
   def setup
     @gateway = ViaklixGateway.new(
       :login => 'LOGIN',

--- a/test/unit/gateways/visanet_peru_test.rb
+++ b/test/unit/gateways/visanet_peru_test.rb
@@ -518,5 +518,4 @@ class VisanetPeruTest < Test::Unit::TestCase
     }
     RESPONSE
   end
-
 end

--- a/test/unit/gateways/wepay_test.rb
+++ b/test/unit/gateways/wepay_test.rb
@@ -425,5 +425,4 @@ class WepayTest < Test::Unit::TestCase
   def invalid_json_response
     %({"checkout_id"=1852898602,"state":"captured")
   end
-
 end

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
-
   def setup
     @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       number: '4242424242424242', :brand => 'visa',

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PostsDataTests < Test::Unit::TestCase
-
   def setup
     @url = 'http://example.com'
     @gateway = SimpleTestGateway.new


### PR DESCRIPTION
Fixes the RuboCop todo that enforces a default of no extra empty lines
around a class definition.

All unit tests:
4408 tests, 71309 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed