### PR TITLE
Authorize.Net: Remove supported countries except for AU CA US

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@
 * Moneris: use dedicated card_verification methods [alexdunae] #3428
 * Paymentez: Correct refund and void message parsing [carrigan] #3509
 * Mercado Pago: Add taxes and net_amount gateway specific fields [carrigan] #3512
+* Authorize.net: Trim down supported countries [fatcatt316] #3511
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -8,7 +8,7 @@ module ActiveMerchant
       self.test_url = 'https://apitest.authorize.net/xml/v1/request.api'
       self.live_url = 'https://api2.authorize.net/xml/v1/request.api'
 
-      self.supported_countries = %w(AD AT AU BE BG CA CH CY CZ DE DK EE ES FI FR GB GI GR HU IE IL IS IT LI LT LU LV MC MT NL NO PL PT RO SE SI SK SM TR US VA)
+      self.supported_countries = %w(AU CA US)
       self.default_currency = 'USD'
       self.money_format = :dollars
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -952,7 +952,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal 4, (['US', 'CA', 'AU', 'VA'] & AuthorizeNetGateway.supported_countries).size
+    assert_equal 3, (%w[US CA AU] & AuthorizeNetGateway.supported_countries).size
   end
 
   def test_supported_card_types


### PR DESCRIPTION
There was a request that we remove all countries except United States,
Canada, and Australia from Authorize.net gateway guide
- https://docs.spreedly.com/payment-gateways/authorize-net/

This is due to PSD2/SCA in Europe. Authorize.net will not add any new customers for the countries being removed because they won't support SCA.

This [change will only affect documentation](https://github.com/activemerchant/active_merchant/wiki/Contributing#setting-the-gateways-metadata).

CE-368

## Test Results

### Unit and Rubocop
```
rake TEST=test/unit/gateways/authorize_net_test.rb

97 tests, 575 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

```
rake test:local

4435 tests, 71401 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

### Remote
I ran this twice. The first time 4 tests failed, and the second time 5 tests failed.

Each time, it was different tests that failed, always with this error:
```
ActiveMerchant::ConnectionError: The connection to the remote server timed out
```
I get these kinds of errors running this test on `master`, too 🤔 

If I run any of those failing tests individually, they pass.
```
rake TEST=test/remote/gateways/remote_authorize_net_test.rb

69 tests, 226 assertions, 0 failures, 3 errors, 0 pendings, 0 omissions, 0 notifications
95.6522% passed
```