### PR TITLE
Merchant Warrior: Add recurringFlag to purchase & authorize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@
 * Moneris: include AVS and CoF fields when storing vault records [alexdunae] #3446
 * Moneris: Add support for temporary vault storage [alexdunae] #3446
 * Clearhaus: Update currencies without fractions list [chinhle23] #3506
+* Merchant Warrior: Add recurringFlag to purchase & authorize [carrigan] #3504
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_order_id(post, options)
         add_address(post, options)
         add_payment_method(post, payment_method)
+        add_recurring_flag(post, options)
         commit('processAuth', post)
       end
 
@@ -39,6 +40,7 @@ module ActiveMerchant #:nodoc:
         add_order_id(post, options)
         add_address(post, options)
         add_payment_method(post, payment_method)
+        add_recurring_flag(post, options)
         commit('processCard', post)
       end
 
@@ -140,6 +142,12 @@ module ActiveMerchant #:nodoc:
         post['transactionAmount'] = amount(money)
         post['transactionCurrency'] = currency
         post['hash'] = verification_hash(amount(money), currency)
+      end
+
+      def add_recurring_flag(post, options)
+        return if options[:recurring_flag].nil?
+
+        post['recurringFlag'] = options[:recurring_flag]
       end
 
       def verification_hash(money, currency)

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -137,6 +137,16 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_purchase_with_recurring_flag
+    @options[:recurring_flag] = 1
+    test_successful_purchase
+  end
+
+  def test_successful_authorize_with_recurring_flag
+    @options[:recurring_flag] = 1
+    test_successful_authorize
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@success_amount, @credit_card, @options)

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -21,6 +21,16 @@ class MerchantWarriorTest < Test::Unit::TestCase
     }
   end
 
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    assert response = @gateway.authorize(@success_amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert response.test?
+    assert_equal '1336-20be3569-b600-11e6-b9c3-005056b209e0', response.authorization
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
@@ -159,6 +169,42 @@ class MerchantWarriorTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_authorize_recurring_flag_absent
+    stub_comms do
+      @gateway.authorize(@success_amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_not_match(/recurringFlag&/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_authorize_recurring_flag_present
+    recurring_flag = 1
+
+    stub_comms do
+      @gateway.authorize(@success_amount, @credit_card, recurring_flag: recurring_flag)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/recurringFlag=#{recurring_flag}&/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_purchase_recurring_flag_absent
+    stub_comms do
+      @gateway.purchase(@success_amount, @credit_card)
+    end.check_request do |endpoint, data, headers|
+      assert_not_match(/recurringFlag&/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_purchase_recurring_flag_present
+    recurring_flag = 1
+
+    stub_comms do
+      @gateway.purchase(@success_amount, @credit_card, recurring_flag: recurring_flag)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/recurringFlag=#{recurring_flag}&/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -238,6 +284,32 @@ class MerchantWarriorTest < Test::Unit::TestCase
   <cardID>KOCI10023982</cardID>
   <cardKey>s5KQIxsZuiyvs3Sc</cardKey>
   <ivrCardID>10023982</ivrCardID>
+</mwResponse>
+    XML
+  end
+
+  def successful_authorize_response
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<mwResponse>
+  <responseCode>0</responseCode>
+  <responseMessage>Transaction approved</responseMessage>
+  <transactionID>1336-20be3569-b600-11e6-b9c3-005056b209e0</transactionID>
+  <transactionReferenceID>12345</transactionReferenceID>
+  <authCode>731357421</authCode>
+  <receiptNo>731357421</receiptNo>
+  <authMessage>Honour with identification</authMessage>
+  <authResponseCode>08</authResponseCode>
+  <authSettledDate>2016-11-29</authSettledDate>
+  <paymentCardNumber>512345XXXXXX2346</paymentCardNumber>
+  <transactionAmount>1.00</transactionAmount>
+  <cardType>mc</cardType>
+  <cardExpiryMonth>05</cardExpiryMonth>
+  <cardExpiryYear>21</cardExpiryYear>
+  <custom1/>
+  <custom2/>
+  <custom3/>
+  <customHash>65b172551b7d3a0706c0ce5330c98470</customHash>
 </mwResponse>
     XML
   end


### PR DESCRIPTION
## Why?

The Merchant Warrior gateway does not support the `recurringFlag` field which is used to indicate if a transaction will be marked as recurring.

- https://dox.merchantwarrior.com/#processcard3162
- https://dox.merchantwarrior.com/#processauth3163
- CE-348

## What Changed?

- Added support for the `recurringFlag` field via a `recurring_flag` option on the `process` and `authorize` functions
- Added missing unit test for Merchant Warrior `authorize` function

## Test Suite Results

Unit:
```
17 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
```

Remote:
```
15 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed
```