### PR TITLE
EBANX: Add additional data in post

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * CyberSource: Add issuer data+MDD to credit & void [leila-alderman] #3481
 * Credorax: add `authorization_type` and `multiple_capture_count` GSFs [therufs] #3478
 * CardStream: use localized_amount to correctly support zero-decimal currencies [britth] #3473
+* EBANX: Add additional data in post [Ruanito] #3482
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -51,6 +51,7 @@ module ActiveMerchant #:nodoc:
         add_card_or_token(post, payment)
         add_address(post, options)
         add_customer_responsible_person(post, payment, options)
+        add_additional_data(post, options)
 
         commit(:purchase, post)
       end
@@ -196,6 +197,10 @@ module ActiveMerchant #:nodoc:
             card_cvv: payment.verification_value
           }
         end
+      end
+
+      def add_additional_data(post, options)
+        post[:device_id] = options[:device_id] if options[:device_id]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -17,7 +17,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
         phone_number: '8522847035'
       }),
       order_id: generate_unique_id,
-      document: '853.513.468-93'
+      document: '853.513.468-93',
+      device_id: '34c376b2767'
     }
   end
 
@@ -71,7 +72,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
 
     response = @gateway.purchase(500, @credit_card, options)
     assert_success response
-    assert_equal 'Sandbox - Test credit card, transaction captured', response.message
+    assert_equal 'Accepted', response.message
   end
 
   def test_failed_purchase


### PR DESCRIPTION
Added the `device_id` gateway specific field to purchase requests
on the EBANX gateway. In addition, added this new field to the
remote gateway tests to ensure that it is working correctly.

Similiar to [a previous commit](https://github.com/activemerchant/active_merchant/commit/7ec0f94c5794592a16bfaaa7280fbf1b853e8afd),
also updated the sandbox gateway response for one of the remote tests to
`Accepted`.

[ECS-966](https://spreedly.atlassian.net/browse/ECS-966)

Unit:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
22 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4411 tests, 71319 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed