### PR TITLE
Authorize.net: Trim supported countries to AU, CA, US in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ guide and [Standardized 3DS Fields](https://github.com/activemerchant/active_mer
 The [ActiveMerchant Wiki](https://github.com/activemerchant/active_merchant/wikis) contains a [table of features supported by each gateway](https://github.com/activemerchant/active_merchant/wiki/Gateway-Feature-Matrix).
 
 * [Authorize.Net CIM](http://www.authorize.net/) - US
-* [Authorize.Net](http://www.authorize.net/) - AD, AT, AU, BE, BG, CA, CH, CY, CZ, DE, DK, ES, FI, FR, GB, GB, GI, GR, HU, IE, IT, LI, LU, MC, MT, NL, NO, PL, PT, RO, SE, SI, SK, SM, TR, US, VA
+* [Authorize.Net](http://www.authorize.net/) - AU, CA, US
 * [Axcess MS](http://www.axcessms.com/) - AD, AT, BE, BG, BR, CA, CH, CY, CZ, DE, DK, EE, ES, FI, FO, FR, GB, GI, GR, HR, HU, IE, IL, IM, IS, IT, LI, LT, LU, LV, MC, MT, MX, NL, NO, PL, PT, RO, RU, SE, SI, SK, TR, US, VA
 * [Balanced](https://www.balancedpayments.com/) - US
 * [Bambora Asia-Pacific](http://www.bambora.com/) - AU, NZ


### PR DESCRIPTION
There was a request that we remove all countries except United States,
Canada, and Australia from Authorize.net

This is due to PSD2/SCA in Europe. Authorize.net will not add any new customers for the countries being removed because they won't support SCA. More [details can be found on their site](https://www.authorize.net/en-gb/).

This PR only affects the README, and keeps Authorize.net's list of supported countries consistent with the changes made in #3511 

[CE-382](https://spreedly.atlassian.net/browse/CE-382)