### PR TITLE
Credorax: Omit phone when nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Credorax: add `authorization_type` and `multiple_capture_count` GSFs [therufs] #3478
 * CardStream: use localized_amount to correctly support zero-decimal currencies [britth] #3473
 * EBANX: Add additional data in post [Ruanito] #3482
+* Credorax: Omit phone when nil [leila-alderman] #3490
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -274,12 +274,12 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         post[:d1] = options[:ip] || '127.0.0.1'
         if (billing_address = options[:billing_address])
-          post[:c5] = billing_address[:address1]
-          post[:c7] = billing_address[:city]
-          post[:c10] = billing_address[:zip]
-          post[:c8] = billing_address[:state]
-          post[:c9] = billing_address[:country]
-          post[:c2] = billing_address[:phone]
+          post[:c5]   = billing_address[:address1]  if billing_address[:address1]
+          post[:c7]   = billing_address[:city]      if billing_address[:city]
+          post[:c10]  = billing_address[:zip]       if billing_address[:zip]
+          post[:c8]   = billing_address[:state]     if billing_address[:state]
+          post[:c9]   = billing_address[:country]   if billing_address[:country]
+          post[:c2]   = billing_address[:phone]     if billing_address[:phone]
         end
       end
 

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -632,6 +632,24 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_credit_response)
   end
 
+  def test_purchase_omits_phone_when_nil
+    # purchase passes the phone number when provided
+    @options[:billing_address][:phone] = '555-444-3333'
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/c2=555-444-3333/, data)
+    end.respond_with(successful_purchase_response)
+
+    # purchase doesn't pass the phone number when nil
+    @options[:billing_address][:phone] = nil
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_not_match(/c2=/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_stored_credential_recurring_cit_initial
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do


### PR DESCRIPTION
Sending Credorax an empty phone number parameter is causing transactions
to fail. To fix this, additional `if` statements have been added to the
address to ensure that only those `billing_address` parameters that
exist are sent to the gateway.

[CE-307](https://spreedly.atlassian.net/browse/CE-307)

Unit:
62 tests, 298 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
39 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4410 tests, 71318 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed