### PR TITLE
RuboCop: Fix Layout/SpaceAroundKeyword

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,11 +51,6 @@ Layout/MultilineMethodCallBraceLayout:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 
-# Offense count: 104
-# Cop supports --auto-correct.
-Layout/SpaceAroundKeyword:
-  Enabled: false
-
 # Offense count: 782
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
 * Credorax: Update non-standard currencies list [chinhle23] #3499
 * RuboCop: Fix Layout/EmptyLineAfterGuardClause [leila-alderman] #3496
 * RuboCop: Fix Layout/MultilineArrayBraceLayout [leila-alderman] #3498
+* RuboCop: Fix Layout/SpaceAroundKeyword [leila-alderman] #3497
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -52,7 +52,7 @@ require 'active_merchant/country'
 module ActiveMerchant
   def self.deprecated(message, caller=Kernel.caller[1])
     warning = caller + ': ' + message
-    if(respond_to?(:logger) && logger.present?)
+    if respond_to?(:logger) && logger.present?
       logger.warn(warning)
     else
       warn(warning)

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -98,7 +98,7 @@ module ActiveMerchant
             result = []
 
             self.each do |key, messages|
-              next unless(messages && !messages.empty?)
+              next unless messages && !messages.empty?
 
               if key == 'base'
                 result << messages.first.to_s

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -329,7 +329,7 @@ module ActiveMerchant #:nodoc:
           errors << [:last_name,  'cannot be empty'] if last_name.blank?
         end
 
-        if(empty?(month) || empty?(year))
+        if empty?(month) || empty?(year)
           errors << [:month, 'is required'] if empty?(month)
           errors << [:year,  'is required'] if empty?(year)
         else

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -442,7 +442,7 @@ module ActiveMerchant #:nodoc:
       def add_3ds2_authenticated_data(post, options)
         three_d_secure_options = options[:three_d_secure]
         # If the transaction was authenticated in a frictionless flow, send the transStatus from the ARes.
-        if(three_d_secure_options[:authentication_response_status].nil?)
+        if three_d_secure_options[:authentication_response_status].nil?
           authentication_response = three_d_secure_options[:directory_response_status]
         else
           authentication_response = three_d_secure_options[:authentication_response_status]

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -141,7 +141,7 @@ module ActiveMerchant #:nodoc:
           raw_response = ssl_post(url(action), post.to_json, headers)
           response = parse(raw_response)
         rescue ResponseError => e
-          raise unless(e.response.code.to_s =~ /4\d\d/)
+          raise unless e.response.code.to_s =~ /4\d\d/
 
           response = parse(e.response.body)
         end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -843,17 +843,17 @@ module ActiveMerchant
 
         response = {action: action}
 
-        response[:response_code] = if(element = doc.at_xpath('//transactionResponse/responseCode'))
+        response[:response_code] = if (element = doc.at_xpath('//transactionResponse/responseCode'))
                                      empty?(element.content) ? nil : element.content.to_i
                                    end
 
-        if(element = doc.at_xpath('//errors/error'))
+        if (element = doc.at_xpath('//errors/error'))
           response[:response_reason_code] = element.at_xpath('errorCode').content[/0*(\d+)$/, 1]
           response[:response_reason_text] = element.at_xpath('errorText').content.chomp('.')
-        elsif(element = doc.at_xpath('//transactionResponse/messages/message'))
+        elsif (element = doc.at_xpath('//transactionResponse/messages/message'))
           response[:response_reason_code] = element.at_xpath('code').content[/0*(\d+)$/, 1]
           response[:response_reason_text] = element.at_xpath('description').content.chomp('.')
-        elsif(element = doc.at_xpath('//messages/message'))
+        elsif (element = doc.at_xpath('//messages/message'))
           response[:response_reason_code] = element.at_xpath('code').content[/0*(\d+)$/, 1]
           response[:response_reason_text] = element.at_xpath('text').content.chomp('.')
         else
@@ -862,7 +862,7 @@ module ActiveMerchant
         end
 
         response[:avs_result_code] =
-          if(element = doc.at_xpath('//avsResultCode'))
+          if (element = doc.at_xpath('//avsResultCode'))
             empty?(element.content) ? nil : element.content
           end
 
@@ -962,7 +962,7 @@ module ActiveMerchant
         if response[:response_code] == DECLINED
           if CARD_CODE_ERRORS.include?(cvv_result.code)
             return cvv_result.message
-          elsif(AVS_REASON_CODES.include?(response[:response_reason_code]) && AVS_ERRORS.include?(avs_result.code))
+          elsif AVS_REASON_CODES.include?(response[:response_reason_code]) && AVS_ERRORS.include?(avs_result.code)
             return avs_result.message
           end
         end

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
 
         MultiResponse.run do |r|
           identifier =
-            if(payment_method.respond_to?(:number))
+            if payment_method.respond_to?(:number)
               r.process { store(payment_method, options) }
               r.authorization
             else
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
 
         MultiResponse.run do |r|
           identifier =
-            if(payment_method.respond_to?(:number))
+            if payment_method.respond_to?(:number)
               r.process { store(payment_method, options) }
               r.authorization
             else
@@ -139,7 +139,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         address = (options[:billing_address] || options[:address])
-        if(address && address[:zip].present?)
+        if address && address[:zip].present?
           post[:address] = {}
           post[:address][:line1] = address[:address1] if address[:address1]
           post[:address][:line2] = address[:address2] if address[:address2]
@@ -167,7 +167,7 @@ module ActiveMerchant #:nodoc:
                 headers
               ))
           rescue ResponseError => e
-            raise unless(e.response.code.to_s =~ /4\d\d/)
+            raise unless e.response.code.to_s =~ /4\d\d/
 
             parse(e.response.body)
           end
@@ -183,13 +183,13 @@ module ActiveMerchant #:nodoc:
 
       def success_from(entity_name, raw_response)
         entity = (raw_response[entity_name] || []).first
-        if(!entity)
+        if !entity
           false
-        elsif((entity_name == 'refunds') && entity.include?('status'))
+        elsif (entity_name == 'refunds') && entity.include?('status')
           %w(succeeded pending).include?(entity['status'])
-        elsif(entity.include?('status'))
+        elsif entity.include?('status')
           (entity['status'] == 'succeeded')
-        elsif(entity_name == 'cards')
+        elsif entity_name == 'cards'
           !!entity['id']
         else
           false
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(raw_response)
-        if(raw_response['errors'])
+        if raw_response['errors']
           error = raw_response['errors'].first
           (error['additional'] || error['message'] || error['description'])
         else

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -155,7 +155,7 @@ module ActiveMerchant #:nodoc:
       #   If the payment_object is either a CreditCard or Check object, then the transaction type will be an unmatched credit placing funds in the specified account. This is referred to a CREDIT transaction in BluePay.
       # * <tt>options</tt> -- A hash of parameters.
       def refund(money, identification, options = {})
-        if(identification && !identification.kind_of?(String))
+        if identification && !identification.kind_of?(String)
           ActiveMerchant.deprecated 'refund should only be used to refund a referenced transaction'
           return credit(money, identification, options)
         end
@@ -317,7 +317,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def commit(action, money, fields, options = {})
-        fields[:AMOUNT] = amount(money) unless(fields[:TRANS_TYPE] == 'VOID' || action == 'rebill')
+        fields[:AMOUNT] = amount(money) unless fields[:TRANS_TYPE] == 'VOID' || action == 'rebill'
         fields[:MODE] = (test? ? 'TEST' : 'LIVE')
         fields[:ACCOUNT_ID] = @options[:login]
         fields[:CUSTOMER_IP] = options[:ip] if options[:ip]
@@ -372,7 +372,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(parsed)
         message = parsed[:message]
-        if(parsed[:response_code].to_i == 2)
+        if parsed[:response_code].to_i == 2
           if CARD_CODE_ERRORS.include?(parsed[:card_code])
             message = CVVResult.messages[parsed[:card_code]]
           elsif AVS_ERRORS.include?(parsed[:avs_result_code])

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -170,7 +170,7 @@ module ActiveMerchant #:nodoc:
 
       def unstore(customer_vault_id, options = {})
         commit do
-          if(!customer_vault_id && options[:credit_card_token])
+          if !customer_vault_id && options[:credit_card_token]
             @braintree_gateway.credit_card.delete(options[:credit_card_token])
           else
             @braintree_gateway.customer.delete(customer_vault_id)
@@ -287,10 +287,9 @@ module ActiveMerchant #:nodoc:
 
       def scrub_zip(zip)
         return nil unless zip.present?
-        return nil if(
+        return nil if
           zip.gsub(/[^a-z0-9]/i, '').length > 9 ||
           zip =~ /[^a-z0-9\- ]/i
-        )
 
         zip
       end

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -147,7 +147,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:Street] = billing_address[:address1]
           post[:Zip]    = billing_address[:zip]
         end

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
           add_amount_tags(money, options, xml)
           xml.tag! 'Email', options[:email] if options[:email]
 
-          if(address = (options[:billing_address] || options[:address]))
+          if (address = (options[:billing_address] || options[:address]))
             xml.tag! 'BillTo' do
               add_address(xml, address)
             end

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -112,7 +112,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:CustomerEmailAddress] = billing_address[:email]
           post[:CustomerPhone] = billing_address[:phone]
           post[:CustomerBillingAddress] = billing_address[:address1]
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
           xml = ssl_post(self.live_url, data, headers)
           raw = parse(xml)
         rescue ActiveMerchant::ResponseError => e
-          if(e.response.code == '500' && e.response.body.start_with?('<s:Envelope'))
+          if e.response.code == '500' && e.response.body.start_with?('<s:Envelope')
             raw = {
               message: 'See transcript for detailed error description.'
             }

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -164,7 +164,7 @@ module ActiveMerchant #:nodoc:
           begin
             parse(ssl_post(url, body, headers))
           rescue ResponseError => e
-            raise unless(e.response.code.to_s =~ /400/)
+            raise unless e.response.code.to_s =~ /400/
 
             parse(e.response.body)
           end

--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -105,7 +105,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_shipment_address(post, options)
-        if(address = options[:shipping_address])
+        if (address = options[:shipping_address])
           post[:address] = {}
           post[:address][:street1] = address[:address1] if address[:address1]
           post[:address][:street2] = address[:address2] if address[:address2]
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_billing_address(post, options)
-        if(address = (options[:billing_address] || options[:address]))
+        if (address = (options[:billing_address] || options[:address]))
           post[:billing_address] = {}
           post[:billing_address][:street1] = address[:address1] if address[:address1]
           post[:billing_address][:street2] = address[:address2] if address[:address2]
@@ -142,7 +142,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        if(address = (options[:billing_address] || options[:address]))
+        if (address = (options[:billing_address] || options[:address]))
           post[:address] = {}
           post[:address][:street1] = address[:address1] if address[:address1]
           post[:address][:street2] = address[:address2] if address[:address2]

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
           begin
             parse(ssl_request(method, get_url(uri), parameters.to_json, headers))
           rescue ResponseError => e
-            return Response.new(false, 'Invalid Login') if(e.response.code == '401')
+            return Response.new(false, 'Invalid Login') if e.response.code == '401'
 
             parse(e.response.body)
           end

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -49,7 +49,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:billToAddressLine1]  = billing_address[:address1]
           post[:billToCity]          = billing_address[:city]
           post[:billToState]         = billing_address[:state]

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -407,9 +407,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        if(response[:faultcode] && response[:faultstring])
+        if response[:faultcode] && response[:faultstring]
           response[:faultstring]
-        elsif(response[:error_number] && response[:error_number] != '0')
+        elsif response[:error_number] && response[:error_number] != '0'
           response[:error_description]
         else
           result = (response[:exact_message] || '')

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:Email] = billing_address[:email]
         end
       end
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
         begin
           raw = parse(ssl_post(url, data, headers(action)), action)
         rescue ActiveMerchant::ResponseError => e
-          if(e.response.code == '500' && e.response.body.start_with?('<?xml'))
+          if e.response.code == '500' && e.response.body.start_with?('<?xml')
             raw = parse(e.response.body, action)
           else
             raise

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
           xml.hps :CardHolderEmail, options[:email] if options[:email]
           xml.hps :CardHolderPhone, options[:phone] if options[:phone]
 
-          if(billing_address = (options[:billing_address] || options[:address]))
+          if (billing_address = (options[:billing_address] || options[:address]))
             xml.hps :CardHolderAddr, billing_address[:address1] if billing_address[:address1]
             xml.hps :CardHolderCity, billing_address[:city] if billing_address[:city]
             xml.hps :CardHolderState, billing_address[:state] if billing_address[:state]
@@ -249,7 +249,7 @@ module ActiveMerchant #:nodoc:
 
         doc = Nokogiri::XML(raw)
         doc.remove_namespaces!
-        if(header = doc.xpath('//Header').first)
+        if (header = doc.xpath('//Header').first)
           header.elements.each do |node|
             if node.elements.size == 0
               response[node.name] = node.text
@@ -260,12 +260,12 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
-        if(transaction = doc.xpath('//Transaction/*[1]').first)
+        if (transaction = doc.xpath('//Transaction/*[1]').first)
           transaction.elements.each do |node|
             response[node.name] = node.text
           end
         end
-        if(fault = doc.xpath('//Fault/Reason/Text').first)
+        if (fault = doc.xpath('//Fault/Reason/Text').first)
           response['Fault'] = fault.text
         end
 
@@ -304,10 +304,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        if(response['Fault'])
+        if response['Fault']
           response['Fault']
-        elsif(response['GatewayRspCode'] == '0')
-          if(response['RspCode'] != '00' && response['RspCode'] != '85')
+        elsif response['GatewayRspCode'] == '0'
+          if response['RspCode'] != '00' && response['RspCode'] != '85'
             issuer_message(response['RspCode'])
           else
             response['GatewayRspMsg']

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options={})
-        if(options[:login])
+        if options[:login]
           ActiveMerchant.deprecated("The 'login' option is deprecated in favor of 'agent_code' and will be removed in a future version.")
           options[:agent_code] = options[:login]
         end
@@ -96,7 +96,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(post, options)
         billing_address = options[:billing_address] || options[:address]
-        if(billing_address)
+        if billing_address
           post[:address] = billing_address[:address1]
           post[:city] = billing_address[:city]
           post[:state] = billing_address[:state]
@@ -217,7 +217,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def recursively_parse_element(node, response)
-        if(node.has_elements?)
+        if node.has_elements?
           node.elements.each { |n| recursively_parse_element(n, response) }
         else
           response[dexmlize_param_name(node.name)] = (node.text ? node.text.strip : nil)
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         if !successful_result_message?(response) && response[:authorization_result]
           return response[:authorization_result].strip
-        elsif(response[:status] == 'Failure')
+        elsif response[:status] == 'Failure'
           return response[:errors]
         else
           response[:status]

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -301,8 +301,8 @@ module ActiveMerchant #:nodoc:
       def add_invoice(xml, money, options)
         xml.AuthCode options[:force] if options[:force]
         if options[:order_items].blank?
-          xml.Total(amount(money)) unless(money.nil? || money < 0.01)
-          xml.Description(options[:description]) unless(options[:description].blank?)
+          xml.Total(amount(money)) unless money.nil? || money < 0.01
+          xml.Description(options[:description]) unless options[:description].blank?
         else
           xml.OrderItems {
             options[:order_items].each do |item|

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment_method)
-        if(payment_method.is_a?(String))
+        if payment_method.is_a?(String)
           user_profile_id, last_4 = split_authorization(payment_method)
           post[:userprofileid] = user_profile_id
           post[:last4digits] = last_4
@@ -127,7 +127,7 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         post[:email] = options[:email] if options[:email]
         post[:ipaddress] = options[:ip] if options[:ip]
-        if(billing_address = options[:billing_address])
+        if (billing_address = options[:billing_address])
           post[:billaddr1] = billing_address[:address1]
           post[:billaddr2] = billing_address[:address2]
           post[:billcity] = billing_address[:city]
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_message_from(response)
-        if(response[:status] == 'Declined')
+        if response[:status] == 'Declined'
           match = response[:result].match(/DECLINED:\d{10}:(.+):/)
           match[1] if match
         end

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -94,7 +94,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        return unless(address = (options[:billing_address] || options[:address]))
+        return unless (address = (options[:billing_address] || options[:address]))
 
         post['customerName'] = scrub_name(address[:name])
         post['customerCountry'] = address[:country]

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -230,7 +230,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'CardType', CARD_CODES[credit_card.brand] if credit_card.brand
 
         include_cvv = !%w(Return PreAuthCapture).include?(action) && !credit_card.track_data.present?
-        xml.tag! 'CVVData', credit_card.verification_value if(include_cvv && credit_card.verification_value)
+        xml.tag! 'CVVData', credit_card.verification_value if include_cvv && credit_card.verification_value
       end
 
       def add_address(xml, options)

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
           begin
             parse(ssl_request(method, get_url(uri), params, headers))
           rescue ResponseError => e
-            return Response.new(false, 'Invalid Login') if(e.response.code == '401')
+            return Response.new(false, 'Invalid Login') if e.response.code == '401'
 
             parse(e.response.body)
           end

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
           :cvv_result => response[:cvv2_code]
         )
       rescue ActiveMerchant::ResponseError => e
-        raise unless(e.response.code =~ /^[67]\d\d$/)
+        raise unless e.response.code =~ /^[67]\d\d$/
 
         return Response.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
       end

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -153,14 +153,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment_method, options)
-        if(payment_method.is_a?(String))
+        if payment_method.is_a?(String)
           customer_vault_id, _ = split_authorization(payment_method)
           post[:customer_vault_id] = customer_vault_id
         elsif payment_method.is_a?(NetworkTokenizationCreditCard)
           post[:ccnumber] = payment_method.number
           post[:ccexp] = exp_date(payment_method)
           post[:token_cryptogram] = payment_method.payment_cryptogram
-        elsif(card_brand(payment_method) == 'check')
+        elsif card_brand(payment_method) == 'check'
           post[:payment] = 'check'
           post[:firstname] = payment_method.first_name
           post[:lastname] = payment_method.last_name
@@ -213,7 +213,7 @@ module ActiveMerchant #:nodoc:
         post[:ipaddress] = options[:ip]
         post[:customer_id] = options[:customer_id] || options[:customer]
 
-        if(billing_address = options[:billing_address] || options[:address])
+        if (billing_address = options[:billing_address] || options[:address])
           post[:company] = billing_address[:company]
           post[:address1] = billing_address[:address1]
           post[:address2] = billing_address[:address2]
@@ -224,7 +224,7 @@ module ActiveMerchant #:nodoc:
           post[:phone] = billing_address[:phone]
         end
 
-        if(shipping_address = options[:shipping_address])
+        if (shipping_address = options[:shipping_address])
           post[:shipping_company] = shipping_address[:company]
           post[:shipping_address1] = shipping_address[:address1]
           post[:shipping_address2] = shipping_address[:address2]

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -213,7 +213,7 @@ module ActiveMerchant #:nodoc:
 
       # Store a credit card by creating an Ogone Alias
       def store(payment_source, options = {})
-        options[:alias_operation] = 'BYPSP' unless(options.has_key?(:billing_id) || options.has_key?(:store))
+        options[:alias_operation] = 'BYPSP' unless options.has_key?(:billing_id) || options.has_key?(:store)
         response = authorize(@options[:store_amount] || 1, payment_source, options)
         void(response.authorization) if response.success?
         response
@@ -410,7 +410,7 @@ module ActiveMerchant #:nodoc:
 
       def add_signature(parameters)
         if @options[:signature].blank?
-          ActiveMerchant.deprecated(OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) unless(@options[:signature_encryptor] == 'none')
+          ActiveMerchant.deprecated(OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) unless @options[:signature_encryptor] == 'none'
           return
         end
 

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -75,7 +75,7 @@ module ActiveMerchant #:nodoc:
           MultiResponse.run(:first) do |r|
             r.process { commit(:post, 'customers', post, options) }
 
-            if(r.success? && !r.params['id'].blank?)
+            if r.success? && !r.params['id'].blank?
               customer_id = r.params['id']
               r.process { commit(:post, "customers/#{customer_id}/cards", card, options) }
             end

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -19,12 +19,12 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Optimal Payments'
 
       def initialize(options = {})
-        if(options[:login])
+        if options[:login]
           ActiveMerchant.deprecated("The 'login' option is deprecated in favor of 'store_id' and will be removed in a future version.")
           options[:store_id] = options[:login]
         end
 
-        if(options[:account])
+        if options[:account]
           ActiveMerchant.deprecated("The 'account' option is deprecated in favor of 'account_number' and will be removed in a future version.")
           options[:account_number] = options[:account]
         end

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -243,7 +243,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(authorization, options = {}, deprecated = {})
-        if(!options.kind_of?(Hash))
+        if !options.kind_of?(Hash)
           ActiveMerchant.deprecated('Calling the void method with an amount parameter is deprecated and will be removed in a future version.')
           return void(options, deprecated.merge(:amount => authorization))
         end
@@ -383,7 +383,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(xml, creditcard, options)
-        if(address = (options[:billing_address] || options[:address]))
+        if (address = (options[:billing_address] || options[:address]))
           avs_supported = AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s) || empty?(address[:country])
 
           if avs_supported
@@ -421,7 +421,7 @@ module ActiveMerchant #:nodoc:
 
       # For Profile requests
       def add_customer_address(xml, options)
-        if(address = (options[:billing_address] || options[:address]))
+        if (address = (options[:billing_address] || options[:address]))
           avs_supported = AVS_SUPPORTED_COUNTRIES.include?(address[:country].to_s)
 
           xml.tag! :CustomerAddress1, byte_limit(format_address_field(address[:address1]), 30)
@@ -833,7 +833,7 @@ module ActiveMerchant #:nodoc:
         limited_value = ''
 
         value.to_s.each_char do |c|
-          break if((limited_value.bytesize + c.bytesize) > byte_length)
+          break if (limited_value.bytesize + c.bytesize) > byte_length
 
           limited_value << c
         end

--- a/lib/active_merchant/billing/gateways/orbital/orbital_soft_descriptors.rb
+++ b/lib/active_merchant/billing/gateways/orbital/orbital_soft_descriptors.rb
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
 
         [:merchant_email, :merchant_url].each do |attr|
           unless self.send(attr).blank?
-            errors << [attr, 'is required to be 13 bytes or less'] if(self.send(attr).bytesize > 13)
+            errors << [attr, 'is required to be 13 bytes or less'] if self.send(attr).bytesize > 13
           end
         end
 

--- a/lib/active_merchant/billing/gateways/payu_in.rb
+++ b/lib/active_merchant/billing/gateways/payu_in.rb
@@ -33,7 +33,7 @@ module ActiveMerchant #:nodoc:
 
         MultiResponse.run do |r|
           r.process { commit(url('purchase'), post) }
-          if(r.params['enrolled'].to_s == '0')
+          if r.params['enrolled'].to_s == '0'
             r.process { commit(r.params['post_uri'], r.params['form_post_vars']) }
           else
             r.process { handle_3dsecure(r) }

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
           )
         end
 
-        if(address = (options[:billing_address] || options[:address]))
+        if (address = (options[:billing_address] || options[:address]))
           params[:Bname] = address[:name] || creditcard.name
           params[:Baddress1]    = address[:address1] unless address[:address1].blank?
           params[:Baddress2]    = address[:address2] unless address[:address2].blank?

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -81,7 +81,7 @@ module ActiveMerchant #:nodoc:
         post[:expiration_month] = creditcard.month
         post[:expiration_year] = creditcard.year
 
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:address] = {}
           post[:address]['address1'] = billing_address[:address1] if billing_address[:address1]
           post[:address]['city']     = billing_address[:city] if billing_address[:city]

--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -91,7 +91,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, options)
-        if(billing_address = (options[:billing_address] || options[:address]))
+        if (billing_address = (options[:billing_address] || options[:address]))
           post[:ci_companyname] = billing_address[:company]
           post[:ci_billaddr1]   = billing_address[:address1]
           post[:ci_billaddr2]   = billing_address[:address2]
@@ -105,7 +105,7 @@ module ActiveMerchant #:nodoc:
           post[:ci_ipaddress]   = billing_address[:ip]
         end
 
-        if(shipping_address = options[:shipping_address])
+        if (shipping_address = options[:shipping_address])
           post[:ci_shipaddr1] = shipping_address[:address1]
           post[:ci_shipaddr2] = shipping_address[:address2]
           post[:ci_shipcity] = shipping_address[:city]

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
         self << response
 
         unless ignore_result
-          if(@use_first_response && response.success?)
+          if @use_first_response && response.success?
             @primary_response ||= response
           else
             @primary_response = response

--- a/test/remote/gateways/remote_pago_facil_test.rb
+++ b/test/remote/gateways/remote_pago_facil_test.rb
@@ -86,7 +86,7 @@ class RemotePagoFacilTest < Test::Unit::TestCase
       random_response = yield
       if random_response.success?
         return random_response
-      elsif(attempts > 2)
+      elsif attempts > 2
         raise 'Unable to get a successful response'
       else
         assert_equal 'Declined_(General).', random_response.params.fetch('error')


### PR DESCRIPTION
Fixes the RuboCop todo for [Layout/SpaceAroundKeyword](https://www.rubocop.org/en/stable/cops_layout/#layoutspacearoundkeyword)
that enforces having a blank space after keywords like `if`.

All unit tests:
4414 tests, 71334 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed