### PR TITLE
Redsys: Properly escape special characters in 3DS requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538
 * Adyen: Fix some remote tests [curiousepic] #3541
+* Redsys: Properly escape cardholder name and description fields in 3DS requests [britth] #3537
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -426,7 +426,11 @@ module ActiveMerchant #:nodoc:
           xml.DS_MERCHANT_AMOUNT             data[:amount]
           xml.DS_MERCHANT_ORDER              data[:order_id]
           xml.DS_MERCHANT_TRANSACTIONTYPE    data[:action]
-          xml.DS_MERCHANT_PRODUCTDESCRIPTION data[:description]
+          if data[:description] && data[:threeds]
+            xml.DS_MERCHANT_PRODUCTDESCRIPTION CGI.escape(data[:description])
+          else
+            xml.DS_MERCHANT_PRODUCTDESCRIPTION data[:description]
+          end
           xml.DS_MERCHANT_TERMINAL           options[:terminal] || @options[:terminal]
           xml.DS_MERCHANT_MERCHANTCODE       @options[:login]
           xml.DS_MERCHANT_MERCHANTSIGNATURE  build_signature(data) unless sha256_authentication?
@@ -434,7 +438,11 @@ module ActiveMerchant #:nodoc:
 
           # Only when card is present
           if data[:card]
-            xml.DS_MERCHANT_TITULAR    data[:card][:name]
+            if data[:card][:name] && data[:threeds]
+              xml.DS_MERCHANT_TITULAR    CGI.escape(data[:card][:name])
+            else
+              xml.DS_MERCHANT_TITULAR    data[:card][:name]
+            end
             xml.DS_MERCHANT_PAN        data[:card][:pan]
             xml.DS_MERCHANT_EXPIRYDATE data[:card][:date]
             xml.DS_MERCHANT_CVV2       data[:card][:cvv]


### PR DESCRIPTION
In some Redsys 3DS requests, the API will return `SIS0042`, which
signifies an error calculating the signature. After some testing,
this appears to be caused by special characters in various fields
of the request (in particular the `DS_MERCHANT_TITULAR` field).
Non-3DS requests escape the entire xml_request_from response, but
after testing the same approach for 3DS, that doesn't quite work
(you'll still end up with an encoding error after the first round of
3ds-related api requests). This PR updates to escape the cardholder
name when the transaction calls for 3DS to prevent such errors. It
also does the same thing for the description field as that seemed
like the most likely other place where a special character could
end up. I feel like there's probably a better way to do this, so if
you have another idea, please feel free to suggest!

If you'd like to manually test, try issuing a 3ds purchase request
against this branch, using a name or description that includes a
special character - the transaction should succeed. Then try issuing
a request using a special character against the active merchant master
branch, and it should fail.

Unit:
38 tests, 122 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed