### PR TITLE
Mercado Pago: Add taxes and net_amount gateway specific fields

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -96,6 +96,8 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, payment, options)
         add_address(post, options)
         add_processing_mode(post, options)
+        add_net_amount(post, options)
+        add_taxes(post, options)
         post[:binary_mode] = (options[:binary_mode].nil? ? true : options[:binary_mode])
         post
       end
@@ -194,6 +196,47 @@ module ActiveMerchant #:nodoc:
         post[:token] = options[:card_token]
         post[:issuer_id] = options[:issuer_id] if options[:issuer_id]
         post[:payment_method_id] = options[:payment_method_id] if options[:payment_method_id]
+      end
+
+      def add_net_amount(post, options)
+        post[:net_amount] = Float(options[:net_amount]) if options[:net_amount]
+      end
+
+      def add_taxes(post, options)
+        return unless (tax_object = options[:taxes])
+
+        if tax_object.is_a?(Array)
+          post[:taxes] = process_taxes_array(tax_object)
+        elsif tax_object.is_a?(Hash)
+          post[:taxes] = process_taxes_hash(tax_object)
+        else
+          raise taxes_error
+        end
+      end
+
+      def process_taxes_hash(tax_object)
+        [sanitize_taxes_hash(tax_object)]
+      end
+
+      def process_taxes_array(taxes_array)
+        taxes_array.map do |tax_object|
+          raise taxes_error unless tax_object.is_a?(Hash)
+
+          sanitize_taxes_hash(tax_object)
+        end
+      end
+
+      def sanitize_taxes_hash(tax_object)
+        tax_value = tax_object['value'] || tax_object[:value]
+        tax_type = tax_object['type'] || tax_object[:type]
+
+        raise taxes_error if tax_value.nil? || tax_type.nil?
+
+        { value: Float(tax_value), type: tax_type }
+      end
+
+      def taxes_error
+        ArgumentError.new("Taxes should be a single object or array of objects with the shape: { value: 500, type: 'IVA' }")
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -4,9 +4,11 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
   def setup
     @gateway = MercadoPagoGateway.new(fixtures(:mercado_pago))
     @argentina_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_argentina))
+    @colombian_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_colombia))
 
     @amount = 500
     @credit_card = credit_card('4509953566233704')
+    @colombian_card = credit_card('4013540682746260')
     @elo_credit_card = credit_card('5067268650517446',
       :month => 10,
       :year => 2020,
@@ -86,6 +88,21 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     amex_card = credit_card('375365153556885', brand: 'american_express', verification_value: '1234')
 
     response = @gateway.purchase(@amount, amex_card, @options)
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
+  def test_successful_purchase_with_taxes_and_net_amount
+    # Minimum transaction amount is 0.30 EUR or ~1112 $COL on 1/27/20.
+    # This value must exceed that
+    amount = 10000_00
+
+    # These values need to be represented as dollars, so divide them by 100
+    tax_amount = amount * 0.19
+    @options[:net_amount] = (amount - tax_amount) / 100
+    @options[:taxes] = [{ value: tax_amount / 100, type: 'IVA' }]
+
+    response = @colombian_gateway.purchase(amount, @colombian_card, @options)
     assert_success response
     assert_equal 'accredited', response.message
   end


### PR DESCRIPTION
## Why?

- For Colombian users to supply IVA tax information to Mercado Pago, support is required for the `taxes` and `net_amount` fields on purchase requests. 
- https://www.mercadopago.com.co/developers/en/guides/localization/iva-colombia/
- CE-365


## What Changed?

- Added support for `taxes` and `net_amount` fields on the Mercado Pago gateway. These optional fields allow Colombian users to add IVA tax information to transactions. 
- The `taxes` field has support for a single tax object or an array of tax objects to better support upstream XML representation of this field.

## Test Suite

Unit:

```
4433 tests, 71395 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

Remote:

```
31 tests, 93 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.5484% passed
```

Remote Test Failures (also on master, unrelated):
- test_partial_capture
- test_successful_purchase_with_processing_mode_gateway