### PR TITLE
Credorax: Fix `3ds_transtype` setting in post

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Redsys: Update scrub method to account for 3DS error responses [britth] #3534
 * RuboCop: Fix Layout/IndentHash [leila-alderman] #3529
 * Bambora Apac: Send void amount in options [leila-alderman] #3532
+* Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -325,7 +325,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds_redirect_url'] = three_ds_2_options[:notification_url]
           post[:'3ds_challengewindowsize'] = options[:three_ds_challenge_window_size] || '03'
           post[:d5] = browser_info[:user_agent]
-          post[:'3ds_transtype'] = options[:transaction_type] || '01'
+          post[:'3ds_transtype'] = options[:three_ds_transtype] || '01'
           post[:'3ds_browsertz'] = browser_info[:timezone]
           post[:'3ds_browserscreenwidth'] = browser_info[:width]
           post[:'3ds_browserscreenheight'] = browser_info[:height]

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -274,6 +274,23 @@ class CredoraxTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_adds_3d2_secure_fields_with_3ds_transtype_specified
+    options_with_3ds = @normalized_3ds_2_options.merge(three_ds_transtype: '03')
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_3ds)
+    end.check_request do |endpoint, data, headers|
+      p data
+      assert_match(/3ds_channel=02/, data)
+      assert_match(/3ds_transtype=03/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '8a82944a5351570601535955efeb513c;006596;02617cf5f02ccaed239b6521748298c5;purchase', response.authorization
+    assert response.test?
+  end
+
   def test_purchase_adds_3d_secure_fields
     options_with_3ds = @options.merge({eci: 'sample-eci', cavv: 'sample-cavv', xid: 'sample-xid', three_ds_version: '1'})
 


### PR DESCRIPTION
ECS-938

https://epower.credorax.com/wp-content/uploads/2019/11/Credorax-Source-Payment-API-Specifications-v1.3-.pdf
The `3ds_transtype` parameter is incorrectly being set by the `transaction_type`
parameter which is meant for setting the `a9` parameter used for stored
credentials transactions and thus causing failed transactions with "At
least one of input parameters is malformed. Parameter 3ds_transtype is
invalid." error.

This change allows the `3ds_transtype` parameter to be explicitly set, otherwise
it defaults to "01"

Unit:
66 tests, 307 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
40 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4446 tests, 71485 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed