### PR TITLE
Stripe: Add connected account support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,7 +54,8 @@
 * Mercado Pago: Add taxes and net_amount gateway specific fields [carrigan] #3512
 * Moneris: use dedicated card_verification methods [alexdunae] #3428
 * Authorize.net: Trim down supported countries [fatcatt316] #3511
-* Stripe: Add support for `statement_descriptor_suffix` field #3528
+* Stripe: Add support for `statement_descriptor_suffix` field [carrigan] #3528
+* Stripe: Add connected account support [carrigan] #3535
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -373,6 +373,7 @@ module ActiveMerchant #:nodoc:
         add_exchange_rate(post, options)
         add_destination(post, options)
         add_level_three(post, options)
+        add_connected_account(post, options)
         post
       end
 
@@ -551,6 +552,16 @@ module ActiveMerchant #:nodoc:
           post[:owner][:phone] = address[:phone] if address[:phone]
           post[:owner][:address] = owner_address
         end
+      end
+
+      def add_connected_account(post, options = {})
+        return unless options[:transfer_destination]
+
+        post[:transfer_data] = { destination: options[:transfer_destination] }
+        post[:transfer_data][:amount] = options[:transfer_amount] if options[:transfer_amount]
+        post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
+        post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
+        post[:application_fee_amount] = options[:application_fee_amount] if options[:application_fee_amount]
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -149,6 +149,11 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_connected_account(post, options = {})
+        super(post, options)
+        post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
+      end
+
       def add_whitelisted_attribute(post, options, attribute)
         post[attribute] = options[attribute] if options[attribute]
         post
@@ -221,18 +226,6 @@ module ActiveMerchant #:nodoc:
       def setup_future_usage(post, options = {})
         post[:setup_future_usage] = options[:setup_future_usage] if %w(on_session off_session).include?(options[:setup_future_usage])
         post[:off_session] = options[:off_session] if options[:off_session] && options[:confirm] == true
-        post
-      end
-
-      def add_connected_account(post, options = {})
-        return unless options[:transfer_destination]
-
-        post[:transfer_data] = {}
-        post[:transfer_data][:destination] = options[:transfer_destination]
-        post[:transfer_data][:amount] = options[:transfer_amount] if options[:transfer_amount]
-        post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
-        post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
-        post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
         post
       end
 

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -227,17 +227,26 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   end
 
   def test_create_payment_intent_with_connected_account
+    transfer_group = 'XFERGROUP'
+    application_fee = 100
+
+    # You may not provide the application_fee_amount parameter and the transfer_data[amount] parameter
+    # simultaneously. They are mutually exclusive.
     options = {
       currency: 'USD',
       customer: @customer,
-      application_fee: 100,
-      transfer_destination: @destination_account
+      application_fee: application_fee,
+      transfer_destination: @destination_account,
+      on_behalf_of: @destination_account,
+      transfer_group: transfer_group
     }
 
     assert response = @gateway.create_intent(@amount, nil, options)
 
     assert_success response
-    assert_equal 100, response.params['application_fee_amount']
+    assert_equal application_fee, response.params['application_fee_amount']
+    assert_equal transfer_group, response.params['transfer_group']
+    assert_equal @destination_account, response.params['on_behalf_of']
     assert_equal @destination_account, response.params.dig('transfer_data', 'destination')
   end
 

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -95,6 +95,32 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       'requires_payment_method, requires_capture, requires_confirmation, requires_action.', cancel.message
   end
 
+  def test_connected_account
+    destination = 'account_27701'
+    amount = 8000
+    on_behalf_of = 'account_27704'
+    transfer_group = 'TG1000'
+    application_fee_amount = 100
+
+    options = @options.merge(
+      transfer_destination: destination,
+      transfer_amount: amount,
+      on_behalf_of: on_behalf_of,
+      transfer_group: transfer_group,
+      application_fee: application_fee_amount
+    )
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/transfer_data\[destination\]=#{destination}/, data)
+      assert_match(/transfer_data\[amount\]=#{amount}/, data)
+      assert_match(/on_behalf_of=#{on_behalf_of}/, data)
+      assert_match(/transfer_group=#{transfer_group}/, data)
+      assert_match(/application_fee_amount=#{application_fee_amount}/, data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   private
 
   def successful_create_intent_response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -373,6 +373,32 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_connected_account
+    destination = 'account_27701'
+    amount = 8000
+    on_behalf_of = 'account_27704'
+    transfer_group = 'TG1000'
+    application_fee_amount = 100
+
+    options = @options.merge(
+      transfer_destination: destination,
+      transfer_amount: amount,
+      on_behalf_of: on_behalf_of,
+      transfer_group: transfer_group,
+      application_fee_amount: application_fee_amount
+    )
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/transfer_data\[destination\]=#{destination}/, data)
+      assert_match(/transfer_data\[amount\]=#{amount}/, data)
+      assert_match(/on_behalf_of=#{on_behalf_of}/, data)
+      assert_match(/transfer_group=#{transfer_group}/, data)
+      assert_match(/application_fee_amount=#{application_fee_amount}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_declined_authorization_with_emv_credit_card
     @gateway.expects(:ssl_request).returns(declined_authorization_response_with_emv_auth_data)
 


### PR DESCRIPTION
## Why?

Stripe has changed the fields that are supported/required for Connect transactions.

## What Changed?

- Adds support for the following fields on the Stripe gateway for Connect transactions:
  - `transfer_data[amount, destination]`
  - `on_behalf_of`
  - `transfer_group`
  - `application_fee_amount`
- Adds support for the following fields on the Stripe Payment Intents gateway:
  - `application_fee_amount` - this was already supported via `application_fee`, this change adds support for its proper name while retaining support for its original one

## Implementation Details

This was done by moving the `add_connected_account` function from the Stripe Payment Intents gateway to the Stripe gateway which it inherits from. One change had to be made to the implementation: since the Stripe Payment Intents gateway called the `application_fee_amount` field `application_fee`, which is already a field in the Stripe gateway, both gateways are to call this field `application_fee_amount` moving forward. The Stripe Payment Intents gateway has code in place to also allow it to be called `application_fee` so that there are no breaking changes.

## Test Suite

Stripe Remote Tests:

```
69 tests, 321 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Stripe Payment Intents Remote Tests:

```
30 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Unit Tests:
```
4450 tests, 71510 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
695 files inspected, no offenses detected
```