### PR TITLE
Mundipagg: Return acquirer code as the error code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * RuboCop: Layout/SpaceInsidePercentLiteralDelimiter [leila-alderman] #3485
 * RuboCop: Layout/SpaceInsideArrayLiteralBrackets [leila-alderman] #3486
 * RuboCop: Layout/EmptyLinesAroundClassBody fix [leila-alderman] #3487
+* Mundipagg: Return acquirer code as the error code [leila-alderman] #3492
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -313,7 +313,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
-        STANDARD_ERROR_CODE[:processing_error] unless success_from(response)
+        return if success_from(response)
+        return response['last_transaction']['acquirer_return_code'] if response['last_transaction']
+        STANDARD_ERROR_CODE[:processing_error]
       end
     end
   end


### PR DESCRIPTION
When the Mundipagg gateway response includes an `acquirer_return_code`,
it will now be returned as the `error_code` in the main response.

The `acquirer_message` was already being returned as the `message` in
the main response, so this change will provide more information for
troubleshooting to supplement the existing format.

Some changes were made to existing unit tests in order to make this
update. Two of the unit tests designed to test failure messages were
expecting `processing_error` as the `error_code`, which doesn't seem
correct. Therefore, these tests were updated to expect the
`acquirer_return_code` as the `error_code`.

[CE-264](https://spreedly.atlassian.net/browse/CE-264)

Unit:
27 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
37 tests, 91 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions,
0 notifications
97.2973% passed

The remote tests are consistently returning one `ConnectionError`,
although it's for a varying remote test, which seems positive.

All unit tests:
4412 tests, 71326 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed