### PR TITLE
Decidir: Add support for establishment_name, site_id, and fraud_detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Paypal: Fix OrderTotal elements in `add_payment_details` [chinhle23] #3517
 * EBANX: Add metadata information in post [miguelxpn] #3522
 * HPS: support eCheck [therufs] #3500
+* Decidir: Add support for fraud_detection, site_id, and establishment_name [fatcatt316] #3527
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['AR']
       self.money_format = :cents
       self.default_currency = 'ARS'
-      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :naranja, :cabal]
+      self.supported_cardtypes = %i[visa master american_express diners_club naranja cabal]
 
       self.homepage_url = 'http://www.decidir.com'
       self.display_name = 'Decidir'
@@ -113,6 +113,9 @@ module ActiveMerchant #:nodoc:
         post[:installments] = options[:installments] ? options[:installments].to_i : 1
         post[:description] = options[:description] if options[:description]
         post[:email] = options[:email] if options[:email]
+        post[:establishment_name] = options[:establishment_name] if options[:establishment_name]
+        post[:fraud_detection] = add_fraud_detection(options[:fraud_detection]) if options[:fraud_detection].present?
+        post[:site_id] = options[:site_id] if options[:site_id]
         post[:sub_payments] = []
 
         add_invoice(post, money, options)
@@ -174,6 +177,19 @@ module ActiveMerchant #:nodoc:
         card_data[:card_holder_identification][:number] = options[:card_holder_identification_number] if options[:card_holder_identification_number]
 
         post[:card_data] = card_data
+      end
+
+      def add_fraud_detection(options = {})
+        {}.tap do |hsh|
+          hsh[:send_to_cs] = options[:send_to_cs] if valid_fraud_detection_option?(options[:send_to_cs]) # true/false
+          hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
+          hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
+        end
+      end
+
+      # Avoid sending fields with empty or null when not populated.
+      def valid_fraud_detection_option?(val)
+        !val.nil? && val != ''
       end
 
       def headers(options = {})

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -73,12 +73,22 @@ class RemoteDecidirTest < Test::Unit::TestCase
       card_holder_birthday: '01011980',
       card_holder_identification_type: 'dni',
       card_holder_identification_number: '123456',
-      installments: '12'
+      establishment_name: 'Heavenly Buffaloes',
+      fraud_detection: {
+        send_to_cs: false,
+        channel: 'Web',
+        dispatch_method: 'Store Pick Up'
+      },
+      installments: '12',
+      site_id: '99999999'
     }
 
     response = @gateway_for_purchase.purchase(@amount, credit_card('4509790112684851'), @options.merge(options))
     assert_success response
     assert_equal 'approved', response.message
+    assert_equal 'Heavenly Buffaloes', response.params['establishment_name']
+    assert_equal '99999999', response.params['site_id']
+    assert_equal({'status' => nil}, response.params['fraud_detection'])
     assert response.authorization
   end
 

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -35,16 +35,26 @@ class DecidirTest < Test::Unit::TestCase
       card_holder_birthday: '01011980',
       card_holder_identification_type: 'dni',
       card_holder_identification_number: '123456',
-      installments: 12
+      establishment_name: 'Heavenly Buffaloes',
+      fraud_detection: {
+        send_to_cs: false,
+        channel: 'Web',
+        dispatch_method: 'Store Pick Up'
+      },
+      installments: 12,
+      site_id: '99999999'
     }
 
     response = stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(options))
     end.check_request do |method, endpoint, data, headers|
-      assert data =~ /card_holder_door_number/, '1234'
-      assert data =~ /card_holder_birthday/, '01011980'
-      assert data =~ /type/, 'dni'
-      assert data =~ /number/, '123456'
+      assert data =~ /"card_holder_door_number":1234/
+      assert data =~ /"card_holder_birthday":"01011980"/
+      assert data =~ /"type":"dni"/
+      assert data =~ /"number":"123456"/
+      assert data =~ /"establishment_name":"Heavenly Buffaloes"/
+      assert data =~ /"site_id":"99999999"/
+      assert data =~ /"fraud_detection":{"send_to_cs":false,"channel":"Web","dispatch_method":"Store Pick Up"}/
     end.respond_with(successful_purchase_response)
 
     assert_equal 7719132, response.authorization
@@ -346,7 +356,7 @@ class DecidirTest < Test::Unit::TestCase
       -> "Via: kong/0.8.3\r\n"
       -> "\r\n"
       reading 659 bytes...
-      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":null,\"aggregate_data\":null,\"establishment_name\":null,\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
+      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":{\"status\":null},\"aggregate_data\":null,\"establishment_name\":\"Heavenly Buffaloes\",\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
       read 659 bytes
       Conn close
     )
@@ -371,7 +381,7 @@ class DecidirTest < Test::Unit::TestCase
       -> "Via: kong/0.8.3\r\n"
       -> "\r\n"
       reading 659 bytes...
-      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":null,\"aggregate_data\":null,\"establishment_name\":null,\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
+      -> "{\"id\":7721017,\"site_transaction_id\":\"d5972b68-87d5-46fd-8d3d-b2512902b9af\",\"payment_method_id\":1,\"card_brand\":\"Visa\",\"amount\":100,\"currency\":\"ars\",\"status\":\"approved\",\"status_details\":{\"ticket\":\"7297\",\"card_authorization_code\":\"153842\",\"address_validation_code\":\"VTE0011\",\"error\":null},\"date\":\"2019-06-24T15:38Z\",\"customer\":null,\"bin\":\"450799\",\"installments\":1,\"first_installment_expiration_date\":null,\"payment_type\":\"single\",\"sub_payments\":[],\"site_id\":\"99999999\",\"fraud_detection\":{\"status\":null},\"aggregate_data\":null,\"establishment_name\":\"Heavenly Buffaloes\",\"spv\":null,\"confirmed\":null,\"pan\":\"345425f15b2c7c4584e0044357b6394d7e\",\"customer_token\":null,\"card_data\":\"/tokens/7721017\"}"
       read 659 bytes
       Conn close
     )
@@ -379,7 +389,7 @@ class DecidirTest < Test::Unit::TestCase
 
   def successful_purchase_response
     %(
-      {"id":7719132,"site_transaction_id":"ebcb2db7-7aab-4f33-a7d1-6617a5749fce","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"approved","status_details":{"ticket":"7156","card_authorization_code":"174838","address_validation_code":"VTE0011","error":null},"date":"2019-06-21T17:48Z","customer":null,"bin":"450799","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999999","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"345425f15b2c7c4584e0044357b6394d7e","customer_token":null,"card_data":"/tokens/7719132"}
+      {"id":7719132,"site_transaction_id":"ebcb2db7-7aab-4f33-a7d1-6617a5749fce","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"approved","status_details":{"ticket":"7156","card_authorization_code":"174838","address_validation_code":"VTE0011","error":null},"date":"2019-06-21T17:48Z","customer":null,"bin":"450799","installments":1,"establishment_name":"Heavenly Buffaloes","first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999999","fraud_detection":{"status":null},"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"345425f15b2c7c4584e0044357b6394d7e","customer_token":null,"card_data":"/tokens/7719132"}
     )
   end
 


### PR DESCRIPTION
## What Changed?
Add support for additional gateway-specific fields for Decidir:
- [x] establishment_name ([docs](https://decidirv2.api-docs.io/1.0/transacciones-simples/flujo-de-una-transaccion-simple))
- [x] site_id ([docs](https://decidirv2.api-docs.io/1.0/transacciones-simples/ejecucion-del-pago-1))
- [x] fraud_detection ([docs](https://decidirv2.api-docs.io/1.0/prevencion-de-fraude-by-cybersource/device-fingerprint))

Also, fixed some remote Decidir tests that weren't quite doing what they seemed to be doing.

## Why?
* `fraud_detection` can be set to help control if a transaction is sent for fraud review. 
* `establishment_name` is a merchant soft descriptor.
* `site_id` helps link the transaction to a specific trade account, as a business may have multiple trade accounts with Decidir.

CE-340
CE-357
CE-380

## Testing
### All local
```
rake test:local

4444 tests, 71479 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

### Decidir local
```
rake TEST=test/unit/gateways/decidir_test.rb

32 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Decidir remote
```
rake TEST=test/remote/gateways/remote_decidir_test.rb

21 tests, 74 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.2381% passed
```

1 failing test that also fails on on `master`:
* test_failed_purchase

Also, I've sometimes seen 504 errors while running remote tests,
although they seem to go away if you wait...

## Questions for Reviewers
1. Any more testing you would like to see? Anything at all!
2. Do you see **_anything_** in the documentation that looks different than what I've done here (Spanish is not my first language)?