### PR TITLE
Merchant Warrior: Send void amount in options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * EBANX: Add metadata information in post [miguelxpn] #3522
 * HPS: support eCheck [therufs] #3500
 * Decidir: Add support for fraud_detection, site_id, and establishment_name [fatcatt316] #3527
+* Merchant Warrior: Send void amount in options [leila-alderman] #3525
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -84,13 +84,13 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     assert purchase = @gateway.purchase(@success_amount, @credit_card, @options)
     assert_success purchase
 
-    assert void = @gateway.void(@success_amount, purchase.authorization)
+    assert void = @gateway.void(purchase.authorization, amount: @success_amount)
     assert_success void
     assert_equal 'Transaction approved', void.message
   end
 
   def test_failed_void
-    assert void = @gateway.void(@success_amount, 'invalid-transaction-id')
+    assert void = @gateway.void('invalid-transaction-id', amount: @success_amount)
     assert_match %r{'transactionID' not found}, void.message
     assert_failure void
   end

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -74,7 +74,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_refund_response)
 
-    assert response = @gateway.void(@success_amount, @transaction_id, @options)
+    assert response = @gateway.void(@transaction_id, amount: @success_amount)
     assert_success response
     assert_equal 'Transaction approved', response.message
     assert response.test?
@@ -84,7 +84,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_failed_void
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 
-    assert response = @gateway.void(@success_amount, @transaction_id)
+    assert response = @gateway.void(@transaction_id, amount: @success_amount)
     assert_failure response
     assert_equal 'MW -016:transactionID has already been reversed', response.message
     assert response.test?


### PR DESCRIPTION
The `void` method for the Merchant Warrior gateway was previously
implemented incorrectly. Throughout Active Merchant, gateway `void`
requests are passed only an authorization number for the original
transaction and an options hash. However, for Merchant Warrior, the void
method was also passed an explicit amount. Due to the implementations on
top of Active Merchant, this was causing issues for Spreedly customers.

The Merchant Warrior `void` method has been rewritten to take in only
authorization and an options hash. Because the Merchant Warrior gateway
requires the amount to be sent on void transactions, this value should
be sent within the `options` hash with the key `amount`.

In addition, the required verification hash for `void` transactions
should consist of the original transaction ID, not the amount and the
currency. This change also adds a new `void_verification_hash` method
that calculates the correct hash for the `void` method.

CE-379

Unit:
17 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
15 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4442 tests, 71468 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed