### PR TITLE
BPoint: Remove amount from void requests

### DIFF
--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -61,10 +61,10 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def void(amount, authorization, options={})
+      def void(authorization, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_void(payment_xml, amount, authorization, options)
+            add_void(payment_xml, authorization, options)
           end
         end
         commit(request_body)
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options={})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(100, r.authorization, options) }
+          r.process(:ignore_result) { void(r.authorization, options.merge(amount: 100)) }
         end
       end
 
@@ -154,7 +154,9 @@ module ActiveMerchant #:nodoc:
         transaction_number_xml(xml, transaction_number)
       end
 
-      def add_void(xml, amount, transaction_number, options)
+      def add_void(xml, transaction_number, options)
+        # The amount parameter is required for void requests on BPoint.
+        amount = options[:amount]
         payment_xml(xml, 'REVERSAL', amount, options)
         transaction_number_xml(xml, transaction_number)
       end

--- a/test/remote/gateways/remote_bpoint_test.rb
+++ b/test/remote/gateways/remote_bpoint_test.rb
@@ -103,12 +103,12 @@ class RemoteBpointTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
-    assert void = @gateway.void(@amount, auth.authorization)
+    assert void = @gateway.void(auth.authorization, amount: @amount)
     assert_success void
   end
 
   def test_failed_void
-    response = @gateway.void(@amount, '')
+    response = @gateway.void('', amount: @amount)
     assert_failure response
   end
 

--- a/test/unit/gateways/bpoint_test.rb
+++ b/test/unit/gateways/bpoint_test.rb
@@ -88,13 +88,23 @@ class BpointTest < Test::Unit::TestCase
 
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
-    response = @gateway.void(@amount, '')
+    response = @gateway.void('', amount: 300)
     assert_success response
+  end
+
+  def test_void_passes_correct_transaction_reference
+    stub_comms do
+      # transaction number from successful authorize response
+      @gateway.void('219388558', amount: 300)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<OriginalTransactionNumber>219388558</OriginalTransactionNumber>)m, data)
+      assert_match(%r(<Amount>300</Amount>)m, data)
+    end.respond_with(successful_void_response)
   end
 
   def test_failed_void
     @gateway.expects(:ssl_post).returns(failed_void_response)
-    response = @gateway.void(@amount, '')
+    response = @gateway.void('')
     assert_failure response
   end
 


### PR DESCRIPTION
The `void` method for the BPoint gateway was previously implemented
incorrectly. Throughout Active Merchant, gateway `void` requests are
passed only an authorization number for the original transaction and an
options hash. However, for BPoint, the `void` method was also passed an
explicit `amount`. Due to the implementations on top of Active Merchant,
this was causing issues for Spreedly customers.

The BPoint `void` method has been rewritten to take in only
`authorization` and an `options` hash. Because the BPoint gateway
requires the amount to be sent on void transactions, this value should
be sent within the `options` hash with the key `amount`.

CE-338

Unit:
19 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
18 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4425 tests, 71371 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed