### PR TITLE
Decidir: Allow string 'true' and 'false' for send_to_cs

### DIFF
--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
 
       def add_fraud_detection(options = {})
         {}.tap do |hsh|
-          hsh[:send_to_cs] = options[:send_to_cs] if valid_fraud_detection_option?(options[:send_to_cs]) # true/false
+          hsh[:send_to_cs] = attempt_boolean(options[:send_to_cs]) if valid_fraud_detection_option?(options[:send_to_cs])
           hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
           hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
         end
@@ -190,6 +190,17 @@ module ActiveMerchant #:nodoc:
       # Avoid sending fields with empty or null when not populated.
       def valid_fraud_detection_option?(val)
         !val.nil? && val != ''
+      end
+
+      # Returns a boolean if a boolean or 'true' or 'false' is sent in.
+      # Otherwise, returns the original value.
+      # This is so if the user sends an invalid boolean value like "okay",
+      # the gateway will send back an error.
+      def attempt_boolean(val)
+        return true if val == 'true'
+        return false if val == 'false'
+
+        val
       end
 
       def headers(options = {})

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -75,7 +75,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
       card_holder_identification_number: '123456',
       establishment_name: 'Heavenly Buffaloes',
       fraud_detection: {
-        send_to_cs: false,
+        send_to_cs: 'false',
         channel: 'Web',
         dispatch_method: 'Store Pick Up'
       },
@@ -103,6 +103,13 @@ class RemoteDecidirTest < Test::Unit::TestCase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options.merge(installments: -1))
     assert_failure response
     assert_equal 'invalid_param: installments', response.message
+    assert_match 'invalid_request_error', response.error_code
+  end
+
+  def test_failed_purchase_with_invalid_boolean_field
+    response = @gateway_for_purchase.purchase(@amount, @declined_card, @options.merge(fraud_detection: { send_to_cs: 'okay' }))
+    assert_failure response
+    assert_equal 'invalid_param: fraud_detection.send_to_cs', response.message
     assert_match 'invalid_request_error', response.error_code
   end
 

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -37,7 +37,7 @@ class DecidirTest < Test::Unit::TestCase
       card_holder_identification_number: '123456',
       establishment_name: 'Heavenly Buffaloes',
       fraud_detection: {
-        send_to_cs: false,
+        send_to_cs: 'false',
         channel: 'Web',
         dispatch_method: 'Store Pick Up'
       },


### PR DESCRIPTION
## What Changed?
This change allows ActiveMerchant to accept the strings `"true"` or `"false"` for this `send_to_cs`, and to convert that to its boolean form, and then send that boolean along for `send_to_cs`.

## Why?
Decidir is strict about accepting only a boolean for its gateway specific field `send_to_cs`. This change allows a boolean to be sent, or the string `"true"` or `"false"`.

CE-424

## Testing
### All local
```
rake test:local

4447 tests, 71494 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

### Decidir local
```
rake TEST=test/unit/gateways/decidir_test.rb

32 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Decidir remote
```
rake TEST=test/remote/gateways/remote_decidir_test.rb

22 tests, 77 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.4545% passed
```

1 failing test that also fails on on `master`:
* test_failed_purchase

## Questions for Reviewers
1. Any more testing you would like to see? Anything at all!
2. Do you see **_anything_** in the documentation that looks different than what I've done here (Spanish is not my first language)?
3. Thoughts about the comment/name of the method "attempt_boolean"?