### PR TITLE
Redsys: Update production URL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * RuboCop: Fix Layout/EmptyLineAfterGuardClause [leila-alderman] #3496
 * RuboCop: Fix Layout/MultilineArrayBraceLayout [leila-alderman] #3498
 * RuboCop: Fix Layout/SpaceAroundKeyword [leila-alderman] #3497
+* Redsys: Update production URL [britth] #3505
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
     #
     #
     class RedsysGateway < Gateway
-      self.live_url = 'https://sis.sermepa.es/sis/operaciones'
+      self.live_url = 'https://sis.redsys.es/sis/operaciones'
       self.test_url = 'https://sis-t.redsys.es:25443/sis/operaciones'
 
       self.supported_countries = ['ES']


### PR DESCRIPTION
Redsys has notified us that the connection URL, https://sis.sermepa.es/,
is obsolete and will be cut in the coming weeks, and that we should
switch over to https://sis.redsys.es/ (replacing sermepa with redsys).
This PR updates the live_url to reflect this.

Unit:
36 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed