### PR TITLE
RuboCop: Fix Layout/EmptyLineAfterGuardClause

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,11 +23,6 @@ Gemspec/OrderedDependencies:
 Layout/AlignHash:
   Enabled: false
 
-# Offense count: 167
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 # Offense count: 255
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * RuboCop: Fix Layout/FirstParameterIndentation [leila-alderman] #3489
 * Braintree Blue: Remove customer hash when using a payment_method_nonce #3495
 * Credorax: Update non-standard currencies list [chinhle23] #3499
+* RuboCop: Fix Layout/EmptyLineAfterGuardClause [leila-alderman] #3496
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -99,6 +99,7 @@ module ActiveMerchant
 
             self.each do |key, messages|
               next unless(messages && !messages.empty?)
+
               if key == 'base'
                 result << messages.first.to_s
               else

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -247,6 +247,7 @@ module ActiveMerchant #:nodoc:
 
         def last_digits(number)
           return '' if number.nil?
+
           number.length <= 4 ? number : number.slice(-4..-1)
         end
 
@@ -268,11 +269,13 @@ module ActiveMerchant #:nodoc:
 
         def valid_card_number_length?(number) #:nodoc:
           return false if number.nil?
+
           number.length >= 12
         end
 
         def valid_card_number_characters?(number) #:nodoc:
           return false if number.nil?
+
           !number.match(/\D/)
         end
 

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -249,6 +249,7 @@ module ActiveMerchant #:nodoc:
 
       def amount(money)
         return nil if money.nil?
+
         cents =
           if money.respond_to?(:cents)
             ActiveMerchant.deprecated 'Support for Money objects is deprecated and will be removed from a future release of ActiveMerchant. Please use an Integer value in cents'
@@ -278,6 +279,7 @@ module ActiveMerchant #:nodoc:
         amount = amount(money)
 
         return amount unless non_fractional_currency?(currency) || three_decimal_currency?(currency)
+
         if non_fractional_currency?(currency)
           if self.money_format == :cents
             sprintf('%.0f', amount.to_f / 100)
@@ -299,6 +301,7 @@ module ActiveMerchant #:nodoc:
 
       def truncate(value, max_size)
         return nil unless value
+
         value.to_s[0, max_size]
       end
 

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -228,6 +228,7 @@ module ActiveMerchant #:nodoc:
 
       def add_splits(post, options)
         return unless split_data = options[:splits]
+
         splits = []
         split_data.each do |split|
           amount = {
@@ -271,6 +272,7 @@ module ActiveMerchant #:nodoc:
 
       def add_recurring_processing_model(post, options)
         return unless options.dig(:stored_credential, :reason_type) || options[:recurring_processing_model]
+
         if options.dig(:stored_credential, :reason_type) && options[:stored_credential][:reason_type] == 'unscheduled'
           recurring_processing_model = 'CardOnFile'
         else
@@ -291,6 +293,7 @@ module ActiveMerchant #:nodoc:
           post[:deliveryAddress][:country] = address[:country] if address[:country]
         end
         return unless post[:card]&.kind_of?(Hash)
+
         if (address = options[:billing_address] || options[:address]) && address[:country]
           post[:billingAddress] = {}
           post[:billingAddress][:street] = address[:address1] || 'NA'
@@ -352,6 +355,7 @@ module ActiveMerchant #:nodoc:
 
       def capture_options(options)
         return options.merge(idempotency_key: "#{options[:idempotency_key]}-cap") if options[:idempotency_key]
+
         options
       end
 
@@ -379,6 +383,7 @@ module ActiveMerchant #:nodoc:
 
       def add_recurring_contract(post, options = {})
         return unless options[:recurring_contract_type]
+
         recurring = {
           contract: options[:recurring_contract_type]
         }
@@ -408,6 +413,7 @@ module ActiveMerchant #:nodoc:
           end
         else
           return unless options[:execute_threed] || options[:threed_dynamic]
+
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
           post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
         end
@@ -453,6 +459,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         return {} if body.blank?
+
         JSON.parse(body)
       end
 
@@ -532,6 +539,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(action, response)
         return authorize_message_from(response) if action.to_s == 'authorise' || action.to_s == 'authorise3d'
+
         response['response'] || response['message'] || response['result']
       end
 
@@ -569,6 +577,7 @@ module ActiveMerchant #:nodoc:
 
       def add_browser_info(browser_info, post)
         return unless browser_info
+
         post[:browserInfo] = {
           acceptHeader: browser_info[:accept_header],
           colorDepth: browser_info[:depth],

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -142,6 +142,7 @@ module ActiveMerchant #:nodoc:
           response = parse(raw_response)
         rescue ResponseError => e
           raise unless(e.response.code.to_s =~ /4\d\d/)
+
           response = parse(e.response.body)
         end
 

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -390,6 +390,7 @@ module ActiveMerchant
 
       def add_payment_source(xml, source, options, action = nil)
         return unless source
+
         if source.is_a?(String)
           add_token_payment_method(xml, source, options)
         elsif card_brand(source) == 'check'
@@ -517,6 +518,7 @@ module ActiveMerchant
 
       def add_market_type_device_type(xml, payment, options)
         return if payment.is_a?(String) || card_brand(payment) == 'check' || card_brand(payment) == 'apple_pay'
+
         if valid_track_data
           xml.retail do
             xml.marketType(options[:market_type] || MARKET_TYPE[:retail])

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -230,6 +230,7 @@ module ActiveMerchant #:nodoc:
       def add_interval(xml, options)
         interval = options[:interval]
         return unless interval
+
         xml.tag!('interval') do
           # The measurement of time, in association with the Interval Unit,
           # that is used to define the frequency of the billing occurrences
@@ -244,6 +245,7 @@ module ActiveMerchant #:nodoc:
       def add_duration(xml, options)
         duration = options[:duration]
         return unless duration
+
         # The date the subscription begins
         # (also the date the initial billing occurs)
         xml.tag!('startDate', duration[:start_date]) if duration[:start_date]
@@ -253,6 +255,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_schedule(xml, options)
         return unless options[:interval] || options[:duration]
+
         xml.tag!('paymentSchedule') do
           # Contains information about the interval of time between payments
           add_interval(xml, options)
@@ -267,6 +270,7 @@ module ActiveMerchant #:nodoc:
       # Adds customer's credit card or bank account payment information
       def add_payment(xml, options)
         return unless options[:credit_card] || options[:bank_account]
+
         xml.tag!('payment') do
           # Contains the customer’s credit card information
           add_credit_card(xml, options)
@@ -281,6 +285,7 @@ module ActiveMerchant #:nodoc:
       def add_credit_card(xml, options)
         credit_card = options[:credit_card]
         return unless credit_card
+
         xml.tag!('creditCard') do
           # The credit card number used for payment of the subscription
           xml.tag!('cardNumber', credit_card.number)
@@ -295,6 +300,7 @@ module ActiveMerchant #:nodoc:
       def add_bank_account(xml, options)
         bank_account = options[:bank_account]
         return unless bank_account
+
         xml.tag!('bankAccount') do
           # The type of bank account used for payment of the subscription
           xml.tag!('accountType', bank_account[:account_type])
@@ -317,6 +323,7 @@ module ActiveMerchant #:nodoc:
       def add_order(xml, options)
         order = options[:order]
         return unless order
+
         xml.tag!('order') do
           # Merchant-assigned invoice number for the subscription (optional)
           xml.tag!('invoiceNumber', order[:invoice_number])
@@ -329,6 +336,7 @@ module ActiveMerchant #:nodoc:
       def add_customer(xml, options)
         customer = options[:customer]
         return unless customer
+
         xml.tag!('customer') do
           xml.tag!('type', customer[:type]) if customer[:type]
           xml.tag!('id', customer[:id]) if customer[:id]
@@ -344,6 +352,7 @@ module ActiveMerchant #:nodoc:
       def add_drivers_license(xml, options)
         return unless customer = options[:customer]
         return unless drivers_license = customer[:drivers_license]
+
         xml.tag!('driversLicense') do
           # The customer's driver's license number
           xml.tag!('number', drivers_license[:number])
@@ -357,6 +366,7 @@ module ActiveMerchant #:nodoc:
       # Adds address information
       def add_address(xml, container_name, address)
         return if address.blank?
+
         xml.tag!(container_name) do
           xml.tag!('firstName', address[:first_name])
           xml.tag!('lastName', address[:last_name])

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -791,6 +791,7 @@ module ActiveMerchant #:nodoc:
       # when the payment method is credit card.
       def add_credit_card(xml, credit_card)
         return unless credit_card
+
         xml.tag!('creditCard') do
           # The credit card number used for payment of the subscription
           xml.tag!('cardNumber', full_or_masked_card_number(credit_card.number))

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -166,6 +166,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, address)
         raise ArgumentError.new('Address is required') unless address
+
         xml.tag! 'Address' do
           xml.tag! 'Street', "#{address[:address1]} #{address[:address2]}".strip
           xml.tag! 'City', address[:city]

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -168,6 +168,7 @@ module ActiveMerchant #:nodoc:
               ))
           rescue ResponseError => e
             raise unless(e.response.code.to_s =~ /4\d\d/)
+
             parse(e.response.body)
           end
 
@@ -226,6 +227,7 @@ module ActiveMerchant #:nodoc:
 
         params.map do |key, value|
           next if value.blank?
+
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -184,6 +184,7 @@ module ActiveMerchant #:nodoc:
         authorization = [parameters[:originalReference], response['pspReference']].compact
 
         return nil if authorization.empty?
+
         return authorization.join('#')
       end
 
@@ -238,6 +239,7 @@ module ActiveMerchant #:nodoc:
         return response['resultCode'] if response.has_key?('resultCode') # Payment request
         return response['response'] if response['response'] # Modification request
         return response['result'] if response.has_key?('result') # Store/Recurring request
+
         'Failure' # Negative fallback in case of error
       end
 
@@ -367,6 +369,7 @@ module ActiveMerchant #:nodoc:
           end
         else
           return unless options[:execute_threed] || options[:threed_dynamic]
+
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
           post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
         end
@@ -374,6 +377,7 @@ module ActiveMerchant #:nodoc:
 
       def add_browser_info(browser_info, post)
         return unless browser_info
+
         post[:browserInfo] = {
           acceptHeader: browser_info[:accept_header],
           colorDepth: browser_info[:depth],

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -258,6 +258,7 @@ module ActiveMerchant #:nodoc:
       def prepare_address_for_non_american_countries(options)
         [options[:billing_address], options[:shipping_address]].compact.each do |address|
           next if empty?(address[:country])
+
           unless ['US', 'CA'].include?(address[:country])
             address[:state] = '--'
             address[:zip]   = '000000' unless address[:zip]
@@ -366,6 +367,7 @@ module ActiveMerchant #:nodoc:
           if interval.respond_to? :parts
             parts = interval.parts
             raise ArgumentError.new("Cannot recur with mixed interval (#{interval}). Use only one of: days, weeks, months or years") if parts.length > 1
+
             parts.first
           elsif interval.kind_of? Hash
             requires!(interval, :unit)

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -513,6 +513,7 @@ module ActiveMerchant #:nodoc:
 
       def handle_response(response)
         return response.body if ignore_http_status || (200...300).cover?(response.code.to_i)
+
         raise ResponseError.new(response)
       end
     end

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -256,6 +256,7 @@ module ActiveMerchant
 
       def add_level_3_data(doc, options)
         return unless options[:customer_reference_number]
+
         doc.send('level-3-data') do
           send_when_present(doc, :customer_reference_number, options)
           send_when_present(doc, :sales_tax_amount, options)
@@ -273,6 +274,7 @@ module ActiveMerchant
 
       def send_when_present(doc, options_key, options, xml_element_name = nil)
         return unless options[options_key]
+
         xml_element_name ||= options_key.to_s
 
         doc.send(xml_element_name.dasherize, options[options_key])
@@ -414,6 +416,7 @@ module ActiveMerchant
 
       def message_from(succeeded, response)
         return 'Success' if succeeded
+
         parsed = parse(response)
         if parsed.dig('error-name') == 'FRAUD_DETECTED'
           fraud_codes_from(response)
@@ -447,6 +450,7 @@ module ActiveMerchant
 
       def vaulted_shopper_id(parsed_response, payment_method_details)
         return nil unless parsed_response['content-location-header']
+
         vaulted_shopper_id = parsed_response['content-location-header'].split('/').last
         vaulted_shopper_id += "|#{payment_method_details.payment_method_type}" if payment_method_details.alt_transaction?
         vaulted_shopper_id

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -14,6 +14,7 @@ module BraintreeCommon
 
   def scrub(transcript)
     return '' if transcript.blank?
+
     transcript.
       gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
       gsub(%r((&?ccnumber=)\d*(&?)), '\1[FILTERED]\2').

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -291,6 +291,7 @@ module ActiveMerchant #:nodoc:
           zip.gsub(/[^a-z0-9]/i, '').length > 9 ||
           zip =~ /[^a-z0-9\- ]/i
         )
+
         zip
       end
 
@@ -638,6 +639,7 @@ module ActiveMerchant #:nodoc:
 
       def add_3ds_info(parameters, three_d_secure_opts)
         return if empty?(three_d_secure_opts)
+
         pass_thru = {}
 
         pass_thru[:three_d_secure_version] = three_d_secure_opts[:version] if three_d_secure_opts[:version]
@@ -660,6 +662,7 @@ module ActiveMerchant #:nodoc:
 
       def add_stored_credential_data(parameters, credit_card_or_vault_id, options)
         return unless (stored_credential = options[:stored_credential])
+
         parameters[:external_vault] = {}
         if stored_credential[:initial_transaction]
           parameters[:external_vault][:status] = 'will_vault'

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -288,6 +288,7 @@ module ActiveMerchant #:nodoc:
         )
       rescue ResponseError => e
         return Response.new(false, 'Unable to authenticate.  Please check your credentials.', {}, :test => test?) if e.response.code == '401'
+
         raise
       end
 

--- a/lib/active_merchant/billing/gateways/cardprocess.rb
+++ b/lib/active_merchant/billing/gateways/cardprocess.rb
@@ -123,6 +123,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         return if money.nil?
+
         post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money))
         post[:merchantInvoiceId] = options[:merchant_invoice_id] if options[:merchant_invoice_id]
@@ -132,6 +133,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(post, payment)
         return if payment.is_a?(String)
+
         post[:paymentBrand] = payment.brand.upcase if payment.brand
         post[:card] ||= {}
         post[:card][:number] = payment.number

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -145,6 +145,7 @@ module ActiveMerchant #:nodoc:
         elsif response.code.to_i == 302
           return ssl_get(URI.parse(response['location']))
         end
+
         raise ResponseError.new(response)
       end
 

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -194,6 +194,7 @@ module ActiveMerchant #:nodoc:
 
         params.map do |key, value|
           next if value.blank?
+
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -277,6 +277,7 @@ module ActiveMerchant #:nodoc:
       def cvv_result_code(xml)
         cvv = validation_result_element(xml, 'CVV')
         return nil unless cvv
+
         validation_result_matches?(*validation_result_element_text(cvv.parent)) ? 'M' : 'N'
       end
 

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -157,6 +157,7 @@ module ActiveMerchant #:nodoc:
           response['id'] = response['_links']['payment']['href'].split('/')[-1] if action == :capture && response.key?('_links')
         rescue ResponseError => e
           raise unless e.response.code.to_s =~ /4\d\d/
+
           response = parse(e.response.body)
         end
 
@@ -257,6 +258,7 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(succeeded, response)
         return if succeeded
+
         if response['error_type'] && response['error_codes']
           "#{response['error_type']}: #{response['error_codes'].join(', ')}"
         elsif response['error_type']

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -165,6 +165,7 @@ module ActiveMerchant #:nodoc:
             parse(ssl_post(url, body, headers))
           rescue ResponseError => e
             raise unless(e.response.code.to_s =~ /400/)
+
             parse(e.response.body)
           end
 

--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -170,6 +170,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         return {} unless body
+
         JSON.parse(body)
       end
 
@@ -187,6 +188,7 @@ module ActiveMerchant #:nodoc:
 
       def conekta_client_user_agent(options)
         return user_agent unless options[:application]
+
         JSON.dump(JSON.parse(user_agent).merge!({application: options[:application]}))
       end
 

--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -175,6 +175,7 @@ module ActiveMerchant #:nodoc:
 
       def add_additional_verification(xml, options)
         return unless (options[:verify_zip].to_s == 'true') || (options[:verify_address].to_s == 'true')
+
         if address = options[:billing_address]
           xml.AdditionalVerification do
             xml.Zip address[:zip] if options[:verify_zip].to_s == 'true'

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -259,6 +259,7 @@ module ActiveMerchant #:nodoc:
         add_transaction_type(post, options)
         # if :transaction_type option is not passed, then check for :stored_credential options
         return unless (stored_credential = options[:stored_credential]) && options.dig(:transaction_type).nil?
+
         if stored_credential[:initiator] == 'merchant'
           case stored_credential[:reason_type]
           when 'recurring'

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -238,6 +238,7 @@ module ActiveMerchant #:nodoc:
         return true if response['returnCode'] == '  00'
         return true if response['returnCode'] == 'true'
         return true if response['recurReturnCode'] == '  00'
+
         return false
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -458,6 +458,7 @@ module ActiveMerchant #:nodoc:
 
       def add_merchant_descriptor(xml, options)
         return unless options[:merchant_descriptor]
+
         xml.tag! 'invoiceHeader' do
           xml.tag! 'merchantDescriptor', options[:merchant_descriptor]
         end
@@ -519,6 +520,7 @@ module ActiveMerchant #:nodoc:
 
       def add_other_tax(xml, options)
         return unless options[:local_tax_amount] || options[:national_tax_amount]
+
         xml.tag! 'otherTax' do
           xml.tag! 'localTaxAmount', options[:local_tax_amount] if options[:local_tax_amount]
           xml.tag! 'nationalTaxAmount', options[:national_tax_amount] if options[:national_tax_amount]
@@ -592,6 +594,7 @@ module ActiveMerchant #:nodoc:
       def stored_credential_commerce_indicator(options)
         return unless options[:stored_credential]
         return if options[:stored_credential][:initial_transaction]
+
         case options[:stored_credential][:reason_type]
         when 'installment' then 'install'
         when 'recurring' then 'recurring'
@@ -748,6 +751,7 @@ module ActiveMerchant #:nodoc:
 
       def add_installments(xml, options)
         return unless options[:installment_total_count]
+
         xml.tag! 'installment' do
           xml.tag! 'totalCount', options[:installment_total_count]
         end
@@ -773,6 +777,7 @@ module ActiveMerchant #:nodoc:
 
       def add_stored_credential_options(xml, options={})
         return unless options[:stored_credential]
+
         if options[:stored_credential][:initial_transaction]
           xml.tag! 'subsequentAuthFirst', 'true'
         elsif options[:stored_credential][:reason_type] == 'unscheduled'
@@ -874,6 +879,7 @@ module ActiveMerchant #:nodoc:
 
       def reason_message(reason_code)
         return if reason_code.blank?
+
         @@response_codes[:"r#{reason_code}"]
       end
 

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -89,6 +89,7 @@ module ActiveMerchant #:nodoc:
 
       def add_country(post, card, options)
         return unless address = options[:billing_address] || options[:address]
+
         post[:country] = lookup_country_code(address[:country])
       end
 
@@ -111,6 +112,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, card, options)
         return unless address = options[:billing_address] || options[:address]
+
         address_object = {}
         address_object[:state] = address[:state] if address[:state]
         address_object[:city] = address[:city] if address[:city]
@@ -165,6 +167,7 @@ module ActiveMerchant #:nodoc:
       # we count 100 as a success.
       def success_from(action, response)
         return false unless response['status_code']
+
         ['100', '200', '400', '600'].include? response['status_code'].to_s
       end
 
@@ -178,6 +181,7 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(action, response)
         return if success_from(action, response)
+
         code = response['status_code'] || response['code']
         code&.to_s
       end

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -188,6 +188,7 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_get(url + "/customers/#{options[:customer_id]}", headers(options)))
 
         return response.try(:[], 'data').try(:[], 'customerId') if success_from(response)
+
         return nil
       end
 
@@ -228,6 +229,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         return response['message'] if response['message']
         return 'Success' if success_from(response)
+
         response['errors'].map { |error_hash| error_hash['detail'] }.join(', ')
       end
 
@@ -276,6 +278,7 @@ module ActiveMerchant #:nodoc:
         return 'cardSplit' if options[:payment_type] == 'card_split'
         return 'tokenSplit' if options[:payment_type] == 'token_split'
         return 'token' if payment.is_a? String
+
         'card'
       end
 

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -239,6 +239,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(response)
         return response['status_message'] if response['status'] == 'ERROR'
+
         response.try(:[], 'payment').try(:[], 'transaction_status').try(:[], 'description')
       end
 
@@ -253,22 +254,26 @@ module ActiveMerchant #:nodoc:
       def post_data(action, parameters = {})
         return nil if requires_http_get(action)
         return convert_to_url_form_encoded(parameters) if action == :refund
+
         "request_body=#{parameters.to_json}"
       end
 
       def url_for(hostname, action, parameters)
         return "#{hostname}#{URL_MAP[action]}?#{convert_to_url_form_encoded(parameters)}" if requires_http_get(action)
+
         "#{hostname}#{URL_MAP[action]}"
       end
 
       def requires_http_get(action)
         return true if [:capture, :void].include?(action)
+
         false
       end
 
       def convert_to_url_form_encoded(parameters)
         parameters.map do |key, value|
           next if value != false && value.blank?
+
           "#{key}=#{value}"
         end.compact.join('&')
       end
@@ -276,6 +281,7 @@ module ActiveMerchant #:nodoc:
       def error_code_from(response, success)
         unless success
           return response['status_code'] if response['status'] == 'ERROR'
+
           response.try(:[], 'payment').try(:[], 'transaction_status').try(:[], 'code')
         end
       end

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -190,6 +190,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(message)
         return 'Unspecified error' if message.blank?
+
         message.gsub(/[^\w]/, ' ').split.join(' ').capitalize
       end
 

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -287,6 +287,7 @@ module ActiveMerchant #:nodoc:
 
       def custom_field?(field_name, options)
         return true if options[:custom_fields]&.include?(field_name.to_sym)
+
         field_name == :customer_number
       end
 

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -145,6 +145,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(message)
         return '' if message.blank?
+
         MESSAGES[message[0, 2]] || message
       end
 

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -268,6 +268,7 @@ module ActiveMerchant #:nodoc:
 
       def add_credit_card(params, credit_card, options)
         return unless credit_card
+
         params['Customer'] ||= {}
         if credit_card.respond_to? :number
           card_details = params['Customer']['CardDetails'] = {}

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -150,6 +150,7 @@ module ActiveMerchant #:nodoc:
             parse(ssl_request(method, get_url(uri), parameters.to_json, headers))
           rescue ResponseError => e
             return Response.new(false, 'Invalid Login') if(e.response.code == '401')
+
             parse(e.response.body)
           end
 

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -83,6 +83,7 @@ module ActiveMerchant #:nodoc:
         end
         element.children.each do |child|
           next if child.text?
+
           response[child.name] = child.text
         end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -315,6 +315,7 @@ module ActiveMerchant #:nodoc:
 
       def add_stored_credentials(xml, card, options)
         return unless options[:stored_credential]
+
         xml.tag! 'StoredCredentials' do
           xml.tag! 'Indicator', stored_credential_indicator(xml, card, options)
           if initiator = options.dig(:stored_credential, :initiator)

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -137,6 +137,7 @@ module ActiveMerchant #:nodoc:
 
       def add_shipping_address(post, options)
         return unless options[:shipping_address]
+
         address = options[:shipping_address]
 
         post[:shipping_address] = {}

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -196,6 +196,7 @@ EOA
 
       def escape(string, max_length=250)
         return '' unless string
+
         string = string[0...max_length] if max_length
         string.gsub(/[^A-Za-z0-9 \-_@\.\n]/, '')
       end

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -206,6 +206,7 @@ module ActiveMerchant #:nodoc:
 
       def strip_leading_zero(value)
         return value unless value[0] == '0'
+
         value[1, 1]
       end
 
@@ -337,6 +338,7 @@ module ActiveMerchant #:nodoc:
         return 'The card was declined.' if %w(02 03 04 05 41 43 44 51 56 61 62 63 65 78).include?(code)
         return 'An error occurred while processing the card.' if %w(06 07 12 15 19 12 52 53 57 58 76 77 91 96 EC).include?(code)
         return "The card's security code is incorrect." if %w(EB N7).include?(code)
+
         ISSUER_MESSAGES[code]
       end
 

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -371,6 +371,7 @@ module ActiveMerchant #:nodoc:
 
       def add_vendor_data(xml, options)
         return if options[:vendor_data].blank?
+
         xml.VendorData {
           options[:vendor_data].each do |k, v|
             xml.Element {

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -66,6 +66,7 @@ module ActiveMerchant #:nodoc:
       def verify_credentials
         void = void('', options)
         return true if void.message == 'Missing OriginalMerchantTrace'
+
         false
       end
 

--- a/lib/active_merchant/billing/gateways/latitude19.rb
+++ b/lib/active_merchant/billing/gateways/latitude19.rb
@@ -364,6 +364,7 @@ module ActiveMerchant #:nodoc:
       def error_from(response)
         return response['error'] if response['error']
         return 'Failed' unless response.key?('result')
+
         return response['result']['pgwResponseCode'] || response['result']['processor']['responseCode'] || 'Failed'
       end
 

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -202,6 +202,7 @@ module ActiveMerchant #:nodoc:
 
       def check?(payment_method)
         return false if payment_method.is_a?(String)
+
         card_brand(payment_method) == 'check'
       end
 
@@ -381,6 +382,7 @@ module ActiveMerchant #:nodoc:
 
       def order_source(options={})
         return options[:order_source] unless options[:stored_credential]
+
         order_source = nil
 
         case options[:stored_credential][:reason_type]
@@ -456,6 +458,7 @@ module ActiveMerchant #:nodoc:
 
       def success_from(kind, parsed)
         return (parsed[:response] == '000') unless kind == :registerToken
+
         %w(000 801 802).include?(parsed[:response])
       end
 

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -175,6 +175,7 @@ module ActiveMerchant
 
       def add_3dsecure_id(post, options)
         return unless options[:threed_secure_id]
+
         post.merge!({'3DSecureId' => options[:threed_secure_id]})
       end
 

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -108,6 +108,7 @@ module ActiveMerchant #:nodoc:
 
       def add_processing_mode(post, options)
         return unless options[:processing_mode]
+
         post[:processing_mode] = options[:processing_mode]
         post[:merchant_account_id] = options[:merchant_account_id] if options[:merchant_account_id]
         add_merchant_services(post, options)
@@ -115,6 +116,7 @@ module ActiveMerchant #:nodoc:
 
       def add_merchant_services(post, options)
         return unless options[:fraud_scoring] || options[:fraud_manual_review]
+
         merchant_services = {}
         merchant_services[:fraud_scoring] = options[:fraud_scoring] if options[:fraud_scoring]
         merchant_services[:fraud_manual_review] = options[:fraud_manual_review] if options[:fraud_manual_review]

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -213,6 +213,7 @@ module ActiveMerchant #:nodoc:
         # if any of :issuer_id, :payment_information, or :payment_indicator is not passed,
         # then check for :stored credential options
         return unless (stored_credential = options[:stored_credential]) && !cof_details_present?(options)
+
         if stored_credential[:initial_transaction]
           add_stored_credential_initial(post, options)
         else
@@ -306,6 +307,7 @@ module ActiveMerchant #:nodoc:
       def hashify_xml!(xml, response)
         xml = REXML::Document.new(xml)
         return if xml.root.nil?
+
         xml.elements.each('//receipt/*') do |node|
           response[node.name.underscore.to_sym] = normalize(node.text)
         end
@@ -382,11 +384,13 @@ module ActiveMerchant #:nodoc:
       def wallet_indicator(token_source)
         return 'APP' if token_source == 'apple_pay'
         return 'ANP' if token_source == 'android_pay'
+
         nil
       end
 
       def message_from(message)
         return 'Unspecified error' if message.blank?
+
         message.gsub(/[^\w]/, ' ').split.join(' ').capitalize
       end
 

--- a/lib/active_merchant/billing/gateways/moneris_us.rb
+++ b/lib/active_merchant/billing/gateways/moneris_us.rb
@@ -249,6 +249,7 @@ module ActiveMerchant #:nodoc:
       def hashify_xml!(xml, response)
         xml = REXML::Document.new(xml)
         return if xml.root.nil?
+
         xml.elements.each('//receipt/*') do |node|
           response[node.name.underscore.to_sym] = normalize(node.text)
         end
@@ -316,6 +317,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(message)
         return 'Unspecified error' if message.blank?
+
         message.gsub(/[^\w]/, ' ').split.join(' ').capitalize
       end
 

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -198,6 +198,7 @@ module ActiveMerchant #:nodoc:
 
       def voucher?(payment)
         return false if payment.is_a?(String)
+
         %w[sodexo vr].include? card_brand(payment)
       end
 
@@ -301,6 +302,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response, action)
         return "#{response['customer']['id']}|#{response['id']}" if action == 'store'
+
         response['id']
       end
 
@@ -315,6 +317,7 @@ module ActiveMerchant #:nodoc:
       def error_code_from(response)
         return if success_from(response)
         return response['last_transaction']['acquirer_return_code'] if response['last_transaction']
+
         STANDARD_ERROR_CODE[:processing_error]
       end
     end

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -84,6 +84,7 @@ module ActiveMerchant #:nodoc:
 
       def scrub(transcript)
         return '' if transcript.blank?
+
         transcript.
           gsub(%r((<cardNumber>)[^<]+(<))i, '\1[FILTERED]\2').
           gsub(%r((<cvv>)[^<]+(<))i, '\1[FILTERED]\2').

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -168,6 +168,7 @@ module ActiveMerchant #:nodoc:
 
       def map_address(address)
         return {} if address.nil?
+
         country = Country.find(address[:country]) if address[:country]
         mapped = {
           :street => address[:address1],
@@ -204,6 +205,7 @@ module ActiveMerchant #:nodoc:
             parse(ssl_request(method, get_url(uri), params, headers))
           rescue ResponseError => e
             return Response.new(false, 'Invalid Login') if(e.response.code == '401')
+
             parse(e.response.body)
           end
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -201,6 +201,7 @@ module ActiveMerchant #:nodoc:
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless(e.response.code =~ /^[67]\d\d$/)
+
         return Response.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
       end
 

--- a/lib/active_merchant/billing/gateways/netpay.rb
+++ b/lib/active_merchant/billing/gateways/netpay.rb
@@ -215,6 +215,7 @@ module ActiveMerchant #:nodoc:
 
       def currency_code(currency)
         return currency if currency =~ /^\d+$/
+
         CURRENCY_CODES[currency]
       end
     end

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -239,6 +239,7 @@ module ActiveMerchant #:nodoc:
 
       def reference_transaction?(identifier)
         return false unless identifier.is_a?(String)
+
         _, action = identifier.split(';')
         !action.nil?
       end
@@ -322,6 +323,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, creditcard, options)
         return unless options[:billing_address]
+
         add_pair post, 'Owneraddress', options[:billing_address][:address1]
         add_pair post, 'OwnerZip',     options[:billing_address][:zip]
         add_pair post, 'ownertown',    options[:billing_address][:city]

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -151,6 +151,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(card, options)
         return unless card.kind_of?(Hash)
+
         if address = (options[:billing_address] || options[:address])
           card[:address] = {
             line1: address[:address1],
@@ -175,6 +176,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         return {} unless body
+
         JSON.parse(body)
       end
 

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -258,6 +258,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment, options)
         return if payment.is_a?(String)
+
         if options[:registrationId]
           post[:card] = {
             cvv: payment.verification_value,

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -165,6 +165,7 @@ module ActiveMerchant #:nodoc:
         end
         REXML::XPath.each(response, '//detail') do |detail|
           next unless detail.is_a?(REXML::Element)
+
           tag = detail.elements['tag'].text
           value = detail.elements['value'].text
           hsh[tag] = value

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -550,6 +550,7 @@ module ActiveMerchant #:nodoc:
 
       def add_stored_credentials(xml, parameters)
         return unless parameters[:mit_stored_credential_ind] == 'Y' || parameters[:stored_credential] && !parameters[:stored_credential].values.all?(&:nil?)
+
         if msg_type = get_msg_type(parameters)
           xml.tag! :MITMsgType, msg_type
         end
@@ -565,6 +566,7 @@ module ActiveMerchant #:nodoc:
         return parameters[:mit_msg_type] if parameters[:mit_msg_type]
         return 'CSTO' if parameters[:stored_credential][:initial_transaction]
         return unless parameters[:stored_credential][:initiator] && parameters[:stored_credential][:reason_type]
+
         initiator =
           case parameters[:stored_credential][:initiator]
           when 'customer' then 'C'
@@ -726,6 +728,7 @@ module ActiveMerchant #:nodoc:
       def set_recurring_ind(xml, parameters)
         if parameters[:recurring_ind]
           raise 'RecurringInd must be set to either "RF" or "RS"' unless %w(RF RS).include?(parameters[:recurring_ind])
+
           xml.tag! :RecurringInd, parameters[:recurring_ind]
         end
       end
@@ -831,6 +834,7 @@ module ActiveMerchant #:nodoc:
 
         value.to_s.each_char do |c|
           break if((limited_value.bytesize + c.bytesize) > byte_length)
+
           limited_value << c
         end
 

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -139,6 +139,7 @@ module ActiveMerchant #:nodoc:
 
       def endpoint(action)
         return 'void' if action == 'void'
+
         'submit'
       end
 

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -119,6 +119,7 @@ module ActiveMerchant #:nodoc:
 
         params.map do |key, value|
           next if value != false && value.blank?
+
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -86,6 +86,7 @@ module ActiveMerchant #:nodoc:
 
       def force_utf8(string)
         return nil unless string
+
         binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?') # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
         binary.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
       end

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -145,6 +145,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, address)
         return unless address
+
         post[:address1] = address[:address1]
         post[:address2] = address[:address2]
         post[:zip] = address[:zip]

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -168,6 +168,7 @@ module ActiveMerchant #:nodoc:
 
       def success_from(response)
         return response['response']['approved'] if response['response']
+
         false
       end
 

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -305,6 +305,7 @@ module ActiveMerchant
 
       def post_data(params)
         return nil unless params
+
         params.reject { |k, v| v.blank? }.collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
@@ -335,6 +336,7 @@ module ActiveMerchant
 
       def error_code(response, success)
         return if success
+
         response['Error'].to_h['messages'].to_a.map { |e| e['code'] }.join(', ')
       end
 

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -132,6 +132,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, tag, address, options)
         return if address.nil?
+
         xml.tag! tag do
           xml.tag! 'Name', address[:name] unless address[:name].blank?
           xml.tag! 'EMail', options[:email] unless options[:email].blank?

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -236,6 +236,7 @@ module ActiveMerchant #:nodoc:
       def card_success_from(response)
         return false if response.include?('error')
         return true if response['message'] == 'card deleted'
+
         response['card']['status'] == 'valid'
       end
 
@@ -274,6 +275,7 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(response)
         return if success_from(response)
+
         if response['transaction']
           detail = response['transaction']['status_detail']
           return STANDARD_ERROR_CODE[STANDARD_ERROR_CODE_MAPPING[detail]] if STANDARD_ERROR_CODE_MAPPING.include?(detail)

--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
       def build_setup_request(action, money, options)
         requires!(options, :items)
         raise ArgumentError, 'Must include at least 1 Item' unless options[:items].length > 0
+
         options[:items].each do |item|
           requires!(item, :name, :number, :quantity, :amount, :description, :category)
           raise ArgumentError, "Each of the items must have the category 'Digital'" unless item[:category] == 'Digital'

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -180,6 +180,7 @@ module ActiveMerchant #:nodoc:
 
       def billing_address_fields(options)
         return unless address = options[:billing_address]
+
         billing_address = {}
         billing_address[:street1] = address[:address1]
         billing_address[:street2] = address[:address2]
@@ -217,6 +218,7 @@ module ActiveMerchant #:nodoc:
 
       def shipping_address_fields(options)
         return unless address = options[:shipping_address]
+
         shipping_address = {}
         shipping_address[:street1] = address[:address1]
         shipping_address[:street2] = address[:address2]
@@ -292,6 +294,7 @@ module ActiveMerchant #:nodoc:
 
       def add_process_without_cvv2(payment_method, options)
         return true if payment_method.verification_value.blank? && options[:cvv].blank?
+
         false
       end
 
@@ -379,10 +382,12 @@ module ActiveMerchant #:nodoc:
         case action
         when 'store'
           return response['code'] if success
+
           error_description = response['creditCardToken']['errorDescription'] if response['creditCardToken']
           response['error'] || error_description || 'FAILED'
         when 'verify_credentials'
           return 'VERIFIED' if success
+
           'FAILED'
         else
           if response['transactionResponse']
@@ -390,6 +395,7 @@ module ActiveMerchant #:nodoc:
             response_code = response['transactionResponse']['responseCode'] || response['transactionResponse']['pendingReason']
           end
           return response_code if success
+
           response['error'] || response_message || response_code || 'FAILED'
         end
       end

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -198,6 +198,7 @@ module ActiveMerchant
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'
+
         return Response.new(false, 'Invalid credentials', {}, :test => test?)
       rescue ActiveMerchant::ClientCertificateError
         return Response.new(false, 'Invalid certificate', {}, :test => test?)

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -101,6 +101,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, creditcard, options)
         return if creditcard.kind_of?(String)
+
         address = (options[:billing_address] || options[:address])
         return unless address
 

--- a/lib/active_merchant/billing/gateways/pro_pay.rb
+++ b/lib/active_merchant/billing/gateways/pro_pay.rb
@@ -284,6 +284,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(response)
         return 'Success' if success_from(response)
+
         message = STATUS_RESPONSE_CODES[response[:status]]
         message += " - #{TRANSACTION_RESPONSE_CODES[response[:response_code]]}" if response[:response_code]
 

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -210,6 +210,7 @@ module ActiveMerchant #:nodoc:
           return SUCCESS_MESSAGE
         else
           return FAILURE_MESSAGE if response[:errmsg].blank?
+
           return response[:errmsg].gsub(/[^\w]/, ' ').split.join(' ').capitalize
         end
       end

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -240,6 +240,7 @@ module ActiveMerchant #:nodoc:
         return oauth_v2_headers if @options[:refresh_token]
 
         raise ArgumentError, "Invalid HTTP method: #{method}. Valid methods are :post and :get" unless [:post, :get].include?(method)
+
         request_uri = URI.parse(uri)
 
         # Following the guidelines from http://nouncer.com/oauth/authentication.html
@@ -285,6 +286,7 @@ module ActiveMerchant #:nodoc:
         return response unless @options[:refresh_token]
         return response unless options[:allow_refresh]
         return response unless response.params['code'] == 'AuthenticationFailed'
+
         refresh_access_token
         commit(endpoint, body)
       end

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -249,6 +249,7 @@ module ActiveMerchant
 
       def map_address(address)
         return {} if address.nil?
+
         requires!(address, :name, :address1, :city, :zip, :country)
         country = Country.find(address[:country])
         mapped = {

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -141,6 +141,7 @@ module ActiveMerchant #:nodoc:
 
       def add_testmode(post)
         return if post[:transaction].present?
+
         post[:testmode] = test? ? '1' : '0'
       end
 

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -147,6 +147,7 @@ module ActiveMerchant #:nodoc:
 
       def stored_credential_usage(post, payment_method, options)
         return unless payment_method.brand == 'visa'
+
         stored_credential = options[:stored_credential]
         if stored_credential[:initial_transaction]
           post['card.storedCredentialUsage'] = 'INITIAL_STORAGE'
@@ -222,6 +223,7 @@ module ActiveMerchant #:nodoc:
 
       def cvv_result(succeeded, raw)
         return unless succeeded
+
         code = CVV_CODE_MAPPING[raw['response.cvnResponse']] || raw['response.cvnResponse']
         CVVResult.new(code)
       end

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -268,6 +268,7 @@ module ActiveMerchant
 
       def add_comments(xml, options)
         return unless options[:description]
+
         xml.tag! 'comments' do
           xml.tag! 'comment', options[:description], 'id' => 1
         end
@@ -305,6 +306,7 @@ module ActiveMerchant
 
       def add_three_d_secure(xml, options)
         return unless three_d_secure = options[:three_d_secure]
+
         version = three_d_secure.fetch(:version, '')
         xml.tag! 'mpi' do
           if version =~ /^2/

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -521,6 +521,7 @@ module ActiveMerchant #:nodoc:
       def currency_code(currency)
         return currency if currency =~ /^\d+$/
         raise ArgumentError, "Unknown currency #{currency}" unless CURRENCY_CODES[currency]
+
         CURRENCY_CODES[currency]
       end
 

--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -143,6 +143,7 @@ module ActiveMerchant #:nodoc:
 
       def add_customer(xml, creditcard, options)
         return unless creditcard.respond_to?(:number)
+
         address = options[:billing_address]
         xml.Customer do
           xml.Contact do

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -207,6 +207,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(response)
         return 'Success' if success_from(response)
+
         response[:reason_codes] || response[:reason]
       end
 
@@ -240,6 +241,7 @@ module ActiveMerchant #:nodoc:
 
         params.map do |key, value|
           next if value != false && value.blank?
+
           "#{key}=#{CGI.escape(value.to_s)}"
         end.compact.join('&')
       end

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -115,6 +115,7 @@ module ActiveMerchant #:nodoc:
       # use the same method as in pay_conex
       def force_utf8(string)
         return nil unless string
+
         binary = string.encode('BINARY', invalid: :replace, undef: :replace, replace: '?') # Needed for Ruby 2.0 since #encode is a no-op if the string is already UTF-8. It's not needed for Ruby 2.1 and up since it's not a no-op there.
         binary.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
       end

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -312,6 +312,7 @@ module ActiveMerchant #:nodoc:
 
       def sanitize_phone(phone)
         return nil unless phone
+
         cleansed = phone.to_s.gsub(/[^0-9+]/, '')
         truncate(cleansed, 20)
       end
@@ -426,6 +427,7 @@ module ActiveMerchant #:nodoc:
 
       def past_purchase_reference?(payment_method)
         return false unless payment_method.is_a?(String)
+
         payment_method.split(';').last == 'purchase'
       end
     end

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -166,6 +166,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         return unless post[:card]&.kind_of?(Hash)
+
         if address = options[:billing_address]
           post[:card][:addressLine1] = address[:address1] if address[:address1]
           post[:card][:addressLine2] = address[:address2] if address[:address2]
@@ -214,6 +215,7 @@ module ActiveMerchant #:nodoc:
 
         params.map do |key, value|
           next if value.blank?
+
           if value.is_a?(Hash)
             h = {}
             value.each do |k, v|

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -434,6 +434,7 @@ module ActiveMerchant #:nodoc:
           return CARD_CODE_MESSAGES[response[:szCVV2ResponseCode]] if CARD_CODE_ERRORS.include?(response[:szCVV2ResponseCode])
           return AVS_MESSAGES[response[:szAVSResponseMessage]] if AVS_ERRORS.include?(response[:szAVSResponseCode])
           return RETURN_CODE_MESSAGES[response[:szReturnCode]] if response[:szReturnCode] != '1'
+
           return response[:szAuthorizationDeclinedMessage]
         end
       end

--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -228,6 +228,7 @@ module ActiveMerchant #:nodoc:
 
       def extra_options_to_doc(doc, value)
         return doc.text value unless value.kind_of? Hash
+
         value.each do |k, v|
           doc.send(k) do
             extra_options_to_doc(doc, v)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -198,6 +198,7 @@ module ActiveMerchant #:nodoc:
         elsif payment.is_a?(Check)
           bank_token_response = tokenize_bank_account(payment)
           return bank_token_response unless bank_token_response.success?
+
           params = { source: bank_token_response.params['token']['id'] }
         else
           add_creditcard(params, payment, options)
@@ -431,6 +432,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         return unless post[:card]&.kind_of?(Hash)
+
         if address = options[:billing_address] || options[:address]
           post[:card][:address_line1] = address[:address1] if address[:address1]
           post[:card][:address_line2] = address[:address2] if address[:address2]
@@ -559,12 +561,14 @@ module ActiveMerchant #:nodoc:
 
       def post_data(params)
         return nil unless params
+
         flatten_params([], params).join('&')
       end
 
       def flatten_params(flattened, params, prefix = nil)
         params.each do |key, value|
           next if value != false && value.blank?
+
           flattened_key = prefix.nil? ? key : "#{prefix}[#{key}]"
           if value.is_a?(Hash)
             flatten_params(flattened, value, flattened_key)
@@ -608,6 +612,7 @@ module ActiveMerchant #:nodoc:
 
       def stripe_client_user_agent(options)
         return user_agent unless options[:application]
+
         JSON.dump(JSON.parse(user_agent).merge!({application: options[:application]}))
       end
 
@@ -761,6 +766,7 @@ module ActiveMerchant #:nodoc:
 
       def auth_minimum_amount(options)
         return 100 unless options[:currency]
+
         return MINIMUM_AUTHORIZE_AMOUNTS[options[:currency].upcase] || 100
       end
 
@@ -768,6 +774,7 @@ module ActiveMerchant #:nodoc:
         source_path ||= dest_path
         source_path.each do |key|
           return nil unless source[key]
+
           source = source[key]
         end
 

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -174,6 +174,7 @@ module ActiveMerchant #:nodoc:
 
       def add_return_url(post, options)
         return unless options[:confirm]
+
         post[:confirm] = options[:confirm]
         post[:return_url] = options[:return_url] if options[:return_url]
         post
@@ -211,6 +212,7 @@ module ActiveMerchant #:nodoc:
 
       def add_exemption(post, options = {})
         return unless options[:confirm]
+
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:moto] = true if options[:moto]
@@ -224,6 +226,7 @@ module ActiveMerchant #:nodoc:
 
       def add_connected_account(post, options = {})
         return unless options[:transfer_destination]
+
         post[:transfer_data] = {}
         post[:transfer_data][:destination] = options[:transfer_destination]
         post[:transfer_data][:amount] = options[:transfer_amount] if options[:transfer_amount]
@@ -235,6 +238,7 @@ module ActiveMerchant #:nodoc:
 
       def add_billing_address(post, options = {})
         return unless billing = options[:billing_address] || options[:address]
+
         post[:billing_details] = {}
         post[:billing_details][:address] = {}
         post[:billing_details][:address][:city] = billing[:city] if billing[:city]
@@ -251,6 +255,7 @@ module ActiveMerchant #:nodoc:
 
       def add_shipping_address(post, options = {})
         return unless shipping = options[:shipping]
+
         post[:shipping] = {}
         post[:shipping][:address] = {}
         post[:shipping][:address][:line1] = shipping[:address][:line1]

--- a/lib/active_merchant/billing/gateways/telr.rb
+++ b/lib/active_merchant/billing/gateways/telr.rb
@@ -109,6 +109,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(doc, payment_method, options)
         return if payment_method.is_a?(String)
+
         doc.card do
           doc.number(payment_method.number)
           doc.cvv(payment_method.verification_value)
@@ -121,6 +122,7 @@ module ActiveMerchant #:nodoc:
 
       def add_customer_data(doc, payment_method, options)
         return if payment_method.is_a?(String)
+
         doc.billing do
           doc.name do
             doc.first(payment_method.first_name)
@@ -140,6 +142,7 @@ module ActiveMerchant #:nodoc:
         doc.city(address[:city] || 'City')
         doc.line1(address[:address1] || 'Address')
         return unless address
+
         doc.line2(address[:address2]) if address[:address2]
         doc.zip(address[:zip]) if address[:zip]
         doc.region(address[:state]) if address[:state]

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -133,6 +133,7 @@ module ActiveMerchant #:nodoc:
 
       def add_or_use_default(payment_data, default_value)
         return payment_data.capitalize if payment_data
+
         return default_value
       end
 

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -291,6 +291,7 @@ module ActiveMerchant #:nodoc:
         MultiResponse.run do |r|
           r.process { commit(:store, store_customer_request) }
           return r unless r.success? && r.params['custId']
+
           customer_id = r.params['custId']
 
           store_payment_method_request = build_xml_payment_storage_request do |doc|
@@ -384,6 +385,7 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(succeeded, response)
         return if succeeded
+
         response['errorCode'] || response['rspCode']
       end
 

--- a/lib/active_merchant/billing/gateways/trexle.rb
+++ b/lib/active_merchant/billing/gateways/trexle.rb
@@ -106,6 +106,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, creditcard, options)
         return if creditcard.kind_of?(String)
+
         address = (options[:billing_address] || options[:address])
         return unless address
 
@@ -181,6 +182,7 @@ module ActiveMerchant #:nodoc:
 
       def error_response(body)
         return invalid_response unless body['error']
+
         Response.new(
           false,
           body['error'],
@@ -207,6 +209,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         return {} if body.blank?
+
         JSON.parse(body)
       end
 

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -204,6 +204,7 @@ module ActiveMerchant #:nodoc:
           if payment.account_type
             account_type = payment.account_type.to_s.capitalize
             raise ArgumentError, 'account_type must be checking or savings' unless %w(Checking Savings).include?(account_type)
+
             post[:accounttype] = account_type
           end
           post[:account] = payment.account_number
@@ -228,6 +229,7 @@ module ActiveMerchant #:nodoc:
       # see: http://wiki.usaepay.com/developer/transactionapi#split_payments
       def add_split_payments(post, options)
         return unless options[:split_payments].is_a?(Array)
+
         options[:split_payments].each_with_index do |payment, index|
           prefix = '%02d' % (index + 2)
           post["#{prefix}key"]         = payment[:key]
@@ -241,6 +243,7 @@ module ActiveMerchant #:nodoc:
 
       def add_recurring_fields(post, options)
         return unless options[:recurring_fields].is_a?(Hash)
+
         options[:recurring_fields].each do |key, value|
           if value == true
             value = 'yes'
@@ -268,6 +271,7 @@ module ActiveMerchant #:nodoc:
       # see: https://wiki.usaepay.com/developer/transactionapi#line_item_details
       def add_line_items(post, options)
         return unless options[:line_items].is_a?(Array)
+
         options[:line_items].each_with_index do |line_item, index|
           %w(product_ref_num sku qty name description taxable tax_rate tax_amount commodity_code discount_rate discount_amount).each do |key|
             post["line#{index}#{key.delete('_')}"] = line_item[key.to_sym] if line_item.has_key?(key.to_sym)
@@ -329,6 +333,7 @@ module ActiveMerchant #:nodoc:
           return 'Success'
         else
           return 'Unspecified error' if response[:error].blank?
+
           return response[:error]
         end
       end

--- a/lib/active_merchant/billing/gateways/vanco.rb
+++ b/lib/active_merchant/billing/gateways/vanco.rb
@@ -108,6 +108,7 @@ module ActiveMerchant
 
       def message_from(succeeded, response)
         return 'Success' if succeeded
+
         response[:error_message]
       end
 

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -213,6 +213,7 @@ module ActiveMerchant #:nodoc:
 
       def action_code_description(response)
         return nil unless response['data']
+
         response['data']['DSC_COD_ACCION']
       end
 

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -263,6 +263,7 @@ module ActiveMerchant #:nodoc:
       # Includes the credit-card data to the transaction-xml
       def add_creditcard(xml, creditcard)
         raise 'Creditcard must be supplied!' if creditcard.nil?
+
         xml.tag! 'CREDIT_CARD_DATA' do
           xml.tag! 'CreditCardNumber', creditcard.number
           xml.tag! 'CVC2', creditcard.verification_value
@@ -275,6 +276,7 @@ module ActiveMerchant #:nodoc:
       # Includes the IP address of the customer to the transaction-xml
       def add_customer_data(xml, options)
         return unless options[:ip]
+
         xml.tag! 'CONTACT_DATA' do
           xml.tag! 'IPAddress', options[:ip]
         end
@@ -283,6 +285,7 @@ module ActiveMerchant #:nodoc:
       # Includes the address to the transaction-xml
       def add_address(xml, address)
         return if address.nil?
+
         xml.tag! 'CORPTRUSTCENTER_DATA' do
           xml.tag! 'ADDRESS' do
             xml.tag! 'Address1', address[:address1]

--- a/lib/active_merchant/billing/gateways/world_net.rb
+++ b/lib/active_merchant/billing/gateways/world_net.rb
@@ -128,6 +128,7 @@ module ActiveMerchant #:nodoc:
       def add_address(post, _creditcard, options)
         address = options[:billing_address] || options[:address]
         return unless address
+
         post[:address1] = address[:address1]
         post[:address2] = address[:address2]
         post[:city]     = address[:city]

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -379,6 +379,7 @@ module ActiveMerchant #:nodoc:
 
       def add_shopper(xml, options)
         return unless options[:execute_threed] || options[:email] || options[:customer]
+
         xml.tag! 'shopper' do
           xml.tag! 'shopperEmailAddress', options[:email] if  options[:email]
           add_authenticated_shopper_id(xml, options)
@@ -545,6 +546,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(success, raw, success_criteria)
         return 'SUCCESS' if success
+
         raw[:iso8583_return_code_description] || raw[:error] || required_status_message(raw, success_criteria)
       end
 
@@ -633,6 +635,7 @@ module ActiveMerchant #:nodoc:
 
       def credit_fund_transfer_attribute(options)
         return unless options[:credit]
+
         {'action' => 'REFUND'}
       end
 
@@ -644,6 +647,7 @@ module ActiveMerchant #:nodoc:
       def currency_exponent(currency)
         return 0 if non_fractional_currency?(currency)
         return 3 if three_decimal_currency?(currency)
+
         return 2
       end
 

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -62,6 +62,7 @@ module ActiveMerchant
 
     def wiredump_device=(device)
       raise ArgumentError, "can't wiredump to frozen #{device.class}" if device&.frozen?
+
       @wiredump_device = device
     end
 
@@ -86,6 +87,7 @@ module ActiveMerchant
               case method
               when :get
                 raise ArgumentError, 'GET requests do not support a request body' if body
+
                 http.get(endpoint.request_uri, headers)
               when :post
                 debug body

--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -330,6 +330,7 @@ module ActiveMerchant #:nodoc:
         country = COUNTRIES.detect { |c| c[:name].casecmp(name).zero? }
       end
       raise InvalidCountryCodeError, "No country could be found for the country #{name}" if country.nil?
+
       Country.new(country.dup)
     end
   end

--- a/lib/active_merchant/net_http_ssl_connection.rb
+++ b/lib/active_merchant/net_http_ssl_connection.rb
@@ -4,6 +4,7 @@ module NetHttpSslConnection
   refine Net::HTTP do
     def ssl_connection
       return {} unless use_ssl? && @socket.present?
+
       { version: @socket.io.ssl_version, cipher: @socket.io.cipher[0] }
     end
   end

--- a/lib/active_merchant/post_data.rb
+++ b/lib/active_merchant/post_data.rb
@@ -7,6 +7,7 @@ module ActiveMerchant
 
     def []=(key, value)
       return if value.blank? && !required?(key)
+
       super
     end
 

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -87,6 +87,7 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_successful_reauthorization
     return if not @three_days_old_auth_id
+
     auth = @gateway.reauthorize(1000, @three_days_old_auth_id)
     assert_success auth
     assert auth.authorization
@@ -100,6 +101,7 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_failed_reauthorization
     return if not @three_days_old_auth_id2 # was authed for $10, attempt $20
+
     auth = @gateway.reauthorize(2000, @three_days_old_auth_id2)
     assert_false auth?
     assert !auth.authorization

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -277,6 +277,7 @@ class BalancedTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, address: a)
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
+
       clean = proc { |s| Regexp.escape(CGI.escape(s)) }
       assert_match(%r{address\[line1\]=#{clean[a[:address1]]}}, data)
       assert_match(%r{address\[line2\]=#{clean[a[:address2]]}}, data)
@@ -294,6 +295,7 @@ class BalancedTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, address: address(zip: nil))
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
+
       assert_no_match(%r{address}, data)
     end.respond_with(cards_response, debits_response)
 
@@ -305,6 +307,7 @@ class BalancedTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, address: address(zip: '   '))
     end.check_request do |method, endpoint, data, headers|
       next if endpoint =~ /debits/
+
       assert_no_match(%r{address}, data)
     end.respond_with(cards_response, debits_response)
 


### PR DESCRIPTION
Fixes the RuboCop todo that enforces having a blank line after any guard
clause (mostly `return if` statements).

All unit tests:
4414 tests, 71334 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed