### PR TITLE
Bambora Apac: Send void amount in options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Authorize.Net: Pass `account_type` to `check` payment types [chinhle23] #3530
 * Redsys: Update scrub method to account for 3DS error responses [britth] #3534
 * RuboCop: Fix Layout/IndentHash [leila-alderman] #3529
+* Bambora Apac: Send void amount in options [leila-alderman] #3532
 
 == Version 1.104.0 (Jan 29, 2020)
 * Adyen: add `recurring_contract_type` GSF [therufs] #3460

--- a/lib/active_merchant/billing/gateways/bambora_apac.rb
+++ b/lib/active_merchant/billing/gateways/bambora_apac.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
-            add_amount(xml, money)
+            xml.Amount amount(money)
             xml.TrnType '1'
             add_payment(xml, payment)
             add_credentials(xml, options)
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
-            add_amount(xml, money)
+            xml.Amount amount(money)
             xml.TrnType '2'
             add_payment(xml, payment)
             add_credentials(xml, options)
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         commit('SubmitSingleCapture') do |xml|
           xml.Capture do
             xml.Receipt authorization
-            add_amount(xml, money)
+            xml.Amount amount(money)
             add_credentials(xml, options)
           end
         end
@@ -66,17 +66,17 @@ module ActiveMerchant #:nodoc:
         commit('SubmitSingleRefund') do |xml|
           xml.Refund do
             xml.Receipt authorization
-            add_amount(xml, money)
+            xml.Amount amount(money)
             add_credentials(xml, options)
           end
         end
       end
 
-      def void(money, authorization, options={})
+      def void(authorization, options={})
         commit('SubmitSingleVoid') do |xml|
           xml.Void do
             xml.Receipt authorization
-            add_amount(xml, money)
+            xml.Amount amount(options[:amount])
             add_credentials(xml, options)
           end
         end
@@ -114,10 +114,6 @@ module ActiveMerchant #:nodoc:
           xml.UserName @options[:username]
           xml.Password @options[:password]
         end
-      end
-
-      def add_amount(xml, money)
-        xml.Amount amount(money)
       end
 
       def add_payment(xml, payment)

--- a/test/remote/gateways/remote_bambora_apac_test.rb
+++ b/test/remote/gateways/remote_bambora_apac_test.rb
@@ -69,14 +69,14 @@ class RemoteBamboraApacTest < Test::Unit::TestCase
   def test_successful_void
     response = @gateway.purchase(200, @credit_card, @options)
     assert_success response
-    response = @gateway.void(200, response.authorization)
+    response = @gateway.void(response.authorization, amount: 200)
     assert_success response
   end
 
   def test_failed_void
     response = @gateway.purchase(200, @credit_card, @options)
     assert_success response
-    response = @gateway.void(200, 123)
+    response = @gateway.void(123, amount: 200)
     assert_failure response
     assert_equal 'Cannot find matching transaction to VOID', response.message
   end

--- a/test/unit/gateways/bambora_apac_test.rb
+++ b/test/unit/gateways/bambora_apac_test.rb
@@ -84,9 +84,10 @@ class BamboraApacTest < Test::Unit::TestCase
 
   def test_successful_void
     response = stub_comms do
-      @gateway.void(@amount, 'receipt')
+      @gateway.void('receipt', amount: 200)
     end.check_request do |endpoint, data, headers|
       assert_match(%r{<SubmitSingleVoid }, data)
+      assert_match(%r{<Amount>200<}, data)
     end.respond_with(successful_void_response)
 
     assert_success response


### PR DESCRIPTION
The `void` method for the Bambora Apac gateway was previously
implemented incorrectly. Throughout Active Merchant, gateway `void`
requests are passed only an authorization number for the original
transaction and an options hash. However, for Bambora Apac, the void
method was also passed an explicit amount. This break in the established
pattern was causing issues for implementations on top of Active
Merchant.

The Bambora Apac `void` method has been rewritten to take in only
authorization and an options hash. Because the Bambora Apac gateway
requires the amount to be sent on void transactions, this value should
be sent within the `options` hash with the key `amount`.

CE-389

Unit:
7 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications
100% passed

Remote:
15 tests, 30 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4444 tests, 71480 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed