### PR TITLE
Worldpay: Remove unnecessary .tag! methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Credorax: Allow optional 3DS 2 fields [jeremywrowe] #3515
 * Stripe: Remove outdated 'customer options' deprecation [alexdunae] #3401
 * BPoint: Remove amount from void requests [leila-alderman] #3518
+* Worldpay: Remove unnecessary .tag! methods [leila-alderman] #3519
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460


### PR DESCRIPTION
When building an XML request, the `.tag!` method is only required if the
XML tag is a non-standard string, e.g., if it contains a hyphen or a
colon. Therefore, this method is often not needed and can be replaced
with a far more concise version.

This commit removes all unnecessary `.tag!` method calls for the
Worldpay gateway to improve the readability of the code.

Unit:
69 tests, 411 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
56 tests, 240 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
96.4286% passed

All unit tests:
4426 tests, 71371 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed