### PR TITLE
Stripe: Add support for `statement_descriptor_suffix` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@
 * Mercado Pago: Add taxes and net_amount gateway specific fields [carrigan] #3512
 * Moneris: use dedicated card_verification methods [alexdunae] #3428
 * Authorize.net: Trim down supported countries [fatcatt316] #3511
+* Stripe: Add support for `statement_descriptor_suffix` field #3528
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -362,6 +362,7 @@ module ActiveMerchant #:nodoc:
           add_customer_data(post, options)
           post[:description] = options[:description]
           post[:statement_descriptor] = options[:statement_description]
+          post[:statement_descriptor_suffix] = options[:statement_descriptor_suffix] if options[:statement_descriptor_suffix]
           post[:receipt_email] = options[:receipt_email] if options[:receipt_email]
           add_customer(post, payment, options)
           add_flags(post, options)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -9,9 +9,9 @@ module ActiveMerchant #:nodoc:
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
-      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email save_payment_method]
+      CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email save_payment_method]
       CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
-      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor receipt_email setup_future_usage]
+      UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email setup_future_usage]
       DEFAULT_API_VERSION = '2019-05-16'
 
       def create_intent(money, payment_method, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -126,12 +126,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   end
 
   def test_create_payment_intent_with_metadata
+    suffix = 'SUFFIX'
+
     options = {
       currency: 'USD',
       customer: @customer,
       description: 'ActiveMerchant Test Purchase',
       receipt_email: 'test@example.com',
       statement_descriptor: 'Statement Descriptor',
+      statement_descriptor_suffix: suffix,
       metadata: { key_1: 'value_1', key_2: 'value_2' }
     }
 
@@ -142,6 +145,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'ActiveMerchant Test Purchase', response.params['description']
     assert_equal 'test@example.com', response.params['receipt_email']
     assert_equal 'Statement Descriptor', response.params['statement_descriptor']
+    assert_equal suffix, response.params['statement_descriptor_suffix']
   end
 
   def test_create_payment_intent_that_saves_payment_method

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -657,6 +657,14 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_statement_descriptor_suffix
+    suffix = 'SUFFIX'
+
+    assert response = @gateway.purchase(@amount, @credit_card, statement_descriptor_suffix: suffix)
+    assert_success response
+    assert_equal suffix, response.params['statement_descriptor_suffix']
+  end
+
   def test_verify_credentials
     assert @gateway.verify_credentials
 

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -55,6 +55,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'requires_confirmation', update.params['status']
   end
 
+  def test_contains_statement_descriptor_suffix
+    options = @options.merge(capture_method: 'manual', statement_descriptor_suffix: 'suffix')
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/statement_descriptor_suffix=suffix/, data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_successful_create_and_void_intent
     @gateway.expects(:ssl_request).twice.returns(successful_create_intent_response, successful_void_response)
     assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(capture_method: 'manual', confirm: true))

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -363,6 +363,16 @@ class StripeTest < Test::Unit::TestCase
     assert response.emv_authorization, 'Response should include emv_authorization containing the EMV ARPC'
   end
 
+  def test_contains_statement_descriptor_suffix
+    options = @options.merge(statement_descriptor_suffix: 'suffix')
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/statement_descriptor_suffix=suffix/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_declined_authorization_with_emv_credit_card
     @gateway.expects(:ssl_request).returns(declined_authorization_response_with_emv_auth_data)
 


### PR DESCRIPTION
## Why?

- https://stripe.com/docs/connect/required-updates/statement-descriptor-updates
- CE-419

## What Changed?

Adds support for the `statement_descriptor_suffix` field on both the Stripe and the Stripe Payment Intents gateways.

## Test Suites

Stripe Remote Tests
```
68 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Stripe Payment Intents Remote Tests
```
30 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Unit Tests
```
4446 tests, 71482 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```