### PR TITLE
Allow optional fields in 3DS 2 based transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Credorax: Allow optional 3DS 2 fields [jeremywrowe] #3515
 * Stripe: Remove outdated 'customer options' deprecation [alexdunae] #3401
 
 == Version 1.104.0 (Jan 29, 2020)

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -132,6 +132,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_email(post, options)
         add_3d_secure(post, options)
+        add_3ds_2_optional_fields(post, options)
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_stored_credential(post, options)
@@ -147,6 +148,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_email(post, options)
         add_3d_secure(post, options)
+        add_3ds_2_optional_fields(post, options)
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_stored_credential(post, options)
@@ -226,6 +228,21 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((b1=)\d+), '\1[FILTERED]').
           gsub(%r((b5=)\d+), '\1[FILTERED]')
+      end
+
+      def add_3ds_2_optional_fields(post, options)
+        three_ds = options[:three_ds_2] || {}
+
+        if three_ds.has_key?(:optional)
+          three_ds[:optional].each do |key, value|
+            normalized_value = normalize(value)
+            next if normalized_value.nil?
+
+            post[key] = normalized_value unless post[key]
+          end
+        end
+
+        post
       end
 
       private
@@ -405,8 +422,10 @@ module ActiveMerchant #:nodoc:
 
       def sign_request(params)
         params = params.sort
-        params.each { |param| param[1].gsub!(/[<>()\\]/, ' ') }
-        values = params.map { |param| param[1].strip }
+        values = params.map do |param|
+          value = param[1].gsub(/[<>()\\]/, ' ')
+          value.strip
+        end
         Digest::MD5.hexdigest(values.join + @options[:cipher_key])
       end
 

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -812,6 +812,33 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_3ds_2_optional_fields_adds_fields_to_the_root_of_the_post
+    post = { }
+    options = { three_ds_2: { optional: { '3ds_optional_field_1': :a, '3ds_optional_field_2': :b } } }
+
+    @gateway.add_3ds_2_optional_fields(post, options)
+
+    assert_equal post, { '3ds_optional_field_1': :a, '3ds_optional_field_2': :b }
+  end
+
+  def test_3ds_2_optional_fields_does_not_overwrite_fields
+    post = { '3ds_optional_field_1': :existing_value }
+    options = { three_ds_2: { optional: { '3ds_optional_field_1': :a, '3ds_optional_field_2': :b } } }
+
+    @gateway.add_3ds_2_optional_fields(post, options)
+
+    assert_equal post, { '3ds_optional_field_1': :existing_value, '3ds_optional_field_2': :b }
+  end
+
+  def test_3ds_2_optional_fields_does_not_empty_fields
+    post = { }
+    options = { three_ds_2: { optional: { '3ds_optional_field_1': '', '3ds_optional_field_2': 'null', '3ds_optional_field_3': nil } } }
+
+    @gateway.add_3ds_2_optional_fields(post, options)
+
+    assert_equal post, { }
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION
This is the start of an effort to create an escape hatch to allow folks to add
additional request data when creating 3DS 2 based transactions. Credorax is the
first gateway to leverage the change. I had added more gateways, but complexity
grew quickly when doing so.

usage summary:

When creating a 3DS 2 based authorization or purchase, if the option `{ three_ds_2: { optional: { ... } }`
is provided, all fields inside of the optional hash will be applied to the post
body root.

example

```rb
options = {
  three_ds_2: {
    optional: {
      a: 1,
      b: 2
    }
  }
}

credorax.purchase(amount, payment_method, options)

...

post data will look like:

{
  ...existing_post_data,
  a: 1,
  b: 2
}
```

In addition to the change, the signing of the credorax request body no longer fails with frozen strings. Checkout unit tests on master for credorax vs this branch.

```
Unit Tests (1 unrelated failure)
----------------------------------------------------------------------------------
4440 tests, 71132 assertions, 1 failures, 71 errors, 0 pendings, 0 omissions, 0 notifications
98.3784% passed
----------------------------------------------------------------------------------
```