### PR TITLE
RuboCop: Fix Layout/FirstParameterIndentation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,13 +28,6 @@ Layout/AlignHash:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-# Offense count: 105
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstParameterIndentation:
-  Enabled: false
-
 # Offense count: 255
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * RuboCop: Layout/SpaceInsideArrayLiteralBrackets [leila-alderman] #3486
 * RuboCop: Layout/EmptyLinesAroundClassBody fix [leila-alderman] #3487
 * Mundipagg: Return acquirer code as the error code [leila-alderman] #3492
+* RuboCop: Fix Layout/FirstParameterIndentation [leila-alderman] #3489
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -159,12 +159,13 @@ module ActiveMerchant #:nodoc:
       def commit(entity_name, path, post, method=:post)
         raw_response =
           begin
-            parse(ssl_request(
-              method,
-              live_url + "/#{path}",
-              post_data(post),
-              headers
-            ))
+            parse(
+              ssl_request(
+                method,
+                live_url + "/#{path}",
+                post_data(post),
+                headers
+              ))
           rescue ResponseError => e
             raise unless(e.response.code.to_s =~ /4\d\d/)
             parse(e.response.body)

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -153,8 +153,10 @@ module ActiveMerchant #:nodoc:
         request_data = post_data(action, parameters)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request_data))
         response = parse(ssl_post(self.live_url_backup, request_data)) if service_unavailable?(response) && !test?
-        Response.new(success?(response), message_from(response), response.merge(
-          :timestamp => parameters[:dateq]),
+        Response.new(
+          success?(response),
+          message_from(response),
+          response.merge(:timestamp => parameters[:dateq]),
           :test => test?,
           :authorization => response[:numappel].to_s + response[:numtrans].to_s,
           :fraud_review => false,

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -170,11 +170,12 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, params, options={})
         begin
-          response = parse(ssl_post(
-            ((test? ? test_url : live_url) + action),
-            params.to_json,
-            headers(options)
-          ))
+          response = parse(
+            ssl_post(
+              ((test? ? test_url : live_url) + action),
+              params.to_json,
+              headers(options)
+            ))
         rescue ResponseError => e
           response = parse(e.response.body)
         end

--- a/test/remote/gateways/remote_allied_wallet_test.rb
+++ b/test/remote/gateways/remote_allied_wallet_test.rb
@@ -32,11 +32,12 @@ class RemoteAlliedWalletTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
-    response = @gateway.purchase(@amount, @credit_card, @options.merge(
+    options = @options.merge(
       order_id: generate_unique_id,
       ip: '127.0.0.1',
       email: 'jim_smith@example.com'
-    ))
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Succeeded', response.message
   end

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -45,9 +45,9 @@ class RemoteBanwireTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BanwireGateway.new(
-                :login => 'fakeuser',
-                :currency => 'MXN'
-              )
+      :login => 'fakeuser',
+      :currency => 'MXN'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'ID de cuenta invalido', response.message

--- a/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
+++ b/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
@@ -216,11 +216,11 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BarclaysEpdqExtraPlusGateway.new(
-                :login => '',
-                :user => '',
-                :password => '',
-                :signature_encryptor => 'none'
-              )
+      :login => '',
+      :user => '',
+      :password => '',
+      :signature_encryptor => 'none'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Some of the data entered is incorrect. please retry.', response.message

--- a/test/remote/gateways/remote_beanstream_interac_test.rb
+++ b/test/remote/gateways/remote_beanstream_interac_test.rb
@@ -41,10 +41,10 @@ class RemoteBeanstreamInteracTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BeanstreamInteracGateway.new(
-                :merchant_id => '',
-                :login => '',
-                :password => ''
-              )
+      :merchant_id => '',
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @options)
     assert_failure response
     assert_equal 'Invalid merchant id (merchant_id = 0)', response.message

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -21,10 +21,10 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     @declined_amex       = credit_card('342400001000180', {:verification_value => 1234})
 
     # Canadian EFT
-    @check               = check(
-                             :institution_number => '001',
-                             :transit_number     => '26729'
-                           )
+    @check = check(
+      :institution_number => '001',
+      :transit_number     => '26729'
+    )
 
     @amount = 1500
 
@@ -308,10 +308,10 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BeanstreamGateway.new(
-                :merchant_id => '',
-                :login => '',
-                :password => ''
-              )
+      :merchant_id => '',
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_failure response
     assert_equal 'merchantid=Invalid merchant id (merchant_id = )', response.message

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -20,12 +20,12 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_echeck
     check = ActiveMerchant::Billing::Check.new(
-              :name => 'Fredd Bloggs',
-              :routing_number => '111000025', # Valid ABA # - Bank of America, TX
-              :account_number => '999999999999',
-              :account_holder_type => 'personal',
-              :account_type => 'checking'
-            )
+      :name => 'Fredd Bloggs',
+      :routing_number => '111000025', # Valid ABA # - Bank of America, TX
+      :account_number => '999999999999',
+      :account_holder_type => 'personal',
+      :account_type => 'checking'
+    )
     assert response = @gateway.purchase(@amount, check, @options)
     assert_equal 'This transaction has been approved', response.message
     assert_success response
@@ -162,9 +162,9 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BraintreeOrangeGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Invalid Username', response.message
     assert_failure response

--- a/test/remote/gateways/remote_checkout_test.rb
+++ b/test/remote/gateways/remote_checkout_test.rb
@@ -27,13 +27,14 @@ class RemoteCheckoutTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_extra_options
-    response = @gateway.purchase(100, @credit_card, @options.merge(
+    options = @options.merge(
       currency: 'EUR',
       email: 'bob@example.com',
       order_id: generate_unique_id,
       customer: generate_unique_id,
       ip: '127.0.0.1'
-    ))
+    )
+    response = @gateway.purchase(100, @credit_card, options)
     assert_success response
     assert_equal 'Successful', response.message
   end

--- a/test/remote/gateways/remote_citrus_pay_test.rb
+++ b/test/remote/gateways/remote_citrus_pay_test.rb
@@ -104,9 +104,9 @@ class RemoteCitrusPayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = CitrusPayGateway.new(
-                :userid => 'nosuch',
-                :password => 'thing'
-              )
+      :userid => 'nosuch',
+      :password => 'thing'
+    )
     response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'ERROR - INVALID_REQUEST - Invalid credentials.', response.message

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -172,9 +172,9 @@ class RemoteFatZebraTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = FatZebraGateway.new(
-                :username => 'invalid',
-                :token => 'wrongtoken'
-              )
+      :username => 'invalid',
+      :token => 'wrongtoken'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid Login', response.message

--- a/test/remote/gateways/remote_federated_canada_test.rb
+++ b/test/remote/gateways/remote_federated_canada_test.rb
@@ -76,9 +76,9 @@ class RemoteFederatedCanadaTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = FederatedCanadaGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Error in transaction data or system error', response.message

--- a/test/remote/gateways/remote_first_giving_test.rb
+++ b/test/remote/gateways/remote_first_giving_test.rb
@@ -46,10 +46,10 @@ class RemoteFirstGivingTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = FirstGivingGateway.new(
-                application_key: '25151616',
-                security_token:  '63131jnkj',
-                charity_id: '1234'
-              )
+      application_key: '25151616',
+      security_token:  '63131jnkj',
+      charity_id: '1234'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'An error occurred. Please check your input and try again.', response.message

--- a/test/remote/gateways/remote_garanti_test.rb
+++ b/test/remote/gateways/remote_garanti_test.rb
@@ -50,11 +50,11 @@ class RemoteGarantiTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = GarantiGateway.new(
-                :login => 'PROVAUT',
-                :terminal_id => '30691300',
-                :merchant_id => '',
-                :password => ''
-              )
+      :login => 'PROVAUT',
+      :terminal_id => '30691300',
+      :merchant_id => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal '0651', response.params['reason_code']

--- a/test/remote/gateways/remote_hdfc_test.rb
+++ b/test/remote/gateways/remote_hdfc_test.rb
@@ -67,9 +67,9 @@ class RemoteHdfcTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = HdfcGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'TranPortal ID required.', response.message

--- a/test/remote/gateways/remote_inspire_test.rb
+++ b/test/remote/gateways/remote_inspire_test.rb
@@ -19,12 +19,12 @@ class RemoteBraintreeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_echeck
     check = ActiveMerchant::Billing::Check.new(
-              :name => 'Fredd Bloggs',
-              :routing_number => '111000025', # Valid ABA # - Bank of America, TX
-              :account_number => '999999999999',
-              :account_holder_type => 'personal',
-              :account_type => 'checking'
-            )
+      :name => 'Fredd Bloggs',
+      :routing_number => '111000025', # Valid ABA # - Bank of America, TX
+      :account_number => '999999999999',
+      :account_holder_type => 'personal',
+      :account_type => 'checking'
+    )
     response = @gateway.purchase(@amount, check, @options)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
@@ -150,9 +150,9 @@ class RemoteBraintreeTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = InspireGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Invalid Username', response.message
     assert_failure response

--- a/test/remote/gateways/remote_iridium_test.rb
+++ b/test/remote/gateways/remote_iridium_test.rb
@@ -164,9 +164,9 @@ class RemoteIridiumTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = IridiumGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
 
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_itransact_test.rb
+++ b/test/remote/gateways/remote_itransact_test.rb
@@ -76,10 +76,10 @@ class RemoteItransactTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ItransactGateway.new(
-                :login => 'x',
-                :password => 'x',
-                :gateway_id => 'x'
-              )
+      :login => 'x',
+      :password => 'x',
+      :gateway_id => 'x'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid login credentials', response.message

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -233,11 +233,11 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_stored_credential_recurring
     credit_card = CreditCard.new(@credit_card_hash.merge(
-      number: '4100200300011001',
-      month: '05',
-      year: '2021',
-      verification_value: '463'
-    ))
+                                   number: '4100200300011001',
+                                   month: '05',
+                                   year: '2021',
+                                   verification_value: '463'
+                                 ))
 
     initial_options = @options.merge(
       order_id: 'Net_Id1',
@@ -277,11 +277,11 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_stored_credential_installment
     credit_card = CreditCard.new(@credit_card_hash.merge(
-      number: '4457010000000009',
-      month: '01',
-      year: '2021',
-      verification_value: '349'
-    ))
+                                   number: '4457010000000009',
+                                   month: '01',
+                                   year: '2021',
+                                   verification_value: '349'
+                                 ))
 
     initial_options = @options.merge(
       order_id: 'Net_Id2',
@@ -321,11 +321,11 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_stored_credential_mit_card_on_file
     credit_card = CreditCard.new(@credit_card_hash.merge(
-      number: '4457000800000002',
-      month: '01',
-      year: '2021',
-      verification_value: '349'
-    ))
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2021',
+                                   verification_value: '349'
+                                 ))
 
     initial_options = @options.merge(
       order_id: 'Net_Id3',
@@ -365,11 +365,11 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_stored_credential_cit_card_on_file
     credit_card = CreditCard.new(@credit_card_hash.merge(
-      number: '4457000800000002',
-      month: '01',
-      year: '2021',
-      verification_value: '349'
-    ))
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2021',
+                                   verification_value: '349'
+                                 ))
 
     initial_options = @options.merge(
       order_id: 'Net_Id3',
@@ -409,11 +409,11 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_purchase_with_stored_credential_cit_card_on_file_non_ecommerce
     credit_card = CreditCard.new(@credit_card_hash.merge(
-      number: '4457000800000002',
-      month: '01',
-      year: '2021',
-      verification_value: '349'
-    ))
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2021',
+                                   verification_value: '349'
+                                 ))
 
     initial_options = @options.merge(
       order_id: 'Net_Id3',
@@ -615,9 +615,9 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_dynamic_descriptors
     assert response = @gateway.purchase(10010, @credit_card1, @options.merge(
-      descriptor_name: 'SuperCompany',
-      descriptor_phone: '9193341121'
-    ))
+                                                                descriptor_name: 'SuperCompany',
+                                                                descriptor_phone: '9193341121'
+                                                              ))
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -176,9 +176,9 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantESolutionsGateway.new(
-              :login => '',
-              :password => ''
-            )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end
@@ -191,9 +191,11 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_3dsecure_params
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
-      { :xid => 'ERERERERERERERERERERERERERE=',
-        :cavv => 'ERERERERERERERERERERERERERE='}))
+    options = @options.merge(
+      { xid: 'ERERERERERERERERERERERERERE=',
+        cavv: 'ERERERERERERERERERERERERERE='}
+    )
+    assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
   end

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -53,9 +53,9 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantOneGateway.new(
-                :username => 'nnn',
-                :password => 'nnn'
-              )
+      :username => 'nnn',
+      :password => 'nnn'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Authentication Failed', response.message

--- a/test/remote/gateways/remote_merchant_ware_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_test.rb
@@ -93,10 +93,10 @@ class RemoteMerchantWareTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantWareGateway.new(
-                :login => '',
-                :password => '',
-                :name => ''
-              )
+      :login => '',
+      :password => '',
+      :name => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Server was unable to process request. ---> Invalid Credentials.', response.message

--- a/test/remote/gateways/remote_merchant_ware_version_four_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_version_four_test.rb
@@ -92,10 +92,10 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantWareVersionFourGateway.new(
-                :login => '',
-                :password => '',
-                :name => ''
-              )
+      :login => '',
+      :password => '',
+      :name => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid Credentials.', response.message

--- a/test/remote/gateways/remote_modern_payments_cim_test.rb
+++ b/test/remote/gateways/remote_modern_payments_cim_test.rb
@@ -46,9 +46,9 @@ class RemoteModernPaymentsCimTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ModernPaymentsCimGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.create_customer(@options)
     assert_failure response
     assert_equal ModernPaymentsCimGateway::ERROR_MESSAGE, response.message

--- a/test/remote/gateways/remote_modern_payments_test.rb
+++ b/test/remote/gateways/remote_modern_payments_test.rb
@@ -33,9 +33,9 @@ class RemoteModernPaymentTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ModernPaymentsGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
 
     assert_raises(ActiveMerchant::ResponseError) do
       gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_money_movers_test.rb
+++ b/test/remote/gateways/remote_money_movers_test.rb
@@ -72,9 +72,9 @@ class RemoteMoneyMoversTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MoneyMoversGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Error in transaction data or system error', response.message

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -181,9 +181,9 @@ class RemoteNabTransactTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NabTransactGateway.new(
-                :login => 'ABCFAKE',
-                :password => 'changeit'
-              )
+      :login => 'ABCFAKE',
+      :password => 'changeit'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid merchant ID', response.message

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -87,9 +87,9 @@ class NetRegistryTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = NetRegistryGateway.new(
-                 :login    => 'bad-login',
-                 :password => 'bad-login'
-               )
+      :login    => 'bad-login',
+      :password => 'bad-login'
+    )
     response = gateway.purchase(@amount, @valid_creditcard)
     assert_equal 'failed', response.params['status']
     assert_failure response

--- a/test/remote/gateways/remote_netaxept_test.rb
+++ b/test/remote/gateways/remote_netaxept_test.rb
@@ -116,9 +116,9 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetaxeptGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match(/Unable to authenticate merchant/, response.message)

--- a/test/remote/gateways/remote_netbilling_test.rb
+++ b/test/remote/gateways/remote_netbilling_test.rb
@@ -88,9 +88,9 @@ class RemoteNetbillingTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetbillingGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match(/missing/i, response.message)
     assert_failure response

--- a/test/remote/gateways/remote_network_merchants_test.rb
+++ b/test/remote/gateways/remote_network_merchants_test.rb
@@ -153,9 +153,9 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetworkMerchantsGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid Username', response.message

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -232,11 +232,11 @@ class RemoteOgoneTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = OgoneGateway.new(
-                login: 'login',
-                user: 'user',
-                password: 'password',
-                signature: 'signature'
-              )
+      login: 'login',
+      user: 'user',
+      password: 'password',
+      signature: 'signature'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -141,10 +141,10 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = OptimalPaymentGateway.new(
-                :account_number => '1',
-                :store_id => 'bad',
-                :password => 'bad'
-              )
+      :account_number => '1',
+      :store_id => 'bad',
+      :password => 'bad'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'invalid merchant account', response.message

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -60,15 +60,14 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_soft_descriptor_hash
-    assert response = @gateway.purchase(
-      @amount, @credit_card, @options.merge(
-        soft_descriptors: {
-          merchant_name: 'Merch',
-          product_description: 'Description',
-          merchant_email: 'email@example',
-        }
-      )
+    options = @options.merge(
+      soft_descriptors: {
+        merchant_name: 'Merch',
+        product_description: 'Description',
+        merchant_email: 'email@example'
+      }
     )
+    assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -200,12 +199,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         verification_value: fixture[:card][:verification_value],
         brand: fixture[:card][:brand]
       })
-      assert response = @gateway.authorize(100, cc, @options.merge(
+      options = @options.merge(
         order_id: '2',
         currency: 'USD',
         three_d_secure: fixture[:three_d_secure],
         address: fixture[:address]
-      ))
+      )
+      assert response = @gateway.authorize(100, cc, options)
 
       assert_success response
       assert_equal 'Approved', response.message
@@ -217,12 +217,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         verification_value: fixture[:card][:verification_value],
         brand: fixture[:card][:brand]
       })
-      assert response = @gateway.purchase(100, cc, @options.merge(
+      options = @options.merge(
         order_id: '2',
         currency: 'USD',
         three_d_secure: fixture[:three_d_secure],
         address: fixture[:address]
-      ))
+      )
+      assert response = @gateway.purchase(100, cc, options)
 
       assert_success response
       assert_equal 'Approved', response.message

--- a/test/remote/gateways/remote_pay_secure_test.rb
+++ b/test/remote/gateways/remote_pay_secure_test.rb
@@ -28,9 +28,9 @@ class RemotePaySecureTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PaySecureGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal "MissingField: 'MERCHANT_ID'", response.message
     assert_failure response

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -90,10 +90,10 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayboxDirectGateway.new(
-                login: '199988899',
-                password: '1999888F',
-                rang: 100
-              )
+      login: '199988899',
+      password: '1999888F',
+      rang: 100
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Non autorise', response.message
@@ -101,9 +101,9 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
 
   def test_invalid_login_without_rang
     gateway = PayboxDirectGateway.new(
-                login: '199988899',
-                password: '1999888F'
-              )
+      login: '199988899',
+      password: '1999888F'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Non autorise', response.message

--- a/test/remote/gateways/remote_payex_test.rb
+++ b/test/remote/gateways/remote_payex_test.rb
@@ -108,9 +108,9 @@ class RemotePayexTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayexGateway.new(
-                :account => '1',
-                :encryption_key => '1'
-              )
+      :account => '1',
+      :encryption_key => '1'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_not_equal 'OK', response.message

--- a/test/remote/gateways/remote_quantum_test.rb
+++ b/test/remote/gateways/remote_quantum_test.rb
@@ -63,9 +63,9 @@ class RemoteQuantumTest < Test::Unit::TestCase
   # So we check to see if the parse failed and report
   def test_invalid_login
     gateway = QuantumGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card)
     assert_failure response
     assert_equal 'ERROR: Invalid Gateway Login!!', response.message

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -191,9 +191,9 @@ class RemoteSageTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SageGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_failure response
     assert_equal 'SECURITY VIOLATION', response.message

--- a/test/remote/gateways/remote_secure_net_test.rb
+++ b/test/remote/gateways/remote_secure_net_test.rb
@@ -28,9 +28,9 @@ class SecureNetTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecureNetGateway.new(
-                :login => '9988776',
-                :password => 'RabbitEarsPo'
-              )
+      :login => '9988776',
+      :password => 'RabbitEarsPo'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'SECURE KEY IS INVALID FOR SECURENET ID PROVIDED', response.message

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -175,9 +175,9 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecurePayAuGateway.new(
-                :login => 'a',
-                :password => 'a'
-              )
+      :login => 'a',
+      :password => 'a'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid merchant ID', response.message

--- a/test/remote/gateways/remote_secure_pay_tech_test.rb
+++ b/test/remote/gateways/remote_secure_pay_tech_test.rb
@@ -43,9 +43,9 @@ class RemoteSecurePayTechTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecurePayTechGateway.new(
-                :login => 'foo',
-                :password => 'bar'
-              )
+      :login => 'foo',
+      :password => 'bar'
+    )
     assert response = gateway.purchase(@accepted_amount, @credit_card, @options)
     assert_equal 'Bad or malformed request', response.message
     assert_failure response

--- a/test/remote/gateways/remote_skipjack_test.rb
+++ b/test/remote/gateways/remote_skipjack_test.rb
@@ -107,9 +107,9 @@ class RemoteSkipJackTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SkipJackGateway.new(
-                :login => '555555555555',
-                :password => '999999999999'
-              )
+      :login => '555555555555',
+      :password => '999999999999'
+    )
 
     response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_so_easy_pay_test.rb
+++ b/test/remote/gateways/remote_so_easy_pay_test.rb
@@ -53,9 +53,9 @@ class RemoteSoEasyPayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SoEasyPayGateway.new(
-                :login => 'one',
-                :password => 'wrong'
-              )
+      :login => 'one',
+      :password => 'wrong'
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Website verification failed, wrong websiteID or password', response.message

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -115,9 +115,9 @@ class RemoteTnsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = TnsGateway.new(
-                :userid => 'nosuch',
-                :password => 'thing'
-              )
+      :userid => 'nosuch',
+      :password => 'thing'
+    )
     response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'ERROR - INVALID_REQUEST - Invalid credentials.', response.message

--- a/test/remote/gateways/remote_transax_test.rb
+++ b/test/remote/gateways/remote_transax_test.rb
@@ -115,9 +115,9 @@ class RemoteTransaxTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = TransaxGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid Username', response.message

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -138,10 +138,10 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = UsaEpayAdvancedGateway.new(
-                :login => '',
-                :password => '',
-                :software_id => ''
-              )
+      :login => '',
+      :password => '',
+      :software_id => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid software ID', response.message

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -147,14 +147,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   def test_successful_authorize_with_3ds
     session_id = generate_unique_id
     options = @options.merge(
-              {
-                execute_threed: true,
-                accept_header: 'text/html',
-                user_agent: 'Mozilla/5.0',
-                session_id: session_id,
-                ip: '127.0.0.1',
-                cookie: 'machine=32423423'
-              })
+      {
+        execute_threed: true,
+        accept_header: 'text/html',
+        user_agent: 'Mozilla/5.0',
+        session_id: session_id,
+        ip: '127.0.0.1',
+        cookie: 'machine=32423423'
+      })
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -240,15 +240,15 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       network_transaction_id: nil
     }
     options = @options.merge(
-              {
-                execute_threed: true,
-                accept_header: 'text/html',
-                user_agent: 'Mozilla/5.0',
-                session_id: session_id,
-                ip: '127.0.0.1',
-                cookie: 'machine=32423423',
-                stored_credential: stored_credential_params
-              })
+      {
+        execute_threed: true,
+        accept_header: 'text/html',
+        user_agent: 'Mozilla/5.0',
+        session_id: session_id,
+        ip: '127.0.0.1',
+        cookie: 'machine=32423423',
+        stored_credential: stored_credential_params
+      })
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -262,15 +262,15 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   def test_successful_authorize_with_3ds_with_gateway_specific_stored_credentials
     session_id = generate_unique_id
     options = @options.merge(
-              {
-                execute_threed: true,
-                accept_header: 'text/html',
-                user_agent: 'Mozilla/5.0',
-                session_id: session_id,
-                ip: '127.0.0.1',
-                cookie: 'machine=32423423',
-                stored_credential_usage: 'FIRST'
-              })
+      {
+        execute_threed: true,
+        accept_header: 'text/html',
+        user_agent: 'Mozilla/5.0',
+        session_id: session_id,
+        ip: '127.0.0.1',
+        cookie: 'machine=32423423',
+        stored_credential_usage: 'FIRST'
+      })
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -305,13 +305,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   def test_failed_authorize_with_3ds
     session_id = generate_unique_id
     options = @options.merge(
-              {
-                execute_threed: true,
-                accept_header: 'text/html',
-                session_id: session_id,
-                ip: '127.0.0.1',
-                cookie: 'machine=32423423'
-              })
+      {
+        execute_threed: true,
+        accept_header: 'text/html',
+        session_id: session_id,
+        ip: '127.0.0.1',
+        cookie: 'machine=32423423'
+      })
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_match %r{missing info for 3D-secure transaction}i, first_message.message
     assert first_message.test?

--- a/test/remote/gateways/remote_worldpay_us_test.rb
+++ b/test/remote/gateways/remote_worldpay_us_test.rb
@@ -107,10 +107,10 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = WorldpayUsGateway.new(
-                :acctid => '',
-                :subid => '',
-                :merchantpin => ''
-              )
+      :acctid => '',
+      :subid => '',
+      :merchantpin => ''
+    )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert response.message =~ /DECLINED/

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -5,8 +5,8 @@ class BanwireTest < Test::Unit::TestCase
 
   def setup
     @gateway = BanwireGateway.new(
-                 :login => 'desarrollo',
-                 :currency => 'MXN')
+      :login => 'desarrollo',
+      :currency => 'MXN')
 
     @credit_card = credit_card('5204164299999999',
       :month => 11,

--- a/test/unit/gateways/be2bill_test.rb
+++ b/test/unit/gateways/be2bill_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class Be2billTest < Test::Unit::TestCase
   def setup
     @gateway = Be2billGateway.new(
-                 :login    => 'login',
-                 :password => 'password'
-               )
+      :login    => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/beanstream_interac_test.rb
+++ b/test/unit/gateways/beanstream_interac_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class BeanstreamInteracTest < Test::Unit::TestCase
   def setup
     @gateway = BeanstreamInteracGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @amount = 100
 

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -7,11 +7,11 @@ class BeanstreamTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = BeanstreamGateway.new(
-                 :login => 'merchant id',
-                 :user => 'username',
-                 :password => 'password',
-                 :api_key => 'api_key'
-               )
+      :login => 'merchant id',
+      :user => 'username',
+      :password => 'password',
+      :api_key => 'api_key'
+    )
 
     @credit_card = credit_card
 
@@ -26,9 +26,9 @@ class BeanstreamTest < Test::Unit::TestCase
     )
 
     @check = check(
-                     :institution_number => '001',
-                     :transit_number     => '26729'
-                   )
+      :institution_number => '001',
+      :transit_number     => '26729'
+    )
 
     @amount = 1000
 

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -72,20 +72,19 @@ class CheckoutTest < Test::Unit::TestCase
 
   def test_passes_correct_currency
     stub_comms do
-      @gateway.purchase(100, credit_card, @options.merge(
-        currency: 'EUR'
-      ))
+      @gateway.purchase(100, credit_card, @options.merge(currency: 'EUR'))
     end.check_request do |endpoint, data, headers|
       assert_match(/<bill_currencycode>EUR<\/bill_currencycode>/, data)
     end.respond_with(successful_purchase_response)
   end
 
   def test_passes_descriptors
+    options = @options.merge(
+      descriptor_name: 'ZahName',
+      descriptor_city: 'Oakland'
+    )
     stub_comms do
-      @gateway.purchase(100, credit_card, @options.merge(
-        descriptor_name: 'ZahName',
-        descriptor_city: 'Oakland'
-      ))
+      @gateway.purchase(100, credit_card, options)
     end.check_request do |endpoint, data, headers|
       assert_match(/<descriptor_name>ZahName<\/descriptor_name>/, data)
       assert_match(/<descriptor_city>Oakland<\/descriptor_city>/, data)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -170,9 +170,8 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
-      ignore_avs: true
-    ))
+    options = @options.merge(ignore_avs: true)
+    assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
   end
 
@@ -186,9 +185,8 @@ class CyberSourceTest < Test::Unit::TestCase
     # globally ignored AVS for gateway instance:
     @gateway.options[:ignore_avs] = true
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
-      ignore_avs: false
-    ))
+    options = @options.merge(ignore_avs: false)
+    assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
   end
 
@@ -200,8 +198,8 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
-      ignore_cvv: true
-    ))
+                                                                 ignore_cvv: true
+                                                               ))
     assert_success response
   end
 
@@ -213,8 +211,8 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
-      ignore_cvv: false
-    ))
+                                                                 ignore_cvv: false
+                                                               ))
     assert_success response
   end
 

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -5,17 +5,17 @@ class ElavonTest < Test::Unit::TestCase
 
   def setup
     @gateway = ElavonGateway.new(
-                 :login => 'login',
-                 :user => 'user',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :user => 'user',
+      :password => 'password'
+    )
 
     @multi_currency_gateway = ElavonGateway.new(
-                                :login => 'login',
-                                :user => 'user',
-                                :password => 'password',
-                                :multi_currency => true
-                              )
+      :login => 'login',
+      :user => 'user',
+      :password => 'password',
+      :multi_currency => true
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -5,9 +5,9 @@ class FatZebraTest < Test::Unit::TestCase
 
   def setup
     @gateway = FatZebraGateway.new(
-                 :username => 'TEST',
-                 :token    => 'TEST'
-               )
+      :username => 'TEST',
+      :token    => 'TEST'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/federated_canada_test.rb
+++ b/test/unit/gateways/federated_canada_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class FederatedCanadaTest < Test::Unit::TestCase
   def setup
     @gateway = FederatedCanadaGateway.new(
-                 :login => 'demo',
-                 :password => 'password'
-               )
+      :login => 'demo',
+      :password => 'password'
+    )
 
     @credit_card = credit_card('4111111111111111')
     @credit_card.verification_value = '999'

--- a/test/unit/gateways/itransact_test.rb
+++ b/test/unit/gateways/itransact_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class ItransactTest < Test::Unit::TestCase
   def setup
     @gateway = ItransactGateway.new(
-                 :login => 'login',
-                 :password => 'password',
-                 :gateway_id => '09999'
-               )
+      :login => 'login',
+      :password => 'password',
+      :gateway_id => '09999'
+    )
 
     @credit_card = credit_card
     @check = check

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -7,9 +7,9 @@ class MerchantESolutionsTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = MerchantESolutionsGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -5,10 +5,10 @@ class MerchantWareTest < Test::Unit::TestCase
 
   def setup
     @gateway = MerchantWareGateway.new(
-                 :login => 'login',
-                 :password => 'password',
-                 :name => 'name'
-               )
+      :login => 'login',
+      :password => 'password',
+      :name => 'name'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/merchant_ware_version_four_test.rb
+++ b/test/unit/gateways/merchant_ware_version_four_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class MerchantWareVersionFourTest < Test::Unit::TestCase
   def setup
     @gateway = MerchantWareVersionFourGateway.new(
-                 :login => 'login',
-                 :password => 'password',
-                 :name => 'name'
-               )
+      :login => 'login',
+      :password => 'password',
+      :name => 'name'
+    )
 
     @credit_card = credit_card
     @authorization = '1236564'

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -5,10 +5,10 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
   def setup
     @gateway = MerchantWarriorGateway.new(
-                 :merchant_uuid => '4e922de8c2a4c',
-                 :api_key => 'g6jrxa9o',
-                 :api_passphrase => 'vp4ujoem'
-               )
+      :merchant_uuid => '4e922de8c2a4c',
+      :api_key => 'g6jrxa9o',
+      :api_passphrase => 'vp4ujoem'
+    )
 
     @credit_card = credit_card
     @success_amount = 10000

--- a/test/unit/gateways/migs_test.rb
+++ b/test/unit/gateways/migs_test.rb
@@ -3,12 +3,12 @@ require 'test_helper'
 class MigsTest < Test::Unit::TestCase
   def setup
     @gateway = MigsGateway.new(
-                 login: 'login',
-                 password: 'password',
-                 secure_hash: '76AF3392002D202A60D0AB5F9D81653C',
-                 advanced_login: 'advlogin',
-                 advanced_password: 'advpass'
-               )
+      login: 'login',
+      password: 'password',
+      secure_hash: '76AF3392002D202A60D0AB5F9D81653C',
+      advanced_login: 'advlogin',
+      advanced_password: 'advpass'
+    )
     @credit_card = credit_card
     @amount = 100
     @authorization = '2070000742'

--- a/test/unit/gateways/modern_payments_cim_test.rb
+++ b/test/unit/gateways/modern_payments_cim_test.rb
@@ -5,9 +5,9 @@ class ModernPaymentsCimTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = ModernPaymentsCimGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -5,9 +5,9 @@ class NabTransactTest < Test::Unit::TestCase
 
   def setup
     @gateway = NabTransactGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
     @credit_card = credit_card
     @amount = 200
 

--- a/test/unit/gateways/netaxept_test.rb
+++ b/test/unit/gateways/netaxept_test.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 class NetaxeptTest < Test::Unit::TestCase
   def setup
     @gateway = NetaxeptGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/netpay_test.rb
+++ b/test/unit/gateways/netpay_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class NetpayTest < Test::Unit::TestCase
   def setup
     @gateway = NetpayGateway.new(
-                 :store_id => '12345',
-                 :login    => 'login',
-                 :password => 'password'
-               )
+      :store_id => '12345',
+      :login    => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 1000

--- a/test/unit/gateways/network_merchants_test.rb
+++ b/test/unit/gateways/network_merchants_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class NetworkMerchantsTest < Test::Unit::TestCase
   def setup
     @gateway = NetworkMerchantsGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @check = check

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -8,9 +8,9 @@ class PayJunctionTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = PayJunctionGateway.new(
-                 :login      => 'pj-ql-01',
-                 :password   => 'pj-ql-01p'
-               )
+      :login      => 'pj-ql-01',
+      :password   => 'pj-ql-01p'
+    )
 
     @credit_card = credit_card
     @options = {
@@ -24,15 +24,15 @@ class PayJunctionTest < Test::Unit::TestCase
     Base.mode = :production
 
     live_gw = PayJunctionGateway.new(
-                 :login      => 'l',
-                 :password   => 'p'
-               )
+      :login      => 'l',
+      :password   => 'p'
+    )
     assert_false live_gw.test?
 
     test_gw = PayJunctionGateway.new(
-                :login      => 'pj-ql-01',
-                :password   => 'pj-ql-01p'
-              )
+      :login      => 'pj-ql-01',
+      :password   => 'pj-ql-01p'
+    )
     assert test_gw.test?
   end
 

--- a/test/unit/gateways/pay_secure_test.rb
+++ b/test/unit/gateways/pay_secure_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class PaySecureTest < Test::Unit::TestCase
   def setup
     @gateway = PaySecureGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @options = {

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 class PayboxDirectTest < Test::Unit::TestCase
   def setup
     @gateway = PayboxDirectGateway.new(
-                 :login => 'l',
-                 :password => 'p'
-               )
+      :login => 'l',
+      :password => 'p'
+    )
 
     @credit_card = credit_card('1111222233334444',
       :brand => 'visa'

--- a/test/unit/gateways/payex_test.rb
+++ b/test/unit/gateways/payex_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class PayexTest < Test::Unit::TestCase
   def setup
     @gateway = PayexGateway.new(
-                 :account => 'account',
-                 :encryption_key => 'encryption_key'
-               )
+      :account => 'account',
+      :encryption_key => 'encryption_key'
+    )
 
     @credit_card = credit_card
     @amount = 1000

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -284,19 +284,19 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_use_test_certificate_endpoint
     gateway = PaypalGateway.new(
-                :login => 'cody',
-                :password => 'test',
-                :pem => 'PEM'
-              )
+      :login => 'cody',
+      :password => 'test',
+      :pem => 'PEM'
+    )
     assert_equal PaypalGateway::URLS[:test][:certificate], gateway.send(:endpoint_url)
   end
 
   def test_should_use_live_certificate_endpoint
     gateway = PaypalGateway.new(
-                :login => 'cody',
-                :password => 'test',
-                :pem => 'PEM'
-              )
+      :login => 'cody',
+      :password => 'test',
+      :pem => 'PEM'
+    )
     gateway.expects(:test?).returns(false)
 
     assert_equal PaypalGateway::URLS[:live][:certificate], gateway.send(:endpoint_url)
@@ -304,20 +304,20 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_use_test_signature_endpoint
     gateway = PaypalGateway.new(
-                :login => 'cody',
-                :password => 'test',
-                :signature => 'SIG'
-              )
+      :login => 'cody',
+      :password => 'test',
+      :signature => 'SIG'
+    )
 
     assert_equal PaypalGateway::URLS[:test][:signature], gateway.send(:endpoint_url)
   end
 
   def test_should_use_live_signature_endpoint
     gateway = PaypalGateway.new(
-                :login => 'cody',
-                :password => 'test',
-                :signature => 'SIG'
-              )
+      :login => 'cody',
+      :password => 'test',
+      :signature => 'SIG'
+    )
     gateway.expects(:test?).returns(false)
 
     assert_equal PaypalGateway::URLS[:live][:signature], gateway.send(:endpoint_url)

--- a/test/unit/gateways/payscout_test.rb
+++ b/test/unit/gateways/payscout_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class PayscoutTest < Test::Unit::TestCase
   def setup
     @gateway = PayscoutGateway.new(
-                 :username => 'xxx',
-                 :password => 'xxx'
-               )
+      :username => 'xxx',
+      :password => 'xxx'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -4,9 +4,9 @@ class PaystationTest < Test::Unit::TestCase
   include CommStub
   def setup
     @gateway = PaystationGateway.new(
-                 :paystation_id => 'some_id_number',
-                 :gateway_id    => 'another_id_number'
-               )
+      :paystation_id => 'some_id_number',
+      :gateway_id    => 'another_id_number'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class PslCardTest < Test::Unit::TestCase
   def setup
     @gateway = PslCardGateway.new(
-                 :login => 'LOGIN',
-                 :password => 'PASSWORD'
-               )
+      :login => 'LOGIN',
+      :password => 'PASSWORD'
+    )
 
     @credit_card = credit_card
     @options = {

--- a/test/unit/gateways/quantum_test.rb
+++ b/test/unit/gateways/quantum_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class QuantumTest < Test::Unit::TestCase
   def setup
     @gateway = QuantumGateway.new(
-                 :login => '',
-                 :password => ''
-               )
+      :login => '',
+      :password => ''
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/sage_test.rb
+++ b/test/unit/gateways/sage_test.rb
@@ -5,9 +5,9 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def setup
     @gateway = SageGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @check = check

--- a/test/unit/gateways/sallie_mae_test.rb
+++ b/test/unit/gateways/sallie_mae_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class SallieMaeTest < Test::Unit::TestCase
   def setup
     @gateway = SallieMaeGateway.new(
-                 :login => 'FAKEACCOUNT'
-               )
+      :login => 'FAKEACCOUNT'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/secure_net_test.rb
+++ b/test/unit/gateways/secure_net_test.rb
@@ -5,9 +5,9 @@ class SecureNetTest < Test::Unit::TestCase
 
   def setup
     @gateway = SecureNetGateway.new(
-                 :login => 'X',
-                 :password => 'Y'
-               )
+      :login => 'X',
+      :password => 'Y'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -5,9 +5,9 @@ class SecurePayAuTest < Test::Unit::TestCase
 
   def setup
     @gateway = SecurePayAuGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/secure_pay_tech_test.rb
+++ b/test/unit/gateways/secure_pay_tech_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class SecurePayTechTest < Test::Unit::TestCase
   def setup
     @gateway = SecurePayTechGateway.new(
-                 :login => 'x',
-                 :password => 'y'
-               )
+      :login => 'x',
+      :password => 'y'
+    )
 
     @amount = 100
     @credit_card = credit_card('4987654321098769')

--- a/test/unit/gateways/so_easy_pay_test.rb
+++ b/test/unit/gateways/so_easy_pay_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class SoEasyPayTest < Test::Unit::TestCase
   def setup
     @gateway = SoEasyPayGateway.new(
-                 :login => 'login',
-                 :password => 'password'
-               )
+      :login => 'login',
+      :password => 'password'
+    )
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -16,10 +16,10 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     # UsaEpayAdvancedGateway.wiredump_device.sync = true
 
     @gateway = UsaEpayAdvancedGateway.new(
-                 :login => 'X',
-                 :password => 'Y',
-                 :software_id => 'Z'
-               )
+      :login => 'X',
+      :password => 'Y',
+      :software_id => 'Z'
+    )
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
       :number => '4000100011112224',

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -5,9 +5,9 @@ class WorldpayTest < Test::Unit::TestCase
 
   def setup
     @gateway = WorldpayGateway.new(
-       :login => 'testlogin',
-       :password => 'testpassword'
-     )
+      :login => 'testlogin',
+      :password => 'testpassword'
+    )
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')


### PR DESCRIPTION
Fixes the RuboCop todo that enforces the indentation of the first
parameter in a defintion.

All unit tests:
4408 tests, 71309 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed