### PR TITLE
Clearhaus: Update currencies without fractions list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@
 * Redsys: Update production URL [britth] #3505
 * Moneris: include AVS and CoF fields when storing vault records [alexdunae] #3446
 * Moneris: Add support for temporary vault storage [alexdunae] #3446
+* Clearhaus: Update currencies without fractions list [chinhle23] #3506
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
                                   'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'GB']
 
       self.default_currency    = 'EUR'
-      self.currencies_without_fractions = %w(BIF BYR DJF GNF JPY KMF KRW PYG RWF VND VUV XAF XOF XPF)
+      self.currencies_without_fractions = %w(BIF CLP DJF GNF JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
       self.supported_cardtypes = [:visa, :master]
 
       self.homepage_url = 'https://www.clearhaus.com'

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -74,6 +74,13 @@ class RemoteClearhausTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_and_amount_for_non_decimal_currency
+    response = @gateway.purchase(14200, @credit_card, @options.merge(currency: 'JPY'))
+    assert_success response
+    assert_equal 142, response.params['amount']
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_more_options
     options = {
       order_id: '1',

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -266,6 +266,14 @@ class ClearhausTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_nonfractional_currency_handling
+    stub_comms do
+      @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/amount=2&card/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
ECS-977

Per Clearhaus' latest [API docs](https://docs.gateway.clearhaus.com/currencies.txt),
their zero-decimal currencies list have changed:
- Add CLP & UGX and remove BYR from the `currencies_without_fractions` list

Unit:
23 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
24 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed