### PR TITLE
Authorize.Net: Pass `account_type` to `check` payment types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * HPS: support eCheck [therufs] #3500
 * Decidir: Add support for fraud_detection, site_id, and establishment_name [fatcatt316] #3527
 * Merchant Warrior: Send void amount in options [leila-alderman] #3525
+* Authorize.Net: Pass `account_type` to `check` payment types [chinhle23] #3530
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -544,6 +544,7 @@ module ActiveMerchant
       def add_check(xml, check)
         xml.payment do
           xml.bankAccount do
+            xml.accountType(check.account_type)
             xml.routingNumber(check.routing_number)
             xml.accountNumber(check.account_number)
             xml.nameOnAccount(truncate(check.name, 22))

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -164,8 +164,17 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_match %r{This transaction has been approved}, response.message
   end
 
-  def test_successful_echeck_purchase
+  def test_successful_echeck_purchase_with_checking_account_type
     response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_echeck_purchase_with_savings_account_type
+    savings_account = check(account_type: 'savings')
+    response = @gateway.purchase(@amount, savings_account, @options)
     assert_success response
     assert response.test?
     assert_equal 'This transaction has been approved', response.message


### PR DESCRIPTION
https://developer.authorize.net/api/reference/features/echeck.html

A Spreedly customer reported notifications from Authorize.Net that a
savings account transaction was processed as a checking account transaction.
Authorize.Net requires `accountType` to be passed for `eCheck` transactions
in order for proper reporting and to avoid these type of notifications.

Though these `eCheck` transactions have been successful without the `accountType`
field being passed, the customer would like the notifications to stop.

Unit:
98 tests, 584 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
70 tests, 242 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4447 tests, 71494 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed