### PR TITLE
Paymentez: Correct refund and void message parsing

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -241,6 +241,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
+        return response['detail'] if response['detail'].present?
+
         if !success_from(response) && response['error']
           response['error'] && response['error']['type']
         else

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -105,6 +105,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, auth.authorization, @options)
     assert_success refund
+    assert_equal 'Completed', refund.message
   end
 
   def test_successful_refund_with_elo
@@ -113,6 +114,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, auth.authorization, @options)
     assert_success refund
+    assert_equal 'Completed', refund.message
   end
 
   def test_successful_void
@@ -121,6 +123,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
+    assert_equal 'Completed', void.message
   end
 
   def test_successful_void_with_elo
@@ -129,6 +132,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
     assert void = @gateway.void(auth.authorization)
     assert_success void
+    assert_equal 'Completed', void.message
   end
 
   def test_failed_void

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -157,6 +157,7 @@ class PaymentezTest < Test::Unit::TestCase
       assert_match(/"amount":1.0/, data)
     end.respond_with(successful_refund_response)
     assert_success response
+    assert_equal 'Completed', response.message
     assert response.test?
   end
 
@@ -165,6 +166,7 @@ class PaymentezTest < Test::Unit::TestCase
 
     response = @gateway.refund(@amount, '1234', @options)
     assert_failure response
+    assert_equal 'Invalid Status', response.message
     assert response.test?
   end
 
@@ -173,6 +175,7 @@ class PaymentezTest < Test::Unit::TestCase
 
     response = @gateway.void('1234', @options)
     assert_success response
+    assert_equal 'Completed', response.message
     assert response.test?
   end
 
@@ -180,6 +183,7 @@ class PaymentezTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_void_response)
 
     response = @gateway.void('1234', @options)
+    assert_equal 'Invalid Status', response.message
     assert_failure response
   end
 
@@ -508,7 +512,7 @@ Conn close
   end
 
   def failed_void_response
-    '{"error": {"type": "Carrier not supported", "help": "", "description": "{}"}}'
+    '{"status": "failure", "detail": "Invalid Status"}'
   end
 
   alias_method :successful_refund_response, :successful_void_response


### PR DESCRIPTION
## Why?

- Per the Paymentez docs, the refund action response has a different shape than other responses from this gateway: https://paymentez.github.io/api-doc/#payment-methods-cards-refund

```json
{"status": "success", "detail": "Completed"}
```

- ActiveMerchant parses the success field of these messages correctly, but not the messages.
  - Success field: https://github.com/activemerchant/active_merchant/blob/cee8dff883dfcfd0e64e10d189a443eee0aac82f/lib/active_merchant/billing/gateways/paymentez.rb#L232-L234
  - Message field: https://github.com/activemerchant/active_merchant/blob/cee8dff883dfcfd0e64e10d189a443eee0aac82f/lib/active_merchant/billing/gateways/paymentez.rb#L243-L249

## What Changed?

- Changed the Paymentez unit test void/refund payload shape to match the specs.
- Added checks on Paymentez unit and remote tests for `nil` message values.
- Added proper message handling for Paymentez void and refunds.

## Test Validation

To capture the failures, the following tests were added to check for a non-nil value for the and failed at first:

```
Failure: test_successful_void(RemotePaymentezTest): <nil> was expected to not be nil.
Failure: test_successful_void_with_elo(RemotePaymentezTest): <nil> was expected to not be nil.
Failure: test_successful_refund(RemotePaymentezTest): <nil> was expected to not be nil.
Failure: test_successful_refund_with_elo(RemotePaymentezTest): <nil> was expected to not be nil.
Failure: test_failed_refund(PaymentezTest): <nil> was expected to not be nil.
Failure: test_failed_void(PaymentezTest): <nil> was expected to not be nil.
Failure: test_partial_refund(PaymentezTest): <nil> was expected to not be nil.
Failure: test_successful_void(PaymentezTest): <nil> was expected to not be nil.
```

This PR includes the changes to make these tests pass.

## Test Suite Results

Unit tests:

```
23 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Remote tests:

```
26 tests, 64 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.3077% passed
```

Note: the two failing remote tests are not related to these changes and are failing on master:
- `test_partial_capture`
- `test_successful_authorize_and_capture_with_different_amount`

