### PR TITLE
Credorax: Update non-standard currencies list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * RuboCop: Layout/EmptyLinesAroundClassBody fix [leila-alderman] #3487
 * Mundipagg: Return acquirer code as the error code [leila-alderman] #3492
 * RuboCop: Fix Layout/FirstParameterIndentation [leila-alderman] #3489
+* Credorax: Update non-standard currencies list [chinhle23] #3499
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -21,8 +21,8 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w(AD AT BE BG HR CY CZ DK EE FR DE GI GR GG HU IS IE IM IT JE LV LI LT LU MT MC NO PL PT RO SM SK ES SE CH GB)
       self.default_currency = 'EUR'
-      self.currencies_without_fractions = %w(CLP JPY KRW PYG VND)
-      self.currencies_with_three_decimal_places = %w(BHD JOD KWD OMR RSD TND)
+      self.currencies_without_fractions = %w(BIF CLP DJF GNF JPY KMF KRW PYG RWF VND VUV XAF XOF XPF)
+      self.currencies_with_three_decimal_places = %w(BHD IQD JOD KWD LYD OMR TND)
 
       self.money_format = :cents
       self.supported_cardtypes = [:visa, :master, :maestro]

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -57,6 +57,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_and_amount_for_non_decimal_currency
+    response = @gateway.purchase(14200, @credit_card, @options.merge(currency: 'JPY'))
+    assert_success response
+    assert_equal '142', response.params['A4']
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_extra_options
     response = @gateway.purchase(@amount, @credit_card, @options.merge(transaction_type: '10'))
     assert_success response

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -804,6 +804,14 @@ class CredoraxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_nonfractional_currency_handling
+    stub_comms do
+      @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/a4=2&a1=/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION
ECS-978

Per Credorax's latest [API docs](https://epower.credorax.com/wp-content/uploads/2019/11/Credorax-Source-Payment-API-Specifications-v1.3-.pdf),
their zero-decimal and three-decimal currencies list have changed:
- Add BIF, DJF, GNF, KMF, RWF, VUV, XAF, XOF, & XPF to the `currencies_without_fractions`
  list
- Add IQD & LYD and remove RSD from the `currencies_with_three_decimal_places`
  list

Some remote tests may fail due to Credorax's remote server timing out, thus
not related to these updates. The specific tests failing or error'ing may
change with each run.

Unit:
63 tests, 301 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
40 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed