### PR TITLE
Stripe Payment Intents: Allow cross_border_classification parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Stripe: Remove outdated 'customer options' deprecation [alexdunae] #3401
 * BPoint: Remove amount from void requests [leila-alderman] #3518
 * Worldpay: Remove unnecessary .tag! methods [leila-alderman] #3519
+* Stripe Payment Intents: Allow cross_border_classification parameter [fatcatt316] #3508
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -9,9 +9,9 @@ module ActiveMerchant #:nodoc:
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
-      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method]
-      CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
-      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage]
+      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method cross_border_classification]
+      CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session cross_border_classification]
+      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage cross_border_classification]
       DEFAULT_API_VERSION = '2019-05-16'
 
       def create_intent(money, payment_method, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -291,6 +291,34 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 2000, capture_response.params['amount']
   end
 
+  def test_cross_border_classification_export
+    omit('"cross_border_classification" is only allowed to be sent for certain accounts (not the account we use for testing).')
+    # Currently get back "Received unknown parameter: cross_border_classification"
+    # if I send that. I've contacted our support contact to see if they can allow
+    # us to send that value across (might be an Indian Stripe thing only).
+    options = {
+      cross_border_classification: 'export',
+      description: 'Exported service',
+      shipping: {
+        name: 'Jane Doe',
+        address: {
+          line1: '1234 Any Street',
+          postal_code: '27703',
+          city: 'Durham',
+          state: 'NC',
+          country: 'US'
+        }
+      }
+    }
+
+    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
+    # intent_id = create_response.params['id']
+
+    assert_success create_response # This line currently fails
+    # Once our test account is able to send cross_border_classification,
+    # assert that this was marked as an export.
+  end
+
   def test_auth_and_capture_with_destination_account_and_fee
     options = {
       currency: 'GBP',


### PR DESCRIPTION
## Why?
Indian Stripe Payment Intents users must specify their transaction as
`cross_border_classification: "export"` in order to sell to customers
outside of India.

### Jira
[CE-358](https://spreedly.atlassian.net/browse/CE-358)

## What Changed?

Adds the ability to specify a Stripe Payment Intent `cross_border_classification`. This must be set to "export" to sell to customers outside of India.

If this parameter is blank or set to "domestic", then it will be
treated as a domestic transaction.

**Note:** this parameter seems like it might only be allowed for Indian Stripe users. When I send the `cross_border_classification` parameter through, I get back the error:
```
Received unknown parameter: cross_border_classification
```
For now, I've commented out the remote test that sends this parameter.

I'm in touch with Stripe support to see if they can provide any info 
about this.

The only documentation I've seen for this is the Word doc that a customer sent us: [Stripe payment intent - accepting-an-export-card-payment.docx](https://github.com/activemerchant/active_merchant/files/4141377/Stripe.payment.intent.-.accepting-an-export-card-payment.docx)

## Testing
### Unit
```
rake TEST=test/unit/gateways/stripe_payment_intents_test.rb

7 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Remote
```
rake TEST=test/remote/gateways/remote_stripe_payment_intents_test.rb

31 tests, 123 assertions, 1 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
96.6667% passed
```

Failing test (which also fails on master):
```
ruby -I test test/remote/gateways/remote_stripe_payment_intents_test.rb -n test_create_payment_intent_that_saves_payment_method
```

## Questions for Reviewers
1. So far I haven't heard back much at all from support about this, so I've been unable to successfully test this. What is the usual recourse in this kind of situation? Should we reach out to the requesting customer, explain the situation to them, and ask them to test it once it's deployed?

If so, I can go back in the code and clear out the "TODO"s, and maybe leave the comments in the test code. How does that sound?