### PR TITLE
Remove customer hash when using a payment_method_nonce

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -628,6 +628,11 @@ module ActiveMerchant #:nodoc:
 
         parameters[:line_items] = options[:line_items] if options[:line_items]
 
+        if options[:payment_method_nonce].is_a?(String)
+          parameters.delete(:customer)
+          parameters[:payment_method_nonce] = options[:payment_method_nonce]
+        end
+
         parameters
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -56,7 +56,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_transaction_uses_payment_method_nonce_when_option
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:payment_method_nonce => 'present')).
+      with(all_of(has_entries(:payment_method_nonce => 'present'), has_key(:customer))).
       returns(braintree_result)
 
     assert response = @gateway.purchase(10, 'present', { payment_method_nonce: true })
@@ -688,6 +688,26 @@ class BraintreeBlueTest < Test::Unit::TestCase
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id'})
+  end
+
+  def test_purchase_string_based_payment_method_nonce_removes_customer
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(Not(has_key(:customer))).
+      returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), payment_method_nonce: '1234')
+  end
+
+  def test_authorize_string_based_payment_method_nonce_removes_customer
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(Not(has_key(:customer))).
+      returns(braintree_result)
+
+    @gateway.authorize(100, credit_card('41111111111111111111'), payment_method_nonce: '1234')
   end
 
   def test_passes_recurring_flag


### PR DESCRIPTION
When processing 3DS based requests there is a need to create a transaction
using a payment method nonce that is generated on the client. To facilitate that
need and keep existing behaviors with payment method nonces, a check for a
string based payment method nonce was added right before finalizing sale
parameters. If the payment method nonce is a string, the customer hash will be
removed since there should already be a customer in Braintree's system.

For further information regarding the need to use a client payment method nonce,
please check here: https://developers.braintreepayments.com/guides/3d-secure/server-side/ruby

Unit:

77 tests, 178 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

80 tests, 435 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed