### PR TITLE
Revert Stripe Payment Intents GSF "cross_border_classification"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,6 @@
 * Stripe: Remove outdated 'customer options' deprecation [alexdunae] #3401
 * BPoint: Remove amount from void requests [leila-alderman] #3518
 * Worldpay: Remove unnecessary .tag! methods [leila-alderman] #3519
-* Stripe Payment Intents: Allow cross_border_classification parameter [fatcatt316] #3508
 * EBANX: Fix `scrub` [chinhle23] #3521
 * Worldpay: Add `riskData` GSF [fatcatt316] #3514
 

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -9,9 +9,9 @@ module ActiveMerchant #:nodoc:
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
-      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method cross_border_classification]
-      CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session cross_border_classification]
-      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage cross_border_classification]
+      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method]
+      CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
+      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage]
       DEFAULT_API_VERSION = '2019-05-16'
 
       def create_intent(money, payment_method, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -291,34 +291,6 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 2000, capture_response.params['amount']
   end
 
-  def test_cross_border_classification_export
-    omit('"cross_border_classification" is only allowed to be sent for certain accounts (not the account we use for testing).')
-    # Currently get back "Received unknown parameter: cross_border_classification"
-    # if I send that. I've contacted our support contact to see if they can allow
-    # us to send that value across (might be an Indian Stripe thing only).
-    options = {
-      cross_border_classification: 'export',
-      description: 'Exported service',
-      shipping: {
-        name: 'Jane Doe',
-        address: {
-          line1: '1234 Any Street',
-          postal_code: '27703',
-          city: 'Durham',
-          state: 'NC',
-          country: 'US'
-        }
-      }
-    }
-
-    assert create_response = @gateway.create_intent(@amount, @visa_payment_method, options)
-    # intent_id = create_response.params['id']
-
-    assert_success create_response # This line currently fails
-    # Once our test account is able to send cross_border_classification,
-    # assert that this was marked as an export.
-  end
-
   def test_auth_and_capture_with_destination_account_and_fee
     options = {
       currency: 'GBP',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -4,7 +4,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = StripePaymentIntentsGateway.new(login: 'login')
+    @gateway = StripePaymentIntentsGateway.new(:login => 'login')
 
     @credit_card = credit_card()
     @threeds_2_card = credit_card('4000000000003220')
@@ -64,26 +64,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'canceled', cancel.params['status']
   end
 
-  def test_successful_create_intent_with_cross_border_classification
-    export_options = {
-      cross_border_classification: 'export',
-      description: 'Exported service',
-      shipping: {
-        name: 'Jane Doe',
-        address: {
-          line1: '1234 Any Street',
-          postal_code: '27703',
-          city: 'Durham',
-          state: 'NC',
-          country: 'US'
-        }
-      }
-    }
-    @gateway.expects(:ssl_request).once.returns(successful_create_intent_response_with_cross_border_classification_export)
-    assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(export_options))
-    assert 'export', create.params['charges']['data'][0]['cross_border_classification']
-  end
-
   def test_failed_capture_after_creation
     @gateway.expects(:ssl_request).returns(failed_capture_response)
 
@@ -110,17 +90,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   def successful_create_intent_response
     <<-RESPONSE
       {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":2020,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_capture","transfer_data":null,"transfer_group":null}
-    RESPONSE
-  end
-
-  # Once we can successfully send a request with `cross_border_classification`
-  # parameter, update this to better reflect the actual response.
-  # Currently get back "Received unknown parameter: cross_border_classification"
-  # if we send that. I've contacted our support contact to see if they can allow
-  # us to send that value across (might be an Indian Stripe thing only).
-  def successful_create_intent_response_with_cross_border_classification_export
-    <<-RESPONSE
-      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":2020,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564501833,"cross_border_classification":"export","currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_capture","transfer_data":null,"transfer_group":null}
     RESPONSE
   end
 


### PR DESCRIPTION
This parameter wasn't able to be tested through our test account,
and the merchant who was going to test it in production is
no longer with our customer.

Also, I was unable to find documentation of this parameter
beyond a Word doc that the customer sent us.

CE-196

## Testing

### Local

```
rake TEST=test/unit/gateways/stripe_payment_intents_test.rb

6 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Remote

```
rake TEST=test/remote/gateways/remote_stripe_payment_intents_test.rb

30 tests, 123 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6667% passed
```
Failing test also fails on `master`:
* test_create_payment_intent_that_saves_payment_method