### PR TITLE
RuboCop: Fix Layout/MultilineArrayBraceLayout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,14 +37,6 @@ Layout/IndentHash:
 Layout/IndentHeredoc:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineArrayBraceLayout:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/optimal_payment.rb'
-
 # Offense count: 232
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * Braintree Blue: Remove customer hash when using a payment_method_nonce #3495
 * Credorax: Update non-standard currencies list [chinhle23] #3499
 * RuboCop: Fix Layout/EmptyLineAfterGuardClause [leila-alderman] #3496
+* RuboCop: Fix Layout/MultilineArrayBraceLayout [leila-alderman] #3498
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -158,8 +158,7 @@ module ActiveMerchant #:nodoc:
         %w(confirmationNumber authCode
            decision code description
            actionCode avsResponse cvdResponse
-           txnTime duplicateFound
-        ).each do |tag|
+           txnTime duplicateFound).each do |tag|
           node = REXML::XPath.first(response, "//#{tag}")
           hsh[tag] = node.text if node
         end


### PR DESCRIPTION
Fixes the RuboCop todo that enforces that layout of the closing brace in
a multiline array literal.

[RuboCop](https://www.rubocop.org/en/stable/cops_layout/#layoutmultilinearraybracelayout)

All unit tests:
4414 tests, 71334 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed