### PR TITLE
CardConnect: Remove domain validation

### DIFF
--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -63,14 +63,7 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options = {})
         requires!(options, :merchant_id, :username, :password)
-        require_valid_domain!(options, :domain)
         super
-      end
-
-      def require_valid_domain!(options, param)
-        if options[param]
-          raise ArgumentError.new('not a valid cardconnect domain') unless /\Dcardconnect.com:\d{1,}\D/ =~ options[param]
-        end
       end
 
       def purchase(money, payment, options = {})

--- a/test/unit/gateways/card_connect_test.rb
+++ b/test/unit/gateways/card_connect_test.rb
@@ -16,10 +16,8 @@ class CardConnectTest < Test::Unit::TestCase
     }
   end
 
-  def test_incorrect_domain
-    assert_raise(ArgumentError) {
-      CardConnectGateway.new(username: 'username', password: 'password', merchant_id: 'merchand_id', domain: 'www.google.com')
-    }
+  def test_allow_domains_without_ports
+    assert CardConnectGateway.new(username: 'username', password: 'password', merchant_id: 'merchand_id', domain: 'www.google.com')
   end
 
   def test_successful_purchase


### PR DESCRIPTION
CardConnect no longer requires ports to be included in their valid
domains, so this change removes that requirement, allowing customers to
use CardConnect domains without specifying a port.

[CE-209](https://spreedly.atlassian.net/browse/CE-209)

Unit:
22 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
25 tests, 58 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
92% passed

Two failing remote tests:
 - `test_successful_refund`
 - `test_partial_refund`
Both of these tests are failing with the message "Txn not settled" and
are failing on master as well. The last commit to CardConnect (Oct 2019)
shows fully passing remote tests, so something appears to have changed
in the gateway integration since then. These new failures seem to be
unrelated to the changes made in this commit.

All unit tests:
4414 tests, 71334 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed