### PR TITLE
Worldpay: Add riskData support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Worldpay: Remove unnecessary .tag! methods [leila-alderman] #3519
 * Stripe Payment Intents: Allow cross_border_classification parameter [fatcatt316] #3508
 * EBANX: Fix `scrub` [chinhle23] #3521
+* Worldpay: Add `riskData` GSF [fatcatt316] #3514
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460


### PR DESCRIPTION
## Why?

* These fields will be needed for Worldpay 3DS2 for frictionless flow. This the requires adding the `<riskData>` field, which contains three child elements: `<authenticationRiskData>`, `<shopperAccountRiskData>`, and `<transactionRiskData>`.

* By providing additional information in the <riskData> element, this lowers the chance that the shopper will be challenged.

* [Relevant Worldpay docs](https://beta.developer.worldpay.com/docs/wpg/directintegration/3ds2#initial-xml-payment-request)

* CE-371

## What Changed?

- Add support for `riskData` element (and child elements) for the Worldpay gateway.

## Testing

### Unit:

```
rake test:local

4441 tests, 71464 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

Gateway-specific Unit Test:
```
rake TEST=test/unit/gateways/worldpay_test.rb

70 tests, 460 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Remote:

```
rake TEST=test/remote/gateways/remote_worldpay_test.rb

57 tests, 243 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4912% passed
```

Remote Test Failures (also on master, unrelated):
```
test_3ds_version_1_parameters_pass_thru
test_3ds_version_2_parameters_pass_thru
```

## Questions for Reviewers
1. This is a chunky XML change. Are there more standard/prettier ways that we'd usually do this (especially in the tests)?
2. Should `transactionRiskDataGiftCardAmount` use `add_amount`? If so... how is the `money` variable defined?
3. Do we have a usual way of dealing with boolean attributes in XML? I ask since `previousSuspiciousActivity` and `shippingNameMatchesAccountName` are booleans.
4. Any more tests y'all would recommend?