### PR TITLE
pay_junction_v2: Passing billing address to auth and purchase methods

### DIFF
--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
+        add_address(post, options)
 
         commit('purchase', post)
       end
@@ -30,6 +31,7 @@ module ActiveMerchant #:nodoc:
         post[:status] = 'HOLD'
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
+        add_address(post, options)
 
         commit('authorize', post)
       end
@@ -108,6 +110,27 @@ module ActiveMerchant #:nodoc:
           post[:cardExpYear] = format(payment_method.year, :four_digits)
           post[:cardCvv] = payment_method.verification_value
         end
+      end
+
+      def add_address(post, options)
+        if (address = options[:billing_address])
+          post[:billing] = {}
+          post[:billing][:firstName] = address[:first_name] if address[:first_name]
+          post[:billing][:lastName] = address[:last_name] if address[:last_name]
+          post[:billing][:companyName] = address[:company] if address[:company]
+          post[:billing][:phone] = address[:phone_number] if address[:phone_number]
+
+          post[:billing][:address] = {}
+          post[:billing][:address][:address] = address[:address1] if address[:address1]
+          post[:billing][:address][:city] = address[:city] if address[:city]
+          post[:billing][:address][:state] = address[:state] if address[:state]
+          post[:billing][:address][:country] = address[:country] if address[:country]
+          post[:billing][:address][:zip] = address[:zip] if address[:zip]
+        end
+      end
+
+      def get_state(address)
+        address[:state] && !address[:state].blank? ? address[:state] : 'NA'
       end
 
       def commit(action, params)

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -129,10 +129,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def get_state(address)
-        address[:state] && !address[:state].blank? ? address[:state] : 'NA'
-      end
-
       def commit(action, params)
         response =
           begin

--- a/test/remote/gateways/remote_pay_junction_v2_test.rb
+++ b/test/remote/gateways/remote_pay_junction_v2_test.rb
@@ -5,9 +5,10 @@ class RemotePayJunctionV2Test < Test::Unit::TestCase
     @gateway = PayJunctionV2Gateway.new(fixtures(:pay_junction_v2))
 
     @amount = 99
-    @credit_card = credit_card('4444333322221111', month: 01, year: 2020, verification_value: 999)
+    @credit_card = credit_card('4444333322221111', month: 01, year: 2021, verification_value: 999)
     @options = {
-      order_id: generate_unique_id
+      order_id: generate_unique_id,
+      billing_address: address()
     }
   end
 
@@ -81,13 +82,13 @@ class RemotePayJunctionV2Test < Test::Unit::TestCase
   end
 
   def test_partial_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    purchase = @gateway.purchase(@amount+50, @credit_card, @options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount-50, purchase.authorization)
+    assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_success refund
     assert_equal 'Approved', refund.message
-    assert_equal sprintf('%.2f', (@amount-50).to_f / 100), refund.params['amountTotal']
+    assert_equal sprintf('%.2f', @amount.to_f / 100), refund.params['amountTotal']
   end
 
   def test_failed_refund

--- a/test/unit/gateways/pay_junction_v2_test.rb
+++ b/test/unit/gateways/pay_junction_v2_test.rb
@@ -5,9 +5,10 @@ class PayJunctionV2Test < Test::Unit::TestCase
     @gateway = PayJunctionV2Gateway.new(api_login: 'api_login', api_password: 'api_password', api_key: 'api_key')
 
     @amount = 99
-    @credit_card = credit_card('4444333322221111', month: 01, year: 2020, verification_value: 999)
+    @credit_card = credit_card('4444333322221111', month: 01, year: 2022, verification_value: 999)
     @options = {
-      order_id: generate_unique_id
+      order_id: generate_unique_id,
+      billing_address: address()
     }
   end
 
@@ -203,6 +204,21 @@ class PayJunctionV2Test < Test::Unit::TestCase
     response = @gateway.store(credit_card, @options)
     assert_failure response
     assert_match %r{Card Number is not a valid card number}, response.message
+  end
+
+  def test_add_address
+    post = {:card => {:billingAddress => {}}}
+    @gateway.send(:add_address, post, @options)
+    # Billing Address
+    assert_equal @options[:billing_address][:first_name], post[:billing][:firstName]
+    assert_equal @options[:billing_address][:last_name], post[:billing][:lastName]
+    assert_equal @options[:billing_address][:company], post[:billing][:companyName]
+    assert_equal @options[:billing_address][:phone_number], post[:billing][:phone]
+    assert_equal @options[:billing_address][:address1], post[:billing][:address][:address]
+    assert_equal @options[:billing_address][:city], post[:billing][:address][:city]
+    assert_equal @options[:billing_address][:state], post[:billing][:address][:state]
+    assert_equal @options[:billing_address][:country], post[:billing][:address][:country]
+    assert_equal @options[:billing_address][:zip], post[:billing][:address][:zip]
   end
 
   def test_scrub

--- a/test/unit/gateways/pay_junction_v2_test.rb
+++ b/test/unit/gateways/pay_junction_v2_test.rb
@@ -8,7 +8,7 @@ class PayJunctionV2Test < Test::Unit::TestCase
     @credit_card = credit_card('4444333322221111', month: 01, year: 2022, verification_value: 999)
     @options = {
       order_id: generate_unique_id,
-      billing_address: address()
+      billing_address: address
     }
   end
 


### PR DESCRIPTION
Added support to PayJunction v2 gateway to send billing address
information with auth and purchase transactions.

CE-261

Unit: 4451 tests, 71520 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed

Remote: 20 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed