### PR TITLE
EBANX: Add metadata information in post

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -201,6 +201,7 @@ module ActiveMerchant #:nodoc:
 
       def add_additional_data(post, options)
         post[:device_id] = options[:device_id] if options[:device_id]
+        post[:metadata] = options[:metadata] if options[:metadata]
       end
 
       def parse(body)
@@ -209,7 +210,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, parameters)
         url = url_for((test? ? test_url : live_url), action, parameters)
-        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), {}))
+        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), {'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}"}))
 
         success = success_from(action, response)
 

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -18,7 +18,11 @@ class RemoteEbanxTest < Test::Unit::TestCase
       }),
       order_id: generate_unique_id,
       document: '853.513.468-93',
-      device_id: '34c376b2767'
+      device_id: '34c376b2767',
+      metadata: {
+        metadata_1: 'test',
+        metadata_2: 'test2'
+      }
     }
   end
 


### PR DESCRIPTION
Adding support for metadata information.

Unit:
17 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 63 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.4545% passed

The only test that's failing is because of the incorrect scrubbing of the integration key which is already being corrected in another pull request.