### PR TITLE
RuboCop: Fix Style/HashSyntax

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -588,13 +588,6 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: false
 
-# Offense count: 7482
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Enabled: false
-
 # Offense count: 6
 Style/IdenticalConditionalBranches:
   Exclude:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538
 * Adyen: Fix some remote tests [curiousepic] #3541
 * Redsys: Properly escape cardholder name and description fields in 3DS requests [britth] #3537
+* RuboCop: Fix Style/HashSyntax [leila-alderman] #3540
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'jruby-openssl', :platforms => :jruby
+gem 'jruby-openssl', platforms: :jruby
 gem 'rubocop', '~> 0.60.0', require: false
 
 group :test, :remote_test do

--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,8 @@ task :tag_release do
 end
 
 desc 'Run the unit test suite'
-task :default => 'test:units'
-task :test => 'test:units'
+task default: 'test:units'
+task test: 'test:units'
 
 RuboCop::RakeTask.new
 
@@ -37,7 +37,7 @@ namespace :test do
   end
 
   desc 'Run all tests that do not require network access'
-  task :local => ['test:units', 'rubocop']
+  task local: ['test:units', 'rubocop']
 
   Rake::TestTask.new(:remote) do |t|
     t.pattern = 'test/remote/**/*_test.rb'

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -80,22 +80,22 @@ module ActiveMerchant #:nodoc:
       #                        as network tokenization.
 
       STANDARD_ERROR_CODE = {
-        :incorrect_number => 'incorrect_number',
-        :invalid_number => 'invalid_number',
-        :invalid_expiry_date => 'invalid_expiry_date',
-        :invalid_cvc => 'invalid_cvc',
-        :expired_card => 'expired_card',
-        :incorrect_cvc => 'incorrect_cvc',
-        :incorrect_zip => 'incorrect_zip',
-        :incorrect_address => 'incorrect_address',
-        :incorrect_pin => 'incorrect_pin',
-        :card_declined => 'card_declined',
-        :processing_error => 'processing_error',
-        :call_issuer => 'call_issuer',
-        :pickup_card => 'pick_up_card',
-        :config_error => 'config_error',
-        :test_mode_live_card => 'test_mode_live_card',
-        :unsupported_feature => 'unsupported_feature',
+        incorrect_number: 'incorrect_number',
+        invalid_number: 'invalid_number',
+        invalid_expiry_date: 'invalid_expiry_date',
+        invalid_cvc: 'invalid_cvc',
+        expired_card: 'expired_card',
+        incorrect_cvc: 'incorrect_cvc',
+        incorrect_zip: 'incorrect_zip',
+        incorrect_address: 'incorrect_address',
+        incorrect_pin: 'incorrect_pin',
+        card_declined: 'card_declined',
+        processing_error: 'processing_error',
+        call_issuer: 'call_issuer',
+        pickup_card: 'pick_up_card',
+        config_error: 'config_error',
+        test_mode_live_card: 'test_mode_live_card',
+        unsupported_feature: 'unsupported_feature',
       }
 
       cattr_reader :implementations
@@ -223,11 +223,11 @@ module ActiveMerchant #:nodoc:
 
       def user_agent
         @@ua ||= JSON.dump({
-          :bindings_version => ActiveMerchant::VERSION,
-          :lang => 'ruby',
-          :lang_version => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
-          :platform => RUBY_PLATFORM,
-          :publisher => 'active_merchant'
+          bindings_version: ActiveMerchant::VERSION,
+          lang: 'ruby',
+          lang_version: "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
+          platform: RUBY_PLATFORM,
+          publisher: 'active_merchant'
         })
       end
 
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
             raise ArgumentError.new("Missing required parameter: #{param.first}") unless hash.has_key?(param.first)
 
             valid_options = param[1..-1]
-            raise ArgumentError.new("Parameter: #{param.first} must be one of #{valid_options.to_sentence(:words_connector => 'or')}") unless valid_options.include?(hash[param.first])
+            raise ArgumentError.new("Parameter: #{param.first} must be one of #{valid_options.to_sentence(words_connector: 'or')}") unless valid_options.include?(hash[param.first])
           else
             raise ArgumentError.new("Missing required parameter: #{param}") unless hash.has_key?(param)
           end

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -479,7 +479,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(action, parameters, response),
           test: test?,
           error_code: success ? nil : error_code_from(response),
-          avs_result: AVSResult.new(:code => avs_code_from(response)),
+          avs_result: AVSResult.new(code: avs_code_from(response)),
           cvv_result: CVVResult.new(cvv_result_from(response))
         )
       end

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -152,8 +152,8 @@ module ActiveMerchant #:nodoc:
           message_from(succeeded, response),
           response,
           authorization: response['id'],
-          :avs_result => AVSResult.new(code: response['avs_response']),
-          :cvv_result => CVVResult.new(response['cvv2_response']),
+          avs_result: AVSResult.new(code: response['avs_response']),
+          cvv_result: CVVResult.new(response['cvv2_response']),
           test: test?
         )
       rescue JSON::ParserError

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -58,21 +58,21 @@ module ActiveMerchant
       }
 
       MARKET_TYPE = {
-        :moto  => '1',
-        :retail  => '2'
+        moto: '1',
+        retail: '2'
       }
 
       DEVICE_TYPE = {
-        :unknown => '1',
-        :unattended_terminal => '2',
-        :self_service_terminal => '3',
-        :electronic_cash_register => '4',
-        :personal_computer_terminal => '5',
-        :airpay => '6',
-        :wireless_pos => '7',
-        :website => '8',
-        :dial_terminal => '9',
-        :virtual_terminal => '10'
+        unknown: '1',
+        unattended_terminal: '2',
+        self_service_terminal: '3',
+        electronic_cash_register: '4',
+        personal_computer_terminal: '5',
+        airpay: '6',
+        wireless_pos: '7',
+        website: '8',
+        dial_terminal: '9',
+        virtual_terminal: '10'
       }
 
       class_attribute :duplicate_window
@@ -221,13 +221,13 @@ module ActiveMerchant
 
       def supports_network_tokenization?
         card = Billing::NetworkTokenizationCreditCard.new({
-          :number => '4111111111111111',
-          :month => 12,
-          :year => 20,
-          :first_name => 'John',
-          :last_name => 'Smith',
-          :brand => 'visa',
-          :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+          number: '4111111111111111',
+          month: 12,
+          year: 20,
+          first_name: 'John',
+          last_name: 'Smith',
+          brand: 'visa',
+          payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
         })
 
         request = post_data(:authorize) do |xml|

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -39,10 +39,10 @@ module ActiveMerchant #:nodoc:
       AUTHORIZE_NET_ARB_NAMESPACE = 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'
 
       RECURRING_ACTIONS = {
-        :create => 'ARBCreateSubscription',
-        :update => 'ARBUpdateSubscription',
-        :cancel => 'ARBCancelSubscription',
-        :status => 'ARBGetSubscriptionStatus'
+        create: 'ARBCreateSubscription',
+        update: 'ARBUpdateSubscription',
+        cancel: 'ARBCancelSubscription',
+        status: 'ARBGetSubscriptionStatus'
       }
 
       # Creates a new AuthorizeNetArbGateway
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>subscription_id</tt> -- A string containing the +subscription_id+ of the recurring payment already in place
       #   for a given credit card. (REQUIRED)
       def cancel_recurring(subscription_id)
-        request = build_recurring_request(:cancel, :subscription_id => subscription_id)
+        request = build_recurring_request(:cancel, subscription_id: subscription_id)
         recurring_commit(:cancel, request)
       end
 
@@ -139,7 +139,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>subscription_id</tt> -- A string containing the +subscription_id+ of the recurring payment already in place
       #   for a given credit card. (REQUIRED)
       def status_recurring(subscription_id)
-        request = build_recurring_request(:status, :subscription_id => subscription_id)
+        request = build_recurring_request(:status, subscription_id: subscription_id)
         recurring_commit(:status, request)
       end
 
@@ -149,9 +149,9 @@ module ActiveMerchant #:nodoc:
       def build_recurring_request(action, options = {})
         raise StandardError, "Invalid Automated Recurring Billing Action: #{action}" unless RECURRING_ACTIONS.include?(action)
 
-        xml = Builder::XmlMarkup.new(:indent => 2)
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
-        xml.tag!("#{RECURRING_ACTIONS[action]}Request", :xmlns => AUTHORIZE_NET_ARB_NAMESPACE) do
+        xml = Builder::XmlMarkup.new(indent: 2)
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
+        xml.tag!("#{RECURRING_ACTIONS[action]}Request", xmlns: AUTHORIZE_NET_ARB_NAMESPACE) do
           add_merchant_authentication(xml)
           # Merchant-assigned reference ID for the request
           xml.tag!('refId', options[:ref_id]) if options[:ref_id]
@@ -394,8 +394,8 @@ module ActiveMerchant #:nodoc:
         success = response[:result_code] == 'Ok'
 
         Response.new(success, message, response,
-          :test => test_mode,
-          :authorization => response[:subscription_id]
+          test: test_mode,
+          authorization: response[:subscription_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -33,49 +33,49 @@ module ActiveMerchant #:nodoc:
       AUTHORIZE_NET_CIM_NAMESPACE = 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'
 
       CIM_ACTIONS = {
-        :create_customer_profile => 'createCustomerProfile',
-        :create_customer_payment_profile => 'createCustomerPaymentProfile',
-        :create_customer_shipping_address => 'createCustomerShippingAddress',
-        :get_customer_profile => 'getCustomerProfile',
-        :get_customer_profile_ids => 'getCustomerProfileIds',
-        :get_customer_payment_profile => 'getCustomerPaymentProfile',
-        :get_customer_shipping_address => 'getCustomerShippingAddress',
-        :delete_customer_profile => 'deleteCustomerProfile',
-        :delete_customer_payment_profile => 'deleteCustomerPaymentProfile',
-        :delete_customer_shipping_address => 'deleteCustomerShippingAddress',
-        :update_customer_profile => 'updateCustomerProfile',
-        :update_customer_payment_profile => 'updateCustomerPaymentProfile',
-        :update_customer_shipping_address => 'updateCustomerShippingAddress',
-        :create_customer_profile_transaction => 'createCustomerProfileTransaction',
-        :validate_customer_payment_profile => 'validateCustomerPaymentProfile'
+        create_customer_profile: 'createCustomerProfile',
+        create_customer_payment_profile: 'createCustomerPaymentProfile',
+        create_customer_shipping_address: 'createCustomerShippingAddress',
+        get_customer_profile: 'getCustomerProfile',
+        get_customer_profile_ids: 'getCustomerProfileIds',
+        get_customer_payment_profile: 'getCustomerPaymentProfile',
+        get_customer_shipping_address: 'getCustomerShippingAddress',
+        delete_customer_profile: 'deleteCustomerProfile',
+        delete_customer_payment_profile: 'deleteCustomerPaymentProfile',
+        delete_customer_shipping_address: 'deleteCustomerShippingAddress',
+        update_customer_profile: 'updateCustomerProfile',
+        update_customer_payment_profile: 'updateCustomerPaymentProfile',
+        update_customer_shipping_address: 'updateCustomerShippingAddress',
+        create_customer_profile_transaction: 'createCustomerProfileTransaction',
+        validate_customer_payment_profile: 'validateCustomerPaymentProfile'
       }
 
       CIM_TRANSACTION_TYPES = {
-        :auth_capture => 'profileTransAuthCapture',
-        :auth_only => 'profileTransAuthOnly',
-        :capture_only => 'profileTransCaptureOnly',
-        :prior_auth_capture => 'profileTransPriorAuthCapture',
-        :refund => 'profileTransRefund',
-        :void => 'profileTransVoid'
+        auth_capture: 'profileTransAuthCapture',
+        auth_only: 'profileTransAuthOnly',
+        capture_only: 'profileTransCaptureOnly',
+        prior_auth_capture: 'profileTransPriorAuthCapture',
+        refund: 'profileTransRefund',
+        void: 'profileTransVoid'
       }
 
       CIM_VALIDATION_MODES = {
-        :none => 'none',
-        :test => 'testMode',
-        :live => 'liveMode',
-        :old => 'oldLiveMode'
+        none: 'none',
+        test: 'testMode',
+        live: 'liveMode',
+        old: 'oldLiveMode'
       }
 
       BANK_ACCOUNT_TYPES = {
-        :checking => 'checking',
-        :savings => 'savings',
-        :business_checking => 'businessChecking'
+        checking: 'checking',
+        savings: 'savings',
+        business_checking: 'businessChecking'
       }
 
       ECHECK_TYPES = {
-        :ccd => 'CCD',
-        :ppd => 'PPD',
-        :web => 'WEB'
+        ccd: 'CCD',
+        ppd: 'PPD',
+        web: 'WEB'
       }
 
       self.homepage_url = 'http://www.authorize.net/'
@@ -487,9 +487,9 @@ module ActiveMerchant #:nodoc:
       def build_request(action, options = {})
         raise StandardError, "Invalid Customer Information Manager Action: #{action}" unless CIM_ACTIONS.include?(action)
 
-        xml = Builder::XmlMarkup.new(:indent => 2)
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
-        xml.tag!("#{CIM_ACTIONS[action]}Request", :xmlns => AUTHORIZE_NET_CIM_NAMESPACE) do
+        xml = Builder::XmlMarkup.new(indent: 2)
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
+        xml.tag!("#{CIM_ACTIONS[action]}Request", xmlns: AUTHORIZE_NET_CIM_NAMESPACE) do
           add_merchant_authentication(xml)
           # Merchant-assigned reference ID for the request
           xml.tag!('refId', options[:ref_id]) if options[:ref_id]

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -72,8 +72,8 @@ module ActiveMerchant #:nodoc:
         authorization = response[:unique_id]
 
         Response.new(success, message, response,
-          :authorization => authorization,
-          :test => (response[:mode] != 'LIVE')
+          authorization: authorization,
+          test: (response[:mode] != 'LIVE')
         )
       end
 
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(payment_code, money, payment, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'Request', 'version' => API_VERSION do
           xml.tag! 'Header' do

--- a/lib/active_merchant/billing/gateways/bambora_apac.rb
+++ b/lib/active_merchant/billing/gateways/bambora_apac.rb
@@ -132,7 +132,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_credit_card(xml, payment)
-        xml.CreditCard :Registered => 'False' do
+        xml.CreditCard Registered: 'False' do
           xml.CardNumber payment.number
           xml.ExpM format(payment.month, :two_digits)
           xml.ExpY format(payment.year, :four_digits)

--- a/lib/active_merchant/billing/gateways/bank_frick.rb
+++ b/lib/active_merchant/billing/gateways/bank_frick.rb
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_xml_request(action, data)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.Request(version: '1.0') do
           xml.Header do
             xml.Security(sender: @options[:sender], type: 'MERCHANT')

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -92,8 +92,8 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response),
           response['message'],
           response,
-          :test => test?,
-          :authorization => response['code_auth'])
+          test: test?,
+          authorization: response['code_auth'])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
       def store(creditcard, options = {})
         post = store_request(options)
         post[:card] = credit_card_hash(creditcard)
-        post[:recurring] = {:contract => 'RECURRING'}
+        post[:recurring] = {contract: 'RECURRING'}
 
         commit('store', post)
       end
@@ -161,20 +161,20 @@ module ActiveMerchant #:nodoc:
           message_from(response),
           response,
           test: test?,
-          avs_result: AVSResult.new(:code => parse_avs_code(response)),
+          avs_result: AVSResult.new(code: parse_avs_code(response)),
           authorization: response['recurringDetailReference'] || authorization_from(post, response)
         )
       rescue ResponseError => e
         case e.response.code
         when '401'
-          return Response.new(false, 'Invalid credentials', {}, :test => test?)
+          return Response.new(false, 'Invalid credentials', {}, test: test?)
         when '403'
-          return Response.new(false, 'Not allowed', {}, :test => test?)
+          return Response.new(false, 'Not allowed', {}, test: test?)
         when '422', '500'
           if e.response.body.split(/\W+/).any? { |word| %w(validation configuration security).include?(word) }
             error_message = e.response.body[/#{Regexp.escape('message=')}(.*?)#{Regexp.escape('&')}/m, 1].tr('+', ' ')
             error_code = e.response.body[/#{Regexp.escape('errorCode=')}(.*?)#{Regexp.escape('&')}/m, 1]
-            return Response.new(false, error_code + ': ' + error_message, {}, :test => test?)
+            return Response.new(false, error_code + ': ' + error_message, {}, test: test?)
           end
         end
         raise

--- a/lib/active_merchant/billing/gateways/be2bill.rb
+++ b/lib/active_merchant/billing/gateways/be2bill.rb
@@ -92,8 +92,8 @@ module ActiveMerchant #:nodoc:
           successful?(response),
           message_from(response),
           response,
-          :authorization => response['TRANSACTIONID'],
-          :test          => test?
+          authorization: response['TRANSACTIONID'],
+          test: test?
         )
       end
 
@@ -111,8 +111,8 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         {
-          :method => action,
-          :params => parameters.merge(HASH: signature(parameters, action))
+          method: action,
+          params: parameters.merge(HASH: signature(parameters, action))
         }.to_query
       end
 

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
       # can't actually delete a secure profile with the supplicated API. This function sets the status of the profile to closed (C).
       # Closed profiles will have to removed manually.
       def delete(vault_id)
-        update(vault_id, false, {:status => 'C'})
+        update(vault_id, false, {status: 'C'})
       end
 
       alias_method :unstore, :delete

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -9,20 +9,20 @@ module ActiveMerchant #:nodoc:
       SP_SERVICE_VERSION = '1.1'
 
       TRANSACTIONS = {
-        :authorization  => 'PA',
-        :purchase       => 'P',
-        :capture        => 'PAC',
-        :refund         => 'R',
-        :void           => 'VP',
-        :check_purchase => 'D',
-        :check_refund   => 'C',
-        :void_purchase  => 'VP',
-        :void_refund    => 'VR'
+        authorization:    'PA',
+        purchase:         'P',
+        capture:          'PAC',
+        refund:           'R',
+        void:             'VP',
+        check_purchase:   'D',
+        check_refund:     'C',
+        void_purchase:    'VP',
+        void_refund:      'VR'
       }
 
       PROFILE_OPERATIONS = {
-        :new => 'N',
-        :modify => 'M'
+        new: 'N',
+        modify: 'M'
       }
 
       CVD_CODES = {
@@ -41,24 +41,24 @@ module ActiveMerchant #:nodoc:
       }
 
       PERIODS = {
-        :days   => 'D',
-        :weeks  => 'W',
-        :months => 'M',
-        :years  => 'Y'
+        days: 'D',
+        weeks: 'W',
+        months: 'M',
+        years: 'Y'
       }
 
       PERIODICITIES = {
-        :daily     => [:days, 1],
-        :weekly    => [:weeks, 1],
-        :biweekly  => [:weeks, 2],
-        :monthly   => [:months, 1],
-        :bimonthly => [:months, 2],
-        :yearly    => [:years, 1]
+        daily: [:days, 1],
+        weekly: [:weeks, 1],
+        biweekly: [:weeks, 2],
+        monthly: [:months, 1],
+        bimonthly: [:months, 2],
+        yearly: [:years, 1]
       }
 
       RECURRING_OPERATION = {
-        :update => 'M',
-        :cancel => 'C'
+        update: 'M',
+        cancel: 'C'
       }
 
       STATES = {
@@ -414,10 +414,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post((use_profile_api ? SECURE_PROFILE_URL : self.live_url), data))
         response[:customer_vault_id] = response[:customerCode] if response[:customerCode]
         build_response(success?(response), message_from(response), response,
-          :test => test? || response[:authCode] == 'TEST',
-          :authorization => authorization_from(response),
-          :cvv_result => CVD_CODES[response[:cvdId]],
-          :avs_result => { :code => AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
+          test: test? || response[:authCode] == 'TEST',
+          authorization: authorization_from(response),
+          cvv_result: CVD_CODES[response[:cvdId]],
+          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/beanstream_interac.rb
+++ b/lib/active_merchant/billing/gateways/beanstream_interac.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
       # post back is for until the response of the confirmation is
       # received, which contains the order number.
       def self.confirm(transaction)
-        gateway = new(:login => '')
+        gateway = new(login: '')
         gateway.confirm(transaction)
       end
 

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -343,8 +343,8 @@ module ActiveMerchant #:nodoc:
         message = parsed[:status]
 
         Response.new(success, message, parsed,
-          :test          => test?,
-          :authorization => parsed[:rebill_id])
+          test: test?,
+          authorization: parsed[:rebill_id])
       end
 
       def parse(body)
@@ -363,10 +363,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(parsed)
         success = parsed[:response_code] == '1'
         Response.new(success, message, parsed,
-          :test          => test?,
-          :authorization => (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
-          :avs_result    => { :code => parsed[:avs_result_code] },
-          :cvv_result    => parsed[:card_code]
+          test: test?,
+          authorization: (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
+          avs_result: { code: parsed[:avs_result_code] },
+          cvv_result: parsed[:card_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -47,9 +47,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -61,9 +61,9 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, REFUND_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
         end
       end
 
@@ -73,9 +73,9 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, CAPTURE_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
         end
       end
 
@@ -84,18 +84,18 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, VOID_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {authorization: reference, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {authorization: reference}, test: true)
         end
       end
 
       def store(paysource, options = {})
         case normalize(paysource)
         when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, {billingid: '1'}, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:billingid => nil, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {billingid: nil, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -104,9 +104,9 @@ module ActiveMerchant #:nodoc:
       def unstore(reference, options = {})
         case reference
         when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
+          Response.new(true, SUCCESS_MESSAGE, {}, test: true)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, UNSTORE_ERROR_MESSAGE
         end
@@ -118,9 +118,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case money
         when /00$/
-          Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION, :emv_authorization => AUTHORIZATION_EMV_SUCCESS)
+          Response.new(true, SUCCESS_MESSAGE, {authorized_amount: money}, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
         when /05$/
-          Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error], :emv_authorization => AUTHORIZATION_EMV_DECLINE)
+          Response.new(false, FAILURE_MESSAGE, {authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
         else
           raise Error, error_message(paysource)
         end
@@ -130,9 +130,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/, AUTHORIZATION
-          Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, {authorized_amount: money}, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -142,9 +142,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case money
         when /00$/
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION, :emv_authorization => AUTHORIZATION_EMV_SUCCESS)
+          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
         when /05$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error], :emv_authorization => AUTHORIZATION_EMV_DECLINE)
+          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
         else
           raise Error, error_message(paysource)
         end
@@ -154,9 +154,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/, AUTHORIZATION
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true, :error_code => STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -182,8 +182,8 @@ module ActiveMerchant #:nodoc:
 
       def build_request(action, post)
         mode = action == 'void' ? 'cancel' : 'get'
-        xml = Builder::XmlMarkup.new :indent => 18
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        xml = Builder::XmlMarkup.new indent: 18
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         xml.tag!("#{mode}Authorization") do
           post.each do |field, value|
             xml.tag!(field, value)

--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -91,7 +91,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def soap_request
-        Nokogiri::XML::Builder.new(:encoding => 'utf-8') do |xml|
+        Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
           xml.send('soap12:Envelope', soap_envelope_attributes) {
             xml.send('soap12:Body') {
               yield(xml) if block_given?

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -60,12 +60,12 @@ module ActiveMerchant #:nodoc:
         end
 
         @configuration = Braintree::Configuration.new(
-          :merchant_id       => options[:merchant_id],
-          :public_key        => options[:public_key],
-          :private_key       => options[:private_key],
-          :environment       => (options[:environment] || (test? ? :sandbox : :production)).to_sym,
-          :custom_user_agent => "ActiveMerchant #{ActiveMerchant::VERSION}",
-          :logger            => options[:logger] || logger
+          merchant_id: options[:merchant_id],
+          public_key: options[:public_key],
+          private_key: options[:private_key],
+          environment: (options[:environment] || (test? ? :sandbox : :production)).to_sym,
+          custom_user_agent: "ActiveMerchant #{ActiveMerchant::VERSION}",
+          logger: options[:logger] || logger
         )
 
         @braintree_gateway = Braintree::Gateway.new(@configuration)
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, credit_card_or_vault_id, options = {})
-        authorize(money, credit_card_or_vault_id, options.merge(:submit_for_settlement => true))
+        authorize(money, credit_card_or_vault_id, options.merge(submit_for_settlement: true))
       end
 
       def credit(money, credit_card_or_vault_id, options = {})
@@ -144,26 +144,26 @@ module ActiveMerchant #:nodoc:
 
           options[:update_existing_token] = braintree_credit_card.token
           credit_card_params = merge_credit_card_options({
-            :credit_card => {
-              :cardholder_name => creditcard.name,
-              :number => creditcard.number,
-              :cvv => creditcard.verification_value,
-              :expiration_month => creditcard.month.to_s.rjust(2, '0'),
-              :expiration_year => creditcard.year.to_s
+            credit_card: {
+              cardholder_name: creditcard.name,
+              number: creditcard.number,
+              cvv: creditcard.verification_value,
+              expiration_month: creditcard.month.to_s.rjust(2, '0'),
+              expiration_year: creditcard.year.to_s
             }
           }, options)[:credit_card]
 
           result = @braintree_gateway.customer.update(vault_id,
-            :first_name => creditcard.first_name,
-            :last_name => creditcard.last_name,
-            :email => scrub_email(options[:email]),
-            :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+            first_name: creditcard.first_name,
+            last_name: creditcard.last_name,
+            email: scrub_email(options[:email]),
+            phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone]),
-            :credit_card => credit_card_params
+            credit_card: credit_card_params
           )
           Response.new(result.success?, message_from_result(result),
-            :braintree_customer => (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
-            :customer_vault_id => (result.customer.id if result.success?)
+            braintree_customer: (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
+            customer_vault_id: (result.customer.id if result.success?)
           )
         end
       end
@@ -215,33 +215,33 @@ module ActiveMerchant #:nodoc:
             credit_card_params = { payment_method_nonce: options[:payment_method_nonce] }
           else
             credit_card_params = {
-              :credit_card => {
-                :cardholder_name => creditcard.name,
-                :number => creditcard.number,
-                :cvv => creditcard.verification_value,
-                :expiration_month => creditcard.month.to_s.rjust(2, '0'),
-                :expiration_year => creditcard.year.to_s,
-                :token => options[:credit_card_token]
+              credit_card: {
+                cardholder_name: creditcard.name,
+                number: creditcard.number,
+                cvv: creditcard.verification_value,
+                expiration_month: creditcard.month.to_s.rjust(2, '0'),
+                expiration_year: creditcard.year.to_s,
+                token: options[:credit_card_token]
               }
             }
           end
           parameters = {
-            :first_name => creditcard.first_name,
-            :last_name => creditcard.last_name,
-            :email => scrub_email(options[:email]),
-            :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+            first_name: creditcard.first_name,
+            last_name: creditcard.last_name,
+            email: scrub_email(options[:email]),
+            phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone]),
-            :id => options[:customer],
-            :device_data => options[:device_data],
+            id: options[:customer],
+            device_data: options[:device_data],
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           Response.new(result.success?, message_from_result(result),
             {
-              :braintree_customer => (customer_hash(result.customer, :include_credit_cards) if result.success?),
-              :customer_vault_id => (result.customer.id if result.success?),
-              :credit_card_token => (result.customer.credit_cards[0].token if result.success?)
+              braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
+              customer_vault_id: (result.customer.id if result.success?),
+              credit_card_token: (result.customer.credit_cards[0].token if result.success?)
             },
-            :authorization => (result.customer.id if result.success?)
+            authorization: (result.customer.id if result.success?)
           )
         end
       end
@@ -313,12 +313,12 @@ module ActiveMerchant #:nodoc:
 
       def map_address(address)
         mapped = {
-          :street_address => address[:address1],
-          :extended_address => address[:address2],
-          :company => address[:company],
-          :locality => address[:city],
-          :region => address[:state],
-          :postal_code => scrub_zip(address[:zip]),
+          street_address: address[:address1],
+          extended_address: address[:address2],
+          company: address[:company],
+          locality: address[:city],
+          region: address[:state],
+          postal_code: scrub_zip(address[:zip]),
         }
 
         mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2]) if address[:country] || address[:country_code_alpha2]
@@ -565,18 +565,18 @@ module ActiveMerchant #:nodoc:
 
       def create_transaction_parameters(money, credit_card_or_vault_id, options)
         parameters = {
-          :amount => localized_amount(money, options[:currency] || default_currency).to_s,
-          :order_id => options[:order_id],
-          :customer => {
-            :id => options[:store] == true ? '' : options[:store],
-            :email => scrub_email(options[:email]),
-            :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+          amount: localized_amount(money, options[:currency] || default_currency).to_s,
+          order_id: options[:order_id],
+          customer: {
+            id: options[:store] == true ? '' : options[:store],
+            email: scrub_email(options[:email]),
+            phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone])
           },
-          :options => {
-            :store_in_vault => options[:store] ? true : false,
-            :submit_for_settlement => options[:submit_for_settlement],
-            :hold_in_escrow => options[:hold_in_escrow],
+          options: {
+            store_in_vault: options[:store] ? true : false,
+            submit_for_settlement: options[:submit_for_settlement],
+            hold_in_escrow: options[:hold_in_escrow],
           }
         }
 
@@ -692,38 +692,38 @@ module ActiveMerchant #:nodoc:
           end
         else
           parameters[:customer].merge!(
-            :first_name => credit_card_or_vault_id.first_name,
-            :last_name => credit_card_or_vault_id.last_name
+            first_name: credit_card_or_vault_id.first_name,
+            last_name: credit_card_or_vault_id.last_name
           )
           if credit_card_or_vault_id.is_a?(NetworkTokenizationCreditCard)
             if credit_card_or_vault_id.source == :apple_pay
               parameters[:apple_pay_card] = {
-                :number => credit_card_or_vault_id.number,
-                :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, '0'),
-                :expiration_year => credit_card_or_vault_id.year.to_s,
-                :cardholder_name => credit_card_or_vault_id.name,
-                :cryptogram => credit_card_or_vault_id.payment_cryptogram,
-                :eci_indicator => credit_card_or_vault_id.eci
+                number: credit_card_or_vault_id.number,
+                expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),
+                expiration_year: credit_card_or_vault_id.year.to_s,
+                cardholder_name: credit_card_or_vault_id.name,
+                cryptogram: credit_card_or_vault_id.payment_cryptogram,
+                eci_indicator: credit_card_or_vault_id.eci
               }
             elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
               parameters[:android_pay_card] = {
-                :number => credit_card_or_vault_id.number,
-                :cryptogram => credit_card_or_vault_id.payment_cryptogram,
-                :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, '0'),
-                :expiration_year => credit_card_or_vault_id.year.to_s,
-                :google_transaction_id => credit_card_or_vault_id.transaction_id,
-                :source_card_type => credit_card_or_vault_id.brand,
-                :source_card_last_four => credit_card_or_vault_id.last_digits,
-                :eci_indicator => credit_card_or_vault_id.eci
+                number: credit_card_or_vault_id.number,
+                cryptogram: credit_card_or_vault_id.payment_cryptogram,
+                expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),
+                expiration_year: credit_card_or_vault_id.year.to_s,
+                google_transaction_id: credit_card_or_vault_id.transaction_id,
+                source_card_type: credit_card_or_vault_id.brand,
+                source_card_last_four: credit_card_or_vault_id.last_digits,
+                eci_indicator: credit_card_or_vault_id.eci
               }
             end
           else
             parameters[:credit_card] = {
-              :number => credit_card_or_vault_id.number,
-              :cvv => credit_card_or_vault_id.verification_value,
-              :expiration_month => credit_card_or_vault_id.month.to_s.rjust(2, '0'),
-              :expiration_year => credit_card_or_vault_id.year.to_s,
-              :cardholder_name => credit_card_or_vault_id.name
+              number: credit_card_or_vault_id.number,
+              cvv: credit_card_or_vault_id.verification_value,
+              expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),
+              expiration_year: credit_card_or_vault_id.year.to_s,
+              cardholder_name: credit_card_or_vault_id.name
             }
           end
         end

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -235,8 +235,8 @@ module ActiveMerchant #:nodoc:
 
       def post_data(post)
         {
-          :UserName => @options[:user_name],
-          :Password => @options[:password]
+          UserName: @options[:user_name],
+          Password: @options[:password]
         }.merge(post).collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
     end

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -287,7 +287,7 @@ module ActiveMerchant #:nodoc:
           error_code: error_code_from(response)
         )
       rescue ResponseError => e
-        return Response.new(false, 'Unable to authenticate.  Please check your credentials.', {}, :test => test?) if e.response.code == '401'
+        return Response.new(false, 'Unable to authenticate.  Please check your credentials.', {}, test: test?) if e.response.code == '401'
 
         raise
       end

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         post = {}
         add_pair(post, :xref, authorization)
-        add_pair(post, :amount, localized_amount(money, options[:currency] || currency(money)), :required => true)
+        add_pair(post, :amount, localized_amount(money, options[:currency] || currency(money)), required: true)
         add_remote_address(post, options)
 
         commit('CAPTURE', post)
@@ -225,7 +225,7 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(post, money, options)
         currency = options[:currency] || currency(money)
-        add_pair(post, :amount, localized_amount(money, currency), :required => true)
+        add_pair(post, :amount, localized_amount(money, currency), required: true)
         add_pair(post, :currencyCode, currency_code(currency))
       end
 
@@ -242,8 +242,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, credit_card_or_reference, money, options)
-        add_pair(post, :transactionUnique, options[:order_id], :required => true)
-        add_pair(post, :orderRef, options[:description] || options[:order_id], :required => true)
+        add_pair(post, :transactionUnique, options[:order_id], required: true)
+        add_pair(post, :orderRef, options[:description] || options[:order_id], required: true)
         add_pair(post, :statementNarrative1, options[:merchant_name]) if options[:merchant_name]
         add_pair(post, :statementNarrative2, options[:dynamic_descriptor]) if options[:dynamic_descriptor]
         if credit_card_or_reference.respond_to?(:number)
@@ -267,14 +267,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_reference(post, reference)
-        add_pair(post, :xref, reference, :required => true)
+        add_pair(post, :xref, reference, required: true)
       end
 
       def add_credit_card(post, credit_card)
-        add_pair(post, :customerName, credit_card.name, :required => true)
-        add_pair(post, :cardNumber, credit_card.number, :required => true)
-        add_pair(post, :cardExpiryMonth, format(credit_card.month, :two_digits), :required => true)
-        add_pair(post, :cardExpiryYear, format(credit_card.year, :two_digits), :required => true)
+        add_pair(post, :customerName, credit_card.name, required: true)
+        add_pair(post, :cardNumber, credit_card.number, required: true)
+        add_pair(post, :cardExpiryMonth, format(credit_card.month, :two_digits), required: true)
+        add_pair(post, :cardExpiryYear, format(credit_card.year, :two_digits), required: true)
         add_pair(post, :cardCVV, credit_card.verification_value)
       end
 
@@ -309,10 +309,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters)
-        parameters.update(:countryCode => self.supported_countries[0]) unless ['CAPTURE', 'CANCEL'].include?(action)
+        parameters.update(countryCode: self.supported_countries[0]) unless ['CAPTURE', 'CANCEL'].include?(action)
         parameters.update(
-          :merchantID => @options[:login],
-          :action => action
+          merchantID: @options[:login],
+          action: action
         )
         # adds a signature to the post hash/array
         add_hmac(parameters)
@@ -323,10 +323,10 @@ module ActiveMerchant #:nodoc:
           response[:responseCode] == '0',
           response[:responseCode] == '0' ? 'APPROVED' : response[:responseMessage],
           response,
-          :test => test?,
-          :authorization => response[:xref],
-          :cvv_result => CVV_CODE[response[:avscv2ResponseCode].to_s[0, 1]],
-          :avs_result => avs_from(response)
+          test: test?,
+          authorization: response[:xref],
+          cvv_result: CVV_CODE[response[:avscv2ResponseCode].to_s[0, 1]],
+          avs_result: avs_from(response)
         )
       end
 
@@ -345,9 +345,9 @@ module ActiveMerchant #:nodoc:
                end
 
         AVSResult.new({
-          :code => code,
-          :postal_match => postal_match,
-          :street_match => street_match
+          code: code,
+          postal_match: postal_match,
+          street_match: street_match
         })
       end
 

--- a/lib/active_merchant/billing/gateways/cc5.rb
+++ b/lib/active_merchant/billing/gateways/cc5.rb
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
       def build_sale_request(type, money, creditcard, options = {})
         requires!(options, :order_id)
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         xml.tag! 'CC5Request' do
           add_login_tags(xml)
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_capture_request(money, authorization, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         xml.tag! 'CC5Request' do
           add_login_tags(xml)
@@ -87,7 +87,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_void_request(authorization, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         xml.tag! 'CC5Request' do
           add_login_tags(xml)
@@ -97,7 +97,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_authorization_credit_request(money, authorization, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         xml.tag! 'CC5Request' do
           add_login_tags(xml)
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_creditcard_credit_request(money, creditcard, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         xml.tag! 'CC5Request' do
           add_login_tags(xml)
@@ -157,8 +157,8 @@ module ActiveMerchant #:nodoc:
           success,
           (success ? 'Approved' : "Declined (Reason: #{response[:proc_return_code]} - #{response[:err_msg]})"),
           response,
-          :test => test?,
-          :authorization => response[:order_id]
+          test: test?,
+          authorization: response[:order_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -173,9 +173,9 @@ module ActiveMerchant #:nodoc:
           response[:success],
           message_from(response),
           response,
-          :test => test?,
-          :authorization => build_authorization(response),
-          :error_code => response[:error_code]
+          test: test?,
+          authorization: build_authorization(response),
+          error_code: response[:error_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(post)
-        xml = Builder::XmlMarkup.new :indent => 8
+        xml = Builder::XmlMarkup.new indent: 8
         xml.tag!('acr:MerchantId', post.delete(:MerchantId))
         xml.tag!('acr:Password', post.delete(:Password))
         xml.tag!('acr:UserId', post.delete(:UserId))

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -38,61 +38,61 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'CyberSource'
 
       @@credit_card_codes = {
-        :visa  => '001',
-        :master => '002',
-        :american_express => '003',
-        :discover => '004',
-        :diners_club => '005',
-        :jcb => '007',
-        :dankort => '034',
-        :maestro => '042',
-        :elo => '054'
+        visa: '001',
+        master: '002',
+        american_express: '003',
+        discover: '004',
+        diners_club: '005',
+        jcb: '007',
+        dankort: '034',
+        maestro: '042',
+        elo: '054'
       }
 
       @@decision_codes = {
-        :accept => 'ACCEPT',
-        :review => 'REVIEW'
+        accept: 'ACCEPT',
+        review: 'REVIEW'
       }
 
       @@response_codes = {
-        :r100 => 'Successful transaction',
-        :r101 => 'Request is missing one or more required fields',
-        :r102 => 'One or more fields contains invalid data',
-        :r150 => 'General failure',
-        :r151 => 'The request was received but a server time-out occurred',
-        :r152 => 'The request was received, but a service timed out',
-        :r200 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
-        :r201 => 'The issuing bank has questions about the request',
-        :r202 => 'Expired card',
-        :r203 => 'General decline of the card',
-        :r204 => 'Insufficient funds in the account',
-        :r205 => 'Stolen or lost card',
-        :r207 => 'Issuing bank unavailable',
-        :r208 => 'Inactive card or card not authorized for card-not-present transactions',
-        :r209 => 'American Express Card Identifiction Digits (CID) did not match',
-        :r210 => 'The card has reached the credit limit',
-        :r211 => 'Invalid card verification number',
-        :r221 => "The customer matched an entry on the processor's negative file",
-        :r230 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
-        :r231 => 'Invalid account number',
-        :r232 => 'The card type is not accepted by the payment processor',
-        :r233 => 'General decline by the processor',
-        :r234 => 'A problem exists with your CyberSource merchant configuration',
-        :r235 => 'The requested amount exceeds the originally authorized amount',
-        :r236 => 'Processor failure',
-        :r237 => 'The authorization has already been reversed',
-        :r238 => 'The authorization has already been captured',
-        :r239 => 'The requested transaction amount must match the previous transaction amount',
-        :r240 => 'The card type sent is invalid or does not correlate with the credit card number',
-        :r241 => 'The request ID is invalid',
-        :r242 => 'You requested a capture, but there is no corresponding, unused authorization record.',
-        :r243 => 'The transaction has already been settled or reversed',
-        :r244 => 'The bank account number failed the validation check',
-        :r246 => 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
-        :r247 => 'You requested a credit for a capture that was previously voided',
-        :r250 => 'The request was received, but a time-out occurred with the payment processor',
-        :r254 => 'Your CyberSource account is prohibited from processing stand-alone refunds',
-        :r255 => 'Your CyberSource account is not configured to process the service in the country you specified'
+        r100: 'Successful transaction',
+        r101: 'Request is missing one or more required fields',
+        r102: 'One or more fields contains invalid data',
+        r150: 'General failure',
+        r151: 'The request was received but a server time-out occurred',
+        r152: 'The request was received, but a service timed out',
+        r200: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
+        r201: 'The issuing bank has questions about the request',
+        r202: 'Expired card',
+        r203: 'General decline of the card',
+        r204: 'Insufficient funds in the account',
+        r205: 'Stolen or lost card',
+        r207: 'Issuing bank unavailable',
+        r208: 'Inactive card or card not authorized for card-not-present transactions',
+        r209: 'American Express Card Identifiction Digits (CID) did not match',
+        r210: 'The card has reached the credit limit',
+        r211: 'Invalid card verification number',
+        r221: "The customer matched an entry on the processor's negative file",
+        r230: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
+        r231: 'Invalid account number',
+        r232: 'The card type is not accepted by the payment processor',
+        r233: 'General decline by the processor',
+        r234: 'A problem exists with your CyberSource merchant configuration',
+        r235: 'The requested amount exceeds the originally authorized amount',
+        r236: 'Processor failure',
+        r237: 'The authorization has already been reversed',
+        r238: 'The authorization has already been captured',
+        r239: 'The requested transaction amount must match the previous transaction amount',
+        r240: 'The card type sent is invalid or does not correlate with the credit card number',
+        r241: 'The request ID is invalid',
+        r242: 'You requested a capture, but there is no corresponding, unused authorization record.',
+        r243: 'The transaction has already been settled or reversed',
+        r244: 'The bank account number failed the validation check',
+        r246: 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
+        r247: 'You requested a credit for a capture that was previously voided',
+        r250: 'The request was received, but a time-out occurred with the payment processor',
+        r254: 'Your CyberSource account is prohibited from processing stand-alone refunds',
+        r255: 'Your CyberSource account is not configured to process the service in the country you specified'
       }
 
       # These are the options that can be used when creating a new CyberSource
@@ -250,18 +250,18 @@ module ActiveMerchant #:nodoc:
       # were only provided with one or two of them or even none
       def setup_address_hash(options)
         default_address = {
-          :address1 => 'Unspecified',
-          :city => 'Unspecified',
-          :state => 'NC',
-          :zip => '00000',
-          :country => 'US'
+          address1: 'Unspecified',
+          city: 'Unspecified',
+          state: 'NC',
+          zip: '00000',
+          country: 'US'
         }
         options[:billing_address] = options[:billing_address] || options[:address] || default_address
         options[:shipping_address] = options[:shipping_address] || {}
       end
 
       def build_auth_request(money, creditcard_or_reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_threeds_2_ucaf_data(xml, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
@@ -277,7 +277,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_tax_calculation_request(creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, creditcard, options[:billing_address], options, false)
         add_address(xml, creditcard, options[:shipping_address], options, true)
         add_line_item_data(xml, options)
@@ -291,7 +291,7 @@ module ActiveMerchant #:nodoc:
         order_id, request_id, request_token = authorization.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_purchase_data(xml, money, true, options)
         add_other_tax(xml, options)
         add_mdd_fields(xml, options)
@@ -302,7 +302,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_purchase_request(money, payment_method_or_reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         add_threeds_2_ucaf_data(xml, payment_method_or_reference, options)
         add_decision_manager_fields(xml, options)
@@ -324,12 +324,12 @@ module ActiveMerchant #:nodoc:
         order_id, request_id, request_token, action, money, currency = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         if action == 'capture'
           add_mdd_fields(xml, options)
           add_void_service(xml, request_id, request_token)
         else
-          add_purchase_data(xml, money, true, options.merge(:currency => currency || default_currency))
+          add_purchase_data(xml, money, true, options.merge(currency: currency || default_currency))
           add_mdd_fields(xml, options)
           add_auth_reversal_service(xml, request_id, request_token)
         end
@@ -341,7 +341,7 @@ module ActiveMerchant #:nodoc:
         order_id, request_id, request_token = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_purchase_data(xml, money, true, options)
         add_credit_service(xml, request_id, request_token)
 
@@ -349,7 +349,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_credit_request(money, creditcard_or_reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_mdd_fields(xml, options)
@@ -360,12 +360,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_create_subscription_request(payment_method, options)
-        default_subscription_params = {:frequency => 'on-demand', :amount => 0, :automatic_renew => false}
+        default_subscription_params = {frequency: 'on-demand', amount: 0, automatic_renew: false}
         options[:subscription] = default_subscription_params.update(
           options[:subscription] || {}
         )
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
         if card_brand(payment_method) == 'check'
@@ -390,7 +390,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_update_subscription_request(reference, creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, creditcard, options[:billing_address], options) unless options[:billing_address].blank?
         add_purchase_data(xml, options[:setup_fee], true, options) unless options[:setup_fee].blank?
         add_creditcard(xml, creditcard)    if creditcard
@@ -402,21 +402,21 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_delete_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_subscription(xml, options, reference)
         add_subscription_delete_service(xml, options)
         xml.target!
       end
 
       def build_retrieve_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_subscription(xml, options, reference)
         add_subscription_retrieve_service(xml, options)
         xml.target!
       end
 
       def build_validate_pinless_debit_request(creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_creditcard(xml, creditcard)
         add_validate_pinless_debit_service(xml)
         xml.target!
@@ -797,7 +797,7 @@ module ActiveMerchant #:nodoc:
       def build_request(body, options)
         xsd_version = test? ? TEST_XSD_VERSION : PRODUCTION_XSD_VERSION
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
           xml.tag! 's:Header' do
@@ -839,11 +839,11 @@ module ActiveMerchant #:nodoc:
         authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization,
-          :fraud_review => in_fraud_review?(response),
-          :avs_result => { :code => response[:avsCode] },
-          :cvv_result => response[:cvCode]
+          test: test?,
+          authorization: authorization,
+          fraud_review: in_fraud_review?(response),
+          avs_result: { code: response[:avsCode] },
+          cvv_result: response[:cvCode]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -92,9 +92,9 @@ module ActiveMerchant
 
       def build_void_or_capture_request(type, money, authorization, options)
         parsed_authorization = parse_authorization_string(authorization)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! :Request, :version => '2' do
+        xml.tag! :Request, version: '2' do
           add_authentication(xml)
 
           xml.tag! :Transaction do
@@ -107,7 +107,7 @@ module ActiveMerchant
             if money
               xml.tag! :TxnDetails do
                 xml.tag! :merchantreference, format_reference_number(options[:order_id])
-                xml.tag! :amount, amount(money), :currency => options[:currency] || currency(money)
+                xml.tag! :amount, amount(money), currency: options[:currency] || currency(money)
                 xml.tag! :capturemethod, 'ecomm'
               end
             end
@@ -117,20 +117,20 @@ module ActiveMerchant
       end
 
       def build_purchase_or_authorization_request_with_credit_card_request(type, money, credit_card, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! :Request, :version => '2' do
+        xml.tag! :Request, version: '2' do
           add_authentication(xml)
 
           xml.tag! :Transaction do
-            xml.tag! :ContAuthTxn, :type => 'setup' if options[:set_up_continuous_authority]
+            xml.tag! :ContAuthTxn, type: 'setup' if options[:set_up_continuous_authority]
             xml.tag! :CardTxn do
               xml.tag! :method, type
               add_credit_card(xml, credit_card, options[:billing_address])
             end
             xml.tag! :TxnDetails do
               xml.tag! :merchantreference, format_reference_number(options[:order_id])
-              xml.tag! :amount, amount(money), :currency => options[:currency] || currency(money)
+              xml.tag! :amount, amount(money), currency: options[:currency] || currency(money)
               xml.tag! :capturemethod, 'ecomm'
             end
           end
@@ -142,19 +142,19 @@ module ActiveMerchant
         parsed_authorization = parse_authorization_string(authorization)
         raise ArgumentError, 'The continuous authority reference is required for continuous authority transactions' if parsed_authorization[:ca_reference].blank?
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! :Request, :version => '2' do
+        xml.tag! :Request, version: '2' do
           add_authentication(xml)
           xml.tag! :Transaction do
-            xml.tag! :ContAuthTxn, :type => 'historic'
+            xml.tag! :ContAuthTxn, type: 'historic'
             xml.tag! :HistoricTxn do
               xml.tag! :reference, parsed_authorization[:ca_reference]
               xml.tag! :method, type
             end
             xml.tag! :TxnDetails do
               xml.tag! :merchantreference, format_reference_number(options[:order_id])
-              xml.tag! :amount, amount(money), :currency => options[:currency] || currency(money)
+              xml.tag! :amount, amount(money), currency: options[:currency] || currency(money)
               xml.tag! :capturemethod, 'cont_auth'
             end
           end
@@ -164,9 +164,9 @@ module ActiveMerchant
 
       def build_transaction_refund_request(money, authorization)
         parsed_authorization = parse_authorization_string(authorization)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! :Request, :version => '2' do
+        xml.tag! :Request, version: '2' do
           add_authentication(xml)
           xml.tag! :Transaction do
             xml.tag! :HistoricTxn do
@@ -185,9 +185,9 @@ module ActiveMerchant
       end
 
       def build_credit_request(money, credit_card, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! :Request, :version => '2' do
+        xml.tag! :Request, version: '2' do
           add_authentication(xml)
           xml.tag! :Transaction do
             xml.tag! :CardTxn do
@@ -235,23 +235,23 @@ module ActiveMerchant
             # a predefined one
             xml.tag! :ExtendedPolicy do
               xml.tag! :cv2_policy,
-                :notprovided =>   POLICY_REJECT,
-                :notchecked =>    POLICY_REJECT,
-                :matched =>       POLICY_ACCEPT,
-                :notmatched =>    POLICY_REJECT,
-                :partialmatch =>  POLICY_REJECT
+                notprovided: POLICY_REJECT,
+                notchecked: POLICY_REJECT,
+                matched: POLICY_ACCEPT,
+                notmatched: POLICY_REJECT,
+                partialmatch: POLICY_REJECT
               xml.tag! :postcode_policy,
-                :notprovided =>   POLICY_ACCEPT,
-                :notchecked =>    POLICY_ACCEPT,
-                :matched =>       POLICY_ACCEPT,
-                :notmatched =>    POLICY_REJECT,
-                :partialmatch =>  POLICY_ACCEPT
+                notprovided: POLICY_ACCEPT,
+                notchecked: POLICY_ACCEPT,
+                matched: POLICY_ACCEPT,
+                notmatched: POLICY_REJECT,
+                partialmatch: POLICY_ACCEPT
               xml.tag! :address_policy,
-                :notprovided =>   POLICY_ACCEPT,
-                :notchecked =>    POLICY_ACCEPT,
-                :matched =>       POLICY_ACCEPT,
-                :notmatched =>    POLICY_REJECT,
-                :partialmatch =>  POLICY_ACCEPT
+                notprovided: POLICY_ACCEPT,
+                notchecked: POLICY_ACCEPT,
+                matched: POLICY_ACCEPT,
+                notmatched: POLICY_REJECT,
+                partialmatch: POLICY_ACCEPT
             end
           end
         end
@@ -261,8 +261,8 @@ module ActiveMerchant
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request))
 
         Response.new(response[:status] == '1', response[:reason], response,
-          :test => test?,
-          :authorization => "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
+          test: test?,
+          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
         )
       end
 
@@ -296,7 +296,7 @@ module ActiveMerchant
 
       def parse_authorization_string(authorization)
         reference, auth_code, ca_reference = authorization.to_s.split(';')
-        {:reference => reference, :auth_code => auth_code, :ca_reference => ca_reference}
+        {reference: reference, auth_code: auth_code, ca_reference: ca_reference}
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         requires!(options, :order_id)
         original_transaction_id, _ = identification.split(';')
-        commit(:void_transaction, {:reference_number => format_reference_number(options[:order_id]), :transaction_id => original_transaction_id})
+        commit(:void_transaction, {reference_number: format_reference_number(options[:order_id]), transaction_id: original_transaction_id})
       end
 
       def voice_authorize(money, authorization_code, creditcard, options = {})
@@ -81,11 +81,11 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
 
         {
-          :reference_number => format_reference_number(options[:order_id]),
-          :transaction_amount => amount(money),
-          :original_transaction_amount => original_transaction_amount,
-          :original_transaction_id => original_transaction_id,
-          :client_ip_address => options[:ip]
+          reference_number: format_reference_number(options[:order_id]),
+          transaction_amount: amount(money),
+          original_transaction_amount: original_transaction_amount,
+          original_transaction_id: original_transaction_id,
+          client_ip_address: options[:ip]
         }
       end
 
@@ -93,10 +93,10 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
 
         post = {
-          :reference_number => format_reference_number(options[:order_id]),
-          :authorization_number => options[:authorization_number],
-          :transaction_amount => amount(money),
-          :client_ip_address => options[:ip]
+          reference_number: format_reference_number(options[:order_id]),
+          authorization_number: options[:authorization_number],
+          transaction_amount: amount(money),
+          client_ip_address: options[:ip]
 
         }
         add_creditcard(post, creditcard)
@@ -146,10 +146,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(action, parameters), 'Content-Type' => 'text/xml'))
 
         Response.new(success?(response), message_from(response[:result_message]), response,
-          :test => test?,
-          :authorization => authorization_from(response, parameters),
-          :avs_result => { :code => response[:avs_response_code] },
-          :cvv_result => response[:cvv_response_code]
+          test: test?,
+          authorization: authorization_from(response, parameters),
+          avs_result: { code: response[:avs_response_code] },
+          cvv_result: response[:cvv_response_code]
         )
       end
 
@@ -201,15 +201,15 @@ module ActiveMerchant #:nodoc:
       CREDIT_CARD_FIELDS = %w(AuthorizationNumber ClientIpAddress BillingAddress BillingCity BillingState BillingPostalCode BillingCountry BillingName CardVerificationValue ExpirationMonth ExpirationYear ReferenceNumber TransactionAmount AccountNumber)
 
       ACTIONS = {
-        :credit_card_authorize       => CREDIT_CARD_FIELDS,
-        :credit_card_charge          => CREDIT_CARD_FIELDS,
-        :credit_card_voice_authorize => CREDIT_CARD_FIELDS,
-        :credit_card_capture         => CREDIT_CARD_FIELDS,
-        :credit_card_credit          => CREDIT_CARD_FIELDS + ['OriginalTransactionAmount'],
-        :credit_card_refund          => %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
-        :void_transaction            => %w(ReferenceNumber TransactionID),
-        :credit_card_settle          => %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
-        :system_check                => %w(SystemCheck),
+        credit_card_authorize: CREDIT_CARD_FIELDS,
+        credit_card_charge: CREDIT_CARD_FIELDS,
+        credit_card_voice_authorize: CREDIT_CARD_FIELDS,
+        credit_card_capture: CREDIT_CARD_FIELDS,
+        credit_card_credit: CREDIT_CARD_FIELDS + ['OriginalTransactionAmount'],
+        credit_card_refund: %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
+        void_transaction: %w(ReferenceNumber TransactionID),
+        credit_card_settle: %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
+        system_check: %w(SystemCheck),
       }
     end
   end

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -17,15 +17,15 @@ module ActiveMerchant #:nodoc:
 
       self.delimiter = "\n"
       self.actions = {
-        :purchase => 'CCSALE',
-        :credit => 'CCCREDIT',
-        :refund => 'CCRETURN',
-        :authorize => 'CCAUTHONLY',
-        :capture => 'CCFORCE',
-        :capture_complete => 'CCCOMPLETE',
-        :void => 'CCDELETE',
-        :store => 'CCGETTOKEN',
-        :update => 'CCUPDATETOKEN',
+        purchase: 'CCSALE',
+        credit: 'CCCREDIT',
+        refund: 'CCRETURN',
+        authorize: 'CCAUTHONLY',
+        capture: 'CCFORCE',
+        capture_complete: 'CCCOMPLETE',
+        void: 'CCDELETE',
+        store: 'CCGETTOKEN',
+        update: 'CCUPDATETOKEN',
       }
 
       def initialize(options = {})
@@ -264,10 +264,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters, options)))
 
         Response.new(response['result'] == '0', message_from(response), response,
-          :test => @options[:test] || test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response['avs_response'] },
-          :cvv_result => response['cvv2_response']
+          test: @options[:test] || test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response['avs_response'] },
+          cvv_result: response['cvv2_response']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -12,41 +12,41 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'ePay'
 
       CURRENCY_CODES = {
-        :ADP => '020', :AED => '784', :AFA => '004', :ALL => '008', :AMD => '051',
-        :ANG => '532', :AOA => '973', :ARS => '032', :AUD => '036', :AWG => '533',
-        :AZM => '031', :BAM => '977', :BBD => '052', :BDT => '050', :BGL => '100',
-        :BGN => '975', :BHD => '048', :BIF => '108', :BMD => '060', :BND => '096',
-        :BOB => '068', :BOV => '984', :BRL => '986', :BSD => '044', :BTN => '064',
-        :BWP => '072', :BYR => '974', :BZD => '084', :CAD => '124', :CDF => '976',
-        :CHF => '756', :CLF => '990', :CLP => '152', :CNY => '156', :COP => '170',
-        :CRC => '188', :CUP => '192', :CVE => '132', :CYP => '196', :CZK => '203',
-        :DJF => '262', :DKK => '208', :DOP => '214', :DZD => '012', :ECS => '218',
-        :ECV => '983', :EEK => '233', :EGP => '818', :ERN => '232', :ETB => '230',
-        :EUR => '978', :FJD => '242', :FKP => '238', :GBP => '826', :GEL => '981',
-        :GHC => '288', :GIP => '292', :GMD => '270', :GNF => '324', :GTQ => '320',
-        :GWP => '624', :GYD => '328', :HKD => '344', :HNL => '340', :HRK => '191',
-        :HTG => '332', :HUF => '348', :IDR => '360', :ILS => '376', :INR => '356',
-        :IQD => '368', :IRR => '364', :ISK => '352', :JMD => '388', :JOD => '400',
-        :JPY => '392', :KES => '404', :KGS => '417', :KHR => '116', :KMF => '174',
-        :KPW => '408', :KRW => '410', :KWD => '414', :KYD => '136', :KZT => '398',
-        :LAK => '418', :LBP => '422', :LKR => '144', :LRD => '430', :LSL => '426',
-        :LTL => '440', :LVL => '428', :LYD => '434', :MAD => '504', :MDL => '498',
-        :MGF => '450', :MKD => '807', :MMK => '104', :MNT => '496', :MOP => '446',
-        :MRO => '478', :MTL => '470', :MUR => '480', :MVR => '462', :MWK => '454',
-        :MXN => '484', :MXV => '979', :MYR => '458', :MZM => '508', :NAD => '516',
-        :NGN => '566', :NIO => '558', :NOK => '578', :NPR => '524', :NZD => '554',
-        :OMR => '512', :PAB => '590', :PEN => '604', :PGK => '598', :PHP => '608',
-        :PKR => '586', :PLN => '985', :PYG => '600', :QAR => '634', :ROL => '642',
-        :RUB => '643', :RUR => '810', :RWF => '646', :SAR => '682', :SBD => '090',
-        :SCR => '690', :SDD => '736', :SEK => '752', :SGD => '702', :SHP => '654',
-        :SIT => '705', :SKK => '703', :SLL => '694', :SOS => '706', :SRG => '740',
-        :STD => '678', :SVC => '222', :SYP => '760', :SZL => '748', :THB => '764',
-        :TJS => '972', :TMM => '795', :TND => '788', :TOP => '776', :TPE => '626',
-        :TRL => '792', :TRY => '949', :TTD => '780', :TWD => '901', :TZS => '834',
-        :UAH => '980', :UGX => '800', :USD => '840', :UYU => '858', :UZS => '860',
-        :VEB => '862', :VND => '704', :VUV => '548', :XAF => '950', :XCD => '951',
-        :XOF => '952', :XPF => '953', :YER => '886', :YUM => '891', :ZAR => '710',
-        :ZMK => '894', :ZWD => '716'
+        ADP: '020', AED: '784', AFA: '004', ALL: '008', AMD: '051',
+        ANG: '532', AOA: '973', ARS: '032', AUD: '036', AWG: '533',
+        AZM: '031', BAM: '977', BBD: '052', BDT: '050', BGL: '100',
+        BGN: '975', BHD: '048', BIF: '108', BMD: '060', BND: '096',
+        BOB: '068', BOV: '984', BRL: '986', BSD: '044', BTN: '064',
+        BWP: '072', BYR: '974', BZD: '084', CAD: '124', CDF: '976',
+        CHF: '756', CLF: '990', CLP: '152', CNY: '156', COP: '170',
+        CRC: '188', CUP: '192', CVE: '132', CYP: '196', CZK: '203',
+        DJF: '262', DKK: '208', DOP: '214', DZD: '012', ECS: '218',
+        ECV: '983', EEK: '233', EGP: '818', ERN: '232', ETB: '230',
+        EUR: '978', FJD: '242', FKP: '238', GBP: '826', GEL: '981',
+        GHC: '288', GIP: '292', GMD: '270', GNF: '324', GTQ: '320',
+        GWP: '624', GYD: '328', HKD: '344', HNL: '340', HRK: '191',
+        HTG: '332', HUF: '348', IDR: '360', ILS: '376', INR: '356',
+        IQD: '368', IRR: '364', ISK: '352', JMD: '388', JOD: '400',
+        JPY: '392', KES: '404', KGS: '417', KHR: '116', KMF: '174',
+        KPW: '408', KRW: '410', KWD: '414', KYD: '136', KZT: '398',
+        LAK: '418', LBP: '422', LKR: '144', LRD: '430', LSL: '426',
+        LTL: '440', LVL: '428', LYD: '434', MAD: '504', MDL: '498',
+        MGF: '450', MKD: '807', MMK: '104', MNT: '496', MOP: '446',
+        MRO: '478', MTL: '470', MUR: '480', MVR: '462', MWK: '454',
+        MXN: '484', MXV: '979', MYR: '458', MZM: '508', NAD: '516',
+        NGN: '566', NIO: '558', NOK: '578', NPR: '524', NZD: '554',
+        OMR: '512', PAB: '590', PEN: '604', PGK: '598', PHP: '608',
+        PKR: '586', PLN: '985', PYG: '600', QAR: '634', ROL: '642',
+        RUB: '643', RUR: '810', RWF: '646', SAR: '682', SBD: '090',
+        SCR: '690', SDD: '736', SEK: '752', SGD: '702', SHP: '654',
+        SIT: '705', SKK: '703', SLL: '694', SOS: '706', SRG: '740',
+        STD: '678', SVC: '222', SYP: '760', SZL: '748', THB: '764',
+        TJS: '972', TMM: '795', TND: '788', TOP: '776', TPE: '626',
+        TRL: '792', TRY: '949', TTD: '780', TWD: '901', TZS: '834',
+        UAH: '980', UGX: '800', USD: '840', UYU: '858', UZS: '860',
+        VEB: '862', VND: '704', VUV: '548', XAF: '950', XCD: '951',
+        XOF: '952', XPF: '953', YER: '886', YUM: '891', ZAR: '710',
+        ZMK: '894', ZWD: '716'
       }
 
       # login: merchant number
@@ -177,14 +177,14 @@ module ActiveMerchant #:nodoc:
           Response.new response['accept'].to_i == 1,
             response['errortext'],
             response,
-            :test => test?,
-            :authorization => response['tid']
+            test: test?,
+            authorization: response['tid']
         else
           Response.new response['result'] == 'true',
             messages(response['epay'], response['pbs']),
             response,
-            :test => test?,
-            :authorization => params[:transaction]
+            test: test?,
+            authorization: params[:transaction]
         end
       end
 
@@ -261,7 +261,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def xml_builder(params, soap_call)
-        xml = Builder::XmlMarkup.new(:indent => 2)
+        xml = Builder::XmlMarkup.new(indent: 2)
         xml.instruct!
         xml.tag! 'soap:Envelope', { 'xmlns:xsi' => 'http://schemas.xmlsoap.org/soap/envelope/',
                                     'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -139,8 +139,8 @@ module ActiveMerchant #:nodoc:
       # <tt>options</tt>.
       def capture(money, authorization, options = {})
         post = {
-          :amount         => amount(money),
-          :transactionid  => authorization
+          amount: amount(money),
+          transactionid: authorization
         }
         add_order(post, options)
         commit('capture', money, post)
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def refund(money, identification)
-        post = {:transactionid => identification}
+        post = {transactionid: identification}
         commit('refund', money, post)
       end
 
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def void(identification)
-        post = {:transactionid => identification}
+        post = {transactionid: identification}
         commit('void', nil, post)
       end
 
@@ -192,7 +192,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def update(identification, options)
-        post = {:transactionid => identification}
+        post = {transactionid: identification}
         add_order(post, options)
         commit('update', nil, post)
       end
@@ -280,10 +280,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          :test          => test?,
-          :authorization => response['transactionid'],
-          :avs_result    => { :code => response['avsresponse'] },
-          :cvv_result    => response['cvvresponse']
+          test: test?,
+          authorization: response['transactionid'],
+          avs_result: { code: response['avsresponse'] },
+          cvv_result: response['cvvresponse']
         )
       end
 
@@ -292,7 +292,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, parameters = {})
-        post = {:type => action}
+        post = {type: action}
 
         if test?
           post[:username] = 'demo'

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -114,8 +114,8 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response),
           message_from(response[:ewaytrxnerror]),
           response,
-          :authorization => response[:ewaytrxnnumber],
-          :test => test?
+          authorization: response[:ewaytrxnnumber],
+          test: test?
         )
       end
 

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -223,8 +223,8 @@ module ActiveMerchant #:nodoc:
         response = parse(raw)
 
         EwayResponse.new(response[:success], response[:message], response,
-          :test => test?,
-          :authorization => response[:auth_code]
+          test: test?,
+          authorization: response[:auth_code]
         )
       end
 
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
                  default_customer_fields.merge(arguments)
                end
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'soap12:Envelope', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'} do
           xml.tag! 'soap12:Header' do

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -232,7 +232,7 @@ module ActiveMerchant #:nodoc:
         params[key] = {}
 
         add_name_and_email(params[key], options[:shipping_address], options[:email])
-        add_address(params[key], options[:shipping_address], {:skip_company => true})
+        add_address(params[key], options[:shipping_address], {skip_company: true})
       end
 
       def add_name_and_email(params, address, email, payment_method = nil)
@@ -304,13 +304,13 @@ module ActiveMerchant #:nodoc:
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(raw),
-          :test => test?,
-          :avs_result => avs_result_from(raw),
-          :cvv_result => cvv_result_from(raw)
+          authorization: authorization_from(raw),
+          test: test?,
+          avs_result: avs_result_from(raw),
+          cvv_result: cvv_result_from(raw)
         )
       rescue ActiveMerchant::ResponseError => e
-        return ActiveMerchant::Billing::Response.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
+        return ActiveMerchant::Billing::Response.new(false, e.response.message, {status_code: e.response.code}, test: test?)
       end
 
       def parse(data)
@@ -365,7 +365,7 @@ module ActiveMerchant #:nodoc:
           else
             'I'
           end
-        {:code => code}
+        {code: code}
       end
 
       def cvv_result_from(response)

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -5,13 +5,13 @@ module ActiveMerchant #:nodoc:
 
       API_VERSION = '8.5'
 
-      TEST_LOGINS = [{:login => 'A00049-01', :password => 'test1'},
-                     {:login => 'A00427-01', :password => 'testus'}]
+      TEST_LOGINS = [{login: 'A00049-01', password: 'test1'},
+                     {login: 'A00427-01', password: 'testus'}]
 
-      TRANSACTIONS = { :sale          => '00',
-                       :authorization => '01',
-                       :capture       => '32',
-                       :credit        => '34' }
+      TRANSACTIONS = { sale: '00',
+                       authorization: '01',
+                       capture: '32',
+                       credit: '34' }
 
       ENVELOPE_NAMESPACES = { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
                               'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/',
@@ -159,15 +159,15 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, build_request(action, request), POST_HEADERS))
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response[:avs] },
-          :cvv_result => response[:cvv2]
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response[:avs] },
+          cvv_result: response[:cvv2]
         )
       rescue ResponseError => e
         case e.response.code
         when '401'
-          return Response.new(false, "Invalid Login: #{e.response.body}", {}, :test => test?)
+          return Response.new(false, "Invalid Login: #{e.response.body}", {}, test: test?)
         else
           raise
         end

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -159,8 +159,8 @@ module ActiveMerchant #:nodoc:
           success,
           message_from(response),
           response,
-          :test => response['test'],
-          :authorization => authorization_from(response, success, uri)
+          test: response['test'],
+          authorization: authorization_from(response, success, uri)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        commit('refund', money, options.merge(:transactionid => authorization))
+        commit('refund', money, options.merge(transactionid: authorization))
       end
 
       def credit(money, authorization, options = {})
@@ -122,10 +122,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          :test => test?,
-          :authorization => response['transactionid'],
-          :avs_result => {:code => response['avsresponse']},
-          :cvv_result => response['cvvresponse']
+          test: test?,
+          authorization: response['transactionid'],
+          avs_result: {code: response['avsresponse']},
+          cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -25,14 +25,14 @@ module ActiveMerchant #:nodoc:
       SENSITIVE_FIELDS = [:verification_str2, :expiry_date, :card_number]
 
       BRANDS = {
-        :visa => 'Visa',
-        :master => 'Mastercard',
-        :american_express => 'American Express',
-        :jcb => 'JCB',
-        :discover => 'Discover'
+        visa: 'Visa',
+        master: 'Mastercard',
+        american_express: 'American Express',
+        jcb: 'JCB',
+        discover: 'Discover'
       }
 
-      E4_BRANDS = BRANDS.merge({:mastercard => 'Mastercard'})
+      E4_BRANDS = BRANDS.merge({mastercard: 'Mastercard'})
 
       DEFAULT_ECI = '07'
 
@@ -298,11 +298,11 @@ module ActiveMerchant #:nodoc:
       def add_credit_card_token(xml, store_authorization, options)
         params = store_authorization.split(';')
         credit_card = CreditCard.new(
-          :brand      => params[1],
-          :first_name => params[2],
-          :last_name  => params[3],
-          :month      => params[4],
-          :year       => params[5])
+          brand: params[1],
+          first_name: params[2],
+          last_name: params[3],
+          month: params[4],
+          year: params[5])
 
         xml.tag! 'TransarmorToken', params[0]
         xml.tag! 'Expiry_Date', expdate(credit_card)
@@ -354,11 +354,11 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : '',
-          :avs_result => {:code => response[:avs]},
-          :cvv_result => response[:cvv2],
-          :error_code => standard_error_code(response)
+          test: test?,
+          authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
+          avs_result: {code: response[:avs]},
+          cvv_result: response[:cvv2],
+          error_code: standard_error_code(response)
         )
       end
 
@@ -420,10 +420,10 @@ module ActiveMerchant #:nodoc:
 
       def parse_error(error)
         {
-          :transaction_approved => 'false',
-          :error_number => error.code,
-          :error_description => error.body,
-          :ecommerce_error_code => error.body.gsub(/[^\d]/, '')
+          transaction_approved: 'false',
+          error_number: error.code,
+          error_description: error.body,
+          ecommerce_error_code: error.body.gsub(/[^\d]/, '')
         }
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -19,11 +19,11 @@ module ActiveMerchant #:nodoc:
       SENSITIVE_FIELDS = [:cvdcode, :expiry_date, :card_number]
 
       BRANDS = {
-        :visa => 'Visa',
-        :master => 'Mastercard',
-        :american_express => 'American Express',
-        :jcb => 'JCB',
-        :discover => 'Discover'
+        visa: 'Visa',
+        master: 'Mastercard',
+        american_express: 'American Express',
+        jcb: 'JCB',
+        discover: 'Discover'
       }
 
       DEFAULT_ECI = '07'
@@ -265,11 +265,11 @@ module ActiveMerchant #:nodoc:
       def add_credit_card_token(xml, store_authorization, options)
         params = store_authorization.split(';')
         credit_card = CreditCard.new(
-          :brand      => params[1],
-          :first_name => params[2],
-          :last_name  => params[3],
-          :month      => params[4],
-          :year       => params[5])
+          brand: params[1],
+          first_name: params[2],
+          last_name: params[3],
+          month: params[4],
+          year: params[5])
 
         xml.tag! 'TransarmorToken', params[0]
         xml.tag! 'Expiry_Date', expdate(credit_card)
@@ -361,11 +361,11 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : '',
-          :avs_result => {:code => response[:avs]},
-          :cvv_result => response[:cvv2],
-          :error_code => standard_error_code(response)
+          test: test?,
+          authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
+          avs_result: {code: response[:avs]},
+          cvv_result: response[:cvv2],
+          error_code: standard_error_code(response)
         )
       end
 
@@ -444,10 +444,10 @@ module ActiveMerchant #:nodoc:
 
       def parse_error(error)
         {
-          :transaction_approved => 'false',
-          :error_number => error.code,
-          :error_description => error.body,
-          :ecommerce_error_code => error.body.gsub(/[^\d]/, '')
+          transaction_approved: 'false',
+          error_number: error.code,
+          error_description: error.body,
+          ecommerce_error_code: error.body.gsub(/[^\d]/, '')
         }
       end
 

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -119,9 +119,9 @@ module ActiveMerchant #:nodoc:
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(action, raw[:transaction_id], post[:OriginalTransactionId]),
-          :error_code => error_code_from(succeeded, raw),
-          :test => test?
+          authorization: authorization_from(action, raw[:transaction_id], post[:OriginalTransactionId]),
+          error_code: error_code_from(succeeded, raw),
+          test: test?
         )
       end
 
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(action, post)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         post.each do |field, value|
           xml.tag!(field, value)
         end

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -36,17 +36,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, credit_card, options = {})
-        options = options.merge(:gvp_order_type => 'sales')
+        options = options.merge(gvp_order_type: 'sales')
         commit(money, build_sale_request(money, credit_card, options))
       end
 
       def authorize(money, credit_card, options = {})
-        options = options.merge(:gvp_order_type => 'preauth')
+        options = options.merge(gvp_order_type: 'preauth')
         commit(money, build_authorize_request(money, credit_card, options))
       end
 
       def capture(money, ref_id, options = {})
-        options = options.merge(:gvp_order_type => 'postauth')
+        options = options.merge(gvp_order_type: 'postauth')
         commit(money, build_capture_request(money, ref_id, options))
       end
 
@@ -66,8 +66,8 @@ module ActiveMerchant #:nodoc:
         card_number = credit_card.respond_to?(:number) ? credit_card.number : ''
         hash_data   = generate_hash_data(format_order_id(options[:order_id]), @options[:terminal_id], card_number, amount(money), security_data)
 
-        xml = Builder::XmlMarkup.new(:indent => 2)
-        xml.instruct! :xml, :version => '1.0', :encoding => 'UTF-8'
+        xml = Builder::XmlMarkup.new(indent: 2)
+        xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
 
         xml.tag! 'GVPSRequest' do
           xml.tag! 'Mode', test? ? 'TEST' : 'PROD'
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_capture_request(money, ref_id, options)
-        options = options.merge(:order_id => ref_id)
+        options = options.merge(order_id: ref_id)
         build_xml_request(money, ref_id, options) do |xml|
           add_customer_data(xml, options)
           add_order_data(xml, options)
@@ -222,8 +222,8 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           success ? 'Approved' : "Declined (Reason: #{response[:reason_code]} - #{response[:error_msg]} - #{response[:sys_err_msg]})",
           response,
-          :test => test?,
-          :authorization => response[:order_id])
+          test: test?,
+          authorization: response[:order_id])
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -149,13 +149,13 @@ EOA
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(post, raw),
-          :test => test?
+          authorization: authorization_from(post, raw),
+          test: test?
         )
       end
 
       def build_request(post)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         post.each do |field, value|
           xml.tag!(field, value)

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -266,7 +266,7 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         xml = Builder::XmlMarkup.new
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         xml.tag! 'soap12:Envelope', envelope_namespaces do
           xml.tag! 'soap12:Body' do
             xml.tag! ACTIONS[action], { 'xmlns' => 'https://www.iatspayments.com/NetGate/' } do

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -93,7 +93,7 @@ module ActiveMerchant #:nodoc:
       # store and unstore need to be defined
       def store(creditcard, options = {})
         billing_id = options.delete(:billing_id).to_s || true
-        authorize(100, creditcard, options.merge(:store => billing_id))
+        authorize(100, creditcard, options.merge(store: billing_id))
       end
 
       alias_method :unstore, :delete
@@ -173,10 +173,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(response['response'] == '1', message_from(response), response,
-          :authorization => response['transactionid'],
-          :test => test?,
-          :cvv_result => response['cvvresponse'],
-          :avs_result => { :code => response['avsresponse'] }
+          authorization: response['transactionid'],
+          test: test?,
+          cvv_result: response['cvvresponse'],
+          avs_result: { code: response['avsresponse'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/instapay.rb
+++ b/lib/active_merchant/billing/gateways/instapay.rb
@@ -141,9 +141,9 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
 
         Response.new(response[:success], response[:message], response,
-          :authorization => response[:transaction_id],
-          :avs_result => { :code => response[:avs_result] },
-          :cvv_result => response[:cvv_result]
+          authorization: response[:transaction_id],
+          avs_result: { code: response[:avs_result] },
+          cvv_result: response[:cvv_result]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -98,7 +98,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_credit_card(xml, payment)
-        xml.CreditCard :Registered => 'False' do
+        xml.CreditCard Registered: 'False' do
           xml.CardNumber payment.number
           xml.ExpM format(payment.month, :two_digits)
           xml.ExpY format(payment.year, :four_digits)

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -304,8 +304,8 @@ module ActiveMerchant #:nodoc:
 
       def build_request(options)
         requires!(options, :action)
-        xml = Builder::XmlMarkup.new :indent => 2
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        xml = Builder::XmlMarkup.new indent: 2
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         xml.tag! 'soap:Envelope', { 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
                                     'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                                     'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
@@ -383,13 +383,13 @@ module ActiveMerchant #:nodoc:
         authorization = success ? [options[:order_id], response[:transaction_output_data][:cross_reference], response[:transaction_output_data][:auth_code]].compact.join(';') : nil
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => {
-            :street_match => AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
-            :postal_match => AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ],
+          test: test?,
+          authorization: authorization,
+          avs_result: {
+            street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
+            postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ],
           },
-          :cvv_result => CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
+          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -388,14 +388,14 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(payload), 'Content-Type' => 'text/xml'))
 
         Response.new(successful?(response), response[:error_message], response,
-          :test => test?,
-          :authorization => response[:xid],
-          :avs_result => { :code => response[:avs_response] },
-          :cvv_result => response[:cvv_response])
+          test: test?,
+          authorization: response[:xid],
+          avs_result: { code: response[:avs_response] },
+          cvv_result: response[:cvv_response])
       end
 
       def post_data(payload)
-        payload_xml = payload.root.to_xml(:indent => 0)
+        payload_xml = payload.root.to_xml(indent: 0)
 
         payload_signature = sign_payload(payload_xml)
 
@@ -410,7 +410,7 @@ module ActiveMerchant #:nodoc:
         end.doc
 
         request.root.children.first.after payload.root
-        request.to_xml(:indent => 0)
+        request.to_xml(indent: 0)
       end
 
       def parse(raw_xml)

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def build_xml_envelope(vxml)
-        builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           xml[:soap].Envelope 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/' do
             xml[:soap].Body do
               xml.Execute 'xmlns' => 'http://iveri.com/' do

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -287,10 +287,10 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           success ? 'APPROVED' : message_from(response),
           response,
-          :test => test?,
-          :authorization => authorization_from(response, money, token),
-          :avs_result => { :code => response[:avs] },
-          :cvv_result => response[:cvv2]
+          test: test?,
+          authorization: authorization_from(response, money, token),
+          avs_result: { code: response[:avs] },
+          cvv_result: response[:cvv2]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -298,11 +298,11 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           success ? 'APPROVED' : message_from(response),
           response,
-          :test => test?,
-          :authorization => authorization_from(response, money, token),
-          :avs_result => AVSResult.new(:code => response[:avs]),
-          :cvv_result => CVVResult.new(response[:cvv2]),
-          :error_code => success ? nil : error_code_from(response)
+          test: test?,
+          authorization: authorization_from(response, money, token),
+          avs_result: AVSResult.new(code: response[:avs]),
+          cvv_result: CVVResult.new(response[:cvv2]),
+          error_code: success ? nil : error_code_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/latitude19.rb
+++ b/lib/active_merchant/billing/gateways/latitude19.rb
@@ -398,7 +398,7 @@ module ActiveMerchant #:nodoc:
           false,
           message_from(response),
           response,
-          :test => test?
+          test: test?
         )
       end
 

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -138,8 +138,8 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login)
 
         @options = {
-          :result => 'LIVE',
-          :pem => LinkpointGateway.pem_file
+          result: 'LIVE',
+          pem: LinkpointGateway.pem_file
         }.update(options)
 
         raise ArgumentError, "You need to pass in your pem file using the :pem parameter or set it globally using ActiveMerchant::Billing::LinkpointGateway.pem_file = File.read( File.dirname(__FILE__) + '/../mycert.pem' ) or similar" if @options[:pem].blank?
@@ -172,13 +172,13 @@ module ActiveMerchant #:nodoc:
         requires!(options, [:periodicity, :bimonthly, :monthly, :biweekly, :weekly, :yearly, :daily], :installments, :order_id)
 
         options.update(
-          :ordertype => 'SALE',
-          :action => options[:action] || 'SUBMIT',
-          :installments => options[:installments] || 12,
-          :startdate => options[:startdate] || 'immediate',
-          :periodicity => options[:periodicity].to_s || 'monthly',
-          :comments => options[:comments] || nil,
-          :threshold => options[:threshold] || 3
+          ordertype: 'SALE',
+          action: options[:action] || 'SUBMIT',
+          installments: options[:installments] || 12,
+          startdate: options[:startdate] || 'immediate',
+          periodicity: options[:periodicity].to_s || 'monthly',
+          comments: options[:comments] || nil,
+          threshold: options[:threshold] || 3
         )
         commit(money, creditcard, options)
       end
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, creditcard, options={})
         requires!(options, :order_id)
         options.update(
-          :ordertype => 'SALE'
+          ordertype: 'SALE'
         )
         commit(money, creditcard, options)
       end
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, creditcard, options = {})
         requires!(options, :order_id)
         options.update(
-          :ordertype => 'PREAUTH'
+          ordertype: 'PREAUTH'
         )
         commit(money, creditcard, options)
       end
@@ -213,8 +213,8 @@ module ActiveMerchant #:nodoc:
       #
       def capture(money, authorization, options = {})
         options.update(
-          :order_id => authorization,
-          :ordertype => 'POSTAUTH'
+          order_id: authorization,
+          ordertype: 'POSTAUTH'
         )
         commit(money, nil, options)
       end
@@ -222,8 +222,8 @@ module ActiveMerchant #:nodoc:
       # Void a previous transaction
       def void(identification, options = {})
         options.update(
-          :order_id => identification,
-          :ordertype => 'VOID'
+          order_id: identification,
+          ordertype: 'VOID'
         )
         commit(nil, nil, options)
       end
@@ -235,8 +235,8 @@ module ActiveMerchant #:nodoc:
       #
       def refund(money, identification, options = {})
         options.update(
-          :ordertype => 'CREDIT',
-          :order_id => identification
+          ordertype: 'CREDIT',
+          order_id: identification
         )
         commit(money, nil, options)
       end
@@ -264,10 +264,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(money, creditcard, options)))
 
         Response.new(successful?(response), response[:message], response,
-          :test => test?,
-          :authorization => response[:ordernum],
-          :avs_result => { :code => response[:avs].to_s[2, 1] },
-          :cvv_result => response[:avs].to_s[3, 1]
+          test: test?,
+          authorization: response[:ordernum],
+          avs_result: { code: response[:avs].to_s[2, 1] },
+          cvv_result: response[:avs].to_s[3, 1]
         )
       end
 
@@ -325,55 +325,55 @@ module ActiveMerchant #:nodoc:
       # for every action.
       def parameters(money, creditcard, options = {})
         params = {
-          :payment => {
-            :subtotal => amount(options[:subtotal]),
-            :tax => amount(options[:tax]),
-            :vattax => amount(options[:vattax]),
-            :shipping => amount(options[:shipping]),
-            :chargetotal => amount(money)
+          payment: {
+            subtotal: amount(options[:subtotal]),
+            tax: amount(options[:tax]),
+            vattax: amount(options[:vattax]),
+            shipping: amount(options[:shipping]),
+            chargetotal: amount(money)
           },
-          :transactiondetails => {
-            :transactionorigin => options[:transactionorigin] || 'ECI',
-            :oid => options[:order_id],
-            :ponumber => options[:ponumber],
-            :taxexempt => options[:taxexempt],
-            :terminaltype => options[:terminaltype],
-            :ip => options[:ip],
-            :reference_number => options[:reference_number],
-            :recurring => options[:recurring] || 'NO', # DO NOT USE if you are using the periodic billing option.
-            :tdate => options[:tdate]
+          transactiondetails: {
+            transactionorigin: options[:transactionorigin] || 'ECI',
+            oid: options[:order_id],
+            ponumber: options[:ponumber],
+            taxexempt: options[:taxexempt],
+            terminaltype: options[:terminaltype],
+            ip: options[:ip],
+            reference_number: options[:reference_number],
+            recurring: options[:recurring] || 'NO', # DO NOT USE if you are using the periodic billing option.
+            tdate: options[:tdate]
           },
-          :orderoptions => {
-            :ordertype => options[:ordertype],
-            :result => @options[:result]
+          orderoptions: {
+            ordertype: options[:ordertype],
+            result: @options[:result]
           },
-          :periodic => {
-            :action => options[:action],
-            :installments => options[:installments],
-            :threshold => options[:threshold],
-            :startdate => options[:startdate],
-            :periodicity => options[:periodicity],
-            :comments => options[:comments]
+          periodic: {
+            action: options[:action],
+            installments: options[:installments],
+            threshold: options[:threshold],
+            startdate: options[:startdate],
+            periodicity: options[:periodicity],
+            comments: options[:comments]
           },
-          :telecheck => {
-            :routing => options[:telecheck_routing],
-            :account => options[:telecheck_account],
-            :checknumber => options[:telecheck_checknumber],
-            :bankname => options[:telecheck_bankname],
-            :dl => options[:telecheck_dl],
-            :dlstate => options[:telecheck_dlstate],
-            :void => options[:telecheck_void],
-            :accounttype => options[:telecheck_accounttype],
-            :ssn => options[:telecheck_ssn],
+          telecheck: {
+            routing: options[:telecheck_routing],
+            account: options[:telecheck_account],
+            checknumber: options[:telecheck_checknumber],
+            bankname: options[:telecheck_bankname],
+            dl: options[:telecheck_dl],
+            dlstate: options[:telecheck_dlstate],
+            void: options[:telecheck_void],
+            accounttype: options[:telecheck_accounttype],
+            ssn: options[:telecheck_ssn],
           }
         }
 
         if creditcard
           params[:creditcard] = {
-            :cardnumber => creditcard.number,
-            :cardexpmonth => creditcard.month,
-            :cardexpyear => format_creditcard_expiry_year(creditcard.year),
-            :track => nil
+            cardnumber: creditcard.number,
+            cardexpmonth: creditcard.month,
+            cardexpyear: format_creditcard_expiry_year(creditcard.year),
+            track: nil
           }
 
           if creditcard.verification_value?
@@ -431,7 +431,7 @@ module ActiveMerchant #:nodoc:
         # <r_approved>APPROVED</r_approved>
         # <r_avs></r_avs>
 
-        response = {:message => 'Global Error Receipt', :complete => false}
+        response = {message: 'Global Error Receipt', complete: false}
 
         xml = REXML::Document.new("<response>#{xml}</response>")
         xml.root&.elements&.each do |node|

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -449,8 +449,8 @@ module ActiveMerchant #:nodoc:
         options = {
           authorization: authorization_from(kind, parsed, money),
           test: test?,
-          :avs_result => { :code => AVS_RESPONSE_CODE[parsed[:fraudResult_avsResult]] },
-          :cvv_result => parsed[:fraudResult_cardValidationResult]
+          avs_result: { code: AVS_RESPONSE_CODE[parsed[:fraudResult_avsResult]] },
+          cvv_result: parsed[:fraudResult_cardValidationResult]
         }
 
         Response.new(success_from(kind, parsed), parsed[:message], parsed, options)

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -207,8 +207,8 @@ module ActiveMerchant
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(post, raw),
-          :test => test?
+          authorization: authorization_from(post, raw),
+          test: test?
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -166,10 +166,10 @@ module ActiveMerchant #:nodoc:
           end
 
         Response.new(response['error_code'] == '000', message_from(response), response,
-          :authorization => response['transaction_id'],
-          :test => test?,
-          :cvv_result => response['cvv2_result'],
-          :avs_result => { :code => response['avs_result'] }
+          authorization: response['transaction_id'],
+          test: test?,
+          cvv_result: response['cvv2_result'],
+          avs_result: { code: response['avs_result'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -101,8 +101,8 @@ module ActiveMerchant #:nodoc:
           (responses['response'].to_i == 1),
           responses['responsetext'],
           responses,
-          :test => test?,
-          :authorization => responses['transactionid']
+          test: test?,
+          authorization: responses['transactionid']
         )
       end
     end

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -172,8 +172,8 @@ module ActiveMerchant #:nodoc:
           message_from(succeeded, response_data),
           response_data,
           authorization: authorization_from(post, response_data),
-          :avs_result => AVSResult.new(code: response_data['avs_response']),
-          :cvv_result => CVVResult.new(response_data['cvv2_response']),
+          avs_result: AVSResult.new(code: response_data['avs_response']),
+          cvv_result: CVVResult.new(response_data['cvv2_response']),
           test: test?
         )
       end
@@ -185,7 +185,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(post)
-        Nokogiri::XML::Builder.new(:encoding => 'utf-8') do |xml|
+        Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
           xml.interface_driver {
             xml.trans_catalog {
               xml.transaction(name: 'creditcard') {

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -22,12 +22,12 @@ module ActiveMerchant #:nodoc:
       TX_NAMESPACE_V4 = 'http://schemas.merchantwarehouse.com/merchantware/40/Credit/'
 
       ACTIONS = {
-        :purchase  => 'IssueKeyedSale',
-        :authorize => 'IssueKeyedPreAuth',
-        :capture   => 'IssuePostAuth',
-        :void      => 'VoidPreAuthorization',
-        :credit    => 'IssueKeyedRefund',
-        :reference_credit => 'IssueRefundByReference'
+        purchase: 'IssueKeyedSale',
+        authorize: 'IssueKeyedPreAuth',
+        capture: 'IssuePostAuth',
+        void: 'VoidPreAuthorization',
+        credit: 'IssueKeyedRefund',
+        reference_credit: 'IssueRefundByReference'
       }
 
       # Creates a new MerchantWareGateway
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def soap_request(action)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'env:Envelope', ENV_NAMESPACES do
           xml.tag! 'env:Body' do
@@ -131,7 +131,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def v4_soap_request(action)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'soap:Envelope', ENV_NAMESPACES_V4 do
           xml.tag! 'soap:Body' do
@@ -300,10 +300,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(response[:success], response[:message], response,
-          :test => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response['AVSResponse'] },
-          :cvv_result => response['CVResponse']
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response['AVSResponse'] },
+          cvv_result: response['CVResponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -16,12 +16,12 @@ module ActiveMerchant #:nodoc:
       TX_NAMESPACE = 'http://schemas.merchantwarehouse.com/merchantware/40/Credit/'
 
       ACTIONS = {
-        :purchase  => 'SaleKeyed',
-        :reference_purchase => 'RepeatSale',
-        :authorize => 'PreAuthorizationKeyed',
-        :capture   => 'PostAuthorization',
-        :void      => 'Void',
-        :refund    => 'Refund'
+        purchase: 'SaleKeyed',
+        reference_purchase: 'RepeatSale',
+        authorize: 'PreAuthorizationKeyed',
+        capture: 'PostAuthorization',
+        void: 'Void',
+        refund: 'Refund'
       }
 
       # Creates a new MerchantWareVersionFourGateway
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def soap_request(action)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'soap:Envelope', ENV_NAMESPACES do
           xml.tag! 'soap:Body' do
@@ -271,10 +271,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(response[:success], response[:message], response,
-          :test => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response['AvsResponse'] },
-          :cvv_result => response['CvResponse']
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response['AvsResponse'] },
+          cvv_result: response['CvResponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -201,8 +201,8 @@ module ActiveMerchant #:nodoc:
           success?(response),
           response[:response_message],
           response,
-          :test => test?,
-          :authorization => (response[:card_id] || response[:transaction_id])
+          test: test?,
+          authorization: (response[:card_id] || response[:transaction_id])
         )
       end
 

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -12,8 +12,8 @@ module ActiveMerchant #:nodoc:
     # and +refund+ will become mandatory.
     class MercuryGateway < Gateway
       URLS = {
-        :test => 'https://w1.mercurycert.net/ws/ws.asmx',
-        :live => 'https://w1.mercurypay.com/ws/ws.asmx'
+        test: 'https://w1.mercurycert.net/ws/ws.asmx',
+        live: 'https://w1.mercurypay.com/ws/ws.asmx'
       }
 
       self.homepage_url = 'http://www.mercurypay.com'
@@ -51,14 +51,14 @@ module ActiveMerchant #:nodoc:
       def authorize(money, credit_card, options = {})
         requires!(options, :order_id)
 
-        request = build_non_authorized_request('PreAuth', money, credit_card, options.merge(:authorized => money))
+        request = build_non_authorized_request('PreAuth', money, credit_card, options.merge(authorized: money))
         commit('PreAuth', request)
       end
 
       def capture(money, authorization, options = {})
         requires!(options, :credit_card) unless @use_tokenization
 
-        request = build_authorized_request('PreAuthCapture', money, authorization, options[:credit_card], options.merge(:authorized => money))
+        request = build_authorized_request('PreAuthCapture', money, authorization, options[:credit_card], options.merge(authorized: money))
         commit('PreAuthCapture', request)
       end
 
@@ -303,11 +303,11 @@ module ActiveMerchant #:nodoc:
         message = success ? 'Success' : message_from(response)
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response[:avs_result] },
-          :cvv_result => response[:cvv_result],
-          :error_code => success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]])
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response[:avs_result] },
+          cvv_result: response[:cvv_result],
+          error_code: success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>money</tt> -- The amount to be captured as an Integer value in cents.
       # * <tt>authorization</tt> -- The authorization returned from the previous authorize request.
       def capture(money, authorization, options = {})
-        post = {:trans_id => authorization}
+        post = {trans_id: authorization}
         add_customer_data(post, options)
         commit('PRIOR_AUTH_CAPTURE', money, post)
       end
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>authorization</tt> - The authorization returned from the previous authorize request.
       def void(authorization, options = {})
-        post = {:trans_id => authorization}
+        post = {trans_id: authorization}
         add_duplicate_window(post)
         commit('VOID', nil, post)
       end
@@ -135,8 +135,8 @@ module ActiveMerchant #:nodoc:
       def refund(money, identification, options = {})
         requires!(options, :card_number)
 
-        post = { :trans_id => identification,
-                 :card_num => options[:card_number]}
+        post = { trans_id: identification,
+                 card_num: options[:card_number]}
 
         post[:first_name] = options[:first_name] if options[:first_name]
         post[:last_name] = options[:last_name] if options[:last_name]
@@ -176,11 +176,11 @@ module ActiveMerchant #:nodoc:
         test_mode = test? || message =~ /TESTMODE/
 
         Response.new(success?(response), message, response,
-          :test => test_mode,
-          :authorization => response[:transaction_id],
-          :fraud_review => fraud_review?(response),
-          :avs_result => { :code => response[:avs_result_code] },
-          :cvv_result => response[:card_code]
+          test: test_mode,
+          authorization: response[:transaction_id],
+          fraud_review: fraud_review?(response),
+          avs_result: { code: response[:avs_result_code] },
+          cvv_result: response[:card_code]
         )
       end
 
@@ -196,12 +196,12 @@ module ActiveMerchant #:nodoc:
         fields = split(body)
 
         results = {
-          :response_code => fields[RESPONSE_CODE].to_i,
-          :response_reason_code => fields[RESPONSE_REASON_CODE],
-          :response_reason_text => fields[RESPONSE_REASON_TEXT],
-          :avs_result_code => fields[AVS_RESULT_CODE],
-          :transaction_id => fields[TRANSACTION_ID],
-          :card_code => fields[CARD_CODE_RESPONSE_CODE]
+          response_code: fields[RESPONSE_CODE].to_i,
+          response_reason_code: fields[RESPONSE_REASON_CODE],
+          response_reason_text: fields[RESPONSE_REASON_TEXT],
+          avs_result_code: fields[AVS_RESULT_CODE],
+          transaction_id: fields[TRANSACTION_ID],
+          card_code: fields[CARD_CODE_RESPONSE_CODE]
         }
         results
       end

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         requires!(@options, :advanced_login, :advanced_password)
 
-        post = options.merge(:TransNo => authorization)
+        post = options.merge(TransNo: authorization)
 
         add_amount(post, money, options)
         add_advanced_user(post)
@@ -96,7 +96,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         requires!(@options, :advanced_login, :advanced_password)
 
-        post = options.merge(:TransNo => authorization)
+        post = options.merge(TransNo: authorization)
 
         add_amount(post, money, options)
         add_advanced_user(post)
@@ -109,7 +109,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         requires!(@options, :advanced_login, :advanced_password)
 
-        post = options.merge(:TransNo => authorization)
+        post = options.merge(TransNo: authorization)
 
         add_advanced_user(post)
         add_standard_parameters('voidAuthorisation', post, options[:unique_id])
@@ -282,11 +282,11 @@ module ActiveMerchant #:nodoc:
         cvv_result_code = 'P' if cvv_result_code == 'Unsupported'
 
         Response.new(success?(response), response[:Message], response,
-          :test => test?,
-          :authorization => response[:TransactionNo],
-          :fraud_review => fraud_review?(response),
-          :avs_result => { :code => avs_response_code },
-          :cvv_result => cvv_result_code
+          test: test?,
+          authorization: response[:TransactionNo],
+          fraud_review: fraud_review?(response),
+          avs_result: { code: avs_response_code },
+          cvv_result: cvv_result_code
         )
       end
 
@@ -300,11 +300,11 @@ module ActiveMerchant #:nodoc:
 
       def add_standard_parameters(action, post, unique_id = nil)
         post.merge!(
-          :Version     => API_VERSION,
-          :Merchant    => @options[:login],
-          :AccessCode  => @options[:password],
-          :Command     => action,
-          :MerchTxnRef => unique_id || generate_unique_id.slice(0, 40)
+          Version: API_VERSION,
+          Merchant: @options[:login],
+          AccessCode: @options[:password],
+          Command: action,
+          MerchTxnRef: unique_id || generate_unique_id.slice(0, 40)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -17,8 +17,8 @@ module ActiveMerchant #:nodoc:
       ERROR_MESSAGE   = 'Transaction error'
 
       PAYMENT_METHOD = {
-        :check => 1,
-        :credit_card => 2
+        check: 1,
+        credit_card: 2
       }
 
       def initialize(options = {})
@@ -111,7 +111,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(action, params)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'env:Envelope',
           { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
@@ -153,9 +153,9 @@ module ActiveMerchant #:nodoc:
 
         response = parse(action, data)
         Response.new(successful?(action, response), message_from(action, response), response,
-          :test => test?,
-          :authorization => authorization_from(action, response),
-          :avs_result => { :code => response[:avs_code] }
+          test: test?,
+          authorization: authorization_from(action, response),
+          avs_result: { code: response[:avs_code] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -151,11 +151,11 @@ module ActiveMerchant #:nodoc:
 
       # Private: Build XML wrapping code yielding to code to fill the transaction information
       def build_request
-        builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
-          xml.Request(:version => '1.0') do
-            xml.Header { xml.Security(:sender => @options[:sender_id]) }
-            xml.Transaction(:mode => test? ? 'CONNECTOR_TEST' : 'LIVE', :response => 'SYNC', :channel => @options[:channel_id]) do
-              xml.User(:login => @options[:login], :pwd => @options[:pwd])
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml.Request(version: '1.0') do
+            xml.Header { xml.Security(sender: @options[:sender_id]) }
+            xml.Transaction(mode: test? ? 'CONNECTOR_TEST' : 'LIVE', response: 'SYNC', channel: @options[:channel_id]) do
+              xml.User(login: @options[:login], pwd: @options[:pwd])
               yield xml
             end
           end
@@ -183,7 +183,7 @@ module ActiveMerchant #:nodoc:
       def add_payment(xml, action, money, options)
         code = tanslate_payment_code(action)
 
-        xml.Payment(:code => code) do
+        xml.Payment(code: code) do
           xml.Presentation do
             xml.Amount amount(money)
             xml.Currency options[:currency] || currency(money)
@@ -198,7 +198,7 @@ module ActiveMerchant #:nodoc:
           xml.Holder credit_card.name
           xml.Number credit_card.number
           xml.Brand credit_card.brand.upcase
-          xml.Expiry(:month => credit_card.month, :year => credit_card.year)
+          xml.Expiry(month: credit_card.month, year: credit_card.year)
           xml.Verification credit_card.verification_value
         end
       end
@@ -248,10 +248,10 @@ module ActiveMerchant #:nodoc:
       # Private : Add the 3DSecure infos to XML
       def add_three_d_secure(xml, options)
         if options[:three_d_secure]
-          xml.Authentication(:type => '3DSecure') do
+          xml.Authentication(type: '3DSecure') do
             xml.ResultIndicator eci_to_result_indicator options[:three_d_secure][:eci]
-            xml.Parameter(:name => 'VERIFICATION_ID') { xml.text options[:three_d_secure][:cavv] }
-            xml.Parameter(:name => 'XID') { xml.text options[:three_d_secure][:xid] }
+            xml.Parameter(name: 'VERIFICATION_ID') { xml.text options[:three_d_secure][:cavv] }
+            xml.Parameter(name: 'XID') { xml.text options[:three_d_secure][:xid] }
           end
         end
       end
@@ -260,10 +260,10 @@ module ActiveMerchant #:nodoc:
       def parse(body)
         xml = Nokogiri::XML(body)
         {
-          :unique_id => xml.xpath('//Response/Transaction/Identification/UniqueID').text,
-          :status => translate_status_code(xml.xpath('//Response/Transaction/Processing/Status/@code').text),
-          :reason => translate_status_code(xml.xpath('//Response/Transaction/Processing/Reason/@code').text),
-          :message => xml.xpath('//Response/Transaction/Processing/Return').text
+          unique_id: xml.xpath('//Response/Transaction/Identification/UniqueID').text,
+          status: translate_status_code(xml.xpath('//Response/Transaction/Processing/Status/@code').text),
+          reason: translate_status_code(xml.xpath('//Response/Transaction/Processing/Reason/@code').text),
+          message: xml.xpath('//Response/Transaction/Processing/Return').text
         }
       end
 
@@ -326,11 +326,11 @@ module ActiveMerchant #:nodoc:
       # Private: Translate AM operations to Monei operations codes
       def tanslate_payment_code(action)
         {
-          :purchase => 'CC.DB',
-          :authorize => 'CC.PA',
-          :capture => 'CC.CP',
-          :refund => 'CC.RF',
-          :void => 'CC.RV'
+          purchase: 'CC.DB',
+          authorize: 'CC.PA',
+          capture: 'CC.CP',
+          refund: 'CC.RF',
+          void: 'CC.RV'
         }[action]
       end
     end

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -92,7 +92,7 @@ module ActiveMerchant #:nodoc:
       # gateways the two numbers are concatenated together with a ; separator as
       # the authorization number returned by authorization
       def capture(money, authorization, options = {})
-        commit 'completion', crediting_params(authorization, :comp_amount => amount(money))
+        commit 'completion', crediting_params(authorization, comp_amount: amount(money))
       end
 
       # Voiding requires the original transaction ID and order ID of some open
@@ -130,7 +130,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        commit 'refund', crediting_params(authorization, :amount => amount(money))
+        commit 'refund', crediting_params(authorization, amount: amount(money))
       end
 
       def verify(credit_card, options={})
@@ -275,9 +275,9 @@ module ActiveMerchant #:nodoc:
       # Common params used amongst the +credit+, +void+ and +capture+ methods
       def crediting_params(authorization, options = {})
         {
-          :txn_number => split_authorization(authorization).first,
-          :order_id   => split_authorization(authorization).last,
-          :crypt_type => options[:crypt_type] || @options[:crypt_type]
+          txn_number: split_authorization(authorization).first,
+          order_id: split_authorization(authorization).last,
+          crypt_type: options[:crypt_type] || @options[:crypt_type]
         }.merge(options)
       end
 
@@ -301,10 +301,10 @@ module ActiveMerchant #:nodoc:
           successful?(response),
           message_from(response[:message]),
           response,
-          :test => test?,
-          :avs_result => {:code => response[:avs_result_code]},
-          :cvv_result => response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
-          :authorization => authorization_from(response))
+          test: test?,
+          avs_result: {code: response[:avs_result_code]},
+          cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
+          authorization: authorization_from(response))
       end
 
       # Generates a Moneris authorization string of the form 'trans_id;receipt_id'.
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(xml)
-        response = { :message => 'Global Error Receipt', :complete => false }
+        response = { message: 'Global Error Receipt', complete: false }
         hashify_xml!(xml, response)
         response
       end

--- a/lib/active_merchant/billing/gateways/moneris_us.rb
+++ b/lib/active_merchant/billing/gateways/moneris_us.rb
@@ -33,7 +33,7 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login, :password)
         @cvv_enabled = options[:cvv_enabled]
         @avs_enabled = options[:avs_enabled]
-        options = { :crypt_type => 7 }.merge(options)
+        options = { crypt_type: 7 }.merge(options)
         super
       end
 
@@ -91,7 +91,7 @@ module ActiveMerchant #:nodoc:
       # gateways the two numbers are concatenated together with a ; separator as
       # the authorization number returned by authorization
       def capture(money, authorization, options = {})
-        commit 'us_completion', crediting_params(authorization, :comp_amount => amount(money))
+        commit 'us_completion', crediting_params(authorization, comp_amount: amount(money))
       end
 
       # Voiding requires the original transaction ID and order ID of some open
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        commit 'us_refund', crediting_params(authorization, :amount => amount(money))
+        commit 'us_refund', crediting_params(authorization, amount: amount(money))
       end
 
       def store(payment_source, options = {})
@@ -198,9 +198,9 @@ module ActiveMerchant #:nodoc:
       # Common params used amongst the +credit+, +void+ and +capture+ methods
       def crediting_params(authorization, options = {})
         {
-          :txn_number => split_authorization(authorization).first,
-          :order_id   => split_authorization(authorization).last,
-          :crypt_type => options[:crypt_type] || @options[:crypt_type]
+          txn_number: split_authorization(authorization).first,
+          order_id: split_authorization(authorization).last,
+          crypt_type: options[:crypt_type] || @options[:crypt_type]
         }.merge(options)
       end
 
@@ -221,10 +221,10 @@ module ActiveMerchant #:nodoc:
         response = parse(raw)
 
         Response.new(successful?(response), message_from(response[:message]), response,
-          :test          => test?,
-          :avs_result    => { :code => response[:avs_result_code] },
-          :cvv_result    => response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
-          :authorization => authorization_from(response)
+          test: test?,
+          avs_result: { code: response[:avs_result_code] },
+          cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
+          authorization: authorization_from(response)
         )
       end
 
@@ -241,7 +241,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(xml)
-        response = { :message => 'Global Error Receipt', :complete => false }
+        response = { message: 'Global Error Receipt', complete: false }
         hashify_xml!(xml, response)
         response
       end

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        commit('refund', money, options.merge(:transactionid => authorization))
+        commit('refund', money, options.merge(transactionid: authorization))
       end
 
       def credit(money, authorization, options = {})
@@ -114,10 +114,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          :test => test?,
-          :authorization => response['transactionid'],
-          :avs_result => {:code => response['avsresponse']},
-          :cvv_result => response['cvvresponse']
+          test: test?,
+          authorization: response['transactionid'],
+          avs_result: {code: response['avsresponse']},
+          cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -25,18 +25,18 @@ module ActiveMerchant #:nodoc:
 
       # Transactions currently accepted by NAB Transact XML API
       TRANSACTIONS = {
-        :purchase => 0,           # Standard Payment
-        :refund => 4,             # Refund
-        :void => 6,               # Client Reversal (Void)
-        :unmatched_refund => 666, # Unmatched Refund
-        :authorization => 10,     # Preauthorise
-        :capture => 11            # Preauthorise Complete (Advice)
+        purchase: 0,           # Standard Payment
+        refund: 4,             # Refund
+        void: 6,               # Client Reversal (Void)
+        unmatched_refund: 666, # Unmatched Refund
+        authorization: 10,     # Preauthorise
+        capture: 11            # Preauthorise Complete (Advice)
       }
 
       PERIODIC_TYPES = {
-        :addcrn    => 5,
-        :deletecrn => 5,
-        :trigger   => 8
+        addcrn: 5,
+        deletecrn: 5,
+        trigger: 8
       }
 
       SUCCESS_CODES = ['00', '08', '11', '16', '77']
@@ -96,8 +96,8 @@ module ActiveMerchant #:nodoc:
       def add_metadata(xml, options)
         if options[:merchant_name] || options[:merchant_location]
           xml.tag! 'metadata' do
-            xml.tag! 'meta', :name => 'ca_name', :value => options[:merchant_name] if options[:merchant_name]
-            xml.tag! 'meta', :name => 'ca_location', :value => options[:merchant_location] if options[:merchant_location]
+            xml.tag! 'meta', name: 'ca_name', value: options[:merchant_name] if options[:merchant_name]
+            xml.tag! 'meta', name: 'ca_location', value: options[:merchant_location] if options[:merchant_location]
           end
         end
       end
@@ -234,16 +234,16 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
         Response.new(success?(response), message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(action, response)
+          test: test?,
+          authorization: authorization_from(action, response)
         )
       end
 
       def commit_periodic(action, request)
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, build_periodic_request(action, request)))
         Response.new(success?(response), message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(action, response)
+          test: test?,
+          authorization: authorization_from(action, response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/ncr_secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/ncr_secure_pay.rb
@@ -141,7 +141,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def request_body(action, parameters = {})
-        Nokogiri::XML::Builder.new(:encoding => 'utf-8') do |xml|
+        Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
           xml.MonetraTrans do
             xml.Trans(identifier: parameters.delete(:identifier) || '1') do
               xml.username(options[:username])

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -37,11 +37,11 @@ module ActiveMerchant
       self.homepage_url = 'http://www.netregistry.com.au'
 
       TRANSACTIONS = {
-        :authorization => 'preauth',
-        :purchase => 'purchase',
-        :capture => 'completion',
-        :status => 'status',
-        :refund => 'refund'
+        authorization: 'preauth',
+        purchase: 'purchase',
+        capture: 'completion',
+        status: 'status',
+        refund: 'refund'
       }
 
       # Create a new NetRegistry gateway.
@@ -145,7 +145,7 @@ module ActiveMerchant
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
         Response.new(response['status'] == 'approved', message_from(response), response,
-          :authorization => authorization_from(response, action)
+          authorization: authorization_from(response, action)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -136,17 +136,17 @@ module ActiveMerchant #:nodoc:
           success,
           message,
           raw,
-          :test => test?,
-          :authorization => authorization
+          test: test?,
+          authorization: authorization
         )
       end
 
       def parse(result, expects_xml=true)
         if expects_xml
           doc = REXML::Document.new(result)
-          extract_xml(doc.root).merge(:container => doc.root.name)
+          extract_xml(doc.root).merge(container: doc.root.name)
         else
-          {:result => result}
+          {result: result}
         end
       end
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -159,7 +159,7 @@ module ActiveMerchant #:nodoc:
         month = format(credit_card.month, :two_digits)
 
         # returns a hash (necessary in the card JSON object)
-        { :month => month, :year => year }
+        { month: month, year: year }
       end
 
       def add_order_id(post, options)
@@ -171,10 +171,10 @@ module ActiveMerchant #:nodoc:
 
         country = Country.find(address[:country]) if address[:country]
         mapped = {
-          :street => address[:address1],
-          :city   => address[:city],
-          :zip    => address[:zip],
-          :state  => address[:state],
+          street: address[:address1],
+          city: address[:city],
+          zip: address[:zip],
+          state: address[:state],
         }
         mapped[:country] = country.code(:alpha2).value unless country.blank?
 
@@ -183,12 +183,12 @@ module ActiveMerchant #:nodoc:
 
       def map_3ds(three_d_secure_options)
         mapped = {
-          :eci => three_d_secure_options[:eci],
-          :cavv => three_d_secure_options[:cavv],
-          :xid => three_d_secure_options[:xid],
-          :threeDResult => three_d_secure_options[:directory_response_status],
-          :threeDSecureVersion => three_d_secure_options[:version],
-          :directoryServerTransactionId => three_d_secure_options[:ds_transaction_id]
+          eci: three_d_secure_options[:eci],
+          cavv: three_d_secure_options[:cavv],
+          xid: three_d_secure_options[:xid],
+          threeDResult: three_d_secure_options[:directory_response_status],
+          threeDSecureVersion: three_d_secure_options[:version],
+          directoryServerTransactionId: three_d_secure_options[:ds_transaction_id]
         }
 
         mapped
@@ -214,9 +214,9 @@ module ActiveMerchant #:nodoc:
           success,
           message_from(success, response),
           response,
-          :test => test?,
-          :error_code => error_code_from(response),
-          :authorization => authorization_from(success, get_url(uri), method, response)
+          test: test?,
+          error_code: error_code_from(response),
+          authorization: authorization_from(success, get_url(uri), method, response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -14,13 +14,13 @@ module ActiveMerchant #:nodoc:
       self.live_url = self.test_url = 'https://secure.netbilling.com:1402/gw/sas/direct3.1'
 
       TRANSACTIONS = {
-        :authorization => 'A',
-        :purchase      => 'S',
-        :refund        => 'R',
-        :credit        => 'C',
-        :capture       => 'D',
-        :void          => 'U',
-        :quasi         => 'Q'
+        authorization: 'A',
+        purchase:      'S',
+        refund:        'R',
+        credit:        'C',
+        capture:       'D',
+        void:          'U',
+        quasi:         'Q'
       }
 
       SUCCESS_CODES = ['1', 'T']
@@ -194,15 +194,15 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(success?(response), message_from(response), response,
-          :test => test_response?(response),
-          :authorization => response[:trans_id],
-          :avs_result => { :code => response[:avs_code]},
-          :cvv_result => response[:cvv2_code]
+          test: test_response?(response),
+          authorization: response[:trans_id],
+          avs_result: { code: response[:avs_code]},
+          cvv_result: response[:cvv2_code]
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code =~ /^[67]\d\d$/
 
-        return Response.new(false, e.response.message, {:status_code => e.response.code}, :test => test?)
+        return Response.new(false, e.response.message, {status_code: e.response.code}, test: test?)
       end
 
       def test_response?(response)

--- a/lib/active_merchant/billing/gateways/netpay.rb
+++ b/lib/active_merchant/billing/gateways/netpay.rb
@@ -180,8 +180,8 @@ module ActiveMerchant #:nodoc:
 
         success = (response_params['ResponseCode'] == '00')
         message = response_params['ResponseText'] || response_params['ResponseMsg']
-        options = @options.merge(:test => test?,
-                                 :authorization => build_authorization(request_params, response_params))
+        options = @options.merge(test: test?,
+                                 authorization: build_authorization(request_params, response_params))
 
         Response.new(success, message, response_params, options)
       end

--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -190,7 +190,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit_vault(action, parameters)
-        commit(nil, parameters.merge(:customer_vault => action))
+        commit(nil, parameters.merge(customer_vault: action))
       end
 
       def commit(action, parameters)
@@ -201,10 +201,10 @@ module ActiveMerchant #:nodoc:
         authorization = authorization_from(success, parameters, raw)
 
         Response.new(success, raw['responsetext'], raw,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => { :code => raw['avsresponse']},
-          :cvv_result => raw['cvvresponse']
+          test: test?,
+          authorization: authorization,
+          avs_result: { code: raw['avsresponse']},
+          cvv_result: raw['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -122,10 +122,10 @@ module ActiveMerchant #:nodoc:
 
       SUCCESS_MESSAGE = 'The transaction was successful'
 
-      THREE_D_SECURE_DISPLAY_WAYS = { :main_window => 'MAINW',  # display the identification page in the main window (default value).
+      THREE_D_SECURE_DISPLAY_WAYS = { main_window: 'MAINW', # display the identification page in the main window (default value).
 
-                                      :pop_up      => 'POPUP',  # display the identification page in a pop-up window and return to the main window at the end.
-                                      :pop_ix      => 'POPIX' } # display the identification page in a pop-up window and remain in the pop-up window.
+                                      pop_up: 'POPUP',  # display the identification page in a pop-up window and return to the main window at the end.
+                                      pop_ix: 'POPIX' } # display the identification page in a pop-up window and remain in the pop-up window.
 
       OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE   = 'Signature usage will be the default for a future release of ActiveMerchant. You should either begin using it, or update your configuration to explicitly disable it (signature_encryptor: none)'
       OGONE_STORE_OPTION_DEPRECATION_MESSAGE   = "The 'store' option has been renamed to 'billing_id', and its usage is deprecated."
@@ -366,10 +366,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url(parameters['PAYID']), post_data(action, parameters)))
 
         options = {
-          :authorization => [response['PAYID'], action].join(';'),
-          :test          => test?,
-          :avs_result    => { :code => AVS_MAPPING[response['AAVCheck']] },
-          :cvv_result    => CVV_MAPPING[response['CVCCheck']]
+          authorization: [response['PAYID'], action].join(';'),
+          test: test?,
+          avs_result: { code: AVS_MAPPING[response['AAVCheck']] },
+          cvv_result: CVV_MAPPING[response['CVCCheck']]
         }
         OgoneResponse.new(successful?(response), message_from(response), response, options)
       end

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -187,8 +187,8 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           (success ? response['error_code'] : response['description']),
           response,
-          :test => test?,
-          :authorization => response['id']
+          test: test?,
+          authorization: response['id']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -118,10 +118,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, "txnMode=#{action}&txnRequest=#{txnRequest}"))
 
         Response.new(successful?(response), message_from(response), hash_from_xml(response),
-          :test          => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => avs_result_from(response) },
-          :cvv_result => cvv_result_from(response)
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: avs_result_from(response) },
+          cvv_result: cvv_result_from(response)
         )
       end
 
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def xml_document(root_tag)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag!(root_tag, schema) do
           yield xml
         end

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -230,7 +230,7 @@ module ActiveMerchant #:nodoc:
 
       # R – Refund request
       def refund(money, authorization, options = {})
-        order = build_new_order_xml(REFUND, money, nil, options.merge(:authorization => authorization)) do |xml|
+        order = build_new_order_xml(REFUND, money, nil, options.merge(authorization: authorization)) do |xml|
           add_refund(xml, options[:currency])
           xml.tag! :CustomerRefNum, options[:customer_ref_num] if @options[:customer_profiles] && options[:profile_txn]
         end
@@ -245,7 +245,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {}, deprecated = {})
         if !options.kind_of?(Hash)
           ActiveMerchant.deprecated('Calling the void method with an amount parameter is deprecated and will be removed in a future version.')
-          return void(options, deprecated.merge(:amount => authorization))
+          return void(options, deprecated.merge(amount: authorization))
         end
 
         order = build_void_request_xml(authorization, options)
@@ -286,13 +286,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def retrieve_customer_profile(customer_ref_num)
-        options = {:customer_profile_action => RETRIEVE, :customer_ref_num => customer_ref_num}
+        options = {customer_profile_action: RETRIEVE, customer_ref_num: customer_ref_num}
         order = build_customer_request_xml(nil, options)
         commit(order, :retrieve_customer_profile)
       end
 
       def delete_customer_profile(customer_ref_num)
-        options = {:customer_profile_action => DELETE, :customer_ref_num => customer_ref_num}
+        options = {customer_profile_action: DELETE, customer_ref_num: customer_ref_num}
         order = build_customer_request_xml(nil, options)
         commit(order, :delete_customer_profile)
       end
@@ -622,10 +622,10 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success?(response, message_type), message_from(response), response,
           {
-            :authorization => authorization_string(response[:tx_ref_num], response[:order_id]),
-            :test => self.test?,
-            :avs_result => OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
-            :cvv_result => OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
+            authorization: authorization_string(response[:tx_ref_num], response[:order_id]),
+            test: self.test?,
+            avs_result: OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
+            cvv_result: OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
           }
         )
       end
@@ -786,8 +786,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def xml_envelope
-        xml = Builder::XmlMarkup.new(:indent => 2)
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'UTF-8')
+        xml = Builder::XmlMarkup.new(indent: 2)
+        xml.instruct!(:xml, version: '1.0', encoding: 'UTF-8')
         xml
       end
 

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -122,14 +122,14 @@ module ActiveMerchant #:nodoc:
         test_mode = test? || message =~ /TESTMODE/
 
         Response.new(success?(response), message, response,
-          :test => test_mode,
-          :authorization => response['TrackingNumber'],
-          :fraud_review => fraud_review?(response),
-          :avs_result => {
-            :postal_match => AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
-            :street_match => AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
+          test: test_mode,
+          authorization: response['TrackingNumber'],
+          fraud_review: fraud_review?(response),
+          avs_result: {
+            postal_match: AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
+            street_match: AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
           },
-          :cvv_result => CVV2_CODES[response['CVV2ResponseCode']]
+          cvv_result: CVV2_CODES[response['CVV2ResponseCode']]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -208,8 +208,8 @@ module ActiveMerchant #:nodoc:
           message_from(response),
           response,
           authorization: response['transaction_id'],
-          :avs_result => AVSResult.new(code: response['avs_response']),
-          :cvv_result => CVVResult.new(response['cvv2_response']),
+          avs_result: AVSResult.new(code: response['avs_response']),
+          cvv_result: CVVResult.new(response['cvv2_response']),
           test: test?
         )
       rescue JSON::ParserError

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new
         xml.instruct!
 
-        xml.tag! 'protocol', :ver => API_VERSION, :pgid => (test? ? TEST_ID : @options[:login]), :pwd => @options[:password] do |protocol|
+        xml.tag! 'protocol', ver: API_VERSION, pgid: (test? ? TEST_ID : @options[:login]), pwd: @options[:password] do |protocol|
           money         = options.delete(:money)
           authorization = options.delete(:authorization)
           creditcard    = options.delete(:creditcard)
@@ -222,29 +222,29 @@ module ActiveMerchant #:nodoc:
 
       def build_authorization(xml, money, creditcard, options={})
         xml.tag! 'authtx', {
-          :cref  => options[:order_id],
-          :cname => creditcard.name,
-          :cc    => creditcard.number,
-          :exp   => "#{format(creditcard.month, :two_digits)}#{format(creditcard.year, :four_digits)}",
-          :budp  => 0,
-          :amt   => amount(money),
-          :cur   => (options[:currency] || currency(money)),
-          :cvv   => creditcard.verification_value,
-          :email => options[:email],
-          :ip    => options[:ip]
+          cref: options[:order_id],
+          cname: creditcard.name,
+          cc: creditcard.number,
+          exp: "#{format(creditcard.month, :two_digits)}#{format(creditcard.year, :four_digits)}",
+          budp: 0,
+          amt: amount(money),
+          cur: (options[:currency] || currency(money)),
+          cvv: creditcard.verification_value,
+          email: options[:email],
+          ip: options[:ip]
         }
       end
 
       def build_capture(xml, money, authorization, options={})
         xml.tag! 'settletx', {
-          :tid => authorization
+          tid: authorization
         }
       end
 
       def build_refund(xml, money, authorization, options={})
         xml.tag! 'refundtx', {
-          :tid => authorization,
-          :amt => amount(money)
+          tid: authorization,
+          amt: amount(money)
         }
       end
 
@@ -265,8 +265,8 @@ module ActiveMerchant #:nodoc:
       def commit(action, request, authorization = nil)
         response = parse(action, ssl_post(self.live_url, request))
         Response.new(successful?(response), message_from(response), response,
-          :test           => test?,
-          :authorization  => authorization || response[:tid]
+          test: test?,
+          authorization: authorization || response[:tid]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
       # transaction_id that can be used later to postauthorize (capture) the funds.
       def authorize(money, payment_source, options = {})
         parameters = {
-          :transaction_amount => amount(money),
+          transaction_amount: amount(money),
         }
 
         add_payment_source(parameters, payment_source)
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
       # Execute authorization and capture in a single step.
       def purchase(money, payment_source, options = {})
         parameters = {
-          :transaction_amount => amount(money),
+          transaction_amount: amount(money),
         }
 
         add_payment_source(parameters, payment_source)
@@ -191,8 +191,8 @@ module ActiveMerchant #:nodoc:
       # Retrieve funds that have been previously authorized with _authorization_
       def capture(money, authorization, options = {})
         parameters = {
-          :transaction_id => authorization,
-          :posture => 'capture'
+          transaction_id: authorization,
+          posture: 'capture'
         }
 
         add_optional_fields(parameters, options)
@@ -203,8 +203,8 @@ module ActiveMerchant #:nodoc:
       # _authorization_ should be the transaction id of the transaction we are returning.
       def refund(money, authorization, options = {})
         parameters = {
-          :transaction_amount => amount(money),
-          :transaction_id => authorization
+          transaction_amount: amount(money),
+          transaction_id: authorization
         }
 
         commit('CREDIT', parameters)
@@ -219,8 +219,8 @@ module ActiveMerchant #:nodoc:
       # through the batch process.
       def void(authorization, options = {})
         parameters = {
-          :transaction_id => authorization,
-          :posture => 'void'
+          transaction_id: authorization,
+          posture: 'void'
         }
 
         add_optional_fields(parameters, options)
@@ -263,12 +263,12 @@ module ActiveMerchant #:nodoc:
         end
 
         parameters = {
-          :transaction_amount => amount(money),
-          :schedule_periodic_type => periodic_type,
-          :schedule_create => 'true',
-          :schedule_limit => options[:payments].to_i > 1 ? options[:payments] : 1,
-          :schedule_periodic_number => 1,
-          :schedule_start => start_date
+          transaction_amount: amount(money),
+          schedule_periodic_type: periodic_type,
+          schedule_create: 'true',
+          schedule_limit: options[:payments].to_i > 1 ? options[:payments] : 1,
+          schedule_periodic_number: 1,
+          schedule_start: start_date
         }
 
         add_payment_source(parameters, payment_source)
@@ -338,8 +338,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(action, parameters)))
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => response[:transaction_id] || parameters[:transaction_id]
+          test: test?,
+          authorization: response[:transaction_id] || parameters[:transaction_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -8,10 +8,10 @@ module ActiveMerchant #:nodoc:
       # Currently Authorization and Capture is not implemented because
       # capturing requires the original credit card information
       TRANSACTIONS = {
-        :purchase       => 'PURCHASE',
-        :authorization  => 'AUTHORISE',
-        :capture        => 'ADVICE',
-        :credit         => 'REFUND'
+        purchase: 'PURCHASE',
+        authorization: 'AUTHORISE',
+        capture: 'ADVICE',
+        credit: 'REFUND'
       }
 
       SUCCESS = 'Accepted'
@@ -69,8 +69,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test_response?(response),
-          :authorization => authorization_from(response)
+          test: test_response?(response),
+          authorization: authorization_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -12,12 +12,12 @@ module ActiveMerchant #:nodoc:
 
       # Transactions hash
       TRANSACTIONS = {
-        :authorization => '00001',
-        :capture => '00002',
-        :purchase => '00003',
-        :unreferenced_credit => '00004',
-        :void => '00005',
-        :refund => '00014'
+        authorization: '00001',
+        capture: '00002',
+        purchase: '00003',
+        unreferenced_credit: '00004',
+        void: '00005',
+        refund: '00014'
       }
 
       CURRENCY_CODES = {
@@ -156,11 +156,11 @@ module ActiveMerchant #:nodoc:
         Response.new(
           success?(response),
           message_from(response),
-          response.merge(:timestamp => parameters[:dateq]),
-          :test => test?,
-          :authorization => response[:numappel].to_s + response[:numtrans].to_s,
-          :fraud_review => false,
-          :sent_params => parameters.delete_if { |key, value| ['porteur', 'dateval', 'cvv'].include?(key.to_s) }
+          response.merge(timestamp: parameters[:dateq]),
+          test: test?,
+          authorization: response[:numappel].to_s + response[:numtrans].to_s,
+          fraud_review: false,
+          sent_params: parameters.delete_if { |key, value| ['porteur', 'dateval', 'cvv'].include?(key.to_s) }
         )
       end
 
@@ -178,15 +178,15 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         parameters.update(
-          :version => API_VERSION,
-          :type => TRANSACTIONS[action.to_sym],
-          :dateq => Time.now.strftime('%d%m%Y%H%M%S'),
-          :numquestion => unique_id(parameters[:order_id]),
-          :site => @options[:login].to_s[0, 7],
-          :rang => @options[:rang] || @options[:login].to_s[7..-1],
-          :cle => @options[:password],
-          :pays => '',
-          :archivage => parameters[:order_id]
+          version: API_VERSION,
+          type: TRANSACTIONS[action.to_sym],
+          dateq: Time.now.strftime('%d%m%Y%H%M%S'),
+          numquestion: unique_id(parameters[:order_id]),
+          site: @options[:login].to_s[0, 7],
+          rang: @options[:rang] || @options[:login].to_s[7..-1],
+          cle: @options[:password],
+          pays: '',
+          archivage: parameters[:order_id]
         )
 
         parameters.collect { |key, value| "#{key.to_s.upcase}=#{CGI.escape(value.to_s)}" }.join('&')

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -80,21 +80,21 @@ module ActiveMerchant #:nodoc:
         request = build_recurring_request(options[:profile_id] ? :modify : :add, money, options) do |xml|
           add_credit_card(xml, credit_card, options) if credit_card
         end
-        commit(request, options.merge(:request_type => :recurring))
+        commit(request, options.merge(request_type: :recurring))
       end
 
       def cancel_recurring(profile_id)
         ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
 
-        request = build_recurring_request(:cancel, 0, :profile_id => profile_id)
-        commit(request, options.merge(:request_type => :recurring))
+        request = build_recurring_request(:cancel, 0, profile_id: profile_id)
+        commit(request, options.merge(request_type: :recurring))
       end
 
       def recurring_inquiry(profile_id, options = {})
         ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
 
-        request = build_recurring_request(:inquiry, nil, options.update(:profile_id => profile_id))
-        commit(request, options.merge(:request_type => :recurring))
+        request = build_recurring_request(:inquiry, nil, options.update(profile_id: profile_id))
+        commit(request, options.merge(request_type: :recurring))
       end
 
       def express

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -37,20 +37,20 @@ module ActiveMerchant #:nodoc:
       XMLNS = 'http://www.paypal.com/XMLPay'
 
       CARD_MAPPING = {
-        :visa => 'Visa',
-        :master => 'MasterCard',
-        :discover => 'Discover',
-        :american_express => 'Amex',
-        :jcb => 'JCB',
-        :diners_club => 'DinersClub',
+        visa: 'Visa',
+        master: 'MasterCard',
+        discover: 'Discover',
+        american_express: 'Amex',
+        jcb: 'JCB',
+        diners_club: 'DinersClub',
       }
 
       TRANSACTIONS = {
-        :purchase       => 'Sale',
-        :authorization  => 'Authorization',
-        :capture        => 'Capture',
-        :void           => 'Void',
-        :credit         => 'Credit'
+        purchase: 'Sale',
+        authorization: 'Authorization',
+        capture: 'Capture',
+        void: 'Void',
+        credit: 'Credit'
       }
 
       CVV_CODE = {

--- a/lib/active_merchant/billing/gateways/payflow_express.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express.rb
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def build_get_express_details_request(token)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'GetExpressCheckout' do
           xml.tag! 'Authorization' do
             xml.tag! 'PayData' do
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_setup_express_sale_or_authorization_request(action, money, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'SetExpressCheckout' do
           xml.tag! action do
             add_pay_data xml, money, options
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_sale_or_authorization_request(action, money, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'DoExpressCheckout' do
           xml.tag! action do
             add_pay_data xml, money, options

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -26,11 +26,11 @@ module ActiveMerchant #:nodoc:
       APPROVED = '1'
 
       TRANSACTIONS = {
-        :purchase       => 'Purchase',
-        :credit         => 'Refund',
-        :authorization  => 'Auth',
-        :capture        => 'Complete',
-        :validate       => 'Validate'
+        purchase: 'Purchase',
+        credit: 'Refund',
+        authorization: 'Auth',
+        capture: 'Complete',
+        validate: 'Validate'
       }
 
       # We require the DPS gateway username and password when the object is created.
@@ -302,8 +302,8 @@ module ActiveMerchant #:nodoc:
 
         # Return a response
         PaymentExpressResponse.new(response[:success] == APPROVED, message_from(response), response,
-          :test => response[:test_mode] == '1',
-          :authorization => authorization_from(action, response)
+          test: response[:test_mode] == '1',
+          authorization: authorization_from(action, response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -112,8 +112,8 @@ module ActiveMerchant #:nodoc:
       def response_from(raw_response)
         parsed = JSON.parse(raw_response)
         options = {
-          :authorization => authorization_from(parsed),
-          :test => (parsed['mode'] == 'test'),
+          authorization: authorization_from(parsed),
+          test: (parsed['mode'] == 'test'),
         }
 
         succeeded = (parsed['data'] == []) || (parsed['data']['response_code'].to_i == 20000)
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_for_save_from(raw_response)
-        options = { :test => test? }
+        options = { test: test? }
 
         parser = ResponseParser.new(raw_response, options)
         parser.generate_response

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -55,7 +55,7 @@ module ActiveMerchant #:nodoc:
         billing_address = options[:billing_address] || options[:address]
         currency_code = options[:currency] || currency(money)
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! transaction_type + 'Req', 'xmlns' => PAYPAL_NAMESPACE do
           xml.tag! transaction_type + 'Request', 'xmlns:n2' => EBAY_NAMESPACE do
             xml.tag! 'n2:Version', API_VERSION

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -17,7 +17,7 @@ module ActiveMerchant
       end
 
       def redirect_url_for(token, options = {})
-        options = {:review => true, :mobile => false}.update(options)
+        options = {review: true, mobile: false}.update(options)
 
         cmd  = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
         url  = "#{redirect_url}?cmd=#{cmd}&token=#{token}"

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -116,11 +116,11 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
         test_mode = (test? || message =~ /TESTMODE/)
         Response.new(success?(response), message, response,
-          :test => test_mode,
-          :authorization => response['transactionid'],
-          :fraud_review => fraud_review?(response),
-          :avs_result => { :code => response['avsresponse'] },
-          :cvv_result => response['cvvresponse']
+          test: test_mode,
+          authorization: response['transactionid'],
+          fraud_review: fraud_review?(response),
+          avs_result: { code: response['avsresponse'] },
+          cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -178,8 +178,8 @@ module ActiveMerchant #:nodoc:
         message  = message_from(response)
 
         PaystationResponse.new(success?(response), message, response,
-          :test          => (response[:tm]&.casecmp('t')&.zero?),
-          :authorization => response[:paystation_transaction_id]
+          test: (response[:tm]&.casecmp('t')&.zero?),
+          authorization: response[:paystation_transaction_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -441,7 +441,7 @@ module ActiveMerchant #:nodoc:
           false,
           message_from('', false, response),
           response,
-          :test => test?
+          test: test?
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -74,13 +74,13 @@ module ActiveMerchant
         'QZ' => 'Zero value transaction'
       }
 
-      TRANSACTIONS  = {
-        :authorize  => 'preauth',
-        :purchase   => 'capture',
-        :capture    => 'captureWithoutAuth',
-        :status     => 'query',
-        :refund     => 'refund',
-        :store      => 'registerAccount'
+      TRANSACTIONS = {
+        authorize: 'preauth',
+        purchase: 'capture',
+        capture: 'captureWithoutAuth',
+        status: 'query',
+        refund: 'refund',
+        store: 'registerAccount'
       }
 
       def initialize(options={})
@@ -193,15 +193,15 @@ module ActiveMerchant
         success = (params[:summary_code] ? (params[:summary_code] == '0') : (params[:response_code] == '00'))
 
         Response.new(success, message, params,
-          :test => (@options[:merchant].to_s == 'TEST'),
-          :authorization => post[:order_number]
+          test: (@options[:merchant].to_s == 'TEST'),
+          authorization: post[:order_number]
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'
 
-        return Response.new(false, 'Invalid credentials', {}, :test => test?)
+        return Response.new(false, 'Invalid credentials', {}, test: test?)
       rescue ActiveMerchant::ClientCertificateError
-        return Response.new(false, 'Invalid certificate', {}, :test => test?)
+        return Response.new(false, 'Invalid certificate', {}, test: test?)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
 
       # Refund a transaction
       def refund(money, token, options = {})
-        commit(:post, "charges/#{CGI.escape(token)}/refunds", { :amount => amount(money) }, options)
+        commit(:post, "charges/#{CGI.escape(token)}/refunds", { amount: amount(money) }, options)
       end
 
       # Authorize an amount on a credit card. Once authorized, you can later
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
       # Captures a previously authorized charge. Capturing only part of the original
       # authorization is currently not supported.
       def capture(money, token, options = {})
-        commit(:put, "charges/#{CGI.escape(token)}/capture", { :amount => amount(money) }, options)
+        commit(:put, "charges/#{CGI.escape(token)}/capture", { amount: amount(money) }, options)
       end
 
       # Updates the credit card for the customer.
@@ -107,11 +107,11 @@ module ActiveMerchant #:nodoc:
 
         post[:card] ||= {}
         post[:card].merge!(
-          :address_line1 => address[:address1],
-          :address_city => address[:city],
-          :address_postcode => address[:zip],
-          :address_state => address[:state],
-          :address_country => address[:country]
+          address_line1: address[:address1],
+          address_city: address[:city],
+          address_postcode: address[:zip],
+          address_state: address[:state],
+          address_country: address[:country]
         )
       end
 
@@ -131,11 +131,11 @@ module ActiveMerchant #:nodoc:
           post[:card] ||= {}
 
           post[:card].merge!(
-            :number => creditcard.number,
-            :expiry_month => creditcard.month,
-            :expiry_year => creditcard.year,
-            :cvc => creditcard.verification_value,
-            :name => creditcard.name
+            number: creditcard.number,
+            expiry_month: creditcard.month,
+            expiry_year: creditcard.year,
+            cvc: creditcard.verification_value,
+            name: creditcard.name
           )
         elsif creditcard.kind_of?(String)
           if creditcard =~ /^card_/
@@ -194,8 +194,8 @@ module ActiveMerchant #:nodoc:
           true,
           response['status_message'],
           body,
-          :authorization => token(response),
-          :test => test?
+          authorization: token(response),
+          test: test?
         )
       end
 
@@ -204,8 +204,8 @@ module ActiveMerchant #:nodoc:
           false,
           body['error_description'],
           body,
-          :authorization => nil,
-          :test => test?
+          authorization: nil,
+          test: test?
         )
       end
 

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -80,12 +80,12 @@ module ActiveMerchant
       }
 
       TRANSACTIONS = {
-        :authorization => 'auth',
-        :purchase => 'auth',
-        :capture => 'mark',
-        :void => 'void',
-        :refund => 'return',
-        :credit => 'newreturn'
+        authorization: 'auth',
+        purchase: 'auth',
+        capture: 'mark',
+        void: 'void',
+        refund: 'return',
+        credit: 'newreturn'
       }
 
       SUCCESS_CODES = ['pending', 'success']
@@ -179,10 +179,10 @@ module ActiveMerchant
         message = success ? 'Success' : message_from(response)
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => response[:orderid],
-          :avs_result => { :code => response[:avs_code] },
-          :cvv_result => response[:cvvresp]
+          test: test?,
+          authorization: response[:orderid],
+          avs_result: { code: response[:avs_code] },
+          cvv_result: response[:cvvresp]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -103,10 +103,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(money, creditcard, options)))
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => build_authorization(response),
-          :avs_result => { :code => response[:avsresult] },
-          :cvv_result => response[:cardidresult]
+          test: test?,
+          authorization: build_authorization(response),
+          avs_result: { code: response[:avsresult] },
+          cvv_result: response[:cardidresult]
         )
       end
 
@@ -119,7 +119,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(xml)
-        response = {:message => 'Global Error Receipt', :complete => false}
+        response = {message: 'Global Error Receipt', complete: false}
 
         xml = REXML::Document.new(xml)
         xml.elements.each('//Result/*') do |node|
@@ -144,26 +144,26 @@ module ActiveMerchant #:nodoc:
       def parameters(money, creditcard, options = {})
         params = {
           # General order parameters
-          :StoreID => @options[:login],
-          :Passphrase => @options[:password],
-          :TestResult => options[:test_result],
-          :OrderID => options[:order_id],
-          :UserID => options[:user_id],
-          :Phone => options[:phone],
-          :Fax => options[:fax],
-          :Email => options[:email],
-          :TransRefNumber => options[:trans_ref_number],
+          StoreID: @options[:login],
+          Passphrase: @options[:password],
+          TestResult: options[:test_result],
+          OrderID: options[:order_id],
+          UserID: options[:user_id],
+          Phone: options[:phone],
+          Fax: options[:fax],
+          Email: options[:email],
+          TransRefNumber: options[:trans_ref_number],
 
           # Credit Card parameters
-          :PaymentType => 'CC',
-          :CardAction => options[:CardAction],
+          PaymentType: 'CC',
+          CardAction: options[:CardAction],
 
           # Financial parameters
-          :CustomerIP => options[:ip],
-          :SubTotal => amount(money),
-          :Tax1 => options[:tax1],
-          :Tax2 => options[:tax2],
-          :ShippingTotal => options[:shipping_total],
+          CustomerIP: options[:ip],
+          SubTotal: amount(money),
+          Tax1: options[:tax1],
+          Tax2: options[:tax2],
+          ShippingTotal: options[:shipping_total],
         }
 
         if creditcard
@@ -172,11 +172,11 @@ module ActiveMerchant #:nodoc:
           card_id_code = (creditcard.verification_value.blank? ? nil : '1')
 
           params.update(
-            :CardNumber => creditcard.number,
-            :CardExpMonth => exp_month,
-            :CardExpYear => exp_year,
-            :CardIDCode => card_id_code,
-            :CardIDNumber => creditcard.verification_value
+            CardNumber: creditcard.number,
+            CardExpMonth: exp_month,
+            CardExpYear: exp_year,
+            CardIDCode: card_id_code,
+            CardIDNumber: creditcard.verification_value
           )
         end
 

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -260,10 +260,10 @@ module ActiveMerchant
         response = parse(ssl_post(self.live_url, post_data(request)))
 
         Response.new(response[:ResponseCode] == APPROVED, response[:Message], response,
-          :test => test?,
-          :authorization => response[:CrossReference],
-          :cvv_result => CVV_CODE[response[:AVSCV2Check]],
-          :avs_result => { :code => AVS_CODE[response[:AVSCV2Check]] }
+          test: test?,
+          authorization: response[:CrossReference],
+          cvv_result: CVV_CODE[response[:AVSCV2Check]],
+          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -15,12 +15,12 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = ['US']
 
       TYPES = {
-        :authorize => 'CustomerCreditCardAuth',
-        :capture   => 'CustomerCreditCardCapture',
-        :purchase  => 'CustomerCreditCardCharge',
-        :refund    => 'CustomerCreditCardTxnVoidOrRefund',
-        :void      => 'CustomerCreditCardTxnVoid',
-        :query     => 'MerchantAccountQuery',
+        authorize: 'CustomerCreditCardAuth',
+        capture: 'CustomerCreditCardCapture',
+        purchase: 'CustomerCreditCardCharge',
+        refund: 'CustomerCreditCardTxnVoidOrRefund',
+        void: 'CustomerCreditCardTxnVoid',
+        query: 'MerchantAccountQuery',
       }
 
       # Creates a new QbmsGateway
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>options</tt> -- A hash of optional parameters.
       #
       def authorize(money, creditcard, options = {})
-        commit(:authorize, money, options.merge(:credit_card => creditcard))
+        commit(:authorize, money, options.merge(credit_card: creditcard))
       end
 
       # Perform a purchase, which is essentially an authorization and capture in a single operation.
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>options</tt> -- A hash of optional parameters.
       #
       def purchase(money, creditcard, options = {})
-        commit(:purchase, money, options.merge(:credit_card => creditcard))
+        commit(:purchase, money, options.merge(credit_card: creditcard))
       end
 
       # Captures the funds from an authorized transaction.
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>authorization</tt> -- The authorization returned from the previous authorize request.
       #
       def capture(money, authorization, options = {})
-        commit(:capture, money, options.merge(:transaction_id => authorization))
+        commit(:capture, money, options.merge(transaction_id: authorization))
       end
 
       # Void a previous transaction
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>authorization</tt> - The authorization returned from the previous authorize request.
       #
       def void(authorization, options = {})
-        commit(:void, nil, options.merge(:transaction_id => authorization))
+        commit(:void, nil, options.merge(transaction_id: authorization))
       end
 
       # Credit an account.
@@ -105,7 +105,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, identification, options = {})
-        commit(:refund, money, options.merge(:transaction_id => identification))
+        commit(:refund, money, options.merge(transaction_id: identification))
       end
 
       # Query the merchant account status
@@ -143,11 +143,11 @@ module ActiveMerchant #:nodoc:
         message = (response[:status_message] || '').strip
 
         Response.new(success?(response), message, response,
-          :test          => test?,
-          :authorization => response[:credit_card_trans_id],
-          :fraud_review  => fraud_review?(response),
-          :avs_result    => { :code => avs_result(response) },
-          :cvv_result    => cvv_result(response)
+          test: test?,
+          authorization: response[:credit_card_trans_id],
+          fraud_review: fraud_review?(response),
+          avs_result: { code: avs_result(response) },
+          cvv_result: cvv_result(response)
         )
       end
 
@@ -167,16 +167,16 @@ module ActiveMerchant #:nodoc:
 
         if status_code != 0
           return {
-            :status_code    => status_code,
-            :status_message => signon.attributes['statusMessage'],
+            status_code: status_code,
+            status_message: signon.attributes['statusMessage'],
           }
         end
 
         response = REXML::XPath.first(xml, "//QBMSXMLMsgsRs/#{type}Rs")
 
         results = {
-          :status_code    => response.attributes['statusCode'].to_i,
-          :status_message => response.attributes['statusMessage'],
+          status_code: response.attributes['statusCode'].to_i,
+          status_message: response.attributes['statusMessage'],
         }
 
         response.elements.each do |e|
@@ -195,10 +195,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_request(type, money, parameters = {})
-        xml = Builder::XmlMarkup.new(:indent => 0)
+        xml = Builder::XmlMarkup.new(indent: 0)
 
-        xml.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
-        xml.instruct!(:qbmsxml, :version => API_VERSION)
+        xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
+        xml.instruct!(:qbmsxml, version: API_VERSION)
 
         xml.tag!('QBMSXML') do
           xml.tag!('SignonMsgsRq') do

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -216,10 +216,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => { :code => response[:AVSResponseCode] },
-          :cvv_result => response[:CVV2ResponseCode]
+          test: test?,
+          authorization: authorization,
+          avs_result: { code: response[:AVSResponseCode] },
+          cvv_result: response[:CVV2ResponseCode]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
@@ -1,151 +1,151 @@
 module QuickpayCommon
   MD5_CHECK_FIELDS = {
     3 => {
-      :authorize => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture cardnumber expirationdate
-                       cvd cardtypelock testmode),
+      authorize: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture cardnumber expirationdate
+                    cvd cardtypelock testmode),
 
-      :capture   => %w(protocol msgtype merchant amount finalize transaction),
+      capture: %w(protocol msgtype merchant amount finalize transaction),
 
-      :cancel    => %w(protocol msgtype merchant transaction),
+      cancel: %w(protocol msgtype merchant transaction),
 
-      :refund    => %w(protocol msgtype merchant amount transaction),
+      refund: %w(protocol msgtype merchant amount transaction),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                       expirationdate cvd cardtypelock description testmode),
+      subscribe: %w(protocol msgtype merchant ordernumber cardnumber
+                    expirationdate cvd cardtypelock description testmode),
 
-      :recurring => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture transaction),
+      recurring: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture transaction),
 
-      :status    => %w(protocol msgtype merchant transaction),
+      status: %w(protocol msgtype merchant transaction),
 
-      :chstatus  => %w(protocol msgtype merchant)
+      chstatus: %w(protocol msgtype merchant)
     },
 
     4 => {
-      :authorize => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture cardnumber expirationdate cvd
-                       cardtypelock testmode fraud_remote_addr
-                       fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      authorize: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture cardnumber expirationdate cvd
+                    cardtypelock testmode fraud_remote_addr
+                    fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :capture   => %w(protocol msgtype merchant amount finalize transaction apikey),
+      capture: %w(protocol msgtype merchant amount finalize transaction apikey),
 
-      :cancel    => %w(protocol msgtype merchant transaction apikey),
+      cancel: %w(protocol msgtype merchant transaction apikey),
 
-      :refund    => %w(protocol msgtype merchant amount transaction apikey),
+      refund: %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                       expirationdate cvd cardtypelock description testmode
-                       fraud_remote_addr fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      subscribe: %w(protocol msgtype merchant ordernumber cardnumber
+                    expirationdate cvd cardtypelock description testmode
+                    fraud_remote_addr fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :recurring => %w(protocol msgtype merchant ordernumber amount currency
-                       autocapture transaction apikey),
+      recurring: %w(protocol msgtype merchant ordernumber amount currency
+                    autocapture transaction apikey),
 
-      :status    => %w(protocol msgtype merchant transaction apikey),
+      status: %w(protocol msgtype merchant transaction apikey),
 
-      :chstatus  => %w(protocol msgtype merchant apikey)
+      chstatus: %w(protocol msgtype merchant apikey)
     },
 
     5 => {
-      :authorize => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture cardnumber expirationdate cvd
-                       cardtypelock testmode fraud_remote_addr
-                       fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      authorize: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture cardnumber expirationdate cvd
+                    cardtypelock testmode fraud_remote_addr
+                    fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :capture   => %w(protocol msgtype merchant amount finalize transaction apikey),
+      capture: %w(protocol msgtype merchant amount finalize transaction apikey),
 
-      :cancel    => %w(protocol msgtype merchant transaction apikey),
+      cancel: %w(protocol msgtype merchant transaction apikey),
 
-      :refund    => %w(protocol msgtype merchant amount transaction apikey),
+      refund: %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                       expirationdate cvd cardtypelock description testmode
-                       fraud_remote_addr fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      subscribe: %w(protocol msgtype merchant ordernumber cardnumber
+                    expirationdate cvd cardtypelock description testmode
+                    fraud_remote_addr fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :recurring => %w(protocol msgtype merchant ordernumber amount currency
-                       autocapture transaction apikey),
+      recurring: %w(protocol msgtype merchant ordernumber amount currency
+                    autocapture transaction apikey),
 
-      :status    => %w(protocol msgtype merchant transaction apikey),
+      status: %w(protocol msgtype merchant transaction apikey),
 
-      :chstatus  => %w(protocol msgtype merchant apikey)
+      chstatus: %w(protocol msgtype merchant apikey)
     },
 
     6 => {
-      :authorize => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture cardnumber expirationdate cvd
-                       cardtypelock testmode fraud_remote_addr
-                       fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      authorize: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture cardnumber expirationdate cvd
+                    cardtypelock testmode fraud_remote_addr
+                    fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :capture   => %w(protocol msgtype merchant amount finalize transaction
-                       apikey),
+      capture: %w(protocol msgtype merchant amount finalize transaction
+                  apikey),
 
-      :cancel    => %w(protocol msgtype merchant transaction apikey),
+      cancel: %w(protocol msgtype merchant transaction apikey),
 
-      :refund    => %w(protocol msgtype merchant amount transaction apikey),
+      refund: %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
-                       expirationdate cvd cardtypelock description testmode
-                       fraud_remote_addr fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      subscribe: %w(protocol msgtype merchant ordernumber cardnumber
+                    expirationdate cvd cardtypelock description testmode
+                    fraud_remote_addr fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :recurring => %w(protocol msgtype merchant ordernumber amount currency
-                       autocapture transaction apikey),
+      recurring: %w(protocol msgtype merchant ordernumber amount currency
+                    autocapture transaction apikey),
 
-      :status    => %w(protocol msgtype merchant transaction apikey),
+      status: %w(protocol msgtype merchant transaction apikey),
 
-      :chstatus  => %w(protocol msgtype merchant apikey)
+      chstatus: %w(protocol msgtype merchant apikey)
     },
 
     7 => {
-      :authorize => %w(protocol msgtype merchant ordernumber amount
-                       currency autocapture cardnumber expirationdate cvd
-                       acquirers cardtypelock testmode fraud_remote_addr
-                       fraud_http_accept fraud_http_accept_language
-                       fraud_http_accept_encoding fraud_http_accept_charset
-                       fraud_http_referer fraud_http_user_agent apikey),
+      authorize: %w(protocol msgtype merchant ordernumber amount
+                    currency autocapture cardnumber expirationdate cvd
+                    acquirers cardtypelock testmode fraud_remote_addr
+                    fraud_http_accept fraud_http_accept_language
+                    fraud_http_accept_encoding fraud_http_accept_charset
+                    fraud_http_referer fraud_http_user_agent apikey),
 
-      :capture   => %w(protocol msgtype merchant amount finalize transaction
-                       apikey),
+      capture: %w(protocol msgtype merchant amount finalize transaction
+                  apikey),
 
-      :cancel    => %w(protocol msgtype merchant transaction apikey),
+      cancel: %w(protocol msgtype merchant transaction apikey),
 
-      :refund    => %w(protocol msgtype merchant amount transaction apikey),
+      refund: %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber amount currency
-                       cardnumber expirationdate cvd acquirers cardtypelock
-                       description testmode fraud_remote_addr fraud_http_accept
-                       fraud_http_accept_language fraud_http_accept_encoding
-                       fraud_http_accept_charset fraud_http_referer
-                       fraud_http_user_agent apikey),
+      subscribe: %w(protocol msgtype merchant ordernumber amount currency
+                    cardnumber expirationdate cvd acquirers cardtypelock
+                    description testmode fraud_remote_addr fraud_http_accept
+                    fraud_http_accept_language fraud_http_accept_encoding
+                    fraud_http_accept_charset fraud_http_referer
+                    fraud_http_user_agent apikey),
 
-      :recurring => %w(protocol msgtype merchant ordernumber amount currency
-                       autocapture transaction apikey),
+      recurring: %w(protocol msgtype merchant ordernumber amount currency
+                    autocapture transaction apikey),
 
-      :status    => %w(protocol msgtype merchant transaction apikey),
+      status: %w(protocol msgtype merchant transaction apikey),
 
-      :chstatus  => %w(protocol msgtype merchant apikey)
+      chstatus: %w(protocol msgtype merchant apikey)
     },
 
     10 => {
-      :authorize => %w(mobile_number acquirer autofee customer_id extras
-                       zero_auth customer_ip),
-      :capture   => %w(extras),
-      :cancel    => %w(extras),
-      :refund    => %w(extras),
-      :subscribe => %w(variables branding_id),
-      :authorize_subscription => %w(mobile_number acquirer customer_ip),
-      :recurring => %w(auto_capture autofee zero_auth)
+      authorize: %w(mobile_number acquirer autofee customer_id extras
+                    zero_auth customer_ip),
+      capture: %w(extras),
+      cancel: %w(extras),
+      refund: %w(extras),
+      subscribe: %w(variables branding_id),
+      authorize_subscription: %w(mobile_number acquirer customer_ip),
+      recurring: %w(auto_capture autofee zero_auth)
     }
   }
 

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -154,8 +154,8 @@ module ActiveMerchant
         end
 
         Response.new(success, message_from(success, response), response,
-          :test => test?,
-          :authorization => authorization_from(response)
+          test: test?,
+          authorization: authorization_from(response)
         )
       end
 
@@ -253,12 +253,12 @@ module ActiveMerchant
         requires!(address, :name, :address1, :city, :zip, :country)
         country = Country.find(address[:country])
         mapped = {
-          :name         => address[:name],
-          :street       => address[:address1],
-          :city         => address[:city],
-          :region       => address[:address2],
-          :zip_code     => address[:zip],
-          :country_code => country.code(:alpha3).value
+          name: address[:name],
+          street: address[:address1],
+          city: address[:city],
+          region: address[:address2],
+          zip_code: address[:zip],
+          country_code: country.code(:alpha3).value
         }
         mapped
       end

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -165,8 +165,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => response[:transaction]
+          test: test?,
+          authorization: response[:transaction]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -107,8 +107,8 @@ module ActiveMerchant
           (response[:result] == '00'),
           message_from(response),
           response,
-          :test => (response[:message] =~ %r{\[ test system \]}),
-          :authorization => authorization_from(response),
+          test: (response[:message] =~ %r{\[ test system \]}),
+          authorization: authorization_from(response),
           avs_result: AVSResult.new(code: response[:avspostcoderesponse]),
           cvv_result: CVVResult.new(response[:cvnresult])
         )
@@ -138,7 +138,7 @@ module ActiveMerchant
 
       def build_purchase_or_authorization_request(action, money, credit_card, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'auth' do
           add_merchant_details(xml, options)
           xml.tag! 'orderid', sanitize_order_id(options[:order_id])
@@ -159,7 +159,7 @@ module ActiveMerchant
 
       def build_capture_request(money, authorization, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'settle' do
           add_merchant_details(xml, options)
           add_amount(xml, money, options)
@@ -172,7 +172,7 @@ module ActiveMerchant
 
       def build_refund_request(money, authorization, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'rebate' do
           add_merchant_details(xml, options)
           add_transaction_identifiers(xml, authorization, options)
@@ -187,7 +187,7 @@ module ActiveMerchant
 
       def build_credit_request(money, credit_card, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'credit' do
           add_merchant_details(xml, options)
           xml.tag! 'orderid', sanitize_order_id(options[:order_id])
@@ -203,7 +203,7 @@ module ActiveMerchant
 
       def build_void_request(authorization, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'void' do
           add_merchant_details(xml, options)
           add_transaction_identifiers(xml, authorization, options)
@@ -216,7 +216,7 @@ module ActiveMerchant
       # Verify initiates an OTB (Open To Buy) request
       def build_verify_request(credit_card, options)
         timestamp = new_timestamp
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.tag! 'request', 'timestamp' => timestamp, 'type' => 'otb' do
           add_merchant_details(xml, options)
           xml.tag! 'orderid', sanitize_order_id(options[:order_id])

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -91,11 +91,11 @@ module ActiveMerchant #:nodoc:
       # More operations are supported by the gateway itself, but
       # are not supported in this library.
       SUPPORTED_TRANSACTIONS = {
-        :purchase   => 'A',
-        :authorize  => '1',
-        :capture    => '2',
-        :refund     => '3',
-        :cancel     => '9'
+        purchase:   'A',
+        authorize:  '1',
+        capture:    '2',
+        refund:     '3',
+        cancel:     '9'
       }
 
       # These are the text meanings sent back by the acquirer when
@@ -236,7 +236,7 @@ module ActiveMerchant #:nodoc:
         data = {}
         add_action(data, :cancel)
         order_id, amount, currency = split_authorization(authorization)
-        add_amount(data, amount, :currency => currency)
+        add_amount(data, amount, currency: currency)
         add_order(data, order_id)
         data[:description] = options[:description]
 
@@ -313,10 +313,10 @@ module ActiveMerchant #:nodoc:
           year  = sprintf('%.4i', card.year)
           month = sprintf('%.2i', card.month)
           data[:card] = {
-            :name => name,
-            :pan  => card.number,
-            :date => "#{year[2..3]}#{month}",
-            :cvv  => card.verification_value
+            name: name,
+            pan: card.number,
+            date: "#{year[2..3]}#{month}",
+            cvv: card.verification_value
           }
         end
       end
@@ -407,7 +407,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_sha1_xml_request(data, options = {})
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         build_merchant_data(xml, data, options)
         xml.target!
       end
@@ -464,7 +464,7 @@ module ActiveMerchant #:nodoc:
         params  = {}
         success = false
         message = ''
-        options = @options.merge(:test => test?)
+        options = @options.merge(test: test?)
         xml     = Nokogiri::XML(data)
         code    = xml.xpath('//RETORNOXML/CODIGO').text
 

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -11,12 +11,12 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :diners_club]
 
       TRANSACTIONS = {
-        :purchase           => '01',
-        :authorization      => '02',
-        :capture            => '11',
-        :void               => '04',
-        :credit             => '06',
-        :refund             => '10'
+        purchase:       '01',
+        authorization:  '02',
+        capture:        '11',
+        void:           '04',
+        credit:         '06',
+        refund:         '10'
       }
 
       SOURCE_CARD   = 'bankcard'
@@ -261,10 +261,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(action, params)), source)
 
         Response.new(success?(response), response[:message], response,
-          :test => test?,
-          :authorization => authorization_from(response, source),
-          :avs_result => { :code => response[:avs_result] },
-          :cvv_result => response[:cvv_result]
+          test: test?,
+          authorization: authorization_from(response, source),
+          avs_result: { code: response[:avs_result] },
+          cvv_result: response[:cvv_result]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -13,26 +13,26 @@ module ActiveMerchant #:nodoc:
       APPROVED = 'OK'
 
       TRANSACTIONS = {
-        :purchase => 'PAYMENT',
-        :credit => 'REFUND',
-        :authorization => 'DEFERRED',
-        :capture => 'RELEASE',
-        :void => 'VOID',
-        :abort => 'ABORT',
-        :store => 'TOKEN',
-        :unstore => 'REMOVETOKEN',
-        :repeat => 'REPEAT'
+        purchase: 'PAYMENT',
+        credit: 'REFUND',
+        authorization: 'DEFERRED',
+        capture: 'RELEASE',
+        void: 'VOID',
+        abort: 'ABORT',
+        store: 'TOKEN',
+        unstore: 'REMOVETOKEN',
+        repeat: 'REPEAT'
       }
 
       CREDIT_CARDS = {
-        :visa => 'VISA',
-        :master => 'MC',
-        :delta => 'DELTA',
-        :maestro => 'MAESTRO',
-        :american_express => 'AMEX',
-        :electron => 'UKE',
-        :diners_club => 'DC',
-        :jcb => 'JCB'
+        visa: 'VISA',
+        master: 'MC',
+        delta: 'DELTA',
+        maestro: 'MAESTRO',
+        american_express: 'AMEX',
+        electron: 'UKE',
+        diners_club: 'DC',
+        jcb: 'JCB'
       }
 
       AVS_CODE = {
@@ -213,18 +213,18 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(post, money, options)
         currency = options[:currency] || currency(money)
-        add_pair(post, :Amount, localized_amount(money, currency), :required => true)
-        add_pair(post, :Currency, currency, :required => true)
+        add_pair(post, :Amount, localized_amount(money, currency), required: true)
+        add_pair(post, :Currency, currency, required: true)
       end
 
       def add_currency(post, money, options)
         currency = options[:currency] || currency(money)
-        add_pair(post, :Currency, currency, :required => true)
+        add_pair(post, :Currency, currency, required: true)
       end
 
       # doesn't actually use the currency -- dodgy!
       def add_release_amount(post, money, options)
-        add_pair(post, :ReleaseAmount, amount(money), :required => true)
+        add_pair(post, :ReleaseAmount, amount(money), required: true)
       end
 
       def add_customer_data(post, options)
@@ -269,7 +269,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, options)
-        add_pair(post, :VendorTxCode, sanitize_order_id(options[:order_id]), :required => true)
+        add_pair(post, :VendorTxCode, sanitize_order_id(options[:order_id]), required: true)
         add_pair(post, :Description, truncate(options[:description] || options[:order_id], 100))
       end
 
@@ -286,10 +286,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_credit_card(post, credit_card)
-        add_pair(post, :CardHolder, truncate(credit_card.name, 50), :required => true)
-        add_pair(post, :CardNumber, credit_card.number, :required => true)
+        add_pair(post, :CardHolder, truncate(credit_card.name, 50), required: true)
+        add_pair(post, :CardNumber, credit_card.number, required: true)
 
-        add_pair(post, :ExpiryDate, format_date(credit_card.month, credit_card.year), :required => true)
+        add_pair(post, :ExpiryDate, format_date(credit_card.month, credit_card.year), required: true)
         add_pair(post, :CardType, map_card_type(credit_card))
 
         add_pair(post, :CV2, credit_card.verification_value)
@@ -347,13 +347,13 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url_for(action), post_data(action, parameters)))
 
         Response.new(response['Status'] == APPROVED, message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(response, parameters, action),
-          :avs_result => {
-            :street_match => AVS_CODE[response['AddressResult']],
-            :postal_match => AVS_CODE[response['PostCodeResult']],
+          test: test?,
+          authorization: authorization_from(response, parameters, action),
+          avs_result: {
+            street_match: AVS_CODE[response['AddressResult']],
+            postal_match: AVS_CODE[response['PostCodeResult']],
           },
-          :cvv_result => CVV_CODE[response['CV2Result']]
+          cvv_result: CVV_CODE[response['CV2Result']]
         )
       end
 
@@ -400,12 +400,12 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         parameters.update(
-          :Vendor => @options[:login],
-          :TxType => TRANSACTIONS[action],
-          :VPSProtocol => @options.fetch(:protocol_version, '3.00')
+          Vendor: @options[:login],
+          TxType: TRANSACTIONS[action],
+          VPSProtocol: @options.fetch(:protocol_version, '3.00')
         )
 
-        parameters.update(:ReferrerID => application_id) if application_id && (application_id != Gateway.application_id)
+        parameters.update(ReferrerID: application_id) if application_id && (application_id != Gateway.application_id)
 
         parameters.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end

--- a/lib/active_merchant/billing/gateways/sallie_mae.rb
+++ b/lib/active_merchant/billing/gateways/sallie_mae.rb
@@ -121,8 +121,8 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(self.live_url, parameters.to_post_data) || '')
         Response.new(successful?(response), message_from(response), response,
-          :test => test?,
-          :authorization => response['refcode']
+          test: test?,
+          authorization: response['refcode']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -4,11 +4,11 @@ module ActiveMerchant #:nodoc:
       API_VERSION = '4.0'
 
       TRANSACTIONS = {
-        :auth_only                      => '0000',
-        :auth_capture                   => '0100',
-        :prior_auth_capture             => '0200',
-        :void                           => '0400',
-        :credit                         => '0500'
+        auth_only:            '0000',
+        auth_capture:         '0100',
+        prior_auth_capture:   '0200',
+        void:                 '0400',
+        credit:               '0500'
       }
 
       XML_ATTRIBUTES = {
@@ -80,10 +80,10 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
 
         Response.new(success?(response), message_from(response), response,
-          :test => test?,
-          :authorization => build_authorization(response),
-          :avs_result => { :code => response[:avs_result_code] },
-          :cvv_result => response[:card_code_response_code]
+          test: test?,
+          authorization: build_authorization(response),
+          avs_result: { code: response[:avs_result_code] },
+          cvv_result: response[:card_code_response_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -57,11 +57,11 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          :test => test?,
-          :authorization => response[:transaction_id],
-          :fraud_review => fraud_review?(response),
-          :avs_result => { :code => response[:avs_result_code] },
-          :cvv_result => response[:card_code]
+          test: test?,
+          authorization: response[:transaction_id],
+          fraud_review: fraud_review?(response),
+          avs_result: { code: response[:avs_result_code] },
+          cvv_result: response[:card_code]
         )
       end
 
@@ -77,14 +77,14 @@ module ActiveMerchant #:nodoc:
         fields = split(body)
 
         results = {
-          :response_code => fields[RESPONSE_CODE].to_i,
-          :response_reason_code => fields[RESPONSE_REASON_CODE],
-          :response_reason_text => fields[RESPONSE_REASON_TEXT],
-          :avs_result_code => fields[AVS_RESULT_CODE],
-          :transaction_id => fields[TRANSACTION_ID],
-          :card_code => fields[CARD_CODE_RESPONSE_CODE],
-          :authorization_code => fields[AUTHORIZATION_CODE],
-          :cardholder_authentication_code => fields[CARDHOLDER_AUTH_CODE]
+          response_code: fields[RESPONSE_CODE].to_i,
+          response_reason_code: fields[RESPONSE_REASON_CODE],
+          response_reason_text: fields[RESPONSE_REASON_TEXT],
+          avs_result_code: fields[AVS_RESULT_CODE],
+          transaction_id: fields[TRANSACTION_ID],
+          card_code: fields[CARD_CODE_RESPONSE_CODE],
+          authorization_code: fields[AUTHORIZATION_CODE],
+          cardholder_authentication_code: fields[CARDHOLDER_AUTH_CODE]
         }
         results
       end

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -35,23 +35,23 @@ module ActiveMerchant #:nodoc:
       # 10 Preauthorise
       # 11 Preauth Complete (Advice)
       TRANSACTIONS = {
-        :purchase => 0,
-        :authorization => 10,
-        :capture => 11,
-        :void => 6,
-        :refund => 4
+        purchase:       0,
+        authorization:  10,
+        capture:        11,
+        void:           6,
+        refund:         4
       }
 
       PERIODIC_ACTIONS = {
-        :add_triggered    => 'add',
-        :remove_triggered => 'delete',
-        :trigger          => 'trigger'
+        add_triggered:      'add',
+        remove_triggered:   'delete',
+        trigger:            'trigger'
       }
 
       PERIODIC_TYPES = {
-        :add_triggered    => 4,
-        :remove_triggered => nil,
-        :trigger          => nil
+        add_triggered:    4,
+        remove_triggered: nil,
+        trigger:          nil
       }
 
       SUCCESS_CODES = ['00', '08', '11', '16', '77']
@@ -184,8 +184,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
         Response.new(success?(response), message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(response)
+          test: test?,
+          authorization: authorization_from(response)
         )
       end
 
@@ -241,8 +241,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, my_request))
 
         Response.new(success?(response), message_from(response), response,
-          :test => test?,
-          :authorization => authorization_from(response)
+          test: test?,
+          authorization: authorization_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -85,8 +85,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, post)))
 
         Response.new(response[:result_code] == 1, message_from(response), response,
-          :test => test?,
-          :authorization => response[:merchant_transaction_reference]
+          test: test?,
+          authorization: response[:merchant_transaction_reference]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -12,9 +12,9 @@ module ActiveMerchant #:nodoc:
       ADVANCED_PATH = '/evolvcc/evolvcc.aspx'
 
       ACTIONS = {
-        :authorization => 'AuthorizeAPI',
-        :change_status => 'SJAPI_TransactionChangeStatusRequest',
-        :get_status => 'SJAPI_TransactionStatusRequest'
+        authorization: 'AuthorizeAPI',
+        change_status: 'SJAPI_TransactionChangeStatusRequest',
+        get_status: 'SJAPI_TransactionStatusRequest'
       }
 
       SUCCESS_MESSAGE = 'The transaction was successful.'
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def status(order_id)
-        commit(:get_status, nil, :szOrderNumber => order_id)
+        commit(:get_status, nil, szOrderNumber: order_id)
       end
 
       private
@@ -264,10 +264,10 @@ module ActiveMerchant #:nodoc:
 
         # Pass along the original transaction id in the case an update transaction
         Response.new(response[:success], message_from(response, action), response,
-          :test => test?,
-          :authorization => response[:szTransactionFileName] || parameters[:szTransactionId],
-          :avs_result => { :code => response[:szAVSResponseCode] },
-          :cvv_result => response[:szCVV2ResponseCode]
+          test: test?,
+          authorization: response[:szTransactionFileName] || parameters[:szTransactionId],
+          avs_result: { code: response[:szAVSResponseCode] },
+          cvv_result: response[:szCVV2ResponseCode]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
       def store(payment_source, options = {})
         post = {}
         billing_id = options.delete(:billing_id).to_s || true
-        add_payment_source(post, payment_source, :store => billing_id)
+        add_payment_source(post, payment_source, store: billing_id)
         add_address(post, options[:billing_address] || options[:address])
         add_customer_data(post, options)
         commit(nil, nil, post)
@@ -227,10 +227,10 @@ module ActiveMerchant #:nodoc:
         parameters[:amount] = localized_amount(money, parameters[:currency] || default_currency) if money
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
         Response.new(response['response'] == '1', message_from(response), response,
-          :authorization => (response['transactionid'] || response['customer_vault_id']),
-          :test => test?,
-          :cvv_result => response['cvvresponse'],
-          :avs_result => { :code => response['avsresponse'] }
+          authorization: (response['transactionid'] || response['customer_vault_id']),
+          test: test?,
+          cvv_result: response['cvvresponse'],
+          avs_result: { code: response['avsresponse'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -164,13 +164,13 @@ module ActiveMerchant #:nodoc:
         return Response.new(response['errorcode'] == '000',
           response['errormessage'],
           response,
-          :test => test?,
-          :authorization => response['transaction_id'])
+          test: test?,
+          authorization: response['transaction_id'])
       end
 
       def build_soap(request)
-        retval = Builder::XmlMarkup.new(:indent => 2)
-        retval.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        retval = Builder::XmlMarkup.new(indent: 2)
+        retval.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         retval.tag!('soap:Envelope', {
           'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
           'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',

--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -283,10 +283,10 @@ module ActiveMerchant #:nodoc:
       def response_from(raw_response, authorization_field)
         parsed = parse(raw_response)
         options = {
-          :authorization => parsed[authorization_field],
-          :test => (parsed[:on_test_gateway] == 'true'),
-          :avs_result => { :code => parsed[:response_avs_code] },
-          :cvv_result => parsed[:response_cvv_code]
+          authorization: parsed[authorization_field],
+          test: (parsed[:on_test_gateway] == 'true'),
+          avs_result: { code: parsed[:response_avs_code] },
+          cvv_result: parsed[:response_cvv_code]
         }
 
         Response.new(parsed[:succeeded] == 'true', parsed[:message] || parsed[:error], parsed, options)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -612,7 +612,7 @@ module ActiveMerchant #:nodoc:
           'User-Agent' => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'Stripe-Version' => api_version(options),
           'X-Stripe-Client-User-Agent' => stripe_client_user_agent(options),
-          'X-Stripe-Client-User-Metadata' => {:ip => options[:ip]}.to_json
+          'X-Stripe-Client-User-Metadata' => {ip: options[:ip]}.to_json
         }
         headers['Idempotency-Key'] = idempotency_key if idempotency_key
         headers['Stripe-Account'] = options[:stripe_account] if options[:stripe_account]
@@ -656,12 +656,12 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           message_from(success, response),
           response,
-          :test => response_is_test?(response),
-          :authorization => authorization_from(success, url, method, response),
-          :avs_result => { :code => avs_code },
-          :cvv_result => cvc_code,
-          :emv_authorization => emv_authorization_from_response(response),
-          :error_code => success ? nil : error_code_from(response)
+          test: response_is_test?(response),
+          authorization: authorization_from(success, url, method, response),
+          avs_result: { code: avs_code },
+          cvv_result: cvc_code,
+          emv_authorization: emv_authorization_from_response(response),
+          error_code: success ? nil : error_code_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -109,7 +109,7 @@ module ActiveMerchant #:nodoc:
                 TRANSACTION_APPROVED_MSG :
                 TRANSACTION_DECLINED_MSG,
                 response,
-                :test => test?
+                test: test?
               )
             else
               build_error_response(message, response)
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
           false,
           message,
           params,
-          :test => test?
+          test: test?
         )
       end
     end

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -175,10 +175,10 @@ module ActiveMerchant #:nodoc:
           success_from(response),
           message_from(response),
           response,
-          :test => test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response[:avs_code] },
-          :cvv_result => response[:cvv2_code]
+          test: test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response[:avs_code] },
+          cvv_result: response[:cvv2_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, creditcard_or_billing_id, options = {})
         parameters = {
-          :amount => amount(money),
+          amount: amount(money),
         }
 
         add_order_id(parameters, options)
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
       # to process a purchase are an amount in cents or a money object and a creditcard object or billingid string.
       def purchase(money, creditcard_or_billing_id, options = {})
         parameters = {
-          :amount => amount(money),
+          amount: amount(money),
         }
 
         add_order_id(parameters, options)
@@ -187,8 +187,8 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         transaction_id, _ = split_authorization(authorization)
         parameters = {
-          :amount => amount(money),
-          :transid => transaction_id,
+          amount: amount(money),
+          transid: transaction_id,
         }
         add_aggregator(parameters, options)
         add_custom_fields(parameters, options)
@@ -202,8 +202,8 @@ module ActiveMerchant #:nodoc:
         transaction_id, _ = split_authorization(identification)
 
         parameters = {
-          :amount => amount(money),
-          :transid => transaction_id
+          amount: amount(money),
+          transid: transaction_id
         }
 
         add_aggregator(parameters, options)
@@ -239,7 +239,7 @@ module ActiveMerchant #:nodoc:
         action = (VOIDABLE_ACTIONS - ['preauth']).include?(original_action) ? 'void' : 'reversal'
 
         parameters = {
-          :transid => transaction_id,
+          transid: transaction_id,
         }
 
         add_aggregator(parameters, options)
@@ -281,11 +281,11 @@ module ActiveMerchant #:nodoc:
           end
 
         parameters = {
-          :amount => amount(money),
-          :cycle => cycle,
-          :verify => options[:verify] || 'y',
-          :billingid => options[:billingid] || nil,
-          :payments => options[:payments] || nil,
+          amount: amount(money),
+          cycle: cycle,
+          verify: options[:verify] || 'y',
+          billingid: options[:billingid] || nil,
+          payments: options[:payments] || nil,
         }
 
         add_creditcard(parameters, creditcard)
@@ -299,8 +299,8 @@ module ActiveMerchant #:nodoc:
 
       def store(creditcard, options = {})
         parameters = {
-          :verify => options[:verify] || 'y',
-          :billingid => options[:billingid] || options[:billing_id] || nil,
+          verify: options[:verify] || 'y',
+          billingid: options[:billingid] || options[:billing_id] || nil,
         }
 
         add_creditcard(parameters, creditcard)
@@ -314,7 +314,7 @@ module ActiveMerchant #:nodoc:
       # unstore() the information will be removed and a Response object will be returned indicating the success of the action.
       def unstore(identification, options = {})
         parameters = {
-          :billingid => identification,
+          billingid: identification,
         }
 
         add_custom_fields(parameters, options)
@@ -444,10 +444,10 @@ module ActiveMerchant #:nodoc:
         success = SUCCESS_TYPES.include?(data['status'])
         message = message_from(data)
         Response.new(success, message, data,
-          :test => test?,
-          :authorization => authorization_from(action, data),
-          :cvv_result => data['cvv'],
-          :avs_result => { :code => data['avs'] }
+          test: test?,
+          authorization: authorization_from(action, data),
+          cvv_result: data['cvv'],
+          avs_result: { code: data['avs'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -78,29 +78,29 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'USA ePay Advanced SOAP Interface'
 
       CUSTOMER_PROFILE_OPTIONS = {
-        :id => [:string, 'CustomerID'], # merchant assigned number
-        :notes => [:string, 'Notes'],
-        :data => [:string, 'CustomData'],
-        :url => [:string, 'URL']
+        id: [:string, 'CustomerID'], # merchant assigned number
+        notes: [:string, 'Notes'],
+        data: [:string, 'CustomData'],
+        url: [:string, 'URL']
       } #:nodoc:
 
       CUSTOMER_RECURRING_BILLING_OPTIONS = {
-        :enabled => [:boolean, 'Enabled'],
-        :schedule => [:string, 'Schedule'],
-        :number_left => [:integer, 'NumLeft'],
-        :currency => [:string, 'Currency'],
-        :description => [:string, 'Description'],
-        :order_id => [:string, 'OrderID'],
-        :user => [:string, 'User'],
-        :source => [:string, 'Source'],
-        :send_receipt => [:boolean, 'SendReceipt'],
-        :receipt_note => [:string, 'ReceiptNote']
+        enabled: [:boolean, 'Enabled'],
+        schedule: [:string, 'Schedule'],
+        number_left: [:integer, 'NumLeft'],
+        currency: [:string, 'Currency'],
+        description: [:string, 'Description'],
+        order_id: [:string, 'OrderID'],
+        user: [:string, 'User'],
+        source: [:string, 'Source'],
+        send_receipt: [:boolean, 'SendReceipt'],
+        receipt_note: [:string, 'ReceiptNote']
       } #:nodoc:
 
       CUSTOMER_POINT_OF_SALE_OPTIONS = {
-        :price_tier => [:string, 'PriceTier'],
-        :tax_class => [:string, 'TaxClass'],
-        :lookup_code => [:string, 'LookupCode']
+        price_tier: [:string, 'PriceTier'],
+        tax_class: [:string, 'TaxClass'],
+        lookup_code: [:string, 'LookupCode']
       } #:nodoc:
 
       CUSTOMER_OPTIONS = [
@@ -110,23 +110,23 @@ module ActiveMerchant #:nodoc:
       ].inject(:merge) #:nodoc:
 
       COMMON_ADDRESS_OPTIONS = {
-        :first_name => [:string, 'FirstName'],
-        :last_name => [:string, 'LastName'],
-        :city => [:string, 'City'],
-        :state => [:string, 'State'],
-        :zip => [:string, 'Zip'],
-        :country => [:string, 'Country'],
-        :phone => [:string, 'Phone'],
-        :email => [:string, 'Email'],
-        :fax => [:string, 'Fax'],
-        :company => [:string, 'Company']
+        first_name: [:string, 'FirstName'],
+        last_name: [:string, 'LastName'],
+        city: [:string, 'City'],
+        state: [:string, 'State'],
+        zip: [:string, 'Zip'],
+        country: [:string, 'Country'],
+        phone: [:string, 'Phone'],
+        email: [:string, 'Email'],
+        fax: [:string, 'Fax'],
+        company: [:string, 'Company']
       } #:nodoc:
 
       ADDRESS_OPTIONS = [
         COMMON_ADDRESS_OPTIONS,
         {
-          :address1 => [:string, 'Street'],
-          :address2 => [:string, 'Street2'],
+          address1: [:string, 'Street'],
+          address2: [:string, 'Street2'],
         }
       ].inject(:merge) #:nodoc
 
@@ -135,98 +135,98 @@ module ActiveMerchant #:nodoc:
         CUSTOMER_RECURRING_BILLING_OPTIONS,
         COMMON_ADDRESS_OPTIONS,
         {
-          :address1 => [:string, 'Address'],
-          :address2 => [:string, 'Address2'],
+          address1: [:string, 'Address'],
+          address2: [:string, 'Address2'],
         },
         {
-          :card_number => [:string, 'CardNumber'],
-          :card_exp => [:string, 'CardExp'],
-          :account => [:string, 'Account'],
-          :routing => [:string, 'Routing'],
-          :check_format => [:string, 'CheckFormat'],
-          :record_type => [:string, 'RecordType'],
+          card_number: [:string, 'CardNumber'],
+          card_exp: [:string, 'CardExp'],
+          account: [:string, 'Account'],
+          routing: [:string, 'Routing'],
+          check_format: [:string, 'CheckFormat'],
+          record_type: [:string, 'RecordType'],
         }
       ].inject(:merge) #:nodoc
 
       CUSTOMER_TRANSACTION_REQUEST_OPTIONS = {
-        :command => [:string, 'Command'],
-        :ignore_duplicate => [:boolean, 'IgnoreDuplicate'],
-        :client_ip => [:string, 'ClientIP'],
-        :customer_receipt => [:boolean, 'CustReceipt'],
-        :customer_email => [:boolean, 'CustReceiptEmail'],
-        :customer_template => [:boolean, 'CustReceiptName'],
-        :merchant_receipt => [:boolean, 'MerchReceipt'],
-        :merchant_email => [:boolean, 'MerchReceiptEmail'],
-        :merchant_template => [:boolean, 'MerchReceiptName'],
-        :recurring => [:boolean, 'isRecurring'],
-        :verification_value => [:string, 'CardCode'],
-        :software => [:string, 'Software']
+        command: [:string, 'Command'],
+        ignore_duplicate: [:boolean, 'IgnoreDuplicate'],
+        client_ip: [:string, 'ClientIP'],
+        customer_receipt: [:boolean, 'CustReceipt'],
+        customer_email: [:boolean, 'CustReceiptEmail'],
+        customer_template: [:boolean, 'CustReceiptName'],
+        merchant_receipt: [:boolean, 'MerchReceipt'],
+        merchant_email: [:boolean, 'MerchReceiptEmail'],
+        merchant_template: [:boolean, 'MerchReceiptName'],
+        recurring: [:boolean, 'isRecurring'],
+        verification_value: [:string, 'CardCode'],
+        software: [:string, 'Software']
       } #:nodoc:
 
       TRANSACTION_REQUEST_OBJECT_OPTIONS = {
-        :command => [:string, 'Command'],
-        :ignore_duplicate => [:boolean, 'IgnoreDuplicate'],
-        :authorization_code => [:string, 'AuthCode'],
-        :reference_number => [:string, 'RefNum'],
-        :account_holder => [:string, 'AccountHolder'],
-        :client_ip => [:string, 'ClientIP'],
-        :customer_id => [:string, 'CustomerID'],
-        :customer_receipt => [:boolean, 'CustReceipt'],
-        :customer_template => [:boolean, 'CustReceiptName'],
-        :software => [:string, 'Software']
+        command: [:string, 'Command'],
+        ignore_duplicate: [:boolean, 'IgnoreDuplicate'],
+        authorization_code: [:string, 'AuthCode'],
+        reference_number: [:string, 'RefNum'],
+        account_holder: [:string, 'AccountHolder'],
+        client_ip: [:string, 'ClientIP'],
+        customer_id: [:string, 'CustomerID'],
+        customer_receipt: [:boolean, 'CustReceipt'],
+        customer_template: [:boolean, 'CustReceiptName'],
+        software: [:string, 'Software']
       } #:nodoc:
 
       TRANSACTION_DETAIL_OPTIONS = {
-        :invoice  => [:string, 'Invoice'],
-        :po_number => [:string, 'PONum'],
-        :order_id => [:string, 'OrderID'],
-        :clerk => [:string, 'Clerk'],
-        :terminal  => [:string, 'Terminal'],
-        :table => [:string, 'Table'],
-        :description => [:string, 'Description'],
-        :comments => [:string, 'Comments'],
-        :allow_partial_auth => [:boolean, 'AllowPartialAuth'],
-        :currency => [:string, 'Currency'],
-        :non_tax => [:boolean, 'NonTax'],
+        invoice: [:string, 'Invoice'],
+        po_number: [:string, 'PONum'],
+        order_id: [:string, 'OrderID'],
+        clerk: [:string, 'Clerk'],
+        terminal: [:string, 'Terminal'],
+        table: [:string, 'Table'],
+        description: [:string, 'Description'],
+        comments: [:string, 'Comments'],
+        allow_partial_auth: [:boolean, 'AllowPartialAuth'],
+        currency: [:string, 'Currency'],
+        non_tax: [:boolean, 'NonTax'],
       } #:nodoc:
 
       TRANSACTION_DETAIL_MONEY_OPTIONS = {
-        :amount => [:double, 'Amount'],
-        :tax => [:double, 'Tax'],
-        :tip => [:double, 'Tip'],
-        :non_tax => [:boolean, 'NonTax'],
-        :shipping => [:double, 'Shipping'],
-        :discount => [:double, 'Discount'],
-        :subtotal => [:double, 'Subtotal']
+        amount: [:double, 'Amount'],
+        tax: [:double, 'Tax'],
+        tip: [:double, 'Tip'],
+        non_tax: [:boolean, 'NonTax'],
+        shipping: [:double, 'Shipping'],
+        discount: [:double, 'Discount'],
+        subtotal: [:double, 'Subtotal']
       } #:nodoc:
 
       CREDIT_CARD_DATA_OPTIONS = {
-        :magnetic_stripe => [:string, 'MagStripe'],
-        :dukpt => [:string, 'DUKPT'],
-        :signature => [:string, 'Signature'],
-        :terminal_type => [:string, 'TermType'],
-        :magnetic_support => [:string, 'MagSupport'],
-        :xid => [:string, 'XID'],
-        :cavv => [:string, 'CAVV'],
-        :eci => [:integer, 'ECI'],
-        :internal_card_authorization => [:boolean, 'InternalCardAuth'],
-        :pares => [:string, 'Pares']
+        magnetic_stripe: [:string, 'MagStripe'],
+        dukpt: [:string, 'DUKPT'],
+        signature: [:string, 'Signature'],
+        terminal_type: [:string, 'TermType'],
+        magnetic_support: [:string, 'MagSupport'],
+        xid: [:string, 'XID'],
+        cavv: [:string, 'CAVV'],
+        eci: [:integer, 'ECI'],
+        internal_card_authorization: [:boolean, 'InternalCardAuth'],
+        pares: [:string, 'Pares']
       } #:nodoc:
 
       CHECK_DATA_OPTIONS = {
-        :drivers_license => [:string, 'DriversLicense'],
-        :drivers_license_state => [:string, 'DriversLicenseState'],
-        :record_type => [:string, 'RecordType'],
-        :aux_on_us => [:string, 'AuxOnUS'],
-        :epc_code => [:string, 'EpcCode'],
-        :front_image => [:string, 'FrontImage'],
-        :back_image => [:string, 'BackImage']
+        drivers_license: [:string, 'DriversLicense'],
+        drivers_license_state: [:string, 'DriversLicenseState'],
+        record_type: [:string, 'RecordType'],
+        aux_on_us: [:string, 'AuxOnUS'],
+        epc_code: [:string, 'EpcCode'],
+        front_image: [:string, 'FrontImage'],
+        back_image: [:string, 'BackImage']
       } #:nodoc:
 
       RECURRING_BILLING_OPTIONS = {
-        :schedule => [:string, 'Schedule'],
-        :number_left => [:integer, 'NumLeft'],
-        :enabled => [:boolean, 'Enabled']
+        schedule: [:string, 'Schedule'],
+        number_left: [:integer, 'NumLeft'],
+        enabled: [:boolean, 'Enabled']
       } #:nodoc:
 
       AVS_RESULTS = {
@@ -290,7 +290,7 @@ module ActiveMerchant #:nodoc:
       # Note: See run_transaction for additional options.
       #
       def purchase(money, creditcard, options={})
-        run_sale(options.merge!(:amount => money, :payment_method => creditcard))
+        run_sale(options.merge!(amount: money, payment_method: creditcard))
       end
 
       # Authorize an amount on a credit card or account.
@@ -298,7 +298,7 @@ module ActiveMerchant #:nodoc:
       # Note: See run_transaction for additional options.
       #
       def authorize(money, creditcard, options={})
-        run_auth_only(options.merge!(:amount => money, :payment_method => creditcard))
+        run_auth_only(options.merge!(amount: money, payment_method: creditcard))
       end
 
       # Capture an authorized transaction.
@@ -306,7 +306,7 @@ module ActiveMerchant #:nodoc:
       # Note: See run_transaction for additional options.
       #
       def capture(money, identification, options={})
-        capture_transaction(options.merge!(:amount => money, :reference_number => identification))
+        capture_transaction(options.merge!(amount: money, reference_number: identification))
       end
 
       # Void a previous transaction that has not been settled.
@@ -314,7 +314,7 @@ module ActiveMerchant #:nodoc:
       # Note: See run_transaction for additional options.
       #
       def void(identification, options={})
-        void_transaction(options.merge!(:reference_number => identification))
+        void_transaction(options.merge!(reference_number: identification))
       end
 
       # Refund a previous transaction.
@@ -322,7 +322,7 @@ module ActiveMerchant #:nodoc:
       # Note: See run_transaction for additional options.
       #
       def refund(money, identification, options={})
-        refund_transaction(options.merge!(:amount => money, :reference_number => identification))
+        refund_transaction(options.merge!(amount: money, reference_number: identification))
       end
 
       def credit(money, identification, options={})
@@ -1031,7 +1031,7 @@ module ActiveMerchant #:nodoc:
       # Build soap header, etc.
       def build_request(action, options = {})
         soap = Builder::XmlMarkup.new
-        soap.instruct!(:xml, :version => '1.0', :encoding => 'utf-8')
+        soap.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         soap.tag! 'SOAP-ENV:Envelope',
           'xmlns:SOAP-ENV' => 'http://schemas.xmlsoap.org/soap/envelope/',
           'xmlns:ns1' => 'urn:usaepay',
@@ -1536,15 +1536,15 @@ module ActiveMerchant #:nodoc:
           success,
           message,
           response_params,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => avs_from(avs),
-          :cvv_result => cvv
+          test: test?,
+          authorization: authorization,
+          avs_result: avs_from(avs),
+          cvv_result: cvv
         )
       end
 
       def avs_from(avs)
-        avs_params = { :code => avs }
+        avs_params = { code: avs }
         avs_params[:message] = AVS_CUSTOM_MESSAGES[avs] if AVS_CUSTOM_MESSAGES.key?(avs)
         avs_params
       end
@@ -1552,7 +1552,7 @@ module ActiveMerchant #:nodoc:
       def parse(action, soap)
         xml = REXML::Document.new(soap)
         root = REXML::XPath.first(xml, '//SOAP-ENV:Body')
-        response = root ? parse_element(root[0]) : { :response => soap }
+        response = root ? parse_element(root[0]) : { response: soap }
 
         success, message, authorization, avs, cvv = false, FAILURE_MESSAGE, nil, nil, nil
 

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -10,13 +10,13 @@ module ActiveMerchant #:nodoc:
       self.display_name         = 'USA ePay'
 
       TRANSACTIONS = {
-        :authorization  => 'cc:authonly',
-        :purchase       => 'cc:sale',
-        :capture        => 'cc:capture',
-        :refund         => 'cc:refund',
-        :void           => 'cc:void',
-        :void_release   => 'cc:void:release',
-        :check_purchase => 'check:sale'
+        authorization: 'cc:authonly',
+        purchase: 'cc:sale',
+        capture: 'cc:capture',
+        refund: 'cc:refund',
+        void: 'cc:void',
+        void_release: 'cc:void:release',
+        check_purchase: 'check:sale'
       }
 
       STANDARD_ERROR_CODE_MAPPING = {
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
-        post = { :refNum => authorization }
+        post = { refNum: authorization }
 
         add_amount(post, money)
         add_test_mode(post, options)
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        post = { :refNum => authorization }
+        post = { refNum: authorization }
 
         add_amount(post, money)
         add_test_mode(post, options)
@@ -107,7 +107,7 @@ module ActiveMerchant #:nodoc:
       # Pass `no_release: true` to keep the void from immediately settling
       def void(authorization, options = {})
         command = (options[:no_release] ? :void : :void_release)
-        post = { :refNum => authorization }
+        post = { refNum: authorization }
         add_test_mode(post, options)
         commit(command, post)
       end
@@ -296,20 +296,20 @@ module ActiveMerchant #:nodoc:
         end
 
         {
-          :status           => fields['UMstatus'],
-          :auth_code        => fields['UMauthCode'],
-          :ref_num          => fields['UMrefNum'],
-          :batch            => fields['UMbatch'],
-          :avs_result       => fields['UMavsResult'],
-          :avs_result_code  => fields['UMavsResultCode'],
-          :cvv2_result      => fields['UMcvv2Result'],
-          :cvv2_result_code => fields['UMcvv2ResultCode'],
-          :vpas_result_code => fields['UMvpasResultCode'],
-          :result           => fields['UMresult'],
-          :error            => fields['UMerror'],
-          :error_code       => fields['UMerrorcode'],
-          :acs_url          => fields['UMacsurl'],
-          :payload          => fields['UMpayload']
+          status: fields['UMstatus'],
+          auth_code: fields['UMauthCode'],
+          ref_num: fields['UMrefNum'],
+          batch: fields['UMbatch'],
+          avs_result: fields['UMavsResult'],
+          avs_result_code: fields['UMavsResultCode'],
+          cvv2_result: fields['UMcvv2Result'],
+          cvv2_result_code: fields['UMcvv2ResultCode'],
+          vpas_result_code: fields['UMvpasResultCode'],
+          result: fields['UMresult'],
+          error: fields['UMerror'],
+          error_code: fields['UMerrorcode'],
+          acs_url: fields['UMacsurl'],
+          payload: fields['UMpayload']
         }.delete_if { |k, v| v.nil? }
       end
 
@@ -320,11 +320,11 @@ module ActiveMerchant #:nodoc:
         error_code = nil
         error_code = (STANDARD_ERROR_CODE_MAPPING[response[:error_code]] || STANDARD_ERROR_CODE[:processing_error]) unless approved
         Response.new(approved, message_from(response), response,
-          :test           => test?,
-          :authorization  => response[:ref_num],
-          :cvv_result     => response[:cvv2_result_code],
-          :avs_result     => { :code => response[:avs_result_code] },
-          :error_code     => error_code
+          test: test?,
+          authorization: response[:ref_num],
+          cvv_result: response[:cvv2_result_code],
+          avs_result: { code: response[:avs_result_code] },
+          error_code: error_code
         )
       end
 

--- a/lib/active_merchant/billing/gateways/verifi.rb
+++ b/lib/active_merchant/billing/gateways/verifi.rb
@@ -50,12 +50,12 @@ module ActiveMerchant #:nodoc:
       SUCCESS = 1
 
       TRANSACTIONS = {
-        :authorization => 'auth',
-        :purchase => 'sale',
-        :capture => 'capture',
-        :void => 'void',
-        :credit => 'credit',
-        :refund => 'refund'
+        authorization: 'auth',
+        purchase: 'sale',
+        capture: 'capture',
+        void: 'void',
+        credit: 'credit',
+        refund: 'refund'
       }
 
       self.supported_countries = ['US']
@@ -195,10 +195,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(trx_type, post)))
 
         Response.new(response[:response].to_i == SUCCESS, message_from(response), response,
-          :test => test?,
-          :authorization => response[:transactionid],
-          :avs_result => { :code => response[:avsresponse] },
-          :cvv_result => response[:cvvresponse]
+          test: test?,
+          authorization: response[:transactionid],
+          avs_result: { code: response[:avsresponse] },
+          cvv_result: response[:cvvresponse]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -8,8 +8,8 @@ module ActiveMerchant #:nodoc:
       self.delimiter = "\r\n"
 
       self.actions = {
-        :purchase => 'SALE',
-        :credit => 'CREDIT'
+        purchase: 'SALE',
+        credit: 'CREDIT'
       }
 
       APPROVED = '0'
@@ -137,10 +137,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters)))
 
         Response.new(response['result'] == APPROVED, message_from(response), response,
-          :test => @options[:test] || test?,
-          :authorization => authorization_from(response),
-          :avs_result => { :code => response['avs_response'] },
-          :cvv_result => response['cvv2_response']
+          test: @options[:test] || test?,
+          authorization: authorization_from(response),
+          avs_result: { code: response['avs_response'] },
+          cvv_result: response['cvv2_response']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -155,9 +155,9 @@ module ActiveMerchant #:nodoc:
           success_from(response),
           message_from(response, options, action),
           response,
-          :test => test?,
-          :authorization => authorization_from(params, response, options),
-          :error_code => response['errorCode']
+          test: test?,
+          authorization: authorization_from(params, response, options),
+          error_code: response['errorCode']
         )
       end
 
@@ -230,9 +230,9 @@ module ActiveMerchant #:nodoc:
           false,
           message_from(response, options, action),
           response,
-          :test => test?,
-          :authorization => response['transactionUUID'],
-          :error_code => response['errorCode']
+          test: test?,
+          authorization: response['transactionUUID'],
+          error_code: response['errorCode']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
 
             return r unless options[:set_default] and r.success? and !r.params['id'].blank?
 
-            r.process { update_customer(options[:customer], :default_card => r.params['id']) }
+            r.process { update_customer(options[:customer], default_card: r.params['id']) }
           end
         else
           commit(:post, 'customers', post, options)
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
           'Authorization' => 'Basic ' + Base64.encode64(@api_key.to_s + ':').strip,
           'User-Agent' => "Webpay/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'X-Webpay-Client-User-Agent' => user_agent,
-          'X-Webpay-Client-User-Metadata' => {:ip => options[:ip]}.to_json
+          'X-Webpay-Client-User-Metadata' => {ip: options[:ip]}.to_json
         }
       end
     end

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -180,10 +180,10 @@ module ActiveMerchant #:nodoc:
         authorization = response[:GuWID]
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => { :code => avs_code(response, options) },
-          :cvv_result => response[:CVCResponseCode]
+          test: test?,
+          authorization: authorization,
+          avs_result: { code: avs_code(response, options) },
+          cvv_result: response[:CVCResponseCode]
         )
       rescue ResponseError => e
         if e.response.code == '401'
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
       def build_request(action, money, options)
         options = prepare_options_hash(options)
         options[:action] = action
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'WIRECARD_BXML' do
           xml.tag! 'W_REQUEST' do

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -37,11 +37,11 @@ module ActiveMerchant #:nodoc:
           Response.new(false,
             'FAILED',
             'FAILED',
-            :test => test?,
-            :authorization => false,
-            :avs_result => {},
-            :cvv_result => {},
-            :error_code => false
+            test: test?,
+            authorization: false,
+            avs_result: {},
+            cvv_result: {},
+            error_code: false
           )
         end
       end
@@ -121,7 +121,7 @@ module ActiveMerchant #:nodoc:
           'Content-Type' => 'application/json',
           'User-Agent' => "Worldpay/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'X-Worldpay-Client-User-Agent' => user_agent,
-          'X-Worldpay-Client-User-Metadata' => {:ip => options[:ip]}.to_json
+          'X-Worldpay-Client-User-Metadata' => {ip: options[:ip]}.to_json
         }
         headers['Authorization'] = options['Authorization'] if options['Authorization']
         headers
@@ -174,11 +174,11 @@ module ActiveMerchant #:nodoc:
         Response.new(success,
           success ? 'SUCCESS' : response['message'],
           response,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => {},
-          :cvv_result => {},
-          :error_code => success ? nil : response['customCode']
+          test: test?,
+          authorization: authorization,
+          avs_result: {},
+          cvv_result: {},
+          error_code: success ? nil : response['customCode']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -196,8 +196,8 @@ module ActiveMerchant #:nodoc:
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(raw),
-          :test => test?
+          authorization: authorization_from(raw),
+          test: test?
         )
       end
 

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -72,7 +72,7 @@ module ActiveMerchant
       headers = headers.dup
       headers['connection'] ||= 'close'
 
-      retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do
+      retry_exceptions(max_retries: max_retries, logger: logger, tag: tag) do
         begin
           info "connection_http_method=#{method.to_s.upcase} connection_uri=#{endpoint}", tag
 

--- a/lib/active_merchant/post_data.rb
+++ b/lib/active_merchant/post_data.rb
@@ -2,7 +2,7 @@ require 'cgi'
 
 module ActiveMerchant
   class PostData < Hash
-    class_attribute :required_fields, :instance_writer => false
+    class_attribute :required_fields, instance_writer: false
     self.required_fields = []
 
     def []=(key, value)

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -27,10 +27,10 @@ class SSLVerify
         success << g
       when :fail
         print 'F'
-        failed << {:gateway => g, :message => message}
+        failed << {gateway: g, message: message}
       when :error
         print 'E'
-        errored << {:gateway => g, :message => message}
+        errored << {gateway: g, message: message}
       end
     end
 

--- a/lib/support/ssl_version.rb
+++ b/lib/support/ssl_version.rb
@@ -29,10 +29,10 @@ class SSLVersion
         success << g
       when :fail
         print 'F'
-        failed << {:gateway => g, :message => message}
+        failed << {gateway: g, message: message}
       when :error
         print 'E'
-        errored << {:gateway => g, :message => message}
+        errored << {gateway: g, message: message}
       end
     end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -7,68 +7,68 @@ class RemoteAdyenTest < Test::Unit::TestCase
     @amount = 100
 
     @credit_card = credit_card('4111111111111111',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'visa'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'visa'
     )
 
     @avs_credit_card = credit_card('4400000000000008',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'visa'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'visa'
     )
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
 
     @three_ds_enrolled_card = credit_card('4917610000000000', month: 10, year: 2020, verification_value: '737', brand: :visa)
 
     @cabal_credit_card = credit_card('6035 2277 1642 7021',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'cabal'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'cabal'
     )
 
     @invalid_cabal_credit_card = credit_card('6035 2200 0000 0006',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'cabal'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'cabal'
     )
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
-      :month => 10,
-      :year => 2030,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'unionpay'
+      month: 10,
+      year: 2030,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'unionpay'
     )
 
     @invalid_unionpay_credit_card = credit_card('8171 9999 1234 0000 921',
-      :month => 10,
-      :year => 2030,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'unionpay'
+      month: 10,
+      year: 2030,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'unionpay'
     )
 
     @declined_card = credit_card('4000300011112220')
@@ -84,19 +84,19 @@ class RemoteAdyenTest < Test::Unit::TestCase
     )
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      :month              => '08',
-      :year               => '2018',
-      :source             => :apple_pay,
-      :verification_value => nil
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      month: '08',
+      year: '2018',
+      source: :apple_pay,
+      verification_value: nil
     )
 
     @google_pay_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      :month              => '08',
-      :year               => '2018',
-      :source             => :google_pay,
-      :verification_value => nil
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      month: '08',
+      year: '2018',
+      source: :google_pay,
+      verification_value: nil
     )
 
     @options = {
@@ -251,12 +251,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
   # with rule set in merchant account to skip 3DS for cards of this brand
   def test_successful_authorize_with_3ds_dynamic_rule_broken
     mastercard_threed = credit_card('5212345678901234',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'mastercard'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'mastercard'
     )
     assert response = @gateway.authorize(@amount, mastercard_threed, @options.merge(threed_dynamic: true))
     assert response.test?

--- a/test/remote/gateways/remote_authorize_net_arb_test.rb
+++ b/test/remote/gateways/remote_authorize_net_arb_test.rb
@@ -8,17 +8,17 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
     @check = check
 
     @options = {
-      :amount => 100,
-      :subscription_name => 'Test Subscription 1',
-      :credit_card => @credit_card,
-      :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
-      :interval => {
-        :length => 1,
-        :unit => :months
+      amount: 100,
+      subscription_name: 'Test Subscription 1',
+      credit_card: @credit_card,
+      billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+      interval: {
+        length: 1,
+        unit: :months
       },
-      :duration => {
-        :start_date => Date.today,
-        :occurrences => 1
+      duration: {
+        start_date: Date.today,
+        occurrences: 1
       }
     }
   end
@@ -30,7 +30,7 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
 
     subscription_id = response.authorization
 
-    assert response = @gateway.update_recurring(:subscription_id => subscription_id, :amount => @amount * 2)
+    assert response = @gateway.update_recurring(subscription_id: subscription_id, amount: @amount * 2)
     assert_success response
 
     assert response = @gateway.status_recurring(subscription_id)
@@ -50,8 +50,8 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = AuthorizeNetArbGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     assert response = gateway.recurring(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -9,39 +9,39 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @payment = {
-      :credit_card => @credit_card
+      credit_card: @credit_card
     }
     @profile = {
-      :merchant_customer_id => 'Up to 20 chars', # Optional
-      :description => 'Up to 255 Characters', # Optional
-      :email => 'Up to 255 Characters', # Optional
-      :payment_profiles => { # Optional
-        :customer_type => 'individual', # Optional
-        :bill_to => address,
-        :payment => @payment
+      merchant_customer_id: 'Up to 20 chars', # Optional
+      description: 'Up to 255 Characters', # Optional
+      email: 'Up to 255 Characters', # Optional
+      payment_profiles: { # Optional
+        customer_type: 'individual', # Optional
+        bill_to: address,
+        payment: @payment
       },
-      :ship_to_list => {
-        :first_name => 'John',
-        :last_name => 'Doe',
-        :company => 'Widgets, Inc',
-        :address1 => '1234 Fake Street',
-        :city => 'Anytown',
-        :state => 'MD',
-        :zip => '12345',
-        :country => 'USA',
-        :phone_number => '(123)123-1234', # Optional - Up to 25 digits (no letters)
-        :fax_number => '(123)123-1234' # Optional - Up to 25 digits (no letters)
+      ship_to_list: {
+        first_name: 'John',
+        last_name: 'Doe',
+        company: 'Widgets, Inc',
+        address1: '1234 Fake Street',
+        city: 'Anytown',
+        state: 'MD',
+        zip: '12345',
+        country: 'USA',
+        phone_number: '(123)123-1234', # Optional - Up to 25 digits (no letters)
+        fax_number: '(123)123-1234' # Optional - Up to 25 digits (no letters)
       }
     }
     @options = {
-      :ref_id => '1234', # Optional
-      :profile => @profile
+      ref_id: '1234', # Optional
+      profile: @profile
     }
   end
 
   def teardown
     if @customer_profile_id
-      assert response = @gateway.delete_customer_profile(:customer_profile_id => @customer_profile_id)
+      assert response = @gateway.delete_customer_profile(customer_profile_id: @customer_profile_id)
       assert_success response
       @customer_profile_id = nil
     end
@@ -54,7 +54,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert response.test?
     assert_success response
     assert_equal @customer_profile_id, response.authorization
@@ -68,11 +68,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal @profile[:ship_to_list][:phone_number], response.params['profile']['ship_to_list']['phone_number']
     assert_equal @profile[:ship_to_list][:company], response.params['profile']['ship_to_list']['company']
 
-    assert response = @gateway.update_customer_profile(:profile => {:customer_profile_id => @customer_profile_id, :email => 'new email address'})
+    assert response = @gateway.update_customer_profile(profile: {customer_profile_id: @customer_profile_id, email: 'new email address'})
     assert response.test?
     assert_success response
     assert_nil response.authorization
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['merchant_customer_id']
     assert_nil response.params['profile']['description']
     assert_equal 'new email address', response.params['profile']['email']
@@ -85,15 +85,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_only,
-        :amount => @amount
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_only,
+        amount: @amount
       }
     )
 
@@ -111,12 +111,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     # Capture the previously authorized funds
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :capture_only,
-        :amount => @amount,
-        :approval_code => approval_code
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :capture_only,
+        amount: @amount,
+        approval_code: approval_code
       }
     )
 
@@ -133,22 +133,22 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => '1234',
-          :description => 'Test Order Description',
-          :purchase_order_number => '4321'
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: '1234',
+          description: 'Test Order Description',
+          purchase_order_number: '4321'
         },
-        :recurring_billing => true,
-        :card_code => '900', # authorize.net says this is a matching CVV
-        :amount => @amount
+        recurring_billing: true,
+        card_code: '900', # authorize.net says this is a matching CVV
+        amount: @amount
       }
     )
 
@@ -169,12 +169,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['payment_profiles']
 
     assert response = @gateway.create_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => payment_profile
+      customer_profile_id: @customer_profile_id,
+      payment_profile: payment_profile
     )
 
     assert response.test?
@@ -189,30 +189,30 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['payment_profiles']
 
     assert response = @gateway.create_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_type => 'individual', # Optional
-        :bill_to => @address,
-        :payment => {
-          :bank_account => {
-            :account_type => :checking,
-            :name_on_account => 'John Doe',
-            :echeck_type => :ccd,
-            :bank_name => 'Bank of America',
-            :routing_number => '123456789',
-            :account_number => '12345'
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_type: 'individual', # Optional
+        bill_to: @address,
+        payment: {
+          bank_account: {
+            account_type: :checking,
+            name_on_account: 'John Doe',
+            echeck_type: :ccd,
+            bank_name: 'Bank of America',
+            routing_number: '123456789',
+            account_number: '12345'
           }
         },
-        :drivers_license => {
-          :state => 'MD',
-          :number => '12345',
-          :date_of_birth => '1981-3-31'
+        drivers_license: {
+          state: 'MD',
+          number: '12345',
+          date_of_birth: '1981-3-31'
         },
-        :tax_id => '123456789'
+        tax_id: '123456789'
       }
     )
 
@@ -228,12 +228,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['ship_to_list']
 
     assert response = @gateway.create_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :address => shipping_address
+      customer_profile_id: @customer_profile_id,
+      address: shipping_address
     )
 
     assert response.test?
@@ -245,20 +245,20 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
   def test_successful_get_customer_profile_with_multiple_payment_profiles
     second_payment_profile = {
-      :customer_type => 'individual',
-      :bill_to => @address,
-      :payment => {
-        :credit_card => credit_card('1234123412341234')
+      customer_type: 'individual',
+      bill_to: @address,
+      payment: {
+        credit_card: credit_card('1234123412341234')
       }
     }
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
 
     assert response = @gateway.create_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => second_payment_profile
+      customer_profile_id: @customer_profile_id,
+      payment_profile: second_payment_profile
     )
 
     assert response.test?
@@ -267,7 +267,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert customer_payment_profile_id = response.params['customer_payment_profile_id']
     assert customer_payment_profile_id =~ /\d+/, "The customerPaymentProfileId should be numeric. It was #{customer_payment_profile_id}"
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_equal 2, response.params['profile']['payment_profiles'].size
     assert_equal 'XXXX4242', response.params['profile']['payment_profiles'][0]['payment']['credit_card']['card_number']
     assert_equal 'XXXX1234', response.params['profile']['payment_profiles'][1]['payment']['credit_card']['card_number']
@@ -277,19 +277,19 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     assert response = @gateway.delete_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     assert response.test?
     assert_success response
     assert_nil response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['payment_profiles']
   end
 
@@ -297,19 +297,19 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     assert response = @gateway.delete_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :customer_address_id => customer_address_id
+      customer_profile_id: @customer_profile_id,
+      customer_address_id: customer_address_id
     )
 
     assert response.test?
     assert_success response
     assert_nil response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['ship_to_list']
   end
 
@@ -317,12 +317,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     assert response.test?
@@ -338,13 +338,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id,
-      :unmask_expiration_date => true
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id,
+      unmask_expiration_date: true
     )
 
     assert response.test?
@@ -360,12 +360,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     assert response = @gateway.get_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :customer_address_id => customer_address_id
+      customer_profile_id: @customer_profile_id,
+      customer_address_id: customer_address_id
     )
 
     assert response.test?
@@ -381,13 +381,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @customer_profile_id = response.authorization
 
     # Get the customerPaymentProfileId
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     # Get the customerPaymentProfile
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     # The value before updating
@@ -395,11 +395,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     # Update the payment profile
     assert response = @gateway.update_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_payment_profile_id => customer_payment_profile_id,
-        :payment => {
-          :credit_card => credit_card('1234123412341234')
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_payment_profile_id: customer_payment_profile_id,
+        payment: {
+          credit_card: credit_card('1234123412341234')
         }
       }
     )
@@ -409,8 +409,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     # Get the updated payment profile
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     # Show that the payment profile was updated
@@ -419,25 +419,25 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_nil response.params['payment_profile']['customer_type']
 
     new_billing_address = response.params['payment_profile']['bill_to']
-    new_billing_address.update(:first_name => 'Frank', :last_name => 'Brown')
-    masked_credit_card = ActiveMerchant::Billing::CreditCard.new(:number => response.params['payment_profile']['payment']['credit_card']['card_number'])
+    new_billing_address.update(first_name: 'Frank', last_name: 'Brown')
+    masked_credit_card = ActiveMerchant::Billing::CreditCard.new(number: response.params['payment_profile']['payment']['credit_card']['card_number'])
 
     # Update only the billing address with a masked card and expiration date
     assert @gateway.update_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_payment_profile_id => customer_payment_profile_id,
-        :bill_to => new_billing_address,
-        :payment => {
-          :credit_card => masked_credit_card
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_payment_profile_id: customer_payment_profile_id,
+        bill_to: new_billing_address,
+        payment: {
+          credit_card: masked_credit_card
         }
       }
     )
 
     # Get the updated payment profile
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     # Show that the billing address on the payment profile was updated
@@ -450,40 +450,40 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @customer_profile_id = response.authorization
 
     # Get the customerPaymentProfileId
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     # Get the customerPaymentProfile
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     # Card number last 4 digits is 4242
     assert_equal 'XXXX4242', response.params['payment_profile']['payment']['credit_card']['card_number'], 'The card number should contain the last 4 digits of the card we passed in 4242'
 
     new_billing_address = response.params['payment_profile']['bill_to']
-    new_billing_address.update(:first_name => 'Frank', :last_name => 'Brown')
+    new_billing_address.update(first_name: 'Frank', last_name: 'Brown')
 
     # Initialize credit card with only last 4 digits as the number
-    last_four_credit_card = ActiveMerchant::Billing::CreditCard.new(:number => '4242') # Credit card with only last four digits
+    last_four_credit_card = ActiveMerchant::Billing::CreditCard.new(number: '4242') # Credit card with only last four digits
 
     # Update only the billing address with a card with the last 4 digits and expiration date
     assert @gateway.update_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_payment_profile_id => customer_payment_profile_id,
-        :bill_to => new_billing_address,
-        :payment => {
-          :credit_card => last_four_credit_card
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_payment_profile_id: customer_payment_profile_id,
+        bill_to: new_billing_address,
+        payment: {
+          credit_card: last_four_credit_card
         }
       }
     )
 
     # Get the updated payment profile
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => customer_payment_profile_id
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: customer_payment_profile_id
     )
 
     # Show that the billing address on the payment profile was updated
@@ -496,13 +496,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @customer_profile_id = response.authorization
 
     # Get the customerAddressId
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     # Get the customerShippingAddress
     assert response = @gateway.get_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :customer_address_id => customer_address_id
+      customer_profile_id: @customer_profile_id,
+      customer_address_id: customer_address_id
     )
 
     assert address = response.params['address']
@@ -511,14 +511,14 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     # Update the address and remove the phone_number
     new_address = address.symbolize_keys.merge!(
-      :address => '5678 Fake Street'
+      address: '5678 Fake Street'
     )
     new_address.delete(:phone_number)
 
     # Update the shipping address
     assert response = @gateway.update_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :address => new_address
+      customer_profile_id: @customer_profile_id,
+      address: new_address
     )
     assert response.test?
     assert_success response
@@ -526,8 +526,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     # Get the updated shipping address
     assert response = @gateway.get_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :customer_address_id => customer_address_id
+      customer_profile_id: @customer_profile_id,
+      customer_address_id: customer_address_id
     )
 
     # Show that the shipping address was updated
@@ -540,15 +540,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
     assert @customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     assert response = @gateway.validate_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id,
-      :customer_address_id => @customer_address_id,
-      :validation_mode => :live
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: @customer_payment_profile_id,
+      customer_address_id: @customer_address_id,
+      validation_mode: :live
     )
 
     assert response.test?
@@ -562,15 +562,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
     assert @customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     assert response = @gateway.validate_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id,
-      :customer_address_id => @customer_address_id,
-      :validation_mode => :live
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: @customer_payment_profile_id,
+      customer_address_id: @customer_address_id,
+      validation_mode: :live
     )
 
     assert response.test?
@@ -583,15 +583,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
     assert @customer_address_id = response.params['profile']['ship_to_list']['customer_address_id']
 
     assert response = @gateway.validate_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id,
-      :customer_address_id => @customer_address_id,
-      :validation_mode => :old
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: @customer_payment_profile_id,
+      customer_address_id: @customer_address_id,
+      validation_mode: :old
     )
 
     assert response.test?
@@ -603,24 +603,24 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     key = (Time.now.to_f * 1000000).to_i.to_s
 
     customer_profile_transaction = {
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => key.to_s,
-          :description => "Test Order Description #{key}",
-          :purchase_order_number => key.to_s
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: key.to_s,
+          description: "Test Order Description #{key}",
+          purchase_order_number: key.to_s
         },
-        :amount => @amount
+        amount: @amount
       },
-      :extra_options => { 'x_duplicate_window' => 1 }
+      extra_options: { 'x_duplicate_window' => 1 }
     }
 
     assert response = @gateway.create_customer_profile_transaction(customer_profile_transaction)
@@ -639,22 +639,22 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     key = (Time.now.to_f * 1000000).to_i.to_s
 
     customer_profile_transaction = {
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => key.to_s,
-          :description => "Test Order Description #{key}",
-          :purchase_order_number => key.to_s
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: key.to_s,
+          description: "Test Order Description #{key}",
+          purchase_order_number: key.to_s
         },
-        :amount => @amount
+        amount: @amount
       }
     }
 
@@ -674,9 +674,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     response = get_and_validate_auth_capture_response
 
     assert response = @gateway.create_customer_profile_transaction_for_void(
-      :transaction => {
-        :type => :void,
-        :trans_id => response.params['direct_response']['transaction_id']
+      transaction: {
+        type: :void,
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -689,12 +689,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     response = get_and_validate_auth_capture_response
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :trans_id => response.params['direct_response']['transaction_id']
+      transaction: {
+        type: :refund,
+        amount: 1,
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -710,13 +710,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     response = get_and_validate_auth_capture_response
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :trans_id => response.params['direct_response']['transaction_id'],
-        :order => {}
+      transaction: {
+        type: :refund,
+        amount: 1,
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        trans_id: response.params['direct_response']['transaction_id'],
+        order: {}
       }
     )
     assert_instance_of Response, response
@@ -732,11 +732,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     response = get_and_validate_auth_capture_response
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
-        :credit_card_number_masked => 'XXXX4242',
-        :trans_id => response.params['direct_response']['transaction_id']
+      transaction: {
+        type: :refund,
+        amount: 1,
+        credit_card_number_masked: 'XXXX4242',
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -752,10 +752,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     response = get_and_validate_auth_only_response
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :prior_auth_capture,
-        :trans_id => response.params['direct_response']['transaction_id'],
-        :amount => response.params['direct_response']['amount']
+      transaction: {
+        type: :prior_auth_capture,
+        trans_id: response.params['direct_response']['transaction_id'],
+        amount: response.params['direct_response']['amount']
       }
     )
     assert_instance_of Response, response
@@ -770,30 +770,30 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_nil response.params['profile']['payment_profiles']
 
     assert response = @gateway.create_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_type => 'individual', # Optional
-        :bill_to => @address,
-        :payment => {
-          :bank_account => {
-            :account_type => :checking,
-            :name_on_account => 'John Doe',
-            :echeck_type => :ccd,
-            :bank_name => 'Bank of America',
-            :routing_number => '123456789',
-            :account_number => '12345678'
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_type: 'individual', # Optional
+        bill_to: @address,
+        payment: {
+          bank_account: {
+            account_type: :checking,
+            name_on_account: 'John Doe',
+            echeck_type: :ccd,
+            bank_name: 'Bank of America',
+            routing_number: '123456789',
+            account_number: '12345678'
           }
         },
-        :drivers_license => {
-          :state => 'MD',
-          :number => '12345',
-          :date_of_birth => '1981-3-31'
+        drivers_license: {
+          state: 'MD',
+          number: '12345',
+          date_of_birth: '1981-3-31'
         },
-        :tax_id => '123456789'
+        tax_id: '123456789'
       }
     )
 
@@ -809,22 +809,22 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.create_customer_profile(@options)
     @customer_profile_id = response.authorization
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
 
     key = (Time.now.to_f * 1000000).to_i.to_s
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => key.to_s,
-          :description => "Test Order Description #{key}",
-          :purchase_order_number => key.to_s
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: key.to_s,
+          description: "Test Order Description #{key}",
+          purchase_order_number: key.to_s
         },
-        :amount => @amount
+        amount: @amount
       }
     )
 
@@ -847,19 +847,19 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     key = (Time.now.to_f * 1000000).to_i.to_s
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     @customer_payment_profile_id = response.params['profile']['payment_profiles']['customer_payment_profile_id']
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_only,
-        :order => {
-          :invoice_number => key.to_s,
-          :description => "Test Order Description #{key}",
-          :purchase_order_number => key.to_s
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_only,
+        order: {
+          invoice_number: key.to_s,
+          description: "Test Order Description #{key}",
+          purchase_order_number: key.to_s
         },
-        :amount => @amount
+        amount: @amount
       }
     )
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -229,7 +229,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_card_present_authorize_and_capture_with_track_data_only
-    track_credit_card = ActiveMerchant::Billing::CreditCard.new(:track_data => '%B378282246310005^LONGSON/LONGBOB^1705101130504392?')
+    track_credit_card = ActiveMerchant::Billing::CreditCard.new(track_data: '%B378282246310005^LONGSON/LONGBOB^1705101130504392?')
     assert authorization = @gateway.authorize(@amount, track_credit_card, @options)
     assert_success authorization
 
@@ -254,7 +254,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_card_present_purchase_with_track_data_only
-    track_credit_card = ActiveMerchant::Billing::CreditCard.new(:track_data => '%B378282246310005^LONGSON/LONGBOB^1705101130504392?')
+    track_credit_card = ActiveMerchant::Billing::CreditCard.new(track_data: '%B378282246310005^LONGSON/LONGBOB^1705101130504392?')
     response = @gateway.purchase(@amount, track_credit_card, @options)
     assert response.test?
     assert_equal 'This transaction has been approved', response.message
@@ -563,8 +563,8 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = AuthorizeNetGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     response = gateway.purchase(@amount, @credit_card)
@@ -720,9 +720,9 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_network_tokenization_transcript_scrubbing
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
 
     transcript = capture_transcript(@gateway) do

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -7,8 +7,8 @@ class RemoteBanwireTest < Test::Unit::TestCase
     @gateway = BanwireGateway.new(fixtures(:banwire))
 
     @amount = 100
-    @credit_card = credit_card('5204164299999999', :verification_value => '999', :brand => 'mastercard')
-    @visa_credit_card = credit_card('4485814063899108', :verification_value => '434')
+    @credit_card = credit_card('5204164299999999', verification_value: '999', brand: 'mastercard')
+    @visa_credit_card = credit_card('4485814063899108', verification_value: '434')
 
     @declined_card = credit_card('4000300011112220')
     @options = {
@@ -45,8 +45,8 @@ class RemoteBanwireTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BanwireGateway.new(
-      :login => 'fakeuser',
-      :currency => 'MXN'
+      login: 'fakeuser',
+      currency: 'MXN'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -7,8 +7,8 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
 
     @amount = 100
     @error_amount = 1_000_000_000_000_000_000_000
-    @credit_card = credit_card('4111111111111111', :month => 10, :year => 2020, :verification_value => 737)
-    @declined_card = credit_card('4000300011112220', :month => 3, :year => 2030, :verification_value => 737)
+    @credit_card = credit_card('4111111111111111', month: 10, year: 2020, verification_value: 737)
+    @declined_card = credit_card('4000300011112220', month: 3, year: 2030, verification_value: 737)
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
     @three_ds_2_enrolled_card = credit_card('4917610000000000', month: 10, year: 2020, verification_value: '737', brand: :visa)
 
@@ -101,9 +101,9 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     }
 
     @avs_credit_card = credit_card('4400000000000008',
-      :month => 8,
-      :year => 2018,
-      :verification_value => 737)
+      month: 8,
+      year: 2018,
+      verification_value: 737)
 
     @avs_address = @options.clone
     @avs_address.update(billing_address: {
@@ -390,7 +390,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_failed_store
-    response = @gateway.store(credit_card('4111111111111111', :month => '', :year => '', :verification_value => ''), @options)
+    response = @gateway.store(credit_card('4111111111111111', month: '', year: '', verification_value: ''), @options)
     assert_failure response
     assert_equal '129: Expiry Date Invalid', response.message
   end
@@ -409,17 +409,17 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_nonfractional_currency
-    response = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'JPY'))
+    response = @gateway.authorize(1234, @credit_card, @options.merge(currency: 'JPY'))
     assert_success response
-    response = @gateway.purchase(1234, @credit_card, @options.merge(:currency => 'JPY'))
+    response = @gateway.purchase(1234, @credit_card, @options.merge(currency: 'JPY'))
     assert_success response
   end
 
   def test_three_decimal_currency
-    response = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'OMR'))
+    response = @gateway.authorize(1234, @credit_card, @options.merge(currency: 'OMR'))
     assert_success response
 
-    response = @gateway.purchase(1234, @credit_card, @options.merge(:currency => 'OMR'))
+    response = @gateway.purchase(1234, @credit_card, @options.merge(currency: 'OMR'))
     assert_success response
   end
 

--- a/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
+++ b/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
@@ -6,15 +6,15 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def setup
     @gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus))
     @amount = 100
-    @credit_card     = credit_card('4000100011112224', :verification_value => '987')
-    @mastercard      = credit_card('5399999999999999', :brand => 'mastercard')
+    @credit_card     = credit_card('4000100011112224', verification_value: '987')
+    @mastercard      = credit_card('5399999999999999', brand: 'mastercard')
     @declined_card   = credit_card('1111111111111111')
-    @credit_card_d3d = credit_card('4000000000000002', :verification_value => '111')
+    @credit_card_d3d = credit_card('4000000000000002', verification_value: '111')
     @options = {
-      :order_id => generate_unique_id[0...30],
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :currency => fixtures(:barclays_epdq_extra_plus)[:currency] || 'GBP'
+      order_id: generate_unique_id[0...30],
+      billing_address: address,
+      description: 'Store Purchase',
+      currency: fixtures(:barclays_epdq_extra_plus)[:currency] || 'GBP'
     }
   end
 
@@ -37,13 +37,13 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_utf8_encoding_1
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', :first_name => 'Rémy', :last_name => 'Fröåïør'), @options)
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', first_name: 'Rémy', last_name: 'Fröåïør'), @options)
     assert_success response
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
   end
 
   def test_successful_purchase_with_utf8_encoding_2
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', :first_name => 'ワタシ', :last_name => 'ёжзийклмнопрсуфхцч'), @options)
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', first_name: 'ワタシ', last_name: 'ёжзийклмнопрсуфхцч'), @options)
     assert_success response
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
   end
@@ -51,7 +51,7 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   # NOTE: You have to set the "Hash algorithm" to "SHA-1" in the "Technical information"->"Global security parameters"
   #       section of your account admin before running this test
   def test_successful_purchase_with_signature_encryptor_to_sha1
-    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:signature_encryptor => 'sha1'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(signature_encryptor: 'sha1'))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
@@ -60,7 +60,7 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   # NOTE: You have to set the "Hash algorithm" to "SHA-256" in the "Technical information"->"Global security parameters"
   #       section of your account admin before running this test
   def test_successful_purchase_with_signature_encryptor_to_sha256
-    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:signature_encryptor => 'sha256'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(signature_encryptor: 'sha256'))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
@@ -69,7 +69,7 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   # NOTE: You have to set the "Hash algorithm" to "SHA-512" in the "Technical information"->"Global security parameters"
   #       section of your account admin before running this test
   def test_successful_purchase_with_signature_encryptor_to_sha512
-    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:signature_encryptor => 'sha512'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(signature_encryptor: 'sha512'))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
@@ -216,10 +216,10 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BarclaysEpdqExtraPlusGateway.new(
-      :login => '',
-      :user => '',
-      :password => '',
-      :signature_encryptor => 'none'
+      login: '',
+      user: '',
+      password: '',
+      signature_encryptor: 'none'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_be2bill_test.rb
+++ b/test/remote/gateways/remote_be2bill_test.rb
@@ -9,13 +9,13 @@ class RemoteBe2billTest < Test::Unit::TestCase
     @declined_card = credit_card('5555557376384001')
 
     @options = {
-      :order_id     => '1',
-      :description  => 'Store Purchase',
-      :client_id    => '1',
-      :referrer     => 'google.com',
-      :user_agent   => 'Firefox 25',
-      :ip           => '127.0.0.1',
-      :email        => 'customer@yopmail.com'
+      order_id: '1',
+      description: 'Store Purchase',
+      client_id: '1',
+      referrer: 'google.com',
+      user_agent: 'Firefox 25',
+      ip: '127.0.0.1',
+      email: 'customer@yopmail.com'
     }
   end
 
@@ -49,8 +49,8 @@ class RemoteBe2billTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = Be2billGateway.new(
-      :login    => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_beanstream_interac_test.rb
+++ b/test/remote/gateways/remote_beanstream_interac_test.rb
@@ -7,23 +7,23 @@ class RemoteBeanstreamInteracTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => {
-        :name => 'xiaobo zzz',
-        :phone => '555-555-5555',
-        :address1 => '1234 Levesque St.',
-        :address2 => 'Apt B',
-        :city => 'Montreal',
-        :state => 'QC',
-        :country => 'CA',
-        :zip => 'H2C1X8'
+      order_id: generate_unique_id,
+      billing_address: {
+        name: 'xiaobo zzz',
+        phone: '555-555-5555',
+        address1: '1234 Levesque St.',
+        address2: 'Apt B',
+        city: 'Montreal',
+        state: 'QC',
+        country: 'CA',
+        zip: 'H2C1X8'
       },
-      :email => 'xiaobozzz@example.com',
-      :subtotal => 800,
-      :shipping => 100,
-      :tax1 => 100,
-      :tax2 => 100,
-      :custom => 'reference one'
+      email: 'xiaobozzz@example.com',
+      subtotal: 800,
+      shipping: 100,
+      tax1: 100,
+      tax2: 100,
+      custom: 'reference one'
     }
   end
 
@@ -41,9 +41,9 @@ class RemoteBeanstreamInteracTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BeanstreamInteracGateway.new(
-      :merchant_id => '',
-      :login => '',
-      :password => ''
+      merchant_id: '',
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @options)
     assert_failure response

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -17,50 +17,50 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     @mastercard          = credit_card('5100000010001004')
     @declined_mastercard = credit_card('5100000020002000')
 
-    @amex                = credit_card('371100001000131', {:verification_value => 1234})
-    @declined_amex       = credit_card('342400001000180', {:verification_value => 1234})
+    @amex                = credit_card('371100001000131', {verification_value: 1234})
+    @declined_amex       = credit_card('342400001000180', {verification_value: 1234})
 
     # Canadian EFT
     @check = check(
-      :institution_number => '001',
-      :transit_number     => '26729'
+      institution_number: '001',
+      transit_number: '26729'
     )
 
     @amount = 1500
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => {
-        :name => 'xiaobo zzz',
-        :phone => '555-555-5555',
-        :address1 => '4444 Levesque St.',
-        :address2 => 'Apt B',
-        :city => 'Montreal',
-        :state => 'Quebec',
-        :country => 'CA',
-        :zip => 'H2C1X8'
+      order_id: generate_unique_id,
+      billing_address: {
+        name: 'xiaobo zzz',
+        phone: '555-555-5555',
+        address1: '4444 Levesque St.',
+        address2: 'Apt B',
+        city: 'Montreal',
+        state: 'Quebec',
+        country: 'CA',
+        zip: 'H2C1X8'
       },
-      :shipping_address => {
-        :name => 'shippy',
-        :phone => '888-888-8888',
-        :address1 => '777 Foster Street',
-        :address2 => 'Ste #100',
-        :city => 'Durham',
-        :state => 'North Carolina',
-        :country => 'US',
-        :zip => '27701'
+      shipping_address: {
+        name: 'shippy',
+        phone: '888-888-8888',
+        address1: '777 Foster Street',
+        address2: 'Ste #100',
+        city: 'Durham',
+        state: 'North Carolina',
+        country: 'US',
+        zip: '27701'
       },
-      :email => 'xiaobozzz@example.com',
-      :subtotal => 800,
-      :shipping => 100,
-      :tax1 => 100,
-      :tax2 => 100,
-      :custom => 'reference one'
+      email: 'xiaobozzz@example.com',
+      subtotal: 800,
+      shipping: 100,
+      tax1: 100,
+      tax2: 100,
+      custom: 'reference one'
     }
 
     @recurring_options = @options.merge(
-      :interval => { :unit => :months, :length => 1 },
-      :occurences => 5)
+      interval: { unit: :months, length: 1 },
+      occurences: 5)
   end
 
   def test_successful_visa_purchase
@@ -145,9 +145,9 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_only_email
     options = {
-      :order_id => generate_unique_id,
-      :email => 'xiaobozzz@example.com',
-      :shipping_email => 'ship@mail.com'
+      order_id: generate_unique_id,
+      email: 'xiaobozzz@example.com',
+      shipping_email: 'ship@mail.com'
     }
 
     assert response = @gateway.purchase(@amount, @visa, options)
@@ -292,7 +292,7 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert response.test?
     assert_false response.authorization.blank?
 
-    assert response = @gateway.update_recurring(@amount + 500, @visa, @recurring_options.merge(:account_id => response.params['rbAccountId']))
+    assert response = @gateway.update_recurring(@amount + 500, @visa, @recurring_options.merge(account_id: response.params['rbAccountId']))
     assert_success response
   end
 
@@ -302,15 +302,15 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert response.test?
     assert_false response.authorization.blank?
 
-    assert response = @gateway.cancel_recurring(:account_id => response.params['rbAccountId'])
+    assert response = @gateway.cancel_recurring(account_id: response.params['rbAccountId'])
     assert_success response
   end
 
   def test_invalid_login
     gateway = BeanstreamGateway.new(
-      :merchant_id => '',
-      :login => '',
-      :password => ''
+      merchant_id: '',
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_failure response

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -8,19 +8,19 @@ class BluePayTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store purchase',
-      :ip => '192.168.0.1'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase',
+      ip: '192.168.0.1'
     }
 
     @recurring_options = {
-      :rebill_amount => 100,
-      :rebill_start_date => Date.today,
-      :rebill_expression => '1 DAY',
-      :rebill_cycles => '4',
-      :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
-      :duplicate_override => 1
+      rebill_amount: 100,
+      rebill_start_date: Date.today,
+      rebill_expression: '1 DAY',
+      rebill_cycles: '4',
+      billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+      duplicate_override: 1
     }
   end
 
@@ -34,7 +34,7 @@ class BluePayTest < Test::Unit::TestCase
 
   #  The included test account credentials do not support ACH processor.
   def test_successful_purchase_with_check
-    assert response = @gateway.purchase(@amount, check, @options.merge(:email=>'foo@example.com'))
+    assert response = @gateway.purchase(@amount, check, @options.merge(email: 'foo@example.com'))
     assert_success response
     assert response.test?
     assert_equal 'App ACH Sale', response.message
@@ -50,7 +50,7 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_forced_test_mode_purchase
-    gateway = BluePayGateway.new(fixtures(:blue_pay).update(:test => true))
+    gateway = BluePayGateway.new(fixtures(:blue_pay).update(test: true))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert response.test?
@@ -81,7 +81,7 @@ class BluePayTest < Test::Unit::TestCase
     assert response = @gateway.recurring(@amount, @credit_card, @recurring_options)
     assert_success response
     rebill_id = response.params['rebid']
-    assert response = @gateway.update_recurring(:rebill_id => rebill_id, :rebill_amount => @amount * 2)
+    assert response = @gateway.update_recurring(rebill_id: rebill_id, rebill_amount: @amount * 2)
     assert_success response
 
     response_keys = response.params.keys.map(&:to_sym)
@@ -111,8 +111,8 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = BluePayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     assert response = gateway.purchase(@amount, @credit_card)
 
@@ -123,8 +123,8 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_using_test_request
     gateway = BluePayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     assert response = gateway.purchase(@amount, @credit_card)
     assert_equal Response, response.class
@@ -140,7 +140,7 @@ class BluePayTest < Test::Unit::TestCase
 
     rebill_id = response.params['rebid']
 
-    assert response = @gateway.update_recurring(:rebill_id => rebill_id, :rebill_amount => @amount * 2)
+    assert response = @gateway.update_recurring(rebill_id: rebill_id, rebill_amount: @amount * 2)
     assert_success response
 
     assert response = @gateway.status_recurring(rebill_id)
@@ -172,19 +172,19 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_check
-    assert response = @gateway.purchase(@amount, check, @options.merge(:email=>'foo@example.com'))
+    assert response = @gateway.purchase(@amount, check, @options.merge(email: 'foo@example.com'))
     assert_success response
     assert response.test?
     assert_equal 'App ACH Sale', response.message
     assert response.authorization
 
-    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(:doc_type=>'PPD'))
+    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(doc_type: 'PPD'))
     assert_success refund
     assert_equal 'App ACH Void', refund.message
   end
 
   def test_successful_credit_with_check
-    assert credit = @gateway.credit(@amount, check, @options.merge(:doc_type=>'PPD'))
+    assert credit = @gateway.credit(@amount, check, @options.merge(doc_type: 'PPD'))
     assert_success credit
     assert_equal 'App ACH Credit', credit.message
   end

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -33,7 +33,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     )
 
     @check = check
-    @invalid_check = check(:routing_number => '123456', :account_number => '123456789')
+    @invalid_check = check(routing_number: '123456', account_number: '123456789')
     @valid_check_options = {
       billing_address: {
         address1: '123 Street',

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -11,9 +11,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address(:country_name => 'Canada'),
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address(country_name: 'Canada'),
+      description: 'Store Purchase'
     }
   end
 
@@ -41,16 +41,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_authorize_with_nil_and_empty_billing_address_options
     credit_card = credit_card('5105105105105100')
     options = {
-      :billing_address => {
-        :name => 'John Smith',
-        :phone => '123-456-7890',
-        :company => nil,
-        :address1 => nil,
-        :address2 => '',
-        :city => nil,
-        :state => nil,
-        :zip => nil,
-        :country => ''
+      billing_address: {
+        name: 'John Smith',
+        phone: '123-456-7890',
+        company: nil,
+        address1: nil,
+        address2: '',
+        city: nil,
+        state: nil,
+        zip: nil,
+        country: ''
       }
     }
     assert response = @gateway.authorize(@amount, credit_card, options)
@@ -68,14 +68,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_order_id
-    assert response = @gateway.authorize(@amount, @credit_card, :order_id => '123')
+    assert response = @gateway.authorize(@amount, @credit_card, order_id: '123')
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal '123', response.params['braintree_transaction']['order_id']
   end
 
   def test_successful_purchase_with_hold_in_escrow
-    @options.merge({:merchant_account_id => fixtures(:braintree_blue)[:merchant_account_id], :hold_in_escrow => true})
+    @options.merge({merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id], hold_in_escrow: true})
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal '1000 Approved', response.message
@@ -116,49 +116,49 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     credit_card_token = response.params['credit_card_token']
     assert_match %r{^\w+$}, credit_card_token
 
-    assert response = @gateway.purchase(@amount, credit_card_token, :payment_method_token => true)
+    assert response = @gateway.purchase(@amount, credit_card_token, payment_method_token: true)
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
   end
 
   def test_successful_purchase_with_level_2_data
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:tax_amount => '20', :purchase_order_number => '6789'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(tax_amount: '20', purchase_order_number: '6789'))
     assert_success response
     assert_equal '1000 Approved', response.message
   end
 
   def test_successful_purchase_with_level_2_and_3_data
     options = {
-      :tax_amount => '20',
-      :purchase_order_number => '6789',
-      :shipping_amount => '300',
-      :discount_amount => '150',
-      :ships_from_postal_code => '90210',
-      :line_items => [
+      tax_amount: '20',
+      purchase_order_number: '6789',
+      shipping_amount: '300',
+      discount_amount: '150',
+      ships_from_postal_code: '90210',
+      line_items: [
         {
-          :name => 'Product Name',
-          :kind => 'debit',
-          :quantity => '10.0000',
-          :unit_amount => '9.5000',
-          :unit_of_measure => 'unit',
-          :total_amount => '95.00',
-          :tax_amount => '5.00',
-          :discount_amount => '0.00',
-          :product_code => '54321',
-          :commodity_code => '98765'
+          name: 'Product Name',
+          kind: 'debit',
+          quantity: '10.0000',
+          unit_amount: '9.5000',
+          unit_of_measure: 'unit',
+          total_amount: '95.00',
+          tax_amount: '5.00',
+          discount_amount: '0.00',
+          product_code: '54321',
+          commodity_code: '98765'
         },
         {
-          :name => 'Other Product Name',
-          :kind => 'debit',
-          :quantity => '1.0000',
-          :unit_amount => '2.5000',
-          :unit_of_measure => 'unit',
-          :total_amount => '90.00',
-          :tax_amount => '2.00',
-          :discount_amount => '1.00',
-          :product_code => '54322',
-          :commodity_code => '98766'
+          name: 'Other Product Name',
+          kind: 'debit',
+          quantity: '1.0000',
+          unit_amount: '2.5000',
+          unit_of_measure: 'unit',
+          total_amount: '90.00',
+          tax_amount: '2.00',
+          discount_amount: '1.00',
+          product_code: '54322',
+          commodity_code: '98766'
         }
       ]
     }
@@ -194,22 +194,22 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_validate_on_store
-    card = credit_card('4111111111111111', :verification_value => '101')
-    assert response = @gateway.store(card, :verify_card => true)
+    card = credit_card('4111111111111111', verification_value: '101')
+    assert response = @gateway.store(card, verify_card: true)
     assert_success response
     assert_equal 'OK', response.message
   end
 
   def test_failed_validate_on_store
-    card = credit_card('4000111111111115', :verification_value => '200')
-    assert response = @gateway.store(card, :verify_card => true)
+    card = credit_card('4000111111111115', verification_value: '200')
+    assert response = @gateway.store(card, verify_card: true)
     assert_failure response
     assert_equal 'Processor declined: Do Not Honor (2000)', response.message
   end
 
   def test_successful_store_with_no_validate
-    card = credit_card('4000111111111115', :verification_value => '200')
-    assert response = @gateway.store(card, :verify_card => false)
+    card = credit_card('4000111111111115', verification_value: '200')
+    assert response = @gateway.store(card, verify_card: false)
     assert_success response
     assert_equal 'OK', response.message
   end
@@ -222,15 +222,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_store_with_billing_address
     billing_address = {
-      :address1 => '1 E Main St',
-      :address2 => 'Suite 403',
-      :city => 'Chicago',
-      :state => 'Illinois',
-      :zip => '60622',
-      :country_name => 'United States of America'
+      address1: '1 E Main St',
+      address2: 'Suite 403',
+      city: 'Chicago',
+      state: 'Illinois',
+      zip: '60622',
+      country_name: 'United States of America'
     }
     credit_card = credit_card('5105105105105100')
-    assert response = @gateway.store(credit_card, :billing_address => billing_address)
+    assert response = @gateway.store(credit_card, billing_address: billing_address)
     assert_success response
     assert_equal 'OK', response.message
 
@@ -250,18 +250,18 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_store_with_nil_billing_address_options
     billing_address = {
-      :name => 'John Smith',
-      :phone => '123-456-7890',
-      :company => nil,
-      :address1 => nil,
-      :address2 => nil,
-      :city => nil,
-      :state => nil,
-      :zip => nil,
-      :country_name => nil
+      name: 'John Smith',
+      phone: '123-456-7890',
+      company: nil,
+      address1: nil,
+      address2: nil,
+      city: nil,
+      state: nil,
+      zip: nil,
+      country_name: nil
     }
     credit_card = credit_card('5105105105105100')
-    assert response = @gateway.store(credit_card, :billing_address => billing_address)
+    assert response = @gateway.store(credit_card, billing_address: billing_address)
     assert_success response
     assert_equal 'OK', response.message
 
@@ -309,17 +309,17 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     credit_card = credit_card('5105105105105100')
     customer_id = generate_unique_id
     options = {
-      :customer => customer_id,
-      :billing_address => {
-        :name => 'John Smith',
-        :phone => '123-456-7890',
-        :company => nil,
-        :address1 => nil,
-        :address2 => nil,
-        :city => nil,
-        :state => nil,
-        :zip => nil,
-        :country_name => nil
+      customer: customer_id,
+      billing_address: {
+        name: 'John Smith',
+        phone: '123-456-7890',
+        company: nil,
+        address1: nil,
+        address2: nil,
+        city: nil,
+        state: nil,
+        zip: nil,
+        country_name: nil
       }
     }
     assert response = @gateway.store(credit_card, options)
@@ -377,20 +377,20 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_cvv_match
-    assert response = @gateway.purchase(@amount, credit_card('5105105105105100', :verification_value => '400'))
+    assert response = @gateway.purchase(@amount, credit_card('5105105105105100', verification_value: '400'))
     assert_success response
     assert_equal({'code' => 'M', 'message' => ''}, response.cvv_result)
   end
 
   def test_cvv_no_match
-    assert response = @gateway.purchase(@amount, credit_card('5105105105105100', :verification_value => '200'))
+    assert response = @gateway.purchase(@amount, credit_card('5105105105105100', verification_value: '200'))
     assert_success response
     assert_equal({'code' => 'N', 'message' => ''}, response.cvv_result)
   end
 
   def test_successful_purchase_with_email
     assert response = @gateway.purchase(@amount, @credit_card,
-      :email => 'customer@example.com'
+      email: 'customer@example.com'
     )
     assert_success response
     transaction = response.params['braintree_transaction']
@@ -398,7 +398,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_phone
-    assert response = @gateway.purchase(@amount, @credit_card, :phone => '123-345-5678')
+    assert response = @gateway.purchase(@amount, @credit_card, phone: '123-345-5678')
     assert_success response
     transaction = response.params['braintree_transaction']
     assert_equal '123-345-5678', transaction['customer_details']['phone']
@@ -448,7 +448,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_purchase_with_store_using_random_customer_id
     assert response = @gateway.purchase(
-      @amount, credit_card('5105105105105100'), @options.merge(:store => true)
+      @amount, credit_card('5105105105105100'), @options.merge(store: true)
     )
     assert_success response
     assert_equal '1000 Approved', response.message
@@ -460,7 +460,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_purchase_with_store_using_specified_customer_id
     customer_id = rand(1_000_000_000).to_s
     assert response = @gateway.purchase(
-      @amount, credit_card('5105105105105100'), @options.merge(:store => customer_id)
+      @amount, credit_card('5105105105105100'), @options.merge(store: customer_id)
     )
     assert_success response
     assert_equal '1000 Approved', response.message
@@ -474,7 +474,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success response
     customer_vault_id = response.params['customer_vault_id']
 
-    assert response = @gateway.purchase(@amount, customer_vault_id, @options.merge(:transaction_source => 'unscheduled'))
+    assert response = @gateway.purchase(@amount, customer_vault_id, @options.merge(transaction_source: 'unscheduled'))
     assert_success response
     assert_equal '1000 Approved', response.message
   end
@@ -482,11 +482,11 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_purchase_using_specified_payment_method_token
     assert response = @gateway.store(
       credit_card('4111111111111111',
-        :first_name => 'Old First', :last_name => 'Old Last',
-        :month => 9, :year => 2012
+        first_name: 'Old First', last_name: 'Old Last',
+        month: 9, year: 2012
       ),
-      :email => 'old@example.com',
-      :phone => '321-654-0987'
+      email: 'old@example.com',
+      phone: '321-654-0987'
     )
     payment_method_token = response.params['braintree_customer']['credit_cards'][0]['token']
     assert response = @gateway.purchase(
@@ -499,26 +499,26 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_addresses
     billing_address = {
-      :address1 => '1 E Main St',
-      :address2 => 'Suite 101',
-      :company => 'Widgets Co',
-      :city => 'Chicago',
-      :state => 'IL',
-      :zip => '60622',
-      :country_name => 'United States of America'
+      address1: '1 E Main St',
+      address2: 'Suite 101',
+      company: 'Widgets Co',
+      city: 'Chicago',
+      state: 'IL',
+      zip: '60622',
+      country_name: 'United States of America'
     }
     shipping_address = {
-      :address1 => '1 W Main St',
-      :address2 => 'Suite 102',
-      :company => 'Widgets Company',
-      :city => 'Bartlett',
-      :state => 'Illinois',
-      :zip => '60103',
-      :country_name => 'Mexico'
+      address1: '1 W Main St',
+      address2: 'Suite 102',
+      company: 'Widgets Company',
+      city: 'Bartlett',
+      state: 'Illinois',
+      zip: '60103',
+      country_name: 'Mexico'
     }
     assert response = @gateway.purchase(@amount, @credit_card,
-      :billing_address => billing_address,
-      :shipping_address => shipping_address
+      billing_address: billing_address,
+      shipping_address: shipping_address
     )
     assert_success response
     transaction = response.params['braintree_transaction']
@@ -579,9 +579,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_apple_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
@@ -594,12 +594,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_android_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      :month              => '01',
-      :year               => '2024',
-      :source             => :android_pay,
-      :transaction_id     => '123456789',
-      :eci                => '05'
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: '2024',
+      source: :android_pay,
+      transaction_id: '123456789',
+      eci: '05'
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
@@ -612,12 +612,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_google_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      :month              => '01',
-      :year               => '2024',
-      :source             => :google_pay,
-      :transaction_id     => '123456789',
-      :eci                => '05'
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: '2024',
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05'
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
@@ -679,7 +679,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = BraintreeBlueGateway.new(:merchant_id => 'invalid', :public_key => 'invalid', :private_key => 'invalid')
+    gateway = BraintreeBlueGateway.new(merchant_id: 'invalid', public_key: 'invalid', private_key: 'invalid')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Braintree::AuthenticationError', response.message
@@ -730,11 +730,11 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_update
     assert response = @gateway.store(
       credit_card('4111111111111111',
-        :first_name => 'Old First', :last_name => 'Old Last',
-        :month => 9, :year => 2012
+        first_name: 'Old First', last_name: 'Old Last',
+        month: 9, year: 2012
       ),
-      :email => 'old@example.com',
-      :phone => '321-654-0987'
+      email: 'old@example.com',
+      phone: '321-654-0987'
     )
     assert_success response
     assert_equal 'OK', response.message
@@ -752,11 +752,11 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.update(
       customer_vault_id,
       credit_card('5105105105105100',
-        :first_name => 'New First', :last_name => 'New Last',
-        :month => 10, :year => 2014
+        first_name: 'New First', last_name: 'New Last',
+        month: 10, year: 2014
       ),
-      :email => 'new@example.com',
-      :phone => '987-765-5432'
+      email: 'new@example.com',
+      phone: '987-765-5432'
     )
     assert_success response
     assert_equal 'new@example.com', response.params['braintree_customer']['email']
@@ -770,7 +770,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_failed_customer_update
-    assert response = @gateway.store(credit_card('4111111111111111'), :email => 'email@example.com', :phone => '321-654-0987')
+    assert response = @gateway.store(credit_card('4111111111111111'), email: 'email@example.com', phone: '321-654-0987')
     assert_success response
     assert_equal 'OK', response.message
     assert customer_vault_id = response.params['customer_vault_id']
@@ -814,7 +814,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.update(
       customer_vault_id,
       credit_card('4000111111111115'),
-      {:verify_card => true}
+      {verify_card: true}
     )
     assert_failure response
     assert_equal 'Processor declined: Do Not Honor (2000)', response.message
@@ -841,14 +841,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_with_merchant_account_id
-    assert response = @gateway.credit(@amount, @credit_card, :merchant_account_id => fixtures(:braintree_blue)[:merchant_account_id])
+    assert response = @gateway.credit(@amount, @credit_card, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id])
     assert_success response, 'You must specify a valid :merchant_account_id key in your fixtures.yml AND get credits enabled in your Sandbox account for this to pass.'
     assert_equal '1002 Processed', response.message
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
   end
 
   def test_successful_authorize_with_merchant_account_id
-    assert response = @gateway.authorize(@amount, @credit_card, :merchant_account_id => fixtures(:braintree_blue)[:merchant_account_id])
+    assert response = @gateway.authorize(@amount, @credit_card, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id])
     assert_success response, 'You must specify a valid :merchant_account_id key in your fixtures.yml for this to pass.'
     assert_equal '1000 Approved', response.message
     assert_equal 'authorized', response.params['braintree_transaction']['status']
@@ -860,8 +860,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_validate_on_store_with_verification_merchant_account
-    card = credit_card('4111111111111111', :verification_value => '101')
-    assert response = @gateway.store(card, :verify_card => true, :verification_merchant_account_id => fixtures(:braintree_blue)[:merchant_account_id])
+    card = credit_card('4111111111111111', verification_value: '101')
+    assert response = @gateway.store(card, verify_card: true, verification_merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id])
     assert_success response, 'You must specify a valid :merchant_account_id key in your fixtures.yml for this to pass.'
     assert_equal 'OK', response.message
   end

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -8,8 +8,8 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
     @check = check()
     @declined_amount = rand(99)
-    @options = {  :order_id => generate_unique_id,
-                  :billing_address => address}
+    @options = {  order_id: generate_unique_id,
+                  billing_address: address}
   end
 
   def test_successful_purchase
@@ -20,11 +20,11 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_echeck
     check = ActiveMerchant::Billing::Check.new(
-      :name => 'Fredd Bloggs',
-      :routing_number => '111000025', # Valid ABA # - Bank of America, TX
-      :account_number => '999999999999',
-      :account_holder_type => 'personal',
-      :account_type => 'checking'
+      name: 'Fredd Bloggs',
+      routing_number: '111000025', # Valid ABA # - Bank of America, TX
+      account_number: '999999999999',
+      account_holder_type: 'personal',
+      account_type: 'checking'
     )
     assert response = @gateway.purchase(@amount, check, @options)
     assert_equal 'This transaction has been approved', response.message
@@ -89,7 +89,7 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
 
   def test_update_vault
     test_add_to_vault_with_custom_vault_id
-    @credit_card = credit_card('4111111111111111', :month => 10)
+    @credit_card = credit_card('4111111111111111', month: 10)
     assert response = @gateway.update(@options[:store], @credit_card)
     assert_success response
     assert_equal 'Customer Update Successful', response.message
@@ -162,8 +162,8 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = BraintreeOrangeGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Invalid Username', response.message

--- a/test/remote/gateways/remote_bridge_pay_test.rb
+++ b/test/remote/gateways/remote_bridge_pay_test.rb
@@ -9,10 +9,10 @@ class RemoteBridgePayTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011100000')
 
     @check = check(
-      :name => 'John Doe',
-      :routing_number => '490000018',
-      :account_number => '1234567890',
-      :number => '1001'
+      name: 'John Doe',
+      routing_number: '490000018',
+      account_number: '1234567890',
+      number: '1001'
     )
 
     @options = {

--- a/test/remote/gateways/remote_card_save_test.rb
+++ b/test/remote/gateways/remote_card_save_test.rb
@@ -5,15 +5,15 @@ class RemoteCardSaveTest < Test::Unit::TestCase
     @gateway = CardSaveGateway.new(fixtures(:card_save))
 
     @amount = 100
-    @credit_card = credit_card('4976000000003436', :verification_value => '452')
-    @declined_card = credit_card('4221690000004963', :verification_value => '125')
-    @addresses = {'4976000000003436' => { :name => 'John Watson', :address1 => '32 Edward Street', :city => 'Camborne,', :state => 'Cornwall', :country => 'GB', :zip => 'TR14 8PA' },
-                  '4221690000004963' => { :name => 'Ian Lee', :address1 => '274 Lymington Avenue', :city => 'London', :state => 'London', :country => 'GB', :zip => 'N22 6JN' }}
+    @credit_card = credit_card('4976000000003436', verification_value: '452')
+    @declined_card = credit_card('4221690000004963', verification_value: '125')
+    @addresses = {'4976000000003436' => { name: 'John Watson', address1: '32 Edward Street', city: 'Camborne,', state: 'Cornwall', country: 'GB', zip: 'TR14 8PA' },
+                  '4221690000004963' => { name: 'Ian Lee', address1: '274 Lymington Avenue', city: 'London', state: 'London', country: 'GB', zip: 'N22 6JN' }}
 
     @options = {
-      :order_id => '1',
-      :billing_address => @addresses[@credit_card.number],
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: @addresses[@credit_card.number],
+      description: 'Store Purchase'
     }
   end
 
@@ -48,8 +48,8 @@ class RemoteCardSaveTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = CardSaveGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -7,117 +7,117 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     @gateway = CardStreamGateway.new(fixtures(:card_stream))
 
     @amex = credit_card('374245455400001',
-      :month => '12',
-      :year => Time.now.year + 1,
-      :verification_value => '4887',
-      :brand => :american_express
+      month: '12',
+      year: Time.now.year + 1,
+      verification_value: '4887',
+      brand: :american_express
     )
 
     @mastercard = credit_card('5301250070000191',
-      :month => '12',
-      :year => Time.now.year + 1,
-      :verification_value => '419',
-      :brand => :master
+      month: '12',
+      year: Time.now.year + 1,
+      verification_value: '419',
+      brand: :master
     )
 
     @visacreditcard = credit_card('4929421234600821',
-      :month => '12',
-      :year => Time.now.year + 1,
-      :verification_value => '356',
-      :brand => :visa
+      month: '12',
+      year: Time.now.year + 1,
+      verification_value: '356',
+      brand: :visa
     )
 
     @visadebitcard = credit_card('4539791001730106',
-      :month => '12',
-      :year => Time.now.year + 1,
-      :verification_value => '289',
-      :brand => :visa
+      month: '12',
+      year: Time.now.year + 1,
+      verification_value: '289',
+      brand: :visa
     )
 
     @declined_card = credit_card('4000300011112220',
-      :month => '9',
-      :year => Time.now.year + 1
+      month: '9',
+      year: Time.now.year + 1
     )
 
     @amex_options = {
-      :billing_address => {
-        :address1 => 'The Hunts Way',
-        :city => '',
-        :state => 'Leicester',
-        :zip => 'SO18 1GW',
-        :country => 'GB'
+      billing_address: {
+        address1: 'The Hunts Way',
+        city: '',
+        state: 'Leicester',
+        zip: 'SO18 1GW',
+        country: 'GB'
       },
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase',
-      :ip => '1.1.1.1'
+      order_id: generate_unique_id,
+      description: 'AM test purchase',
+      ip: '1.1.1.1'
     }
 
     @visacredit_options = {
-      :billing_address => {
-        :address1 => 'Flat 6, Primrose Rise',
-        :address2 => '347 Lavender Road',
-        :city => '',
-        :state => 'Northampton',
-        :zip => 'NN17 8YG',
-        :country => 'GB'
+      billing_address: {
+        address1: 'Flat 6, Primrose Rise',
+        address2: '347 Lavender Road',
+        city: '',
+        state: 'Northampton',
+        zip: 'NN17 8YG',
+        country: 'GB'
       },
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase',
-      :ip => '1.1.1.1'
+      order_id: generate_unique_id,
+      description: 'AM test purchase',
+      ip: '1.1.1.1'
     }
 
     @visacredit_descriptor_options = {
-      :billing_address => {
-        :address1 => 'Flat 6, Primrose Rise',
-        :address2 => '347 Lavender Road',
-        :city => '',
-        :state => 'Northampton',
-        :zip => 'NN17 8YG',
-        :country => 'GB'
+      billing_address: {
+        address1: 'Flat 6, Primrose Rise',
+        address2: '347 Lavender Road',
+        city: '',
+        state: 'Northampton',
+        zip: 'NN17 8YG',
+        country: 'GB'
       },
-      :order_id => generate_unique_id,
-      :merchant_name => 'merchant',
-      :dynamic_descriptor => 'product',
-      :ip => '1.1.1.1',
+      order_id: generate_unique_id,
+      merchant_name: 'merchant',
+      dynamic_descriptor: 'product',
+      ip: '1.1.1.1',
     }
 
     @visacredit_reference_options = {
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase',
-      :ip => '1.1.1.1'
+      order_id: generate_unique_id,
+      description: 'AM test purchase',
+      ip: '1.1.1.1'
     }
 
     @visadebit_options = {
-      :billing_address => {
-        :address1 => 'Unit 5, Pickwick Walk',
-        :address2 => '120 Uxbridge Road',
-        :city => 'Hatch End',
-        :state => 'Middlesex',
-        :zip => 'HA6 7HJ',
-        :country => 'GB'
+      billing_address: {
+        address1: 'Unit 5, Pickwick Walk',
+        address2: '120 Uxbridge Road',
+        city: 'Hatch End',
+        state: 'Middlesex',
+        zip: 'HA6 7HJ',
+        country: 'GB'
       },
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase',
-      :ip => '1.1.1.1'
+      order_id: generate_unique_id,
+      description: 'AM test purchase',
+      ip: '1.1.1.1'
     }
 
     @mastercard_options = {
-      :billing_address => {
-        :address1 => '25 The Larches',
-        :city => 'Narborough',
-        :state => 'Leicester',
-        :zip => 'LE10 2RT',
-        :country => 'GB'
+      billing_address: {
+        address1: '25 The Larches',
+        city: 'Narborough',
+        state: 'Leicester',
+        zip: 'LE10 2RT',
+        country: 'GB'
       },
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase',
-      :ip => '1.1.1.1'
+      order_id: generate_unique_id,
+      description: 'AM test purchase',
+      ip: '1.1.1.1'
     }
 
     @three_ds_enrolled_card = credit_card('4012001037141112',
-      :month => '12',
-      :year => '2020',
-      :brand => :visa
+      month: '12',
+      year: '2020',
+      brand: :visa
     )
   end
 
@@ -314,7 +314,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
   end
 
   def test_successful_visacreditcard_purchase_via_reference
-    assert response = @gateway.purchase(142, @visacreditcard, @visacredit_options.merge({:type => '9'}))
+    assert response = @gateway.purchase(142, @visacreditcard, @visacredit_options.merge({type: '9'}))
     assert_equal 'APPROVED', response.message
     assert_success response
     assert response.test?
@@ -384,8 +384,8 @@ class RemoteCardStreamTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = CardStreamGateway.new(
-      :login => '',
-      :shared_secret => ''
+      login: '',
+      shared_secret: ''
     )
     assert response = gateway.purchase(142, @mastercard, @mastercard_options)
     assert_match %r{MISSING_MERCHANTID}, response.message

--- a/test/remote/gateways/remote_cecabank_test.rb
+++ b/test/remote/gateways/remote_cecabank_test.rb
@@ -5,12 +5,12 @@ class RemoteCecabankTest < Test::Unit::TestCase
     @gateway = CecabankGateway.new(fixtures(:cecabank))
 
     @amount = 100
-    @credit_card = credit_card('5540500001000004', {:month => 12, :year => Time.now.year, :verification_value => 989})
-    @declined_card = credit_card('5540500001000004', {:month => 11, :year => Time.now.year + 1, :verification_value => 001})
+    @credit_card = credit_card('5540500001000004', {month: 12, year: Time.now.year, verification_value: 989})
+    @declined_card = credit_card('5540500001000004', {month: 11, year: Time.now.year + 1, verification_value: 001})
 
     @options = {
-      :order_id => generate_unique_id,
-      :description => 'Active Merchant Test Purchase'
+      order_id: generate_unique_id,
+      description: 'Active Merchant Test Purchase'
     }
   end
 

--- a/test/remote/gateways/remote_citrus_pay_test.rb
+++ b/test/remote/gateways/remote_citrus_pay_test.rb
@@ -104,8 +104,8 @@ class RemoteCitrusPayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = CitrusPayGateway.new(
-      :userid => 'nosuch',
-      :password => 'thing'
+      userid: 'nosuch',
+      password: 'thing'
     )
     response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -191,7 +191,7 @@ class RemoteClearhausTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_nonfractional_currency
-    assert response = @gateway.authorize(100, @credit_card, @options.merge(:currency => 'KRW'))
+    assert response = @gateway.authorize(100, @credit_card, @options.merge(currency: 'KRW'))
     assert_equal 1, response.params['amount']
     assert_success response
   end

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -25,7 +25,7 @@ class RemoteConektaTest < Test::Unit::TestCase
     )
 
     @options = {
-      :device_fingerprint => '41l9l92hjco6cuekf0c7dq68v4',
+      device_fingerprint: '41l9l92hjco6cuekf0c7dq68v4',
       description: 'Blue clip',
       billing_address: {
         address1: 'Rio Missisipi #123',

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -44,37 +44,37 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => generate_unique_id,
-      :line_items => [
+      order_id: generate_unique_id,
+      line_items: [
         {
-          :declared_value => 100,
-          :quantity => 2,
-          :code => 'default',
-          :description => 'Giant Walrus',
-          :sku => 'WA323232323232323'
+          declared_value: 100,
+          quantity: 2,
+          code: 'default',
+          description: 'Giant Walrus',
+          sku: 'WA323232323232323'
         },
         {
-          :declared_value => 100,
-          :quantity => 2,
-          :description => 'Marble Snowcone',
-          :sku => 'FAKE1232132113123'
+          declared_value: 100,
+          quantity: 2,
+          description: 'Marble Snowcone',
+          sku: 'FAKE1232132113123'
         }
       ],
-      :currency => 'USD',
-      :ignore_avs => 'true',
-      :ignore_cvv => 'true',
-      :commerce_indicator => 'internet'
+      currency: 'USD',
+      ignore_avs: 'true',
+      ignore_cvv: 'true',
+      commerce_indicator: 'internet'
     }
 
     @subscription_options = {
-      :order_id => generate_unique_id,
-      :credit_card => @credit_card,
-      :subscription => {
-        :frequency => 'weekly',
-        :start_date => Date.today.next_week,
-        :occurrences => 4,
-        :auto_renew => true,
-        :amount => 100
+      order_id: generate_unique_id,
+      credit_card: @credit_card,
+      subscription: {
+        frequency: 'weekly',
+        start_date: Date.today.next_week,
+        occurrences: 4,
+        auto_renew: true,
+        amount: 100
       }
     }
 
@@ -95,9 +95,9 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_network_tokenization_transcript_scrubbing
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
 
     transcript = capture_transcript(@gateway) do
@@ -250,7 +250,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_pinless_debit_card_puchase
-    assert response = @gateway.purchase(@amount, @pinless_debit_card, @options.merge(:pinless_debit_card => true))
+    assert response = @gateway.purchase(@amount, @pinless_debit_card, @options.merge(pinless_debit_card: true))
     assert_successful_response(response)
   end
 
@@ -302,7 +302,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = CyberSourceGateway.new(:login => 'asdf', :password => 'qwer')
+    gateway = CyberSourceGateway.new(login: 'asdf', password: 'qwer')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal "wsse:FailedCheck: \nSecurity Data : UsernameToken authentication failed.\n", response.message
@@ -329,9 +329,9 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_network_tokenization_authorize_and_capture
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
@@ -373,7 +373,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_nonfractional_currency
-    assert response = @gateway.authorize(100, @credit_card, @options.merge(:currency => 'JPY'))
+    assert response = @gateway.authorize(100, @credit_card, @options.merge(currency: 'JPY'))
     assert_equal '1', response.params['amount']
     assert_successful_response(response)
   end
@@ -382,7 +382,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.authorize(@amount, response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.authorize(@amount, response.authorization, order_id: generate_unique_id)
     assert_successful_response(response)
     assert !response.authorization.blank?
   end
@@ -391,7 +391,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.purchase(@amount, response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.purchase(@amount, response.authorization, order_id: generate_unique_id)
     assert_successful_response(response)
   end
 
@@ -399,7 +399,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@elo_credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.purchase(@amount, response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.purchase(@amount, response.authorization, order_id: generate_unique_id)
     assert_successful_response(response)
   end
 
@@ -438,7 +438,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.credit(@amount, response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.credit(@amount, response.authorization, order_id: generate_unique_id)
     assert_successful_response(response)
   end
 
@@ -447,7 +447,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.credit(@amount, response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.credit(@amount, response.authorization, order_id: generate_unique_id)
     assert_successful_response(response)
   end
 
@@ -462,12 +462,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_create_subscription_with_setup_fee
-    assert response = @gateway.store(@credit_card, @subscription_options.merge(:setup_fee => 100))
+    assert response = @gateway.store(@credit_card, @subscription_options.merge(setup_fee: 100))
     assert_successful_response(response)
   end
 
   def test_successful_create_subscription_with_monthly_options
-    response = @gateway.store(@credit_card, @subscription_options.merge(:setup_fee => 99.0, :subscription => {:amount => 49.0, :automatic_renew => false, frequency: 'monthly'}))
+    response = @gateway.store(@credit_card, @subscription_options.merge(setup_fee: 99.0, subscription: {amount: 49.0, automatic_renew: false, frequency: 'monthly'}))
     assert_equal 'Successful transaction', response.message
     response = @gateway.retrieve(response.authorization, order_id: @subscription_options[:order_id])
     assert_equal '0.49', response.params['recurringAmount']
@@ -478,7 +478,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.update(response.authorization, @credit_card, {:order_id => generate_unique_id, :setup_fee => 100})
+    assert response = @gateway.update(response.authorization, @credit_card, {order_id: generate_unique_id, setup_fee: 100})
     assert_successful_response(response)
   end
 
@@ -487,7 +487,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
 
     assert response = @gateway.update(response.authorization, nil,
-      {:order_id => generate_unique_id, :setup_fee => 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
+      {order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
 
     assert_successful_response(response)
   end
@@ -497,7 +497,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.success?
     assert response.test?
 
-    assert response = @gateway.unstore(response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.unstore(response.authorization, order_id: generate_unique_id)
     assert response.success?
     assert response.test?
   end
@@ -507,7 +507,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.success?
     assert response.test?
 
-    assert response = @gateway.unstore(response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.unstore(response.authorization, order_id: generate_unique_id)
     assert response.success?
     assert response.test?
   end
@@ -517,7 +517,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.success?
     assert response.test?
 
-    assert response = @gateway.retrieve(response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.retrieve(response.authorization, order_id: generate_unique_id)
     assert response.success?
     assert response.test?
   end
@@ -644,10 +644,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_first_unscheduled_cof_transaction
     @options[:stored_credential] = {
-      :initiator => 'cardholder',
-      :reason_type => 'unscheduled',
-      :initial_transaction => true,
-      :network_transaction_id => ''
+      initiator: 'cardholder',
+      reason_type: 'unscheduled',
+      initial_transaction: true,
+      network_transaction_id: ''
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)
@@ -655,10 +655,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_subsequent_unscheduled_cof_transaction
     @options[:stored_credential] = {
-      :initiator => 'merchant',
-      :reason_type => 'unscheduled',
-      :initial_transaction => false,
-      :network_transaction_id => '016150703802094'
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)
@@ -666,10 +666,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_first_recurring_cof_transaction
     @options[:stored_credential] = {
-      :initiator => 'cardholder',
-      :reason_type => 'recurring',
-      :initial_transaction => true,
-      :network_transaction_id => ''
+      initiator: 'cardholder',
+      reason_type: 'recurring',
+      initial_transaction: true,
+      network_transaction_id: ''
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)
@@ -677,10 +677,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_subsequent_recurring_cof_transaction
     @options[:stored_credential] = {
-      :initiator => 'merchant',
-      :reason_type => 'recurring',
-      :initial_transaction => false,
-      :network_transaction_id => '016150703802094'
+      initiator: 'merchant',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)

--- a/test/remote/gateways/remote_data_cash_test.rb
+++ b/test/remote/gateways/remote_data_cash_test.rb
@@ -6,57 +6,57 @@ class RemoteDataCashTest < Test::Unit::TestCase
     @gateway = DataCashGateway.new(fixtures(:data_cash))
 
     @mastercard = CreditCard.new(
-      :number => '5120790000000034',
-      :month => 3,
-      :year => Date.today.year + 2,
-      :first_name => 'Mark',
-      :last_name => 'McBride',
-      :brand => :master
+      number: '5120790000000034',
+      month: 3,
+      year: Date.today.year + 2,
+      first_name: 'Mark',
+      last_name: 'McBride',
+      brand: :master
     )
 
     @mastercard_declined = CreditCard.new(
-      :number => '5473000000000106',
-      :month => 3,
-      :year => Date.today.year + 2,
-      :first_name => 'Mark',
-      :last_name => 'McBride',
-      :brand => :master,
-      :verification_value => '547'
+      number: '5473000000000106',
+      month: 3,
+      year: Date.today.year + 2,
+      first_name: 'Mark',
+      last_name: 'McBride',
+      brand: :master,
+      verification_value: '547'
     )
 
     @visa_delta = CreditCard.new(
-      :number => '4539792100000003',
-      :month => 3,
-      :year => Date.today.year + 2,
-      :first_name => 'Mark',
-      :last_name => 'McBride',
-      :brand => :visa,
-      :verification_value => '444'
+      number: '4539792100000003',
+      month: 3,
+      year: Date.today.year + 2,
+      first_name: 'Mark',
+      last_name: 'McBride',
+      brand: :visa,
+      verification_value: '444'
     )
 
     @solo = CreditCard.new(
-      :first_name => 'Cody',
-      :last_name => 'Fauser',
-      :number => '633499100000000004',
-      :month => 3,
-      :year => Date.today.year + 2,
-      :brand => :solo,
-      :start_month => 12,
-      :start_year => 2006
+      first_name: 'Cody',
+      last_name: 'Fauser',
+      number: '633499100000000004',
+      month: 3,
+      year: Date.today.year + 2,
+      brand: :solo,
+      start_month: 12,
+      start_year: 2006
     )
 
     @address = {
-      :name     => 'Mark McBride',
-      :address1 => 'Flat 12/3',
-      :address2 => '45 Main Road',
-      :city     => 'Sometown',
-      :state    => 'Somecounty',
-      :zip      => 'A987AA',
-      :phone    => '(555)555-5555'
+      name: 'Mark McBride',
+      address1: 'Flat 12/3',
+      address2: '45 Main Road',
+      city: 'Sometown',
+      state: 'Somecounty',
+      zip: 'A987AA',
+      phone: '(555)555-5555'
     }
 
     @params = {
-      :order_id => generate_unique_id
+      order_id: generate_unique_id
     }
 
     @amount = 198
@@ -108,7 +108,7 @@ class RemoteDataCashTest < Test::Unit::TestCase
     assert response.test?
 
     # Make second payment on the continuous authorization that was set up in the first purchase
-    second_order_params = { :order_id => generate_unique_id }
+    second_order_params = { order_id: generate_unique_id }
     purchase = @gateway.purchase(201, response.authorization, second_order_params)
     assert_success purchase
   end
@@ -120,7 +120,7 @@ class RemoteDataCashTest < Test::Unit::TestCase
     assert !response.authorization.to_s.split(';')[2].blank?
 
     # Make second payment on the continuous authorization that was set up in the first purchase
-    second_order_params = { :order_id => generate_unique_id }
+    second_order_params = { order_id: generate_unique_id }
     purchase = @gateway.purchase(201, response.authorization, second_order_params)
     assert_success purchase
   end
@@ -146,7 +146,7 @@ class RemoteDataCashTest < Test::Unit::TestCase
     assert capture.test?
 
     # Collect second purchase
-    second_order_params = { :order_id => generate_unique_id }
+    second_order_params = { order_id: generate_unique_id }
     purchase = @gateway.purchase(201, first_authorization.authorization, second_order_params)
     assert_success purchase
     assert purchase.test?
@@ -309,7 +309,7 @@ class RemoteDataCashTest < Test::Unit::TestCase
     assert response.test?
 
     # Make second payment on the continuous authorization that was set up in the first purchase
-    second_order_params = { :order_id => generate_unique_id }
+    second_order_params = { order_id: generate_unique_id }
     purchase = @gateway.purchase(201, response.authorization, second_order_params)
     assert_success purchase
 

--- a/test/remote/gateways/remote_dibs_test.rb
+++ b/test/remote/gateways/remote_dibs_test.rb
@@ -5,10 +5,10 @@ class RemoteDibsTest < Test::Unit::TestCase
     @gateway = DibsGateway.new(fixtures(:dibs))
 
     cc_options = {
-      :month => 6,
-      :year => 24,
-      :verification_value => '684',
-      :brand => 'visa'
+      month: 6,
+      year: 24,
+      verification_value: '684',
+      brand: 'visa'
     }
 
     @amount = 100

--- a/test/remote/gateways/remote_efsnet_test.rb
+++ b/test/remote/gateways/remote_efsnet_test.rb
@@ -11,8 +11,8 @@ class RemoteEfsnetTest < Test::Unit::TestCase
     @amount = 100
     @declined_amount = 156
 
-    @options = { :order_id => generate_unique_id,
-                 :billing_address => address}
+    @options = { order_id: generate_unique_id,
+                 billing_address: address}
   end
 
   def test_successful_purchase
@@ -69,8 +69,8 @@ class RemoteEfsnetTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = EfsnetGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Invalid credentials', response.message

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -9,10 +9,10 @@ class RemoteElavonTest < Test::Unit::TestCase
     @bad_credit_card = credit_card('invalid')
 
     @options = {
-      :email => 'paul@domain.com',
-      :description => 'Test Transaction',
-      :billing_address => address,
-      :ip => '203.0.113.0'
+      email: 'paul@domain.com',
+      description: 'Test Transaction',
+      billing_address: address,
+      ip: '203.0.113.0'
     }
     @amount = 100
   end
@@ -40,7 +40,7 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_equal 'APPROVAL', auth.message
     assert auth.authorization
 
-    assert capture = @gateway.capture(@amount, auth.authorization, :credit_card => @credit_card)
+    assert capture = @gateway.capture(@amount, auth.authorization, credit_card: @credit_card)
     assert_success capture
   end
 
@@ -55,7 +55,7 @@ class RemoteElavonTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_capture
-    assert response = @gateway.capture(@amount, '', :credit_card => @credit_card)
+    assert response = @gateway.capture(@amount, '', credit_card: @credit_card)
     assert_failure response
     assert_equal 'The FORCE Approval Code supplied in the authorization request appears to be invalid or blank.  The FORCE Approval Code must be 6 or less alphanumeric characters.', response.message
   end
@@ -168,7 +168,7 @@ class RemoteElavonTest < Test::Unit::TestCase
   def test_successful_update
     store_response = @gateway.store(@credit_card, @options)
     token = store_response.params['token']
-    credit_card = credit_card('4124939999999990', :month => 10)
+    credit_card = credit_card('4124939999999990', month: 10)
     assert response = @gateway.update(token, credit_card, @options)
     assert_success response
     assert response.test?

--- a/test/remote/gateways/remote_evo_ca_test.rb
+++ b/test/remote/gateways/remote_evo_ca_test.rb
@@ -7,12 +7,12 @@ class RemoteEvoCaTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111')
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :invoice => 'AB-1234',
-      :email => 'evo@example.com',
-      :ip => '127.0.0.1'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      invoice: 'AB-1234',
+      email: 'evo@example.com',
+      ip: '127.0.0.1'
     }
   end
 
@@ -72,7 +72,7 @@ class RemoteEvoCaTest < Test::Unit::TestCase
   def test_purchase_and_update
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert response = @gateway.update(response.authorization, :shipping_carrier => 'fedex', :tracking_number => '12345')
+    assert response = @gateway.update(response.authorization, shipping_carrier: 'fedex', tracking_number: '12345')
     assert_success response
     assert_equal EvoCaGateway::MESSAGES[100], response.message
   end
@@ -102,7 +102,7 @@ class RemoteEvoCaTest < Test::Unit::TestCase
 
   def test_avs_match
     # To simulate an AVS Match, pass 888 in the address1 field, 77777 for zip.
-    opts = @options.merge(:billing_address => address({:address1 => '888', :zip => '77777'}))
+    opts = @options.merge(billing_address: address({address1: '888', zip: '77777'}))
     assert response = @gateway.purchase(@amount, @credit_card, opts)
     assert_success response
     assert_equal 'Y', response.avs_result['code']
@@ -112,7 +112,7 @@ class RemoteEvoCaTest < Test::Unit::TestCase
 
   def test_cvv_match
     # To simulate a CVV Match, pass 999 in the cvv field.
-    assert response = @gateway.purchase(@amount, credit_card('4111111111111111', :verification_value => 999), @options)
+    assert response = @gateway.purchase(@amount, credit_card('4111111111111111', verification_value: 999), @options)
     assert_success response
     assert_equal 'M', response.cvv_result['code']
   end

--- a/test/remote/gateways/remote_eway_managed_test.rb
+++ b/test/remote/gateways/remote_eway_managed_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteEwayManagedTest < Test::Unit::TestCase
   def setup
-    @gateway = EwayManagedGateway.new(fixtures(:eway_managed).merge({ :test => true }))
+    @gateway = EwayManagedGateway.new(fixtures(:eway_managed).merge({ test: true }))
 
     @valid_card='4444333322221111'
     @valid_customer_id='9876543211000'
@@ -10,9 +10,9 @@ class RemoteEwayManagedTest < Test::Unit::TestCase
     @credit_card = credit_card(@valid_card)
 
     @options = {
-      :billing_address => {
-        :country => 'au',
-        :title => 'Mr.'
+      billing_address: {
+        country: 'au',
+        title: 'Mr.'
       }
     }
 
@@ -29,9 +29,9 @@ class RemoteEwayManagedTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = EwayManagedGateway.new(
-      :login => '',
-      :password => '',
-      :username => ''
+      login: '',
+      password: '',
+      username: ''
     )
     assert response = gateway.purchase(@amount, @valid_customer_id, @options)
     assert_equal 'Login failed. ', response.message

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -5,19 +5,19 @@ class EwayTest < Test::Unit::TestCase
     @gateway = EwayGateway.new(fixtures(:eway))
     @credit_card_success = credit_card('4444333322221111')
     @credit_card_fail = credit_card('1234567812345678',
-      :month => Time.now.month,
-      :year => Time.now.year-1
+      month: Time.now.month,
+      year: Time.now.year-1
     )
 
     @params = {
-      :order_id => '1230123',
-      :email => 'bob@testbob.com',
-      :billing_address => { :address1 => '47 Bobway',
-                            :city => 'Bobville',
-                            :state => 'WA',
-                            :country => 'AU',
-                            :zip => '2000'},
-      :description => 'purchased items'
+      order_id: '1230123',
+      email: 'bob@testbob.com',
+      billing_address: { address1: '47 Bobway',
+                            city: 'Bobville',
+                            state: 'WA',
+                            country: 'AU',
+                            zip: '2000'},
+      description: 'purchased items'
     }
   end
 

--- a/test/remote/gateways/remote_exact_test.rb
+++ b/test/remote/gateways/remote_exact_test.rb
@@ -6,9 +6,9 @@ class RemoteExactTest < Test::Unit::TestCase
     @credit_card = credit_card
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -49,8 +49,8 @@ class RemoteExactTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = ExactGateway.new(:login    => 'NotARealUser',
-                               :password => 'NotARealPassword')
+    gateway = ExactGateway.new(login: 'NotARealUser',
+                               password: 'NotARealPassword')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match %r{^Invalid Login}, response.message
     assert_failure response

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -9,8 +9,8 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     @declined_card = credit_card('4557012345678902')
 
     @options = {
-      :order_id => rand(100000).to_s,
-      :ip => '1.2.3.4'
+      order_id: rand(100000).to_s,
+      ip: '1.2.3.4'
     }
   end
 
@@ -21,14 +21,14 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_multi_currency_purchase
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'USD'))
     assert_success response
     assert_equal 'Approved', response.message
     assert_equal 'USD', response.params['response']['currency']
   end
 
   def test_unsuccessful_multi_currency_purchase
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'XYZ'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'XYZ'))
     assert_failure response
     assert_match(/Currency XYZ is not valid for this merchant/, response.message)
   end
@@ -64,12 +64,12 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   end
 
   def test_multi_currency_authorize_and_capture
-    assert auth_response = @gateway.authorize(@amount, @credit_card, @options.merge(:currency => 'USD'))
+    assert auth_response = @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'USD'))
     assert_success auth_response
     assert_equal 'Approved', auth_response.message
     assert_equal 'USD', auth_response.params['response']['currency']
 
-    assert capture_response = @gateway.capture(@amount, auth_response.authorization, @options.merge(:currency => 'USD'))
+    assert capture_response = @gateway.capture(@amount, auth_response.authorization, @options.merge(currency: 'USD'))
     assert_success capture_response
     assert_equal 'Approved', capture_response.message
     assert_equal 'USD', capture_response.params['response']['currency']
@@ -141,39 +141,39 @@ class RemoteFatZebraTest < Test::Unit::TestCase
 
   def test_purchase_with_token
     assert card = @gateway.store(@credit_card)
-    assert purchase = @gateway.purchase(@amount, card.authorization, @options.merge(:cvv => 123))
+    assert purchase = @gateway.purchase(@amount, card.authorization, @options.merge(cvv: 123))
     assert_success purchase
   end
 
   def test_successful_purchase_with_descriptor
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(merchant: 'Merchant', merchant_location: 'Location'))
     assert_success response
     assert_equal 'Approved', response.message
   end
 
   def test_successful_purchase_with_metadata
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:metadata => { :description => 'Invoice #1234356' }))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { description: 'Invoice #1234356' }))
     assert_success response
     assert_equal 'Approved', response.message
     assert_equal 'Invoice #1234356', response.params['response']['metadata']['description']
   end
 
   def test_successful_purchase_with_3DS_information
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:cavv => 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', :xid => 'MGVmMmNlMzI4NjAyOWU2ZDgwNTQ=', :sli => '05'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(cavv: 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', xid: 'MGVmMmNlMzI4NjAyOWU2ZDgwNTQ=', sli: '05'))
     assert_success response
     assert_equal 'Approved', response.message
   end
 
   def test_failed_purchase_with_incomplete_3DS_information
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:cavv => 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', :sli => '05'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(cavv: 'MDRjN2MxZTAxYjllNTBkNmM2MTA=', sli: '05'))
     assert_failure response
     assert_match %r{Extra/xid is required for SLI 05}, response.message
   end
 
   def test_invalid_login
     gateway = FatZebraGateway.new(
-      :username => 'invalid',
-      :token => 'wrongtoken'
+      username: 'invalid',
+      token: 'wrongtoken'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_federated_canada_test.rb
+++ b/test/remote/gateways/remote_federated_canada_test.rb
@@ -10,9 +10,9 @@ class RemoteFederatedCanadaTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111') # Visa
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Active Merchant Remote Test Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Active Merchant Remote Test Purchase'
     }
   end
 
@@ -76,8 +76,8 @@ class RemoteFederatedCanadaTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = FederatedCanadaGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_finansbank_test.rb
+++ b/test/remote/gateways/remote_finansbank_test.rb
@@ -12,10 +12,10 @@ class RemoteFinansbankTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => '#' + generate_unique_id,
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :email => 'xyz@gmail.com'
+      order_id: '#' + generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase',
+      email: 'xyz@gmail.com'
     }
   end
 
@@ -89,9 +89,9 @@ class RemoteFinansbankTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = FinansbankGateway.new(
-      :login => '',
-      :password => '',
-      :client_id => ''
+      login: '',
+      password: '',
+      client_id: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -8,9 +8,9 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     @credit_card_with_track_data = credit_card_with_track_data('4003000123456781')
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @options_with_authentication_data = @options.merge({
       eci: '5',
@@ -178,8 +178,8 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = FirstdataE4Gateway.new(:login    => 'NotARealUser',
-                                     :password => 'NotARealPassword')
+    gateway = FirstdataE4Gateway.new(login: 'NotARealUser',
+                                     password: 'NotARealPassword')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match %r{Unauthorized Request}, response.message
     assert_failure response

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -4,14 +4,14 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
   def setup
     @gateway = FirstdataE4V27Gateway.new(fixtures(:firstdata_e4_v27))
     @credit_card = credit_card
-    @credit_card_master = credit_card('5500000000000004', :brand => 'master')
+    @credit_card_master = credit_card('5500000000000004', brand: 'master')
     @bad_credit_card = credit_card('4111111111111113')
     @credit_card_with_track_data = credit_card_with_track_data('4003000123456781')
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @options_with_authentication_data = @options.merge({
       eci: '5',
@@ -208,10 +208,10 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = FirstdataE4V27Gateway.new(:login    => 'NotARealUser',
-                                        :password => 'NotARealPassword',
-                                        :key_id   => 'NotARealKey',
-                                        :hmac_key => 'NotARealHMAC')
+    gateway = FirstdataE4V27Gateway.new(login: 'NotARealUser',
+                                        password: 'NotARealPassword',
+                                        key_id: 'NotARealKey',
+                                        hmac_key: 'NotARealHMAC')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match %r{Unauthorized Request}, response.message
     assert_failure response

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -10,13 +10,13 @@ class RemoteForteTest < Test::Unit::TestCase
 
     @check = check
     @bad_check = check({
-      :name => 'Jim Smith',
-      :bank_name => 'Bank of Elbonia',
-      :routing_number => '1234567890',
-      :account_number => '0987654321',
-      :account_holder_type => '',
-      :account_type => 'checking',
-      :number => '0'
+      name: 'Jim Smith',
+      bank_name: 'Bank of Elbonia',
+      routing_number: '1234567890',
+      account_number: '0987654321',
+      account_holder_type: '',
+      account_type: 'checking',
+      number: '0'
     })
 
     @options = {

--- a/test/remote/gateways/remote_garanti_test.rb
+++ b/test/remote/gateways/remote_garanti_test.rb
@@ -10,9 +10,9 @@ class RemoteGarantiTest < Test::Unit::TestCase
     @credit_card = credit_card('4282209027132016', month: 5, year: 2018, verification_value: 358)
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -50,10 +50,10 @@ class RemoteGarantiTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = GarantiGateway.new(
-      :login => 'PROVAUT',
-      :terminal_id => '30691300',
-      :merchant_id => '',
-      :password => ''
+      login: 'PROVAUT',
+      terminal_id: '30691300',
+      merchant_id: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_hdfc_test.rb
+++ b/test/remote/gateways/remote_hdfc_test.rb
@@ -11,12 +11,12 @@ class RemoteHdfcTest < Test::Unit::TestCase
 
     # Use an American Express card to simulate a failure since HDFC does not
     # support any proper decline cards outside of 3D secure failures.
-    @declined_card = credit_card('377182068239368', :brand => :american_express)
+    @declined_card = credit_card('377182068239368', brand: :american_express)
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -61,14 +61,14 @@ class RemoteHdfcTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:billing_address => address))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: address))
     assert_success response
   end
 
   def test_invalid_login
     gateway = HdfcGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -350,10 +350,10 @@ class RemoteHpsTest < Test::Unit::TestCase
     @credit_card.brand = 'visa'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -367,10 +367,10 @@ class RemoteHpsTest < Test::Unit::TestCase
     @credit_card.brand = 'master'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -384,10 +384,10 @@ class RemoteHpsTest < Test::Unit::TestCase
     @credit_card.brand = 'discover'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -401,10 +401,10 @@ class RemoteHpsTest < Test::Unit::TestCase
     @credit_card.brand = 'american_express'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -418,10 +418,10 @@ class RemoteHpsTest < Test::Unit::TestCase
     @credit_card.brand = 'jcb'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -9,9 +9,9 @@ class IatsPaymentsTest < Test::Unit::TestCase
     @credit_card = credit_card('4222222222222220')
     @check = check(routing_number: '111111111', account_number: '12345678')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase'
     }
   end
 
@@ -104,9 +104,9 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = IatsPaymentsGateway.new(
-      :agent_code => 'X',
-      :password => 'Y',
-      :region => 'na'
+      agent_code: 'X',
+      password: 'Y',
+      region: 'na'
     )
 
     assert response = gateway.purchase(@amount, @credit_card)

--- a/test/remote/gateways/remote_inspire_test.rb
+++ b/test/remote/gateways/remote_inspire_test.rb
@@ -5,10 +5,10 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     @gateway = InspireGateway.new(fixtures(:inspire))
 
     @amount = rand(1001..11000)
-    @credit_card = credit_card('4111111111111111', :brand => 'visa')
+    @credit_card = credit_card('4111111111111111', brand: 'visa')
     @declined_amount = rand(99)
-    @options = {  :order_id => generate_unique_id,
-                  :billing_address => address}
+    @options = {  order_id: generate_unique_id,
+                  billing_address: address}
   end
 
   def test_successful_purchase
@@ -19,11 +19,11 @@ class RemoteBraintreeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_echeck
     check = ActiveMerchant::Billing::Check.new(
-      :name => 'Fredd Bloggs',
-      :routing_number => '111000025', # Valid ABA # - Bank of America, TX
-      :account_number => '999999999999',
-      :account_holder_type => 'personal',
-      :account_type => 'checking'
+      name: 'Fredd Bloggs',
+      routing_number: '111000025', # Valid ABA # - Bank of America, TX
+      account_number: '999999999999',
+      account_holder_type: 'personal',
+      account_type: 'checking'
     )
     response = @gateway.purchase(@amount, check, @options)
     assert_success response
@@ -73,7 +73,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
 
   def test_update_vault
     test_add_to_vault_with_custom_vault_id
-    @credit_card = credit_card('4111111111111111', :month => 10)
+    @credit_card = credit_card('4111111111111111', month: 10)
     response = @gateway.update(@options[:store], @credit_card)
     assert_success response
     assert_equal 'Customer Update Successful', response.message
@@ -150,8 +150,8 @@ class RemoteBraintreeTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = InspireGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Invalid Username', response.message

--- a/test/remote/gateways/remote_instapay_test.rb
+++ b/test/remote/gateways/remote_instapay_test.rb
@@ -9,10 +9,10 @@ class RemoteInstapayTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :shipping_address => address,
-      :description => 'Store Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      shipping_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -49,8 +49,8 @@ class RemoteInstapayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = InstapayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     assert response = gateway.purchase(@amount, @credit_card)

--- a/test/remote/gateways/remote_iridium_test.rb
+++ b/test/remote/gateways/remote_iridium_test.rb
@@ -7,21 +7,21 @@ class RemoteIridiumTest < Test::Unit::TestCase
     @gateway = IridiumGateway.new(fixtures(:iridium))
 
     @amount = 100
-    @avs_card = credit_card('4921810000005462', {:verification_value => '441'})
-    @cv2_card = credit_card('4976000000003436', {:verification_value => '777'})
-    @avs_cv2_card = credit_card('4921810000005462', {:verification_value => '777'})
-    @credit_card = credit_card('4976000000003436', {:verification_value => '452'})
+    @avs_card = credit_card('4921810000005462', {verification_value: '441'})
+    @cv2_card = credit_card('4976000000003436', {verification_value: '777'})
+    @avs_cv2_card = credit_card('4921810000005462', {verification_value: '777'})
+    @credit_card = credit_card('4976000000003436', {verification_value: '452'})
     @declined_card = credit_card('4221690000004963')
 
-    our_address = address(:address1 => '32 Edward Street',
-                          :address2 => 'Camborne',
-                          :state => 'Cornwall',
-                          :zip => 'TR14 8PA',
-                          :country => '826')
+    our_address = address(address1: '32 Edward Street',
+                          address2: 'Camborne',
+                          state: 'Cornwall',
+                          zip: 'TR14 8PA',
+                          country: '826')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => our_address,
-      :description => 'Store Purchase'
+      order_id: generate_unique_id,
+      billing_address: our_address,
+      description: 'Store Purchase'
     }
   end
 
@@ -111,7 +111,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert(reference = response.authorization)
 
-    assert response = @gateway.purchase(@amount, reference, {:order_id => generate_unique_id})
+    assert response = @gateway.purchase(@amount, reference, {order_id: generate_unique_id})
     assert_success response
   end
 
@@ -120,7 +120,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
 
-    assert response = @gateway.purchase(@amount, 'bogusref', {:order_id => generate_unique_id})
+    assert response = @gateway.purchase(@amount, 'bogusref', {order_id: generate_unique_id})
     assert_failure response
   end
 
@@ -129,7 +129,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert(reference = response.authorization)
 
-    assert response = @gateway.authorize(@amount, reference, {:order_id => generate_unique_id})
+    assert response = @gateway.authorize(@amount, reference, {order_id: generate_unique_id})
     assert_success response
   end
 
@@ -164,8 +164,8 @@ class RemoteIridiumTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = IridiumGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
 
     assert response = gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_itransact_test.rb
+++ b/test/remote/gateways/remote_itransact_test.rb
@@ -9,9 +9,9 @@ class RemoteItransactTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -76,9 +76,9 @@ class RemoteItransactTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ItransactGateway.new(
-      :login => 'x',
-      :password => 'x',
-      :gateway_id => 'x'
+      login: 'x',
+      password: 'x',
+      gateway_id: 'x'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_jetpay_test.rb
+++ b/test/remote/gateways/remote_jetpay_test.rb
@@ -8,12 +8,12 @@ class RemoteJetpayTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300020001000')
 
     @options = {
-      :billing_address => address(:country => 'US', :zip => '75008'),
-      :shipping_address => address(:country => 'US'),
-      :email => 'test@test.com',
-      :ip => '127.0.0.1',
-      :order_id => '12345',
-      :tax => 7
+      billing_address: address(country: 'US', zip: '75008'),
+      shipping_address: address(country: 'US'),
+      email: 'test@test.com',
+      ip: '127.0.0.1',
+      order_id: '12345',
+      tax: 7
     }
   end
 
@@ -32,7 +32,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_origin
-    assert response = @gateway.purchase(9900, @credit_card, {:origin => 'RECURRING'})
+    assert response = @gateway.purchase(9900, @credit_card, {origin: 'RECURRING'})
     assert_success response
     assert_equal 'APPROVED', response.message
     assert_not_nil response.authorization
@@ -122,7 +122,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
 
   def test_refund_backwards_compatible
     # no need for csv
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
 
     assert response = @gateway.purchase(9900, card, @options)
     assert_success response
@@ -133,7 +133,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
     old_authorization = [response.params['transaction_id'], response.params['approval'], 9900].join(';')
 
     # linked to a specific transaction_id
-    assert credit = @gateway.refund(9900, old_authorization, :credit_card => card)
+    assert credit = @gateway.refund(9900, old_authorization, credit_card: card)
     assert_success credit
     assert_not_nil(credit.authorization)
     assert_not_nil(response.params['approval'])
@@ -142,7 +142,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
 
   def test_credit
     # no need for csv
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
 
     # no link to a specific transaction_id
     assert credit = @gateway.credit(9900, card)
@@ -158,7 +158,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = JetpayGateway.new(:login => 'bogus')
+    gateway = JetpayGateway.new(login: 'bogus')
     assert response = gateway.purchase(9900, @credit_card, @options)
     assert_failure response
 
@@ -166,7 +166,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
   end
 
   def test_missing_login
-    gateway = JetpayGateway.new(:login => '')
+    gateway = JetpayGateway.new(login: '')
     assert response = gateway.purchase(9900, @credit_card, @options)
     assert_failure response
 

--- a/test/remote/gateways/remote_jetpay_v2_certification_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_certification_test.rb
@@ -7,13 +7,13 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     @unique_id = ''
 
     @options = {
-      :device => 'spreedly',
-      :application => 'spreedly',
-      :developer_id => 'GenkID',
-      :billing_address => address(:address1 => '1234 Fifth Street', :address2 => '', :city => 'Beaumont', :state => 'TX', :country => 'US', :zip => '77708'),
-      :shipping_address => address(:address1 => '1234 Fifth Street', :address2 => '', :city => 'Beaumont', :state => 'TX', :country => 'US', :zip => '77708'),
-      :email => 'test@test.com',
-      :ip => '127.0.0.1'
+      device: 'spreedly',
+      application: 'spreedly',
+      developer_id: 'GenkID',
+      billing_address: address(address1: '1234 Fifth Street', address2: '', city: 'Beaumont', state: 'TX', country: 'US', zip: '77708'),
+      shipping_address: address(address1: '1234 Fifth Street', address2: '', city: 'Beaumont', state: 'TX', country: 'US', zip: '77708'),
+      email: 'test@test.com',
+      ip: '127.0.0.1'
     }
   end
 
@@ -24,7 +24,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp1_authorize_mastercard
     @options[:order_id] = 'CNP1'
     amount = 1000
-    master = credit_card('5111111111111118', :month => 12, :year => 2017, :brand => 'master', :verification_value => '121')
+    master = credit_card('5111111111111118', month: 12, year: 2017, brand: 'master', verification_value: '121')
     assert response = @gateway.authorize(amount, master, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -34,7 +34,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp2_authorize_visa
     @options[:order_id] = 'CNP2'
     amount = 1105
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '121')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '121')
     assert response = @gateway.authorize(amount, visa, @options)
     assert_failure response
     assert_equal 'Do not honor.', response.message
@@ -44,7 +44,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp3_cnp4_authorize_and_capture_amex
     @options[:order_id] = 'CNP3'
     amount = 1200
-    amex = credit_card('378282246310005', :month => 12, :year => 2017, :brand => 'american_express', :verification_value => '1221')
+    amex = credit_card('378282246310005', month: 12, year: 2017, brand: 'american_express', verification_value: '1221')
     assert response = @gateway.authorize(amount, amex, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -60,7 +60,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp5_purchase_discover
     @options[:order_id] = 'CNP5'
     amount = 1300
-    discover = credit_card('6011111111111117', :month => 12, :year => 2017, :brand => 'discover', :verification_value => '121')
+    discover = credit_card('6011111111111117', month: 12, year: 2017, brand: 'discover', verification_value: '121')
     assert response = @gateway.purchase(amount, discover, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -70,7 +70,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp6_purchase_visa
     @options[:order_id] = 'CNP6'
     amount = 1405
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '120')
     assert response = @gateway.purchase(amount, visa, @options)
     assert_failure response
     assert_equal 'Do not honor.', response.message
@@ -80,7 +80,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp7_authorize_mastercard
     @options[:order_id] = 'CNP7'
     amount = 1500
-    master = credit_card('5111111111111118', :month => 12, :year => 2017, :brand => 'master', :verification_value => '120')
+    master = credit_card('5111111111111118', month: 12, year: 2017, brand: 'master', verification_value: '120')
     assert response = @gateway.authorize(amount, master, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -90,7 +90,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp8_authorize_visa
     @options[:order_id] = 'CNP8'
     amount = 1605
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '120')
     assert response = @gateway.authorize(amount, visa, @options)
     assert_failure response
     assert_equal 'Do not honor.', response.message
@@ -100,7 +100,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp9_cnp10_authorize_and_capture_amex
     @options[:order_id] = 'CNP9'
     amount = 1700
-    amex = credit_card('378282246310005', :month => 12, :year => 2017, :brand => 'american_express', :verification_value => '1220')
+    amex = credit_card('378282246310005', month: 12, year: 2017, brand: 'american_express', verification_value: '1220')
     assert response = @gateway.authorize(amount, amex, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -116,7 +116,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cnp11_purchase_discover
     @options[:order_id] = 'CNP11'
     amount = 1800
-    discover = credit_card('6011111111111117', :month => 12, :year => 2017, :brand => 'discover', :verification_value => '120')
+    discover = credit_card('6011111111111117', month: 12, year: 2017, brand: 'discover', verification_value: '120')
     assert response = @gateway.purchase(amount, discover, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -129,7 +129,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     @options[:billing_address] = nil
     @options[:shipping_address] = nil
     amount = 2000
-    master = credit_card('5111111111111118', :month => 12, :year => 2017, :brand => 'master', :verification_value => '120')
+    master = credit_card('5111111111111118', month: 12, year: 2017, brand: 'master', verification_value: '120')
     assert response = @gateway.purchase(amount, master, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -140,7 +140,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     @options[:order_id] = 'REC02'
     @options[:origin] = 'RECURRING'
     amount = 2100
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '')
     assert response = @gateway.purchase(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -151,7 +151,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     @options[:order_id] = 'REC03'
     @options[:origin] = 'RECURRING'
     amount = 2200
-    amex = credit_card('378282246310005', :month => 12, :year => 2017, :brand => 'american_express', :verification_value => '1221')
+    amex = credit_card('378282246310005', month: 12, year: 2017, brand: 'american_express', verification_value: '1221')
     assert response = @gateway.purchase(amount, amex, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -161,7 +161,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_corp07_corp08_authorize_and_capture_discover
     @options[:order_id] = 'CORP07'
     amount = 2500
-    discover = credit_card('6011111111111117', :month => 12, :year => 2018, :brand => 'discover', :verification_value => '120')
+    discover = credit_card('6011111111111117', month: 12, year: 2018, brand: 'discover', verification_value: '120')
     assert response = @gateway.authorize(amount, discover, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -169,7 +169,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     puts "\n#{@options[:order_id]}: #{@unique_id}"
 
     @options[:order_id] = 'CORP08'
-    assert response = @gateway.capture(amount, response.authorization, @options.merge(:tax_amount => '200'))
+    assert response = @gateway.capture(amount, response.authorization, @options.merge(tax_amount: '200'))
     assert_success response
     @unique_id = response.params['unique_id']
   end
@@ -177,7 +177,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_corp09_corp10_authorize_and_capture_visa
     @options[:order_id] = 'CORP09'
     amount = 5000
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2018, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2018, brand: 'visa', verification_value: '120')
     assert response = @gateway.authorize(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -185,7 +185,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     puts "\n#{@options[:order_id]}: #{@unique_id}"
 
     @options[:order_id] = 'CORP10'
-    assert response = @gateway.capture(amount, response.authorization, @options.merge(:tax_amount => '0', :tax_exempt => 'true'))
+    assert response = @gateway.capture(amount, response.authorization, @options.merge(tax_amount: '0', tax_exempt: 'true'))
     assert_success response
     @unique_id = response.params['unique_id']
   end
@@ -193,7 +193,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_corp11_corp12_authorize_and_capture_mastercard
     @options[:order_id] = 'CORP11'
     amount = 7500
-    master = credit_card('5111111111111118', :month => 12, :year => 2018, :brand => 'master', :verification_value => '120')
+    master = credit_card('5111111111111118', month: 12, year: 2018, brand: 'master', verification_value: '120')
     assert response = @gateway.authorize(amount, master, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -201,7 +201,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
     puts "\n#{@options[:order_id]}: #{@unique_id}"
 
     @options[:order_id] = 'CORP12'
-    assert response = @gateway.capture(amount, response.authorization, @options.merge(:tax_amount => '0', :tax_exempt => 'false', :purchase_order => '456456'))
+    assert response = @gateway.capture(amount, response.authorization, @options.merge(tax_amount: '0', tax_exempt: 'false', purchase_order: '456456'))
     assert_success response
     @unique_id = response.params['unique_id']
   end
@@ -209,7 +209,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cred02_credit_visa
     @options[:order_id] = 'CRED02'
     amount = 100
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '120')
     assert response = @gateway.credit(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -219,7 +219,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_cred03_credit_amex
     @options[:order_id] = 'CRED03'
     amount = 200
-    amex = credit_card('378282246310005', :month => 12, :year => 2017, :brand => 'american_express', :verification_value => '1220')
+    amex = credit_card('378282246310005', month: 12, year: 2017, brand: 'american_express', verification_value: '1220')
     assert response = @gateway.credit(amount, amex, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -229,7 +229,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_void03_void04_purchase_void_visa
     @options[:order_id] = 'VOID03'
     amount = 300
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '120')
     assert response = @gateway.purchase(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -248,7 +248,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_void07_void08_void09_authorize_capture_void_discover
     @options[:order_id] = 'VOID07'
     amount = 400
-    discover = credit_card('6011111111111117', :month => 12, :year => 2017, :brand => 'discover', :verification_value => '120')
+    discover = credit_card('6011111111111117', month: 12, year: 2017, brand: 'discover', verification_value: '120')
     assert response = @gateway.authorize(amount, discover, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -271,7 +271,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_void12_void13_credit_void_visa
     @options[:order_id] = 'VOID12'
     amount = 800
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '120')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '120')
     assert response = @gateway.credit(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -286,7 +286,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
 
   def test_certification_tok15_tokenize_mastercard
     @options[:order_id] = 'TOK15'
-    master = credit_card('5111111111111118', :month => 12, :year => 2017, :brand => 'master', :verification_value => '101')
+    master = credit_card('5111111111111118', month: 12, year: 2017, brand: 'master', verification_value: '101')
     assert response = @gateway.store(master, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -297,7 +297,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_tok16_authorize_with_token_request_visa
     @options[:order_id] = 'TOK16'
     amount = 3100
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '101')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '101')
     assert response = @gateway.authorize(amount, visa, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -309,7 +309,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   def test_certification_tok17_purchase_with_token_request_amex
     @options[:order_id] = 'TOK17'
     amount = 3200
-    amex = credit_card('378282246310005', :month => 12, :year => 2017, :brand => 'american_express', :verification_value => '1001')
+    amex = credit_card('378282246310005', month: 12, year: 2017, brand: 'american_express', verification_value: '1001')
     assert response = @gateway.purchase(amount, amex, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
@@ -319,7 +319,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   end
 
   def test_certification_tok18_authorize_using_token_mastercard
-    master = credit_card('5111111111111118', :month => 12, :year => 2017, :brand => 'master', :verification_value => '101')
+    master = credit_card('5111111111111118', month: 12, year: 2017, brand: 'master', verification_value: '101')
     assert response = @gateway.store(master, @options)
     assert_success response
 
@@ -332,7 +332,7 @@ class RemoteJetpayV2CertificationTest < Test::Unit::TestCase
   end
 
   def test_certification_tok19_purchase_using_token_visa
-    visa   = credit_card('4111111111111111', :month => 12, :year => 2017, :brand => 'visa', :verification_value => '101')
+    visa   = credit_card('4111111111111111', month: 12, year: 2017, brand: 'visa', verification_value: '101')
     assert response = @gateway.store(visa, @options)
     assert_success response
 

--- a/test/remote/gateways/remote_jetpay_v2_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_test.rb
@@ -10,14 +10,14 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
     @amount_declined = 5205
 
     @options = {
-      :device => 'spreedly',
-      :application => 'spreedly',
-      :developer_id => 'GenkID',
-      :billing_address => address(:city => 'Durham', :state => 'NC', :country => 'US', :zip => '27701'),
-      :shipping_address => address(:city => 'Durham', :state => 'NC', :country => 'US', :zip => '27701'),
-      :email => 'test@test.com',
-      :ip => '127.0.0.1',
-      :order_id => '12345'
+      device: 'spreedly',
+      application: 'spreedly',
+      developer_id: 'GenkID',
+      billing_address: address(city: 'Durham', state: 'NC', country: 'US', zip: '27701'),
+      shipping_address: address(city: 'Durham', state: 'NC', country: 'US', zip: '27701'),
+      email: 'test@test.com',
+      ip: '127.0.0.1',
+      order_id: '12345'
     }
   end
 
@@ -36,7 +36,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_minimal_options
-    assert response = @gateway.purchase(@amount_approved, @credit_card, {:device => 'spreedly', :application => 'spreedly'})
+    assert response = @gateway.purchase(@amount_approved, @credit_card, {device: 'spreedly', application: 'spreedly'})
     assert_success response
     assert_equal 'APPROVED', response.message
     assert_not_nil response.authorization
@@ -71,7 +71,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
     assert_not_nil auth.authorization
     assert_not_nil auth.params['approval']
 
-    assert capture = @gateway.capture(@amount_approved, auth.authorization, @options.merge(:tax_amount => '990', :purchase_order => 'ABC12345'))
+    assert capture = @gateway.capture(@amount_approved, auth.authorization, @options.merge(tax_amount: '990', purchase_order: 'ABC12345'))
     assert_success capture
   end
 
@@ -146,7 +146,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_successful_credit
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
 
     assert credit = @gateway.credit(@amount_approved, card, @options)
     assert_success credit
@@ -155,7 +155,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_failed_credit
-    card = credit_card('2424242424242424', :verification_value => nil)
+    card = credit_card('2424242424242424', verification_value: nil)
 
     assert credit = @gateway.credit(@amount_approved, card, @options)
     assert_failure credit
@@ -168,7 +168,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    card = credit_card('2424242424242424', :verification_value => nil)
+    card = credit_card('2424242424242424', verification_value: nil)
 
     assert verify = @gateway.verify(card, @options)
     assert_failure verify
@@ -176,7 +176,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = JetpayV2Gateway.new(:login => 'bogus')
+    gateway = JetpayV2Gateway.new(login: 'bogus')
     assert response = gateway.purchase(@amount_approved, @credit_card, @options)
     assert_failure response
 
@@ -184,7 +184,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_missing_login
-    gateway = JetpayV2Gateway.new(:login => '')
+    gateway = JetpayV2Gateway.new(login: '')
     assert response = gateway.purchase(@amount_approved, @credit_card, @options)
     assert_failure response
 

--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -11,13 +11,13 @@ class RemoteKomojuTest < Test::Unit::TestCase
     @fraudulent_card = credit_card('4123111111111083')
 
     @options = {
-      :order_id => generate_unique_id,
-      :description => 'Store Purchase',
-      :tax => '10.0',
-      :ip => '192.168.0.1',
-      :email => 'valid@email.com',
-      :browser_language => 'en',
-      :browser_user_agent => 'user_agent'
+      order_id: generate_unique_id,
+      description: 'Store Purchase',
+      tax: '10.0',
+      ip: '192.168.0.1',
+      email: 'valid@email.com',
+      browser_language: 'en',
+      browser_user_agent: 'user_agent'
     }
   end
 
@@ -65,7 +65,7 @@ class RemoteKomojuTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = KomojuGateway.new(:login => 'abc')
+    gateway = KomojuGateway.new(login: 'abc')
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -36,7 +36,7 @@ class LinkpointTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
-    @options = { :order_id => generate_unique_id, :billing_address => address }
+    @options = { order_id: generate_unique_id, billing_address: address }
   end
 
   def test_successful_authorization
@@ -91,9 +91,9 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_successfull_purchase_with_item_entity
     @options[:line_items] = [
-      {:id => '123456', :description => 'Logo T-Shirt', :price => '12.00', :quantity => '1',
-       :options => [{:name => 'Color', :value => 'Red'}, {:name => 'Size', :value => 'XL'}]},
-      {:id => '111', :description => 'keychain', :price => '3.00', :quantity => '1'}
+      {id: '123456', description: 'Logo T-Shirt', price: '12.00', quantity: '1',
+       options: [{name: 'Color', value: 'Red'}, {name: 'Size', value: 'XL'}]},
+      {id: '111', description: 'keychain', price: '3.00', quantity: '1'}
     ]
     assert purchase = @gateway.purchase(1500, @credit_card, @options)
     assert_success purchase
@@ -101,11 +101,11 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_successful_recurring_payment
     assert response = @gateway.recurring(2400, @credit_card,
-      :order_id => generate_unique_id,
-      :installments => 12,
-      :startdate => 'immediate',
-      :periodicity => :monthly,
-      :billing_address => address
+      order_id: generate_unique_id,
+      installments: 12,
+      startdate: 'immediate',
+      periodicity: :monthly,
+      billing_address: address
     )
 
     assert_success response

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -9,146 +9,146 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test1
     credit_card = CreditCard.new(
-      :number => '4457010000000009',
-      :month => '01',
-      :year => '2021',
-      :verification_value => '349',
-      :brand => 'visa'
+      number: '4457010000000009',
+      month: '01',
+      year: '2021',
+      verification_value: '349',
+      brand: 'visa'
     )
 
     options = {
-      :order_id => '1',
-      :billing_address => {
-        :name => 'John & Mary Smith',
-        :address1 => '1 Main St.',
-        :city => 'Burlington',
-        :state => 'MA',
-        :zip => '01803-3747',
-        :country => 'US'
+      order_id: '1',
+      billing_address: {
+        name: 'John & Mary Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
       }
     }
 
-    auth_assertions(10100, credit_card, options, :avs => 'X', :cvv => 'M')
+    auth_assertions(10100, credit_card, options, avs: 'X', cvv: 'M')
 
-    authorize_avs_assertions(credit_card, options, :avs => 'X', :cvv => 'M')
+    authorize_avs_assertions(credit_card, options, avs: 'X', cvv: 'M')
 
-    sale_assertions(10100, credit_card, options, :avs => 'X', :cvv => 'M')
+    sale_assertions(10100, credit_card, options, avs: 'X', cvv: 'M')
   end
 
   def test2
-    credit_card = CreditCard.new(:number => '5112010000000003', :month => '02',
-                                 :year => '2021', :brand => 'master',
-                                 :verification_value => '261',
-                                 :name => 'Mike J. Hammer')
+    credit_card = CreditCard.new(number: '5112010000000003', month: '02',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '261',
+                                 name: 'Mike J. Hammer')
 
     options = {
-      :order_id => '2',
-      :billing_address => {
-        :address1 => '2 Main St.',
-        :address2 => 'Apt. 222',
-        :city => 'Riverside',
-        :state => 'RI',
-        :zip => '02915',
-        :country => 'US'
+      order_id: '2',
+      billing_address: {
+        address1: '2 Main St.',
+        address2: 'Apt. 222',
+        city: 'Riverside',
+        state: 'RI',
+        zip: '02915',
+        country: 'US'
       }
     }
 
-    auth_assertions(10100, credit_card, options, :avs => 'Z', :cvv => 'M')
+    auth_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
 
-    authorize_avs_assertions(credit_card, options, :avs => 'Z', :cvv => 'M')
+    authorize_avs_assertions(credit_card, options, avs: 'Z', cvv: 'M')
 
-    sale_assertions(10100, credit_card, options, :avs => 'Z', :cvv => 'M')
+    sale_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
   end
 
   def test3
     credit_card = CreditCard.new(
-      :number => '6011010000000003',
-      :month => '03',
-      :year => '2021',
-      :verification_value => '758',
-      :brand => 'discover'
+      number: '6011010000000003',
+      month: '03',
+      year: '2021',
+      verification_value: '758',
+      brand: 'discover'
     )
 
     options = {
-      :order_id => '3',
-      :billing_address => {
-        :name => 'Eileen Jones',
-        :address1 => '3 Main St.',
-        :city => 'Bloomfield',
-        :state => 'CT',
-        :zip => '06002',
-        :country => 'US'
+      order_id: '3',
+      billing_address: {
+        name: 'Eileen Jones',
+        address1: '3 Main St.',
+        city: 'Bloomfield',
+        state: 'CT',
+        zip: '06002',
+        country: 'US'
       }
     }
-    auth_assertions(10100, credit_card, options, :avs => 'Z', :cvv => 'M')
+    auth_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
 
-    authorize_avs_assertions(credit_card, options, :avs => 'Z', :cvv => 'M')
+    authorize_avs_assertions(credit_card, options, avs: 'Z', cvv: 'M')
 
-    sale_assertions(10100, credit_card, options, :avs => 'Z', :cvv => 'M')
+    sale_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
   end
 
   def test4
     credit_card = CreditCard.new(
-      :number => '375001000000005',
-      :month => '04',
-      :year => '2021',
-      :brand => 'american_express'
+      number: '375001000000005',
+      month: '04',
+      year: '2021',
+      brand: 'american_express'
     )
 
     options = {
-      :order_id => '4',
-      :billing_address => {
-        :name => 'Bob Black',
-        :address1 => '4 Main St.',
-        :city => 'Laurel',
-        :state => 'MD',
-        :zip => '20708',
-        :country => 'US'
+      order_id: '4',
+      billing_address: {
+        name: 'Bob Black',
+        address1: '4 Main St.',
+        city: 'Laurel',
+        state: 'MD',
+        zip: '20708',
+        country: 'US'
       }
     }
 
-    auth_assertions(10100, credit_card, options, :avs => 'A', :cvv => nil)
+    auth_assertions(10100, credit_card, options, avs: 'A', cvv: nil)
 
-    authorize_avs_assertions(credit_card, options, :avs => 'A')
+    authorize_avs_assertions(credit_card, options, avs: 'A')
 
-    sale_assertions(10100, credit_card, options, :avs => 'A', :cvv => nil)
+    sale_assertions(10100, credit_card, options, avs: 'A', cvv: nil)
   end
 
   def test5
     credit_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
-      :number => '4100200300011001',
-      :month => '05',
-      :year => '2021',
-      :verification_value => '463',
-      :brand => 'visa',
-      :payment_cryptogram => 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      number: '4100200300011001',
+      month: '05',
+      year: '2021',
+      verification_value: '463',
+      brand: 'visa',
+      payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
     )
 
     options = {
-      :order_id => '5'
+      order_id: '5'
     }
 
-    auth_assertions(10100, credit_card, options, :avs => 'U', :cvv => 'M')
+    auth_assertions(10100, credit_card, options, avs: 'U', cvv: 'M')
 
-    authorize_avs_assertions(credit_card, options, :avs => 'U', :cvv => 'M')
+    authorize_avs_assertions(credit_card, options, avs: 'U', cvv: 'M')
 
-    sale_assertions(10100, credit_card, options, :avs => 'U', :cvv => 'M')
+    sale_assertions(10100, credit_card, options, avs: 'U', cvv: 'M')
   end
 
   def test6
-    credit_card = CreditCard.new(:number => '4457010100000008', :month => '06',
-                                 :year => '2021', :brand => 'visa',
-                                 :verification_value => '992')
+    credit_card = CreditCard.new(number: '4457010100000008', month: '06',
+                                 year: '2021', brand: 'visa',
+                                 verification_value: '992')
 
     options = {
-      :order_id => '6',
-      :billing_address => {
-        :name => 'Joe Green',
-        :address1 => '6 Main St.',
-        :city => 'Derry',
-        :state => 'NH',
-        :zip => '03038',
-        :country => 'US'
+      order_id: '6',
+      billing_address: {
+        name: 'Joe Green',
+        address1: '6 Main St.',
+        city: 'Derry',
+        state: 'NH',
+        zip: '03038',
+        country: 'US'
       }
     }
 
@@ -171,26 +171,26 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
 
     # 6A. void
-    assert response = @gateway.void(response.authorization, {:order_id => '6A'})
+    assert response = @gateway.void(response.authorization, {order_id: '6A'})
     assert_equal '360', response.params['response']
     assert_equal 'No transaction found with specified transaction Id', response.message
     puts "Test #{options[:order_id]}A: #{txn_id(response)}"
   end
 
   def test7
-    credit_card = CreditCard.new(:number => '5112010100000002', :month => '07',
-                                 :year => '2021', :brand => 'master',
-                                 :verification_value => '251')
+    credit_card = CreditCard.new(number: '5112010100000002', month: '07',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '251')
 
     options = {
-      :order_id => '7',
-      :billing_address => {
-        :name => 'Jane Murray',
-        :address1 => '7 Main St.',
-        :city => 'Amesbury',
-        :state => 'MA',
-        :zip => '01913',
-        :country => 'US'
+      order_id: '7',
+      billing_address: {
+        name: 'Jane Murray',
+        address1: '7 Main St.',
+        city: 'Amesbury',
+        state: 'MA',
+        zip: '01913',
+        country: 'US'
       }
     }
 
@@ -204,7 +204,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 7: authorize avs
-    authorize_avs_assertions(credit_card, options, :avs => 'I', :cvv => 'N', :message => 'Invalid Account Number', :success => false)
+    authorize_avs_assertions(credit_card, options, avs: 'I', cvv: 'N', message: 'Invalid Account Number', success: false)
 
     # 7. sale
     assert response = @gateway.purchase(10100, credit_card, options)
@@ -217,19 +217,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test8
-    credit_card = CreditCard.new(:number => '6011010100000002', :month => '08',
-                                 :year => '2021', :brand => 'discover',
-                                 :verification_value => '184')
+    credit_card = CreditCard.new(number: '6011010100000002', month: '08',
+                                 year: '2021', brand: 'discover',
+                                 verification_value: '184')
 
     options = {
-      :order_id => '8',
-      :billing_address => {
-        :name => 'Mark Johnson',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US'
+      order_id: '8',
+      billing_address: {
+        name: 'Mark Johnson',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US'
       }
     }
 
@@ -243,7 +243,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 8: authorize avs
-    authorize_avs_assertions(credit_card, options, :avs => 'I', :cvv => 'P', :message => 'Call Discover', :success => false)
+    authorize_avs_assertions(credit_card, options, avs: 'I', cvv: 'P', message: 'Call Discover', success: false)
 
     # 8: sale
     assert response = @gateway.purchase(80080, credit_card, options)
@@ -256,19 +256,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test9
-    credit_card = CreditCard.new(:number => '375001010000003', :month => '09',
-                                 :year => '2021', :brand => 'american_express',
-                                 :verification_value => '0421')
+    credit_card = CreditCard.new(number: '375001010000003', month: '09',
+                                 year: '2021', brand: 'american_express',
+                                 verification_value: '0421')
 
     options = {
-      :order_id => '9',
-      :billing_address => {
-        :name => 'James Miller',
-        :address1 => '9 Main St.',
-        :city => 'Boston',
-        :state => 'MA',
-        :zip => '02134',
-        :country => 'US'
+      order_id: '9',
+      billing_address: {
+        name: 'James Miller',
+        address1: '9 Main St.',
+        city: 'Boston',
+        state: 'MA',
+        zip: '02134',
+        country: 'US'
       }
     }
 
@@ -281,7 +281,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
 
     # 9: authorize avs
-    authorize_avs_assertions(credit_card, options, :avs => 'I', :message => 'Pick Up Card', :success => false)
+    authorize_avs_assertions(credit_card, options, avs: 'I', message: 'Pick Up Card', success: false)
 
     # 9: sale
     assert response = @gateway.purchase(10100, credit_card, options)
@@ -294,19 +294,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   # Authorization Reversal Tests
   def test32
-    credit_card = CreditCard.new(:number => '4457010000000009', :month => '01',
-                                 :year => '2021', :brand => 'visa',
-                                 :verification_value => '349')
+    credit_card = CreditCard.new(number: '4457010000000009', month: '01',
+                                 year: '2021', brand: 'visa',
+                                 verification_value: '349')
 
     options = {
-      :order_id => '32',
-      :billing_address => {
-        :name => 'John Smith',
-        :address1 => '1 Main St.',
-        :city => 'Burlington',
-        :state => 'MA',
-        :zip => '01803-3747',
-        :country => 'US'
+      order_id: '32',
+      billing_address: {
+        name: 'John Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
       }
     }
 
@@ -326,21 +326,21 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test33
-    credit_card = CreditCard.new(:number => '5112010000000003', :month => '01',
-                                 :year => '2021', :brand => 'master',
-                                 :verification_value => '261')
+    credit_card = CreditCard.new(number: '5112010000000003', month: '01',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '261')
 
     options = {
-      :order_id => '33',
-      :billing_address => {
-        :name => 'Mike J. Hammer',
-        :address1 => '2 Main St.',
-        :address2 => 'Apt. 222',
-        :city => 'Riverside',
-        :state => 'RI',
-        :zip => '02915',
-        :country => 'US',
-        :payment_cryptogram => 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      order_id: '33',
+      billing_address: {
+        name: 'Mike J. Hammer',
+        address1: '2 Main St.',
+        address2: 'Apt. 222',
+        city: 'Riverside',
+        state: 'RI',
+        zip: '02915',
+        country: 'US',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
       }
     }
 
@@ -355,19 +355,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test34
-    credit_card = CreditCard.new(:number => '6011010000000003', :month => '01',
-                                 :year => '2021', :brand => 'discover',
-                                 :verification_value => '758')
+    credit_card = CreditCard.new(number: '6011010000000003', month: '01',
+                                 year: '2021', brand: 'discover',
+                                 verification_value: '758')
 
     options = {
-      :order_id => '34',
-      :billing_address => {
-        :name => 'Eileen Jones',
-        :address1 => '3 Main St.',
-        :city => 'Bloomfield',
-        :state => 'CT',
-        :zip => '06002',
-        :country => 'US'
+      order_id: '34',
+      billing_address: {
+        name: 'Eileen Jones',
+        address1: '3 Main St.',
+        city: 'Bloomfield',
+        state: 'CT',
+        zip: '06002',
+        country: 'US'
       }
     }
 
@@ -382,18 +382,18 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test35
-    credit_card = CreditCard.new(:number => '375001000000005', :month => '01',
-                                 :year => '2021', :brand => 'american_express')
+    credit_card = CreditCard.new(number: '375001000000005', month: '01',
+                                 year: '2021', brand: 'american_express')
 
     options = {
-      :order_id => '35',
-      :billing_address => {
-        :name => 'Bob Black',
-        :address1 => '4 Main St.',
-        :city => 'Laurel',
-        :state => 'MD',
-        :zip => '20708',
-        :country => 'US'
+      order_id: '35',
+      billing_address: {
+        name: 'Bob Black',
+        address1: '4 Main St.',
+        city: 'Laurel',
+        state: 'MD',
+        zip: '20708',
+        country: 'US'
       }
     }
 
@@ -414,11 +414,11 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test36
-    credit_card = CreditCard.new(:number => '375000026600004', :month => '01',
-                                 :year => '2021', :brand => 'american_express')
+    credit_card = CreditCard.new(number: '375000026600004', month: '01',
+                                 year: '2021', brand: 'american_express')
 
     options = {
-      :order_id => '36'
+      order_id: '36'
     }
 
     assert auth_response = @gateway.authorize(20500, credit_card, options)
@@ -440,16 +440,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '37',
-      :billing_address => {
-        :name => 'Tom Black',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '37',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert auth_response = @gateway.authorize(3001, check, options)
@@ -467,16 +467,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '38',
-      :billing_address => {
-        :name => 'John Smith',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '38',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert auth_response = @gateway.authorize(3002, check, options)
@@ -494,17 +494,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '39',
-      :billing_address => {
-        :name => 'John Smith',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Good Goods Inc',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '39',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Good Goods Inc',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert auth_response = @gateway.authorize(3003, check, options)
@@ -522,17 +522,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '40',
-      :billing_address => {
-        :name => 'Peter Green',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Green Co',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '40',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert auth_response = @gateway.authorize(3004, declined_authorize_check, options)
@@ -550,16 +550,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '41',
-      :billing_address => {
-        :name => 'Mike Hammer',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '41',
+      billing_address: {
+        name: 'Mike Hammer',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2008, check, options)
@@ -577,16 +577,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '42',
-      :billing_address => {
-        :name => 'Tom Black',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '42',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2004, check, options)
@@ -604,17 +604,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '43',
-      :billing_address => {
-        :name => 'Peter Green',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Green Co',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '43',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2007, check, options)
@@ -632,17 +632,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '44',
-      :billing_address => {
-        :name => 'Peter Green',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Green Co',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '44',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2009, check, options)
@@ -660,16 +660,16 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '45',
-      :billing_address => {
-        :name => 'John Smith',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '45',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert refund_response = @gateway.refund(1001, check, options)
@@ -687,18 +687,18 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '46',
-      :order_source => 'telephone',
-      :billing_address => {
-        :name => 'Robert Jones',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444',
-        :company => 'Widget Inc'
+      order_id: '46',
+      order_source: 'telephone',
+      billing_address: {
+        name: 'Robert Jones',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444',
+        company: 'Widget Inc'
       }
     }
     assert purchase_response = @gateway.purchase(1003, check, options)
@@ -718,17 +718,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '47',
-      :billing_address => {
-        :name => 'Peter Green',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Green Co',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '47',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(1007, check, options)
@@ -747,17 +747,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Corporate'
     )
     options = {
-      :order_id => '43',
-      :billing_address => {
-        :name => 'Peter Green',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :company => 'Green Co',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '43',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2007, check, options)
@@ -783,17 +783,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '42',
-      :id => '236222',
-      :billing_address => {
-        :name => 'Tom Black',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '42',
+      id: '236222',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(2004, check, options)
@@ -812,17 +812,17 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_type: 'Checking'
     )
     options = {
-      :order_id => '46',
-      :id => '232222',
-      :billing_address => {
-        :name => 'Robert Jones',
-        :address1 => '8 Main St.',
-        :city => 'Manchester',
-        :state => 'NH',
-        :zip => '03101',
-        :country => 'US',
-        :email => 'test@test.com',
-        :phone => '2233334444'
+      order_id: '46',
+      id: '232222',
+      billing_address: {
+        name: 'Robert Jones',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
       }
     }
     assert purchase_response = @gateway.purchase(1003, check, options)
@@ -843,9 +843,9 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   # Explicit Token Registration Tests
   def test50
-    credit_card = CreditCard.new(:number => '4457119922390123')
+    credit_card = CreditCard.new(number: '4457119922390123')
     options     = {
-      :order_id => '50'
+      order_id: '50'
     }
 
     # store
@@ -861,9 +861,9 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test51
-    credit_card = CreditCard.new(:number => '4457119999999999')
+    credit_card = CreditCard.new(number: '4457119999999999')
     options = {
-      :order_id => '51'
+      order_id: '51'
     }
 
     # store
@@ -876,9 +876,9 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test52
-    credit_card = CreditCard.new(:number => '4457119922390123')
+    credit_card = CreditCard.new(number: '4457119922390123')
     options = {
-      :order_id => '52'
+      order_id: '52'
     }
 
     # store
@@ -899,7 +899,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_number: '1099999998'
     )
     options     = {
-      :order_id => '53'
+      order_id: '53'
     }
 
     store_response = @gateway.store(check, options)
@@ -918,7 +918,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
       account_number: '1022222102'
     )
     options     = {
-      :order_id => '54'
+      order_id: '54'
     }
 
     store_response = @gateway.store(check, options)
@@ -931,13 +931,13 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   # Implicit Token Registration Tests
   def test55
-    credit_card = CreditCard.new(:number             => '5435101234510196',
-                                 :month              => '11',
-                                 :year               => '2014',
-                                 :brand              => 'master',
-                                 :verification_value => '987')
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
     options = {
-      :order_id => '55'
+      order_id: '55'
     }
 
     # authorize
@@ -952,13 +952,13 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test56
-    credit_card = CreditCard.new(:number             => '5435109999999999',
-                                 :month              => '11',
-                                 :year               => '2014',
-                                 :brand              => 'master',
-                                 :verification_value => '987')
+    credit_card = CreditCard.new(number: '5435109999999999',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
     options = {
-      :order_id => '56'
+      order_id: '56'
     }
 
     # authorize
@@ -970,13 +970,13 @@ class RemoteLitleCertification < Test::Unit::TestCase
   end
 
   def test57_58
-    credit_card = CreditCard.new(:number             => '5435101234510196',
-                                 :month              => '11',
-                                 :year               => '2014',
-                                 :brand              => 'master',
-                                 :verification_value => '987')
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
     options = {
-      :order_id => '57'
+      order_id: '57'
     }
 
     # authorize card
@@ -993,10 +993,10 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # authorize token
     token   = response.params['tokenResponse_litleToken']
     options = {
-      :order_id => '58',
-      :token    => {
-        :month => credit_card.month,
-        :year  => credit_card.year
+      order_id: '58',
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
       }
     }
 
@@ -1011,10 +1011,10 @@ class RemoteLitleCertification < Test::Unit::TestCase
   def test59
     token   = '1111000100092332'
     options = {
-      :order_id => '59',
-      :token    => {
-        :month => '11',
-        :year  => '2021'
+      order_id: '59',
+      token: {
+        month: '11',
+        year: '2021'
       }
     }
 
@@ -1030,10 +1030,10 @@ class RemoteLitleCertification < Test::Unit::TestCase
   def test60
     token   = '171299999999999'
     options = {
-      :order_id => '60',
-      :token    => {
-        :month => '11',
-        :year  => '2014'
+      order_id: '60',
+      token: {
+        month: '11',
+        year: '2014'
       }
     }
 
@@ -1048,7 +1048,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test_apple_pay_purchase
     options = {
-      :order_id => transaction_id,
+      order_id: transaction_id,
     }
     decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {
@@ -1066,7 +1066,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test_android_pay_purchase
     options = {
-      :order_id => transaction_id,
+      order_id: transaction_id,
     }
     decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {
@@ -1104,22 +1104,22 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test_authorize_and_purchase_and_credit_with_token
     options = {
-      :order_id => transaction_id,
-      :billing_address => {
-        :name => 'John Smith',
-        :address1 => '1 Main St.',
-        :city => 'Burlington',
-        :state => 'MA',
-        :zip => '01803-3747',
-        :country => 'US'
+      order_id: transaction_id,
+      billing_address: {
+        name: 'John Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
       }
     }
 
-    credit_card = CreditCard.new(:number             => '5435101234510196',
-                                 :month              => '11',
-                                 :year               => '2014',
-                                 :brand              => 'master',
-                                 :verification_value => '987')
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
 
     # authorize
     assert auth_response = @gateway.authorize(0, credit_card, options)
@@ -1132,10 +1132,10 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     # purchase
     purchase_options = options.merge({
-      :order_id => transaction_id,
-      :token    => {
-        :month => credit_card.month,
-        :year  => credit_card.year
+      order_id: transaction_id,
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
       }
     })
 
@@ -1146,10 +1146,10 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
     # credit
     credit_options = options.merge({
-      :order_id => transaction_id,
-      :token    => {
-        :month => credit_card.month,
-        :year  => credit_card.year
+      order_id: transaction_id,
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
       }
     })
 
@@ -1171,15 +1171,15 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal auth_code(options[:order_id]), response.params['authCode']
 
     # 1A: capture
-    assert response = @gateway.capture(amount, response.authorization, {:id => transaction_id})
+    assert response = @gateway.capture(amount, response.authorization, {id: transaction_id})
     assert_equal 'Approved', response.message
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
+    assert response = @gateway.credit(amount, response.authorization, {id: transaction_id})
     assert_equal 'Approved', response.message
 
     # 1C: void
-    assert response = @gateway.void(response.authorization, {:id => transaction_id})
+    assert response = @gateway.void(response.authorization, {id: transaction_id})
     assert_equal 'Approved', response.message
   end
 
@@ -1201,19 +1201,19 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # assert_equal auth_code(options[:order_id]), response.params['authCode']
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization, {:id => transaction_id})
+    assert response = @gateway.credit(amount, response.authorization, {id: transaction_id})
     assert_equal 'Approved', response.message
 
     # 1C: void
-    assert response = @gateway.void(response.authorization, {:id => transaction_id})
+    assert response = @gateway.void(response.authorization, {id: transaction_id})
     assert_equal 'Approved', response.message
   end
 
   def three_d_secure_assertions(test_id, card, type, source, result)
-    credit_card = CreditCard.new(:number => card, :month => '01',
-                                 :year => '2021', :brand => type,
-                                 :verification_value => '261',
-                                 :name => 'Mike J. Hammer')
+    credit_card = CreditCard.new(number: card, month: '01',
+                                 year: '2021', brand: type,
+                                 verification_value: '261',
+                                 name: 'Mike J. Hammer')
 
     options = {
       order_id: test_id,

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -115,14 +115,14 @@ class RemoteLitleTest < Test::Unit::TestCase
   def test_unsuccessful_authorization
     assert response = @gateway.authorize(60060, @credit_card2,
       {
-        :order_id=>'6',
-        :billing_address=>{
-          :name      => 'Joe Green',
-          :address1  => '6 Main St.',
-          :city      => 'Derry',
-          :state     => 'NH',
-          :zip       => '03038',
-          :country   => 'US'
+        order_id: '6',
+        billing_address: {
+          name: 'Joe Green',
+          address1: '6 Main St.',
+          city: 'Derry',
+          state: 'NH',
+          zip: '03038',
+          country: 'US'
         },
       }
     )
@@ -199,14 +199,14 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(60060, @credit_card2, {
-      :order_id=>'6',
-      :billing_address=>{
-        :name      => 'Joe Green',
-        :address1  => '6 Main St.',
-        :city      => 'Derry',
-        :state     => 'NH',
-        :zip       => '03038',
-        :country   => 'US'
+      order_id: '6',
+      billing_address: {
+        name: 'Joe Green',
+        address1: '6 Main St.',
+        city: 'Derry',
+        state: 'NH',
+        zip: '03038',
+        country: 'US'
       },
     })
     assert_failure response
@@ -544,8 +544,8 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_store_successful
-    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '4457119922390123'))
-    assert store_response = @gateway.store(credit_card, :order_id => '50')
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4457119922390123'))
+    assert store_response = @gateway.store(credit_card, order_id: '50')
 
     assert_success store_response
     assert_equal 'Account number was successfully registered', store_response.message
@@ -557,7 +557,7 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_store_with_paypage_registration_id_successful
     paypage_registration_id = 'cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg='
-    assert store_response = @gateway.store(paypage_registration_id, :order_id => '50')
+    assert store_response = @gateway.store(paypage_registration_id, order_id: '50')
 
     assert_success store_response
     assert_equal 'Account number was successfully registered', store_response.message
@@ -566,8 +566,8 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_store_unsuccessful
-    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '4457119999999999'))
-    assert store_response = @gateway.store(credit_card, :order_id => '51')
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4457119999999999'))
+    assert store_response = @gateway.store(credit_card, order_id: '51')
 
     assert_failure store_response
     assert_equal 'Credit card number was invalid', store_response.message
@@ -575,8 +575,8 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_store_and_purchase_with_token_successful
-    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '4100280190123000'))
-    assert store_response = @gateway.store(credit_card, :order_id => '50')
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4100280190123000'))
+    assert store_response = @gateway.store(credit_card, order_id: '50')
     assert_success store_response
 
     token = store_response.authorization
@@ -623,8 +623,8 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_xml_schema_validation
-    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '123456'))
-    assert store_response = @gateway.store(credit_card, :order_id => '51')
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '123456'))
+    assert store_response = @gateway.store(credit_card, order_id: '51')
 
     assert_failure store_response
     assert_match(/^Error validating xml data against the schema/, store_response.message)

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -10,25 +10,25 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @credit_card = credit_card('4509953566233704')
     @colombian_card = credit_card('4013540682746260')
     @elo_credit_card = credit_card('5067268650517446',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737'
     )
     @cabal_credit_card = credit_card('6035227716427021',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737'
     )
     @naranja_credit_card = credit_card('5895627823453005',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '123'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '123'
     )
     @declined_card = credit_card('4000300011112220')
     @options = {

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -11,16 +11,16 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
     @declined_card = credit_card('4111111111111112')
 
     @options = {
-      :order_id => '123',
-      :billing_address => {
-        :name     => 'John Doe',
-        :address1 => '123 State Street',
-        :address2 => 'Apartment 1',
-        :city     => 'Nowhere',
-        :state    => 'MT',
-        :country  => 'US',
-        :zip      => '55555',
-        :phone    => '555-555-5555'
+      order_id: '123',
+      billing_address: {
+        name: 'John Doe',
+        address1: '123 State Street',
+        address2: 'Apartment 1',
+        city: 'Nowhere',
+        state: 'MT',
+        country: 'US',
+        zip: '55555',
+        phone: '555-555-5555'
       }
     }
   end
@@ -116,15 +116,15 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 
   def test_unsuccessful_avs_check_with_bad_street_address
     options = {
-      :billing_address => {
-        :name     => 'John Doe',
-        :address1 => '124 State Street',
-        :address2 => 'Apartment 1',
-        :city     => 'Nowhere',
-        :state    => 'MT',
-        :country  => 'US',
-        :zip      => '55555',
-        :phone    => '555-555-5555'
+      billing_address: {
+        name: 'John Doe',
+        address1: '124 State Street',
+        address2: 'Apartment 1',
+        city: 'Nowhere',
+        state: 'MT',
+        country: 'US',
+        zip: '55555',
+        phone: '555-555-5555'
       }
     }
     assert response = @gateway.purchase(@amount, @credit_card, options)
@@ -136,15 +136,15 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 
   def test_unsuccessful_avs_check_with_bad_zip
     options = {
-      :billing_address => {
-        :name     => 'John Doe',
-        :address1 => '123 State Street',
-        :address2 => 'Apartment 1',
-        :city     => 'Nowhere',
-        :state    => 'MT',
-        :country  => 'US',
-        :zip      => '55554',
-        :phone    => '555-555-5555'
+      billing_address: {
+        name: 'John Doe',
+        address1: '123 State Street',
+        address2: 'Apartment 1',
+        city: 'Nowhere',
+        state: 'MT',
+        country: 'US',
+        zip: '55554',
+        phone: '555-555-5555'
       }
     }
     assert response = @gateway.purchase(@amount, @credit_card, options)
@@ -162,12 +162,12 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 
   def test_unsuccessful_cvv_check
     credit_card = ActiveMerchant::Billing::CreditCard.new({
-      :first_name => 'John',
-      :last_name  => 'Doe',
-      :number => '4111111111111111',
-      :month      => '11',
-      :year       => (Time.now.year + 1).to_s,
-      :verification_value => '555'
+      first_name: 'John',
+      last_name: 'Doe',
+      number: '4111111111111111',
+      month: '11',
+      year: (Time.now.year + 1).to_s,
+      verification_value: '555'
     })
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_equal 'N', response.cvv_result['code']
@@ -176,8 +176,8 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantESolutionsGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_merchant_one_test.rb
+++ b/test/remote/gateways/remote_merchant_one_test.rb
@@ -9,9 +9,9 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
     @declined_card = credit_card('1111111111111111')
 
     @options = {
-      :order_id => '1',
-      :description => 'Store Purchase',
-      :billing_address => {
+      order_id: '1',
+      description: 'Store Purchase',
+      billing_address: {
         name: 'Jim Smith',
         address1: '1234 My Street',
         address2: 'Apt 1',
@@ -53,8 +53,8 @@ class RemoteMerchantOneTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantOneGateway.new(
-      :username => 'nnn',
-      :password => 'nnn'
+      username: 'nnn',
+      password: 'nnn'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_merchant_ware_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_test.rb
@@ -6,11 +6,11 @@ class RemoteMerchantWareTest < Test::Unit::TestCase
 
     @amount = rand(200..1199)
 
-    @credit_card = credit_card('5424180279791732', {:brand => 'master'})
+    @credit_card = credit_card('5424180279791732', {brand: 'master'})
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address
+      order_id: generate_unique_id,
+      billing_address: address
     }
   end
 
@@ -93,9 +93,9 @@ class RemoteMerchantWareTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantWareGateway.new(
-      :login => '',
-      :password => '',
-      :name => ''
+      login: '',
+      password: '',
+      name: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_merchant_ware_version_four_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_version_four_test.rb
@@ -4,16 +4,16 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
   def setup
     @gateway = MerchantWareVersionFourGateway.new(fixtures(:merchant_ware_version_four))
     @amount = rand(200..1199)
-    @credit_card = credit_card('5424180279791732', {:brand => 'master'})
+    @credit_card = credit_card('5424180279791732', {brand: 'master'})
     @declined_card = credit_card('1234567890123')
 
     @options = {
-      :order_id => generate_unique_id[0, 8],
-      :billing_address => address
+      order_id: generate_unique_id[0, 8],
+      billing_address: address
     }
 
     @reference_purchase_options = {
-      :order_id => generate_unique_id[0, 8]
+      order_id: generate_unique_id[0, 8]
     }
   end
 
@@ -92,9 +92,9 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MerchantWareVersionFourGateway.new(
-      :login => '',
-      :password => '',
-      :name => ''
+      login: '',
+      password: '',
+      name: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -2,37 +2,37 @@ require 'test_helper'
 
 class RemoteMerchantWarriorTest < Test::Unit::TestCase
   def setup
-    @gateway = MerchantWarriorGateway.new(fixtures(:merchant_warrior).merge(:test => true))
+    @gateway = MerchantWarriorGateway.new(fixtures(:merchant_warrior).merge(test: true))
 
     @success_amount = 100
     @failure_amount = 205
 
     @credit_card = credit_card(
       '4564710000000004',
-      :month => '2',
-      :year => '29',
-      :verification_value => '847',
-      :brand => 'visa'
+      month: '2',
+      year: '29',
+      verification_value: '847',
+      brand: 'visa'
     )
 
     @expired_card = credit_card(
       '4564710000000012',
-      :month => '2',
-      :year => '05',
-      :verification_value => '963',
-      :brand => 'visa'
+      month: '2',
+      year: '05',
+      verification_value: '963',
+      brand: 'visa'
     )
 
     @options = {
-      :billing_address => {
-        :name => 'Longbob Longsen',
-        :country => 'AU',
-        :state => 'Queensland',
-        :city => 'Brisbane',
-        :address1 => '123 test st',
-        :zip => '4000'
+      billing_address: {
+        name: 'Longbob Longsen',
+        country: 'AU',
+        state: 'Queensland',
+        city: 'Brisbane',
+        address1: '123 test st',
+        zip: '4000'
       },
-      :description => 'TestProduct'
+      description: 'TestProduct'
     }
   end
 

--- a/test/remote/gateways/remote_mercury_certification_test.rb
+++ b/test/remote/gateways/remote_mercury_certification_test.rb
@@ -13,7 +13,7 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     assert_success sale
     assert_equal 'AP', sale.params['text_response']
 
-    reversal = tokenization_gateway.void(sale.authorization, options.merge(:try_reversal => true))
+    reversal = tokenization_gateway.void(sale.authorization, options.merge(try_reversal: true))
     assert_success reversal
     assert_equal 'REVERSED', reversal.params['text_response']
   end
@@ -45,7 +45,7 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     assert_success preauth
     assert_equal 'AP', preauth.params['text_response']
 
-    reversal = tokenization_gateway.void(preauth.authorization, options.merge(:try_reversal => true))
+    reversal = tokenization_gateway.void(preauth.authorization, options.merge(try_reversal: true))
     assert_success reversal
     assert_equal 'REVERSED', reversal.params['text_response']
   end
@@ -70,45 +70,45 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
 
   def tokenization_gateway
     @tokenization_gateway ||= MercuryGateway.new(
-      :login => '023358150511666',
-      :password => 'xyz'
+      login: '023358150511666',
+      password: 'xyz'
     )
   end
 
   def visa
     @visa ||= credit_card(
       '4003000123456781',
-      :brand => 'visa',
-      :month => '12',
-      :year => '15',
-      :verification_value => '123'
+      brand: 'visa',
+      month: '12',
+      year: '15',
+      verification_value: '123'
     )
   end
 
   def disc
     @disc ||= credit_card(
       '6011000997235373',
-      :brand => 'discover',
-      :month => '12',
-      :year => '15',
-      :verification_value => '362'
+      brand: 'discover',
+      month: '12',
+      year: '15',
+      verification_value: '362'
     )
   end
 
   def mc
     @mc ||= credit_card(
       '5439750001500248',
-      :brand => 'master',
-      :month => '12',
-      :year => '15',
-      :verification_value => '123'
+      brand: 'master',
+      month: '12',
+      year: '15',
+      verification_value: '123'
     )
   end
 
   def options(order_id=nil, other={})
     {
-      :order_id => order_id,
-      :description => 'ActiveMerchant',
+      order_id: order_id,
+      description: 'ActiveMerchant',
     }.merge(other)
   end
 end

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -9,27 +9,27 @@ class RemoteMercuryTest < Test::Unit::TestCase
 
     @amount = 100
 
-    @credit_card = credit_card('4003000123456781', :brand => 'visa', :month => '12', :year => '18')
+    @credit_card = credit_card('4003000123456781', brand: 'visa', month: '12', year: '18')
 
     @track_1_data = '%B4003000123456781^LONGSEN/L. ^18121200000000000000**123******?*'
     @track_2_data = ';5413330089010608=2512101097750213?'
 
     @options = {
-      :order_id => 'c111111111.1',
-      :description => 'ActiveMerchant'
+      order_id: 'c111111111.1',
+      description: 'ActiveMerchant'
     }
     @options_with_billing = @options.merge(
-      :merchant => '999',
-      :billing_address => {
-        :address1 => '4 Corporate SQ',
-        :zip => '30329'
+      merchant: '999',
+      billing_address: {
+        address1: '4 Corporate SQ',
+        zip: '30329'
       }
     )
     @full_options = @options_with_billing.merge(
-      :ip => '123.123.123.123',
-      :merchant => 'Open Dining',
-      :customer => 'Tim',
-      :tax => '5'
+      ip: '123.123.123.123',
+      merchant: 'Open Dining',
+      customer: 'Tim',
+      tax: '5'
     )
 
     close_batch
@@ -144,7 +144,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
   end
 
   def test_mastercard_authorize_and_capture_with_refund
-    mc = credit_card('5499990123456781', :brand => 'master')
+    mc = credit_card('5499990123456781', brand: 'master')
 
     response = @gateway.authorize(200, mc, @options)
     assert_success response
@@ -161,7 +161,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
   end
 
   def test_amex_authorize_and_capture_with_refund
-    amex = credit_card('373953244361001', :brand => 'american_express', :verification_value => '1234')
+    amex = credit_card('373953244361001', brand: 'american_express', verification_value: '1234')
 
     response = @gateway.authorize(201, amex, @options)
     assert_success response
@@ -177,7 +177,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
   end
 
   def test_discover_authorize_and_capture
-    discover = credit_card('6011000997235373', :brand => 'discover')
+    discover = credit_card('6011000997235373', brand: 'discover')
 
     response = @gateway.authorize(225, discover, @options_with_billing)
     assert_success response
@@ -206,7 +206,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
     assert_success response
     assert_equal '1.00', response.params['authorize']
 
-    capture = gateway.capture(nil, response.authorization, :credit_card => @credit_card)
+    capture = gateway.capture(nil, response.authorization, credit_card: @credit_card)
     assert_success capture
     assert_equal '1.00', capture.params['authorize']
   end

--- a/test/remote/gateways/remote_metrics_global_test.rb
+++ b/test/remote/gateways/remote_metrics_global_test.rb
@@ -6,11 +6,11 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
     @gateway = MetricsGlobalGateway.new(fixtures(:metrics_global))
     @amount = 100
-    @credit_card = credit_card('4111111111111111', :verification_value => '999')
+    @credit_card = credit_card('4111111111111111', verification_value: '999')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address(:address1 => '888 Test Street', :zip => '77777'),
-      :description => 'Store purchase'
+      order_id: generate_unique_id,
+      billing_address: address(address1: '888 Test Street', zip: '77777'),
+      description: 'Store purchase'
     }
   end
 
@@ -57,8 +57,8 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = MetricsGlobalGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     assert response = gateway.purchase(@amount, @credit_card)
@@ -78,8 +78,8 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_using_test_request
     gateway = MetricsGlobalGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     assert response = gateway.purchase(@amount, @credit_card)

--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -10,18 +10,18 @@ class RemoteMigsTest < Test::Unit::TestCase
 
     @amount = 100
     @declined_amount = 105
-    @visa   = credit_card('4987654321098769', :month => 5, :year => 2021, :brand => 'visa')
-    @master = credit_card('5123456789012346', :month => 5, :year => 2021, :brand => 'master')
-    @amex   = credit_card('371449635311004',  :month => 5, :year => 2021, :brand => 'american_express')
-    @diners = credit_card('30123456789019',   :month => 5, :year => 2021, :brand => 'diners_club')
+    @visa   = credit_card('4987654321098769', month: 5, year: 2021, brand: 'visa')
+    @master = credit_card('5123456789012346', month: 5, year: 2021, brand: 'master')
+    @amex   = credit_card('371449635311004',  month: 5, year: 2021, brand: 'american_express')
+    @diners = credit_card('30123456789019',   month: 5, year: 2021, brand: 'diners_club')
     @credit_card = @visa
 
     @valid_tx_source = 'MOTO'
     @invalid_tx_source = 'penguin'
 
     @options = {
-      :order_id => '1',
-      :currency => 'SAR'
+      order_id: '1',
+      currency: 'SAR'
     }
 
     @three_ds_options = {
@@ -36,10 +36,10 @@ class RemoteMigsTest < Test::Unit::TestCase
 
   def test_server_purchase_url
     options = {
-      :order_id   => 1,
-      :unique_id  => 9,
-      :return_url => 'http://localhost:8080/payments/return',
-      :currency => 'SAR'
+      order_id: 1,
+      unique_id: 9,
+      return_url: 'http://localhost:8080/payments/return',
+      currency: 'SAR'
     }
 
     choice_url = @gateway.purchase_offsite_url(@amount, options)
@@ -52,7 +52,7 @@ class RemoteMigsTest < Test::Unit::TestCase
     }
 
     responses.each_pair do |card_type, response_text|
-      url = @gateway.purchase_offsite_url(@amount, options.merge(:card_type => card_type))
+      url = @gateway.purchase_offsite_url(@amount, options.merge(card_type: card_type))
       assert_response_match response_text, url
     end
   end
@@ -157,7 +157,7 @@ class RemoteMigsTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = MigsGateway.new(:login => '', :password => '')
+    gateway = MigsGateway.new(login: '', password: '')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Required field vpc_Merchant was not present in the request', response.message

--- a/test/remote/gateways/remote_modern_payments_cim_test.rb
+++ b/test/remote/gateways/remote_modern_payments_cim_test.rb
@@ -9,8 +9,8 @@ class RemoteModernPaymentsCimTest < Test::Unit::TestCase
     @declined_card = credit_card('4000000000000000')
 
     @options = {
-      :billing_address => address,
-      :customer => 'JIMSMITH2000'
+      billing_address: address,
+      customer: 'JIMSMITH2000'
     }
   end
 
@@ -46,8 +46,8 @@ class RemoteModernPaymentsCimTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ModernPaymentsCimGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.create_customer(@options)
     assert_failure response

--- a/test/remote/gateways/remote_modern_payments_test.rb
+++ b/test/remote/gateways/remote_modern_payments_test.rb
@@ -9,9 +9,9 @@ class RemoteModernPaymentTest < Test::Unit::TestCase
     @declined_card = credit_card('4000000000000000')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -33,8 +33,8 @@ class RemoteModernPaymentTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ModernPaymentsGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
 
     assert_raises(ActiveMerchant::ResponseError) do

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -154,10 +154,10 @@ class RemoteMoneiTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MoneiGateway.new(
-      :sender_id => 'mother',
-      :channel_id => 'there is no other',
-      :login => 'like mother',
-      :pwd => 'so treat Her right'
+      sender_id: 'mother',
+      channel_id: 'there is no other',
+      login: 'like mother',
+      pwd: 'so treat Her right'
     )
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -6,11 +6,11 @@ class MonerisRemoteTest < Test::Unit::TestCase
 
     @gateway = MonerisGateway.new(fixtures(:moneris))
     @amount = 100
-    @credit_card = credit_card('4242424242424242', :verification_value => '012')
+    @credit_card = credit_card('4242424242424242', verification_value: '012')
     @options = {
-      :order_id => generate_unique_id,
-      :customer => generate_unique_id,
-      :billing_address => address
+      order_id: generate_unique_id,
+      customer: generate_unique_id,
+      billing_address: address
     }
   end
 
@@ -130,7 +130,7 @@ class MonerisRemoteTest < Test::Unit::TestCase
     response = @gateway.capture(@amount, response.authorization)
     assert_success response
 
-    void = @gateway.void(response.authorization, :purchasecorrection => true)
+    void = @gateway.void(response.authorization, purchasecorrection: true)
     assert_success void
   end
 
@@ -159,7 +159,7 @@ class MonerisRemoteTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    void = @gateway.void(purchase.authorization, :purchasecorrection => true)
+    void = @gateway.void(purchase.authorization, purchasecorrection: true)
     assert_success void
   end
 
@@ -216,7 +216,7 @@ class MonerisRemoteTest < Test::Unit::TestCase
     gateway = MonerisGateway.new(fixtures(:moneris).merge(avs_enabled: true))
 
     # card number triggers AVS match
-    @credit_card = credit_card('4761739012345637', :verification_value => '012')
+    @credit_card = credit_card('4761739012345637', verification_value: '012')
     assert response = gateway.store(@credit_card, @options)
     assert_success response
     assert_equal 'Successfully registered cc details', response.message

--- a/test/remote/gateways/remote_moneris_us_test.rb
+++ b/test/remote/gateways/remote_moneris_us_test.rb
@@ -8,9 +8,9 @@ class MonerisUsRemoteTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @check = check({
       routing_number: '011000015',

--- a/test/remote/gateways/remote_money_movers_test.rb
+++ b/test/remote/gateways/remote_money_movers_test.rb
@@ -10,9 +10,9 @@ class RemoteMoneyMoversTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Active Merchant Remote Test Purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Active Merchant Remote Test Purchase'
     }
   end
 
@@ -72,8 +72,8 @@ class RemoteMoneyMoversTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = MoneyMoversGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -11,9 +11,9 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     @declined_card = credit_card('4111111111111234')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'NAB Transact Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'NAB Transact Purchase'
     }
   end
 
@@ -63,8 +63,8 @@ class RemoteNabTransactTest < Test::Unit::TestCase
   # ensure we get the error.
   def test_successful_purchase_with_card_acceptor
     card_acceptor_options = {
-      :merchant_name => 'ActiveMerchant',
-      :merchant_location => 'Melbourne'
+      merchant_name: 'ActiveMerchant',
+      merchant_location: 'Melbourne'
     }
     card_acceptor_options.each do |key, value|
       options = @options.merge({key => value})
@@ -128,8 +128,8 @@ class RemoteNabTransactTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_card_acceptor
     card_acceptor_options = {
-      :merchant_name => 'ActiveMerchant',
-      :merchant_location => 'Melbourne'
+      merchant_name: 'ActiveMerchant',
+      merchant_location: 'Melbourne'
     }
     card_acceptor_options.each do |key, value|
       options = @options.merge({key => value})
@@ -161,11 +161,11 @@ class RemoteNabTransactTest < Test::Unit::TestCase
   # You need to speak to NAB Transact to have this feature enabled on
   # your account otherwise you will receive a "Permission denied" error
   def test_credit
-    assert response = @gateway.credit(@amount, @credit_card, {:order_id => '1'})
+    assert response = @gateway.credit(@amount, @credit_card, {order_id: '1'})
     assert_failure response
     assert_equal 'Permission denied', response.message
 
-    assert response = @privileged_gateway.credit(@amount, @credit_card, {:order_id => '1'})
+    assert response = @privileged_gateway.credit(@amount, @credit_card, {order_id: '1'})
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -181,8 +181,8 @@ class RemoteNabTransactTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NabTransactGateway.new(
-      :login => 'ABCFAKE',
-      :password => 'changeit'
+      login: 'ABCFAKE',
+      password: 'changeit'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -204,11 +204,11 @@ class RemoteNabTransactTest < Test::Unit::TestCase
   def test_duplicate_store
     @gateway.unstore(1236)
 
-    assert response = @gateway.store(@credit_card, {:billing_id => 1236})
+    assert response = @gateway.store(@credit_card, {billing_id: 1236})
     assert_success response
     assert_equal 'Successful', response.message
 
-    assert response = @gateway.store(@credit_card, {:billing_id => 1236})
+    assert response = @gateway.store(@credit_card, {billing_id: 1236})
     assert_failure response
     assert_equal 'Duplicate CRN Found', response.message
   end
@@ -239,7 +239,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     trigger_amount = 0
     @gateway.unstore(gateway_id)
 
-    assert response = @gateway.store(@credit_card, {:billing_id => gateway_id, :amount => 150})
+    assert response = @gateway.store(@credit_card, {billing_id: gateway_id, amount: 150})
     assert_success response
     assert_equal 'Successful', response.message
 

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -16,8 +16,8 @@ class NetRegistryTest < Test::Unit::TestCase
     @amount = 100
     @valid_creditcard = credit_card
     @invalid_creditcard = credit_card('41111111111111111')
-    @expired_creditcard = credit_card('4111111111111111', :year => '2000')
-    @invalid_month_creditcard = credit_card('4111111111111111', :month => '13')
+    @expired_creditcard = credit_card('4111111111111111', year: '2000')
+    @invalid_month_creditcard = credit_card('4111111111111111', month: '13')
   end
 
   def test_successful_purchase_and_credit
@@ -58,7 +58,7 @@ class NetRegistryTest < Test::Unit::TestCase
 
       response = @gateway.capture(@amount,
         response.authorization,
-        :credit_card => @valid_creditcard)
+        credit_card: @valid_creditcard)
       assert_success response
       assert_equal 'approved', response.params['status']
     end
@@ -87,8 +87,8 @@ class NetRegistryTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = NetRegistryGateway.new(
-      :login    => 'bad-login',
-      :password => 'bad-login'
+      login: 'bad-login',
+      password: 'bad-login'
     )
     response = gateway.purchase(@amount, @valid_creditcard)
     assert_equal 'failed', response.params['status']

--- a/test/remote/gateways/remote_netaxept_test.rb
+++ b/test/remote/gateways/remote_netaxept_test.rb
@@ -9,7 +9,7 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
     @declined_card = credit_card('4925000000000087')
 
     @options = {
-      :order_id => generate_unique_id
+      order_id: generate_unique_id
     }
   end
 
@@ -75,20 +75,20 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
   end
 
   def test_error_in_transaction_setup
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'BOGG'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'BOGG'))
     assert_failure response
     assert_match(/currency code/, response.message)
   end
 
   def test_successful_amex_purchase
-    credit_card = credit_card('378282246310005', :brand => 'american_express')
+    credit_card = credit_card('378282246310005', brand: 'american_express')
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'OK', response.message
   end
 
   def test_successful_master_purchase
-    credit_card = credit_card('5413000000000000', :brand => 'master')
+    credit_card = credit_card('5413000000000000', brand: 'master')
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'OK', response.message
@@ -116,8 +116,8 @@ class RemoteNetaxeptTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetaxeptGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_netbilling_test.rb
+++ b/test/remote/gateways/remote_netbilling_test.rb
@@ -6,17 +6,17 @@ class RemoteNetbillingTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4444111111111119')
 
-    @address = {  :address1 => '1600 Amphitheatre Parkway',
-                  :city => 'Mountain View',
-                  :state => 'CA',
-                  :country => 'US',
-                  :zip => '94043',
-                  :phone => '650-253-0001'}
+    @address = {  address1: '1600 Amphitheatre Parkway',
+                  city: 'Mountain View',
+                  state: 'CA',
+                  country: 'US',
+                  zip: '94043',
+                  phone: '650-253-0001'}
 
     @options = {
-      :billing_address => @address,
-      :description => 'Internet purchase',
-      :order_id => 987654321
+      billing_address: @address,
+      description: 'Internet purchase',
+      order_id: 987654321
     }
 
     @amount = 100
@@ -88,8 +88,8 @@ class RemoteNetbillingTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetbillingGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match(/missing/i, response.message)

--- a/test/remote/gateways/remote_netpay_test.rb
+++ b/test/remote/gateways/remote_netpay_test.rb
@@ -9,7 +9,7 @@ class RemoteNetpayTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :description => 'Store Purchase'
+      description: 'Store Purchase'
     }
   end
 

--- a/test/remote/gateways/remote_network_merchants_test.rb
+++ b/test/remote/gateways/remote_network_merchants_test.rb
@@ -11,9 +11,9 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
     @check = check
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -54,7 +54,7 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
   end
 
   def test_purchase_and_store
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:store => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(store: true))
     assert_success response
     assert_equal response.params['transactionid'], response.authorization
     assert response.params['customer_vault_id']
@@ -153,8 +153,8 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = NetworkMerchantsGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -163,16 +163,16 @@ class RemoteNetworkMerchantsTest < Test::Unit::TestCase
 
   def test_successful_purchase_without_state
     @options[:billing_address] = {
-      :name     => 'Jim Smith',
-      :address1 => 'Gullhauggrenda 30',
-      :address2 => 'Apt 1',
-      :company  => 'Widgets Inc',
-      :city     => 'Baerums Verk',
-      :state    => nil,
-      :zip      => '1354',
-      :country  => 'NO',
-      :phone    => '(555)555-5555',
-      :fax      => '(555)555-6666'
+      name: 'Jim Smith',
+      address1: 'Gullhauggrenda 30',
+      address2: 'Apt 1',
+      company: 'Widgets Inc',
+      city: 'Baerums Verk',
+      state: nil,
+      zip: '1354',
+      country: 'NO',
+      phone: '(555)555-5555',
+      fax: '(555)555-6666'
     }
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -6,21 +6,21 @@ class RemoteNmiTest < Test::Unit::TestCase
     @amount = Random.rand(100...1000)
     @credit_card = credit_card('4111111111111111', verification_value: 917)
     @check = check(
-      :routing_number => '123123123',
-      :account_number => '123123123'
+      routing_number: '123123123',
+      account_number: '123123123'
     )
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      :month              => '01',
-      :year               => '2024',
-      :source             => :apple_pay,
-      :eci                => '5',
-      :transaction_id     => '123456789'
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: '2024',
+      source: :apple_pay,
+      eci: '5',
+      transaction_id: '123456789'
     )
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase'
     }
     @level3_options = {
       tax: 5.25, shipping: 10.51, ponumber: 1002

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -7,15 +7,15 @@ class RemoteOgoneTest < Test::Unit::TestCase
     @gateway = OgoneGateway.new(fixtures(:ogone))
     @amount = 100
     @credit_card     = credit_card('4000100011112224')
-    @mastercard      = credit_card('5399999999999999', :brand => 'mastercard')
+    @mastercard      = credit_card('5399999999999999', brand: 'mastercard')
     @declined_card   = credit_card('1111111111111111')
-    @credit_card_d3d = credit_card('4000000000000002', :verification_value => '111')
+    @credit_card_d3d = credit_card('4000000000000002', verification_value: '111')
     @options = {
-      :order_id => generate_unique_id[0...30],
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :currency => fixtures(:ogone)[:currency] || 'EUR',
-      :origin => 'STORE'
+      order_id: generate_unique_id[0...30],
+      billing_address: address,
+      description: 'Store Purchase',
+      currency: fixtures(:ogone)[:currency] || 'EUR',
+      origin: 'STORE'
     }
   end
 
@@ -27,13 +27,13 @@ class RemoteOgoneTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_utf8_encoding_1
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', :first_name => 'Rémy', :last_name => 'Fröåïør'), @options)
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', first_name: 'Rémy', last_name: 'Fröåïør'), @options)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
   end
 
   def test_successful_purchase_with_utf8_encoding_2
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', :first_name => 'ワタシ', :last_name => 'ёжзийклмнопрсуфхцч'), @options)
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224', first_name: 'ワタシ', last_name: 'ёжзийклмнопрсуфхцч'), @options)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
   end
@@ -61,7 +61,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   # NOTE: You have to set the "Hash algorithm" to "SHA-512" in the "Technical information"->"Global security parameters"
   #       section of your account admin on https://secure.ogone.com/ncol/test/frame_ogone.asp before running this test
   def test_successful_purchase_with_signature_encryptor_to_sha512
-    gateway = OgoneGateway.new(fixtures(:ogone).merge(:signature_encryptor => 'sha512'))
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(signature_encryptor: 'sha512'))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
@@ -69,7 +69,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
 
   # NOTE: You have to contact Ogone to make sure your test account allow 3D Secure transactions before running this test
   def test_successful_purchase_with_3d_secure
-    assert response = @gateway.purchase(@amount, @credit_card_d3d, @options.merge(:d3d => true))
+    assert response = @gateway.purchase(@amount, @credit_card_d3d, @options.merge(d3d: true))
     assert_success response
     assert_equal '46', response.params['STATUS']
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
@@ -91,7 +91,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_custom_eci
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:eci => 4))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(eci: 4))
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
   end
@@ -99,7 +99,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
   #       section of your account admin on https://secure.ogone.com/ncol/test/frame_ogone.asp before running this test
   def test_successful_purchase_with_custom_currency_at_the_gateway_level
-    gateway = OgoneGateway.new(fixtures(:ogone).merge(:currency => 'USD'))
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(currency: 'USD'))
     assert response = gateway.purchase(@amount, @credit_card)
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
@@ -108,8 +108,8 @@ class RemoteOgoneTest < Test::Unit::TestCase
   # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
   #       section of your account admin on https://secure.ogone.com/ncol/test/frame_ogone.asp before running this test
   def test_successful_purchase_with_custom_currency
-    gateway = OgoneGateway.new(fixtures(:ogone).merge(:currency => 'EUR'))
-    assert response = gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(currency: 'EUR'))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(currency: 'USD'))
     assert_success response
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
   end
@@ -136,7 +136,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture_with_custom_eci
-    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(:eci => 4))
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(eci: 4))
     assert_success auth
     assert_equal OgoneGateway::SUCCESS_MESSAGE, auth.message
     assert auth.authorization
@@ -160,15 +160,15 @@ class RemoteOgoneTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
+    assert response = @gateway.store(@credit_card, billing_id: 'test_alias')
     assert_success response
     assert purchase = @gateway.purchase(@amount, 'test_alias')
     assert_success purchase
   end
 
   def test_successful_store_with_store_amount_at_the_gateway_level
-    gateway = OgoneGateway.new(fixtures(:ogone).merge(:store_amount => 100))
-    assert response = gateway.store(@credit_card, :billing_id => 'test_alias')
+    gateway = OgoneGateway.new(fixtures(:ogone).merge(store_amount: 100))
+    assert response = gateway.store(@credit_card, billing_id: 'test_alias')
     assert_success response
     assert purchase = gateway.purchase(@amount, 'test_alias')
     assert_success purchase
@@ -220,13 +220,13 @@ class RemoteOgoneTest < Test::Unit::TestCase
 
   def test_reference_transactions
     # Setting an alias
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(:billing_id => 'awesomeman', :order_id=>Time.now.to_i.to_s+'1'))
+    assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(billing_id: 'awesomeman', order_id: Time.now.to_i.to_s+'1'))
     assert_success response
     # Updating an alias
-    assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(:billing_id => 'awesomeman', :order_id=>Time.now.to_i.to_s+'2'))
+    assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(billing_id: 'awesomeman', order_id: Time.now.to_i.to_s+'2'))
     assert_success response
     # Using an alias (i.e. don't provide the credit card)
-    assert response = @gateway.purchase(@amount, 'awesomeman', @options.merge(:order_id => Time.now.to_i.to_s + '3'))
+    assert response = @gateway.purchase(@amount, 'awesomeman', @options.merge(order_id: Time.now.to_i.to_s + '3'))
     assert_success response
   end
 

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -9,11 +9,11 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     @credit_card = credit_card('4387751111011')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Basic Subscription',
-      :email => 'email@example.com',
-      :ip => '1.2.3.4'
+      order_id: '1',
+      billing_address: address,
+      description: 'Basic Subscription',
+      email: 'email@example.com',
+      ip: '1.2.3.4'
     }
   end
 
@@ -141,9 +141,9 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = OptimalPaymentGateway.new(
-      :account_number => '1',
-      :store_id => 'bad',
-      :password => 'bad'
+      account_number: '1',
+      store_id: 'bad',
+      password: 'bad'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -10,18 +10,18 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => generate_unique_id,
-      :address => address,
-      :merchant_id => 'merchant1234'
+      order_id: generate_unique_id,
+      address: address,
+      merchant_id: 'merchant1234'
     }
 
     @cards = {
-      :visa => '4788250000028291',
-      :mc => '5454545454545454',
-      :amex => '371449635398431',
-      :ds => '6011000995500000',
-      :diners => '36438999960016',
-      :jcb => '3566002020140006'
+      visa: '4788250000028291',
+      mc: '5454545454545454',
+      amex: '371449635398431',
+      ds: '6011000995500000',
+      diners: '36438999960016',
+      jcb: '3566002020140006'
     }
 
     @level_2_options = {
@@ -41,15 +41,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     }
 
     @test_suite = [
-      {:card => :visa, :AVSzip => 11111, :CVD => 111,  :amount => 3000},
-      {:card => :visa, :AVSzip => 33333, :CVD => nil,  :amount => 3801},
-      {:card => :mc,   :AVSzip => 44444, :CVD => nil,  :amount => 4100},
-      {:card => :mc,   :AVSzip => 88888, :CVD => 666,  :amount => 1102},
-      {:card => :amex, :AVSzip => 55555, :CVD => nil,  :amount => 105500},
-      {:card => :amex, :AVSzip => 66666, :CVD => 2222, :amount => 7500},
-      {:card => :ds,   :AVSzip => 77777, :CVD => nil,  :amount => 1000},
-      {:card => :ds,   :AVSzip => 88888, :CVD => 444,  :amount => 6303},
-      {:card => :jcb,  :AVSzip => 33333, :CVD => nil,  :amount => 2900}
+      {card: :visa, AVSzip: 11111, CVD: 111,  amount: 3000},
+      {card: :visa, AVSzip: 33333, CVD: nil,  amount: 3801},
+      {card: :mc,   AVSzip: 44444, CVD: nil,  amount: 4100},
+      {card: :mc,   AVSzip: 88888, CVD: 666,  amount: 1102},
+      {card: :amex, AVSzip: 55555, CVD: nil,  amount: 105500},
+      {card: :amex, AVSzip: 66666, CVD: 2222, amount: 7500},
+      {card: :ds,   AVSzip: 77777, CVD: nil,  amount: 1000},
+      {card: :ds,   AVSzip: 88888, CVD: 444,  amount: 6303},
+      {card: :jcb,  AVSzip: 33333, CVD: nil,  amount: 2900}
     ]
   end
 
@@ -313,11 +313,11 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_authorize_and_capture
     amount = @amount
-    assert auth = @gateway.authorize(amount, @credit_card, @options.merge(:order_id => '2'))
+    assert auth = @gateway.authorize(amount, @credit_card, @options.merge(order_id: '2'))
     assert_success auth
     assert_equal 'Approved', auth.message
     assert auth.authorization
-    assert capture = @gateway.capture(amount, auth.authorization, :order_id => '2')
+    assert capture = @gateway.capture(amount, auth.authorization, order_id: '2')
     assert_success capture
   end
 
@@ -331,11 +331,11 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_void
-    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(:order_id => '2'))
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2'))
     assert_success auth
     assert_equal 'Approved', auth.message
     assert auth.authorization
-    assert void = @gateway.void(auth.authorization, :order_id => '2')
+    assert void = @gateway.void(auth.authorization, order_id: '2')
     assert_success void
   end
 
@@ -369,7 +369,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   def test_auth_only_transactions
     for suite in @test_suite do
       amount = suite[:amount]
-      card = credit_card(@cards[suite[:card]], :verification_value => suite[:CVD])
+      card = credit_card(@cards[suite[:card]], verification_value: suite[:CVD])
       @options[:address][:zip] = suite[:AVSzip]
       assert response = @gateway.authorize(amount, card, @options)
       assert_kind_of Response, response
@@ -387,7 +387,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   def test_auth_capture_transactions
     for suite in @test_suite do
       amount = suite[:amount]
-      card = credit_card(@cards[suite[:card]], :verification_value => suite[:CVD])
+      card = credit_card(@cards[suite[:card]], verification_value: suite[:CVD])
       options = @options; options[:address][:zip] = suite[:AVSzip]
       assert response = @gateway.purchase(amount, card, options)
       assert_kind_of Response, response
@@ -437,7 +437,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   def test_void_transactions
     [3000, 105500, 2900].each do |amount|
       assert auth_response = @gateway.authorize(amount, @credit_card, @options)
-      assert void_response = @gateway.void(auth_response.authorization, @options.merge(:transaction_index => 1))
+      assert void_response = @gateway.void(auth_response.authorization, @options.merge(transaction_index: 1))
       assert_kind_of Response, void_response
 
       # Makes it easier to fill in cert sheet if you print these to the command line

--- a/test/remote/gateways/remote_pagarme_test.rb
+++ b/test/remote/gateways/remote_pagarme_test.rb
@@ -14,7 +14,7 @@ class RemotePagarmeTest < Test::Unit::TestCase
     @declined_card = credit_card('4242424242424242', {
       first_name: 'Richard',
       last_name: 'Deschamps',
-      :verification_value => '688'
+      verification_value: '688'
     })
 
     @options = {

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -9,11 +9,11 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
     @declined_card  = credit_card('4000000000000036')
 
     @options = {
-      :order_id         => generate_unique_id,
-      :billing_address  => address,
-      :email           => 'john.doe@example.com',
-      :ip              => '127.0.0.1',
-      :description      => 'Store Purchase',
+      order_id: generate_unique_id,
+      billing_address: address,
+      email: 'john.doe@example.com',
+      ip: '127.0.0.1',
+      description: 'Store Purchase',
     }
   end
 
@@ -47,8 +47,8 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayGateXmlGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
@@ -59,7 +59,7 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+    credit = @gateway.refund(@amount, purchase.authorization, note: 'Sorry')
     assert_success credit
     assert credit.test?
   end

--- a/test/remote/gateways/remote_pay_hub_test.rb
+++ b/test/remote/gateways/remote_pay_hub_test.rb
@@ -7,14 +7,14 @@ class RemotePayHubTest < Test::Unit::TestCase
     @credit_card = credit_card('5466410004374507', verification_value: '998')
     @invalid_card = credit_card('371449635398431', verification_value: '9997')
     @options = {
-      :first_name => 'Garrya',
-      :last_name => 'Barrya',
-      :email => 'payhubtest@mailinator.com',
-      :address => {
-        :address1 => '123a ahappy St.',
-        :city => 'Happya City',
-        :state => 'CA',
-        :zip => '94901'
+      first_name: 'Garrya',
+      last_name: 'Barrya',
+      email: 'payhubtest@mailinator.com',
+      address: {
+        address1: '123a ahappy St.',
+        city: 'Happya City',
+        state: 'CA',
+        zip: '94901'
       }
     }
   end

--- a/test/remote/gateways/remote_pay_junction_test.rb
+++ b/test/remote/gateways/remote_pay_junction_test.rb
@@ -10,28 +10,28 @@ class PayJunctionTest < Test::Unit::TestCase
   def setup
     @gateway = PayJunctionGateway.new(fixtures(:pay_junction))
 
-    @credit_card = credit_card('4444333322221111', :verification_value => '999')
+    @credit_card = credit_card('4444333322221111', verification_value: '999')
 
     @valid_verification_value = '999'
     @invalid_verification_value = '1234'
 
     @valid_address = {
-      :address1 => '123 Test St.',
-      :address2 => nil,
-      :city => 'Somewhere',
-      :state => 'CA',
-      :zip => '90001'
+      address1: '123 Test St.',
+      address2: nil,
+      city: 'Somewhere',
+      state: 'CA',
+      zip: '90001'
     }
 
     @invalid_address = {
-      :address1 => '187 Apple Tree Lane.',
-      :address2 => nil,
-      :city => 'Woodside',
-      :state => 'CA',
-      :zip => '94062'
+      address1: '187 Apple Tree Lane.',
+      address2: nil,
+      city: 'Woodside',
+      state: 'CA',
+      zip: '94062'
     }
 
-    @options = { :billing_address => @valid_address, :order_id => generate_unique_id }
+    @options = { billing_address: @valid_address, order_id: generate_unique_id }
   end
 
   def test_successful_purchase
@@ -90,7 +90,7 @@ class PayJunctionTest < Test::Unit::TestCase
     purchase = @gateway.purchase(AMOUNT, @credit_card, @options)
     assert_success purchase
 
-    assert response = @gateway.void(purchase.authorization, :order_id => order_id)
+    assert response = @gateway.void(purchase.authorization, order_id: order_id)
     assert_success response
     assert_equal 'void', response.params['posture'], 'Should be a capture'
     assert_equal purchase.authorization, response.authorization,
@@ -105,7 +105,7 @@ class PayJunctionTest < Test::Unit::TestCase
     purchase = @gateway.purchase(AMOUNT, @credit_card, @options)
     assert_success purchase
 
-    assert response = @gateway.purchase(AMOUNT, purchase.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.purchase(AMOUNT, purchase.authorization, order_id: generate_unique_id)
 
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message
     assert_equal 'capture', response.params['posture'], 'Should be captured funds'
@@ -118,9 +118,9 @@ class PayJunctionTest < Test::Unit::TestCase
 
   def test_successful_recurring
     assert response = @gateway.recurring(AMOUNT, @credit_card,
-      :periodicity  => :monthly,
-      :payments     => 12,
-      :order_id => generate_unique_id[0..15]
+      periodicity: :monthly,
+      payments: 12,
+      order_id: generate_unique_id[0..15]
     )
 
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message

--- a/test/remote/gateways/remote_pay_secure_test.rb
+++ b/test/remote/gateways/remote_pay_secure_test.rb
@@ -6,8 +6,8 @@ class RemotePaySecureTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4000100011112224')
     @options = {
-      :billing_address => address,
-      :order_id => generate_unique_id
+      billing_address: address,
+      order_id: generate_unique_id
     }
     @amount = 100
   end
@@ -28,8 +28,8 @@ class RemotePaySecureTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PaySecureGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal "MissingField: 'MERCHANT_ID'", response.message

--- a/test/remote/gateways/remote_paybox_direct_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_test.rb
@@ -11,9 +11,9 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
     @declined_card = credit_card('1111222233334445')
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -35,7 +35,7 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'The transaction was approved', auth.message
     assert auth.authorization
-    assert capture = @gateway.capture(amount, auth.authorization, :order_id => '1')
+    assert capture = @gateway.capture(amount, auth.authorization, order_id: '1')
     assert_success capture
   end
 
@@ -45,13 +45,13 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
     assert_equal 'The transaction was approved', purchase.message
     assert purchase.authorization
     # Paybox requires you to remember the expiration date
-    assert void = @gateway.void(purchase.authorization, :order_id => '1', :amount => @amount)
+    assert void = @gateway.void(purchase.authorization, order_id: '1', amount: @amount)
     assert_equal 'The transaction was approved', void.message
     assert_success void
   end
 
   def test_failed_capture
-    assert response = @gateway.capture(@amount, '', :order_id => '1')
+    assert response = @gateway.capture(@amount, '', order_id: '1')
     assert_failure response
     assert_equal 'Invalid data', response.message
   end
@@ -61,7 +61,7 @@ class RemotePayboxDirectTest < Test::Unit::TestCase
     assert_success purchase
     assert_equal 'The transaction was approved', purchase.message
     assert purchase.authorization
-    assert credit = @gateway.credit(@amount / 2, purchase.authorization, :order_id => '1')
+    assert credit = @gateway.credit(@amount / 2, purchase.authorization, order_id: '1')
     assert_equal 'The transaction was approved', credit.message
     assert_success credit
   end

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -9,9 +9,9 @@ class RemotePayeezyTest < Test::Unit::TestCase
     @amount = 100
     @reversal_id = "REV-#{SecureRandom.random_number(1000000)}"
     @options = {
-      :billing_address => address,
-      :merchant_ref => 'Store Purchase',
-      :ta_token => 'NOIW'
+      billing_address: address,
+      merchant_ref: 'Store Purchase',
+      ta_token: 'NOIW'
     }
     @options_mdd = {
       soft_descriptors: {

--- a/test/remote/gateways/remote_payex_test.rb
+++ b/test/remote/gateways/remote_payex_test.rb
@@ -9,7 +9,7 @@ class RemotePayexTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => '1234',
+      order_id: '1234',
     }
   end
 
@@ -108,8 +108,8 @@ class RemotePayexTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayexGateway.new(
-      :account => '1',
-      :encryption_key => '1'
+      account: '1',
+      encryption_key: '1'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_payflow_express_test.rb
+++ b/test/remote/gateways/remote_payflow_express_test.rb
@@ -7,17 +7,16 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
     @gateway = PayflowExpressGateway.new(fixtures(:payflow))
 
     @options = {
-      :billing_address =>
-        {
-          :name => 'Cody Fauser',
-          :address1 => '1234 Shady Brook Lane',
-          :city => 'Ottawa',
-          :state => 'ON',
-          :country => 'CA',
-          :zip => '90210',
-          :phone => '555-555-5555'
-        },
-      :email => 'cody@example.com'
+      billing_address:         {
+        name: 'Cody Fauser',
+          address1: '1234 Shady Brook Lane',
+          city: 'Ottawa',
+          state: 'ON',
+          country: 'CA',
+          zip: '90210',
+          phone: '555-555-5555'
+      },
+      email: 'cody@example.com'
     }
   end
 
@@ -28,9 +27,9 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
   # the tests to work correctly
   def test_set_express_authorization
     @options.update(
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com',
-      :email => 'Buyer1@paypal.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com',
+      email: 'Buyer1@paypal.com'
     )
     response = @gateway.setup_authorization(500, @options)
     assert response.success?
@@ -40,9 +39,9 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
 
   def test_set_express_purchase
     @options.update(
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com',
-      :email => 'Buyer1@paypal.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com',
+      email: 'Buyer1@paypal.com'
     )
     response = @gateway.setup_purchase(500, @options)
     assert response.success?
@@ -53,25 +52,25 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
   def test_setup_authorization_discount_taxes_included_free_shipping
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'USD',
-      :subtotal=>2798,
-      :items => [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'USD',
+      subtotal: 2798,
+      items: [
         {
-          :name => 'test4',
-          :description => 'test4',
-          :quantity=>2,
-          :amount=> 1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>true
+      discount: 280,
+      no_shipping: true
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message
@@ -80,25 +79,25 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
   def test_setup_authorization_with_discount_taxes_additional
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'USD',
-      :subtotal=>2798,
-      :items => [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'USD',
+      subtotal: 2798,
+      items: [
         {
-          :name => 'test4',
-          :description => 'test4',
-          :quantity=>2,
-          :amount=> 1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>true
+      discount: 280,
+      no_shipping: true
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message
@@ -107,25 +106,25 @@ class RemotePayflowExpressTest < Test::Unit::TestCase
   def test_setup_authorization_with_discount_taxes_and_shipping_addtiional
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'USD',
-      :subtotal=>2798,
-      :items => [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'USD',
+      subtotal: 2798,
+      items: [
         {
-          :name => 'test4',
-          :description => 'test4',
-          :quantity=>2,
-          :amount=> 1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>false
+      discount: 280,
+      no_shipping: false
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message
@@ -140,25 +139,25 @@ class RemotePayflowExpressUkTest < Test::Unit::TestCase
   def test_setup_authorization_discount_taxes_included_free_shipping
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'GBP',
-      :subtotal=>2798,
-      :items=> [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'GBP',
+      subtotal: 2798,
+      items: [
         {
-          :name=>'test4',
-          :description=>'test4',
-          :quantity=>2,
-          :amount=>1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>true
+      discount: 280,
+      no_shipping: true
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message
@@ -167,25 +166,25 @@ class RemotePayflowExpressUkTest < Test::Unit::TestCase
   def test_setup_authorization_with_discount_taxes_additional
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'GBP',
-      :subtotal=>2798,
-      :items=> [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'GBP',
+      subtotal: 2798,
+      items: [
         {
-          :name=>'test4',
-          :description=>'test4',
-          :quantity=>2,
-          :amount=>1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>true
+      discount: 280,
+      no_shipping: true
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message
@@ -194,25 +193,25 @@ class RemotePayflowExpressUkTest < Test::Unit::TestCase
   def test_setup_authorization_with_discount_taxes_and_shipping_addtiional
     amount = 2518
     options = {
-      :ip=>'127.0.0.1',
-      :return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
-      :cancel_return_url=>'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
-      :customer=>'test6@test.com',
-      :email=>'test6@test.com',
-      :order_id=>'#1092',
-      :currency=>'GBP',
-      :subtotal=>2798,
-      :items=> [
+      ip: '127.0.0.1',
+      return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?buyer_accepts_marketing=true&utm_nooverride=1',
+      cancel_return_url: 'http://localhost:3000/orders/1/8e06ea26f8add7608671d433f13c2193/commit_paypal?utm_nooverride=1',
+      customer: 'test6@test.com',
+      email: 'test6@test.com',
+      order_id: '#1092',
+      currency: 'GBP',
+      subtotal: 2798,
+      items: [
         {
-          :name=>'test4',
-          :description=>'test4',
-          :quantity=>2,
-          :amount=>1399,
-          :url=>'http://localhost:3000/products/test4'
+          name: 'test4',
+          description: 'test4',
+          quantity: 2,
+          amount: 1399,
+          url: 'http://localhost:3000/products/test4'
         }
       ],
-      :discount=>280,
-      :no_shipping=>false
+      discount: 280,
+      no_shipping: false
     }
     response = @gateway.setup_authorization(amount, options)
     assert response.success?, response.message

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -8,26 +8,26 @@ class RemotePayflowTest < Test::Unit::TestCase
 
     @credit_card = credit_card(
       '5105105105105100',
-      :brand => 'master'
+      brand: 'master'
     )
 
     @options = {
-      :billing_address => address,
-      :email => 'cody@example.com',
-      :customer => 'codyexample'
+      billing_address: address,
+      email: 'cody@example.com',
+      customer: 'codyexample'
     }
 
     @extra_options = {
-      :order_id => '123',
-      :description => 'Description string',
-      :order_desc => 'OrderDesc string',
-      :comment => 'Comment string',
-      :comment2 => 'Comment2 string'
+      order_id: '123',
+      description: 'Description string',
+      order_desc: 'OrderDesc string',
+      comment: 'Comment string',
+      comment2: 'Comment2 string'
     }
 
     @check = check(
-      :routing_number => '111111118',
-      :account_number => '1111111111'
+      routing_number: '111111118',
+      account_number: '1111111111'
     )
 
     @l2_json = '{
@@ -192,7 +192,7 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
     assert auth.authorization
 
-    assert capture = @gateway.capture(100, auth.authorization, :capture_complete => 'Y')
+    assert capture = @gateway.capture(100, auth.authorization, capture_complete: 'Y')
     assert_success capture
 
     assert capture = @gateway.capture(100, auth.authorization)
@@ -205,7 +205,7 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
     assert auth.authorization
 
-    assert capture = @gateway.capture(100, auth.authorization, :capture_complete => 'N')
+    assert capture = @gateway.capture(100, auth.authorization, capture_complete: 'N')
     assert_success capture
 
     assert capture = @gateway.capture(100, auth.authorization)
@@ -236,7 +236,7 @@ class RemotePayflowTest < Test::Unit::TestCase
   def test_successful_verify_amex
     @amex_credit_card = credit_card(
       '378282246310005',
-      :brand => 'american_express'
+      brand: 'american_express'
     )
     assert response = @gateway.verify(@amex_credit_card, @options)
     assert_success response
@@ -251,8 +251,8 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayflowGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(100, @credit_card, @options)
     assert_equal 'Invalid vendor account', response.message
@@ -274,7 +274,7 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_create_recurring_profile
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+      @gateway.recurring(1000, @credit_card, periodicity: :monthly)
     end
     assert_success response
     assert !response.params['profile_id'].blank?
@@ -283,7 +283,7 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_create_recurring_profile_with_invalid_date
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(1000, @credit_card, :periodicity => :monthly, :starting_at => Time.now)
+      @gateway.recurring(1000, @credit_card, periodicity: :monthly, starting_at: Time.now)
     end
     assert_failure response
     assert_equal 'Field format error: Start or next payment date must be a valid future date', response.message
@@ -293,7 +293,7 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_create_and_cancel_recurring_profile
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(1000, @credit_card, :periodicity => :monthly)
+      @gateway.recurring(1000, @credit_card, periodicity: :monthly)
     end
     assert_success response
     assert !response.params['profile_id'].blank?
@@ -309,10 +309,10 @@ class RemotePayflowTest < Test::Unit::TestCase
   def test_full_feature_set_for_recurring_profiles
     # Test add
     @options.update(
-      :periodicity => :weekly,
-      :payments => '12',
-      :starting_at => Time.now + 1.day,
-      :comment => 'Test Profile'
+      periodicity: :weekly,
+      payments: '12',
+      starting_at: Time.now + 1.day,
+      comment: 'Test Profile'
     )
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(100, @credit_card, @options)
@@ -326,10 +326,10 @@ class RemotePayflowTest < Test::Unit::TestCase
 
     # Test modify
     @options.update(
-      :periodicity => :monthly,
-      :starting_at => Time.now + 1.day,
-      :payments => '4',
-      :profile_id => @recurring_profile_id
+      periodicity: :monthly,
+      starting_at: Time.now + 1.day,
+      payments: '4',
+      profile_id: @recurring_profile_id
     )
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(400, @credit_card, @options)
@@ -349,7 +349,7 @@ class RemotePayflowTest < Test::Unit::TestCase
 
     # Test payment history inquiry
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring_inquiry(@recurring_profile_id, :history => true)
+      @gateway.recurring_inquiry(@recurring_profile_id, history: true)
     end
     assert_equal '0', response.params['result']
     assert_success response
@@ -383,10 +383,10 @@ class RemotePayflowTest < Test::Unit::TestCase
   def test_recurring_with_initial_authorization
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(1000, @credit_card,
-        :periodicity => :monthly,
-        :initial_transaction => {
-          :type => :purchase,
-          :amount => 500
+        periodicity: :monthly,
+        initial_transaction: {
+          type: :purchase,
+          amount: 500
         }
       )
     end
@@ -455,12 +455,12 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def three_d_secure_option
     {
-      :three_d_secure => {
-        :authentication_id => 'QvDbSAxSiaQs241899E0',
-        :authentication_response_status => 'Y',
-        :eci => '02',
-        :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
-        :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+      three_d_secure: {
+        authentication_id: 'QvDbSAxSiaQs241899E0',
+        authentication_response_status: 'Y',
+        eci: '02',
+        cavv: 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+        xid: 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
       }
     }
   end

--- a/test/remote/gateways/remote_payflow_uk_test.rb
+++ b/test/remote/gateways/remote_payflow_uk_test.rb
@@ -8,26 +8,26 @@ class RemotePayflowUkTest < Test::Unit::TestCase
     @gateway = PayflowUkGateway.new(fixtures(:payflow_uk))
 
     @creditcard = CreditCard.new(
-      :number => '5105105105105100',
-      :month => 11,
-      :year => 2009,
-      :first_name => 'Cody',
-      :last_name => 'Fauser',
-      :verification_value => '000',
-      :brand => 'master'
+      number: '5105105105105100',
+      month: 11,
+      year: 2009,
+      first_name: 'Cody',
+      last_name: 'Fauser',
+      verification_value: '000',
+      brand: 'master'
     )
 
     @options = {
-      :billing_address => {
-        :name => 'Cody Fauser',
-        :address1 => '1234 Shady Brook Lane',
-        :city => 'Ottawa',
-        :state => 'ON',
-        :country => 'CA',
-        :zip => '90210',
-        :phone => '555-555-5555'
+      billing_address: {
+        name: 'Cody Fauser',
+        address1: '1234 Shady Brook Lane',
+        city: 'Ottawa',
+        state: 'ON',
+        country: 'CA',
+        zip: '90210',
+        phone: '555-555-5555'
       },
-      :email => 'cody@example.com'
+      email: 'cody@example.com'
     }
   end
 
@@ -128,8 +128,8 @@ class RemotePayflowUkTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayflowGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(100, @creditcard, @options)
     assert_equal 'Invalid vendor account', response.message
@@ -138,8 +138,8 @@ class RemotePayflowUkTest < Test::Unit::TestCase
 
   def test_duplicate_request_id
     gateway = PayflowUkGateway.new(
-      :login => @login,
-      :password => @password
+      login: @login,
+      password: @password
     )
 
     request_id = Digest::SHA1.hexdigest(rand.to_s).slice(0, 32)

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -7,10 +7,10 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :email => 'cody@example.com',
-      :description => 'Store purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      email: 'cody@example.com',
+      description: 'Store purchase'
     }
 
     @amount = 100
@@ -31,7 +31,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_ip
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:ip => '192.168.0.1'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(ip: '192.168.0.1'))
     assert_success response
     assert_equal 'The Transaction was approved', response.message
     assert_not_nil response.authorization
@@ -65,7 +65,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
     assert_success purchase
     assert_equal 'The Transaction was approved', purchase.message
     assert !purchase.authorization.blank?
-    assert refund = @gateway.refund(amount, purchase.authorization, :description => 'Giving a refund')
+    assert refund = @gateway.refund(amount, purchase.authorization, description: 'Giving a refund')
     assert_success refund
   end
 
@@ -77,8 +77,8 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PaymentExpressGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_match %r{Invalid Credentials}i, response.message
@@ -95,7 +95,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
 
   def test_store_with_custom_token
     token = Time.now.to_i.to_s
-    assert response = @gateway.store(@credit_card, :billing_id => token)
+    assert response = @gateway.store(@credit_card, billing_id: token)
     assert_success response
     assert_equal 'The Transaction was approved', response.message
     assert_not_nil response.authorization

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -7,12 +7,12 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111', verification_value: '666')
     @elo_credit_card = credit_card('6362970000457013',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
     @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {

--- a/test/remote/gateways/remote_paymill_test.rb
+++ b/test/remote/gateways/remote_paymill_test.rb
@@ -7,7 +7,7 @@ class RemotePaymillTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('5500000000000004')
     @options = {
-      :email => 'Longbob.Longse@example.com'
+      email: 'Longbob.Longse@example.com'
     }
     @declined_card = credit_card('5105105105105100', month: 5, year: 2020)
 

--- a/test/remote/gateways/remote_paypal_express_test.rb
+++ b/test/remote/gateways/remote_paypal_express_test.rb
@@ -7,29 +7,28 @@ class PaypalExpressTest < Test::Unit::TestCase
     @gateway = PaypalExpressGateway.new(fixtures(:paypal_certificate))
 
     @options = {
-      :order_id => '230000',
-      :email => 'buyer@jadedpallet.com',
-      :billing_address =>
-        {
-          :name => 'Fred Brooks',
-          :address1 => '1234 Penny Lane',
-          :city => 'Jonsetown',
-          :state => 'NC',
-          :country => 'US',
-          :zip => '23456'
-        },
-      :description => 'Stuff that you purchased, yo!',
-      :ip => '10.0.0.1',
-      :return_url => 'http://example.com/return',
-      :cancel_return_url => 'http://example.com/cancel'
+      order_id: '230000',
+      email: 'buyer@jadedpallet.com',
+      billing_address: {
+        name: 'Fred Brooks',
+          address1: '1234 Penny Lane',
+          city: 'Jonsetown',
+          state: 'NC',
+          country: 'US',
+          zip: '23456'
+      },
+      description: 'Stuff that you purchased, yo!',
+      ip: '10.0.0.1',
+      return_url: 'http://example.com/return',
+      cancel_return_url: 'http://example.com/cancel'
     }
   end
 
   def test_set_express_authorization
     @options.update(
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com',
-      :email => 'Buyer1@paypal.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com',
+      email: 'Buyer1@paypal.com'
     )
     response = @gateway.setup_authorization(500, @options)
     assert response.success?
@@ -39,9 +38,9 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_set_express_purchase
     @options.update(
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com',
-      :email => 'Buyer1@paypal.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com',
+      email: 'Buyer1@paypal.com'
     )
     response = @gateway.setup_purchase(500, @options)
     assert response.success?

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -8,19 +8,18 @@ class PaypalTest < Test::Unit::TestCase
     @declined_card = credit_card('234234234234')
 
     @params = {
-      :order_id => generate_unique_id,
-      :email => 'buyer@jadedpallet.com',
-      :billing_address =>
-        {
-          :name => 'Longbob Longsen',
-          :address1 => '4321 Penny Lane',
-          :city => 'Jonsetown',
-          :state => 'NC',
-          :country => 'US',
-          :zip => '23456'
-        },
-      :description => 'Stuff that you purchased, yo!',
-      :ip => '10.0.0.1'
+      order_id: generate_unique_id,
+      email: 'buyer@jadedpallet.com',
+      billing_address: {
+        name: 'Longbob Longsen',
+          address1: '4321 Penny Lane',
+          city: 'Jonsetown',
+          state: 'NC',
+          country: 'US',
+          zip: '23456'
+      },
+      description: 'Stuff that you purchased, yo!',
+      ip: '10.0.0.1'
     }
 
     @amount = 100
@@ -120,7 +119,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_successful_incomplete_captures
     auth = @gateway.authorize(100, @credit_card, @params)
     assert_success auth
-    response = @gateway.capture(60, auth.authorization, {:complete_type => 'NotComplete'})
+    response = @gateway.capture(60, auth.authorization, {complete_type: 'NotComplete'})
     assert_success response
     assert response.params['transaction_id']
     assert_equal '0.60', response.params['gross_amount']
@@ -133,7 +132,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_successful_capture_updating_the_invoice_id
     auth = @gateway.authorize(@amount, @credit_card, @params)
     assert_success auth
-    response = @gateway.capture(@amount, auth.authorization, :order_id => "NEWID#{generate_unique_id}")
+    response = @gateway.capture(@amount, auth.authorization, order_id: "NEWID#{generate_unique_id}")
     assert_success response
     assert response.params['transaction_id']
     assert_equal '1.00', response.params['gross_amount']
@@ -151,7 +150,7 @@ class PaypalTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @params)
     assert_success purchase
 
-    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+    credit = @gateway.refund(@amount, purchase.authorization, note: 'Sorry')
     assert_success credit
     assert credit.test?
     assert_equal 'USD',  credit.params['net_refund_amount_currency_id']
@@ -193,7 +192,7 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
-    response = @gateway.transfer(@amount, 'joe@example.com', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    response = @gateway.transfer(@amount, 'joe@example.com', subject: 'Your money', note: 'Thanks for taking care of that')
     assert_success response
   end
 
@@ -208,8 +207,8 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
 
     response = @gateway.transfer([@amount, 'joe@example.com'],
-      [600, 'jane@example.com', {:note => 'Thanks for taking care of that'}],
-      :subject => 'Your money')
+      [600, 'jane@example.com', {note: 'Thanks for taking care of that'}],
+      subject: 'Your money')
     assert_success response
   end
 
@@ -227,7 +226,7 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
-    response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'EmailAddress', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    response = @gateway.transfer([@amount, 'joe@example.com'], receiver_type: 'EmailAddress', subject: 'Your money', note: 'Thanks for taking care of that')
     assert_success response
   end
 
@@ -235,7 +234,7 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
-    response = @gateway.transfer([@amount, '4ET96X3PQEN8H'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    response = @gateway.transfer([@amount, '4ET96X3PQEN8H'], receiver_type: 'UserID', subject: 'Your money', note: 'Thanks for taking care of that')
     assert_success response
   end
 
@@ -243,7 +242,7 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @params)
     assert_success response
 
-    response = @gateway.transfer([@amount, 'joe@example.com'], :receiver_type => 'UserID', :subject => 'Your money', :note => 'Thanks for taking care of that')
+    response = @gateway.transfer([@amount, 'joe@example.com'], receiver_type: 'UserID', subject: 'Your money', note: 'Thanks for taking care of that')
     assert_failure response
   end
 

--- a/test/remote/gateways/remote_payscout_test.rb
+++ b/test/remote/gateways/remote_payscout_test.rb
@@ -9,9 +9,9 @@ class RemotePayscoutTest < Test::Unit::TestCase
     @declined_card = credit_card('34343')
 
     @options = {
-      :order_id => '1',
-      :description => 'Store Purchase',
-      :billing_address => address
+      order_id: '1',
+      description: 'Store Purchase',
+      billing_address: address
     }
   end
 
@@ -148,8 +148,8 @@ class RemotePayscoutTest < Test::Unit::TestCase
 
   def test_invalid_credentials
     gateway = PayscoutGateway.new(
-      :username => 'xxx',
-      :password => 'xxx'
+      username: 'xxx',
+      password: 'xxx'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_paystation_test.rb
+++ b/test/remote/gateways/remote_paystation_test.rb
@@ -4,7 +4,7 @@ class RemotePaystationTest < Test::Unit::TestCase
   def setup
     @gateway = PaystationGateway.new(fixtures(:paystation))
 
-    @credit_card = credit_card('5123456789012346', :month => 5, :year => 13, :verification_value => 123)
+    @credit_card = credit_card('5123456789012346', month: 5, year: 13, verification_value: 123)
 
     @successful_amount          = 10000
     @insufficient_funds_amount  = 10051
@@ -13,8 +13,8 @@ class RemotePaystationTest < Test::Unit::TestCase
     @bank_error_amount          = 10091
 
     @options = {
-      :billing_address => address,
-      :description     => 'Store Purchase'
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -26,7 +26,7 @@ class RemotePaystationTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_in_gbp
-    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(:currency => 'GBP'))
+    assert response = @gateway.purchase(@successful_amount, @credit_card, @options.merge(currency: 'GBP'))
     assert_success response
 
     assert_equal 'Transaction successful', response.message
@@ -47,7 +47,7 @@ class RemotePaystationTest < Test::Unit::TestCase
 
   def test_storing_token
     time = Time.now.to_i
-    assert response = @gateway.store(@credit_card, @options.merge(:token => "justatest#{time}"))
+    assert response = @gateway.store(@credit_card, @options.merge(token: "justatest#{time}"))
     assert_success response
 
     assert_equal 'Future Payment Saved Ok', response.message
@@ -69,7 +69,7 @@ class RemotePaystationTest < Test::Unit::TestCase
     assert_success auth
     assert auth.authorization
 
-    assert capture = @gateway.capture(@successful_amount, auth.authorization, @options.merge(:credit_card_verification => 123))
+    assert capture = @gateway.capture(@successful_amount, auth.authorization, @options.merge(credit_card_verification: 123))
     assert_success capture
   end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -8,9 +8,9 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     @credit_card = credit_card('4097440000000004', verification_value: '444', first_name: 'APPROVED', last_name: '')
     @declined_card = credit_card('4097440000000004', verification_value: '444', first_name: 'REJECTED', last_name: '')
     @pending_card = credit_card('4097440000000004', verification_value: '444', first_name: 'PENDING', last_name: '')
-    @naranja_credit_card = credit_card('5895620000000002', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'naranja')
-    @cabal_credit_card = credit_card('5896570000000004', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
-    @invalid_cabal_card = credit_card('6271700000000000', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
+    @naranja_credit_card = credit_card('5895620000000002', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'naranja')
+    @cabal_credit_card = credit_card('5896570000000004', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')
+    @invalid_cabal_card = credit_card('6271700000000000', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')
 
     @options = {
       dni_number: '5415668464654',
@@ -75,7 +75,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_buyer
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => '512327', payment_country: 'BR'))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(account_id: '512327', payment_country: 'BR'))
 
     options_buyer = {
       currency: 'BRL',
@@ -114,7 +114,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_brazil
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => '512327', payment_country: 'BR'))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(account_id: '512327', payment_country: 'BR'))
 
     options_brazil = {
       payment_country: 'BR',
@@ -149,7 +149,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_colombia
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => '512321', payment_country: 'CO'))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(account_id: '512321', payment_country: 'CO'))
 
     options_colombia = {
       payment_country: 'CO',
@@ -183,7 +183,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_mexico
-    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(:account_id => '512324', payment_country: 'MX'))
+    gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(account_id: '512324', payment_country: 'MX'))
 
     options_mexico = {
       payment_country: 'MX',

--- a/test/remote/gateways/remote_payway_test.rb
+++ b/test/remote/gateways/remote_payway_test.rb
@@ -4,46 +4,46 @@ class PaywayTest < Test::Unit::TestCase
   def setup
     @amount = 1100
 
-    @options = {:order_id => generate_unique_id}
+    @options = {order_id: generate_unique_id}
 
     @gateway = ActiveMerchant::Billing::PaywayGateway.new(fixtures(:payway))
 
     @visa = credit_card('4564710000000004',
-      :month              => 2,
-      :year               => 2019,
-      :verification_value => '847'
+      month: 2,
+      year: 2019,
+      verification_value: '847'
     )
 
     @mastercard = credit_card('5163200000000008',
-      :month              => 8,
-      :year               => 2020,
-      :verification_value => '070',
-      :brand              => 'master'
+      month: 8,
+      year: 2020,
+      verification_value: '070',
+      brand: 'master'
     )
 
     @expired = credit_card('4564710000000012',
-      :month              => 2,
-      :year               => 2005,
-      :verification_value => '963'
+      month: 2,
+      year: 2005,
+      verification_value: '963'
     )
 
     @low = credit_card('4564710000000020',
-      :month              => 5,
-      :year               => 2020,
-      :verification_value => '234'
+      month: 5,
+      year: 2020,
+      verification_value: '234'
     )
 
     @stolen_mastercard = credit_card('5163200000000016',
-      :month              => 12,
-      :year               => 2019,
-      :verification_value => '728',
-      :brand              => 'master'
+      month: 12,
+      year: 2019,
+      verification_value: '728',
+      brand: 'master'
     )
 
     @invalid = credit_card('4564720000000037',
-      :month              => 9,
-      :year               => 2019,
-      :verification_value => '030'
+      month: 9,
+      year: 2019,
+      verification_value: '030'
     )
   end
 
@@ -85,10 +85,10 @@ class PaywayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = ActiveMerchant::Billing::PaywayGateway.new(
-      :username => 'bogus',
-      :password => 'bogus',
-      :merchant => 'TEST',
-      :pem      => fixtures(:payway)['pem']
+      username: 'bogus',
+      password: 'bogus',
+      merchant: 'TEST',
+      pem: fixtures(:payway)['pem']
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_failure response

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -5,16 +5,16 @@ class RemotePinTest < Test::Unit::TestCase
     @gateway = PinGateway.new(fixtures(:pin))
 
     @amount = 100
-    @credit_card = credit_card('5520000000000000', :year => Time.now.year + 2)
-    @visa_credit_card = credit_card('4200000000000000', :year => Time.now.year + 3)
+    @credit_card = credit_card('5520000000000000', year: Time.now.year + 2)
+    @visa_credit_card = credit_card('4200000000000000', year: Time.now.year + 3)
     @declined_card = credit_card('4100000000000001')
 
     @options = {
-      :email => 'roland@pinpayments.com',
-      :ip => '203.59.39.62',
-      :order_id => '1',
-      :billing_address => address,
-      :description => "Store Purchase #{DateTime.now.to_i}"
+      email: 'roland@pinpayments.com',
+      ip: '203.59.39.62',
+      order_id: '1',
+      billing_address: address,
+      description: "Store Purchase #{DateTime.now.to_i}"
     }
   end
 
@@ -94,16 +94,16 @@ class RemotePinTest < Test::Unit::TestCase
     }
     # Get a token equivalent to what is returned by Pin.js
     card_attrs = {
-      :number => @credit_card.number,
-      :expiry_month => @credit_card.month,
-      :expiry_year => @credit_card.year,
-      :cvc => @credit_card.verification_value,
-      :name => "#{@credit_card.first_name} #{@credit_card.last_name}",
-      :address_line1 => '42 Sevenoaks St',
-      :address_city => 'Lathlain',
-      :address_postcode => '6454',
-      :address_start => 'WA',
-      :address_country => 'Australia'
+      number: @credit_card.number,
+      expiry_month: @credit_card.month,
+      expiry_year: @credit_card.year,
+      cvc: @credit_card.verification_value,
+      name: "#{@credit_card.first_name} #{@credit_card.last_name}",
+      address_line1: '42 Sevenoaks St',
+      address_city: 'Lathlain',
+      address_postcode: '6454',
+      address_start: 'WA',
+      address_country: 'Australia'
     }
     url = @gateway.test_url + '/cards'
 
@@ -141,7 +141,7 @@ class RemotePinTest < Test::Unit::TestCase
     assert_not_nil response.authorization
     assert_equal @credit_card.year, response.params['response']['card']['expiry_year']
 
-    response = @gateway.update(response.authorization, @visa_credit_card, :address => address)
+    response = @gateway.update(response.authorization, @visa_credit_card, address: address)
     assert_success response
     assert_not_nil response.authorization
     assert_equal @visa_credit_card.year, response.params['response']['card']['expiry_year']
@@ -171,7 +171,7 @@ class RemotePinTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = PinGateway.new(:api_key => '')
+    gateway = PinGateway.new(api_key: '')
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
   end

--- a/test/remote/gateways/remote_plugnpay_test.rb
+++ b/test/remote/gateways/remote_plugnpay_test.rb
@@ -6,8 +6,8 @@ class PlugnpayTest < Test::Unit::TestCase
     @good_card = credit_card('4111111111111111', first_name: 'cardtest')
     @bad_card = credit_card('1234123412341234')
     @options = {
-      :billing_address => address,
-      :description => 'Store purchaes'
+      billing_address: address,
+      description: 'Store purchaes'
     }
     @amount = 100
   end

--- a/test/remote/gateways/remote_psigate_test.rb
+++ b/test/remote/gateways/remote_psigate_test.rb
@@ -9,9 +9,9 @@ class PsigateRemoteTest < Test::Unit::TestCase
     @amount = 2400
     @creditcard = credit_card('4111111111111111')
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :email => 'jack@example.com'
+      order_id: generate_unique_id,
+      billing_address: address,
+      email: 'jack@example.com'
     }
   end
 
@@ -44,7 +44,7 @@ class PsigateRemoteTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    assert response = @gateway.purchase(@amount, @creditcard, @options.update(:test_result => 'D'))
+    assert response = @gateway.purchase(@amount, @creditcard, @options.update(test_result: 'D'))
     assert_failure response
   end
 

--- a/test/remote/gateways/remote_psl_card_test.rb
+++ b/test/remote/gateways/remote_psl_card_test.rb
@@ -25,7 +25,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_visa_purchase
     response = @gateway.purchase(@accept_amount, @visa,
-      :billing_address => @visa_address
+      billing_address: @visa_address
     )
     assert_success response
     assert response.test?
@@ -33,7 +33,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_visa_debit_purchase
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      :billing_address => @visa_debit_address
+      billing_address: @visa_debit_address
     )
     assert_success response
   end
@@ -42,15 +42,15 @@ class RemotePslCardTest < Test::Unit::TestCase
   def test_visa_debit_purchase_should_not_send_debit_info_if_present
     @visa_debit.start_month = '07'
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      :billing_address => @visa_debit_address
+      billing_address: @visa_debit_address
     )
     assert_success response
   end
 
   def test_successful_visa_purchase_specifying_currency
     response = @gateway.purchase(@accept_amount, @visa,
-      :billing_address => @visa_address,
-      :currency => 'GBP'
+      billing_address: @visa_address,
+      currency: 'GBP'
     )
     assert_success response
     assert response.test?
@@ -58,7 +58,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_solo_purchase
     response = @gateway.purchase(@accept_amount, @solo,
-      :billing_address => @solo_address
+      billing_address: @solo_address
     )
     assert_success response
     assert response.test?
@@ -66,7 +66,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_referred_purchase
     response = @gateway.purchase(@referred_amount, @uk_maestro,
-      :billing_address => @uk_maestro_address
+      billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -74,7 +74,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_declined_purchase
     response = @gateway.purchase(@declined_amount, @uk_maestro,
-      :billing_address => @uk_maestro_address
+      billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -82,7 +82,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_declined_keep_card_purchase
     response = @gateway.purchase(@keep_card_amount, @uk_maestro,
-      :billing_address => @uk_maestro_address
+      billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -90,7 +90,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_authorization
     response = @gateway.authorize(@accept_amount, @visa,
-      :billing_address => @visa_address
+      billing_address: @visa_address
     )
     assert_success response
     assert response.test?
@@ -98,10 +98,10 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_no_login
     @gateway = PslCardGateway.new(
-      :login => ''
+      login: ''
     )
     response = @gateway.authorize(@accept_amount, @uk_maestro,
-      :billing_address => @uk_maestro_address
+      billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -109,7 +109,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_authorization_and_capture
     authorization = @gateway.authorize(@accept_amount, @visa,
-      :billing_address => @visa_address
+      billing_address: @visa_address
     )
     assert_success authorization
     assert authorization.test?

--- a/test/remote/gateways/remote_qbms_test.rb
+++ b/test/remote/gateways/remote_qbms_test.rb
@@ -11,7 +11,7 @@ class QbmsTest < Test::Unit::TestCase
     @card    = credit_card('4111111111111111')
 
     @options = {
-      :billing_address => address,
+      billing_address: address,
     }
   end
 
@@ -66,7 +66,7 @@ class QbmsTest < Test::Unit::TestCase
   end
 
   def test_invalid_ticket
-    gateway = QbmsGateway.new(@gateway_options.merge(:ticket => 'test123'))
+    gateway = QbmsGateway.new(@gateway_options.merge(ticket: 'test123'))
 
     assert response = gateway.authorize(@amount, @card, @options)
     assert_instance_of Response, response
@@ -102,6 +102,6 @@ class QbmsTest < Test::Unit::TestCase
   private
 
   def error_card(config_id)
-    credit_card('4111111111111111', :first_name => "configid=#{config_id}", :last_name => '')
+    credit_card('4111111111111111', first_name: "configid=#{config_id}", last_name: '')
   end
 end

--- a/test/remote/gateways/remote_quantum_test.rb
+++ b/test/remote/gateways/remote_quantum_test.rb
@@ -53,7 +53,7 @@ class RemoteQuantumTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    options = {:billing_address => address}
+    options = {billing_address: address}
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Transaction is APPROVED', response.message
@@ -63,8 +63,8 @@ class RemoteQuantumTest < Test::Unit::TestCase
   # So we check to see if the parse failed and report
   def test_invalid_login
     gateway = QuantumGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card)
     assert_failure response

--- a/test/remote/gateways/remote_quickpay_test.rb
+++ b/test/remote/gateways/remote_quickpay_test.rb
@@ -8,11 +8,11 @@ class RemoteQuickpayTest < Test::Unit::TestCase
 
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address
+      order_id: generate_unique_id[0...10],
+      billing_address: address
     }
 
-    @visa_no_cvv2   = credit_card('4000300011112220', :verification_value => nil)
+    @visa_no_cvv2   = credit_card('4000300011112220', verification_value: nil)
     @visa           = credit_card('4000100011112224')
     @dankort        = credit_card('5019717010103742')
     @visa_dankort   = credit_card('4571100000000000')
@@ -26,7 +26,7 @@ class RemoteQuickpayTest < Test::Unit::TestCase
     @amex           = credit_card('3700100000000000')
 
     # forbrugsforeningen doesn't use a verification value
-    @forbrugsforeningen = credit_card('6007221000000000', :verification_value => nil)
+    @forbrugsforeningen = credit_card('6007221000000000', verification_value: nil)
   end
 
   def test_successful_purchase
@@ -38,7 +38,7 @@ class RemoteQuickpayTest < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(currency: 'USD'))
     assert_equal 'OK', response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -174,22 +174,22 @@ class RemoteQuickpayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription'))
     assert_success store
-    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(order_id: generate_unique_id[0...10]))
     assert_success purchase
   end
 
   def test_failed_store
-    assert store = @gateway.store(credit_card('4'), @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(credit_card('4'), @options.merge(description: 'New subscription'))
     assert_failure store
     assert_equal 'Error in field: cardnumber', store.message
   end
 
   def test_invalid_login
     gateway = QuickpayGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_equal 'Invalid merchant id', response.message

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -5,8 +5,8 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     @gateway = QuickpayV10Gateway.new(fixtures(:quickpay_v10_api_key))
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address(country: 'DNK')
+      order_id: generate_unique_id[0...10],
+      billing_address: address(country: 'DNK')
     }
 
     @valid_card    = credit_card('1000000000000008')
@@ -15,8 +15,8 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
     @capture_rejected_card = credit_card('1000000000000032')
     @refund_rejected_card = credit_card('1000000000000040')
 
-    @valid_address   = address(:phone => '4500000001')
-    @invalid_address = address(:phone => '4500000002')
+    @valid_address   = address(phone: '4500000001')
+    @invalid_address = address(phone: '4500000002')
   end
 
   def card_brand(response)
@@ -59,7 +59,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @valid_card, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @valid_card, @options.update(currency: 'USD'))
     assert_equal 'OK',  response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -67,13 +67,13 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_acquirers
-    assert response = @gateway.purchase(@amount, @valid_card, @options.update(:acquirer => 'nets'))
+    assert response = @gateway.purchase(@amount, @valid_card, @options.update(acquirer: 'nets'))
     assert_equal 'OK', response.message
     assert_success response
   end
 
   def test_unsuccessful_purchase_with_invalid_acquirers
-    assert response = @gateway.purchase(@amount, @valid_card, @options.update(:acquirer => 'invalid'))
+    assert response = @gateway.purchase(@amount, @valid_card, @options.update(acquirer: 'invalid'))
     assert_failure response
     assert_equal 'Validation error', response.message
   end

--- a/test/remote/gateways/remote_quickpay_v4_test.rb
+++ b/test/remote/gateways/remote_quickpay_v4_test.rb
@@ -4,15 +4,15 @@ class RemoteQuickpayV4Test < Test::Unit::TestCase
   # These test assumes that you have not added your development IP in
   # the Quickpay Manager.
   def setup
-    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(:version => 4))
+    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(version: 4))
 
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address
+      order_id: generate_unique_id[0...10],
+      billing_address: address
     }
 
-    @visa_no_cvv2   = credit_card('4000300011112220', :verification_value => nil)
+    @visa_no_cvv2   = credit_card('4000300011112220', verification_value: nil)
     @visa           = credit_card('4000100011112224')
     @dankort        = credit_card('5019717010103742')
     @visa_dankort   = credit_card('4571100000000000')
@@ -52,7 +52,7 @@ class RemoteQuickpayV4Test < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(currency: 'USD'))
     assert_equal 'OK', response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -189,16 +189,16 @@ class RemoteQuickpayV4Test < Test::Unit::TestCase
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription'))
     assert_success store
-    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(order_id: generate_unique_id[0...10]))
     assert_success purchase
   end
 
   def test_invalid_login
     gateway = QuickpayGateway.new(
-      :login => '999999999',
-      :password => ''
+      login: '999999999',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_equal 'Invalid merchant id', response.message

--- a/test/remote/gateways/remote_quickpay_v5_test.rb
+++ b/test/remote/gateways/remote_quickpay_v5_test.rb
@@ -4,15 +4,15 @@ class RemoteQuickpayV5Test < Test::Unit::TestCase
   # These test assumes that you have not added your development IP in
   # the Quickpay Manager.
   def setup
-    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(:version => 5))
+    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(version: 5))
 
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address
+      order_id: generate_unique_id[0...10],
+      billing_address: address
     }
 
-    @visa_no_cvv2   = credit_card('4000300011112220', :verification_value => nil)
+    @visa_no_cvv2   = credit_card('4000300011112220', verification_value: nil)
     @visa           = credit_card('4000100011112224')
     @dankort        = credit_card('5019717010103742')
     @visa_dankort   = credit_card('4571100000000000')
@@ -52,7 +52,7 @@ class RemoteQuickpayV5Test < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(currency: 'USD'))
     assert_equal 'OK', response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -189,16 +189,16 @@ class RemoteQuickpayV5Test < Test::Unit::TestCase
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription'))
     assert_success store
-    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(order_id: generate_unique_id[0...10]))
     assert_success purchase
   end
 
   def test_invalid_login
     gateway = QuickpayGateway.new(
-      :login => '999999999',
-      :password => ''
+      login: '999999999',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_equal 'Invalid merchant id', response.message

--- a/test/remote/gateways/remote_quickpay_v6_test.rb
+++ b/test/remote/gateways/remote_quickpay_v6_test.rb
@@ -4,15 +4,15 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
   # These test assumes that you have not added your development IP in
   # the Quickpay Manager.
   def setup
-    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(:version => 6))
+    @gateway = QuickpayGateway.new(fixtures(:quickpay_with_api_key).merge(version: 6))
 
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address
+      order_id: generate_unique_id[0...10],
+      billing_address: address
     }
 
-    @visa_no_cvv2   = credit_card('4000300011112220', :verification_value => nil)
+    @visa_no_cvv2   = credit_card('4000300011112220', verification_value: nil)
     @visa           = credit_card('4000100011112224')
     @dankort        = credit_card('5019717010103742')
     @visa_dankort   = credit_card('4571100000000000')
@@ -52,7 +52,7 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(currency: 'USD'))
     assert_equal 'OK', response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -189,16 +189,16 @@ class RemoteQuickpayV6Test < Test::Unit::TestCase
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription'))
     assert_success store
-    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(order_id: generate_unique_id[0...10]))
     assert_success purchase
   end
 
   def test_invalid_login
     gateway = QuickpayGateway.new(
-      :login => '999999999',
-      :password => ''
+      login: '999999999',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_equal 'Invalid merchant id', response.message

--- a/test/remote/gateways/remote_quickpay_v7_test.rb
+++ b/test/remote/gateways/remote_quickpay_v7_test.rb
@@ -8,11 +8,11 @@ class RemoteQuickpayV7Test < Test::Unit::TestCase
 
     @amount = 100
     @options = {
-      :order_id => generate_unique_id[0...10],
-      :billing_address => address
+      order_id: generate_unique_id[0...10],
+      billing_address: address
     }
 
-    @visa_no_cvv2   = credit_card('4000300011112220', :verification_value => nil)
+    @visa_no_cvv2   = credit_card('4000300011112220', verification_value: nil)
     @visa           = credit_card('4000100011112224')
     @dankort        = credit_card('5019717010103742')
     @visa_dankort   = credit_card('4571100000000000')
@@ -52,7 +52,7 @@ class RemoteQuickpayV7Test < Test::Unit::TestCase
   end
 
   def test_successful_usd_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(currency: 'USD'))
     assert_equal 'OK', response.message
     assert_equal 'USD', response.params['currency']
     assert_success response
@@ -60,13 +60,13 @@ class RemoteQuickpayV7Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_acquirers
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:acquirers => 'nets'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(acquirers: 'nets'))
     assert_equal 'OK', response.message
     assert_success response
   end
 
   def test_unsuccessful_purchase_with_invalid_acquirers
-    assert response = @gateway.purchase(@amount, @visa, @options.update(:acquirers => 'invalid'))
+    assert response = @gateway.purchase(@amount, @visa, @options.update(acquirers: 'invalid'))
     assert_equal 'Error in field: acquirers', response.message
     assert_failure response
   end
@@ -201,26 +201,26 @@ class RemoteQuickpayV7Test < Test::Unit::TestCase
   end
 
   def test_successful_store_and_reference_purchase
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription'))
     assert_success store
-    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(:order_id => generate_unique_id[0...10]))
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options.merge(order_id: generate_unique_id[0...10]))
     assert_success purchase
   end
 
   def test_successful_store_with_acquirers
-    assert store = @gateway.store(@visa, @options.merge(:description => 'New subscription', :acquirers => 'nets'))
+    assert store = @gateway.store(@visa, @options.merge(description: 'New subscription', acquirers: 'nets'))
     assert_success store
   end
 
   def test_successful_store_sans_description
-    assert store = @gateway.store(@visa, @options.merge(:acquirers => 'nets'))
+    assert store = @gateway.store(@visa, @options.merge(acquirers: 'nets'))
     assert_success store
   end
 
   def test_invalid_login
     gateway = QuickpayGateway.new(
-      :login => '999999999',
-      :password => ''
+      login: '999999999',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_equal 'Invalid merchant id', response.message

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -41,11 +41,11 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase
     [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex Purchase',
-        :billing_address => {
-          :zip => '90210',
-          :country => 'US'
+        order_id: generate_unique_id,
+        description: 'Test Realex Purchase',
+        billing_address: {
+          zip: '90210',
+          country: 'US'
         }
       )
       assert_not_nil response
@@ -58,12 +58,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_with_invalid_login
     gateway = RealexGateway.new(
-      :login => 'invalid',
-      :password => 'invalid'
+      login: 'invalid',
+      password: 'invalid'
     )
     response = gateway.purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Invalid login test'
+      order_id: generate_unique_id,
+      description: 'Invalid login test'
     )
 
     assert_not_nil response
@@ -75,8 +75,8 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_with_invalid_account
     response = RealexGateway.new(fixtures(:realex_with_account).merge(account: 'invalid')).purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex purchase with invalid account'
+      order_id: generate_unique_id,
+      description: 'Test Realex purchase with invalid account'
     )
 
     assert_not_nil response
@@ -87,7 +87,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_with_apple_pay
-    response = @gateway.purchase(1000, @apple_pay, :order_id => generate_unique_id, :description => 'Test Realex with ApplePay')
+    response = @gateway.purchase(1000, @apple_pay, order_id: generate_unique_id, description: 'Test Realex with ApplePay')
     assert_success response
     assert response.test?
     assert_equal 'Successful', response.message
@@ -96,8 +96,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_declined
     [@visa_declined, @mastercard_declined].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex purchase declined'
+        order_id: generate_unique_id,
+        description: 'Test Realex purchase declined'
       )
       assert_not_nil response
       assert_failure response
@@ -108,7 +108,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_with_apple_pay_declined
-    response = @gateway.purchase(1101, @declined_apple_pay, :order_id => generate_unique_id, :description => 'Test Realex with ApplePay')
+    response = @gateway.purchase(1101, @declined_apple_pay, order_id: generate_unique_id, description: 'Test Realex with ApplePay')
     assert_failure response
     assert response.test?
     assert_equal '101', response.params['result']
@@ -125,8 +125,8 @@ class RemoteRealexTest < Test::Unit::TestCase
         xid: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY=',
         version: '1.0.2',
       },
-      :order_id => generate_unique_id,
-      :description => 'Test Realex with 3DS'
+      order_id: generate_unique_id,
+      description: 'Test Realex with 3DS'
     )
     assert_success response
     assert response.test?
@@ -143,8 +143,8 @@ class RemoteRealexTest < Test::Unit::TestCase
         ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
         version: '2.1.0',
       },
-      :order_id => generate_unique_id,
-      :description => 'Test Realex with 3DS'
+      order_id: generate_unique_id,
+      description: 'Test Realex with 3DS'
     )
     assert_success response
     assert response.test?
@@ -154,8 +154,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_referral_b
     [@visa_referral_b, @mastercard_referral_b].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex Referral B'
+        order_id: generate_unique_id,
+        description: 'Test Realex Referral B'
       )
       assert_not_nil response
       assert_failure response
@@ -168,8 +168,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_referral_a
     [@visa_referral_a, @mastercard_referral_a].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex Rqeferral A'
+        order_id: generate_unique_id,
+        description: 'Test Realex Rqeferral A'
       )
       assert_not_nil response
       assert_failure response
@@ -181,8 +181,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_coms_error
     [@visa_coms_error, @mastercard_coms_error].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex coms error'
+        order_id: generate_unique_id,
+        description: 'Test Realex coms error'
       )
       assert_not_nil response
       assert_failure response
@@ -196,8 +196,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.month = 13
 
     response = @gateway.purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex expiry month error'
+      order_id: generate_unique_id,
+      description: 'Test Realex expiry month error'
     )
     assert_not_nil response
     assert_failure response
@@ -210,8 +210,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.year = 2005
 
     response = @gateway.purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex expiry year error'
+      order_id: generate_unique_id,
+      description: 'Test Realex expiry year error'
     )
     assert_not_nil response
     assert_failure response
@@ -225,8 +225,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.last_name = ''
 
     response = @gateway.purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'test_chname_error'
+      order_id: generate_unique_id,
+      description: 'test_chname_error'
     )
     assert_not_nil response
     assert_failure response
@@ -239,8 +239,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa_cvn = @visa.clone
     @visa_cvn.verification_value = '111'
     response = @gateway.purchase(@amount, @visa_cvn,
-      :order_id => generate_unique_id,
-      :description => 'test_cvn'
+      order_id: generate_unique_id,
+      description: 'test_cvn'
     )
     assert_not_nil response
     assert_success response
@@ -249,9 +249,9 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_customer_number
     response = @gateway.purchase(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'test_cust_num',
-      :customer => 'my customer id'
+      order_id: generate_unique_id,
+      description: 'test_cust_num',
+      customer: 'my customer id'
     )
     assert_not_nil response
     assert_success response
@@ -260,11 +260,11 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_authorize
     response = @gateway.authorize(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex Purchase',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: generate_unique_id,
+      description: 'Test Realex Purchase',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
 
@@ -279,11 +279,11 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     auth_response = @gateway.authorize(@amount, @visa,
-      :order_id => order_id,
-      :description => 'Test Realex Purchase',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: order_id,
+      description: 'Test Realex Purchase',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
     assert auth_response.test?
@@ -301,11 +301,11 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     auth_response = @gateway.authorize(@amount*115, @visa,
-      :order_id => order_id,
-      :description => 'Test Realex Purchase',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: order_id,
+      description: 'Test Realex Purchase',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
     assert auth_response.test?
@@ -323,11 +323,11 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     purchase_response = @gateway.purchase(@amount, @visa,
-      :order_id => order_id,
-      :description => 'Test Realex Purchase',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: order_id,
+      description: 'Test Realex Purchase',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
     assert purchase_response.test?
@@ -343,14 +343,14 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_then_refund
     order_id = generate_unique_id
 
-    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:rebate_secret => 'rebate'))
+    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(rebate_secret: 'rebate'))
 
     purchase_response = gateway_with_refund_password.purchase(@amount, @visa,
-      :order_id => order_id,
-      :description => 'Test Realex Purchase',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: order_id,
+      description: 'Test Realex Purchase',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
     assert purchase_response.test?
@@ -365,8 +365,8 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_verify
     response = @gateway.verify(@visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex verify'
+      order_id: generate_unique_id,
+      description: 'Test Realex verify'
     )
 
     assert_not_nil response
@@ -378,8 +378,8 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_verify_declined
     response = @gateway.verify(@visa_declined,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex verify declined'
+      order_id: generate_unique_id,
+      description: 'Test Realex verify declined'
     )
 
     assert_not_nil response
@@ -390,14 +390,14 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_successful_credit
-    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:refund_secret => 'refund'))
+    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(refund_secret: 'refund'))
 
     credit_response = gateway_with_refund_password.credit(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex Credit',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: generate_unique_id,
+      description: 'Test Realex Credit',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
 
@@ -409,11 +409,11 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_failed_credit
     credit_response = @gateway.credit(@amount, @visa,
-      :order_id => generate_unique_id,
-      :description => 'Test Realex Credit',
-      :billing_address => {
-        :zip => '90210',
-        :country => 'US'
+      order_id: generate_unique_id,
+      description: 'Test Realex Credit',
+      billing_address: {
+        zip: '90210',
+        country: 'US'
       }
     )
 
@@ -426,11 +426,11 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_maps_avs_and_cvv_response_codes
     [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex Purchase',
-        :billing_address => {
-          :zip => '90210',
-          :country => 'US'
+        order_id: generate_unique_id,
+        description: 'Test Realex Purchase',
+        billing_address: {
+          zip: '90210',
+          country: 'US'
         }
       )
       assert_not_nil response
@@ -443,11 +443,11 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @visa_declined,
-        :order_id => generate_unique_id,
-        :description => 'Test Realex Purchase',
-        :billing_address => {
-          :zip => '90210',
-          :country => 'US'
+        order_id: generate_unique_id,
+        description: 'Test Realex Purchase',
+        billing_address: {
+          zip: '90210',
+          country: 'US'
         }
       )
     end

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -89,7 +89,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
 
   # Multiple currencies are not supported in test, but should at least fail.
   def test_purchase_and_refund_with_currency
-    response = @gateway.purchase(600, @credit_card, @options.merge(:currency => 'PEN'))
+    response = @gateway.purchase(600, @credit_card, @options.merge(currency: 'PEN'))
     assert_failure response
     assert_equal 'SIS0027 ERROR', response.message
   end

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -53,7 +53,7 @@ class RemoteRedsysTest < Test::Unit::TestCase
 
   # Multiple currencies are not supported in test, but should at least fail.
   def test_purchase_and_refund_with_currency
-    response = @gateway.purchase(600, @credit_card, @options.merge(:currency => 'PEN'))
+    response = @gateway.purchase(600, @credit_card, @options.merge(currency: 'PEN'))
     assert_failure response
     assert_equal 'SIS0027 ERROR', response.message
   end

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -12,90 +12,90 @@ class RemoteSagePayTest < Test::Unit::TestCase
     @gateway = SagePayGateway.new(fixtures(:sage_pay))
 
     @amex = CreditCard.new(
-      :number => '374200000000004',
-      :month => 12,
-      :year => next_year,
-      :verification_value => 4887,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'american_express'
+      number: '374200000000004',
+      month: 12,
+      year: next_year,
+      verification_value: 4887,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'american_express'
     )
 
     @maestro = CreditCard.new(
-      :number => '5641820000000005',
-      :month => 12,
-      :year => next_year,
-      :issue_number => '01',
-      :start_month => 12,
-      :start_year => next_year - 2,
-      :verification_value => 123,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'maestro'
+      number: '5641820000000005',
+      month: 12,
+      year: next_year,
+      issue_number: '01',
+      start_month: 12,
+      start_year: next_year - 2,
+      verification_value: 123,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'maestro'
     )
 
     @visa = CreditCard.new(
-      :number => '4929000000006',
-      :month => 6,
-      :year => next_year,
-      :verification_value => 123,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'visa'
+      number: '4929000000006',
+      month: 6,
+      year: next_year,
+      verification_value: 123,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'visa'
     )
 
     @mastercard = CreditCard.new(
-      :number => '5404000000000001',
-      :month => 12,
-      :year => next_year,
-      :verification_value => 419,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'master'
+      number: '5404000000000001',
+      month: 12,
+      year: next_year,
+      verification_value: 419,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'master'
     )
 
     @electron = CreditCard.new(
-      :number => '4917300000000008',
-      :month => 12,
-      :year => next_year,
-      :verification_value => 123,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'electron'
+      number: '4917300000000008',
+      month: 12,
+      year: next_year,
+      verification_value: 123,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'electron'
     )
 
     @declined_card = CreditCard.new(
-      :number => '4111111111111111',
-      :month => 9,
-      :year => next_year,
-      :first_name => 'Tekin',
-      :last_name => 'Suleyman',
-      :brand => 'visa'
+      number: '4111111111111111',
+      month: 9,
+      year: next_year,
+      first_name: 'Tekin',
+      last_name: 'Suleyman',
+      brand: 'visa'
     )
 
     @options = {
-      :billing_address => {
-        :name => 'Tekin Suleyman',
-        :address1 => 'Flat 10 Lapwing Court',
-        :address2 => 'West Didsbury',
-        :city => 'Manchester',
-        :county => 'Greater Manchester',
-        :country => 'GB',
-        :zip => 'M20 2PS'
+      billing_address: {
+        name: 'Tekin Suleyman',
+        address1: 'Flat 10 Lapwing Court',
+        address2: 'West Didsbury',
+        city: 'Manchester',
+        county: 'Greater Manchester',
+        country: 'GB',
+        zip: 'M20 2PS'
       },
-      :shipping_address => {
-        :name => 'Tekin Suleyman',
-        :address1 => '120 Grosvenor St',
-        :city => 'Manchester',
-        :county => 'Greater Manchester',
-        :country => 'GB',
-        :zip => 'M1 7QW'
+      shipping_address: {
+        name: 'Tekin Suleyman',
+        address1: '120 Grosvenor St',
+        city: 'Manchester',
+        county: 'Greater Manchester',
+        country: 'GB',
+        zip: 'M1 7QW'
       },
-      :order_id => generate_unique_id,
-      :description => 'Store purchase',
-      :ip => '86.150.65.37',
-      :email => 'tekin@tekin.co.uk',
-      :phone => '0161 123 4567'
+      order_id: generate_unique_id,
+      description: 'Store purchase',
+      ip: '86.150.65.37',
+      email: 'tekin@tekin.co.uk',
+      phone: '0161 123 4567'
     }
 
     @amount = 100
@@ -132,8 +132,8 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success capture
 
     assert refund = @gateway.refund(@amount, capture.authorization,
-      :description => 'Crediting trx',
-      :order_id => generate_unique_id
+      description: 'Crediting trx',
+      order_id: generate_unique_id
     )
     assert_success refund
   end
@@ -159,8 +159,8 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success purchase
 
     assert refund = @gateway.refund(@amount, purchase.authorization,
-      :description => 'Crediting trx',
-      :order_id => generate_unique_id
+      description: 'Crediting trx',
+      order_id: generate_unique_id
     )
 
     assert_success refund
@@ -331,7 +331,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
     message = SagePayGateway.simulate ? 'VSP Simulator cannot find your vendor name.  Ensure you have have supplied a Vendor field with your VSP Vendor name assigned to it.' : '3034 : The Vendor or VendorName value is required.'
 
     gateway = SagePayGateway.new(
-      :login => ''
+      login: ''
     )
     assert response = gateway.purchase(@amount, @mastercard, @options)
     assert_equal message, response.message
@@ -364,13 +364,13 @@ class RemoteSagePayTest < Test::Unit::TestCase
   end
 
   def test_successful_token_creation_from_purchase
-    assert response = @gateway.purchase(@amount, @visa, @options.merge(:store => true))
+    assert response = @gateway.purchase(@amount, @visa, @options.merge(store: true))
     assert_success response
     assert !response.authorization.blank?
   end
 
   def test_successful_token_creation_from_authorize
-    assert response = @gateway.authorize(@amount, @visa, @options.merge(:store => true))
+    assert response = @gateway.authorize(@amount, @visa, @options.merge(store: true))
     assert_success response
     assert !response.authorization.blank?
   end

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -15,10 +15,10 @@ class RemoteSageTest < Test::Unit::TestCase
     @declined_card = credit_card('4000')
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :shipping_address => address,
-      :email => 'longbob@example.com'
+      order_id: generate_unique_id,
+      billing_address: address,
+      shipping_address: address,
+      email: 'longbob@example.com'
     }
   end
 
@@ -191,8 +191,8 @@ class RemoteSageTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SageGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @visa, @options)
     assert_failure response

--- a/test/remote/gateways/remote_sallie_mae_test.rb
+++ b/test/remote/gateways/remote_sallie_mae_test.rb
@@ -9,8 +9,8 @@ class RemoteSallieMaeTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :billing_address => address,
-      :description => 'Store Purchase'
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -43,7 +43,7 @@ class RemoteSallieMaeTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = SallieMaeGateway.new(:login => '')
+    gateway = SallieMaeGateway.new(login: '')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid merchant', response.message

--- a/test/remote/gateways/remote_secure_net_test.rb
+++ b/test/remote/gateways/remote_secure_net_test.rb
@@ -28,8 +28,8 @@ class SecureNetTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecureNetGateway.new(
-      :login => '9988776',
-      :password => 'RabbitEarsPo'
+      login: '9988776',
+      password: 'RabbitEarsPo'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -14,12 +14,12 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     @gateway = SecurePayAuGateway.new(fixtures(:secure_pay_au))
 
     @amount = 100
-    @credit_card = credit_card('4242424242424242', {:month => 9, :year => 15})
+    @credit_card = credit_card('4242424242424242', {month: 9, year: 15})
 
     @options = {
-      :order_id => '2',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '2',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -31,13 +31,13 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_custom_credit_card_class
     options = {
-      :number => 4242424242424242,
-      :month => 9,
-      :year => Time.now.year + 1,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :verification_value => '123',
-      :brand => 'visa'
+      number: 4242424242424242,
+      month: 9,
+      year: Time.now.year + 1,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      verification_value: '123',
+      brand: 'visa'
     }
     credit_card = MyCreditCard.new(options)
     assert response = @gateway.purchase(@amount, credit_card, @options)
@@ -120,7 +120,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil
+    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil
 
     assert response = @gateway.unstore('test1234')
     assert_success response
@@ -139,23 +139,23 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   def test_successful_store
     @gateway.unstore('test1234') rescue nil
 
-    assert response = @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000})
+    assert response = @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000})
     assert_success response
 
     assert_equal 'Successful', response.message
   end
 
   def test_failed_store
-    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil # Ensure it already exists
+    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
 
-    assert response = @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000})
+    assert response = @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000})
     assert_failure response
 
     assert_equal 'Duplicate Client ID Found', response.message
   end
 
   def test_successful_triggered_payment
-    @gateway.store(@credit_card, {:billing_id => 'test1234', :amount => 15000}) rescue nil # Ensure it already exists
+    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
 
     assert response = @gateway.purchase(12300, 'test1234', @options)
     assert_success response
@@ -175,8 +175,8 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecurePayAuGateway.new(
-      :login => 'a',
-      :password => 'a'
+      login: 'a',
+      password: 'a'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_secure_pay_tech_test.rb
+++ b/test/remote/gateways/remote_secure_pay_tech_test.rb
@@ -9,8 +9,8 @@ class RemoteSecurePayTechTest < Test::Unit::TestCase
     @accepted_amount = 10000
     @declined_amount = 10075
 
-    @credit_card = credit_card('4987654321098769', :month => '5', :year => '2013')
-    @options = { :billing_address => address }
+    @credit_card = credit_card('4987654321098769', month: '5', year: '2013')
+    @options = { billing_address: address }
   end
 
   def test_successful_purchase
@@ -43,8 +43,8 @@ class RemoteSecurePayTechTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SecurePayTechGateway.new(
-      :login => 'foo',
-      :password => 'bar'
+      login: 'foo',
+      password: 'bar'
     )
     assert response = gateway.purchase(@accepted_amount, @credit_card, @options)
     assert_equal 'Bad or malformed request', response.message

--- a/test/remote/gateways/remote_secure_pay_test.rb
+++ b/test/remote/gateways/remote_secure_pay_test.rb
@@ -5,14 +5,14 @@ class RemoteSecurePayTest < Test::Unit::TestCase
     @gateway = SecurePayGateway.new(fixtures(:secure_pay))
 
     @credit_card = credit_card('4111111111111111',
-      :month => '7',
-      :year  => '2014'
+      month: '7',
+      year: '2014'
     )
 
     @options = {
-      :order_id => generate_unique_id,
-      :description => 'Store purchase',
-      :billing_address => address
+      order_id: generate_unique_id,
+      description: 'Store purchase',
+      billing_address: address
     }
 
     @amount = 100

--- a/test/remote/gateways/remote_skipjack_test.rb
+++ b/test/remote/gateways/remote_skipjack_test.rb
@@ -7,15 +7,15 @@ class RemoteSkipJackTest < Test::Unit::TestCase
     @gateway = SkipJackGateway.new(fixtures(:skip_jack))
 
     @credit_card = credit_card('4445999922225',
-      :verification_value => '999'
+      verification_value: '999'
     )
 
     @amount = 100
 
     @options = {
-      :order_id => generate_unique_id,
-      :email => 'email@foo.com',
-      :billing_address => address
+      order_id: generate_unique_id,
+      email: 'email@foo.com',
+      billing_address: address
     }
   end
 
@@ -75,7 +75,7 @@ class RemoteSkipJackTest < Test::Unit::TestCase
     authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
 
-    capture = @gateway.capture(@amount, authorization.authorization, :force_settlement => true)
+    capture = @gateway.capture(@amount, authorization.authorization, force_settlement: true)
     assert_success capture
 
     # developer login won't change transaction immediately to settled, so status will have to mismatch
@@ -107,8 +107,8 @@ class RemoteSkipJackTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SkipJackGateway.new(
-      :login => '555555555555',
-      :password => '999999999999'
+      login: '555555555555',
+      password: '999999999999'
     )
 
     response = gateway.authorize(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_so_easy_pay_test.rb
+++ b/test/remote/gateways/remote_so_easy_pay_test.rb
@@ -5,16 +5,16 @@ class RemoteSoEasyPayTest < Test::Unit::TestCase
     @gateway = SoEasyPayGateway.new(fixtures(:so_easy_pay))
 
     @amount = 100
-    @credit_card = credit_card('4111111111111111', {:verification_value => '000', :month => '12', :year => '2015'})
+    @credit_card = credit_card('4111111111111111', {verification_value: '000', month: '12', year: '2015'})
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :currency => 'EUR',
-      :ip => '192.168.19.123',
-      :email => 'test@blaha.com',
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store Purchase'
+      currency: 'EUR',
+      ip: '192.168.19.123',
+      email: 'test@blaha.com',
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -53,8 +53,8 @@ class RemoteSoEasyPayTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = SoEasyPayGateway.new(
-      :login => 'one',
-      :password => 'wrong'
+      login: 'one',
+      password: 'wrong'
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -70,8 +70,8 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_card_and_address
     options = {
-      :email => 'joebob@example.com',
-      :billing_address => address,
+      email: 'joebob@example.com',
+      billing_address: address,
     }
 
     assert response = @gateway.purchase(@amount, @credit_card, options)
@@ -123,8 +123,8 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_card_and_address
     options = {
-      :email => 'joebob@example.com',
-      :billing_address => address,
+      email: 'joebob@example.com',
+      billing_address: address,
     }
 
     assert response = @gateway.authorize(@amount, @credit_card, options)
@@ -173,16 +173,16 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_successful_store_simple_data
-    assert response = @gateway.store(@credit_card, { :data => 'SomeData' })
+    assert response = @gateway.store(@credit_card, { data: 'SomeData' })
     assert_success response
     assert_equal 'SomeData', response.params['payment_method_data']
   end
 
   def test_successful_store_nested_data
     options = {
-      :data => {
-        :first_attribute => { :sub_dude => 'ExcellentSubValue' },
-        :second_attribute => 'AnotherValue'
+      data: {
+        first_attribute: { sub_dude: 'ExcellentSubValue' },
+        second_attribute: 'AnotherValue'
       }
     }
     assert response = @gateway.store(@credit_card, options)
@@ -193,8 +193,8 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
 
   def test_successful_store_with_address
     options = {
-      :email => 'joebob@example.com',
-      :billing_address => address,
+      email: 'joebob@example.com',
+      billing_address: address,
     }
 
     assert response = @gateway.store(@credit_card, options)
@@ -208,7 +208,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_failed_store
-    assert response = @gateway.store(credit_card('5555555555554444', :last_name => '  '))
+    assert response = @gateway.store(credit_card('5555555555554444', last_name: '  '))
     assert_failure response
     assert_equal "Last name can't be blank", response.message
   end
@@ -291,7 +291,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = SpreedlyCoreGateway.new(:login => 'Bogus', :password => 'MoreBogus', :gateway_token => 'EvenMoreBogus')
+    gateway = SpreedlyCoreGateway.new(login: 'Bogus', password: 'MoreBogus', gateway_token: 'EvenMoreBogus')
 
     assert response = gateway.purchase(@amount, @existing_payment_method)
     assert_failure response

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -10,13 +10,13 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     @billing_details = address()
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com',
-      :execute_threed => true,
-      :redirect_url => 'http://www.example.com/redirect',
-      :callback_url => 'http://www.example.com/callback',
-      :billing_address => @billing_details
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com',
+      execute_threed: true,
+      redirect_url: 'http://www.example.com/redirect',
+      callback_url: 'http://www.example.com/callback',
+      billing_address: @billing_details
     }
     @credit_card = credit_card('4000000000003063')
     @non_3ds_card = credit_card('378282246310005')
@@ -58,7 +58,7 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_equal 'enabled', response.params['status']
     assert_nil response.params['application']
 
-    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: response.params['id']))
     assert_equal true, deleted_response.params['deleted']
   end
 
@@ -69,46 +69,46 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     assert_equal 'enabled', response.params['status']
     assert_not_nil response.params['application']
 
-    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: response.params['id']))
     assert_equal true, deleted_response.params['deleted']
   end
 
   def test_delete_webhook_endpoint
     webhook = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
-    response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook.params['id']))
+    response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook.params['id']))
     assert_equal response.params['id'], webhook.params['id']
     assert_equal true, response.params['deleted']
   end
 
   def test_delete_webhook_endpoint_on_connected_account
     webhook = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
-    response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook.params['id']))
+    response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook.params['id']))
     assert_equal response.params['id'], webhook.params['id']
     assert_equal true, response.params['deleted']
   end
 
   def test_show_webhook_endpoint
     webhook = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
-    response = @gateway.send(:show_webhook_endpoint,  @options.merge(:webhook_id => webhook.params['id']))
+    response = @gateway.send(:show_webhook_endpoint,  @options.merge(webhook_id: webhook.params['id']))
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
     assert_equal 'enabled', response.params['status']
     assert_nil response.params['application']
 
-    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: response.params['id']))
     assert_equal true, deleted_response.params['deleted']
   end
 
   def test_show_webhook_endpoint_on_connected_account
     webhook = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
-    response = @gateway.send(:show_webhook_endpoint,  @options.merge({:webhook_id => webhook.params['id'], stripe_account: @stripe_account}))
+    response = @gateway.send(:show_webhook_endpoint,  @options.merge({webhook_id: webhook.params['id'], stripe_account: @stripe_account}))
 
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
     assert_equal 'enabled', response.params['status']
     assert_not_nil response.params['application']
 
-    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => response.params['id']))
+    deleted_response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: response.params['id']))
     assert_equal true, deleted_response.params['deleted']
   end
 
@@ -125,8 +125,8 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
     webhook_id_set = Set.new(response.params['data'].map { |webhook| webhook['id'] }.uniq)
     assert Set[webhook1.params['id'], webhook2.params['id']].subset?(webhook_id_set)
 
-    deleted_response1 = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook1.params['id']))
-    deleted_response2 = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook2.params['id']))
+    deleted_response1 = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook1.params['id']))
+    deleted_response2 = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook2.params['id']))
     assert_equal true, deleted_response1.params['deleted']
     assert_equal true, deleted_response2.params['deleted']
   end

--- a/test/remote/gateways/remote_stripe_android_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_android_pay_test.rb
@@ -8,9 +8,9 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com'
     }
   end
 

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -8,9 +8,9 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com'
     }
     @apple_pay_payment_token = apple_pay_payment_token
   end
@@ -54,7 +54,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {:description => 'Active Merchant Test Customer', :email => 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
     assert_success response
     assert_equal 'customer', response.params['object']
     assert_equal 'Active Merchant Test Customer', response.params['description']
@@ -66,10 +66,10 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_with_existing_customer_and_apple_pay_payment_token
-    assert response = @gateway.store(@credit_card, {:description => 'Active Merchant Test Customer'})
+    assert response = @gateway.store(@credit_card, {description: 'Active Merchant Test Customer'})
     assert_success response
 
-    assert response = @gateway.store(@apple_pay_payment_token, {:customer => response.params['id'], :description => 'Active Merchant Test Customer', :email => 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, {customer: response.params['id'], description: 'Active Merchant Test Customer', email: 'email@example.com'})
     assert_success response
     assert_equal 2, response.responses.size
 
@@ -86,9 +86,9 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_recurring_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {:description => 'Active Merchant Test Customer', :email => 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
     assert_success response
-    assert recharge_options = @options.merge(:customer => response.params['id'])
+    assert recharge_options = @options.merge(customer: response.params['id'])
     assert response = @gateway.purchase(@amount, nil, recharge_options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_connect_test.rb
+++ b/test/remote/gateways/remote_stripe_connect_test.rb
@@ -10,21 +10,21 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
     @new_credit_card = credit_card('5105105105105100')
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com',
-      :stripe_account => fixtures(:stripe_destination)[:stripe_user_id]
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com',
+      stripe_account: fixtures(:stripe_destination)[:stripe_user_id]
     }
   end
 
   def test_application_fee_for_stripe_connect
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(application_fee: 12))
     assert_success response
   end
 
   def test_successful_refund_with_application_fee
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(:refund_application_fee => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(application_fee: 12))
+    assert refund = @gateway.refund(@amount, response.authorization, @options.merge(refund_application_fee: true))
     assert_success refund
 
     # Verify the application fee is refunded
@@ -35,8 +35,8 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
   end
 
   def test_refund_partial_application_fee
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => '10'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(application_fee: 12))
+    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(refund_fee_amount: '10'))
     assert_success refund
 
     # Verify the application fee is partially refunded
@@ -47,8 +47,8 @@ class RemoteStripeConnectTest < Test::Unit::TestCase
   end
 
   def test_refund_application_fee_amount_zero
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(:refund_fee_amount => '0'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(application_fee: 12))
+    assert refund = @gateway.refund(@amount-20, response.authorization, @options.merge(refund_fee_amount: '0'))
     assert_success refund
 
     # Verify the application fee is not refunded

--- a/test/remote/gateways/remote_stripe_emv_test.rb
+++ b/test/remote/gateways/remote_stripe_emv_test.rb
@@ -14,9 +14,9 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
     }
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com'
     }
 
     #  This capture hex says that the payload is a transaction cryptogram (TC) but does not
@@ -140,7 +140,7 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
   end
 
   def test_authorization_emv_credit_card_in_us_with_metadata
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => '42', :email => 'foo@wonderfullyfakedomain.com'}))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'}))
     assert_success authorization
   end
 end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -18,9 +18,9 @@ class RemoteStripeTest < Test::Unit::TestCase
     @verified_bank_account = fixtures(:stripe_verified_bank_account)
 
     @options = {
-      :currency => 'USD',
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com'
     }
   end
 
@@ -57,7 +57,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_recurring_flag
-    custom_options = @options.merge(:eci => 'recurring')
+    custom_options = @options.merge(eci: 'recurring')
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -68,7 +68,7 @@ class RemoteStripeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_destination
     destination = fixtures(:stripe_destination)[:stripe_user_id]
-    custom_options = @options.merge(:destination => destination)
+    custom_options = @options.merge(destination: destination)
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -80,7 +80,7 @@ class RemoteStripeTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_destination_and_amount
     destination = fixtures(:stripe_destination)[:stripe_user_id]
-    custom_options = @options.merge(:destination => destination, :destination_amount => @amount - 20)
+    custom_options = @options.merge(destination: destination, destination_amount: @amount - 20)
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -156,7 +156,7 @@ class RemoteStripeTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase_with_destination_and_amount
     destination = fixtures(:stripe_destination)[:stripe_user_id]
-    custom_options = @options.merge(:destination => destination, :destination_amount => @amount + 20)
+    custom_options = @options.merge(destination: destination, destination_amount: @amount + 20)
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)
     assert_failure response
     assert_match %r{must be less than or equal to the charge amount}, response.message
@@ -193,7 +193,7 @@ class RemoteStripeTest < Test::Unit::TestCase
 
   def test_authorization_and_capture_with_destination
     destination = fixtures(:stripe_destination)[:stripe_user_id]
-    custom_options = @options.merge(:destination => destination)
+    custom_options = @options.merge(destination: destination)
 
     assert authorization = @gateway.authorize(@amount, @credit_card, custom_options)
     assert_success authorization
@@ -208,7 +208,7 @@ class RemoteStripeTest < Test::Unit::TestCase
 
   def test_authorization_and_capture_with_destination_and_amount
     destination = fixtures(:stripe_destination)[:stripe_user_id]
-    custom_options = @options.merge(:destination => destination, :destination_amount => @amount - 20)
+    custom_options = @options.merge(destination: destination, destination_amount: @amount - 20)
 
     assert authorization = @gateway.authorize(@amount, @credit_card, custom_options)
     assert_success authorization
@@ -495,14 +495,14 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert store = @gateway.store(@credit_card)
     assert_success store
 
-    recharge_options = @options.merge(:customer => store.params['id'])
+    recharge_options = @options.merge(customer: store.params['id'])
     response = @gateway.purchase(@amount, nil, recharge_options)
     assert_success response
     assert_equal '4242', response.params['source']['last4']
   end
 
   def test_successful_unstore
-    creation = @gateway.store(@credit_card, {:description => 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
     card_id = creation.params['sources']['data'].first['id']
 
     assert response = @gateway.unstore(creation.authorization)
@@ -513,7 +513,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore_using_deprecated_api
-    creation = @gateway.store(@credit_card, {:description => 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
     card_id = creation.params['sources']['data'].first['id']
     customer_id = creation.params['id']
 
@@ -557,7 +557,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = StripeGateway.new(:login => 'active_merchant_test')
+    gateway = StripeGateway.new(login: 'active_merchant_test')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match 'Invalid API Key provided', response.message
@@ -584,25 +584,25 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_creditcard_purchase_with_customer
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:customer => '1234'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(customer: '1234'))
     assert_success response
     assert_equal 'charge', response.params['object']
     assert response.params['paid']
   end
 
   def test_expanding_objects
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:expand => 'balance_transaction'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(expand: 'balance_transaction'))
     assert_success response
     assert response.params['balance_transaction'].is_a?(Hash)
     assert_equal 'balance_transaction', response.params['balance_transaction']['object']
   end
 
   def test_successful_update
-    creation    = @gateway.store(@credit_card, {:description => 'Active Merchant Update Credit Card'})
+    creation    = @gateway.store(@credit_card, {description: 'Active Merchant Update Credit Card'})
     customer_id = creation.params['id']
     card_id     = creation.params['sources']['data'].first['id']
 
-    assert response = @gateway.update(customer_id, card_id, { :name => 'John Doe', :address_line1 => '123 Main Street', :address_city => 'Pleasantville', :address_state => 'NY', :address_zip => '12345', :exp_year => Time.now.year + 2, :exp_month => 6 })
+    assert response = @gateway.update(customer_id, card_id, { name: 'John Doe', address_line1: '123 Main Street', address_city: 'Pleasantville', address_state: 'NY', address_zip: '12345', exp_year: Time.now.year + 2, exp_month: 6 })
     assert_success response
     assert_equal 'John Doe',        response.params['name']
     assert_equal '123 Main Street', response.params['address_line1']

--- a/test/remote/gateways/remote_swipe_checkout_test.rb
+++ b/test/remote/gateways/remote_swipe_checkout_test.rb
@@ -24,7 +24,7 @@ class RemoteSwipeCheckoutTest < Test::Unit::TestCase
   end
 
   def test_region_switching
-    assert response = @gateway.purchase(@amount, @accepted_card, @options.merge(:region => 'CA'))
+    assert response = @gateway.purchase(@amount, @accepted_card, @options.merge(region: 'CA'))
     assert_success response
     assert_equal 'Transaction approved', response.message
   end

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -115,8 +115,8 @@ class RemoteTnsTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = TnsGateway.new(
-      :userid => 'nosuch',
-      :password => 'thing'
+      userid: 'nosuch',
+      password: 'thing'
     )
     response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_trans_first_test.rb
+++ b/test/remote/gateways/remote_trans_first_test.rb
@@ -8,9 +8,9 @@ class RemoteTransFirstTest < Test::Unit::TestCase
     @check = check
     @amount = 1201
     @options = {
-      :order_id => generate_unique_id,
-      :invoice => 'ActiveMerchant Sale',
-      :billing_address => address
+      order_id: generate_unique_id,
+      invoice: 'ActiveMerchant Sale',
+      billing_address: address
     }
   end
 
@@ -106,8 +106,8 @@ class RemoteTransFirstTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = TransFirstGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(1100, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -97,12 +97,12 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_successful_purchase_without_cvv
     credit_card_opts = {
-      :number => 4485896261017708,
-      :month => Date.new((Time.now.year + 1), 9, 30).month,
-      :year => Date.new((Time.now.year + 1), 9, 30).year,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :brand => 'visa'
+      number: 4485896261017708,
+      month: Date.new((Time.now.year + 1), 9, 30).month,
+      year: Date.new((Time.now.year + 1), 9, 30).year,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      brand: 'visa'
     }
 
     credit_card = CreditCard.new(credit_card_opts)
@@ -113,13 +113,13 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_empty_string_cvv
     credit_card_opts = {
-      :number => 4485896261017708,
-      :month => Date.new((Time.now.year + 1), 9, 30).month,
-      :year => Date.new((Time.now.year + 1), 9, 30).year,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :verification_value => '',
-      :brand => 'visa'
+      number: 4485896261017708,
+      month: Date.new((Time.now.year + 1), 9, 30).month,
+      year: Date.new((Time.now.year + 1), 9, 30).year,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      verification_value: '',
+      brand: 'visa'
     }
 
     credit_card = CreditCard.new(credit_card_opts)
@@ -130,11 +130,11 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_successful_purchase_without_name
     credit_card_opts = {
-      :number => 4485896261017708,
-      :month => Date.new((Time.now.year + 1), 9, 30).month,
-      :year => Date.new((Time.now.year + 1), 9, 30).year,
-      :first_name => '',
-      :last_name => ''
+      number: 4485896261017708,
+      month: Date.new((Time.now.year + 1), 9, 30).month,
+      year: Date.new((Time.now.year + 1), 9, 30).year,
+      first_name: '',
+      last_name: ''
     }
 
     credit_card = CreditCard.new(credit_card_opts)
@@ -143,9 +143,9 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
 
     credit_card_opts = {
-      :number => 4485896261017708,
-      :month => Date.new((Time.now.year + 1), 9, 30).month,
-      :year => Date.new((Time.now.year + 1), 9, 30).year
+      number: 4485896261017708,
+      month: Date.new((Time.now.year + 1), 9, 30).month,
+      year: Date.new((Time.now.year + 1), 9, 30).year
     }
 
     credit_card = CreditCard.new(credit_card_opts)

--- a/test/remote/gateways/remote_transax_test.rb
+++ b/test/remote/gateways/remote_transax_test.rb
@@ -5,15 +5,15 @@ class RemoteTransaxTest < Test::Unit::TestCase
     @gateway = TransaxGateway.new(fixtures(:transax))
 
     @amount = 100
-    @credit_card = credit_card('4111111111111111', :year => 10, :month => 10)
+    @credit_card = credit_card('4111111111111111', year: 10, month: 10)
     @declined_card = credit_card(0xDEADBEEF_0000.to_s)
 
     @check = check()
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -76,7 +76,7 @@ class RemoteTransaxTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'This transaction has been approved', response.message
     assert response.authorization
-    assert update = @gateway.amend(response.authorization, :shipping_carrier => 'usps')
+    assert update = @gateway.amend(response.authorization, shipping_carrier: 'usps')
     assert_equal 'This transaction has been approved', update.message
     assert_success update
   end
@@ -115,8 +115,8 @@ class RemoteTransaxTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = TransaxGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -14,19 +14,19 @@ class TrustCommerceTest < Test::Unit::TestCase
     @invalid_verification_value = '1234'
 
     @valid_address = {
-      :address1 => '123 Test St.',
-      :address2 => nil,
-      :city => 'Somewhere',
-      :state => 'CA',
-      :zip => '90001'
+      address1: '123 Test St.',
+      address2: nil,
+      city: 'Somewhere',
+      state: 'CA',
+      zip: '90001'
     }
 
     @invalid_address = {
-      :address1 => '187 Apple Tree Lane.',
-      :address2 => nil,
-      :city => 'Woodside',
-      :state => 'CA',
-      :zip => '94062'
+      address1: '187 Apple Tree Lane.',
+      address2: nil,
+      city: 'Woodside',
+      state: 'CA',
+      zip: '94062'
     }
 
     # The Trust Commerce API does not return anything different when custom fields are present.
@@ -38,12 +38,12 @@ class TrustCommerceTest < Test::Unit::TestCase
     }
 
     @options = {
-      :ip => '10.10.10.10',
-      :order_id => '#1000.1',
-      :email => 'cody@example.com',
-      :billing_address => @valid_address,
-      :shipping_address => @valid_address,
-      :custom_fields => custom_fields
+      ip: '10.10.10.10',
+      order_id: '#1000.1',
+      email: 'cody@example.com',
+      billing_address: @valid_address,
+      shipping_address: @valid_address,
+      custom_fields: custom_fields
     }
   end
 
@@ -88,7 +88,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_avs_for_invalid_address
-    assert response = @gateway.purchase(@amount, @credit_card, @options.update(:billing_address => @invalid_address))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.update(billing_address: @invalid_address))
     assert_equal 'N', response.params['avs']
     assert_match %r{The transaction was successful}, response.message
     assert_success response
@@ -107,7 +107,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_avs
-    assert response = @gateway.authorize(@amount, @credit_card, :billing_address => @valid_address)
+    assert response = @gateway.authorize(@amount, @credit_card, billing_address: @valid_address)
 
     assert_equal 'Y', response.avs_result['code']
     assert_match %r{The transaction was successful}, response.message
@@ -124,7 +124,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_authorization_with_avs_for_invalid_address
-    assert response = @gateway.authorize(@amount, @credit_card, @options.update(:billing_address => @invalid_address))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.update(billing_address: @invalid_address))
     assert_equal 'N', response.params['avs']
     assert_match %r{The transaction was successful}, response.message
     assert_success response
@@ -190,14 +190,14 @@ class TrustCommerceTest < Test::Unit::TestCase
   end
 
   def test_successful_recurring
-    assert response = @gateway.recurring(@amount, @credit_card, :periodicity => :weekly)
+    assert response = @gateway.recurring(@amount, @credit_card, periodicity: :weekly)
 
     assert_match %r{The transaction was successful}, response.message
     assert_success response
   end
 
   def test_failed_recurring
-    assert response = @gateway.recurring(@amount, @declined_credit_card, :periodicity => :weekly)
+    assert response = @gateway.recurring(@amount, @declined_credit_card, periodicity: :weekly)
 
     assert_bad_data_response(response)
   end

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -8,89 +8,89 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     @amount = 2111
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :number => '4000100011112224',
-      :month => 9,
-      :year => Time.now.year + 1,
-      :brand => 'visa',
-      :verification_value => '123',
-      :first_name => 'Fred',
-      :last_name => 'Flintstone'
+      number: '4000100011112224',
+      month: 9,
+      year: Time.now.year + 1,
+      brand: 'visa',
+      verification_value: '123',
+      first_name: 'Fred',
+      last_name: 'Flintstone'
     )
 
     @bad_credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :number => '4000300011112220',
-      :month => 9,
-      :year => 14,
-      :brand => 'visa',
-      :verification_value => '999',
-      :first_name => 'Fred',
-      :last_name => 'Flintstone'
+      number: '4000300011112220',
+      month: 9,
+      year: 14,
+      brand: 'visa',
+      verification_value: '999',
+      first_name: 'Fred',
+      last_name: 'Flintstone'
     )
 
     @check = ActiveMerchant::Billing::Check.new(
-      :account_number => '123456789',
-      :routing_number => '120450780',
-      :account_type => 'checking',
-      :first_name => 'Fred',
-      :last_name => 'Flintstone'
+      account_number: '123456789',
+      routing_number: '120450780',
+      account_type: 'checking',
+      first_name: 'Fred',
+      last_name: 'Flintstone'
     )
 
     cc_method = [
-      {:name => 'My CC', :sort => 5, :method => @credit_card},
-      {:name => 'Other CC', :sort => 12, :method => @credit_card}
+      {name: 'My CC', sort: 5, method: @credit_card},
+      {name: 'Other CC', sort: 12, method: @credit_card}
     ]
 
     @options = {
-      :client_ip => '127.0.0.1',
-      :billing_address => address,
+      client_ip: '127.0.0.1',
+      billing_address: address,
     }
 
     @transaction_options = {
-      :order_id => '1',
-      :description => 'Store Purchase'
+      order_id: '1',
+      description: 'Store Purchase'
     }
 
     @customer_options = {
-      :id => 123,
-      :notes => 'Customer note.',
-      :data => 'complex data',
-      :url => 'somesite.com',
-      :payment_methods => cc_method
+      id: 123,
+      notes: 'Customer note.',
+      data: 'complex data',
+      url: 'somesite.com',
+      payment_methods: cc_method
     }
 
     @update_customer_options = {
-      :notes => 'NEW NOTE!'
+      notes: 'NEW NOTE!'
     }
 
     @add_payment_options = {
-      :make_default => true,
-      :payment_method => {
-        :name => 'My new card.',
-        :sort => 10,
-        :method => @credit_card
+      make_default: true,
+      payment_method: {
+        name: 'My new card.',
+        sort: 10,
+        method: @credit_card
       }
     }
 
     @run_transaction_options = {
-      :payment_method => @credit_card,
-      :command => 'sale',
-      :amount => 10000
+      payment_method: @credit_card,
+      command: 'sale',
+      amount: 10000
     }
 
     @run_transaction_check_options = {
-      :payment_method => @check,
-      :command => 'check',
-      :amount => 10000
+      payment_method: @check,
+      command: 'check',
+      amount: 10000
     }
 
     @run_sale_options = {
-      :payment_method => @credit_card,
-      :amount => 5000
+      payment_method: @credit_card,
+      amount: 5000
     }
 
     @run_check_sale_options = {
-      :payment_method => @check,
-      :amount => 2500
+      payment_method: @check,
+      amount: 2500
     }
   end
 
@@ -138,9 +138,9 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = UsaEpayAdvancedGateway.new(
-      :login => '',
-      :password => '',
-      :software_id => ''
+      login: '',
+      password: '',
+      software_id: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -158,7 +158,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    @options.merge!(@update_customer_options.merge!(:customer_number => customer_number))
+    @options.merge!(@update_customer_options.merge!(customer_number: customer_number))
     response = @gateway.update_customer(@options)
     assert response.params['update_customer_return']
   end
@@ -175,10 +175,10 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.enable_customer(:customer_number => customer_number)
+    response = @gateway.enable_customer(customer_number: customer_number)
     assert response.params['enable_customer_return']
 
-    response = @gateway.disable_customer(:customer_number => customer_number)
+    response = @gateway.disable_customer(customer_number: customer_number)
     assert response.params['disable_customer_return']
   end
 
@@ -186,7 +186,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    @options.merge!(:customer_number => customer_number).merge!(@add_payment_options)
+    @options.merge!(customer_number: customer_number).merge!(@add_payment_options)
     response = @gateway.add_customer_payment_method(@options)
     assert response.params['add_customer_payment_method_return']
   end
@@ -196,7 +196,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     customer_number = response.params['add_customer_return']
 
     @add_payment_options[:payment_method][:method] = @bad_credit_card
-    @options.merge!(:customer_number => customer_number, :verify => true).merge!(@add_payment_options)
+    @options.merge!(customer_number: customer_number, verify: true).merge!(@add_payment_options)
     response = @gateway.add_customer_payment_method(@options)
     assert response.params['faultstring']
   end
@@ -205,7 +205,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.get_customer_payment_methods(:customer_number => customer_number)
+    response = @gateway.get_customer_payment_methods(customer_number: customer_number)
     assert response.params['get_customer_payment_methods_return']['item']
   end
 
@@ -213,10 +213,10 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.get_customer_payment_methods(:customer_number => customer_number)
+    response = @gateway.get_customer_payment_methods(customer_number: customer_number)
     id = response.params['get_customer_payment_methods_return']['item'][0]['method_id']
 
-    response = @gateway.get_customer_payment_method(:customer_number => customer_number, :method_id => id)
+    response = @gateway.get_customer_payment_method(customer_number: customer_number, method_id: id)
     assert response.params['get_customer_payment_method_return']
   end
 
@@ -224,12 +224,12 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    @options.merge!(:customer_number => customer_number).merge!(@add_payment_options)
+    @options.merge!(customer_number: customer_number).merge!(@add_payment_options)
     response = @gateway.add_customer_payment_method(@options)
     payment_method_id = response.params['add_customer_payment_method_return']
 
-    update_payment_options = @add_payment_options[:payment_method].merge(:method_id => payment_method_id,
-                                                                         :name => 'Updated Card.')
+    update_payment_options = @add_payment_options[:payment_method].merge(method_id: payment_method_id,
+                                                                         name: 'Updated Card.')
 
     response = @gateway.update_customer_payment_method(update_payment_options)
     assert response.params['update_customer_payment_method_return']
@@ -239,11 +239,11 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    @options.merge!(:customer_number => customer_number).merge!(@add_payment_options)
+    @options.merge!(customer_number: customer_number).merge!(@add_payment_options)
     response = @gateway.add_customer_payment_method(@options)
     id = response.params['add_customer_payment_method_return']
 
-    response = @gateway.delete_customer_payment_method(:customer_number => customer_number, :method_id => id)
+    response = @gateway.delete_customer_payment_method(customer_number: customer_number, method_id: id)
     assert response.params['delete_customer_payment_method_return']
   end
 
@@ -251,7 +251,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.delete_customer(:customer_number => customer_number)
+    response = @gateway.delete_customer(customer_number: customer_number)
     assert response.params['delete_customer_return']
   end
 
@@ -259,8 +259,8 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.run_customer_transaction(:customer_number => customer_number, # :method_id => 0, # optional
-                                                 :command => 'Sale', :amount => 3000)
+    response = @gateway.run_customer_transaction(customer_number: customer_number, # :method_id => 0, # optional
+                                                 command: 'Sale', amount: 3000)
     assert response.params['run_customer_transaction_return']
   end
 
@@ -322,7 +322,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_auth_only(options)
     reference_number = response.params['run_auth_only_return']['ref_num']
 
-    options = @options.merge(:reference_number => reference_number)
+    options = @options.merge(reference_number: reference_number)
     response = @gateway.capture_transaction(options)
     assert response.params['capture_transaction_return']
   end
@@ -332,7 +332,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(options)
     reference_number = response.params['run_sale_return']['ref_num']
 
-    options = @options.merge(:reference_number => reference_number)
+    options = @options.merge(reference_number: reference_number)
     response = @gateway.void_transaction(options)
     assert response.params['void_transaction_return']
   end
@@ -342,7 +342,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(options)
     reference_number = response.params['run_sale_return']['ref_num']
 
-    options = @options.merge(:reference_number => reference_number, :amount => 0)
+    options = @options.merge(reference_number: reference_number, amount: 0)
     response = @gateway.refund_transaction(options)
     assert response.params['refund_transaction_return']
   end
@@ -353,7 +353,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_check_sale(options)
     reference_number = response.params['run_check_sale_return']['ref_num']
 
-    response = @gateway.override_transaction(:reference_number => reference_number, :reason => 'Because I said so')
+    response = @gateway.override_transaction(reference_number: reference_number, reason: 'Because I said so')
     assert response.params['faultstring']
   end
 
@@ -362,7 +362,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(@options)
     reference_number = response.params['run_sale_return']['ref_num']
 
-    response = @gateway.run_quick_sale(:reference_number => reference_number, :amount => 9900)
+    response = @gateway.run_quick_sale(reference_number: reference_number, amount: 9900)
     assert response.params['run_quick_sale_return']
   end
 
@@ -371,7 +371,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_check_sale(@options)
     reference_number = response.params['run_check_sale_return']['ref_num']
 
-    response = @gateway.run_quick_sale(:reference_number => reference_number, :amount => 9900)
+    response = @gateway.run_quick_sale(reference_number: reference_number, amount: 9900)
     assert response.params['run_quick_sale_return']
   end
 
@@ -380,7 +380,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(@options)
     reference_number = response.params['run_sale_return']['ref_num']
 
-    response = @gateway.run_quick_credit(:reference_number => reference_number, :amount => 0)
+    response = @gateway.run_quick_credit(reference_number: reference_number, amount: 0)
     assert response.params['run_quick_credit_return']
   end
 
@@ -389,7 +389,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_check_sale(@options)
     reference_number = response.params['run_check_sale_return']['ref_num']
 
-    response = @gateway.run_quick_credit(:reference_number => reference_number, :amount => 1234)
+    response = @gateway.run_quick_credit(reference_number: reference_number, amount: 1234)
     assert response.params['run_quick_credit_return']
   end
 
@@ -399,7 +399,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(@options.merge(@run_sale_options))
     reference_number = response.params['run_sale_return']['ref_num']
 
-    response = @gateway.get_transaction(:reference_number => reference_number)
+    response = @gateway.get_transaction(reference_number: reference_number)
     assert response.params['get_transaction_return']
   end
 
@@ -407,7 +407,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(@options.merge(@run_sale_options))
     reference_number = response.params['run_sale_return']['ref_num']
 
-    response = @gateway.get_transaction_status(:reference_number => reference_number)
+    response = @gateway.get_transaction_status(reference_number: reference_number)
     assert response.params['get_transaction_status_return']
   end
 
@@ -415,11 +415,11 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_sale(@options.merge(@run_sale_options))
     reference_number = response.params['run_sale_return']['ref_num']
 
-    response = @gateway.get_transaction_custom(:reference_number => reference_number,
-                                               :fields => ['Response.StatusCode', 'Response.Status'])
+    response = @gateway.get_transaction_custom(reference_number: reference_number,
+                                               fields: ['Response.StatusCode', 'Response.Status'])
     assert response.params['get_transaction_custom_return']
-    response = @gateway.get_transaction_custom(:reference_number => reference_number,
-                                               :fields => ['Response.StatusCode'])
+    response = @gateway.get_transaction_custom(reference_number: reference_number,
+                                               fields: ['Response.StatusCode'])
     assert response.params['get_transaction_custom_return']
   end
 
@@ -427,7 +427,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.run_check_sale(@options.merge(@run_check_sale_options))
     reference_number = response.params['run_check_sale_return']['ref_num']
 
-    response = @gateway.get_check_trace(:reference_number => reference_number)
+    response = @gateway.get_check_trace(reference_number: reference_number)
     assert response.params['get_check_trace_return']
   end
 

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -8,7 +8,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     @credit_card_with_track_data = credit_card_with_track_data('4000100011112224')
     @invalid_transaction_card = credit_card('4000300511112225')
     @check = check
-    @options = { :billing_address => address(:zip => '27614', :state => 'NC'), :shipping_address => address }
+    @options = { billing_address: address(zip: '27614', state: 'NC'), shipping_address: address }
     @amount = 100
   end
 
@@ -52,19 +52,19 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_extra_details
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:order_id => generate_unique_id, :description => 'socool'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(order_id: generate_unique_id, description: 'socool'))
     assert_equal 'Success', response.message
     assert_success response
   end
 
   def test_successful_purchase_with_extra_test_mode
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:test_mode => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(test_mode: true))
     assert_equal 'Success', response.message
     assert_success response
   end
 
   def test_successful_purchase_with_email_receipt
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:email => 'hank@hill.com', :cust_receipt => 'Yes'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(email: 'hank@hill.com', cust_receipt: 'Yes'))
     assert_equal 'Success', response.message
     assert_success response
   end
@@ -113,7 +113,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     # For some reason this will fail with "You have tried this card too
     # many times, please contact merchant" unless a unique order id is
     # passed.
-    assert response = @gateway.purchase(@amount, @declined_card, @options.merge(:order_id => generate_unique_id))
+    assert response = @gateway.purchase(@amount, @declined_card, @options.merge(order_id: generate_unique_id))
     assert_failure response
     assert_match(/declined/i, response.message)
     assert Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
@@ -209,7 +209,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_invalid_key
-    gateway = UsaEpayTransactionGateway.new(:login => '')
+    gateway = UsaEpayTransactionGateway.new(login: '')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Specified source key not found.', response.message
     assert_failure response

--- a/test/remote/gateways/remote_verifi_test.rb
+++ b/test/remote/gateways/remote_verifi_test.rb
@@ -10,9 +10,9 @@ class VerifiTest < Test::Unit::TestCase
 
     #  Replace with your login and password for the Verifi test environment
     @options = {
-      :order_id => '37',
-      :email => 'test@example.com',
-      :billing_address => address
+      order_id: '37',
+      email: 'test@example.com',
+      billing_address: address
     }
 
     @amount = 100
@@ -85,8 +85,8 @@ class VerifiTest < Test::Unit::TestCase
 
   def test_bad_login
     gateway = VerifiGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     assert response = gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_viaklix_test.rb
+++ b/test/remote/gateways/remote_viaklix_test.rb
@@ -8,10 +8,10 @@ class RemoteViaklixTest < Test::Unit::TestCase
     @bad_credit_card = credit_card('invalid')
 
     @options = {
-      :order_id => '#1000.1',
-      :email => 'paul@domain.com',
-      :description => 'Test Transaction',
-      :billing_address => address
+      order_id: '#1000.1',
+      email: 'paul@domain.com',
+      description: 'Test Transaction',
+      billing_address: address
     }
     @amount = 100
   end

--- a/test/remote/gateways/remote_webpay_test.rb
+++ b/test/remote/gateways/remote_webpay_test.rb
@@ -13,8 +13,8 @@ class RemoteWebpayTest < Test::Unit::TestCase
     @new_credit_card = credit_card('5105105105105100')
 
     @options = {
-      :description => 'ActiveMerchant Test Purchase',
-      :email => 'wow@example.com'
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com'
     }
   end
 
@@ -32,10 +32,10 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_purchase_description
-    assert response = @gateway.purchase(@amount, @credit_card, { :description => 'TheDescription', :email => 'email@example.com' })
+    assert response = @gateway.purchase(@amount, @credit_card, { description: 'TheDescription', email: 'email@example.com' })
     assert_equal 'TheDescription', response.params['description'], "Use the description if it's specified."
 
-    assert response = @gateway.purchase(@amount, @credit_card, { :email => 'email@example.com' })
+    assert response = @gateway.purchase(@amount, @credit_card, { email: 'email@example.com' })
     assert_equal 'email@example.com', response.params['description'], 'Use the email if no description is specified.'
 
     assert response = @gateway.purchase(@amount, @credit_card, { })
@@ -104,7 +104,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, {:description => 'Active Merchant Test Customer', :email => 'email@example.com'})
+    assert response = @gateway.store(@credit_card, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
     assert_success response
     assert_equal 'customer', response.params['object']
     assert_equal 'Active Merchant Test Customer', response.params['description']
@@ -113,7 +113,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_update
-    creation = @gateway.store(@credit_card, {:description => 'Active Merchant Update Customer'})
+    creation = @gateway.store(@credit_card, {description: 'Active Merchant Update Customer'})
     assert response = @gateway.update(creation.params['id'], @new_credit_card)
     assert_success response
     assert_equal 'Active Merchant Update Customer', response.params['description']
@@ -121,14 +121,14 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-    creation = @gateway.store(@credit_card, {:description => 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
     assert response = @gateway.unstore(creation.params['id'])
     assert_success response
     assert_equal true, response.params['deleted']
   end
 
   def test_invalid_login
-    gateway = WebpayGateway.new(:login => 'active_merchant_test')
+    gateway = WebpayGateway.new(login: 'active_merchant_test')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid API key provided. Check your API key is correct.', response.message

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -190,13 +190,13 @@ class RemoteWirecardTest < Test::Unit::TestCase
   end
 
   def test_successful_authorization_as_recurring_transaction_type_initial
-    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:recurring => 'Initial'))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(recurring: 'Initial'))
     assert_success response
     assert response.authorization
   end
 
   def test_successful_purchase_as_recurring_transaction_type_initial
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:recurring => 'Initial'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(recurring: 'Initial'))
     assert_success response
     assert response.authorization
   end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -8,20 +8,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111')
     @elo_credit_card = credit_card('4514 1600 0000 0008',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
-    @declined_card = credit_card('4111111111111111', :first_name => nil, :last_name => 'REFUSED')
-    @threeDS_card = credit_card('4111111111111111', :first_name => nil, :last_name => '3D')
-    @threeDS2_card = credit_card('4111111111111111', :first_name => nil, :last_name => '3DS_V2_FRICTIONLESS_IDENTIFIED')
-    @threeDS_card_external_MPI = credit_card('4444333322221111', :first_name => 'AA', :last_name => 'BD')
+    @declined_card = credit_card('4111111111111111', first_name: nil, last_name: 'REFUSED')
+    @threeDS_card = credit_card('4111111111111111', first_name: nil, last_name: '3D')
+    @threeDS2_card = credit_card('4111111111111111', first_name: nil, last_name: '3DS_V2_FRICTIONLESS_IDENTIFIED')
+    @threeDS_card_external_MPI = credit_card('4444333322221111', first_name: 'AA', last_name: 'BD')
 
     @options = {
       order_id: generate_unique_id,
@@ -58,7 +58,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_avs_and_cvv
-    card = credit_card('4111111111111111', :verification_value => 555)
+    card = credit_card('4111111111111111', verification_value: 555)
     assert response = @gateway.authorize(@amount, card, @options.merge(billing_address: address.update(zip: 'CCCC')))
     assert_success response
     assert_equal 'SUCCESS', response.message
@@ -404,21 +404,21 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_authorize_fractional_currency
-    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'USD')))
+    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(currency: 'USD')))
     assert_equal 'USD', result.params['amount_currency_code']
     assert_equal '1234', result.params['amount_value']
     assert_equal '2', result.params['amount_exponent']
   end
 
   def test_authorize_nonfractional_currency
-    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'IDR')))
+    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(currency: 'IDR')))
     assert_equal 'IDR', result.params['amount_currency_code']
     assert_equal '12', result.params['amount_value']
     assert_equal '0', result.params['amount_exponent']
   end
 
   def test_authorize_three_decimal_currency
-    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(:currency => 'OMR')))
+    assert_success(result = @gateway.authorize(1234, @credit_card, @options.merge(currency: 'OMR')))
     assert_equal 'OMR', result.params['amount_currency_code']
     assert_equal '1234', result.params['amount_value']
     assert_equal '3', result.params['amount_exponent']
@@ -426,11 +426,11 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_reference_transaction
     assert_success(original = @gateway.authorize(100, @credit_card, @options))
-    assert_success(@gateway.authorize(200, original.authorization, :order_id => generate_unique_id))
+    assert_success(@gateway.authorize(200, original.authorization, order_id: generate_unique_id))
   end
 
   def test_invalid_login
-    gateway = WorldpayGateway.new(:login => '', :password => '')
+    gateway = WorldpayGateway.new(login: '', password: '')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Invalid credentials', response.message

--- a/test/remote/gateways/remote_worldpay_us_test.rb
+++ b/test/remote/gateways/remote_worldpay_us_test.rb
@@ -5,9 +5,9 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
     @gateway = WorldpayUsGateway.new(fixtures(:worldpay_us))
 
     @amount = 100
-    @credit_card = credit_card('4446661234567892', :verification_value => '987')
+    @credit_card = credit_card('4446661234567892', verification_value: '987')
     @declined_card = credit_card('4000300011112220')
-    @check = check(:number => '12345654321')
+    @check = check(number: '12345654321')
 
     @options = {
       order_id: generate_unique_id,
@@ -101,15 +101,15 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:billing_address => address))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: address))
     assert_success response
   end
 
   def test_invalid_login
     gateway = WorldpayUsGateway.new(
-      :acctid => '',
-      :subid => '',
-      :merchantpin => ''
+      acctid: '',
+      subid: '',
+      merchantpin: ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -152,13 +152,13 @@ module ActiveMerchant
 
     def credit_card(number = '4242424242424242', options = {})
       defaults = {
-        :number => number,
-        :month => default_expiration_date.month,
-        :year => default_expiration_date.year,
-        :first_name => 'Longbob',
-        :last_name => 'Longsen',
-        :verification_value => options[:verification_value] || '123',
-        :brand => 'visa'
+        number: number,
+        month: default_expiration_date.month,
+        year: default_expiration_date.year,
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        verification_value: options[:verification_value] || '123',
+        brand: 'visa'
       }.update(options)
 
       Billing::CreditCard.new(defaults)
@@ -168,7 +168,7 @@ module ActiveMerchant
       exp_date = default_expiration_date.strftime('%y%m')
 
       defaults = {
-        :track_data => "%B#{number}^LONGSEN/L. ^#{exp_date}1200000000000000**123******?",
+        track_data: "%B#{number}^LONGSEN/L. ^#{exp_date}1200000000000000**123******?",
       }.update(options)
 
       Billing::CreditCard.new(defaults)
@@ -176,13 +176,13 @@ module ActiveMerchant
 
     def network_tokenization_credit_card(number = '4242424242424242', options = {})
       defaults = {
-        :number => number,
-        :month => default_expiration_date.month,
-        :year => default_expiration_date.year,
-        :first_name => 'Longbob',
-        :last_name => 'Longsen',
-        :verification_value => '123',
-        :brand => 'visa'
+        number: number,
+        month: default_expiration_date.month,
+        year: default_expiration_date.year,
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        verification_value: '123',
+        brand: 'visa'
       }.update(options)
 
       Billing::NetworkTokenizationCreditCard.new(defaults)
@@ -190,13 +190,13 @@ module ActiveMerchant
 
     def check(options = {})
       defaults = {
-        :name => 'Jim Smith',
-        :bank_name => 'Bank of Elbonia',
-        :routing_number => '244183602',
-        :account_number => '15378535',
-        :account_holder_type => 'personal',
-        :account_type => 'checking',
-        :number => '1'
+        name: 'Jim Smith',
+        bank_name: 'Bank of Elbonia',
+        routing_number: '244183602',
+        account_number: '15378535',
+        account_holder_type: 'personal',
+        account_type: 'checking',
+        number: '1'
       }.update(options)
 
       Billing::Check.new(defaults)

--- a/test/unit/avs_result_test.rb
+++ b/test/unit/avs_result_test.rb
@@ -6,7 +6,7 @@ class AVSResultTest < Test::Unit::TestCase
   end
 
   def test_no_match
-    result = AVSResult.new(:code => 'N')
+    result = AVSResult.new(code: 'N')
     assert_equal 'N', result.code
     assert_equal 'N', result.street_match
     assert_equal 'N', result.postal_match
@@ -14,7 +14,7 @@ class AVSResultTest < Test::Unit::TestCase
   end
 
   def test_only_street_match
-    result = AVSResult.new(:code => 'A')
+    result = AVSResult.new(code: 'A')
     assert_equal 'A', result.code
     assert_equal 'Y', result.street_match
     assert_equal 'N', result.postal_match
@@ -22,7 +22,7 @@ class AVSResultTest < Test::Unit::TestCase
   end
 
   def test_only_postal_match
-    result = AVSResult.new(:code => 'W')
+    result = AVSResult.new(code: 'W')
     assert_equal 'W', result.code
     assert_equal 'N', result.street_match
     assert_equal 'Y', result.postal_match
@@ -30,30 +30,30 @@ class AVSResultTest < Test::Unit::TestCase
   end
 
   def test_nil_data
-    result = AVSResult.new(:code => nil)
+    result = AVSResult.new(code: nil)
     assert_nil result.code
     assert_nil result.message
   end
 
   def test_empty_data
-    result = AVSResult.new(:code => '')
+    result = AVSResult.new(code: '')
     assert_nil result.code
     assert_nil result.message
   end
 
   def test_to_hash
-    avs_data = AVSResult.new(:code => 'X').to_hash
+    avs_data = AVSResult.new(code: 'X').to_hash
     assert_equal 'X', avs_data['code']
     assert_equal AVSResult.messages['X'], avs_data['message']
   end
 
   def test_street_match
-    avs_data = AVSResult.new(:street_match => 'Y')
+    avs_data = AVSResult.new(street_match: 'Y')
     assert_equal 'Y', avs_data.street_match
   end
 
   def test_postal_match
-    avs_data = AVSResult.new(:postal_match => 'Y')
+    avs_data = AVSResult.new(postal_match: 'Y')
     assert_equal 'Y', avs_data.postal_match
   end
 end

--- a/test/unit/check_test.rb
+++ b/test/unit/check_test.rb
@@ -12,14 +12,14 @@ class CheckTest < Test::Unit::TestCase
   end
 
   def test_first_name_last_name
-    check = Check.new(:name => 'Fred Bloggs')
+    check = Check.new(name: 'Fred Bloggs')
     assert_equal 'Fred', check.first_name
     assert_equal 'Bloggs', check.last_name
     assert_equal 'Fred Bloggs', check.name
   end
 
   def test_nil_name
-    check = Check.new(:name => nil)
+    check = Check.new(name: nil)
     assert_nil check.first_name
     assert_nil check.last_name
     assert_equal '', check.name
@@ -27,11 +27,11 @@ class CheckTest < Test::Unit::TestCase
 
   def test_valid
     assert_valid Check.new(
-      :name => 'Fred Bloggs',
-      :routing_number => VALID_ABA,
-      :account_number => ACCOUNT_NUMBER,
-      :account_holder_type => 'personal',
-      :account_type => 'checking'
+      name: 'Fred Bloggs',
+      routing_number: VALID_ABA,
+      account_number: ACCOUNT_NUMBER,
+      account_holder_type: 'personal',
+      account_type: 'checking'
     )
   end
 
@@ -40,12 +40,12 @@ class CheckTest < Test::Unit::TestCase
   end
 
   def test_invalid_routing_number
-    errors = assert_not_valid Check.new(:routing_number => INVALID_ABA)
+    errors = assert_not_valid Check.new(routing_number: INVALID_ABA)
     assert_equal ['is invalid'], errors[:routing_number]
   end
 
   def test_malformed_routing_number
-    errors = assert_not_valid Check.new(:routing_number => MALFORMED_ABA)
+    errors = assert_not_valid Check.new(routing_number: MALFORMED_ABA)
     assert_equal ['is invalid'], errors[:routing_number]
   end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class ConnectionTest < Test::Unit::TestCase
   def setup
-    @ok = stub(:code => 200, :message => 'OK', :body => 'success')
+    @ok = stub(code: 200, message: 'OK', body: 'success')
 
     @endpoint   = 'https://example.com/tx.php'
     @connection = ActiveMerchant::Connection.new(@endpoint)
-    @connection.logger = stub(:info => nil, :debug => nil, :error => nil)
+    @connection.logger = stub(info: nil, debug: nil, error: nil)
   end
 
   def test_connection_endpoint_parses_string_to_uri

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CountryTest < Test::Unit::TestCase
   def test_country_from_hash
-    country = ActiveMerchant::Country.new(:name => 'Canada', :alpha2 => 'CA', :alpha3 => 'CAN', :numeric => '124')
+    country = ActiveMerchant::Country.new(name: 'Canada', alpha2: 'CA', alpha3: 'CAN', numeric: '124')
     assert_equal 'CA', country.code(:alpha2).value
     assert_equal 'CAN', country.code(:alpha3).value
     assert_equal '124', country.code(:numeric).value

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -49,7 +49,7 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_be_able_to_liberate_a_bogus_card
-    c = credit_card('', :brand => 'bogus')
+    c = credit_card('', brand: 'bogus')
     assert_valid c
 
     c.brand = 'visa'
@@ -173,20 +173,20 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_identify_wrong_card_brand
-    c = credit_card(:brand => 'master')
+    c = credit_card(brand: 'master')
     assert_not_valid c
   end
 
   def test_should_display_number
-    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(:number => '1111222233331234').display_number
-    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(:number => '111222233331234').display_number
-    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(:number => '1112223331234').display_number
+    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(number: '1111222233331234').display_number
+    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(number: '111222233331234').display_number
+    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(number: '1112223331234').display_number
 
-    assert_equal 'XXXX-XXXX-XXXX-', CreditCard.new(:number => nil).display_number
-    assert_equal 'XXXX-XXXX-XXXX-', CreditCard.new(:number => '').display_number
-    assert_equal 'XXXX-XXXX-XXXX-123', CreditCard.new(:number => '123').display_number
-    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(:number => '1234').display_number
-    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(:number => '01234').display_number
+    assert_equal 'XXXX-XXXX-XXXX-', CreditCard.new(number: nil).display_number
+    assert_equal 'XXXX-XXXX-XXXX-', CreditCard.new(number: '').display_number
+    assert_equal 'XXXX-XXXX-XXXX-123', CreditCard.new(number: '123').display_number
+    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(number: '1234').display_number
+    assert_equal 'XXXX-XXXX-XXXX-1234', CreditCard.new(number: '01234').display_number
   end
 
   def test_should_correctly_identify_card_brand
@@ -204,7 +204,7 @@ class CreditCardTest < Test::Unit::TestCase
 
   def test_should_not_be_valid_when_requiring_a_verification_value
     CreditCard.require_verification_value = true
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
     assert_not_valid card
 
     card.verification_value = '1234'
@@ -214,7 +214,7 @@ class CreditCardTest < Test::Unit::TestCase
     card.verification_value = '123'
     assert_valid card
 
-    card = credit_card('341111111111111', :verification_value => '123', :brand => 'american_express')
+    card = credit_card('341111111111111', verification_value: '123', brand: 'american_express')
     errors = assert_not_valid card
     assert_equal errors[:verification_value], ['should be 4 digits']
 
@@ -224,7 +224,7 @@ class CreditCardTest < Test::Unit::TestCase
 
   def test_should_be_valid_when_not_requiring_a_verification_value
     CreditCard.require_verification_value = true
-    card = credit_card('4242424242424242', :verification_value => nil, :require_verification_value => false)
+    card = credit_card('4242424242424242', verification_value: nil, require_verification_value: false)
     assert_valid card
 
     card.verification_value = '1234'
@@ -242,12 +242,12 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_return_last_four_digits_of_card_number
-    ccn = CreditCard.new(:number => '4779139500118580')
+    ccn = CreditCard.new(number: '4779139500118580')
     assert_equal '8580', ccn.last_digits
   end
 
   def test_bogus_last_digits
-    ccn = CreditCard.new(:number => '1')
+    ccn = CreditCard.new(number: '1')
     assert_equal '1', ccn.last_digits
   end
 
@@ -262,12 +262,12 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_return_first_four_digits_of_card_number
-    ccn = CreditCard.new(:number => '4779139500118580')
+    ccn = CreditCard.new(number: '4779139500118580')
     assert_equal '477913', ccn.first_digits
   end
 
   def test_should_return_first_bogus_digit_of_card_number
-    ccn = CreditCard.new(:number => '1')
+    ccn = CreditCard.new(number: '1')
     assert_equal '1', ccn.first_digits
   end
 
@@ -275,7 +275,7 @@ class CreditCardTest < Test::Unit::TestCase
     c = CreditCard.new
     assert_false c.first_name?
 
-    c = CreditCard.new(:first_name => 'James')
+    c = CreditCard.new(first_name: 'James')
     assert c.first_name?
   end
 
@@ -283,7 +283,7 @@ class CreditCardTest < Test::Unit::TestCase
     c = CreditCard.new
     assert_false c.last_name?
 
-    c = CreditCard.new(:last_name => 'Herdman')
+    c = CreditCard.new(last_name: 'Herdman')
     assert c.last_name?
   end
 
@@ -291,48 +291,48 @@ class CreditCardTest < Test::Unit::TestCase
     c = CreditCard.new
     assert_false c.name?
 
-    c = CreditCard.new(:first_name => 'James', :last_name => 'Herdman')
+    c = CreditCard.new(first_name: 'James', last_name: 'Herdman')
     assert c.name?
   end
 
   def test_should_handle_full_name_when_first_or_last_is_missing
-    c = CreditCard.new(:first_name => 'James')
+    c = CreditCard.new(first_name: 'James')
     assert c.name?
     assert_equal 'James', c.name
 
-    c = CreditCard.new(:last_name => 'Herdman')
+    c = CreditCard.new(last_name: 'Herdman')
     assert c.name?
     assert_equal 'Herdman', c.name
   end
 
   def test_should_assign_a_full_name
-    c = CreditCard.new :name => 'James Herdman'
+    c = CreditCard.new name: 'James Herdman'
     assert_equal 'James', c.first_name
     assert_equal 'Herdman', c.last_name
 
-    c = CreditCard.new :name => 'Rocket J. Squirrel'
+    c = CreditCard.new name: 'Rocket J. Squirrel'
     assert_equal 'Rocket J.', c.first_name
     assert_equal 'Squirrel', c.last_name
 
-    c = CreditCard.new :name => 'Twiggy'
+    c = CreditCard.new name: 'Twiggy'
     assert_equal '', c.first_name
     assert_equal 'Twiggy', c.last_name
     assert_equal 'Twiggy', c.name
   end
 
   def test_should_remove_trailing_whitespace_on_name
-    c = CreditCard.new(:last_name => 'Herdman')
+    c = CreditCard.new(last_name: 'Herdman')
     assert_equal 'Herdman', c.name
 
-    c = CreditCard.new(:last_name => 'Herdman', first_name: '')
+    c = CreditCard.new(last_name: 'Herdman', first_name: '')
     assert_equal 'Herdman', c.name
   end
 
   def test_should_remove_leading_whitespace_on_name
-    c = CreditCard.new(:first_name => 'James')
+    c = CreditCard.new(first_name: 'James')
     assert_equal 'James', c.name
 
-    c = CreditCard.new(:last_name => '', first_name: 'James')
+    c = CreditCard.new(last_name: '', first_name: 'James')
     assert_equal 'James', c.name
   end
 
@@ -349,29 +349,29 @@ class CreditCardTest < Test::Unit::TestCase
   # The following is a regression for a bug where the keys of the
   # credit card card_companies hash were not duped when detecting the brand
   def test_create_and_validate_credit_card_from_brand
-    credit_card = CreditCard.new(:brand => CreditCard.brand?('4242424242424242'))
+    credit_card = CreditCard.new(brand: CreditCard.brand?('4242424242424242'))
     assert_nothing_raised do
       credit_card.validate
     end
   end
 
   def test_autodetection_of_credit_card_brand
-    credit_card = CreditCard.new(:number => '4242424242424242')
+    credit_card = CreditCard.new(number: '4242424242424242')
     assert_equal 'visa', credit_card.brand
   end
 
   def test_card_brand_should_not_be_autodetected_when_provided
-    credit_card = CreditCard.new(:number => '4242424242424242', :brand => 'master')
+    credit_card = CreditCard.new(number: '4242424242424242', brand: 'master')
     assert_equal 'master', credit_card.brand
   end
 
   def test_detecting_bogus_card
-    credit_card = CreditCard.new(:number => '1')
+    credit_card = CreditCard.new(number: '1')
     assert_equal 'bogus', credit_card.brand
   end
 
   def test_validating_bogus_card
-    credit_card = credit_card('1', :brand => nil)
+    credit_card = credit_card('1', brand: nil)
     assert_valid credit_card
   end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -11,49 +11,49 @@ class AdyenTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card('4111111111111111',
-      :month => 8,
-      :year => 2018,
-      :first_name => 'Test',
-      :last_name => 'Card',
-      :verification_value => '737',
-      :brand => 'visa'
+      month: 8,
+      year: 2018,
+      first_name: 'Test',
+      last_name: 'Card',
+      verification_value: '737',
+      brand: 'visa'
     )
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
 
     @cabal_credit_card = credit_card('6035 2277 1642 7021',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'cabal'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'cabal'
     )
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
-      :month => 10,
-      :year => 2030,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'unionpay'
+      month: 10,
+      year: 2030,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'unionpay'
     )
 
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      :payment_cryptogram => 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      :month              => '08',
-      :year               => '2018',
-      :source             => :apple_pay,
-      :verification_value => nil
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      month: '08',
+      year: '2018',
+      source: :apple_pay,
+      verification_value: nil
     )
 
     @amount = 100
@@ -659,7 +659,7 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = {:card => {:billingAddress => {}}}
+    post = {card: {billingAddress: {}}}
     @options[:billing_address].delete(:address1)
     @options[:billing_address].delete(:address2)
     @options[:billing_address].delete(:state)
@@ -712,7 +712,7 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_key_header
-    options = @options.merge(:idempotency_key => 'test123')
+    options = @options.merge(idempotency_key: 'test123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|

--- a/test/unit/gateways/authorize_net_arb_test.rb
+++ b/test/unit/gateways/authorize_net_arb_test.rb
@@ -6,8 +6,8 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
   def setup
     ActiveMerchant.expects(:deprecated).with('ARB functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.')
     @gateway = AuthorizeNetArbGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     @amount = 100
     @credit_card = credit_card
@@ -19,14 +19,14 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
     response = @gateway.recurring(@amount, @credit_card,
-      :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
-      :interval => {
-        :length => 10,
-        :unit => :days
+      billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+      interval: {
+        length: 10,
+        unit: :days
       },
-      :duration => {
-        :start_date => Time.now.strftime('%Y-%m-%d'),
-        :occurrences => 30
+      duration: {
+        start_date: Time.now.strftime('%Y-%m-%d'),
+        occurrences: 30
       }
     )
 
@@ -39,7 +39,7 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
   def test_successful_update_recurring
     @gateway.expects(:ssl_post).returns(successful_update_recurring_response)
 
-    response = @gateway.update_recurring(:subscription_id => @subscription_id, :amount => @amount * 2)
+    response = @gateway.update_recurring(subscription_id: @subscription_id, amount: @amount * 2)
 
     assert_instance_of Response, response
     assert response.success?
@@ -69,8 +69,8 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
   end
 
   def test_expdate_formatting
-    assert_equal '2009-09', @gateway.send(:expdate, credit_card('4111111111111111', :month => '9', :year => '2009'))
-    assert_equal '2013-11', @gateway.send(:expdate, credit_card('4111111111111111', :month => '11', :year => '2013'))
+    assert_equal '2009-09', @gateway.send(:expdate, credit_card('4111111111111111', month: '9', year: '2009'))
+    assert_equal '2013-11', @gateway.send(:expdate, credit_card('4111111111111111', month: '11', year: '2013'))
   end
 
   private

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -5,8 +5,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
   def setup
     @gateway = AuthorizeNetCimGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     @amount = 100
     @credit_card = credit_card
@@ -15,40 +15,40 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @customer_payment_profile_id = '7813'
     @customer_address_id = '4321'
     @payment = {
-      :credit_card => @credit_card
+      credit_card: @credit_card
     }
     @profile = {
-      :merchant_customer_id => 'Up to 20 chars', # Optional
-      :description => 'Up to 255 Characters', # Optional
-      :email => 'Up to 255 Characters', # Optional
-      :payment_profiles => { # Optional
-        :customer_type => 'individual or business', # Optional
-        :bill_to => @address,
-        :payment => @payment
+      merchant_customer_id: 'Up to 20 chars', # Optional
+      description: 'Up to 255 Characters', # Optional
+      email: 'Up to 255 Characters', # Optional
+      payment_profiles: { # Optional
+        customer_type: 'individual or business', # Optional
+        bill_to: @address,
+        payment: @payment
       },
-      :ship_to_list => {
-        :first_name => 'John',
-        :last_name => 'Doe',
-        :company => 'Widgets, Inc',
-        :address1 => '1234 Fake Street',
-        :city => 'Anytown',
-        :state => 'MD',
-        :zip => '12345',
-        :country => 'USA',
-        :phone_number => '(123)123-1234', # Optional - Up to 25 digits (no letters)
-        :fax_number => '(123)123-1234' # Optional - Up to 25 digits (no letters)
+      ship_to_list: {
+        first_name: 'John',
+        last_name: 'Doe',
+        company: 'Widgets, Inc',
+        address1: '1234 Fake Street',
+        city: 'Anytown',
+        state: 'MD',
+        zip: '12345',
+        country: 'USA',
+        phone_number: '(123)123-1234', # Optional - Up to 25 digits (no letters)
+        fax_number: '(123)123-1234' # Optional - Up to 25 digits (no letters)
       }
     }
     @options = {
-      :ref_id => '1234', # Optional
-      :profile => @profile
+      ref_id: '1234', # Optional
+      profile: @profile
     }
   end
 
   def test_expdate_formatting
-    assert_equal '2009-09', @gateway.send(:expdate, credit_card('4111111111111111', :month => '9', :year => '2009'))
-    assert_equal '2013-11', @gateway.send(:expdate, credit_card('4111111111111111', :month => '11', :year => '2013'))
-    assert_equal 'XXXX', @gateway.send(:expdate, credit_card('XXXX1234', :month => nil, :year => nil))
+    assert_equal '2009-09', @gateway.send(:expdate, credit_card('4111111111111111', month: '9', year: '2009'))
+    assert_equal '2013-11', @gateway.send(:expdate, credit_card('4111111111111111', month: '11', year: '2013'))
+    assert_equal 'XXXX', @gateway.send(:expdate, credit_card('XXXX1234', month: nil, year: nil))
   end
 
   def test_should_create_customer_profile_request
@@ -65,13 +65,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_payment_profile_response)
 
     assert response = @gateway.create_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_type => 'individual',
-        :bill_to => @address,
-        :payment => @payment
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_type: 'individual',
+        bill_to: @address,
+        payment: @payment
       },
-      :validation_mode => :test
+      validation_mode: :test
     )
     assert_instance_of Response, response
     assert_success response
@@ -83,17 +83,17 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_shipping_address_response)
 
     assert response = @gateway.create_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :address => {
-        :first_name => 'John',
-        :last_name => 'Doe',
-        :company => 'Widgets, Inc',
-        :address1 => '1234 Fake Street',
-        :city => 'Anytown',
-        :state => 'MD',
-        :country => 'USA',
-        :phone_number => '(123)123-1234',
-        :fax_number => '(123)123-1234'
+      customer_profile_id: @customer_profile_id,
+      address: {
+        first_name: 'John',
+        last_name: 'Doe',
+        company: 'Widgets, Inc',
+        address1: '1234 Fake Street',
+        city: 'Anytown',
+        state: 'MD',
+        country: 'USA',
+        phone_number: '(123)123-1234',
+        fax_number: '(123)123-1234'
       }
     )
     assert_instance_of Response, response
@@ -106,11 +106,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_only))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_only,
-        :amount => @amount
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_only,
+        amount: @amount
       }
     )
     assert_instance_of Response, response
@@ -163,12 +163,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:prior_auth_capture))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :prior_auth_capture,
-        :amount => @amount,
-        :trans_id => trans_id
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :prior_auth_capture,
+        amount: @amount,
+        trans_id: trans_id
       }
     )
     assert_instance_of Response, response
@@ -187,11 +187,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_only))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_only,
-        :amount => @amount
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_only,
+        amount: @amount
       }
     )
     assert_instance_of Response, response
@@ -204,12 +204,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:capture_only))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :capture_only,
-        :amount => @amount,
-        :approval_code => approval_code
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :capture_only,
+        amount: @amount,
+        approval_code: approval_code
       }
     )
     assert_instance_of Response, response
@@ -221,17 +221,17 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_capture))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => '1234',
-          :description => 'Test Order Description',
-          :purchase_order_number => '4321'
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: '1234',
+          description: 'Test Order Description',
+          purchase_order_number: '4321'
         },
-        :amount => @amount,
-        :card_code => '123'
+        amount: @amount,
+        card_code: '123'
       }
     )
     assert_instance_of Response, response
@@ -245,16 +245,16 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_capture_version_3_1))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => '1234',
-          :description => 'Test Order Description',
-          :purchase_order_number => '4321'
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: '1234',
+          description: 'Test Order Description',
+          purchase_order_number: '4321'
         },
-        :amount => @amount
+        amount: @amount
       }
     )
     assert_instance_of Response, response
@@ -311,7 +311,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_delete_customer_profile_request
     @gateway.expects(:ssl_post).returns(successful_delete_customer_profile_response)
 
-    assert response = @gateway.delete_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.delete_customer_profile(customer_profile_id: @customer_profile_id)
     assert_instance_of Response, response
     assert_success response
     assert_equal @customer_profile_id, response.authorization
@@ -320,7 +320,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_delete_customer_payment_profile_request
     @gateway.expects(:ssl_post).returns(successful_delete_customer_payment_profile_response)
 
-    assert response = @gateway.delete_customer_payment_profile(:customer_profile_id => @customer_profile_id, :customer_payment_profile_id => @customer_payment_profile_id)
+    assert response = @gateway.delete_customer_payment_profile(customer_profile_id: @customer_profile_id, customer_payment_profile_id: @customer_payment_profile_id)
     assert_instance_of Response, response
     assert_success response
     assert_nil response.authorization
@@ -329,7 +329,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_delete_customer_shipping_address_request
     @gateway.expects(:ssl_post).returns(successful_delete_customer_shipping_address_response)
 
-    assert response = @gateway.delete_customer_shipping_address(:customer_profile_id => @customer_profile_id, :customer_address_id => @customer_address_id)
+    assert response = @gateway.delete_customer_shipping_address(customer_profile_id: @customer_profile_id, customer_address_id: @customer_address_id)
     assert_instance_of Response, response
     assert_success response
     assert_nil response.authorization
@@ -338,7 +338,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_get_customer_profile_request
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response)
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_instance_of Response, response
     assert_success response
     assert_equal @customer_profile_id, response.authorization
@@ -355,7 +355,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_get_customer_profile_request_with_multiple_payment_profiles
     @gateway.expects(:ssl_post).returns(successful_get_customer_profile_response_with_multiple_payment_profiles)
 
-    assert response = @gateway.get_customer_profile(:customer_profile_id => @customer_profile_id)
+    assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_instance_of Response, response
     assert_success response
 
@@ -367,9 +367,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_get_customer_payment_profile_response)
 
     assert response = @gateway.get_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id,
-      :unmask_expiration_date => true
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: @customer_payment_profile_id,
+      unmask_expiration_date: true
     )
     assert_instance_of Response, response
     assert_success response
@@ -382,8 +382,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_get_customer_shipping_address_response)
 
     assert response = @gateway.get_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :customer_address_id => @customer_address_id
+      customer_profile_id: @customer_profile_id,
+      customer_address_id: @customer_address_id
     )
     assert_instance_of Response, response
     assert_success response
@@ -394,9 +394,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_update_customer_profile_response)
 
     assert response = @gateway.update_customer_profile(
-      :profile => {
-        :customer_profile_id => @customer_profile_id,
-        :email => 'new email address'
+      profile: {
+        customer_profile_id: @customer_profile_id,
+        email: 'new email address'
       }
     )
     assert_instance_of Response, response
@@ -408,10 +408,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_update_customer_payment_profile_response)
 
     assert response = @gateway.update_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :payment_profile => {
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :customer_type => 'business'
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        customer_payment_profile_id: @customer_payment_profile_id,
+        customer_type: 'business'
       }
     )
     assert_instance_of Response, response
@@ -420,17 +420,17 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   end
 
   def test_should_update_customer_payment_profile_request_with_last_four_digits
-    last_four_credit_card = ActiveMerchant::Billing::CreditCard.new(:number => '4242') # Credit card with only last four digits
+    last_four_credit_card = ActiveMerchant::Billing::CreditCard.new(number: '4242') # Credit card with only last four digits
 
     response = stub_comms do
       @gateway.update_customer_payment_profile(
-        :customer_profile_id => @customer_profile_id,
-        :payment_profile => {
-          :customer_payment_profile_id => @customer_payment_profile_id,
-          :bill_to => address(:address1 => '345 Avenue B',
-                              :address2 => 'Apt 101'),
-          :payment => {
-            :credit_card => last_four_credit_card
+        customer_profile_id: @customer_profile_id,
+        payment_profile: {
+          customer_payment_profile_id: @customer_payment_profile_id,
+          bill_to: address(address1: '345 Avenue B',
+                           address2: 'Apt 101'),
+          payment: {
+            credit_card: last_four_credit_card
           }
         }
       )
@@ -447,10 +447,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_update_customer_shipping_address_response)
 
     assert response = @gateway.update_customer_shipping_address(
-      :customer_profile_id => @customer_profile_id,
-      :address => {
-        :customer_address_id => @customer_address_id,
-        :city => 'New City'
+      customer_profile_id: @customer_profile_id,
+      address: {
+        customer_address_id: @customer_address_id,
+        city: 'New City'
       }
     )
     assert_instance_of Response, response
@@ -462,10 +462,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_validate_customer_payment_profile_response)
 
     assert response = @gateway.validate_customer_payment_profile(
-      :customer_profile_id => @customer_profile_id,
-      :customer_payment_profile_id => @customer_payment_profile_id,
-      :customer_address_id => @customer_address_id,
-      :validation_mode => :live
+      customer_profile_id: @customer_profile_id,
+      customer_payment_profile_id: @customer_payment_profile_id,
+      customer_address_id: @customer_address_id,
+      validation_mode: :live
     )
     assert_instance_of Response, response
     assert_success response
@@ -478,9 +478,9 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:void))
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :void,
-        :trans_id => response.params['direct_response']['transaction_id']
+      transaction: {
+        type: :void,
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -495,12 +495,12 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(unsuccessful_create_customer_profile_transaction_response(:refund))
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :trans_id => response.params['direct_response']['transaction_id']
+      transaction: {
+        type: :refund,
+        amount: 1,
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -519,13 +519,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(unsuccessful_create_customer_profile_transaction_response(:refund))
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
+      transaction: {
+        type: :refund,
+        amount: 1,
 
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :trans_id => response.params['direct_response']['transaction_id']
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        trans_id: response.params['direct_response']['transaction_id']
       }
     )
     assert_instance_of Response, response
@@ -559,8 +559,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:void))
 
     assert response = @gateway.create_customer_profile_transaction_for_void(
-      :transaction => {
-        :trans_id => 1
+      transaction: {
+        trans_id: 1
       }
     )
     assert_instance_of Response, response
@@ -573,10 +573,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:refund))
 
     assert response = @gateway.create_customer_profile_transaction_for_refund(
-      :transaction => {
-        :trans_id => 1,
-        :amount => '1.00',
-        :credit_card_number_masked => 'XXXX1234'
+      transaction: {
+        trans_id: 1,
+        amount: '1.00',
+        credit_card_number_masked: 'XXXX1234'
       }
     )
     assert_instance_of Response, response
@@ -588,18 +588,18 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_should_create_customer_profile_transaction_passing_recurring_flag
     response = stub_comms do
       @gateway.create_customer_profile_transaction(
-        :transaction => {
-          :customer_profile_id => @customer_profile_id,
-          :customer_payment_profile_id => @customer_payment_profile_id,
-          :type => :auth_capture,
-          :order => {
-            :invoice_number => '1234',
-            :description => 'Test Order Description',
-            :purchase_order_number => '4321'
+        transaction: {
+          customer_profile_id: @customer_profile_id,
+          customer_payment_profile_id: @customer_payment_profile_id,
+          type: :auth_capture,
+          order: {
+            invoice_number: '1234',
+            description: 'Test Order Description',
+            purchase_order_number: '4321'
           },
-          :amount => @amount,
-          :card_code => '123',
-          :recurring_billing => true
+          amount: @amount,
+          card_code: '123',
+          recurring_billing: true
         }
       )
     end.check_request do |endpoint, data, headers|
@@ -623,13 +623,13 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   def test_multiple_errors_when_creating_customer_profile
     @gateway.expects(:ssl_post).returns(unsuccessful_create_customer_profile_transaction_response_with_multiple_errors(:refund))
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :type => :refund,
-        :amount => 1,
+      transaction: {
+        type: :refund,
+        amount: 1,
 
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :trans_id => 1
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        trans_id: 1
       }
     )
     assert_equal 'The transaction was unsuccessful.', response.message
@@ -642,11 +642,11 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_only))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_only,
-        :amount => @amount
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_only,
+        amount: @amount
       }
     )
     assert_instance_of Response, response
@@ -662,16 +662,16 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_create_customer_profile_transaction_response(:auth_capture))
 
     assert response = @gateway.create_customer_profile_transaction(
-      :transaction => {
-        :customer_profile_id => @customer_profile_id,
-        :customer_payment_profile_id => @customer_payment_profile_id,
-        :type => :auth_capture,
-        :order => {
-          :invoice_number => '1234',
-          :description => 'Test Order Description',
-          :purchase_order_number => '4321'
+      transaction: {
+        customer_profile_id: @customer_profile_id,
+        customer_payment_profile_id: @customer_payment_profile_id,
+        type: :auth_capture,
+        order: {
+          invoice_number: '1234',
+          description: 'Test Order Description',
+          purchase_order_number: '4321'
         },
-        :amount => @amount
+        amount: @amount
       }
     )
     assert_instance_of Response, response
@@ -1003,16 +1003,16 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
   end
 
   SUCCESSFUL_DIRECT_RESPONSE = {
-    :auth_only => '1,1,1,This transaction has been approved.,Gw4NGI,Y,508223659,,,100.00,CC,auth_only,Up to 20 chars,,,,,,,,,,,Up to 255 Characters,,,,,,,,,,,,,,6E5334C13C78EA078173565FD67318E4,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :capture_only => '1,1,1,This transaction has been approved.,,Y,508223660,,,100.00,CC,capture_only,Up to 20 chars,,,,,,,,,,,Up to 255 Characters,,,,,,,,,,,,,,6E5334C13C78EA078173565FD67318E4,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :auth_capture => '1,1,1,This transaction has been approved.,d1GENk,Y,508223661,32968c18334f16525227,Store purchase,1.00,CC,auth_capture,,Longbob,Longsen,,,,,,,,,,,,,,,,,,,,,,,269862C030129C1173727CC10B1935ED,M,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :void => '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,void,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :refund => '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,refund,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :prior_auth_capture => '1,1,1,This transaction has been approved.,VR0lrD,P,2149227870,1245958544,,1.00,CC,prior_auth_capture,1245958544,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,0B8BFE0A0DE6FDB69740ED20F79D04B0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
-    :auth_capture_version_3_1 => '1,1,1,This transaction has been approved.,CSYM0K,Y,2163585627,1234,Test Order Description,100.00,CC,auth_capture,Up to 20 chars,,,Widgets Inc,1234 My Street,Ottawa,ON,K1C2N6,CA,,,Up to 255 Characters,,,,,,,,,,,,,4321,02DFBD7934AD862AB16688D44F045D31,,2,,,,,,,,,,,XXXX4242,Visa,,,,,,,,,,,,,,,,'
+    auth_only: '1,1,1,This transaction has been approved.,Gw4NGI,Y,508223659,,,100.00,CC,auth_only,Up to 20 chars,,,,,,,,,,,Up to 255 Characters,,,,,,,,,,,,,,6E5334C13C78EA078173565FD67318E4,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    capture_only: '1,1,1,This transaction has been approved.,,Y,508223660,,,100.00,CC,capture_only,Up to 20 chars,,,,,,,,,,,Up to 255 Characters,,,,,,,,,,,,,,6E5334C13C78EA078173565FD67318E4,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    auth_capture: '1,1,1,This transaction has been approved.,d1GENk,Y,508223661,32968c18334f16525227,Store purchase,1.00,CC,auth_capture,,Longbob,Longsen,,,,,,,,,,,,,,,,,,,,,,,269862C030129C1173727CC10B1935ED,M,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    void: '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,void,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    refund: '1,1,1,This transaction has been approved.,nnCMEx,P,2149222068,1245879759,,0.00,CC,refund,1245879759,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,F240D65BB27ADCB8C80410B92342B22C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    prior_auth_capture: '1,1,1,This transaction has been approved.,VR0lrD,P,2149227870,1245958544,,1.00,CC,prior_auth_capture,1245958544,,,,,,,K1C2N6,,,,,,,,,,,,,,,,,,0B8BFE0A0DE6FDB69740ED20F79D04B0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    auth_capture_version_3_1: '1,1,1,This transaction has been approved.,CSYM0K,Y,2163585627,1234,Test Order Description,100.00,CC,auth_capture,Up to 20 chars,,,Widgets Inc,1234 My Street,Ottawa,ON,K1C2N6,CA,,,Up to 255 Characters,,,,,,,,,,,,,4321,02DFBD7934AD862AB16688D44F045D31,,2,,,,,,,,,,,XXXX4242,Visa,,,,,,,,,,,,,,,,'
   }
   UNSUCCESSUL_DIRECT_RESPONSE = {
-    :refund => '3,2,54,The referenced transaction does not meet the criteria for issuing a credit.,,P,0,,,1.00,CC,credit,1245952682,,,Widgets Inc,1245952682 My Street,Ottawa,ON,K1C2N6,CA,,,bob1245952682@email.com,,,,,,,,,,,,,,207BCBBF78E85CF174C87AE286B472D2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,447250,406104'
+    refund: '3,2,54,The referenced transaction does not meet the criteria for issuing a credit.,,P,0,,,1.00,CC,credit,1245952682,,,Widgets Inc,1245952682 My Street,Ottawa,ON,K1C2N6,CA,,,bob1245952682@email.com,,,,,,,,,,,,,,207BCBBF78E85CF174C87AE286B472D2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,447250,406104'
   }
 
   def successful_create_customer_profile_transaction_response(transaction_type)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -1226,7 +1226,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_apple_pay_authorization_with_network_tokenization
     credit_card = network_tokenization_credit_card('4242424242424242',
-      :payment_cryptogram => '111111111100cryptogram'
+      payment_cryptogram: '111111111100cryptogram'
     )
 
     response = stub_comms do
@@ -1246,7 +1246,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_failed_apple_pay_authorization_with_network_tokenization_not_supported
     credit_card = network_tokenization_credit_card('4242424242424242',
-      :payment_cryptogram => '111111111100cryptogram'
+      payment_cryptogram: '111111111100cryptogram'
     )
 
     response = stub_comms do

--- a/test/unit/gateways/axcessms_test.rb
+++ b/test/unit/gateways/axcessms_test.rb
@@ -21,12 +21,12 @@ class AxcessmsTest < Test::Unit::TestCase
       ip: '0.0.0.0',
       mode: @mode,
       billing_address: {
-        :address1 => '10 Marklar St',
-        :address2 => 'Musselburgh',
-        :city => 'Dunedin',
-        :zip => '9013',
-        :state => 'Otago',
-        :country => 'NZ'
+        address1: '10 Marklar St',
+        address2: 'Musselburgh',
+        city: 'Dunedin',
+        zip: '9013',
+        state: 'Otago',
+        country: 'NZ'
       }
     }
   end

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -5,32 +5,32 @@ class BanwireTest < Test::Unit::TestCase
 
   def setup
     @gateway = BanwireGateway.new(
-      :login => 'desarrollo',
-      :currency => 'MXN')
+      login: 'desarrollo',
+      currency: 'MXN')
 
     @credit_card = credit_card('5204164299999999',
-      :month => 11,
-      :year => 2012,
-      :verification_value => '999')
+      month: 11,
+      year: 2012,
+      verification_value: '999')
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :email => 'test@email.com',
-      :billing_address => address,
-      :description => 'Store purchase'
+      order_id: '1',
+      email: 'test@email.com',
+      billing_address: address,
+      description: 'Store purchase'
     }
 
     @amex_credit_card = credit_card('375932134599999',
-      :month => 3,
-      :year => 2017,
-      :first_name => 'Banwire',
-      :last_name => 'Test Card')
+      month: 3,
+      year: 2017,
+      first_name: 'Banwire',
+      last_name: 'Test Card')
     @amex_options = {
-      :order_id => '2',
-      :email => 'test@email.com',
-      :billing_address => address(:address1 => 'Horacio', :zip => 11560),
-      :description  => 'Store purchase amex'
+      order_id: '2',
+      email: 'test@email.com',
+      billing_address: address(address1: 'Horacio', zip: 11560),
+      description: 'Store purchase amex'
     }
   end
 

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -257,7 +257,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(:code => '422', :body => failed_capture_response)))
+    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(code: '422', body: failed_capture_response)))
 
     response = @gateway.capture(@amount, '0000000000000000', @options)
     assert_failure response
@@ -289,7 +289,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(:code => '422', :body => failed_refund_response)))
+    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(code: '422', body: failed_refund_response)))
 
     response = @gateway.refund(@amount, '0000000000000000', @options)
     assert_failure response
@@ -399,7 +399,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_failed_store
-    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(:code => '422', :body => failed_store_response)))
+    @gateway.stubs(:ssl_post).raises(ActiveMerchant::ResponseError.new(stub(code: '422', body: failed_store_response)))
 
     response = @gateway.store(@credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/barclays_epdq_extra_plus_test.rb
+++ b/test/unit/gateways/barclays_epdq_extra_plus_test.rb
@@ -2,21 +2,21 @@ require 'test_helper'
 
 class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def setup
-    @credentials = { :login => 'pspid',
-                     :user => 'username',
-                     :password => 'password',
-                     :signature => 'mynicesig',
-                     :signature_encryptor => 'sha512' }
+    @credentials = { login: 'pspid',
+                     user: 'username',
+                     password: 'password',
+                     signature: 'mynicesig',
+                     signature_encryptor: 'sha512' }
     @gateway = BarclaysEpdqExtraPlusGateway.new(@credentials)
     @credit_card = credit_card
-    @mastercard  = credit_card('5399999999999999', :brand => 'mastercard')
+    @mastercard  = credit_card('5399999999999999', brand: 'mastercard')
     @amount = 100
     @identification = '3014726'
     @billing_id = 'myalias'
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @parameters = {
       'orderID' => '1',
@@ -54,7 +54,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:action => 'SAS'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(action: 'SAS'))
     assert_success response
     assert_equal '3014726;SAS', response.authorization
     assert response.params['HTML_ANSWER'].nil?
@@ -74,7 +74,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '4')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:eci => 4))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(eci: 4))
     assert_success response
     assert_equal '3014726;SAL', response.authorization
     assert response.test?
@@ -82,7 +82,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_3dsecure
     @gateway.expects(:ssl_post).returns(successful_3dsecure_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:d3d => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(d3d: true))
     assert_success response
     assert_equal '3014726;SAL', response.authorization
     assert response.params['HTML_ANSWER']
@@ -115,7 +115,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '4')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:eci => 4))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(eci: 4))
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert response.test?
@@ -123,7 +123,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_3dsecure
     @gateway.expects(:ssl_post).returns(successful_3dsecure_purchase_response)
-    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:d3d => true))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(d3d: true))
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert response.params['HTML_ANSWER']
@@ -141,7 +141,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
 
   def test_successful_capture_with_action_option
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    assert response = @gateway.capture(@amount, '3048326', :action => 'SAS')
+    assert response = @gateway.capture(@amount, '3048326', action: 'SAS')
     assert_success response
     assert_equal '3048326;SAS', response.authorization
     assert response.test?
@@ -185,7 +185,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
     @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
-    assert response = @gateway.store(@credit_card, :billing_id => @billing_id)
+    assert response = @gateway.store(@credit_card, billing_id: @billing_id)
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert_equal '2', response.billing_id
@@ -197,7 +197,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
     @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
     assert_deprecation_warning(BarclaysEpdqExtraPlusGateway::OGONE_STORE_OPTION_DEPRECATION_MESSAGE) do
-      assert response = @gateway.store(@credit_card, :store => @billing_id)
+      assert response = @gateway.store(@credit_card, store: @billing_id)
       assert_success response
       assert_equal '3014726;RES', response.authorization
       assert response.test?
@@ -239,7 +239,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   end
 
   def test_custom_currency_at_gateway_level
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(currency: 'USD'))
     gateway.expects(:add_pair).at_least(1)
     gateway.expects(:add_pair).with(anything, 'currency', 'USD')
     gateway.expects(:ssl_post).returns(successful_purchase_response)
@@ -247,11 +247,11 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   end
 
   def test_local_custom_currency_overwrite_gateway_level
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(currency: 'USD'))
     gateway.expects(:add_pair).at_least(1)
     gateway.expects(:add_pair).with(anything, 'currency', 'EUR')
     gateway.expects(:ssl_post).returns(successful_purchase_response)
-    gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'EUR'))
+    gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR'))
   end
 
   def test_avs_result
@@ -310,13 +310,13 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   end
 
   def test_without_signature
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature => nil, :signature_encryptor => nil))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature: nil, signature_encryptor: nil))
     gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning(BarclaysEpdqExtraPlusGateway::OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) do
       gateway.purchase(@amount, @credit_card, @options)
     end
 
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature => nil, :signature_encryptor => 'none'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature: nil, signature_encryptor: 'none'))
     gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_no_deprecation_warning do
       gateway.purchase(@amount, @credit_card, @options)
@@ -324,27 +324,27 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   end
 
   def test_signature_for_accounts_created_before_10_may_20101
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature_encryptor => nil))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature_encryptor: nil))
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA1.hexdigest('1100EUR4111111111111111MrPSPIDRES2mynicesig').upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha1
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature_encryptor => 'sha1'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature_encryptor: 'sha1'))
 
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA1.hexdigest(string_to_digest).upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha256
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature_encryptor => 'sha256'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature_encryptor: 'sha256'))
 
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA256.hexdigest(string_to_digest).upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha512
-    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(:signature_encryptor => 'sha512'))
+    gateway = BarclaysEpdqExtraPlusGateway.new(@credentials.merge(signature_encryptor: 'sha512'))
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA512.hexdigest(string_to_digest).upcase, signature
   end
@@ -359,13 +359,13 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     post = {}
     gateway = BarclaysEpdqExtraPlusGateway.new(@credentials)
 
-    gateway.send(:add_d3d, post, { :win_3ds => :pop_up })
+    gateway.send(:add_d3d, post, { win_3ds: :pop_up })
     assert 'POPUP', post['WIN3DS']
 
-    gateway.send(:add_d3d, post, { :win_3ds => :pop_ix })
+    gateway.send(:add_d3d, post, { win_3ds: :pop_ix })
     assert 'POPIX', post['WIN3DS']
 
-    gateway.send(:add_d3d, post, { :win_3ds => :invalid })
+    gateway.send(:add_d3d, post, { win_3ds: :invalid })
     assert 'MAINW', post['WIN3DS']
   end
 
@@ -374,14 +374,14 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     gateway = BarclaysEpdqExtraPlusGateway.new(@credentials)
 
     gateway.send(:add_d3d, post, {
-      :http_accept => 'text/html',
-      :http_user_agent => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)',
-      :accept_url => 'https://accept_url',
-      :decline_url => 'https://decline_url',
-      :exception_url => 'https://exception_url',
-      :paramsplus => 'params_plus',
-      :complus => 'com_plus',
-      :language => 'fr_FR'
+      http_accept: 'text/html',
+      http_user_agent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)',
+      accept_url: 'https://accept_url',
+      decline_url: 'https://decline_url',
+      exception_url: 'https://exception_url',
+      paramsplus: 'params_plus',
+      complus: 'com_plus',
+      language: 'fr_FR'
     })
     assert 'HTTP_ACCEPT', 'text/html'
     assert 'HTTP_USER_AGENT', 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)'

--- a/test/unit/gateways/be2bill_test.rb
+++ b/test/unit/gateways/be2bill_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class Be2billTest < Test::Unit::TestCase
   def setup
     @gateway = Be2billGateway.new(
-      :login    => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id        => '1',
-      :billing_address => address,
-      :description     => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/beanstream_interac_test.rb
+++ b/test/unit/gateways/beanstream_interac_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class BeanstreamInteracTest < Test::Unit::TestCase
   def setup
     @gateway = BeanstreamInteracGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -7,10 +7,10 @@ class BeanstreamTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = BeanstreamGateway.new(
-      :login => 'merchant id',
-      :user => 'username',
-      :password => 'password',
-      :api_key => 'api_key'
+      login: 'merchant id',
+      user: 'username',
+      password: 'password',
+      api_key: 'api_key'
     )
 
     @credit_card = credit_card
@@ -26,35 +26,35 @@ class BeanstreamTest < Test::Unit::TestCase
     )
 
     @check = check(
-      :institution_number => '001',
-      :transit_number     => '26729'
+      institution_number: '001',
+      transit_number: '26729'
     )
 
     @amount = 1000
 
     @options = {
-      :order_id => '1234',
-      :billing_address => {
-        :name => 'xiaobo zzz',
-        :phone => '555-555-5555',
-        :address1 => '1234 Levesque St.',
-        :address2 => 'Apt B',
-        :city => 'Montreal',
-        :state => 'QC',
-        :country => 'CA',
-        :zip => 'H2C1X8'
+      order_id: '1234',
+      billing_address: {
+        name: 'xiaobo zzz',
+        phone: '555-555-5555',
+        address1: '1234 Levesque St.',
+        address2: 'Apt B',
+        city: 'Montreal',
+        state: 'QC',
+        country: 'CA',
+        zip: 'H2C1X8'
       },
-      :email => 'xiaobozzz@example.com',
-      :subtotal => 800,
-      :shipping => 100,
-      :tax1 => 100,
-      :tax2 => 100,
-      :custom => 'reference one'
+      email: 'xiaobozzz@example.com',
+      subtotal: 800,
+      shipping: 100,
+      tax1: 100,
+      tax2: 100,
+      custom: 'reference one'
     }
 
     @recurring_options = @options.merge(
-      :interval => { :unit => :months, :length => 1 },
-      :occurrences => 5)
+      interval: { unit: :months, length: 1 },
+      occurrences: 5)
   end
 
   def test_successful_purchase
@@ -210,7 +210,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_update_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.update_recurring(@amount, @credit_card, @recurring_options.merge(:account_id => response.params['rbAccountId']))
+      @gateway.update_recurring(@amount, @credit_card, @recurring_options.merge(account_id: response.params['rbAccountId']))
     end
     assert_success response
     assert_equal 'Request successful', response.message
@@ -228,7 +228,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_cancel_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.cancel_recurring(:account_id => response.params['rbAccountId'])
+      @gateway.cancel_recurring(account_id: response.params['rbAccountId'])
     end
     assert_success response
     assert_equal 'Request successful', response.message
@@ -340,11 +340,11 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def brazilian_address_params_without_zip_and_state
-    { :shipProvince => '--', :shipPostalCode => '000000', :ordProvince => '--', :ordPostalCode => '000000', :ordCountry => 'BR', :trnCardOwner => 'Longbob Longsen', :shipCity => 'Rio de Janeiro', :ordAddress1 => '1234 Levesque St.', :ordShippingPrice => '1.00', :deliveryEstimate => nil, :shipName => 'xiaobo zzz', :trnCardNumber => '4242424242424242', :trnAmount => '10.00', :trnType => 'P', :ordAddress2 => 'Apt B', :ordTax1Price => '1.00', :shipEmailAddress => 'xiaobozzz@example.com', :trnExpMonth => '09', :ordCity => 'Rio de Janeiro', :shipPhoneNumber => '555-555-5555', :ordName => 'xiaobo zzz', :trnExpYear => next_year, :trnOrderNumber => '1234', :shipCountry => 'BR', :ordTax2Price => '1.00', :shipAddress1 => '1234 Levesque St.', :ordEmailAddress => 'xiaobozzz@example.com', :trnCardCvd => '123', :trnComments => nil, :shippingMethod => nil, :ref1 => 'reference one', :shipAddress2 => 'Apt B', :ordPhoneNumber => '555-555-5555', :ordItemPrice => '8.00' }
+    { shipProvince: '--', shipPostalCode: '000000', ordProvince: '--', ordPostalCode: '000000', ordCountry: 'BR', trnCardOwner: 'Longbob Longsen', shipCity: 'Rio de Janeiro', ordAddress1: '1234 Levesque St.', ordShippingPrice: '1.00', deliveryEstimate: nil, shipName: 'xiaobo zzz', trnCardNumber: '4242424242424242', trnAmount: '10.00', trnType: 'P', ordAddress2: 'Apt B', ordTax1Price: '1.00', shipEmailAddress: 'xiaobozzz@example.com', trnExpMonth: '09', ordCity: 'Rio de Janeiro', shipPhoneNumber: '555-555-5555', ordName: 'xiaobo zzz', trnExpYear: next_year, trnOrderNumber: '1234', shipCountry: 'BR', ordTax2Price: '1.00', shipAddress1: '1234 Levesque St.', ordEmailAddress: 'xiaobozzz@example.com', trnCardCvd: '123', trnComments: nil, shippingMethod: nil, ref1: 'reference one', shipAddress2: 'Apt B', ordPhoneNumber: '555-555-5555', ordItemPrice: '8.00' }
   end
 
   def german_address_params_without_state
-    { :shipProvince => '--', :shipPostalCode => '12345', :ordProvince => '--', :ordPostalCode => '12345', :ordCountry => 'DE', :trnCardOwner => 'Longbob Longsen', :shipCity => 'Berlin', :ordAddress1 => '1234 Levesque St.', :ordShippingPrice => '1.00', :deliveryEstimate => nil, :shipName => 'xiaobo zzz', :trnCardNumber => '4242424242424242', :trnAmount => '10.00', :trnType => 'P', :ordAddress2 => 'Apt B', :ordTax1Price => '1.00', :shipEmailAddress => 'xiaobozzz@example.com', :trnExpMonth => '09', :ordCity => 'Berlin', :shipPhoneNumber => '555-555-5555', :ordName => 'xiaobo zzz', :trnExpYear => next_year, :trnOrderNumber => '1234', :shipCountry => 'DE', :ordTax2Price => '1.00', :shipAddress1 => '1234 Levesque St.', :ordEmailAddress => 'xiaobozzz@example.com', :trnCardCvd => '123', :trnComments => nil, :shippingMethod => nil, :ref1 => 'reference one', :shipAddress2 => 'Apt B', :ordPhoneNumber => '555-555-5555', :ordItemPrice => '8.00' }
+    { shipProvince: '--', shipPostalCode: '12345', ordProvince: '--', ordPostalCode: '12345', ordCountry: 'DE', trnCardOwner: 'Longbob Longsen', shipCity: 'Berlin', ordAddress1: '1234 Levesque St.', ordShippingPrice: '1.00', deliveryEstimate: nil, shipName: 'xiaobo zzz', trnCardNumber: '4242424242424242', trnAmount: '10.00', trnType: 'P', ordAddress2: 'Apt B', ordTax1Price: '1.00', shipEmailAddress: 'xiaobozzz@example.com', trnExpMonth: '09', ordCity: 'Berlin', shipPhoneNumber: '555-555-5555', ordName: 'xiaobo zzz', trnExpYear: next_year, trnOrderNumber: '1234', shipCountry: 'DE', ordTax2Price: '1.00', shipAddress1: '1234 Levesque St.', ordEmailAddress: 'xiaobozzz@example.com', trnCardCvd: '123', trnComments: nil, shippingMethod: nil, ref1: 'reference one', shipAddress2: 'Apt B', ordPhoneNumber: '555-555-5555', ordItemPrice: '8.00' }
   end
 
   def next_year

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
 
 RSP = {
-  :approved_auth => 'AUTH_CODE=XCADZ&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=AUTH&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203758&CVV2=_&MESSAGE=Approved%20Auth',
-  :approved_capture => 'AUTH_CODE=CHTHX&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=CAPTURE&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203760&CVV2=_&MESSAGE=Approved%20Capture',
-  :approved_void => 'AUTH_CODE=KTMHB&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=VOID&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203763&CVV2=_&MESSAGE=Approved%20Void',
-  :declined => 'TRANS_ID=100000000150&STATUS=0&AVS=0&CVV2=7&MESSAGE=Declined&REBID=',
-  :approved_purchase => 'AUTH_CODE=GYRUY&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=SALE&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203767&CVV2=_&MESSAGE=Approved%20Sale'
+  approved_auth: 'AUTH_CODE=XCADZ&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=AUTH&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203758&CVV2=_&MESSAGE=Approved%20Auth',
+  approved_capture: 'AUTH_CODE=CHTHX&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=CAPTURE&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203760&CVV2=_&MESSAGE=Approved%20Capture',
+  approved_void: 'AUTH_CODE=KTMHB&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=VOID&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203763&CVV2=_&MESSAGE=Approved%20Void',
+  declined: 'TRANS_ID=100000000150&STATUS=0&AVS=0&CVV2=7&MESSAGE=Declined&REBID=',
+  approved_purchase: 'AUTH_CODE=GYRUY&PAYMENT_ACCOUNT_MASK=xxxxxxxxxxxx4242&CARD_TYPE=VISA&TRANS_TYPE=SALE&REBID=&STATUS=1&AVS=_&TRANS_ID=100134203767&CVV2=_&MESSAGE=Approved%20Sale'
 }
 
 class BluePayTest < Test::Unit::TestCase
@@ -13,8 +13,8 @@ class BluePayTest < Test::Unit::TestCase
 
   def setup
     @gateway = BluePayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     @amount = 100
     @credit_card = credit_card
@@ -66,7 +66,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = {}
 
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'DE', :state => ''})
+    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'DE', state: ''})
     assert_equal ['ADDR1', 'ADDR2', 'CITY', 'COMPANY_NAME', 'COUNTRY', 'PHONE', 'STATE', 'ZIP'], result.stringify_keys.keys.sort
     assert_equal 'n/a', result[:STATE]
     assert_equal '123 Test St.', result[:ADDR1]
@@ -76,7 +76,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'US', :state => 'AK'})
+    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK'})
 
     assert_equal ['ADDR1', 'ADDR2', 'CITY', 'COMPANY_NAME', 'COUNTRY', 'PHONE', 'STATE', 'ZIP'], result.stringify_keys.keys.sort
     assert_equal 'AK', result[:STATE]
@@ -88,7 +88,7 @@ class BluePayTest < Test::Unit::TestCase
     result = {}
 
     @gateway.send(:add_creditcard, result, @credit_card)
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Test St.', :address2 => '5F', :city => 'Testville', :company => 'Test Company', :country => 'US', :state => 'AK'})
+    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK'})
 
     assert_equal @credit_card.first_name, result[:NAME1]
     assert_equal @credit_card.last_name, result[:NAME2]
@@ -96,19 +96,19 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_add_invoice
     result = {}
-    @gateway.send(:add_invoice, result, :order_id => '#1001')
+    @gateway.send(:add_invoice, result, order_id: '#1001')
     assert_equal '#1001', result[:invoice_num]
   end
 
   def test_add_description
     result = {}
-    @gateway.send(:add_invoice, result, :description => 'My Purchase is great')
+    @gateway.send(:add_invoice, result, description: 'My Purchase is great')
     assert_equal 'My Purchase is great', result[:description]
   end
 
   def test_purchase_meets_minimum_requirements
     params = {
-      :amount => '1.01',
+      amount: '1.01',
     }
 
     @gateway.send(:add_creditcard, params, @credit_card)
@@ -121,7 +121,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_successful_refund
     response = stub_comms do
-      @gateway.refund(@amount, '100134230412', @options.merge({:card_number => @credit_card.number}))
+      @gateway.refund(@amount, '100134230412', @options.merge({card_number: @credit_card.number}))
     end.check_request do |endpoint, data, headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(successful_refund_response)
@@ -133,7 +133,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', @options.merge({:card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345', :doc_type => 'WEB'}))
+      @gateway.refund(50, '123456789', @options.merge({card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', doc_type: 'WEB'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/NAME1=Bob/, data)
       assert_match(/NAME2=Smith/, data)
@@ -147,7 +147,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_failed_refund
     response = stub_comms do
-      @gateway.refund(@amount, '123456789', @options.merge({:card_number => @credit_card.number}))
+      @gateway.refund(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
     end.check_request do |endpoint, data, headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(failed_refund_response)
@@ -161,7 +161,7 @@ class BluePayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning('credit should only be used to credit a payment method') do
       response = stub_comms do
-        @gateway.credit(@amount, '123456789', @options.merge({:card_number => @credit_card.number}))
+        @gateway.credit(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
       end.check_request do |endpoint, data, headers|
         assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
       end.respond_with(failed_refund_response)
@@ -174,7 +174,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_successful_credit_with_check
     response = stub_comms do
-      @gateway.credit(50, @check, @options.merge({:doc_type => 'PPD'}))
+      @gateway.credit(50, @check, @options.merge({doc_type: 'PPD'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/DOC_TYPE=PPD/, data)
     end.respond_with(successful_credit_response)
@@ -230,11 +230,11 @@ class BluePayTest < Test::Unit::TestCase
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(@amount, @credit_card,
-        :billing_address => address.merge(:first_name => 'Jim', :last_name => 'Smith'),
-        :rebill_start_date => '1 MONTH',
-        :rebill_expression => '14 DAYS',
-        :rebill_cycles     => '24',
-        :rebill_amount     => @amount * 4
+        billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+        rebill_start_date: '1 MONTH',
+        rebill_expression: '14 DAYS',
+        rebill_cycles: '24',
+        rebill_amount: @amount * 4
       )
     end
 
@@ -248,7 +248,7 @@ class BluePayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_update_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.update_recurring(:rebill_id => @rebill_id, :rebill_amount => @amount * 2)
+      @gateway.update_recurring(rebill_id: @rebill_id, rebill_amount: @amount * 2)
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -8,13 +8,13 @@ class BogusTest < Test::Unit::TestCase
 
   def setup
     @gateway = BogusGateway.new(
-      :login => 'bogus',
-      :password => 'bogus'
+      login: 'bogus',
+      password: 'bogus'
     )
 
     @creditcard = credit_card(CC_SUCCESS_PLACEHOLDER)
 
-    @response = ActiveMerchant::Billing::Response.new(true, 'Transaction successful', :transid => BogusGateway::AUTHORIZATION)
+    @response = ActiveMerchant::Billing::Response.new(true, 'Transaction successful', transid: BogusGateway::AUTHORIZATION)
   end
 
   def test_authorize
@@ -78,7 +78,7 @@ class BogusTest < Test::Unit::TestCase
   end
 
   def test_credit_uses_refund
-    options = {:foo => :bar}
+    options = {foo: :bar}
     @gateway.expects(:refund).with(1000, '1337', options)
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
       @gateway.credit(1000, '1337', options)
@@ -125,47 +125,47 @@ class BogusTest < Test::Unit::TestCase
   end
 
   def test_authorize_with_check
-    assert  @gateway.authorize(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
-    assert !@gateway.authorize(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
+    assert  @gateway.authorize(1000, check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: nil)).success?
+    assert !@gateway.authorize(1000, check(account_number: CHECK_FAILURE_PLACEHOLDER, number: nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.authorize(1000, check(:account_number => '123', :number => nil))
+      @gateway.authorize(1000, check(account_number: '123', number: nil))
     end
     assert_equal('Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error', e.message)
   end
 
   def test_purchase_with_check
     # use account number if number isn't given
-    assert  @gateway.purchase(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
-    assert !@gateway.purchase(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
+    assert  @gateway.purchase(1000, check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: nil)).success?
+    assert !@gateway.purchase(1000, check(account_number: CHECK_FAILURE_PLACEHOLDER, number: nil)).success?
     # give priority to number over account_number if given
-    assert !@gateway.purchase(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => CHECK_FAILURE_PLACEHOLDER)).success?
-    assert  @gateway.purchase(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => CHECK_SUCCESS_PLACEHOLDER)).success?
+    assert !@gateway.purchase(1000, check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: CHECK_FAILURE_PLACEHOLDER)).success?
+    assert  @gateway.purchase(1000, check(account_number: CHECK_FAILURE_PLACEHOLDER, number: CHECK_SUCCESS_PLACEHOLDER)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.purchase(1000, check(:account_number => '123', :number => nil))
+      @gateway.purchase(1000, check(account_number: '123', number: nil))
     end
     assert_equal('Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error', e.message)
   end
 
   def test_store_with_check
-    assert  @gateway.store(check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
-    assert !@gateway.store(check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
+    assert  @gateway.store(check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: nil)).success?
+    assert !@gateway.store(check(account_number: CHECK_FAILURE_PLACEHOLDER, number: nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.store(check(:account_number => '123', :number => nil))
+      @gateway.store(check(account_number: '123', number: nil))
     end
     assert_equal('Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error', e.message)
   end
 
   def test_credit_with_check
-    assert  @gateway.credit(1000, check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil)).success?
-    assert !@gateway.credit(1000, check(:account_number => CHECK_FAILURE_PLACEHOLDER, :number => nil)).success?
+    assert  @gateway.credit(1000, check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: nil)).success?
+    assert !@gateway.credit(1000, check(account_number: CHECK_FAILURE_PLACEHOLDER, number: nil)).success?
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.credit(1000, check(:account_number => '123', :number => nil))
+      @gateway.credit(1000, check(account_number: '123', number: nil))
     end
     assert_equal('Bogus Gateway: Use bank account number ending in 1 for success, 2 for exception and anything else for error', e.message)
   end
 
   def test_store_then_purchase_with_check
-    reference = @gateway.store(check(:account_number => CHECK_SUCCESS_PLACEHOLDER, :number => nil))
+    reference = @gateway.store(check(account_number: CHECK_SUCCESS_PLACEHOLDER, number: nil))
     assert @gateway.purchase(1000, reference.authorization).success?
   end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -5,10 +5,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @old_verbose, $VERBOSE = $VERBOSE, false
 
     @gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'test',
-      :public_key => 'test',
-      :private_key => 'test',
-      :test => true
+      merchant_id: 'test',
+      public_key: 'test',
+      private_key: 'test',
+      test: true
     )
 
     @internal_gateway = @gateway.instance_variable_get(:@braintree_gateway)
@@ -21,22 +21,22 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_refund_legacy_method_signature
     Braintree::TransactionGateway.any_instance.expects(:refund).
       with('transaction_id', nil).
-      returns(braintree_result(:id => 'refund_transaction_id'))
-    response = @gateway.refund('transaction_id', :test => true)
+      returns(braintree_result(id: 'refund_transaction_id'))
+    response = @gateway.refund('transaction_id', test: true)
     assert_equal 'refund_transaction_id', response.authorization
   end
 
   def test_refund_method_signature
     Braintree::TransactionGateway.any_instance.expects(:refund).
       with('transaction_id', '10.00').
-      returns(braintree_result(:id => 'refund_transaction_id'))
-    response = @gateway.refund(1000, 'transaction_id', :test => true)
+      returns(braintree_result(id: 'refund_transaction_id'))
+    response = @gateway.refund(1000, 'transaction_id', test: true)
     assert_equal 'refund_transaction_id', response.authorization
   end
 
   def test_transaction_uses_customer_id_by_default
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:customer_id => 'present')).
+      with(has_entries(customer_id: 'present')).
       returns(braintree_result)
 
     assert response = @gateway.purchase(10, 'present', {})
@@ -46,7 +46,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_transaction_uses_payment_method_token_when_option
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:payment_method_token => 'present')).
+      with(has_entries(payment_method_token: 'present')).
       returns(braintree_result)
 
     assert response = @gateway.purchase(10, 'present', { payment_method_token: true })
@@ -56,7 +56,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_transaction_uses_payment_method_nonce_when_option
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(all_of(has_entries(:payment_method_nonce => 'present'), has_key(:customer))).
+      with(all_of(has_entries(payment_method_nonce: 'present'), has_key(:customer))).
       returns(braintree_result)
 
     assert response = @gateway.purchase(10, 'present', { payment_method_nonce: true })
@@ -86,7 +86,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_capture_transaction
     Braintree::TransactionGateway.any_instance.expects(:submit_for_settlement).
-      returns(braintree_result(:id => 'capture_transaction_id'))
+      returns(braintree_result(id: 'capture_transaction_id'))
 
     response = @gateway.capture(100, 'transaction_id')
 
@@ -96,7 +96,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_refund_transaction
     Braintree::TransactionGateway.any_instance.expects(:refund).
-      returns(braintree_result(:id => 'refund_transaction_id'))
+      returns(braintree_result(id: 'refund_transaction_id'))
 
     response = @gateway.refund(1000, 'transaction_id')
     assert_equal 'refund_transaction_id', response.authorization
@@ -106,7 +106,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_void_transaction
     Braintree::TransactionGateway.any_instance.expects(:void).
       with('transaction_id').
-      returns(braintree_result(:id => 'void_transaction_id'))
+      returns(braintree_result(id: 'void_transaction_id'))
 
     response = @gateway.void('transaction_id')
     assert_equal 'void_transaction_id', response.authorization
@@ -133,14 +133,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_merchant_account_id_present_when_provided_on_gateway_initialization
     @gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'test',
-      :merchant_account_id => 'present',
-      :public_key => 'test',
-      :private_key => 'test'
+      merchant_id: 'test',
+      merchant_account_id: 'present',
+      public_key: 'test',
+      private_key: 'test'
     )
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:merchant_account_id => 'present')).
+      with(has_entries(merchant_account_id: 'present')).
       returns(braintree_result)
 
     @gateway.authorize(100, credit_card('41111111111111111111'))
@@ -148,33 +148,33 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_merchant_account_id_on_transaction_takes_precedence
     @gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'test',
-      :merchant_account_id => 'present',
-      :public_key => 'test',
-      :private_key => 'test'
+      merchant_id: 'test',
+      merchant_account_id: 'present',
+      public_key: 'test',
+      private_key: 'test'
     )
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:merchant_account_id => 'account_on_transaction')).
+      with(has_entries(merchant_account_id: 'account_on_transaction')).
       returns(braintree_result)
 
-    @gateway.authorize(100, credit_card('41111111111111111111'), :merchant_account_id => 'account_on_transaction')
+    @gateway.authorize(100, credit_card('41111111111111111111'), merchant_account_id: 'account_on_transaction')
   end
 
   def test_merchant_account_id_present_when_provided
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:merchant_account_id => 'present')).
+      with(has_entries(merchant_account_id: 'present')).
       returns(braintree_result)
 
-    @gateway.authorize(100, credit_card('41111111111111111111'), :merchant_account_id => 'present')
+    @gateway.authorize(100, credit_card('41111111111111111111'), merchant_account_id: 'present')
   end
 
   def test_service_fee_amount_can_be_specified
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:service_fee_amount => '2.31')).
+      with(has_entries(service_fee_amount: '2.31')).
       returns(braintree_result)
 
-    @gateway.authorize(100, credit_card('41111111111111111111'), :service_fee_amount => '2.31')
+    @gateway.authorize(100, credit_card('41111111111111111111'), service_fee_amount: '2.31')
   end
 
   def test_hold_in_escrow_can_be_specified
@@ -182,7 +182,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       (params[:options][:hold_in_escrow] == true)
     end.returns(braintree_result)
 
-    @gateway.authorize(100, credit_card('41111111111111111111'), :hold_in_escrow => true)
+    @gateway.authorize(100, credit_card('41111111111111111111'), hold_in_escrow: true)
   end
 
   def test_merchant_account_id_absent_if_not_provided
@@ -195,61 +195,61 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_verification_merchant_account_id_exists_when_verify_card_and_merchant_account_id
     gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'merchant_id',
-      :merchant_account_id => 'merchant_account_id',
-      :public_key => 'public_key',
-      :private_key => 'private_key'
+      merchant_id: 'merchant_id',
+      merchant_account_id: 'merchant_account_id',
+      public_key: 'public_key',
+      private_key: 'private_key'
     )
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      credit_cards: [stub_everything],
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     )
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
 
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options][:verification_merchant_account_id] == 'merchant_account_id'
     end.returns(result)
 
-    gateway.store(credit_card('41111111111111111111'), :verify_card => true)
+    gateway.store(credit_card('41111111111111111111'), verify_card: true)
   end
 
   def test_merchant_account_id_can_be_set_by_options
     gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'merchant_id',
-      :merchant_account_id => 'merchant_account_id',
-      :public_key => 'public_key',
-      :private_key => 'private_key'
+      merchant_id: 'merchant_id',
+      merchant_account_id: 'merchant_account_id',
+      public_key: 'public_key',
+      private_key: 'private_key'
     )
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      credit_cards: [stub_everything],
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     )
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options][:verification_merchant_account_id] == 'value_from_options'
     end.returns(result)
 
-    gateway.store(credit_card('41111111111111111111'), :verify_card => true, :verification_merchant_account_id => 'value_from_options')
+    gateway.store(credit_card('41111111111111111111'), verify_card: true, verification_merchant_account_id: 'value_from_options')
   end
 
   def test_store_with_verify_card_true
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      credit_cards: [stub_everything],
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     )
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options].has_key?(:verify_card)
       assert_equal true, params[:credit_card][:options][:verify_card]
@@ -257,89 +257,89 @@ class BraintreeBlueTest < Test::Unit::TestCase
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :verify_card => true)
+    response = @gateway.store(credit_card('41111111111111111111'), verify_card: true)
     assert_equal '123', response.params['customer_vault_id']
     assert_equal response.params['customer_vault_id'], response.authorization
   end
 
   def test_passes_email
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => 'bob@example.com',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith',
+      credit_cards: [stub_everything],
+      email: 'bob@example.com',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith',
       id: '123'
     )
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_equal 'bob@example.com', params[:email]
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :email => 'bob@example.com')
+    response = @gateway.store(credit_card('41111111111111111111'), email: 'bob@example.com')
     assert_success response
   end
 
   def test_scrubs_invalid_email
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => nil,
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :id => '123'
+      credit_cards: [stub_everything],
+      email: nil,
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith',
+      id: '123'
     )
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_equal nil, params[:email]
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :email => 'bogus')
+    response = @gateway.store(credit_card('41111111111111111111'), email: 'bogus')
     assert_success response
   end
 
   def test_store_with_verify_card_false
     customer = stub(
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      credit_cards: [stub_everything],
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     )
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       params[:credit_card][:options].has_key?(:verify_card)
       assert_equal false, params[:credit_card][:options][:verify_card]
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :verify_card => false)
+    response = @gateway.store(credit_card('41111111111111111111'), verify_card: false)
     assert_equal '123', response.params['customer_vault_id']
     assert_equal response.params['customer_vault_id'], response.authorization
   end
 
   def test_store_with_billing_address_options
     customer_attributes = {
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      credit_cards: [stub_everything],
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     }
     billing_address = {
-      :address1 => '1 E Main St',
-      :address2 => 'Suite 403',
-      :city => 'Chicago',
-      :state => 'Illinois',
-      :zip => '60622',
-      :country_name => 'US'
+      address1: '1 E Main St',
+      address2: 'Suite 403',
+      city: 'Chicago',
+      state: 'Illinois',
+      zip: '60622',
+      country_name: 'US'
     }
     customer = stub(customer_attributes)
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_not_nil params[:credit_card][:billing_address]
       [:street_address, :extended_address, :locality, :region, :postal_code, :country_name].each do |billing_attribute|
@@ -348,80 +348,80 @@ class BraintreeBlueTest < Test::Unit::TestCase
       params
     end.returns(result)
 
-    @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
+    @gateway.store(credit_card('41111111111111111111'), billing_address: billing_address)
   end
 
   def test_store_with_phone_only_billing_address_option
     customer_attributes = {
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :phone => '123-456-7890'
+      credit_cards: [stub_everything],
+      email: 'email',
+      first_name: 'John',
+      last_name: 'Smith',
+      phone: '123-456-7890'
     }
     billing_address = {
-      :phone => '123-456-7890'
+      phone: '123-456-7890'
     }
     customer = stub(customer_attributes)
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_nil params[:credit_card][:billing_address]
       params
     end.returns(result)
 
-    @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
+    @gateway.store(credit_card('41111111111111111111'), billing_address: billing_address)
   end
 
   def test_store_with_nil_billing_address_options
     customer_attributes = {
-      :credit_cards => [stub_everything],
-      :email => 'email',
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :phone => '123-456-7890'
+      credit_cards: [stub_everything],
+      email: 'email',
+      first_name: 'John',
+      last_name: 'Smith',
+      phone: '123-456-7890'
     }
     billing_address = {
-      :name => 'John Smith',
-      :phone => '123-456-7890',
-      :company => nil,
-      :address1 => nil,
-      :address2 => '',
-      :city => nil,
-      :state => nil,
-      :zip => nil,
-      :country_name => nil
+      name: 'John Smith',
+      phone: '123-456-7890',
+      company: nil,
+      address1: nil,
+      address2: '',
+      city: nil,
+      state: nil,
+      zip: nil,
+      country_name: nil
     }
     customer = stub(customer_attributes)
     customer.stubs(:id).returns('123')
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_nil params[:credit_card][:billing_address]
       params
     end.returns(result)
 
-    @gateway.store(credit_card('41111111111111111111'), :billing_address => billing_address)
+    @gateway.store(credit_card('41111111111111111111'), billing_address: billing_address)
   end
 
   def test_store_with_credit_card_token
     customer = stub(
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith'
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith'
     )
     customer.stubs(:id).returns('123')
 
     braintree_credit_card = stub_everything(token: 'cctoken')
     customer.stubs(:credit_cards).returns([braintree_credit_card])
 
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
       assert_equal 'cctoken', params[:credit_card][:token]
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :credit_card_token => 'cctoken')
+    response = @gateway.store(credit_card('41111111111111111111'), credit_card_token: 'cctoken')
     assert_success response
     assert_equal 'cctoken', response.params['braintree_customer']['credit_cards'][0]['token']
     assert_equal 'cctoken', response.params['credit_card_token']
@@ -429,15 +429,15 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_store_with_customer_id
     customer = stub(
-      :email => 'email',
-      :phone => '321-654-0987',
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :credit_cards => [stub_everything]
+      email: 'email',
+      phone: '321-654-0987',
+      first_name: 'John',
+      last_name: 'Smith',
+      credit_cards: [stub_everything]
     )
     customer.stubs(:id).returns('customerid')
 
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:find).
       with('customerid').
       raises(Braintree::NotFoundError)
@@ -446,7 +446,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       params
     end.returns(result)
 
-    response = @gateway.store(credit_card('41111111111111111111'), :customer => 'customerid')
+    response = @gateway.store(credit_card('41111111111111111111'), customer: 'customerid')
     assert_success response
     assert_equal 'customerid', response.params['braintree_customer']['id']
   end
@@ -479,17 +479,17 @@ class BraintreeBlueTest < Test::Unit::TestCase
       token: 'cctoken'
     )
     options = {
-      :customer => 'customerid',
-      :billing_address => {
-        :name => 'John Smith',
-        :phone => '123-456-7890',
-        :company => nil,
-        :address1 => nil,
-        :address2 => nil,
-        :city => nil,
-        :state => nil,
-        :zip => nil,
-        :country_name => nil
+      customer: 'customerid',
+      billing_address: {
+        name: 'John Smith',
+        phone: '123-456-7890',
+        company: nil,
+        address1: nil,
+        address2: nil,
+        city: nil,
+        state: nil,
+        zip: nil,
+        country_name: nil
       }
     }
 
@@ -510,88 +510,88 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_update_with_cvv
-    stored_credit_card = mock(:token => 'token', :default? => true)
-    customer = mock(:credit_cards => [stored_credit_card], :id => '123')
+    stored_credit_card = mock(token: 'token', default?: true)
+    customer = mock(credit_cards: [stored_credit_card], id: '123')
     Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
     BraintreeBlueGateway.any_instance.stubs(:customer_hash)
 
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
       assert_equal '567', params[:credit_card][:cvv]
       assert_equal 'Longbob Longsen', params[:credit_card][:cardholder_name]
       [vault, params]
     end.returns(result)
 
-    @gateway.update('vault_id', credit_card('41111111111111111111', :verification_value => '567'))
+    @gateway.update('vault_id', credit_card('41111111111111111111', verification_value: '567'))
   end
 
   def test_update_with_verify_card_true
-    stored_credit_card = stub(:token => 'token', :default? => true)
-    customer = stub(:credit_cards => [stored_credit_card], :id => '123')
+    stored_credit_card = stub(token: 'token', default?: true)
+    customer = stub(credit_cards: [stored_credit_card], id: '123')
     Braintree::CustomerGateway.any_instance.stubs(:find).with('vault_id').returns(customer)
     BraintreeBlueGateway.any_instance.stubs(:customer_hash)
 
-    result = Braintree::SuccessfulResult.new(:customer => customer)
+    result = Braintree::SuccessfulResult.new(customer: customer)
     Braintree::CustomerGateway.any_instance.expects(:update).with do |vault, params|
       assert_equal true, params[:credit_card][:options][:verify_card]
       [vault, params]
     end.returns(result)
 
-    @gateway.update('vault_id', credit_card('41111111111111111111'), :verify_card => true)
+    @gateway.update('vault_id', credit_card('41111111111111111111'), verify_card: true)
   end
 
   def test_merge_credit_card_options_ignores_bad_option
-    params = {:first_name => 'John', :credit_card => {:cvv => '123'}}
-    options = {:verify_card => true, :bogus => 'ignore me'}
+    params = {first_name: 'John', credit_card: {cvv: '123'}}
+    options = {verify_card: true, bogus: 'ignore me'}
     merged_params = @gateway.send(:merge_credit_card_options, params, options)
-    expected_params = {:first_name => 'John', :credit_card => {:cvv => '123', :options => {:verify_card => true}}}
+    expected_params = {first_name: 'John', credit_card: {cvv: '123', options: {verify_card: true}}}
     assert_equal expected_params, merged_params
   end
 
   def test_merge_credit_card_options_handles_nil_credit_card
-    params = {:first_name => 'John'}
-    options = {:verify_card => true, :bogus => 'ignore me'}
+    params = {first_name: 'John'}
+    options = {verify_card: true, bogus: 'ignore me'}
     merged_params = @gateway.send(:merge_credit_card_options, params, options)
-    expected_params = {:first_name => 'John', :credit_card => {:options => {:verify_card => true}}}
+    expected_params = {first_name: 'John', credit_card: {options: {verify_card: true}}}
     assert_equal expected_params, merged_params
   end
 
   def test_merge_credit_card_options_handles_billing_address
     billing_address = {
-      :address1 => '1 E Main St',
-      :city => 'Chicago',
-      :state => 'Illinois',
-      :zip => '60622',
-      :country => 'US'
+      address1: '1 E Main St',
+      city: 'Chicago',
+      state: 'Illinois',
+      zip: '60622',
+      country: 'US'
     }
-    params = {:first_name => 'John'}
-    options = {:billing_address => billing_address}
+    params = {first_name: 'John'}
+    options = {billing_address: billing_address}
     expected_params = {
-      :first_name => 'John',
-      :credit_card => {
-        :billing_address => {
-          :street_address => '1 E Main St',
-          :extended_address => nil,
-          :company => nil,
-          :locality => 'Chicago',
-          :region => 'Illinois',
-          :postal_code => '60622',
-          :country_code_alpha2 => 'US',
-          :country_code_alpha3 => 'USA'
+      first_name: 'John',
+      credit_card: {
+        billing_address: {
+          street_address: '1 E Main St',
+          extended_address: nil,
+          company: nil,
+          locality: 'Chicago',
+          region: 'Illinois',
+          postal_code: '60622',
+          country_code_alpha2: 'US',
+          country_code_alpha3: 'USA'
         },
-        :options => {}
+        options: {}
       }
     }
     assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
   end
 
   def test_merge_credit_card_options_only_includes_billing_address_when_present
-    params = {:first_name => 'John'}
+    params = {first_name: 'John'}
     options = {}
     expected_params = {
-      :first_name => 'John',
-      :credit_card => {
-        :options => {}
+      first_name: 'John',
+      credit_card: {
+        options: {}
       }
     }
     assert_equal expected_params, @gateway.send(:merge_credit_card_options, params, options)
@@ -601,46 +601,46 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == 'US')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:country => 'US'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country: 'US'})
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == 'US')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:country_code_alpha2 => 'US'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_alpha2: 'US'})
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_name] == 'United States of America')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:country_name => 'United States of America'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_name: 'United States of America'})
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha3] == 'USA')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:country_code_alpha3 => 'USA'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_alpha3: 'USA'})
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_numeric] == 840)
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:country_code_numeric => 840})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_numeric: 840})
   end
 
   def test_address_zip_handling
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:postal_code] == '12345')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:zip => '12345'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {zip: '12345'})
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:postal_code] == nil)
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :billing_address => {:zip => '1234567890'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {zip: '1234567890'})
   end
 
   def test_cardholder_name_passing_with_card
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:credit_card][:cardholder_name] == 'Longbob Longsen')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :customer => {:first_name => 'Longbob', :last_name => 'Longsen'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), customer: {first_name: 'Longbob', last_name: 'Longsen'})
   end
 
   def test_three_d_secure_pass_thru_handling_version_1
@@ -712,20 +712,20 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_passes_recurring_flag
     @gateway = BraintreeBlueGateway.new(
-      :merchant_id => 'test',
-      :merchant_account_id => 'present',
-      :public_key => 'test',
-      :private_key => 'test'
+      merchant_id: 'test',
+      merchant_account_id: 'present',
+      public_key: 'test',
+      private_key: 'test'
     )
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(:recurring => true)).
+      with(has_entries(recurring: true)).
       returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), :recurring => true)
+    @gateway.purchase(100, credit_card('41111111111111111111'), recurring: true)
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(Not(has_entries(:recurring => true))).
+      with(Not(has_entries(recurring: true))).
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'))
@@ -736,24 +736,24 @@ class BraintreeBlueTest < Test::Unit::TestCase
       (params[:transaction_source] == 'recurring')
       (params[:recurring] == nil)
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), :transaction_source => 'recurring', :recurring => true)
+    @gateway.purchase(100, credit_card('41111111111111111111'), transaction_source: 'recurring', recurring: true)
   end
 
   def test_passes_skip_avs
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:options][:skip_avs] == true)
-    end.returns(braintree_result(:avs_postal_code_response_code => 'B', :avs_street_address_response_code => 'B'))
+    end.returns(braintree_result(avs_postal_code_response_code: 'B', avs_street_address_response_code: 'B'))
 
-    response = @gateway.purchase(100, credit_card('41111111111111111111'), :skip_avs => true)
+    response = @gateway.purchase(100, credit_card('41111111111111111111'), skip_avs: true)
     assert_equal 'B', response.avs_result['code']
   end
 
   def test_passes_skip_cvv
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:options][:skip_cvv] == true)
-    end.returns(braintree_result(:cvv_response_code => 'B'))
+    end.returns(braintree_result(cvv_response_code: 'B'))
 
-    response = @gateway.purchase(100, credit_card('41111111111111111111'), :skip_cvv => true)
+    response = @gateway.purchase(100, credit_card('41111111111111111111'), skip_cvv: true)
     assert_equal 'B', response.cvv_result['code']
   end
 
@@ -775,9 +775,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
       # Re-instantiate a gateway to show it doesn't touch the global
       gateway = BraintreeBlueGateway.new(
-        :merchant_id => 'test',
-        :public_key => 'test',
-        :private_key => 'test'
+        merchant_id: 'test',
+        public_key: 'test',
+        private_key: 'test'
       )
       internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
 
@@ -794,9 +794,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
       assert_not_equal logger, Braintree::Configuration.logger
 
       gateway = BraintreeBlueGateway.new(
-        :merchant_id => 'test',
-        :public_key => 'test',
-        :private_key => 'test'
+        merchant_id: 'test',
+        public_key: 'test',
+        private_key: 'test'
       )
       internal_gateway = gateway.instance_variable_get(:@braintree_gateway)
 
@@ -810,7 +810,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'ABC123'
     assert_equal @gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'ABC123'
 
-    gateway = BraintreeBlueGateway.new(:merchant_id => 'test', :public_key => 'test', :private_key => 'test', channel: 'overidden-channel')
+    gateway = BraintreeBlueGateway.new(merchant_id: 'test', public_key: 'test', private_key: 'test', channel: 'overidden-channel')
     assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'overidden-channel'
   ensure
     ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
@@ -843,99 +843,99 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_apple_pay_card
     Braintree::TransactionGateway.any_instance.expects(:sale).
       with(
-        :amount => '1.00',
-        :order_id => '1',
-        :customer => {:id => nil, :email => nil, :phone => nil,
-                      :first_name => 'Longbob', :last_name => 'Longsen'},
-        :options => {:store_in_vault => false, :submit_for_settlement => nil, :hold_in_escrow => nil},
-        :custom_fields => nil,
-        :apple_pay_card => {
-          :number => '4111111111111111',
-          :expiration_month => '09',
-          :expiration_year => (Time.now.year + 1).to_s,
-          :cardholder_name => 'Longbob Longsen',
-          :cryptogram => '111111111100cryptogram',
-          :eci_indicator => '05'
+        amount: '1.00',
+        order_id: '1',
+        customer: {id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen'},
+        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        custom_fields: nil,
+        apple_pay_card: {
+          number: '4111111111111111',
+          expiration_month: '09',
+          expiration_year: (Time.now.year + 1).to_s,
+          cardholder_name: 'Longbob Longsen',
+          cryptogram: '111111111100cryptogram',
+          eci_indicator: '05'
         }
       ).
-      returns(braintree_result(:id => 'transaction_id'))
+      returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :transaction_id     => '123',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram'
+      brand: 'visa',
+      transaction_id: '123',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram'
     )
 
-    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1')
+    response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
   end
 
   def test_android_pay_card
     Braintree::TransactionGateway.any_instance.expects(:sale).
       with(
-        :amount => '1.00',
-        :order_id => '1',
-        :customer => {:id => nil, :email => nil, :phone => nil,
-                      :first_name => 'Longbob', :last_name => 'Longsen'},
-        :options => {:store_in_vault => false, :submit_for_settlement => nil, :hold_in_escrow => nil},
-        :custom_fields => nil,
-        :android_pay_card => {
-          :number => '4111111111111111',
-          :expiration_month => '09',
-          :expiration_year => (Time.now.year + 1).to_s,
-          :cryptogram => '111111111100cryptogram',
-          :google_transaction_id => '1234567890',
-          :source_card_type => 'visa',
-          :source_card_last_four => '1111',
-          :eci_indicator => '05'
+        amount: '1.00',
+        order_id: '1',
+        customer: {id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen'},
+        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        custom_fields: nil,
+        android_pay_card: {
+          number: '4111111111111111',
+          expiration_month: '09',
+          expiration_year: (Time.now.year + 1).to_s,
+          cryptogram: '111111111100cryptogram',
+          google_transaction_id: '1234567890',
+          source_card_type: 'visa',
+          source_card_last_four: '1111',
+          eci_indicator: '05'
         }
       ).
-      returns(braintree_result(:id => 'transaction_id'))
+      returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram',
-      :source             => :android_pay,
-      :transaction_id     => '1234567890'
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :android_pay,
+      transaction_id: '1234567890'
     )
 
-    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1')
+    response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
   end
 
   def test_google_pay_card
     Braintree::TransactionGateway.any_instance.expects(:sale).
       with(
-        :amount => '1.00',
-        :order_id => '1',
-        :customer => {:id => nil, :email => nil, :phone => nil,
-                      :first_name => 'Longbob', :last_name => 'Longsen'},
-        :options => {:store_in_vault => false, :submit_for_settlement => nil, :hold_in_escrow => nil},
-        :custom_fields => nil,
-        :android_pay_card => {
-          :number => '4111111111111111',
-          :expiration_month => '09',
-          :expiration_year => (Time.now.year + 1).to_s,
-          :cryptogram => '111111111100cryptogram',
-          :google_transaction_id => '1234567890',
-          :source_card_type => 'visa',
-          :source_card_last_four => '1111',
-          :eci_indicator => '05'
+        amount: '1.00',
+        order_id: '1',
+        customer: {id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen'},
+        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        custom_fields: nil,
+        android_pay_card: {
+          number: '4111111111111111',
+          expiration_month: '09',
+          expiration_year: (Time.now.year + 1).to_s,
+          cryptogram: '111111111100cryptogram',
+          google_transaction_id: '1234567890',
+          source_card_type: 'visa',
+          source_card_last_four: '1111',
+          eci_indicator: '05'
         }
       ).
-      returns(braintree_result(:id => 'transaction_id'))
+      returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram',
-      :source             => :google_pay,
-      :transaction_id     => '1234567890'
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :google_pay,
+      transaction_id: '1234567890'
     )
 
-    response = @gateway.authorize(100, credit_card, :test => true, :order_id => '1')
+    response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
   end
 
@@ -989,10 +989,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1003,11 +1003,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1018,10 +1018,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => 'recurring'
+          transaction_source: 'recurring'
         })
     ).returns(braintree_result)
 
@@ -1032,11 +1032,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => 'recurring'
+          transaction_source: 'recurring'
         })
     ).returns(braintree_result)
 
@@ -1047,10 +1047,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1061,11 +1061,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1076,10 +1076,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => 'recurring'
+          transaction_source: 'recurring'
         })
     ).returns(braintree_result)
 
@@ -1090,11 +1090,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => 'recurring'
+          transaction_source: 'recurring'
         })
     ).returns(braintree_result)
 
@@ -1105,10 +1105,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1119,11 +1119,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => ''
+          transaction_source: ''
         })
     ).returns(braintree_result)
 
@@ -1134,10 +1134,10 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'will_vault'
+          external_vault: {
+            status: 'will_vault'
           },
-          :transaction_source => 'unscheduled'
+          transaction_source: 'unscheduled'
         })
     ).returns(braintree_result)
 
@@ -1148,11 +1148,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
-          :external_vault => {
-            :status => 'vaulted',
-            :previous_network_transaction_id => '123ABC'
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
           },
-          :transaction_source => 'unscheduled'
+          transaction_source: 'unscheduled'
         })
     ).returns(braintree_result)
 
@@ -1162,7 +1162,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   private
 
   def braintree_result(options = {})
-    Braintree::SuccessfulResult.new(:transaction => Braintree::Transaction._new(nil, {:id => 'transaction_id'}.merge(options)))
+    Braintree::SuccessfulResult.new(transaction: Braintree::Transaction._new(nil, {id: 'transaction_id'}.merge(options)))
   end
 
   def braintree_error_result(options = {})
@@ -1184,18 +1184,18 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def standard_purchase_params
     {
-      :amount => '1.00',
-      :order_id => '1',
-      :customer => {:id => nil, :email => nil, :phone => nil,
-                    :first_name => 'Longbob', :last_name => 'Longsen'},
-      :options => {:store_in_vault => false, :submit_for_settlement => true, :hold_in_escrow => nil},
-      :custom_fields => nil,
-      :credit_card => {
-        :number => '41111111111111111111',
-        :cvv => '123',
-        :expiration_month => '09',
-        :expiration_year => (Time.now.year + 1).to_s,
-        :cardholder_name => 'Longbob Longsen',
+      amount: '1.00',
+      order_id: '1',
+      customer: {id: nil, email: nil, phone: nil,
+                 first_name: 'Longbob', last_name: 'Longsen'},
+      options: {store_in_vault: false, submit_for_settlement: true, hold_in_escrow: nil},
+      custom_fields: nil,
+      credit_card: {
+        number: '41111111111111111111',
+        cvv: '123',
+        expiration_month: '09',
+        expiration_year: (Time.now.year + 1).to_s,
+        cardholder_name: 'Longbob Longsen',
       }
     }
   end

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -5,14 +5,14 @@ class BraintreeOrangeTest < Test::Unit::TestCase
 
   def setup
     @gateway = BraintreeOrangeGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @credit_card = credit_card
     @amount = 100
 
-    @options = { :billing_address => address }
+    @options = { billing_address: address }
   end
 
   def test_successful_purchase
@@ -47,7 +47,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_processor
     result = {}
 
-    @gateway.send(:add_processor, result, {:processor => 'ccprocessorb'})
+    @gateway.send(:add_processor, result, {processor: 'ccprocessorb'})
     assert_equal ['processor_id'], result.stringify_keys.keys.sort
     assert_equal 'ccprocessorb', result[:processor_id]
   end
@@ -86,7 +86,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
+    @gateway.send(:add_address, result, {address1: '164 Waverley Street', country: 'US', state: 'CO'})
     assert_equal ['address1', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result['state']
     assert_equal '164 Waverley Street', result['address1']
@@ -96,7 +96,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_shipping_address
     result = {}
 
-    @gateway.send(:add_address, result, {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'}, 'shipping')
+    @gateway.send(:add_address, result, {address1: '164 Waverley Street', country: 'US', state: 'CO'}, 'shipping')
     assert_equal ['shipping_address1', 'shipping_city', 'shipping_company', 'shipping_country', 'shipping_phone', 'shipping_state', 'shipping_zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result['shipping_state']
     assert_equal '164 Waverley Street', result['shipping_address1']
@@ -106,7 +106,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_adding_store_adds_vault_id_flag
     result = {}
 
-    @gateway.send(:add_creditcard, result, @credit_card, :store => true)
+    @gateway.send(:add_creditcard, result, @credit_card, store: true)
     assert_equal ['ccexp', 'ccnumber', 'customer_vault', 'cvv', 'firstname', 'lastname'], result.stringify_keys.keys.sort
     assert_equal 'add_customer', result[:customer_vault]
   end
@@ -121,11 +121,11 @@ class BraintreeOrangeTest < Test::Unit::TestCase
 
   def test_accept_check
     post = {}
-    check = Check.new(:name => 'Fred Bloggs',
-                      :routing_number => '111000025',
-                      :account_number => '123456789012',
-                      :account_holder_type => 'personal',
-                      :account_type => 'checking')
+    check = Check.new(name: 'Fred Bloggs',
+                      routing_number: '111000025',
+                      account_number: '123456789012',
+                      account_holder_type: 'personal',
+                      account_type: 'checking')
     @gateway.send(:add_check, post, check, {})
     assert_equal %w[account_holder_type account_type checkaba checkaccount checkname payment], post.stringify_keys.keys.sort
   end
@@ -155,7 +155,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, {})
 
     @gateway.expects(:commit).with { |_, _, parameters| parameters[:billing_method] == 'recurring' }
-    @gateway.purchase(@amount, @credit_card, {:eci => 'recurring'})
+    @gateway.purchase(@amount, @credit_card, {eci: 'recurring'})
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/braintree_test.rb
+++ b/test/unit/gateways/braintree_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class BraintreeTest < Test::Unit::TestCase
   def test_new_with_login_password_creates_braintree_orange
     gateway = BraintreeGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
     assert_instance_of BraintreeOrangeGateway, gateway
   end
 
   def test_new_with_merchant_id_creates_braintree_blue
     gateway = BraintreeGateway.new(
-      :merchant_id => 'MERCHANT_ID',
-      :public_key => 'PUBLIC_KEY',
-      :private_key => 'PRIVATE_KEY'
+      merchant_id: 'MERCHANT_ID',
+      public_key: 'PUBLIC_KEY',
+      private_key: 'PRIVATE_KEY'
     )
     assert_instance_of BraintreeBlueGateway, gateway
   end

--- a/test/unit/gateways/bridge_pay_test.rb
+++ b/test/unit/gateways/bridge_pay_test.rb
@@ -130,7 +130,7 @@ class BridgePayTest < Test::Unit::TestCase
 
   def test_passing_billing_address
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/Street=456\+My\+Street/, data)
       assert_match(/Zip=K1C2N6/, data)

--- a/test/unit/gateways/cams_test.rb
+++ b/test/unit/gateways/cams_test.rb
@@ -7,8 +7,8 @@ class CamsTest < Test::Unit::TestCase
       password: 'password9'
     )
 
-    @credit_card = credit_card('4111111111111111', :month => 5, :year => 10)
-    @bad_credit_card = credit_card('4242424245555555', :month => 5, :year => 10)
+    @credit_card = credit_card('4111111111111111', month: 5, year: 10)
+    @bad_credit_card = credit_card('4242424245555555', month: 5, year: 10)
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/card_save_test.rb
+++ b/test/unit/gateways/card_save_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class CardSaveTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
-    @gateway = CardSaveGateway.new(:login => 'login', :password => 'password')
+    @gateway = CardSaveGateway.new(login: 'login', password: 'password')
     @credit_card = credit_card
     @amount = 100
-    @options = {:order_id =>'1', :billing_address => address, :description =>'Store Purchase'}
+    @options = {order_id: '1', billing_address: address, description: 'Store Purchase'}
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -5,51 +5,51 @@ class CardStreamTest < Test::Unit::TestCase
 
   def setup
     @gateway = CardStreamGateway.new(
-      :login => 'login',
-      :shared_secret => 'secret'
+      login: 'login',
+      shared_secret: 'secret'
     )
 
     @visacreditcard = credit_card('4929421234600821',
-      :month => '12',
-      :year => '2014',
-      :verification_value => '356',
-      :brand => :visa
+      month: '12',
+      year: '2014',
+      verification_value: '356',
+      brand: :visa
     )
 
     @visacredit_options = {
-      :billing_address => {
-        :address1 => 'Flat 6, Primrose Rise',
-        :address2 => '347 Lavender Road',
-        :city => '',
-        :state => 'Northampton',
-        :zip => 'NN17 8YG '
+      billing_address: {
+        address1: 'Flat 6, Primrose Rise',
+        address2: '347 Lavender Road',
+        city: '',
+        state: 'Northampton',
+        zip: 'NN17 8YG '
       },
-      :order_id => generate_unique_id,
-      :description => 'AM test purchase'
+      order_id: generate_unique_id,
+      description: 'AM test purchase'
     }
 
     @visacredit_descriptor_options = {
-      :billing_address => {
-        :address1 => 'Flat 6, Primrose Rise',
-        :address2 => '347 Lavender Road',
-        :city => '',
-        :state => 'Northampton',
-        :zip => 'NN17 8YG '
+      billing_address: {
+        address1: 'Flat 6, Primrose Rise',
+        address2: '347 Lavender Road',
+        city: '',
+        state: 'Northampton',
+        zip: 'NN17 8YG '
       },
-      :merchant_name => 'merchant',
-      :dynamic_descriptor => 'product'
+      merchant_name: 'merchant',
+      dynamic_descriptor: 'product'
     }
 
     @amex = credit_card('374245455400001',
-      :month => '12',
-      :year => 2014,
-      :verification_value => '4887',
-      :brand => :american_express
+      month: '12',
+      year: 2014,
+      verification_value: '4887',
+      brand: :american_express
     )
 
     @declined_card = credit_card('4000300011112220',
-      :month => '9',
-      :year => '2014'
+      month: '9',
+      year: '2014'
     )
   end
 
@@ -285,9 +285,9 @@ class CardStreamTest < Test::Unit::TestCase
   def test_deprecated_3ds_required
     assert_deprecation_warning(CardStreamGateway::THREEDSECURE_REQUIRED_DEPRECATION_MESSAGE) do
       @gateway = CardStreamGateway.new(
-        :login => 'login',
-        :shared_secret => 'secret',
-        :threeDSRequired => true
+        login: 'login',
+        shared_secret: 'secret',
+        threeDSRequired: true
       )
     end
     stub_comms do

--- a/test/unit/gateways/cecabank_test.rb
+++ b/test/unit/gateways/cecabank_test.rb
@@ -5,18 +5,18 @@ class CecabankTest < Test::Unit::TestCase
 
   def setup
     @gateway = CecabankGateway.new(
-      :merchant_id  => '12345678',
-      :acquirer_bin => '12345678',
-      :terminal_id  => '00000003',
-      :key => 'enc_key'
+      merchant_id: '12345678',
+      acquirer_bin: '12345678',
+      terminal_id: '00000003',
+      key: 'enc_key'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :description => 'Store Purchase'
+      order_id: '1',
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/cenpos_test.rb
+++ b/test/unit/gateways/cenpos_test.rb
@@ -5,9 +5,9 @@ class CenposTest < Test::Unit::TestCase
 
   def setup
     @gateway = CenposGateway.new(
-      :merchant_id => 'merchant_id',
-      :password => 'password',
-      :user_id => 'user_id'
+      merchant_id: 'merchant_id',
+      password: 'password',
+      user_id: 'user_id'
     )
 
     @credit_card = credit_card

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -5,8 +5,8 @@ class CheckoutTest < Test::Unit::TestCase
 
   def setup
     @gateway = ActiveMerchant::Billing::CheckoutGateway.new(
-      :merchant_id    => 'SBMTEST', # Merchant Code
-      :password => 'Password1!' # Processing Password
+      merchant_id: 'SBMTEST', # Merchant Code
+      password: 'Password1!' # Processing Password
     )
     @options = {
       order_id: generate_unique_id

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -91,7 +91,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => {country: 'US'})
+      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
@@ -99,7 +99,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => {country: 'Blah'})
+      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)
@@ -115,7 +115,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_passing_billing_address
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => address)
+      @gateway.authorize(@amount, @credit_card, billing_address: address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
       assert_equal('456 My Street', parsed['billing']['address']['street'])
@@ -125,7 +125,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_passing_shipping_name
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :shipping_address => address)
+      @gateway.authorize(@amount, @credit_card, shipping_address: address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
       assert_equal('Jim', parsed['shipping']['firstName'])

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -4,41 +4,41 @@ class ConektaTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = ConektaGateway.new(:key => 'key_eYvWV7gSDkNYXsmr')
+    @gateway = ConektaGateway.new(key: 'key_eYvWV7gSDkNYXsmr')
 
     @amount = 300
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :number             => '4242424242424242',
-      :verification_value => '183',
-      :month              => '01',
-      :year               => '2018',
-      :first_name         => 'Mario F.',
-      :last_name          => 'Moreno Reyes'
+      number: '4242424242424242',
+      verification_value: '183',
+      month: '01',
+      year: '2018',
+      first_name: 'Mario F.',
+      last_name: 'Moreno Reyes'
     )
 
     @declined_card = ActiveMerchant::Billing::CreditCard.new(
-      :number             => '4000000000000002',
-      :verification_value => '183',
-      :month              => '01',
-      :year               => '2018',
-      :first_name         => 'Mario F.',
-      :last_name          => 'Moreno Reyes'
+      number: '4000000000000002',
+      verification_value: '183',
+      month: '01',
+      year: '2018',
+      first_name: 'Mario F.',
+      last_name: 'Moreno Reyes'
     )
 
     @options = {
-      :device_fingerprint => '41l9l92hjco6cuekf0c7dq68v4',
-      :description => 'Blue clip',
-      :success_url => 'https://www.example.com/success',
-      :failure_url => 'https://www.example.com/failure',
-      :address1 => 'Rio Missisipi #123',
-      :address2 => 'Paris',
-      :city => 'Guerrero',
-      :country => 'Mexico',
-      :zip => '5555',
-      :customer => 'Mario Reyes',
-      :phone => '12345678',
-      :carrier => 'Estafeta'
+      device_fingerprint: '41l9l92hjco6cuekf0c7dq68v4',
+      description: 'Blue clip',
+      success_url: 'https://www.example.com/success',
+      failure_url: 'https://www.example.com/failure',
+      address1: 'Rio Missisipi #123',
+      address2: 'Paris',
+      city: 'Guerrero',
+      country: 'Mexico',
+      zip: '5555',
+      customer: 'Mario Reyes',
+      phone: '12345678',
+      carrier: 'Estafeta'
     }
   end
 
@@ -139,7 +139,7 @@ class ConektaTest < Test::Unit::TestCase
   end
 
   def test_invalid_key
-    gateway = ConektaGateway.new(:key => 'invalid_token')
+    gateway = ConektaGateway.new(key: 'invalid_token')
     gateway.expects(:ssl_request).returns(failed_login_response)
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -8,49 +8,49 @@ class CyberSourceTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = CyberSourceGateway.new(
-      :login => 'l',
-      :password => 'p'
+      login: 'l',
+      password: 'p'
     )
 
     @amount = 100
     @customer_ip = '127.0.0.1'
-    @credit_card = credit_card('4111111111111111', :brand => 'visa')
-    @master_credit_card = credit_card('4111111111111111', :brand => 'master')
-    @elo_credit_card = credit_card('5067310000000010', :brand => 'elo')
-    @declined_card = credit_card('801111111111111', :brand => 'visa')
+    @credit_card = credit_card('4111111111111111', brand: 'visa')
+    @master_credit_card = credit_card('4111111111111111', brand: 'master')
+    @elo_credit_card = credit_card('5067310000000010', brand: 'elo')
+    @declined_card = credit_card('801111111111111', brand: 'visa')
     @check = check()
 
     @options = {
-      :ip => @customer_ip,
-      :order_id => '1000',
-      :line_items => [
+      ip: @customer_ip,
+      order_id: '1000',
+      line_items: [
         {
-          :declared_value => @amount,
-          :quantity => 2,
-          :code => 'default',
-          :description => 'Giant Walrus',
-          :sku => 'WA323232323232323'
+          declared_value: @amount,
+          quantity: 2,
+          code: 'default',
+          description: 'Giant Walrus',
+          sku: 'WA323232323232323'
         },
         {
-          :declared_value => @amount,
-          :quantity => 2,
-          :description => 'Marble Snowcone',
-          :sku => 'FAKE1232132113123'
+          declared_value: @amount,
+          quantity: 2,
+          description: 'Marble Snowcone',
+          sku: 'FAKE1232132113123'
         }
       ],
-      :currency => 'USD'
+      currency: 'USD'
     }
 
     @subscription_options = {
-      :order_id => generate_unique_id,
-      :credit_card => @credit_card,
-      :setup_fee => 100,
-      :subscription => {
-        :frequency => 'weekly',
-        :start_date => Date.today.next_week,
-        :occurrences => 4,
-        :automatic_renew => true,
-        :amount => 100
+      order_id: generate_unique_id,
+      credit_card: @credit_card,
+      setup_fee: 100,
+      subscription: {
+        frequency: 'weekly',
+        start_date: Date.today.next_week,
+        occurrences: 4,
+        automatic_renew: true,
+        amount: 100
       }
     }
 
@@ -156,7 +156,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_pinless_debit_card_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:pinless_debit_card => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(pinless_debit_card: true))
     assert_equal 'Successful transaction', response.message
     assert_success response
     assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
@@ -362,7 +362,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?
     assert response.test?
-    assert response = @gateway.unstore(response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.unstore(response.authorization, order_id: generate_unique_id)
     assert response.success?
     assert response.test?
   end
@@ -372,7 +372,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert response.success?
     assert response.test?
-    assert response = @gateway.retrieve(response.authorization, :order_id => generate_unique_id)
+    assert response = @gateway.retrieve(response.authorization, order_id: generate_unique_id)
     assert response.success?
     assert response.test?
   end
@@ -537,10 +537,10 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_auth_with_network_tokenization_for_visa
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :transaction_id     => '123',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram'
+      brand: 'visa',
+      transaction_id: '123',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram'
     )
 
     response = stub_comms do
@@ -555,10 +555,10 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokenization_for_visa
     credit_card = network_tokenization_credit_card('4111111111111111',
-      :brand              => 'visa',
-      :transaction_id     => '123',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram'
+      brand: 'visa',
+      transaction_id: '123',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram'
     )
 
     response = stub_comms do
@@ -579,10 +579,10 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     credit_card = network_tokenization_credit_card('5555555555554444',
-      :brand              => 'master',
-      :transaction_id     => '123',
-      :eci                => '05',
-      :payment_cryptogram => '111111111100cryptogram'
+      brand: 'master',
+      transaction_id: '123',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram'
     )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
@@ -597,10 +597,10 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     credit_card = network_tokenization_credit_card('378282246310005',
-      :brand              => 'american_express',
-      :transaction_id     => '123',
-      :eci                => '05',
-      :payment_cryptogram => Base64.encode64('111111111100cryptogram')
+      brand: 'american_express',
+      transaction_id: '123',
+      eci: '05',
+      payment_cryptogram: Base64.encode64('111111111100cryptogram')
     )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
@@ -610,10 +610,10 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_auth_first_unscheduled_stored_cred
     @gateway.stubs(:ssl_post).returns(successful_authorization_response)
     @options[:stored_credential] = {
-      :initiator => 'cardholder',
-      :reason_type => 'unscheduled',
-      :initial_transaction => true,
-      :network_transaction_id => ''
+      initiator: 'cardholder',
+      reason_type: 'unscheduled',
+      initial_transaction: true,
+      network_transaction_id: ''
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_equal Response, response.class
@@ -624,10 +624,10 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_auth_subsequent_unscheduled_stored_cred
     @gateway.stubs(:ssl_post).returns(successful_authorization_response)
     @options[:stored_credential] = {
-      :initiator => 'merchant',
-      :reason_type => 'unscheduled',
-      :initial_transaction => false,
-      :network_transaction_id => '016150703802094'
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_equal Response, response.class
@@ -638,10 +638,10 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_auth_first_recurring_stored_cred
     @gateway.stubs(:ssl_post).returns(successful_authorization_response)
     @options[:stored_credential] = {
-      :initiator => 'cardholder',
-      :reason_type => 'recurring',
-      :initial_transaction => true,
-      :network_transaction_id => ''
+      initiator: 'cardholder',
+      reason_type: 'recurring',
+      initial_transaction: true,
+      network_transaction_id: ''
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_equal Response, response.class
@@ -652,10 +652,10 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_auth_subsequent_recurring_stored_cred
     @gateway.stubs(:ssl_post).returns(successful_authorization_response)
     @options[:stored_credential] = {
-      :initiator => 'merchant',
-      :reason_type => 'recurring',
-      :initial_transaction => false,
-      :network_transaction_id => '016150703802094'
+      initiator: 'merchant',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_equal Response, response.class

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class DataCashTest < Test::Unit::TestCase
   def setup
     @gateway = DataCashGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @credit_card = credit_card('4242424242424242')
@@ -12,19 +12,19 @@ class DataCashTest < Test::Unit::TestCase
     @amount = 100
 
     @address = {
-      :name     => 'Mark McBride',
-      :address1 => 'Flat 12/3',
-      :address2 => '45 Main Road',
-      :city     => 'London',
-      :state    => 'None',
-      :country  => 'GBR',
-      :zip      => 'A987AA',
-      :phone    => '(555)555-5555'
+      name: 'Mark McBride',
+      address1: 'Flat 12/3',
+      address2: '45 Main Road',
+      city: 'London',
+      state: 'None',
+      country: 'GBR',
+      zip: 'A987AA',
+      phone: '(555)555-5555'
     }
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => @address
+      order_id: generate_unique_id,
+      billing_address: @address
     }
   end
 
@@ -96,7 +96,7 @@ class DataCashTest < Test::Unit::TestCase
 
   def test_purchase_does_not_raise_exception_with_missing_billing_address
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert @gateway.authorize(100, @credit_card, {:order_id => generate_unique_id }).is_a?(ActiveMerchant::Billing::Response)
+    assert @gateway.authorize(100, @credit_card, {order_id: generate_unique_id }).is_a?(ActiveMerchant::Billing::Response)
   end
 
   def test_continuous_authority_purchase_with_missing_continuous_authority_reference

--- a/test/unit/gateways/efsnet_test.rb
+++ b/test/unit/gateways/efsnet_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class EfsnetTest < Test::Unit::TestCase
   def setup
     @gateway = EfsnetGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :order_id => 1, :billing_address => address }
+    @options = { order_id: 1, billing_address: address }
   end
 
   def test_successful_purchase
@@ -35,28 +35,28 @@ class EfsnetTest < Test::Unit::TestCase
 
   def test_credit
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/AccountNumber>#{@credit_card.number}<\/AccountNumber/), anything).returns('')
-    @gateway.credit(@amount, @credit_card, :order_id => 5)
+    @gateway.credit(@amount, @credit_card, order_id: 5)
   end
 
   def test_deprecated_credit
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<OriginalTransactionID>transaction_id<\/OriginalTransactionID>/), anything).returns('')
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
-      @gateway.credit(@amount, 'transaction_id', :order_id => 5)
+      @gateway.credit(@amount, 'transaction_id', order_id: 5)
     end
   end
 
   def test_refund
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<OriginalTransactionID>transaction_id<\/OriginalTransactionID>/), anything).returns('')
-    @gateway.refund(@amount, 'transaction_id', :order_id => 5)
+    @gateway.refund(@amount, 'transaction_id', order_id: 5)
   end
 
   def test_authorize_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :transaction_amount => '1.01',
-      :account_number => '4242424242424242',
-      :expiration_month => '12',
-      :expiration_year => '2029',
+      order_id: 'order1',
+      transaction_amount: '1.01',
+      account_number: '4242424242424242',
+      expiration_month: '12',
+      expiration_year: '2029',
     }
 
     assert data = @gateway.send(:post_data, :credit_card_authorize, params)
@@ -65,10 +65,10 @@ class EfsnetTest < Test::Unit::TestCase
 
   def test_settle_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :transaction_amount => '1.01',
-      :original_transaction_amount => '1.01',
-      :original_transaction_id => '1',
+      order_id: 'order1',
+      transaction_amount: '1.01',
+      original_transaction_amount: '1.01',
+      original_transaction_id: '1',
     }
 
     assert data = @gateway.send(:post_data, :credit_card_settle, params)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -5,25 +5,25 @@ class ElavonTest < Test::Unit::TestCase
 
   def setup
     @gateway = ElavonGateway.new(
-      :login => 'login',
-      :user => 'user',
-      :password => 'password'
+      login: 'login',
+      user: 'user',
+      password: 'password'
     )
 
     @multi_currency_gateway = ElavonGateway.new(
-      :login => 'login',
-      :user => 'user',
-      :password => 'password',
-      :multi_currency => true
+      login: 'login',
+      user: 'user',
+      password: 'password',
+      multi_currency: true
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -60,7 +60,7 @@ class ElavonTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     authorization = '123456;00000000-0000-0000-0000-00000000000'
 
-    assert response = @gateway.capture(@amount, authorization, :credit_card => @credit_card)
+    assert response = @gateway.capture(@amount, authorization, credit_card: @credit_card)
     assert_instance_of Response, response
     assert_success response
 
@@ -85,7 +85,7 @@ class ElavonTest < Test::Unit::TestCase
   def test_successful_capture_with_additional_options
     authorization = '123456;00000000-0000-0000-0000-00000000000'
     response = stub_comms do
-      @gateway.capture(@amount, authorization, :test_mode => true, :partial_shipment_flag => true)
+      @gateway.capture(@amount, authorization, test_mode: true, partial_shipment_flag: true)
     end.check_request do |endpoint, data, headers|
       assert_match(/ssl_transaction_type=CCCOMPLETE/, data)
       assert_match(/ssl_test_mode=TRUE/, data)
@@ -146,7 +146,7 @@ class ElavonTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
     authorization = '123456INVALID;00000000-0000-0000-0000-00000000000'
 
-    assert response = @gateway.capture(@amount, authorization, :credit_card => @credit_card)
+    assert response = @gateway.capture(@amount, authorization, credit_card: @credit_card)
     assert_instance_of Response, response
     assert_failure response
   end
@@ -279,7 +279,7 @@ class ElavonTest < Test::Unit::TestCase
 
     @options[:billing_address][:zip] = bad_zip
 
-    @gateway.expects(:commit).with(anything, anything, has_entries(:avs_zip => stripped_zip), anything)
+    @gateway.expects(:commit).with(anything, anything, has_entries(avs_zip: stripped_zip), anything)
 
     @gateway.purchase(@amount, @credit_card, @options)
   end
@@ -287,14 +287,14 @@ class ElavonTest < Test::Unit::TestCase
   def test_zip_codes_with_letters_are_left_intact
     @options[:billing_address][:zip] = '.K1%Z_5E3-'
 
-    @gateway.expects(:commit).with(anything, anything, has_entries(:avs_zip => 'K1Z5E3'), anything)
+    @gateway.expects(:commit).with(anything, anything, has_entries(avs_zip: 'K1Z5E3'), anything)
 
     @gateway.purchase(@amount, @credit_card, @options)
   end
 
   def test_custom_fields_in_request
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:customer_number => '123', :custom_fields => {:a_key => 'a value'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge(customer_number: '123', custom_fields: {a_key: 'a value'}))
     end.check_request do |endpoint, data, headers|
       assert_match(/customer_number=123/, data)
       assert_match(/a_key/, data)

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -5,8 +5,8 @@ class EpayTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = EpayGateway.new(
-      :login    => '10100111001',
-      :password => 'http://example.com'
+      login: '10100111001',
+      password: 'http://example.com'
     )
 
     @credit_card = credit_card
@@ -122,13 +122,13 @@ class EpayTest < Test::Unit::TestCase
   def test_authorize_sends_order_number
     @gateway.expects(:raw_ssl_request).with(anything, anything, regexp_matches(/orderid=1234/), anything).returns(valid_authorize_response)
 
-    @gateway.authorize(100, '123', :order_id => '#1234')
+    @gateway.authorize(100, '123', order_id: '#1234')
   end
 
   def test_purchase_sends_order_number
     @gateway.expects(:raw_ssl_request).with(anything, anything, regexp_matches(/orderid=1234/), anything).returns(valid_authorize_response)
 
-    @gateway.purchase(100, '123', :order_id => '#1234')
+    @gateway.purchase(100, '123', order_id: '#1234')
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/evo_ca_test.rb
+++ b/test/unit/gateways/evo_ca_test.rb
@@ -2,19 +2,19 @@ require 'test_helper'
 
 class EvoCaTest < Test::Unit::TestCase
   def setup
-    @gateway = EvoCaGateway.new(:username => 'demo', :password => 'password')
+    @gateway = EvoCaGateway.new(username: 'demo', password: 'password')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :tracking_number => '123456789-0',
-      :shipping_carrier => 'fedex',
-      :email => 'evo@example.com',
-      :ip => '127.0.0.1'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      tracking_number: '123456789-0',
+      shipping_carrier: 'fedex',
+      email: 'evo@example.com',
+      ip: '127.0.0.1'
     }
   end
 
@@ -84,7 +84,7 @@ class EvoCaTest < Test::Unit::TestCase
 
   def test_successful_update
     @gateway.expects(:ssl_post).returns(successful_update_response)
-    assert response = @gateway.update('1812639342', :tracking_number => '1234', :shipping_carrier => 'fedex')
+    assert response = @gateway.update('1812639342', tracking_number: '1234', shipping_carrier: 'fedex')
     assert_success response
     assert_equal '1812639342', response.authorization
   end
@@ -99,7 +99,7 @@ class EvoCaTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, :address => {:address1 => '123 Main Street', :country => 'CA', :state => 'BC'})
+    @gateway.send(:add_address, result, address: {address1: '123 Main Street', country: 'CA', state: 'BC'})
     assert_equal %w{address1 address2 city company country firstname lastname phone state zip}, result.stringify_keys.keys.sort
     assert_equal 'BC', result[:state]
     assert_equal '123 Main Street', result[:address1]
@@ -109,7 +109,7 @@ class EvoCaTest < Test::Unit::TestCase
   def test_add_shipping_address
     result = {}
 
-    @gateway.send(:add_address, result, :shipping_address => {:address1 => '123 Main Street', :country => 'CA', :state => 'BC'})
+    @gateway.send(:add_address, result, shipping_address: {address1: '123 Main Street', country: 'CA', state: 'BC'})
     assert_equal %w{shipping_address1 shipping_address2 shipping_city shipping_company shipping_country shipping_firstname shipping_lastname shipping_state shipping_zip}, result.stringify_keys.keys.sort
     assert_equal 'BC', result[:shipping_state]
     assert_equal '123 Main Street', result[:shipping_address1]

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -4,7 +4,7 @@ class EwayManagedTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
 
-    @gateway = EwayManagedGateway.new(:username => 'username', :login => 'login', :password => 'password')
+    @gateway = EwayManagedGateway.new(username: 'username', login: 'login', password: 'password')
 
     @valid_card='4444333322221111'
     @valid_customer_id='9876543211000'
@@ -15,22 +15,22 @@ class EwayManagedTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :billing_address => {
-        :address1 => '1234 My Street',
-        :address2 => 'Apt 1',
-        :company => 'Widgets Inc',
-        :city => 'Ottawa',
-        :state => 'ON',
-        :zip => 'K1C2N6',
-        :country => 'au',
-        :title => 'Mr.',
-        :phone => '(555)555-5555'
+      billing_address: {
+        address1: '1234 My Street',
+        address2: 'Apt 1',
+        company: 'Widgets Inc',
+        city: 'Ottawa',
+        state: 'ON',
+        zip: 'K1C2N6',
+        country: 'au',
+        title: 'Mr.',
+        phone: '(555)555-5555'
       },
-      :email => 'someguy1232@fakeemail.net',
-      :order_id => '1000',
-      :customer => 'mycustomerref',
-      :description => 'My Description',
-      :invoice => 'invoice-4567'
+      email: 'someguy1232@fakeemail.net',
+      order_id: '1000',
+      customer: 'mycustomerref',
+      description: 'My Description',
+      invoice: 'invoice-4567'
     }
   end
 
@@ -39,17 +39,17 @@ class EwayManagedTest < Test::Unit::TestCase
       @gateway.store(@credit_card, { })
     end
     assert_raise ArgumentError do
-      @gateway.store(@credit_card, { :billing_address => {} })
+      @gateway.store(@credit_card, { billing_address: {} })
     end
     assert_raise ArgumentError do
-      @gateway.store(@credit_card, { :billing_address => { :title => 'Mr.' } })
+      @gateway.store(@credit_card, { billing_address: { title: 'Mr.' } })
     end
     assert_raise ArgumentError do
-      @gateway.store(@credit_card, { :billing_address => { :country => 'au' } })
+      @gateway.store(@credit_card, { billing_address: { country: 'au' } })
     end
     assert_nothing_raised do
       @gateway.expects(:ssl_post).returns(successful_store_response)
-      @gateway.store(@credit_card, { :billing_address => { :title => 'Mr.', :country => 'au' } })
+      @gateway.store(@credit_card, { billing_address: { title: 'Mr.', country: 'au' } })
     end
   end
 
@@ -58,17 +58,17 @@ class EwayManagedTest < Test::Unit::TestCase
       @gateway.update(@valid_customer_id, @credit_card, { })
     end
     assert_raise ArgumentError do
-      @gateway.update(@valid_customer_id, @credit_card, { :billing_address => {} })
+      @gateway.update(@valid_customer_id, @credit_card, { billing_address: {} })
     end
     assert_raise ArgumentError do
-      @gateway.update(@valid_customer_id, @credit_card, { :billing_address => { :title => 'Mr.' } })
+      @gateway.update(@valid_customer_id, @credit_card, { billing_address: { title: 'Mr.' } })
     end
     assert_raise ArgumentError do
-      @gateway.update(@valid_customer_id, @credit_card, { :billing_address => { :country => 'au' } })
+      @gateway.update(@valid_customer_id, @credit_card, { billing_address: { country: 'au' } })
     end
     assert_nothing_raised do
       @gateway.expects(:ssl_post).returns(successful_update_response)
-      @gateway.update(@valid_customer_id, @credit_card, { :billing_address => { :title => 'Mr.', :country => 'au' } })
+      @gateway.update(@valid_customer_id, @credit_card, { billing_address: { title: 'Mr.', country: 'au' } })
     end
   end
 

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -6,8 +6,8 @@ class EwayRapidTest < Test::Unit::TestCase
   def setup
     ActiveMerchant::Billing::EwayRapidGateway.partner_id = nil
     @gateway = EwayRapidGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
@@ -106,13 +106,13 @@ class EwayRapidTest < Test::Unit::TestCase
 
   def test_localized_currency
     stub_comms do
-      @gateway.purchase(100, @credit_card, :currency => 'CAD')
+      @gateway.purchase(100, @credit_card, currency: 'CAD')
     end.check_request do |endpoint, data, headers|
       assert_match '"TotalAmount":"100"', data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.purchase(100, @credit_card, :currency => 'JPY')
+      @gateway.purchase(100, @credit_card, currency: 'JPY')
     end.check_request do |endpoint, data, headers|
       assert_match '"TotalAmount":"1"', data
     end.respond_with(successful_purchase_response)
@@ -154,41 +154,41 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_with_all_options
     response = stub_comms do
       @gateway.purchase(200, @credit_card,
-        :transaction_type => 'CustomTransactionType',
-        :redirect_url => 'http://awesomesauce.com',
-        :ip => '0.0.0.0',
-        :application_id => 'Woohoo',
-        :partner_id => 'SomePartner',
-        :description => 'The Really Long Description More Than Sixty Four Characters Gets Truncated',
-        :order_id => 'orderid1',
-        :invoice => 'I1234',
-        :currency => 'INR',
-        :email => 'jim@example.com',
-        :billing_address => {
-          :title    => 'Mr.',
-          :name     => 'Jim Awesome Smith',
-          :company  => 'Awesome Co',
-          :address1 => '1234 My Street',
-          :address2 => 'Apt 1',
-          :city     => 'Ottawa',
-          :state    => 'ON',
-          :zip      => 'K1C2N6',
-          :country  => 'CA',
-          :phone    => '(555)555-5555',
-          :fax      => '(555)555-6666'
+        transaction_type: 'CustomTransactionType',
+        redirect_url: 'http://awesomesauce.com',
+        ip: '0.0.0.0',
+        application_id: 'Woohoo',
+        partner_id: 'SomePartner',
+        description: 'The Really Long Description More Than Sixty Four Characters Gets Truncated',
+        order_id: 'orderid1',
+        invoice: 'I1234',
+        currency: 'INR',
+        email: 'jim@example.com',
+        billing_address: {
+          title: 'Mr.',
+          name: 'Jim Awesome Smith',
+          company: 'Awesome Co',
+          address1: '1234 My Street',
+          address2: 'Apt 1',
+          city: 'Ottawa',
+          state: 'ON',
+          zip: 'K1C2N6',
+          country: 'CA',
+          phone: '(555)555-5555',
+          fax: '(555)555-6666'
         },
-        :shipping_address => {
-          :title    => 'Ms.',
-          :name     => 'Baker',
-          :company  => 'Elsewhere Inc.',
-          :address1 => '4321 Their St.',
-          :address2 => 'Apt 2',
-          :city     => 'Chicago',
-          :state    => 'IL',
-          :zip      => '60625',
-          :country  => 'US',
-          :phone    => '1115555555',
-          :fax      => '1115556666'
+        shipping_address: {
+          title: 'Ms.',
+          name: 'Baker',
+          company: 'Elsewhere Inc.',
+          address1: '4321 Their St.',
+          address2: 'Apt 2',
+          city: 'Chicago',
+          state: 'IL',
+          zip: '60625',
+          country: 'US',
+          phone: '1115555555',
+          fax: '1115556666'
         }
       )
     end.check_request do |endpoint, data, headers|
@@ -383,18 +383,18 @@ class EwayRapidTest < Test::Unit::TestCase
 
   def test_successful_store
     response = stub_comms do
-      @gateway.store(@credit_card, :billing_address => {
-        :title    => 'Mr.',
-        :name     => 'Jim Awesome Smith',
-        :company  => 'Awesome Co',
-        :address1 => '1234 My Street',
-        :address2 => 'Apt 1',
-        :city     => 'Ottawa',
-        :state    => 'ON',
-        :zip      => 'K1C2N6',
-        :country  => 'CA',
-        :phone    => '(555)555-5555',
-        :fax      => '(555)555-6666'
+      @gateway.store(@credit_card, billing_address: {
+        title: 'Mr.',
+        name: 'Jim Awesome Smith',
+        company: 'Awesome Co',
+        address1: '1234 My Street',
+        address2: 'Apt 1',
+        city: 'Ottawa',
+        state: 'ON',
+        zip: 'K1C2N6',
+        country: 'CA',
+        phone: '(555)555-5555',
+        fax: '(555)555-6666'
       })
     end.check_request do |endpoint, data, headers|
       assert_match '"Method":"CreateTokenCustomer"', data
@@ -433,7 +433,7 @@ class EwayRapidTest < Test::Unit::TestCase
 
   def test_failed_store
     response = stub_comms do
-      @gateway.store(@credit_card, :billing_address => {})
+      @gateway.store(@credit_card, billing_address: {})
     end.respond_with(failed_store_response)
 
     assert_failure response
@@ -548,7 +548,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_verification_results
     response = stub_comms do
       @gateway.purchase(100, @credit_card)
-    end.respond_with(successful_purchase_response(:verification_status => 'Valid'))
+    end.respond_with(successful_purchase_response(verification_status: 'Valid'))
 
     assert_success response
     assert_equal 'M', response.cvv_result['code']
@@ -556,7 +556,7 @@ class EwayRapidTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(100, @credit_card)
-    end.respond_with(successful_purchase_response(:verification_status => 'Invalid'))
+    end.respond_with(successful_purchase_response(verification_status: 'Invalid'))
 
     assert_success response
     assert_equal 'N', response.cvv_result['code']
@@ -564,7 +564,7 @@ class EwayRapidTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(100, @credit_card)
-    end.respond_with(successful_purchase_response(:verification_status => 'Unchecked'))
+    end.respond_with(successful_purchase_response(verification_status: 'Unchecked'))
 
     assert_success response
     assert_equal 'P', response.cvv_result['code']

--- a/test/unit/gateways/eway_test.rb
+++ b/test/unit/gateways/eway_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class EwayTest < Test::Unit::TestCase
   def setup
     @gateway = EwayGateway.new(
-      :login => '87654321'
+      login: '87654321'
     )
 
     @amount = 100
@@ -11,17 +11,17 @@ class EwayTest < Test::Unit::TestCase
     @credit_card = credit_card('4646464646464646')
 
     @options = {
-      :order_id => '1230123',
-      :email => 'bob@testbob.com',
-      :billing_address => {
-        :address1 => '1234 First St.',
-        :address2 => 'Apt. 1',
-        :city     => 'Melbourne',
-        :state    => 'ACT',
-        :country  => 'AU',
-        :zip      => '12345'
+      order_id: '1230123',
+      email: 'bob@testbob.com',
+      billing_address: {
+        address1: '1234 First St.',
+        address2: 'Apt. 1',
+        city: 'Melbourne',
+        state: 'ACT',
+        country: 'AU',
+        zip: '12345'
       },
-      :description => 'purchased items'
+      description: 'purchased items'
     }
   end
 

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -2,15 +2,15 @@ require 'test_helper'
 
 class ExactTest < Test::Unit::TestCase
   def setup
-    @gateway = ExactGateway.new(:login    => 'A00427-01',
-                                :password => 'testus')
+    @gateway = ExactGateway.new(login: 'A00427-01',
+                                password: 'testus')
 
     @credit_card = credit_card
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -5,17 +5,17 @@ class FatZebraTest < Test::Unit::TestCase
 
   def setup
     @gateway = FatZebraGateway.new(
-      :username => 'TEST',
-      :token    => 'TEST'
+      username: 'TEST',
+      token: 'TEST'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => rand(10000),
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: rand(10000),
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -34,7 +34,7 @@ class FatZebraTest < Test::Unit::TestCase
       body.match '"metadata":{"foo":"bar"}'
     }.returns(successful_purchase_response_with_metadata)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:metadata => { 'foo' => 'bar' }))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { 'foo' => 'bar' }))
     assert_success response
 
     assert_equal '001-P-12345AA|purchases', response.authorization
@@ -70,7 +70,7 @@ class FatZebraTest < Test::Unit::TestCase
       body.match '"currency":"USD"'
     }.returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, 'e1q7dbj2', @options.merge(:currency => 'USD'))
+    assert response = @gateway.purchase(@amount, 'e1q7dbj2', @options.merge(currency: 'USD'))
     assert_success response
 
     assert_equal '001-P-12345AA|purchases', response.authorization
@@ -91,7 +91,7 @@ class FatZebraTest < Test::Unit::TestCase
       json['extra']['name'] == 'Merchant' && json['extra']['location'] == 'Location'
     }.returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, 'e1q7dbj2', @options.merge(:merchant => 'Merchant', :merchant_location => 'Location'))
+    assert response = @gateway.purchase(@amount, 'e1q7dbj2', @options.merge(merchant: 'Merchant', merchant_location: 'Location'))
     assert_success response
 
     assert_equal '001-P-12345AA|purchases', response.authorization
@@ -252,204 +252,204 @@ Conn close
   # Place raw successful response from gateway here
   def successful_purchase_response
     {
-      :successful => true,
-      :response => {
-        :authorization => 55355,
-        :id => '001-P-12345AA',
-        :card_number => 'XXXXXXXXXXXX1111',
-        :card_holder => 'John Smith',
-        :card_expiry => '10/2011',
-        :card_token => 'a1bhj98j',
-        :amount => 349,
-        :decimal_amount => 3.49,
-        :successful => true,
-        :message => 'Approved',
-        :reference => 'ABC123',
-        :currency => 'AUD',
-        :transaction_id => '001-P-12345AA',
-        :settlement_date => '2011-07-01',
-        :transaction_date => '2011-07-01T12:00:00+11:00',
-        :response_code => '08',
-        :captured => true,
-        :captured_amount => 349,
-        :rrn => '000000000000',
-        :cvv_match => 'U',
-        :metadata => {
+      successful: true,
+      response: {
+        authorization: 55355,
+        id: '001-P-12345AA',
+        card_number: 'XXXXXXXXXXXX1111',
+        card_holder: 'John Smith',
+        card_expiry: '10/2011',
+        card_token: 'a1bhj98j',
+        amount: 349,
+        decimal_amount: 3.49,
+        successful: true,
+        message: 'Approved',
+        reference: 'ABC123',
+        currency: 'AUD',
+        transaction_id: '001-P-12345AA',
+        settlement_date: '2011-07-01',
+        transaction_date: '2011-07-01T12:00:00+11:00',
+        response_code: '08',
+        captured: true,
+        captured_amount: 349,
+        rrn: '000000000000',
+        cvv_match: 'U',
+        metadata: {
         },
       },
-      :test => true,
-      :errors => []
+      test: true,
+      errors: []
     }.to_json
   end
 
   def successful_purchase_response_with_metadata
     {
-      :successful => true,
-      :response => {
-        :authorization => 55355,
-        :id => '001-P-12345AA',
-        :card_number => 'XXXXXXXXXXXX1111',
-        :card_holder => 'John Smith',
-        :card_expiry => '2011-10-31',
-        :card_token => 'a1bhj98j',
-        :amount => 349,
-        :decimal_amount => 3.49,
-        :successful => true,
-        :message => 'Approved',
-        :reference => 'ABC123',
-        :currency => 'AUD',
-        :transaction_id => '001-P-12345AA',
-        :settlement_date => '2011-07-01',
-        :transaction_date => '2011-07-01T12:00:00+11:00',
-        :response_code => '08',
-        :captured => true,
-        :captured_amount => 349,
-        :rrn => '000000000000',
-        :cvv_match => 'U',
-        :metadata => {
+      successful: true,
+      response: {
+        authorization: 55355,
+        id: '001-P-12345AA',
+        card_number: 'XXXXXXXXXXXX1111',
+        card_holder: 'John Smith',
+        card_expiry: '2011-10-31',
+        card_token: 'a1bhj98j',
+        amount: 349,
+        decimal_amount: 3.49,
+        successful: true,
+        message: 'Approved',
+        reference: 'ABC123',
+        currency: 'AUD',
+        transaction_id: '001-P-12345AA',
+        settlement_date: '2011-07-01',
+        transaction_date: '2011-07-01T12:00:00+11:00',
+        response_code: '08',
+        captured: true,
+        captured_amount: 349,
+        rrn: '000000000000',
+        cvv_match: 'U',
+        metadata: {
           'foo' => 'bar',
         },
       },
-      :test => true,
-      :errors => []
+      test: true,
+      errors: []
     }.to_json
   end
 
   def declined_purchase_response
     {
-      :successful => true,
-      :response => {
-        :authorization => 0,
-        :id => '001-P-12345AB',
-        :card_number => 'XXXXXXXXXXXX1111',
-        :card_holder => 'John Smith',
-        :card_expiry => '10/2011',
-        :amount => 100,
-        :authorized => false,
-        :reference => 'ABC123',
-        :decimal_amount => 1.0,
-        :successful => false,
-        :message => 'Card Declined - check with issuer',
-        :currency => 'AUD',
-        :transaction_id => '001-P-12345AB',
-        :settlement_date => nil,
-        :transaction_date => '2011-07-01T12:00:00+11:00',
-        :response_code => '01',
-        :captured => false,
-        :captured_amount => 0,
-        :rrn => '000000000001',
-        :cvv_match => 'U',
-        :metadata => {
+      successful: true,
+      response: {
+        authorization: 0,
+        id: '001-P-12345AB',
+        card_number: 'XXXXXXXXXXXX1111',
+        card_holder: 'John Smith',
+        card_expiry: '10/2011',
+        amount: 100,
+        authorized: false,
+        reference: 'ABC123',
+        decimal_amount: 1.0,
+        successful: false,
+        message: 'Card Declined - check with issuer',
+        currency: 'AUD',
+        transaction_id: '001-P-12345AB',
+        settlement_date: nil,
+        transaction_date: '2011-07-01T12:00:00+11:00',
+        response_code: '01',
+        captured: false,
+        captured_amount: 0,
+        rrn: '000000000001',
+        cvv_match: 'U',
+        metadata: {
         }
       },
-      :test => true,
-      :errors => []
+      test: true,
+      errors: []
     }.to_json
   end
 
   def successful_refund_response
     {
-      :successful => true,
-      :response => {
-        :authorization => 1339973263,
-        :id => '003-R-7MNIUMY6',
-        :amount => 10,
-        :refunded => 'Approved',
-        :message => 'Approved',
-        :card_holder => 'Harry Smith',
-        :card_number => 'XXXXXXXXXXXX4444',
-        :card_expiry => '2013-05-31',
-        :card_type => 'MasterCard',
-        :transaction_id => '003-R-7MNIUMY6',
-        :reference => '18280',
-        :currency => 'USD',
-        :successful => true,
-        :transaction_date => '2013-07-01T12:00:00+11:00',
-        :response_code => '08',
-        :settlement_date => '2013-07-01',
-        :metadata => {
+      successful: true,
+      response: {
+        authorization: 1339973263,
+        id: '003-R-7MNIUMY6',
+        amount: 10,
+        refunded: 'Approved',
+        message: 'Approved',
+        card_holder: 'Harry Smith',
+        card_number: 'XXXXXXXXXXXX4444',
+        card_expiry: '2013-05-31',
+        card_type: 'MasterCard',
+        transaction_id: '003-R-7MNIUMY6',
+        reference: '18280',
+        currency: 'USD',
+        successful: true,
+        transaction_date: '2013-07-01T12:00:00+11:00',
+        response_code: '08',
+        settlement_date: '2013-07-01',
+        metadata: {
         },
-        :standalone => false,
-        :rrn => '000000000002',
+        standalone: false,
+        rrn: '000000000002',
       },
-      :errors => [],
-      :test => true
+      errors: [],
+      test: true
     }.to_json
   end
 
   def unsuccessful_refund_response
     {
-      :successful => false,
-      :response => {
-        :authorization => nil,
-        :id => nil,
-        :amount => nil,
-        :refunded => nil,
-        :message => nil,
-        :card_holder => 'Matthew Savage',
-        :card_number => 'XXXXXXXXXXXX4444',
-        :card_expiry => '2013-05-31',
-        :card_type => 'MasterCard',
-        :transaction_id => nil,
-        :successful => false
+      successful: false,
+      response: {
+        authorization: nil,
+        id: nil,
+        amount: nil,
+        refunded: nil,
+        message: nil,
+        card_holder: 'Matthew Savage',
+        card_number: 'XXXXXXXXXXXX4444',
+        card_expiry: '2013-05-31',
+        card_type: 'MasterCard',
+        transaction_id: nil,
+        successful: false
       },
-      :errors => [
+      errors: [
         "Reference can't be blank"
       ],
-      :test => true
+      test: true
     }.to_json
   end
 
   def successful_tokenize_response
     {
-      :successful => true,
-      :response => {
-        :token => 'e1q7dbj2',
-        :card_holder => 'Bob Smith',
-        :card_number => 'XXXXXXXXXXXX2346',
-        :card_expiry => '2013-05-31T23:59:59+10:00',
-        :authorized => true,
-        :transaction_count => 0
+      successful: true,
+      response: {
+        token: 'e1q7dbj2',
+        card_holder: 'Bob Smith',
+        card_number: 'XXXXXXXXXXXX2346',
+        card_expiry: '2013-05-31T23:59:59+10:00',
+        authorized: true,
+        transaction_count: 0
       },
-      :errors => [],
-      :test => true
+      errors: [],
+      test: true
     }.to_json
   end
 
   def failed_tokenize_response
     {
-      :successful => false,
-      :response => {
-        :token => nil,
-        :card_holder => 'Bob ',
-        :card_number => '512345XXXXXX2346',
-        :card_expiry => nil,
-        :authorized => false,
-        :transaction_count => 10
+      successful: false,
+      response: {
+        token: nil,
+        card_holder: 'Bob ',
+        card_number: '512345XXXXXX2346',
+        card_expiry: nil,
+        authorized: false,
+        transaction_count: 10
       },
-      :errors => [
+      errors: [
         "Expiry date can't be blank"
       ],
-      :test => false
+      test: false
     }.to_json
   end
 
   # Place raw failed response from gateway here
   def failed_purchase_response
     {
-      :successful => false,
-      :response => {},
-      :test => true,
-      :errors => ['Invalid Card Number']
+      successful: false,
+      response: {},
+      test: true,
+      errors: ['Invalid Card Number']
     }.to_json
   end
 
   def missing_data_response
     {
-      :successful => false,
-      :response => {},
-      :test => true,
-      :errors => ['Card Number is required']
+      successful: false,
+      response: {},
+      test: true,
+      errors: ['Card Number is required']
     }.to_json
   end
 end

--- a/test/unit/gateways/federated_canada_test.rb
+++ b/test/unit/gateways/federated_canada_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class FederatedCanadaTest < Test::Unit::TestCase
   def setup
     @gateway = FederatedCanadaGateway.new(
-      :login => 'demo',
-      :password => 'password'
+      login: 'demo',
+      password: 'password'
     )
 
     @credit_card = credit_card('4111111111111111')
@@ -12,15 +12,15 @@ class FederatedCanadaTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    options = {:billing_address => {:address1 => '888', :address2 => 'apt 13', :country => 'CA', :state => 'SK', :city => 'Big Beaver', :zip => '77777'}}
+    options = {billing_address: {address1: '888', address2: 'apt 13', country: 'CA', state: 'SK', city: 'Big Beaver', zip: '77777'}}
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_instance_of Response, response
     assert_success response
@@ -47,7 +47,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '123 Happy Town Road', :address2 => 'apt 13', :country => 'CA', :state => 'SK', :phone => '1234567890'})
+    @gateway.send(:add_address, result, billing_address: {address1: '123 Happy Town Road', address2: 'apt 13', country: 'CA', state: 'SK', phone: '1234567890'})
     assert_equal ['address1', 'address2', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'SK', result[:state]
     assert_equal '123 Happy Town Road', result[:address1]
@@ -57,13 +57,13 @@ class FederatedCanadaTest < Test::Unit::TestCase
 
   def test_add_invoice
     result = {}
-    @gateway.send(:add_invoice, result, :order_id => '#1001', :description => 'This is a great order')
+    @gateway.send(:add_invoice, result, order_id: '#1001', description: 'This is a great order')
     assert_equal '#1001', result[:orderid]
     assert_equal 'This is a great order', result[:orderdescription]
   end
 
   def test_purchase_is_valid_csv
-    params = {:amount => @amount}
+    params = {amount: @amount}
     @gateway.send(:add_creditcard, params, @credit_card)
 
     assert data = @gateway.send(:post_data, 'auth', params)
@@ -71,7 +71,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
   end
 
   def test_purchase_meets_minimum_requirements
-    params = {:amount => @amount}
+    params = {amount: @amount}
     @gateway.send(:add_creditcard, params, @credit_card)
     assert data = @gateway.send(:post_data, 'auth', params)
     minimum_requirements.each do |key|
@@ -80,8 +80,8 @@ class FederatedCanadaTest < Test::Unit::TestCase
   end
 
   def test_expdate_formatting
-    assert_equal '0909', @gateway.send(:expdate, credit_card('4111111111111111', :month => '9', :year => '2009'))
-    assert_equal '0711', @gateway.send(:expdate, credit_card('4111111111111111', :month => '7', :year => '2011'))
+    assert_equal '0909', @gateway.send(:expdate, credit_card('4111111111111111', month: '9', year: '2009'))
+    assert_equal '0711', @gateway.send(:expdate, credit_card('4111111111111111', month: '7', year: '2011'))
   end
 
   def test_supported_countries

--- a/test/unit/gateways/finansbank_test.rb
+++ b/test/unit/gateways/finansbank_test.rb
@@ -7,18 +7,18 @@ class FinansbankTest < Test::Unit::TestCase
     @original_kcode = nil
 
     @gateway = FinansbankGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :client_id => 'client_id'
+      login: 'login',
+      password: 'password',
+      client_id: 'client_id'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -7,16 +7,16 @@ class FirstdataE4Test < Test::Unit::TestCase
 
   def setup
     @gateway = FirstdataE4Gateway.new(
-      :login    => 'A00427-01',
-      :password => 'testus'
+      login: 'A00427-01',
+      password: 'testus'
     )
 
     @credit_card = credit_card
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @authorization = 'ET1700;106625152;4738'
   end

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -7,18 +7,18 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
   def setup
     @gateway = FirstdataE4V27Gateway.new(
-      :login    => 'A00427-01',
-      :password => 'testus',
-      :key_id   => '12345',
-      :hmac_key => 'hexkey'
+      login: 'A00427-01',
+      password: 'testus',
+      key_id: '12345',
+      hmac_key: 'hexkey'
     )
 
     @credit_card = credit_card
     @amount = 100
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @authorization = 'ET1700;106625152;4738'
   end

--- a/test/unit/gateways/flo2cash_simple_test.rb
+++ b/test/unit/gateways/flo2cash_simple_test.rb
@@ -7,9 +7,9 @@ class Flo2cashSimpleTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = Flo2cashSimpleGateway.new(
-      :username => 'username',
-      :password => 'password',
-      :account_id => 'account_id'
+      username: 'username',
+      password: 'password',
+      account_id: 'account_id'
     )
 
     @credit_card = credit_card

--- a/test/unit/gateways/flo2cash_test.rb
+++ b/test/unit/gateways/flo2cash_test.rb
@@ -7,9 +7,9 @@ class Flo2cashTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = Flo2cashGateway.new(
-      :username => 'username',
-      :password => 'password',
-      :account_id => 'account_id'
+      username: 'username',
+      password: 'password',
+      account_id: 'account_id'
     )
 
     @credit_card = credit_card

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -28,7 +28,7 @@ class ForteTest < Test::Unit::TestCase
 
   def test_purchase_passes_options
     options = { order_id: '1' }
-    @gateway.expects(:commit).with(anything, has_entries(:order_number => '1'))
+    @gateway.expects(:commit).with(anything, has_entries(order_number: '1'))
 
     stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)

--- a/test/unit/gateways/garanti_test.rb
+++ b/test/unit/gateways/garanti_test.rb
@@ -7,15 +7,15 @@ class GarantiTest < Test::Unit::TestCase
     @original_kcode = nil
 
     Base.mode = :test
-    @gateway = GarantiGateway.new(:login => 'a', :password => 'b', :terminal_id => 'c', :merchant_id => 'd')
+    @gateway = GarantiGateway.new(login: 'a', password: 'b', terminal_id: 'c', merchant_id: 'd')
 
     @credit_card = credit_card(4242424242424242)
     @amount = 1000 # 1000 cents, 10$
 
     @options = {
-      :order_id => 'db4af18c5222503d845180350fbda516',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: 'db4af18c5222503d845180350fbda516',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -54,12 +54,12 @@ class GatewayTest < Test::Unit::TestCase
   end
 
   def test_card_brand
-    credit_card = stub(:brand => 'visa')
+    credit_card = stub(brand: 'visa')
     assert_equal 'visa', Gateway.card_brand(credit_card)
   end
 
   def test_card_brand_using_type
-    credit_card = stub(:type => 'String')
+    credit_card = stub(type: 'String')
     assert_equal 'string', Gateway.card_brand(credit_card)
   end
 

--- a/test/unit/gateways/hdfc_test.rb
+++ b/test/unit/gateways/hdfc_test.rb
@@ -7,8 +7,8 @@ class HdfcTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = HdfcGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
@@ -81,7 +81,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_currency
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :currency => 'INR')
+      @gateway.purchase(@amount, @credit_card, currency: 'INR')
     end.check_request do |endpoint, data, headers|
       assert_match(/currencycode>356</, data)
     end.respond_with(successful_purchase_response)
@@ -89,13 +89,13 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_invalid_currency
     assert_raise(ArgumentError, 'Unsupported currency for HDFC: AOA') do
-      @gateway.purchase(@amount, @credit_card, :currency => 'AOA')
+      @gateway.purchase(@amount, @credit_card, currency: 'AOA')
     end
   end
 
   def test_passing_order_id
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :order_id => '932823723')
+      @gateway.purchase(@amount, @credit_card, order_id: '932823723')
     end.check_request do |endpoint, data, headers|
       assert_match(/932823723/, data)
     end.respond_with(successful_purchase_response)
@@ -103,7 +103,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_description
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :description => 'Awesome Services By Us')
+      @gateway.purchase(@amount, @credit_card, description: 'Awesome Services By Us')
     end.check_request do |endpoint, data, headers|
       assert_match(/Awesome Services By Us/, data)
     end.respond_with(successful_purchase_response)
@@ -111,7 +111,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_escaping
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :order_id => 'a' * 41, :description => "This has 'Hack Characters' ~`!\#$%^=+|\\:'\",;<>{}[]() and non-Hack Characters -_@.")
+      @gateway.purchase(@amount, @credit_card, order_id: 'a' * 41, description: "This has 'Hack Characters' ~`!\#$%^=+|\\:'\",;<>{}[]() and non-Hack Characters -_@.")
     end.check_request do |endpoint, data, headers|
       assert_match(/>This has Hack Characters  and non-Hack Characters -_@.</, data)
       assert_match(/>#{"a" * 40}</, data)
@@ -120,7 +120,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_billing_address
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/udf4>Jim Smith\nWidgets Inc\n456 My Street\nApt 1\nOttawa ON K1C2N6\nCA/, data)
     end.respond_with(successful_purchase_response)
@@ -128,7 +128,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_phone_number
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/udf3>555555-5555</, data)
     end.respond_with(successful_purchase_response)
@@ -136,7 +136,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_billing_address_without_phone
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address(:phone => nil))
+      @gateway.purchase(@amount, @credit_card, billing_address: address(phone: nil))
     end.check_request do |endpoint, data, headers|
       assert_no_match(/udf3/, data)
     end.respond_with(successful_purchase_response)
@@ -144,7 +144,7 @@ class HdfcTest < Test::Unit::TestCase
 
   def test_passing_eci
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :eci => 22)
+      @gateway.purchase(@amount, @credit_card, eci: 22)
     end.check_request do |endpoint, data, headers|
       assert_match(/eci>22</, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -4,7 +4,7 @@ class HpsTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = HpsGateway.new({:secret_api_key => '12'})
+    @gateway = HpsGateway.new({secret_api_key: '12'})
 
     @credit_card = credit_card
     @amount = 100
@@ -332,10 +332,10 @@ class HpsTest < Test::Unit::TestCase
     @credit_card.brand = 'visa'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -359,10 +359,10 @@ class HpsTest < Test::Unit::TestCase
     @credit_card.brand = 'master'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -386,10 +386,10 @@ class HpsTest < Test::Unit::TestCase
     @credit_card.brand = 'discover'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '5',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '5',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -413,10 +413,10 @@ class HpsTest < Test::Unit::TestCase
     @credit_card.brand = 'american_express'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '05',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '05',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 
@@ -440,10 +440,10 @@ class HpsTest < Test::Unit::TestCase
     @credit_card.brand = 'jcb'
 
     options = {
-      :three_d_secure => {
-        :cavv => 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-        :eci => '5',
-        :xid => 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
+      three_d_secure: {
+        cavv: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+        eci: '5',
+        xid: 'TTBCSkVTa1ZpbDI1bjRxbGk5ODE='
       }
     }
 

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -5,18 +5,18 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
   def setup
     @gateway = IatsPaymentsGateway.new(
-      :agent_code => 'login',
-      :password => 'password',
-      :region => 'uk'
+      agent_code: 'login',
+      password: 'password',
+      region: 'uk'
     )
     @amount = 100
     @credit_card = credit_card
     @check = check
     @options = {
-      :ip => '71.65.249.145',
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :description => 'Store purchase'
+      ip: '71.65.249.145',
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase'
     }
   end
 
@@ -205,8 +205,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_deprecated_options
     assert_deprecation_warning("The 'login' option is deprecated in favor of 'agent_code' and will be removed in a future version.") do
       @gateway = IatsPaymentsGateway.new(
-        :login => 'login',
-        :password => 'password'
+        login: 'login',
+        password: 'password'
       )
     end
 
@@ -223,9 +223,9 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
   def test_region_urls
     @gateway = IatsPaymentsGateway.new(
-      :agent_code => 'code',
-      :password => 'password',
-      :region => 'na' # North america
+      agent_code: 'code',
+      password: 'password',
+      region: 'na' # North america
     )
 
     response = stub_comms do

--- a/test/unit/gateways/in_context_paypal_express_test.rb
+++ b/test/unit/gateways/in_context_paypal_express_test.rb
@@ -8,9 +8,9 @@ class InContextPaypalExpressTest < Test::Unit::TestCase
 
   def setup
     @gateway = InContextPaypalExpressGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
 
     Base.mode = :test

--- a/test/unit/gateways/inspire_test.rb
+++ b/test/unit/gateways/inspire_test.rb
@@ -5,12 +5,12 @@ class InspireTest < Test::Unit::TestCase
 
   def setup
     @gateway = InspireGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :billing_address => address }
+    @options = { billing_address: address }
   end
 
   def test_successful_purchase
@@ -60,7 +60,7 @@ class InspireTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, nil, :billing_address => {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
+    @gateway.send(:add_address, result, nil, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
     assert_equal ['address1', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result[:state]
     assert_equal '164 Waverley Street', result[:address1]
@@ -78,7 +78,7 @@ class InspireTest < Test::Unit::TestCase
   def test_adding_store_adds_vault_id_flag
     result = {}
 
-    @gateway.send(:add_creditcard, result, @credit_card, :store => true)
+    @gateway.send(:add_creditcard, result, @credit_card, store: true)
     assert_equal ['ccexp', 'ccnumber', 'customer_vault', 'cvv', 'firstname', 'lastname'], result.stringify_keys.keys.sort
     assert_equal 'add_customer', result[:customer_vault]
   end
@@ -93,11 +93,11 @@ class InspireTest < Test::Unit::TestCase
 
   def test_accept_check
     post = {}
-    check = Check.new(:name => 'Fred Bloggs',
-                      :routing_number => '111000025',
-                      :account_number => '123456789012',
-                      :account_holder_type => 'personal',
-                      :account_type => 'checking')
+    check = Check.new(name: 'Fred Bloggs',
+                      routing_number: '111000025',
+                      account_number: '123456789012',
+                      account_holder_type: 'personal',
+                      account_type: 'checking')
     @gateway.send(:add_check, post, check)
     assert_equal %w[account_holder_type account_type checkaba checkaccount checkname payment], post.stringify_keys.keys.sort
   end

--- a/test/unit/gateways/instapay_test.rb
+++ b/test/unit/gateways/instapay_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class InstapayTest < Test::Unit::TestCase
   def setup
-    @gateway = InstapayGateway.new(:login => 'TEST0')
+    @gateway = InstapayGateway.new(login: 'TEST0')
     @credit_card = credit_card
     @amount = 100
   end

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -4,15 +4,15 @@ class IridiumTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
 
-    @gateway = IridiumGateway.new(:login => 'login', :password => 'password')
+    @gateway = IridiumGateway.new(login: 'login', password: 'password')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -89,7 +89,7 @@ class IridiumTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).
       with(anything, all_of(regexp_matches(/Amount="400"/), regexp_matches(/CurrencyCode="484"/)), anything).
       returns(successful_purchase_response)
-    assert_success @gateway.purchase(400, @credit_card, @options.merge(:currency => 'MXN'))
+    assert_success @gateway.purchase(400, @credit_card, @options.merge(currency: 'MXN'))
   end
 
   def test_do_not_depend_on_expiry_date_class
@@ -102,7 +102,7 @@ class IridiumTest < Test::Unit::TestCase
   def test_use_ducktyping_for_credit_card
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
-    credit_card = stub(:number => '4242424242424242', :verification_value => '123', :name => 'Hans Tester', :year => 2012, :month => 1)
+    credit_card = stub(number: '4242424242424242', verification_value: '123', name: 'Hans Tester', year: 2012, month: 1)
 
     assert_nothing_raised do
       assert_success @gateway.purchase(@amount, credit_card, @options)

--- a/test/unit/gateways/itransact_test.rb
+++ b/test/unit/gateways/itransact_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class ItransactTest < Test::Unit::TestCase
   def setup
     @gateway = ItransactGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :gateway_id => '09999'
+      login: 'login',
+      password: 'password',
+      gateway_id: '09999'
     )
 
     @credit_card = credit_card
@@ -13,11 +13,11 @@ class ItransactTest < Test::Unit::TestCase
     @amount = 1014 # = $10.14
 
     @options = {
-      :email => 'name@domain.com',
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :email_text => ['line1', 'line2', 'line3']
+      email: 'name@domain.com',
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      email_text: ['line1', 'line2', 'line3']
     }
   end
 

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -6,18 +6,18 @@ class JetpayTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
 
-    @gateway = JetpayGateway.new(:login => 'login')
+    @gateway = JetpayGateway.new(login: 'login')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :billing_address => address(:country => 'US'),
-      :shipping_address => address(:country => 'US'),
-      :email => 'test@test.com',
-      :ip => '127.0.0.1',
-      :order_id => '12345',
-      :tax => 7
+      billing_address: address(country: 'US'),
+      shipping_address: address(country: 'US'),
+      email: 'test@test.com',
+      ip: '127.0.0.1',
+      order_id: '12345',
+      tax: 7
     }
   end
 
@@ -76,7 +76,7 @@ class JetpayTest < Test::Unit::TestCase
 
   def test_successful_credit
     # no need for csv
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
 
     @gateway.expects(:ssl_post).returns(successful_credit_response)
 
@@ -137,7 +137,7 @@ class JetpayTest < Test::Unit::TestCase
   def test_purchase_sends_order_origin
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<Origin>RECURRING<\/Origin>/)).returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, {:origin => 'RECURRING'})
+    @gateway.purchase(@amount, @credit_card, {origin: 'RECURRING'})
   end
 
   private

--- a/test/unit/gateways/jetpay_v2_test.rb
+++ b/test/unit/gateways/jetpay_v2_test.rb
@@ -2,20 +2,20 @@ require 'test_helper'
 
 class JetpayV2Test < Test::Unit::TestCase
   def setup
-    @gateway = JetpayV2Gateway.new(:login => 'login')
+    @gateway = JetpayV2Gateway.new(login: 'login')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :device => 'spreedly',
-      :application => 'spreedly',
-      :developer_id => 'GenkID',
-      :billing_address => address(:country => 'US'),
-      :shipping_address => address(:country => 'US'),
-      :email => 'test@test.com',
-      :ip => '127.0.0.1',
-      :order_id => '12345'
+      device: 'spreedly',
+      application: 'spreedly',
+      developer_id: 'GenkID',
+      billing_address: address(country: 'US'),
+      shipping_address: address(country: 'US'),
+      email: 'test@test.com',
+      ip: '127.0.0.1',
+      order_id: '12345'
     }
   end
 
@@ -88,7 +88,7 @@ class JetpayV2Test < Test::Unit::TestCase
   end
 
   def test_successful_credit
-    card = credit_card('4242424242424242', :verification_value => nil)
+    card = credit_card('4242424242424242', verification_value: nil)
 
     @gateway.expects(:ssl_post).returns(successful_credit_response)
 
@@ -97,7 +97,7 @@ class JetpayV2Test < Test::Unit::TestCase
   end
 
   def test_failed_credit
-    card = credit_card('2424242424242424', :verification_value => nil)
+    card = credit_card('2424242424242424', verification_value: nil)
 
     @gateway.expects(:ssl_post).returns(failed_credit_response)
 
@@ -132,7 +132,7 @@ class JetpayV2Test < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    card = credit_card('2424242424242424', :verification_value => nil)
+    card = credit_card('2424242424242424', verification_value: nil)
 
     @gateway.expects(:ssl_post).returns(failed_credit_response)
 
@@ -168,7 +168,7 @@ class JetpayV2Test < Test::Unit::TestCase
       with(anything, regexp_matches(/<UDField3>Value3<\/UDField3>/)).
       returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, {:tax => '777', :ud_field_1 => 'Value1', :ud_field_2 => 'Value2', :ud_field_3 => 'Value3'})
+    @gateway.purchase(@amount, @credit_card, {tax: '777', ud_field_1: 'Value1', ud_field_2: 'Value2', ud_field_3: 'Value3'})
   end
 
   private

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -2,19 +2,19 @@ require 'test_helper'
 
 class KomojuTest < Test::Unit::TestCase
   def setup
-    @gateway = KomojuGateway.new(:login => 'login')
+    @gateway = KomojuGateway.new(login: 'login')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :description => 'Store Purchase',
-      :tax => '10',
-      :ip => '192.168.0.1',
-      :email => 'valid@email.com',
-      :browser_language => 'en',
-      :browser_user_agent => 'user_agent'
+      order_id: '1',
+      description: 'Store Purchase',
+      tax: '10',
+      ip: '192.168.0.1',
+      email: 'valid@email.com',
+      browser_language: 'en',
+      browser_user_agent: 'user_agent'
     }
   end
 

--- a/test/unit/gateways/linkpoint_test.rb
+++ b/test/unit/gateways/linkpoint_test.rb
@@ -5,13 +5,13 @@ class LinkpointTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = LinkpointGateway.new(
-      :login => 123123,
-      :pem => 'PEM'
+      login: 123123,
+      pem: 'PEM'
     )
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
-    @options = { :order_id => 1000, :billing_address => address }
+    @options = { order_id: 1000, billing_address: address }
   end
 
   def test_instantiating_without_credential_raises
@@ -65,7 +65,7 @@ class LinkpointTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(2400, @credit_card, :order_id => 1003, :installments => 12, :startdate => 'immediate', :periodicity => :monthly)
+      @gateway.recurring(2400, @credit_card, order_id: 1003, installments: 12, startdate: 'immediate', periodicity: :monthly)
     end
     assert_success response
   end
@@ -81,13 +81,13 @@ class LinkpointTest < Test::Unit::TestCase
   def test_purchase_is_valid_xml
     @gateway.send(
       :parameters, 1000, @credit_card,
-      :ordertype => 'SALE',
-      :order_id => 1004,
-      :billing_address => {
-        :address1 => '1313 lucky lane',
-        :city => 'Lost Angeles',
-        :state => 'CA',
-        :zip => '90210'
+      ordertype: 'SALE',
+      order_id: 1004,
+      billing_address: {
+        address1: '1313 lucky lane',
+        city: 'Lost Angeles',
+        state: 'CA',
+        zip: '90210'
       }
     )
 
@@ -98,17 +98,17 @@ class LinkpointTest < Test::Unit::TestCase
   def test_recurring_is_valid_xml
     @gateway.send(
       :parameters, 1000, @credit_card,
-      :ordertype => 'SALE',
-      :action => 'SUBMIT',
-      :installments => 12,
-      :startdate => 'immediate',
-      :periodicity => 'monthly',
-      :order_id => 1006,
-      :billing_address => {
-        :address1 => '1313 lucky lane',
-        :city => 'Lost Angeles',
-        :state => 'CA',
-        :zip => '90210'
+      ordertype: 'SALE',
+      action: 'SUBMIT',
+      installments: 12,
+      startdate: 'immediate',
+      periodicity: 'monthly',
+      order_id: 1006,
+      billing_address: {
+        address1: '1313 lucky lane',
+        city: 'Lost Angeles',
+        state: 'CA',
+        zip: '90210'
       }
     )
     assert data = @gateway.send(:post_data, @amount, @credit_card, @options)
@@ -117,40 +117,40 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_line_items_are_valid_xml
     options = {
-      :ordertype => 'SALE',
-      :action => 'SUBMIT',
-      :installments => 12,
-      :startdate => 'immediate',
-      :periodicity => 'monthly',
-      :order_id => 1006,
-      :billing_address => {
-        :address1 => '1313 lucky lane',
-        :city => 'Lost Angeles',
-        :state => 'CA',
-        :zip => '90210'
+      ordertype: 'SALE',
+      action: 'SUBMIT',
+      installments: 12,
+      startdate: 'immediate',
+      periodicity: 'monthly',
+      order_id: 1006,
+      billing_address: {
+        address1: '1313 lucky lane',
+        city: 'Lost Angeles',
+        state: 'CA',
+        zip: '90210'
       },
-      :line_items => [
+      line_items: [
         {
-          :id => '123456',
-          :description => 'Logo T-Shirt',
-          :price => '12.00',
-          :quantity => '1',
-          :options => [
+          id: '123456',
+          description: 'Logo T-Shirt',
+          price: '12.00',
+          quantity: '1',
+          options: [
             {
-              :name => 'Color',
-              :value => 'Red'
+              name: 'Color',
+              value: 'Red'
             },
             {
-              :name => 'Size',
-              :value => 'XL'
+              name: 'Size',
+              value: 'XL'
             }
           ]
         },
         {
-          :id => '111',
-          :description => 'keychain',
-          :price => '3.00',
-          :quantity => '1'
+          id: '111',
+          description: 'keychain',
+          price: '3.00',
+          quantity: '1'
         }
       ]
     }
@@ -160,17 +160,17 @@ class LinkpointTest < Test::Unit::TestCase
   end
 
   def test_declined_purchase_is_valid_xml
-    @gateway = LinkpointGateway.new(:login => 123123, :pem => 'PEM')
+    @gateway = LinkpointGateway.new(login: 123123, pem: 'PEM')
 
     @gateway.send(
       :parameters, 1000, @credit_card,
-      :ordertype => 'SALE',
-      :order_id => 1005,
-      :billing_address => {
-        :address1 => '1313 lucky lane',
-        :city => 'Lost Angeles',
-        :state => 'CA',
-        :zip => '90210'
+      ordertype: 'SALE',
+      order_id: 1005,
+      billing_address: {
+        address1: '1313 lucky lane',
+        city: 'Lost Angeles',
+        state: 'CA',
+        zip: '90210'
       }
     )
 
@@ -182,9 +182,9 @@ class LinkpointTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = LinkpointGateway.new(
-      :login => 'LOGIN',
-      :pem => 'PEM',
-      :test => true
+      login: 'LOGIN',
+      pem: 'PEM',
+      test: true
     )
 
     assert gateway.test?
@@ -194,8 +194,8 @@ class LinkpointTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = LinkpointGateway.new(
-      :login => 'LOGIN',
-      :pem => 'PEM'
+      login: 'LOGIN',
+      pem: 'PEM'
     )
 
     assert !gateway.test?

--- a/test/unit/gateways/maxipago_test.rb
+++ b/test/unit/gateways/maxipago_test.rb
@@ -3,18 +3,18 @@ require 'test_helper'
 class MaxipagoTest < Test::Unit::TestCase
   def setup
     @gateway = MaxipagoGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :installments => 3
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      installments: 3
     }
   end
 

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -7,25 +7,25 @@ class MercadoPagoTest < Test::Unit::TestCase
     @gateway = MercadoPagoGateway.new(access_token: 'access_token')
     @credit_card = credit_card
     @elo_credit_card = credit_card('5067268650517446',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737'
     )
     @cabal_credit_card = credit_card('6035227716427021',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737'
     )
     @naranja_credit_card = credit_card('5895627823453005',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '123'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '123'
     )
     @amount = 100
 

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -7,17 +7,17 @@ class MerchantESolutionsTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = MerchantESolutionsGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -143,7 +143,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
 
   def test_visa_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:xid => '1', :cavv => '2'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({xid: '1', cavv: '2'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/xid=1/, data)
       assert_match(/cavv=2/, data)
@@ -152,7 +152,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
 
   def test_mastercard_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:ucaf_collection_ind => '1', :ucaf_auth_data => '2'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ucaf_collection_ind: '1', ucaf_auth_data: '2'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/ucaf_collection_ind=1/, data)
       assert_match(/ucaf_auth_data=2/, data)

--- a/test/unit/gateways/merchant_one_test.rb
+++ b/test/unit/gateways/merchant_one_test.rb
@@ -6,17 +6,17 @@ class MerchantOneTest < Test::Unit::TestCase
     @credit_card = credit_card
     @amount = 1000
     @options = {
-      :order_id => '1',
-      :description => 'Store Purchase',
-      :billing_address => {
-        :name =>'Jim Smith',
-        :address1 =>'1234 My Street',
-        :address2 =>'Apt 1',
-        :city =>'Tampa',
-        :state =>'FL',
-        :zip =>'33603',
-        :country =>'US',
-        :phone =>'(813)421-4331'
+      order_id: '1',
+      description: 'Store Purchase',
+      billing_address: {
+        name: 'Jim Smith',
+        address1: '1234 My Street',
+        address2: 'Apt 1',
+        city: 'Tampa',
+        state: 'FL',
+        zip: '33603',
+        country: 'US',
+        phone: '(813)421-4331'
       }
     }
   end

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -5,17 +5,17 @@ class MerchantWareTest < Test::Unit::TestCase
 
   def setup
     @gateway = MerchantWareGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :name => 'name'
+      login: 'login',
+      password: 'password',
+      name: 'name'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address
+      order_id: '1',
+      billing_address: address
     }
   end
 
@@ -32,7 +32,7 @@ class MerchantWareTest < Test::Unit::TestCase
   end
 
   def test_soap_fault_during_authorization
-    response_500 = stub(:code => '500', :message => 'Internal Server Error', :body => fault_authorization_response)
+    response_500 = stub(code: '500', message: 'Internal Server Error', body: fault_authorization_response)
     @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response_500))
 
     assert response = @gateway.authorize(@amount, @credit_card, @options)
@@ -110,7 +110,7 @@ class MerchantWareTest < Test::Unit::TestCase
 
   def test_add_swipe_data_with_creditcard
     @credit_card.track_data = 'Track Data'
-    options = {:order_id => '1'}
+    options = {order_id: '1'}
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|

--- a/test/unit/gateways/merchant_ware_version_four_test.rb
+++ b/test/unit/gateways/merchant_ware_version_four_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class MerchantWareVersionFourTest < Test::Unit::TestCase
   def setup
     @gateway = MerchantWareVersionFourGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :name => 'name'
+      login: 'login',
+      password: 'password',
+      name: 'name'
     )
 
     @credit_card = credit_card
@@ -13,8 +13,8 @@ class MerchantWareVersionFourTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address
+      order_id: '1',
+      billing_address: address
     }
   end
 
@@ -31,7 +31,7 @@ class MerchantWareVersionFourTest < Test::Unit::TestCase
   end
 
   def test_soap_fault_during_authorization
-    response_400 = stub(:code => '400', :message => 'Bad Request', :body => failed_authorize_response)
+    response_400 = stub(code: '400', message: 'Bad Request', body: failed_authorize_response)
     @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response_400))
 
     assert response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -5,9 +5,9 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
   def setup
     @gateway = MerchantWarriorGateway.new(
-      :merchant_uuid => '4e922de8c2a4c',
-      :api_key => 'g6jrxa9o',
-      :api_passphrase => 'vp4ujoem'
+      merchant_uuid: '4e922de8c2a4c',
+      api_key: 'g6jrxa9o',
+      api_passphrase: 'vp4ujoem'
     )
 
     @credit_card = credit_card
@@ -16,8 +16,8 @@ class MerchantWarriorTest < Test::Unit::TestCase
     @failure_amount = 10033
 
     @options = {
-      :address => address,
-      :transaction_product => 'TestProduct'
+      address: address,
+      transaction_product: 'TestProduct'
     }
   end
 

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -9,11 +9,11 @@ class MercuryTest < Test::Unit::TestCase
     @gateway = MercuryGateway.new(fixtures(:mercury))
 
     @amount = 100
-    @credit_card = credit_card('5499990123456781', :brand => 'master')
+    @credit_card = credit_card('5499990123456781', brand: 'master')
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      :order_id => 'c111111111.1'
+      order_id: 'c111111111.1'
     }
   end
 

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -5,11 +5,11 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def setup
     @gateway = ActiveMerchant::Billing::MetricsGlobalGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
     @amount = 100
-    @credit_card = credit_card('4111111111111111', :verification_value => '999')
+    @credit_card = credit_card('4111111111111111', verification_value: '999')
     @subscription_id = '100748'
     @subscription_status = 'active'
   end
@@ -44,7 +44,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = {}
 
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'DE', :state => ''})
+    @gateway.send(:add_address, result, billing_address: {address1: '164 Waverley Street', country: 'DE', state: ''})
 
     assert_equal ['address', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'n/a', result[:state]
@@ -55,7 +55,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
+    @gateway.send(:add_address, result, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
 
     assert_equal ['address', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'CO', result[:state]
@@ -65,13 +65,13 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_add_invoice
     result = {}
-    @gateway.send(:add_invoice, result, :order_id => '#1001')
+    @gateway.send(:add_invoice, result, order_id: '#1001')
     assert_equal '#1001', result[:invoice_num]
   end
 
   def test_add_description
     result = {}
-    @gateway.send(:add_invoice, result, :description => 'My Purchase is great')
+    @gateway.send(:add_invoice, result, description: 'My Purchase is great')
     assert_equal 'My Purchase is great', result[:description]
   end
 
@@ -90,7 +90,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   end
 
   def test_purchase_is_valid_csv
-    params = { :amount => '1.01' }
+    params = { amount: '1.01' }
 
     @gateway.send(:add_creditcard, params, @credit_card)
 
@@ -100,7 +100,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_purchase_meets_minimum_requirements
     params = {
-      :amount => '1.01',
+      amount: '1.01',
     }
 
     @gateway.send(:add_creditcard, params, @credit_card)
@@ -113,14 +113,14 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_successful_refund
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.refund(@amount, '123456789', :card_number => @credit_card.number)
+    assert response = @gateway.refund(@amount, '123456789', card_number: @credit_card.number)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
   end
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', :card_number => @credit_card.number, :first_name => 'Bob', :last_name => 'Smith', :zip => '12345')
+      @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345')
     end.check_request do |endpoint, data, headers|
       assert_match(/x_first_name=Bob/, data)
       assert_match(/x_last_name=Smith/, data)
@@ -132,7 +132,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 
-    assert response = @gateway.refund(@amount, '123456789', :card_number => @credit_card.number)
+    assert response = @gateway.refund(@amount, '123456789', card_number: @credit_card.number)
     assert_failure response
     assert_equal 'The referenced transaction does not meet the criteria for issuing a credit', response.message
   end
@@ -140,7 +140,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_deprecated_credit
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
-      assert response = @gateway.credit(@amount, '123456789', :card_number => @credit_card.number)
+      assert response = @gateway.credit(@amount, '123456789', card_number: @credit_card.number)
       assert_success response
       assert_equal 'This transaction has been approved', response.message
     end
@@ -188,11 +188,11 @@ class MetricsGlobalTest < Test::Unit::TestCase
       public :message_from
     }
     result = {
-      :response_code => 2,
-      :card_code => 'N',
-      :avs_result_code => 'A',
-      :response_reason_code => '27',
-      :response_reason_text => 'Failure.',
+      response_code: 2,
+      card_code: 'N',
+      avs_result_code: 'A',
+      response_reason_code: '27',
+      response_reason_text: 'Failure.',
     }
     assert_equal 'CVV does not match', @gateway.message_from(result)
 

--- a/test/unit/gateways/modern_payments_cim_test.rb
+++ b/test/unit/gateways/modern_payments_cim_test.rb
@@ -5,17 +5,17 @@ class ModernPaymentsCimTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = ModernPaymentsCimGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -7,13 +7,13 @@ class MonerisTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = MonerisGateway.new(
-      :login => 'store3',
-      :password => 'yesguy'
+      login: 'store3',
+      password: 'yesguy'
     )
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = { :order_id => '1', :customer => '1', :billing_address => address}
+    @options = { order_id: '1', customer: '1', billing_address: address}
   end
 
   def test_default_options
@@ -32,8 +32,8 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_successful_first_purchase_with_credential_on_file
     gateway = MonerisGateway.new(
-      :login => 'store3',
-      :password => 'yesguy'
+      login: 'store3',
+      password: 'yesguy'
     )
     gateway.expects(:ssl_post).returns(successful_first_cof_purchase_response)
     assert response = gateway.purchase(
@@ -53,8 +53,8 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_successful_subsequent_purchase_with_credential_on_file
     gateway = MonerisGateway.new(
-      :login => 'store3',
-      :password => 'yesguy'
+      login: 'store3',
+      password: 'yesguy'
     )
     gateway.expects(:ssl_post).returns(successful_first_cof_authorize_response)
     assert response = gateway.authorize(
@@ -129,11 +129,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_preauth_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'preauth', params)
@@ -143,11 +143,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_purchase_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'purchase', params)
@@ -157,11 +157,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_capture_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'preauth', params)
@@ -231,7 +231,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_purchase_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.purchase(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
+    assert response = @gateway.purchase(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?
@@ -251,7 +251,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_authorization_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.authorize(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
+    assert response = @gateway.authorize(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?

--- a/test/unit/gateways/moneris_us_test.rb
+++ b/test/unit/gateways/moneris_us_test.rb
@@ -7,8 +7,8 @@ class MonerisUsTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = MonerisUsGateway.new(
-      :login => 'monusqa002',
-      :password => 'qatoken'
+      login: 'monusqa002',
+      password: 'qatoken'
     )
 
     @amount = 100
@@ -18,7 +18,7 @@ class MonerisUsTest < Test::Unit::TestCase
       account_number: '1234455',
       number: 123
     })
-    @options = { :order_id => '1', :billing_address => address }
+    @options = { order_id: '1', billing_address: address }
   end
 
   def test_default_options
@@ -99,11 +99,11 @@ class MonerisUsTest < Test::Unit::TestCase
 
   def test_preauth_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'us_preauth', params)
@@ -113,11 +113,11 @@ class MonerisUsTest < Test::Unit::TestCase
 
   def test_purchase_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'us_purchase', params)
@@ -127,11 +127,11 @@ class MonerisUsTest < Test::Unit::TestCase
 
   def test_capture_is_valid_xml
     params = {
-      :order_id => 'order1',
-      :amount => '1.01',
-      :pan => '4242424242424242',
-      :expdate => '0303',
-      :crypt_type => 7,
+      order_id: 'order1',
+      amount: '1.01',
+      pan: '4242424242424242',
+      expdate: '0303',
+      crypt_type: 7,
     }
 
     assert data = @gateway.send(:post_data, 'us_preauth', params)
@@ -183,7 +183,7 @@ class MonerisUsTest < Test::Unit::TestCase
   def test_successful_purchase_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.purchase(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
+    assert response = @gateway.purchase(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?
@@ -192,7 +192,7 @@ class MonerisUsTest < Test::Unit::TestCase
   def test_successful_authorization_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.authorize(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
+    assert response = @gateway.authorize(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?

--- a/test/unit/gateways/money_movers_test.rb
+++ b/test/unit/gateways/money_movers_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class MoneyMoversTest < Test::Unit::TestCase
   def setup
     @gateway = MoneyMoversGateway.new(
-      :login => 'demo',
-      :password => 'password'
+      login: 'demo',
+      password: 'password'
     )
 
     @credit_card = credit_card('4111111111111111')
@@ -12,9 +12,9 @@ class MoneyMoversTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -44,7 +44,7 @@ class MoneyMoversTest < Test::Unit::TestCase
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, :billing_address => {:address1 => '1 Main St.', :address2 => 'apt 13', :country => 'US', :state => 'MI', :phone => '1234567890'})
+    @gateway.send(:add_address, result, billing_address: {address1: '1 Main St.', address2: 'apt 13', country: 'US', state: 'MI', phone: '1234567890'})
     assert_equal ['address1', 'address2', 'city', 'company', 'country', 'phone', 'state', 'zip'], result.stringify_keys.keys.sort
     assert_equal 'MI', result[:state]
     assert_equal '1 Main St.', result[:address1]
@@ -54,13 +54,13 @@ class MoneyMoversTest < Test::Unit::TestCase
 
   def test_add_invoice
     result = {}
-    @gateway.send(:add_invoice, result, :order_id => '#1001', :description => 'This is a great order')
+    @gateway.send(:add_invoice, result, order_id: '#1001', description: 'This is a great order')
     assert_equal '#1001', result[:orderid]
     assert_equal 'This is a great order', result[:orderdescription]
   end
 
   def test_purchase_is_valid_csv
-    params = {:amount => @amount}
+    params = {amount: @amount}
     @gateway.send(:add_creditcard, params, @credit_card)
 
     assert data = @gateway.send(:post_data, 'auth', params)
@@ -68,7 +68,7 @@ class MoneyMoversTest < Test::Unit::TestCase
   end
 
   def test_purchase_meets_minimum_requirements
-    params = {:amount => @amount}
+    params = {amount: @amount}
     @gateway.send(:add_creditcard, params, @credit_card)
     assert data = @gateway.send(:post_data, 'auth', params)
     minimum_requirements.each do |key|
@@ -77,8 +77,8 @@ class MoneyMoversTest < Test::Unit::TestCase
   end
 
   def test_expdate_formatting
-    assert_equal '0909', @gateway.send(:expdate, credit_card('4111111111111111', :month => '9', :year => '2009'))
-    assert_equal '0711', @gateway.send(:expdate, credit_card('4111111111111111', :month => '7', :year => '2011'))
+    assert_equal '0909', @gateway.send(:expdate, credit_card('4111111111111111', month: '9', year: '2009'))
+    assert_equal '0711', @gateway.send(:expdate, credit_card('4111111111111111', month: '7', year: '2011'))
   end
 
   def test_supported_countries

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -5,16 +5,16 @@ class NabTransactTest < Test::Unit::TestCase
 
   def setup
     @gateway = NabTransactGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
     @credit_card = credit_card
     @amount = 200
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Test NAB Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Test NAB Purchase'
     }
   end
 
@@ -33,7 +33,7 @@ class NabTransactTest < Test::Unit::TestCase
     name, location = 'Active Merchant', 'USA'
 
     response = assert_metadata(name, location) do
-      response = @gateway.purchase(@amount, @credit_card, @options.merge(:merchant_name => name, :merchant_location => location))
+      response = @gateway.purchase(@amount, @credit_card, @options.merge(merchant_name: name, merchant_location: location))
     end
 
     assert response
@@ -52,7 +52,7 @@ class NabTransactTest < Test::Unit::TestCase
     name, location = 'Active Merchant', 'USA'
 
     response = assert_metadata(name, location) do
-      response = @gateway.authorize(@amount, @credit_card, @options.merge(:merchant_name => name, :merchant_location => location))
+      response = @gateway.authorize(@amount, @credit_card, @options.merge(merchant_name: name, merchant_location: location))
     end
 
     assert response
@@ -71,7 +71,7 @@ class NabTransactTest < Test::Unit::TestCase
     name, location = 'Active Merchant', 'USA'
 
     response = assert_metadata(name, location) do
-      response = @gateway.capture(@amount, '009887*test*009887*200', @options.merge(:merchant_name => name, :merchant_location => location))
+      response = @gateway.capture(@amount, '009887*test*009887*200', @options.merge(merchant_name: name, merchant_location: location))
     end
 
     assert response
@@ -108,14 +108,14 @@ class NabTransactTest < Test::Unit::TestCase
 
   def test_successful_refund
     @gateway.expects(:ssl_post).with(&check_transaction_type(:refund)).returns(successful_refund_response)
-    assert_success @gateway.refund(@amount, '009887', {:order_id => '1'})
+    assert_success @gateway.refund(@amount, '009887', {order_id: '1'})
   end
 
   def test_successful_refund_with_merchant_descriptor
     name, location = 'Active Merchant', 'USA'
 
     response = assert_metadata(name, location) do
-      response = @gateway.refund(@amount, '009887', {:order_id => '1', :merchant_name => name, :merchant_location => location})
+      response = @gateway.refund(@amount, '009887', {order_id: '1', merchant_name: name, merchant_location: location})
     end
 
     assert response
@@ -125,13 +125,13 @@ class NabTransactTest < Test::Unit::TestCase
 
   def test_successful_credit
     @gateway.expects(:ssl_post).with(&check_transaction_type(:unmatched_refund)).returns(successful_refund_response)
-    assert_success @gateway.credit(@amount, @credit_card, {:order_id => '1'})
+    assert_success @gateway.credit(@amount, @credit_card, {order_id: '1'})
   end
 
   def test_failed_refund
     @gateway.expects(:ssl_post).with(&check_transaction_type(:refund)).returns(failed_refund_response)
 
-    response = @gateway.refund(@amount, '009887', {:order_id => '1'})
+    response = @gateway.refund(@amount, '009887', {order_id: '1'})
     assert_failure response
     assert_equal 'Only $1.00 available for refund', response.message
   end

--- a/test/unit/gateways/net_registry_test.rb
+++ b/test/unit/gateways/net_registry_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 class NetRegistryTest < Test::Unit::TestCase
   def setup
     @gateway = NetRegistryGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     @amount = 100
     @credit_card = credit_card
     @options = {
-      :order_id => '1',
-      :billing_address => address
+      order_id: '1',
+      billing_address: address
     }
   end
 
@@ -67,7 +67,7 @@ class NetRegistryTest < Test::Unit::TestCase
     assert_success response
     assert_match %r{\A\d{6}\z}, response.authorization
 
-    response = @gateway.capture(@amount, response.authorization, :credit_card => @credit_card)
+    response = @gateway.capture(@amount, response.authorization, credit_card: @credit_card)
     assert_success response
   end
 
@@ -96,7 +96,7 @@ class NetRegistryTest < Test::Unit::TestCase
   end
 
   def test_bad_login
-    gateway = NetRegistryGateway.new(:login => 'bad-login', :password => 'bad-login')
+    gateway = NetRegistryGateway.new(login: 'bad-login', password: 'bad-login')
     gateway.stubs(:ssl_post).returns(bad_login_response)
 
     response = gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/netaxept_test.rb
+++ b/test/unit/gateways/netaxept_test.rb
@@ -5,15 +5,15 @@ require 'test_helper'
 class NetaxeptTest < Test::Unit::TestCase
   def setup
     @gateway = NetaxeptGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1'
+      order_id: '1'
     }
   end
 
@@ -57,7 +57,7 @@ class NetaxeptTest < Test::Unit::TestCase
     @gateway.expects(:ssl_get).returns(successful_purchase_response[2]).in_sequence(s)
     @gateway.expects(:ssl_get).returns(successful_purchase_response[3]).in_sequence(s)
 
-    assert_success @gateway.purchase(100, @credit_card, @options.merge(:currency => 'USD'))
+    assert_success @gateway.purchase(100, @credit_card, @options.merge(currency: 'USD'))
   end
 
   def test_handles_currency_with_option
@@ -67,7 +67,7 @@ class NetaxeptTest < Test::Unit::TestCase
     @gateway.expects(:ssl_get).returns(successful_purchase_response[2]).in_sequence(s)
     @gateway.expects(:ssl_get).returns(successful_purchase_response[3]).in_sequence(s)
 
-    assert_success @gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
+    assert_success @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'USD'))
   end
 
   def test_handles_setup_transaction_error
@@ -91,7 +91,7 @@ class NetaxeptTest < Test::Unit::TestCase
   end
 
   def test_url_escape_password
-    @gateway = NetaxeptGateway.new(:login => 'login', :password => '1a=W+Yr2')
+    @gateway = NetaxeptGateway.new(login: 'login', password: '1a=W+Yr2')
 
     s = sequence('request')
     @gateway.expects(:ssl_get).with(regexp_matches(/token=1a%3DW%2BYr2/)).returns(successful_purchase_response[0]).in_sequence(s)

--- a/test/unit/gateways/netbilling_test.rb
+++ b/test/unit/gateways/netbilling_test.rb
@@ -4,11 +4,11 @@ class NetbillingTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = NetbillingGateway.new(:login => 'login')
+    @gateway = NetbillingGateway.new(login: 'login')
 
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :billing_address => address }
+    @options = { billing_address: address }
   end
 
   def test_successful_request
@@ -43,7 +43,7 @@ class NetbillingTest < Test::Unit::TestCase
   end
 
   def test_site_tag_sent_if_provided
-    @gateway = NetbillingGateway.new(:login => 'login', :site_tag => 'dummy-site-tag')
+    @gateway = NetbillingGateway.new(login: 'login', site_tag: 'dummy-site-tag')
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/netpay_test.rb
+++ b/test/unit/gateways/netpay_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class NetpayTest < Test::Unit::TestCase
   def setup
     @gateway = NetpayGateway.new(
-      :store_id => '12345',
-      :login    => 'login',
-      :password => 'password'
+      store_id: '12345',
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
@@ -14,7 +14,7 @@ class NetpayTest < Test::Unit::TestCase
     @order_id = 'C3836048-631F-112B-001E-7C08C0406975'
 
     @options = {
-      :description => 'Store Purchase'
+      description: 'Store Purchase'
     }
   end
 
@@ -64,7 +64,7 @@ class NetpayTest < Test::Unit::TestCase
       )
     ).returns(successful_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, :ip => '127.0.0.1')
+    assert response = @gateway.purchase(@amount, @credit_card, ip: '127.0.0.1')
     assert_success response
   end
 

--- a/test/unit/gateways/network_merchants_test.rb
+++ b/test/unit/gateways/network_merchants_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class NetworkMerchantsTest < Test::Unit::TestCase
   def setup
     @gateway = NetworkMerchantsGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
@@ -12,9 +12,9 @@ class NetworkMerchantsTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -60,7 +60,7 @@ class NetworkMerchantsTest < Test::Unit::TestCase
   def test_purchase_and_store
     @gateway.expects(:ssl_post).returns(successful_purchase_and_store)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:store => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(store: true))
     assert_success response
     assert_equal 'SUCCESS', response.message
     assert_equal '1378262091', response.params['customer_vault_id']
@@ -156,7 +156,7 @@ class NetworkMerchantsTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = NetworkMerchantsGateway.new(:login => '', :password => '')
+    gateway = NetworkMerchantsGateway.new(login: '', password: '')
     gateway.expects(:ssl_post).returns(failed_login)
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -2,23 +2,23 @@ require 'test_helper'
 
 class OgoneTest < Test::Unit::TestCase
   def setup
-    @credentials = { :login => 'pspid',
-                     :user => 'username',
-                     :password => 'password',
-                     :signature => 'mynicesig',
-                     :signature_encryptor => 'sha512',
-                     :timeout => '30' }
+    @credentials = { login: 'pspid',
+                     user: 'username',
+                     password: 'password',
+                     signature: 'mynicesig',
+                     signature_encryptor: 'sha512',
+                     timeout: '30' }
 
     @gateway = OgoneGateway.new(@credentials)
     @credit_card = credit_card
-    @mastercard  = credit_card('5399999999999999', :brand => 'mastercard')
+    @mastercard  = credit_card('5399999999999999', brand: 'mastercard')
     @amount = 100
     @identification = '3014726'
     @billing_id = 'myalias'
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
     @parameters = {
       'orderID' => '1',
@@ -56,7 +56,7 @@ class OgoneTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:action => 'SAS'))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(action: 'SAS'))
     assert_success response
     assert_equal '3014726;SAS', response.authorization
     assert response.params['HTML_ANSWER'].nil?
@@ -76,7 +76,7 @@ class OgoneTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '4')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:eci => 4))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(eci: 4))
     assert_success response
     assert_equal '3014726;SAL', response.authorization
     assert response.test?
@@ -84,7 +84,7 @@ class OgoneTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_3dsecure
     @gateway.expects(:ssl_post).returns(successful_3dsecure_purchase_response)
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:d3d => true))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(d3d: true))
     assert_success response
     assert_equal '3014726;SAL', response.authorization
     assert response.params['HTML_ANSWER']
@@ -126,7 +126,7 @@ class OgoneTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '4')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:eci => 4))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(eci: 4))
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert response.test?
@@ -134,7 +134,7 @@ class OgoneTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_3dsecure
     @gateway.expects(:ssl_post).returns(successful_3dsecure_purchase_response)
-    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:d3d => true))
+    assert response = @gateway.authorize(@amount, @credit_card, @options.merge(d3d: true))
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert response.params['HTML_ANSWER']
@@ -152,7 +152,7 @@ class OgoneTest < Test::Unit::TestCase
 
   def test_successful_capture_with_action_option
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    assert response = @gateway.capture(@amount, '3048326', :action => 'SAS')
+    assert response = @gateway.capture(@amount, '3048326', action: 'SAS')
     assert_success response
     assert_equal '3048326;SAS', response.authorization
     assert response.test?
@@ -207,19 +207,19 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    @gateway.expects(:authorize).with(1, @credit_card, :billing_id => @billing_id).returns(OgoneResponse.new(true, '', @gateway.send(:parse, successful_purchase_response), :authorization => '3014726;RES'))
+    @gateway.expects(:authorize).with(1, @credit_card, billing_id: @billing_id).returns(OgoneResponse.new(true, '', @gateway.send(:parse, successful_purchase_response), authorization: '3014726;RES'))
     @gateway.expects(:void).with('3014726;RES')
-    assert response = @gateway.store(@credit_card, :billing_id => @billing_id)
+    assert response = @gateway.store(@credit_card, billing_id: @billing_id)
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert_equal @billing_id, response.billing_id
   end
 
   def test_store_amount_at_gateway_level
-    gateway = OgoneGateway.new(@credentials.merge(:store_amount => 100))
-    gateway.expects(:authorize).with(100, @credit_card, :billing_id => @billing_id).returns(OgoneResponse.new(true, '', gateway.send(:parse, successful_purchase_response_100), :authorization => '3014726;RES'))
+    gateway = OgoneGateway.new(@credentials.merge(store_amount: 100))
+    gateway.expects(:authorize).with(100, @credit_card, billing_id: @billing_id).returns(OgoneResponse.new(true, '', gateway.send(:parse, successful_purchase_response_100), authorization: '3014726;RES'))
     gateway.expects(:void).with('3014726;RES')
-    assert response = gateway.store(@credit_card, :billing_id => @billing_id)
+    assert response = gateway.store(@credit_card, billing_id: @billing_id)
     assert_success response
     assert_equal '3014726;RES', response.authorization
     assert_equal @billing_id, response.billing_id
@@ -230,7 +230,7 @@ class OgoneTest < Test::Unit::TestCase
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
     @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
     assert_deprecation_warning(OgoneGateway::OGONE_STORE_OPTION_DEPRECATION_MESSAGE) do
-      assert response = @gateway.store(@credit_card, :store => @billing_id)
+      assert response = @gateway.store(@credit_card, store: @billing_id)
       assert_success response
       assert_equal '3014726;RES', response.authorization
       assert response.test?
@@ -272,7 +272,7 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_custom_currency_at_gateway_level
-    gateway = OgoneGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway = OgoneGateway.new(@credentials.merge(currency: 'USD'))
     gateway.expects(:add_pair).at_least(1)
     gateway.expects(:add_pair).with(anything, 'currency', 'USD')
     gateway.expects(:ssl_post).returns(successful_purchase_response)
@@ -280,11 +280,11 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_local_custom_currency_overwrite_gateway_level
-    gateway = OgoneGateway.new(@credentials.merge(:currency => 'USD'))
+    gateway = OgoneGateway.new(@credentials.merge(currency: 'USD'))
     gateway.expects(:add_pair).at_least(1)
     gateway.expects(:add_pair).with(anything, 'currency', 'EUR')
     gateway.expects(:ssl_post).returns(successful_purchase_response)
-    gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'EUR'))
+    gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR'))
   end
 
   def test_avs_result
@@ -343,13 +343,13 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_without_signature
-    gateway = OgoneGateway.new(@credentials.merge(:signature => nil, :signature_encryptor => nil))
+    gateway = OgoneGateway.new(@credentials.merge(signature: nil, signature_encryptor: nil))
     gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning(OgoneGateway::OGONE_NO_SIGNATURE_DEPRECATION_MESSAGE) do
       gateway.purchase(@amount, @credit_card, @options)
     end
 
-    gateway = OgoneGateway.new(@credentials.merge(:signature => nil, :signature_encryptor => 'none'))
+    gateway = OgoneGateway.new(@credentials.merge(signature: nil, signature_encryptor: 'none'))
     gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_no_deprecation_warning do
       gateway.purchase(@amount, @credit_card, @options)
@@ -357,27 +357,27 @@ class OgoneTest < Test::Unit::TestCase
   end
 
   def test_signature_for_accounts_created_before_10_may_20101
-    gateway = OgoneGateway.new(@credentials.merge(:signature_encryptor => nil))
+    gateway = OgoneGateway.new(@credentials.merge(signature_encryptor: nil))
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA1.hexdigest('1100EUR4111111111111111MrPSPIDRES2mynicesig').upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha1
-    gateway = OgoneGateway.new(@credentials.merge(:signature_encryptor => 'sha1'))
+    gateway = OgoneGateway.new(@credentials.merge(signature_encryptor: 'sha1'))
 
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA1.hexdigest(string_to_digest).upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha256
-    gateway = OgoneGateway.new(@credentials.merge(:signature_encryptor => 'sha256'))
+    gateway = OgoneGateway.new(@credentials.merge(signature_encryptor: 'sha256'))
 
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA256.hexdigest(string_to_digest).upcase, signature
   end
 
   def test_signature_for_accounts_with_signature_encryptor_to_sha512
-    gateway = OgoneGateway.new(@credentials.merge(:signature_encryptor => 'sha512'))
+    gateway = OgoneGateway.new(@credentials.merge(signature_encryptor: 'sha512'))
     assert signature = gateway.send(:add_signature, @parameters)
     assert_equal Digest::SHA512.hexdigest(string_to_digest).upcase, signature
   end
@@ -392,13 +392,13 @@ class OgoneTest < Test::Unit::TestCase
     post = {}
     gateway = OgoneGateway.new(@credentials)
 
-    gateway.send(:add_d3d, post, { :win_3ds => :pop_up })
+    gateway.send(:add_d3d, post, { win_3ds: :pop_up })
     assert 'POPUP', post['WIN3DS']
 
-    gateway.send(:add_d3d, post, { :win_3ds => :pop_ix })
+    gateway.send(:add_d3d, post, { win_3ds: :pop_ix })
     assert 'POPIX', post['WIN3DS']
 
-    gateway.send(:add_d3d, post, { :win_3ds => :invalid })
+    gateway.send(:add_d3d, post, { win_3ds: :invalid })
     assert 'MAINW', post['WIN3DS']
   end
 
@@ -407,16 +407,16 @@ class OgoneTest < Test::Unit::TestCase
     gateway = OgoneGateway.new(@credentials)
 
     gateway.send(:add_d3d, post, {
-      :http_accept => 'text/html',
-      :http_user_agent => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)',
-      :accept_url => 'https://accept_url',
-      :decline_url => 'https://decline_url',
-      :exception_url => 'https://exception_url',
-      :cancel_url => 'https://cancel_url',
-      :paramvar => 'param_var',
-      :paramplus => 'param_plus',
-      :complus => 'com_plus',
-      :language => 'fr_FR'
+      http_accept: 'text/html',
+      http_user_agent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)',
+      accept_url: 'https://accept_url',
+      decline_url: 'https://decline_url',
+      exception_url: 'https://exception_url',
+      cancel_url: 'https://cancel_url',
+      paramvar: 'param_var',
+      paramplus: 'param_plus',
+      complus: 'com_plus',
+      language: 'fr_FR'
     })
     assert_equal post['HTTP_ACCEPT'], 'text/html'
     assert_equal post['HTTP_USER_AGENT'], 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)'

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -10,19 +10,19 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def setup
     @gateway = OptimalPaymentGateway.new(
-      :account_number => '12345678',
-      :store_id => 'login',
-      :password => 'password'
+      account_number: '12345678',
+      store_id: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :email => 'email@example.com'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      email: 'email@example.com'
     }
   end
 
@@ -41,19 +41,19 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_minimal_request
     options = {
-      :order_id => '1',
-      :description => 'Store Purchase',
-      :billing_address => {
-        :zip      => 'K1C2N6',
+      order_id: '1',
+      description: 'Store Purchase',
+      billing_address: {
+        zip: 'K1C2N6',
       }
     }
     credit_card = CreditCard.new(
-      :number => '4242424242424242',
-      :month => 9,
-      :year => Time.now.year + 1,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :brand => 'visa'
+      number: '4242424242424242',
+      month: 9,
+      year: Time.now.year + 1,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      brand: 'visa'
     )
     @gateway.instance_variable_set('@credit_card', credit_card)
     assert_match minimal_request, @gateway.cc_auth_request(@amount, options)
@@ -99,7 +99,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_shipping_address
-    @options[:shipping_address] = {:country => 'CA'}
+    @options[:shipping_address] = {country: 'CA'}
     @gateway.expects(:ssl_post).with do |url, data|
       xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))
@@ -136,12 +136,12 @@ class OptimalPaymentTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     credit_card = CreditCard.new(
-      :number => '4242424242424242',
-      :month => 9,
-      :year => Time.now.year + 1,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :brand => 'visa'
+      number: '4242424242424242',
+      month: 9,
+      year: Time.now.year + 1,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      brand: 'visa'
     )
 
     stub_comms do
@@ -174,10 +174,10 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_in_production_with_test_param_sends_request_to_test_server
     ActiveMerchant::Billing::Base.mode = :production
     @gateway = OptimalPaymentGateway.new(
-      :account_number => '12345678',
-      :store_id => 'login',
-      :password => 'password',
-      :test => true
+      account_number: '12345678',
+      store_id: 'login',
+      password: 'password',
+      test: true
     )
     @gateway.expects(:ssl_post).with('https://webservices.test.optimalpayments.com/creditcardWS/CreditCardServlet/v1', anything).returns(successful_purchase_response)
 
@@ -214,17 +214,17 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_deprecated_options
     assert_deprecation_warning("The 'account' option is deprecated in favor of 'account_number' and will be removed in a future version.") do
       @gateway = OptimalPaymentGateway.new(
-        :account => '12345678',
-        :store_id => 'login',
-        :password => 'password'
+        account: '12345678',
+        store_id: 'login',
+        password: 'password'
       )
     end
 
     assert_deprecation_warning("The 'login' option is deprecated in favor of 'store_id' and will be removed in a future version.") do
       @gateway = OptimalPaymentGateway.new(
-        :account_number => '12345678',
-        :login => 'login',
-        :password => 'password'
+        account_number: '12345678',
+        login: 'login',
+        password: 'password'
       )
     end
   end

--- a/test/unit/gateways/orbital_avs_result_test.rb
+++ b/test/unit/gateways/orbital_avs_result_test.rb
@@ -26,13 +26,13 @@ class OrbitalAVSResultTest < Test::Unit::TestCase
   end
 
   def test_response_with_orbital_avs
-    response = Response.new(true, 'message', {}, :avs_result => OrbitalGateway::AVSResult.new('A'))
+    response = Response.new(true, 'message', {}, avs_result: OrbitalGateway::AVSResult.new('A'))
 
     assert_equal 'A', response.avs_result['code']
   end
 
   def test_response_with_orbital_avs_nil
-    response = Response.new(true, 'message', {}, :avs_result => OrbitalGateway::AVSResult.new(nil))
+    response = Response.new(true, 'message', {}, avs_result: OrbitalGateway::AVSResult.new(nil))
 
     assert response.avs_result.has_key?('code')
   end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -8,9 +8,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def setup
     @gateway = ActiveMerchant::Billing::OrbitalGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :merchant_id => 'merchant_id'
+      login: 'login',
+      password: 'password',
+      merchant_id: 'merchant_id'
     )
     @customer_ref_num = 'ABC'
 
@@ -30,7 +30,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       zip: address[:zip],
     }
 
-    @options = { :order_id => '1'}
+    @options = { order_id: '1'}
     @options_stored_credentials = {
       mit_msg_type: 'MRSB',
       mit_stored_credential_ind: 'Y',
@@ -62,7 +62,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(50, credit_card, :order_id => '1')
+    assert response = @gateway.purchase(50, credit_card, order_id: '1')
     assert_instance_of Response, response
     assert_success response
     assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
@@ -159,19 +159,19 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_currency_exponents
     stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => '1')
+      @gateway.purchase(50, credit_card, order_id: '1')
     end.check_request do |endpoint, data, headers|
       assert_match %r{<CurrencyExponent>2<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => '1', :currency => 'CAD')
+      @gateway.purchase(50, credit_card, order_id: '1', currency: 'CAD')
     end.check_request do |endpoint, data, headers|
       assert_match %r{<CurrencyExponent>2<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => '1', :currency => 'JPY')
+      @gateway.purchase(50, credit_card, order_id: '1', currency: 'JPY')
     end.check_request do |endpoint, data, headers|
       assert_match %r{<CurrencyExponent>0<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
@@ -180,7 +180,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_unauthenticated_response
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 
-    assert response = @gateway.purchase(101, credit_card, :order_id => '1')
+    assert response = @gateway.purchase(101, credit_card, order_id: '1')
     assert_instance_of Response, response
     assert_failure response
     assert_equal 'AUTH DECLINED                   12001', response.message
@@ -215,13 +215,13 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_order_id_as_number
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_nothing_raised do
-      @gateway.purchase(101, credit_card, :order_id => 1)
+      @gateway.purchase(101, credit_card, order_id: 1)
     end
   end
 
   def test_order_id_format
     response = stub_comms do
-      @gateway.purchase(101, credit_card, :order_id => ' #101.23,56 $Hi &thére@Friends')
+      @gateway.purchase(101, credit_card, order_id: ' #101.23,56 $Hi &thére@Friends')
     end.check_request do |endpoint, data, headers|
       assert_match(/<OrderID>101-23,56 \$Hi &amp;thre@Fr<\/OrderID>/, data)
     end.respond_with(successful_purchase_response)
@@ -230,7 +230,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_order_id_format_for_capture
     response = stub_comms do
-      @gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1001.1', :order_id => '#1001.1')
+      @gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1001.1', order_id: '#1001.1')
     end.check_request do |endpoint, data, headers|
       assert_match(/<OrderID>1001-1<\/OrderID>/, data)
     end.respond_with(successful_purchase_response)
@@ -239,9 +239,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_numeric_merchant_id_for_caputre
     gateway = ActiveMerchant::Billing::OrbitalGateway.new(
-      :login => 'login',
-      :password => 'password',
-      :merchant_id => 700000123456
+      login: 'login',
+      password: 'password',
+      merchant_id: 700000123456
     )
 
     response = stub_comms(gateway) do
@@ -259,7 +259,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_phone_number
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:phone => '123-456-7890'))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(phone: '123-456-7890'))
     end.check_request do |endpoint, data, headers|
       assert_match(/1234567890/, data)
     end.respond_with(successful_purchase_response)
@@ -270,7 +270,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     long_address = '1850 Treebeard Drive in Fangorn Forest by the Fields of Rohan'
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:address1 => long_address))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(address1: long_address))
     end.check_request do |endpoint, data, headers|
       assert_match(/1850 Treebeard Drive/, data)
       assert_no_match(/Fields of Rohan/, data)
@@ -280,11 +280,11 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_truncates_name
     card = credit_card('4242424242424242',
-      :first_name => 'John',
-      :last_name => 'Jacob Jingleheimer Smith-Jones')
+      first_name: 'John',
+      last_name: 'Jacob Jingleheimer Smith-Jones')
 
     response = stub_comms do
-      @gateway.purchase(50, card, :order_id => 1, :billing_address => address)
+      @gateway.purchase(50, card, order_id: 1, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/John Jacob/, data)
       assert_no_match(/Jones/, data)
@@ -296,7 +296,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     long_city = 'Friendly Village of Crooked Creek'
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:city => long_city))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(city: long_city))
     end.check_request do |endpoint, data, headers|
       assert_match(/Friendly Village/, data)
       assert_no_match(/Creek/, data)
@@ -308,7 +308,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     long_phone = '123456789012345'
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:phone => long_phone))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(phone: long_phone))
     end.check_request do |endpoint, data, headers|
       assert_match(/12345678901234</, data)
     end.respond_with(successful_purchase_response)
@@ -319,7 +319,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     long_zip = '1234567890123'
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:zip => long_zip))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(zip: long_zip))
     end.check_request do |endpoint, data, headers|
       assert_match(/1234567890</, data)
     end.respond_with(successful_purchase_response)
@@ -328,20 +328,20 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_address_format
     address_with_invalid_chars = address(
-      :address1 =>      '456% M|a^in \\S/treet',
-      :address2 =>      '|Apt. ^Num\\ber /One%',
-      :city =>          'R^ise o\\f /th%e P|hoenix',
-      :state =>         '%O|H\\I/O',
-      :dest_address1 => '2/21%B |B^aker\\ St.',
-      :dest_address2 => 'L%u%xury S|u^i\\t/e',
-      :dest_city =>     '/Winn/i%p|e^g\\',
-      :dest_zip =>      'A1A 2B2',
-      :dest_state =>    '^MB'
+      address1: '456% M|a^in \\S/treet',
+      address2: '|Apt. ^Num\\ber /One%',
+      city: 'R^ise o\\f /th%e P|hoenix',
+      state: '%O|H\\I/O',
+      dest_address1: '2/21%B |B^aker\\ St.',
+      dest_address2: 'L%u%xury S|u^i\\t/e',
+      dest_city: '/Winn/i%p|e^g\\',
+      dest_zip: 'A1A 2B2',
+      dest_state: '^MB'
     )
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1,
-                                         :billing_address => address_with_invalid_chars)
+      @gateway.purchase(50, credit_card, order_id: 1,
+                                         billing_address: address_with_invalid_chars)
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Main Street</, data)
       assert_match(/Apt. Number One</, data)
@@ -357,7 +357,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card,
-          :billing_address => address_with_invalid_chars)
+          billing_address: address_with_invalid_chars)
       end
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Main Street</, data)
@@ -369,26 +369,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_truncates_by_byte_length
     card = credit_card('4242424242424242',
-      :first_name => 'John',
-      :last_name => 'Jacob Jingleheimer Smith-Jones')
+      first_name: 'John',
+      last_name: 'Jacob Jingleheimer Smith-Jones')
 
     long_address = address(
-      :address1 =>      '456 Stréêt Name is Really Long',
-      :address2 =>      'Apårtmeñt 123456789012345678901',
-      :city =>          '¡Vancouver-by-the-sea!',
-      :state =>         'ßC',
-      :zip =>           'Postäl Cøde',
-      :dest_name =>     'Pierré von Bürgermeister de Queso',
-      :dest_address1 => '9876 Stréêt Name is Really Long',
-      :dest_address2 => 'Apårtmeñt 987654321098765432109',
-      :dest_city =>     'Montréal-of-the-south!',
-      :dest_state =>    'Oñtario',
-      :dest_zip =>      'Postäl Zïps'
+      address1: '456 Stréêt Name is Really Long',
+      address2: 'Apårtmeñt 123456789012345678901',
+      city: '¡Vancouver-by-the-sea!',
+      state: 'ßC',
+      zip: 'Postäl Cøde',
+      dest_name: 'Pierré von Bürgermeister de Queso',
+      dest_address1: '9876 Stréêt Name is Really Long',
+      dest_address2: 'Apårtmeñt 987654321098765432109',
+      dest_city: 'Montréal-of-the-south!',
+      dest_state: 'Oñtario',
+      dest_zip: 'Postäl Zïps'
     )
 
     response = stub_comms do
-      @gateway.purchase(50, card, :order_id => 1,
-                                  :billing_address => long_address)
+      @gateway.purchase(50, card, order_id: 1,
+                                  billing_address: long_address)
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
       assert_match(/Apårtmeñt 123456789012345678</, data)
@@ -407,7 +407,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card,
-          :billing_address => long_address)
+          billing_address: long_address)
       end
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
@@ -423,33 +423,33 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
     address_options = {
-      :address1 => nil,
-      :address2 => nil,
-      :city     => nil,
-      :state    => nil,
-      :zip      => nil,
-      :email    => nil,
-      :phone    => nil,
-      :fax      => nil
+      address1: nil,
+      address2: nil,
+      city: nil,
+      state: nil,
+      zip: nil,
+      email: nil,
+      phone: nil,
+      fax: nil
     }
 
-    response = @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(address_options))
+    response = @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(address_options))
     assert_success response
   end
 
   def test_dest_address
     billing_address = address(
-      :dest_zip      => '90001',
-      :dest_address1 => '456 Main St.',
-      :dest_city     => 'Somewhere',
-      :dest_state    => 'CA',
-      :dest_name     => 'Joan Smith',
-      :dest_phone    => '(123) 456-7890',
-      :dest_country  => 'US')
+      dest_zip: '90001',
+      dest_address1: '456 Main St.',
+      dest_city: 'Somewhere',
+      dest_state: 'CA',
+      dest_name: 'Joan Smith',
+      dest_phone: '(123) 456-7890',
+      dest_country: 'US')
 
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1,
-                                         :billing_address => billing_address)
+      @gateway.purchase(50, credit_card, order_id: 1,
+                                         billing_address: billing_address)
     end.check_request do |endpoint, data, headers|
       assert_match(/<AVSDestzip>90001/, data)
       assert_match(/<AVSDestaddress1>456 Main St./, data)
@@ -464,8 +464,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     # non-AVS country
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1,
-                                         :billing_address => billing_address.merge(:dest_country => 'BR'))
+      @gateway.purchase(50, credit_card, order_id: 1,
+                                         billing_address: billing_address.merge(dest_country: 'BR'))
     end.check_request do |endpoint, data, headers|
       assert_match(/<AVSDestcountryCode></, data)
     end.respond_with(successful_purchase_response)
@@ -524,7 +524,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         assert_deprecation_warning do
-          @gateway.add_customer_profile(credit_card, :managed_billing => {:start_date => '10-10-2014' })
+          @gateway.add_customer_profile(credit_card, managed_billing: {start_date: '10-10-2014' })
         end
       end
     end.check_request do |endpoint, data, headers|
@@ -541,11 +541,11 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         assert_deprecation_warning do
           @gateway.add_customer_profile(credit_card,
-            :managed_billing => {
-              :start_date => '10-10-2014',
-              :end_date => '10-10-2015',
-              :max_dollar_value => 1500,
-              :max_transactions => 12
+            managed_billing: {
+              start_date: '10-10-2014',
+              end_date: '10-10-2015',
+              max_dollar_value: 1500,
+              max_transactions: 12
             })
         end
       end
@@ -562,7 +562,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_dont_send_customer_data_by_default
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1)
+      @gateway.purchase(50, credit_card, order_id: 1)
     end.check_request do |endpoint, data, headers|
       assert_no_match(/<CustomerRefNum>K1C2N6/, data)
       assert_no_match(/<CustomerProfileFromOrderInd>456 My Street/, data)
@@ -574,7 +574,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_send_customer_data_when_customer_profiles_is_enabled
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1)
+      @gateway.purchase(50, credit_card, order_id: 1)
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerProfileFromOrderInd>A/, data)
       assert_match(/<CustomerProfileOrderOverrideInd>NO/, data)
@@ -585,7 +585,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_send_customer_data_when_customer_ref_is_provided
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :customer_ref_num => @customer_ref_num)
+      @gateway.purchase(50, credit_card, order_id: 1, customer_ref_num: @customer_ref_num)
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CustomerProfileFromOrderInd>S/, data)
@@ -597,7 +597,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_dont_send_customer_profile_from_order_ind_for_profile_purchase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.purchase(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+      @gateway.purchase(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
     end.check_request do |endpoint, data, headers|
       assert_no_match(/<CustomerProfileFromOrderInd>/, data)
     end.respond_with(successful_purchase_response)
@@ -607,7 +607,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_dont_send_customer_profile_from_order_ind_for_profile_authorize
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.authorize(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+      @gateway.authorize(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
     end.check_request do |endpoint, data, headers|
       assert_no_match(/<CustomerProfileFromOrderInd>/, data)
     end.respond_with(successful_purchase_response)
@@ -617,7 +617,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_currency_code_and_exponent_are_set_for_profile_purchase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.purchase(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+      @gateway.purchase(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CurrencyCode>124/, data)
@@ -629,7 +629,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_currency_code_and_exponent_are_set_for_profile_authorizations
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
-      @gateway.authorize(50, nil, :order_id => 1, :customer_ref_num => @customer_ref_num)
+      @gateway.authorize(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CurrencyCode>124/, data)
@@ -648,7 +648,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   #   <AVScountryCode>CA</AVScountryCode>
   def test_send_address_details_for_united_states
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address)
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/<AVSzip>K1C2N6/, data)
       assert_match(/<AVSaddress1>456 My Street/, data)
@@ -666,7 +666,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_dont_send_address_details_for_germany
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:country => 'DE'))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: 'DE'))
     end.check_request do |endpoint, data, headers|
       assert_no_match(/<AVSzip>K1C2N6/, data)
       assert_no_match(/<AVSaddress1>456 My Street/, data)
@@ -682,7 +682,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_allow_sending_avs_parts_when_no_country_specified
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:country => nil))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: nil))
     end.check_request do |endpoint, data, headers|
       assert_match(/<AVSzip>K1C2N6/, data)
       assert_match(/<AVSaddress1>456 My Street/, data)
@@ -698,7 +698,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_american_requests_adhere_to_xml_schema
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address)
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address)
     end.check_request do |endpoint, data, headers|
       schema_file = File.read("#{File.dirname(__FILE__)}/../../schema/orbital/Request_PTI77.xsd")
       doc = Nokogiri::XML(data)
@@ -710,7 +710,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_german_requests_adhere_to_xml_schema
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :billing_address => address(:country => 'DE'))
+      @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: 'DE'))
     end.check_request do |endpoint, data, headers|
       schema_file = File.read("#{File.dirname(__FILE__)}/../../schema/orbital/Request_PTI77.xsd")
       doc = Nokogiri::XML(data)
@@ -735,7 +735,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_add_customer_profile_with_email
     response = stub_comms do
       assert_deprecation_warning do
-        @gateway.add_customer_profile(credit_card, { :billing_address => { :email => 'xiaobozzz@example.com' } })
+        @gateway.add_customer_profile(credit_card, { billing_address: { email: 'xiaobozzz@example.com' } })
       end
     end.check_request do |endpoint, data, headers|
       assert_match(/<CustomerProfileAction>C/, data)
@@ -786,7 +786,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).with(OrbitalGateway.test_url, anything, anything).raises(ActiveMerchant::ConnectionError.new('message', nil))
     @gateway.expects(:ssl_post).with(OrbitalGateway.secondary_test_url, anything, anything).returns(successful_purchase_response)
 
-    response = @gateway.purchase(50, credit_card, :order_id => '1')
+    response = @gateway.purchase(50, credit_card, order_id: '1')
     assert_success response
   end
 
@@ -794,7 +794,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_headers_when_retry_logic_is_enabled
     @gateway.options[:retry_logic] = true
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :trace_number => 1)
+      @gateway.purchase(50, credit_card, order_id: 1, trace_number: 1)
     end.check_request do |endpoint, data, headers|
       assert_equal('1', headers['Trace-number'])
       assert_equal('merchant_id', headers['Merchant-Id'])
@@ -805,7 +805,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_retry_logic_not_enabled
     @gateway.options[:retry_logic] = false
     response = stub_comms do
-      @gateway.purchase(50, credit_card, :order_id => 1, :trace_number => 1)
+      @gateway.purchase(50, credit_card, order_id: 1, trace_number: 1)
     end.check_request do |endpoint, data, headers|
       assert_equal(false, headers.has_key?('Trace-number'))
       assert_equal(false, headers.has_key?('Merchant-Id'))
@@ -817,7 +817,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     define_method "test_approval_response_code_#{resp_code}" do
       @gateway.expects(:ssl_post).returns(successful_purchase_response(resp_code))
 
-      assert response = @gateway.purchase(50, credit_card, :order_id => '1')
+      assert response = @gateway.purchase(50, credit_card, order_id: '1')
       assert_instance_of Response, response
       assert_success response
     end
@@ -826,7 +826,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_account_num_is_removed_from_response
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
-    response = @gateway.purchase(50, credit_card, :order_id => '1')
+    response = @gateway.purchase(50, credit_card, order_id: '1')
     assert_instance_of Response, response
     assert_success response
     assert_nil response.params['account_num']
@@ -839,7 +839,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     assert_deprecation_warning do
       response = @gateway.add_customer_profile(credit_card,
-        :billing_address => address)
+        billing_address: address)
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/pac_net_raven_test.rb
+++ b/test/unit/gateways/pac_net_raven_test.rb
@@ -158,28 +158,28 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_argument_error_prn
     exception = assert_raises(ArgumentError) {
-      PacNetRavenGateway.new(:user => 'user', :secret => 'secret')
+      PacNetRavenGateway.new(user: 'user', secret: 'secret')
     }
     assert_equal 'Missing required parameter: prn', exception.message
   end
 
   def test_argument_error_user
     exception = assert_raises(ArgumentError) {
-      PacNetRavenGateway.new(:secret => 'secret', :prn => 123456)
+      PacNetRavenGateway.new(secret: 'secret', prn: 123456)
     }
     assert_equal 'Missing required parameter: user', exception.message
   end
 
   def test_argument_error_secret
     exception = assert_raises(ArgumentError) {
-      PacNetRavenGateway.new(:user => 'user', :prn => 123456)
+      PacNetRavenGateway.new(user: 'user', prn: 123456)
     }
     assert_equal 'Missing required parameter: secret', exception.message
   end
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, :billing_address => {:address1 => 'Address 1', :address2 => 'Address 2', :zip => 'ZIP'})
+    @gateway.send(:add_address, result, billing_address: {address1: 'Address 1', address2: 'Address 2', zip: 'ZIP'})
     assert_equal ['BillingPostalCode', 'BillingStreetAddressLineFour', 'BillingStreetAddressLineOne'], result.stringify_keys.keys.sort
     assert_equal 'ZIP', result['BillingPostalCode']
     assert_equal 'Address 2', result['BillingStreetAddressLineFour']
@@ -334,8 +334,8 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
   end
 
   def test_post_data
-    @gateway.stubs(:request_id => 'wouykiikdvqbwwxueppby')
-    @gateway.stubs(:timestamp => '2013-10-08T14:31:54.Z')
+    @gateway.stubs(request_id: 'wouykiikdvqbwwxueppby')
+    @gateway.stubs(timestamp: '2013-10-08T14:31:54.Z')
 
     assert_equal "PymtType=cc_preauth&RAPIVersion=2&UserName=user&Timestamp=2013-10-08T14%3A31%3A54.Z&RequestID=wouykiikdvqbwwxueppby&Signature=7794efc8c0d39f0983edc10f778e6143ba13531d&CardNumber=4242424242424242&Expiry=09#{@credit_card.year.to_s[-2..-1]}&CVV2=123&Currency=USD&BillingStreetAddressLineOne=Address+1&BillingStreetAddressLineFour=Address+2&BillingPostalCode=ZIP123",
       @gateway.send(:post_data, 'cc_preauth', {

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -10,11 +10,11 @@ class PayGateTest < Test::Unit::TestCase
 
     # May need to generate a unique order id as server responds with duplicate order detected
     @options = {
-      :order_id         => Time.now.getutc,
-      :billing_address  => address,
-      :email           => 'john.doe@example.com',
-      :ip              => '127.0.0.1',
-      :description      => 'Store Purchase',
+      order_id: Time.now.getutc,
+      billing_address: address,
+      email: 'john.doe@example.com',
+      ip: '127.0.0.1',
+      description: 'Store Purchase',
     }
   end
 

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -190,7 +190,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_unsuccessful_request
     @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    @gateway.options.merge!({:mode => 'live', :test => false})
+    @gateway.options.merge!({mode: 'live', test: false})
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -200,7 +200,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_unsuccessful_authorize
     @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    @gateway.options.merge!({:mode => 'live', :test => false})
+    @gateway.options.merge!({mode: 'live', test: false})
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -8,14 +8,14 @@ class PayJunctionTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = PayJunctionGateway.new(
-      :login      => 'pj-ql-01',
-      :password   => 'pj-ql-01p'
+      login: 'pj-ql-01',
+      password: 'pj-ql-01p'
     )
 
     @credit_card = credit_card
     @options = {
-      :billing_address => address,
-      :description => 'Test purchase'
+      billing_address: address,
+      description: 'Test purchase'
     }
     @amount = 100
   end
@@ -24,14 +24,14 @@ class PayJunctionTest < Test::Unit::TestCase
     Base.mode = :production
 
     live_gw = PayJunctionGateway.new(
-      :login      => 'l',
-      :password   => 'p'
+      login: 'l',
+      password: 'p'
     )
     assert_false live_gw.test?
 
     test_gw = PayJunctionGateway.new(
-      :login      => 'pj-ql-01',
-      :password   => 'pj-ql-01p'
+      login: 'pj-ql-01',
+      password: 'pj-ql-01p'
     )
     assert test_gw.test?
   end

--- a/test/unit/gateways/pay_junction_v2_test.rb
+++ b/test/unit/gateways/pay_junction_v2_test.rb
@@ -207,7 +207,7 @@ class PayJunctionV2Test < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = {:card => {:billingAddress => {}}}
+    post = {card: {billingAddress: {}}}
     @gateway.send(:add_address, post, @options)
     # Billing Address
     assert_equal @options[:billing_address][:first_name], post[:billing][:firstName]

--- a/test/unit/gateways/pay_secure_test.rb
+++ b/test/unit/gateways/pay_secure_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 class PaySecureTest < Test::Unit::TestCase
   def setup
     @gateway = PaySecureGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @options = {
-      :order_id => '1000',
-      :billing_address => address,
-      :description => 'Test purchase'
+      order_id: '1000',
+      billing_address: address,
+      description: 'Test purchase'
     }
     @amount = 100
   end

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -5,19 +5,19 @@ require 'test_helper'
 class PayboxDirectTest < Test::Unit::TestCase
   def setup
     @gateway = PayboxDirectGateway.new(
-      :login => 'l',
-      :password => 'p'
+      login: 'l',
+      password: 'p'
     )
 
     @credit_card = credit_card('1111222233334444',
-      :brand => 'visa'
+      brand: 'visa'
     )
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -12,8 +12,8 @@ class PayeezyGateway < Test::Unit::TestCase
     @check = check
     @amount = 100
     @options = {
-      :billing_address => address,
-      :ta_token => '123'
+      billing_address: address,
+      ta_token: '123'
     }
     @options_stored_credentials = {
       cardbrand_original_transaction_id: 'abc123',

--- a/test/unit/gateways/payex_test.rb
+++ b/test/unit/gateways/payex_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 class PayexTest < Test::Unit::TestCase
   def setup
     @gateway = PayexGateway.new(
-      :account => 'account',
-      :encryption_key => 'encryption_key'
+      account: 'account',
+      encryption_key: 'encryption_key'
     )
 
     @credit_card = credit_card
     @amount = 1000
 
     @options = {
-      :order_id => '1234',
+      order_id: '1234',
     }
   end
 

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -15,18 +15,18 @@ class PayflowExpressTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = PayflowExpressGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
-    @address = { :address1 => '1234 My Street',
-                 :address2 => 'Apt 1',
-                 :company => 'Widgets Inc',
-                 :city => 'Ottawa',
-                 :state => 'ON',
-                 :zip => 'K1C2N6',
-                 :country => 'Canada',
-                 :phone => '(555)555-5555'}
+    @address = { address1: '1234 My Street',
+                 address2: 'Apt 1',
+                 company: 'Widgets Inc',
+                 city: 'Ottawa',
+                 state: 'ON',
+                 zip: 'K1C2N6',
+                 country: 'Canada',
+                 phone: '(555)555-5555'}
   end
 
   def teardown
@@ -41,9 +41,9 @@ class PayflowExpressTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = PayflowExpressGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD',
-      :test => true
+      login: 'LOGIN',
+      password: 'PASSWORD',
+      test: true
     )
 
     assert gateway.test?
@@ -53,8 +53,8 @@ class PayflowExpressTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = PayflowExpressGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     assert !gateway.test?
@@ -63,24 +63,24 @@ class PayflowExpressTest < Test::Unit::TestCase
   def test_live_redirect_url
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
+    assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_test_redirect_url
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_live_redirect_url_without_review
     Base.mode = :production
-    assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
+    assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+    assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
   end
 
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
-    assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
+    assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+    assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
   end
 
   def test_invalid_get_express_details_request
@@ -142,7 +142,7 @@ class PayflowExpressTest < Test::Unit::TestCase
   end
 
   def test_get_express_details_with_invalid_xml
-    @gateway.expects(:ssl_post).returns(successful_get_express_details_response(:street => 'Main & Magic'))
+    @gateway.expects(:ssl_post).returns(successful_get_express_details_response(street: 'Main & Magic'))
     response = @gateway.details_for('EC-2OPN7UJGFWK9OYFV')
     assert_instance_of PayflowExpressResponse, response
     assert_success response
@@ -161,7 +161,7 @@ class PayflowExpressTest < Test::Unit::TestCase
 
   private
 
-  def successful_get_express_details_response(options={:street => '111 Main St.'})
+  def successful_get_express_details_response(options={street: '111 Main St.'})
     <<-RESPONSE
 <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
   <ResponseData>

--- a/test/unit/gateways/payflow_express_uk_test.rb
+++ b/test/unit/gateways/payflow_express_uk_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class PayflowExpressUkTest < Test::Unit::TestCase
   def setup
     @gateway = PayflowExpressUkGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
   end
 

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -7,14 +7,14 @@ class PayflowTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = PayflowGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = { :billing_address => address.merge(:first_name => 'Longbob', :last_name => 'Longsen') }
-    @check = check(:name => 'Jim Smith')
+    @options = { billing_address: address.merge(first_name: 'Longbob', last_name: 'Longsen') }
+    @check = check(name: 'Jim Smith')
     @l2_json = '{
       "Tender": {
         "ACH": {
@@ -229,9 +229,9 @@ class PayflowTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = PayflowGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD',
-      :test => true
+      login: 'LOGIN',
+      password: 'PASSWORD',
+      test: true
     )
 
     assert gateway.test?
@@ -241,8 +241,8 @@ class PayflowTest < Test::Unit::TestCase
     Base.mode = :production
 
     gateway = PayflowGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     refute gateway.test?
@@ -250,26 +250,26 @@ class PayflowTest < Test::Unit::TestCase
 
   def test_partner_class_accessor
     assert_equal 'PayPal', PayflowGateway.partner
-    gateway = PayflowGateway.new(:login => 'test', :password => 'test')
+    gateway = PayflowGateway.new(login: 'test', password: 'test')
     assert_equal 'PayPal', gateway.options[:partner]
   end
 
   def test_partner_class_accessor_used_when_passed_in_partner_is_blank
     assert_equal 'PayPal', PayflowGateway.partner
-    gateway = PayflowGateway.new(:login => 'test', :password => 'test', :partner => '')
+    gateway = PayflowGateway.new(login: 'test', password: 'test', partner: '')
     assert_equal 'PayPal', gateway.options[:partner]
   end
 
   def test_passed_in_partner_overrides_class_accessor
     assert_equal 'PayPal', PayflowGateway.partner
-    gateway = PayflowGateway.new(:login => 'test', :password => 'test', :partner => 'PayPalUk')
+    gateway = PayflowGateway.new(login: 'test', password: 'test', partner: 'PayPalUk')
     assert_equal 'PayPalUk', gateway.options[:partner]
   end
 
   def test_express_instance
     gateway = PayflowGateway.new(
-      :login => 'test',
-      :password => 'password'
+      login: 'test',
+      password: 'password'
     )
     express = gateway.express
     assert_instance_of PayflowExpressGateway, express
@@ -309,8 +309,8 @@ class PayflowTest < Test::Unit::TestCase
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
-          :periodicity => :monthly,
-          :initial_transaction => { }
+          periodicity: :monthly,
+          initial_transaction: { }
         )
       end
     end
@@ -320,8 +320,8 @@ class PayflowTest < Test::Unit::TestCase
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
-          :periodicity => :monthly,
-          :initial_transaction => { :amount => :purchase }
+          periodicity: :monthly,
+          initial_transaction: { amount: :purchase }
         )
       end
     end
@@ -347,7 +347,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, @credit_card, :periodicity => :monthly)
+      @gateway.recurring(@amount, @credit_card, periodicity: :monthly)
     end
 
     assert_instance_of PayflowResponse, response
@@ -361,7 +361,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, nil, :profile_id => 'RT0000000009', :periodicity => :monthly)
+      @gateway.recurring(@amount, nil, profile_id: 'RT0000000009', periodicity: :monthly)
     end
 
     assert_instance_of PayflowResponse, response
@@ -375,7 +375,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(successful_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, nil, :profile_id => 'RT0000000009', :retry_num_days => 3, :periodicity => :monthly)
+      @gateway.recurring(@amount, nil, profile_id: 'RT0000000009', retry_num_days: 3, periodicity: :monthly)
     end
 
     assert_instance_of PayflowResponse, response
@@ -389,7 +389,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(start_date_error_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, nil, :profile_id => 'RT0000000009', :starting_at => Date.yesterday, :periodicity => :monthly)
+      @gateway.recurring(@amount, nil, profile_id: 'RT0000000009', starting_at: Date.yesterday, periodicity: :monthly)
     end
 
     assert_instance_of PayflowResponse, response
@@ -404,7 +404,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(start_date_missing_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, nil, :profile_id => 'RT0000000009', :periodicity => :yearly)
+      @gateway.recurring(@amount, nil, profile_id: 'RT0000000009', periodicity: :yearly)
     end
 
     assert_instance_of PayflowResponse, response
@@ -419,7 +419,7 @@ class PayflowTest < Test::Unit::TestCase
     @gateway.stubs(:ssl_post).returns(successful_payment_history_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring_inquiry('RT0000000009', :history => true)
+      @gateway.recurring_inquiry('RT0000000009', history: true)
     end
     assert_equal 1, response.payment_history.size
     assert_equal '1', response.payment_history.first['payment_num']
@@ -427,7 +427,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_recurring_profile_payment_history_inquiry_contains_the_proper_xml
-    request = @gateway.send(:build_recurring_request, :inquiry, nil, :profile_id => 'RT0000000009', :history => true)
+    request = @gateway.send(:build_recurring_request, :inquiry, nil, profile_id: 'RT0000000009', history: true)
     assert_match %r(<PaymentHistory>Y</PaymentHistory), request
   end
 
@@ -435,7 +435,7 @@ class PayflowTest < Test::Unit::TestCase
     xml = Builder::XmlMarkup.new
     credit_card = credit_card(
       '5641820000000005',
-      :brand => 'maestro'
+      brand: 'maestro'
     )
 
     @gateway.send(:add_credit_card, xml, credit_card, @options.merge(three_d_secure_option))
@@ -446,7 +446,7 @@ class PayflowTest < Test::Unit::TestCase
     xml = Builder::XmlMarkup.new
     credit_card = credit_card(
       '5641820000000005',
-      :brand => 'maestro'
+      brand: 'maestro'
     )
 
     @gateway.send(:add_credit_card, xml, credit_card, @options.merge(three_d_secure_option_frictionless))
@@ -484,8 +484,8 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_passed_in_verbosity
-    assert_nil PayflowGateway.new(:login => 'test', :password => 'test').options[:verbosity]
-    gateway = PayflowGateway.new(:login => 'test', :password => 'test', :verbosity => 'HIGH')
+    assert_nil PayflowGateway.new(login: 'test', password: 'test').options[:verbosity]
+    gateway = PayflowGateway.new(login: 'test', password: 'test', verbosity: 'HIGH')
     assert_equal 'HIGH', gateway.options[:verbosity]
     @gateway.expects(:ssl_post).returns(verbose_transaction_response)
     response = @gateway.purchase(100, @credit_card, @options)
@@ -907,28 +907,28 @@ Conn close
 
   def three_d_secure_option
     {
-      :three_d_secure => {
-        :authentication_id => 'QvDbSAxSiaQs241899E0',
-        :authentication_response_status => 'Y',
-        :pareq => 'pareq block',
-        :acs_url => 'https://bankacs.bank.com/ascurl',
-        :eci => '02',
-        :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
-        :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+      three_d_secure: {
+        authentication_id: 'QvDbSAxSiaQs241899E0',
+        authentication_response_status: 'Y',
+        pareq: 'pareq block',
+        acs_url: 'https://bankacs.bank.com/ascurl',
+        eci: '02',
+        cavv: 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+        xid: 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
       }
     }
   end
 
   def three_d_secure_option_frictionless
     {
-      :three_d_secure => {
-        :authentication_id => 'QvDbSAxSiaQs241899E0',
-        :directory_response_status => 'C',
-        :pareq => 'pareq block',
-        :acs_url => 'https://bankacs.bank.com/ascurl',
-        :eci => '02',
-        :cavv => 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
-        :xid => 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
+      three_d_secure: {
+        authentication_id: 'QvDbSAxSiaQs241899E0',
+        directory_response_status: 'C',
+        pareq: 'pareq block',
+        acs_url: 'https://bankacs.bank.com/ascurl',
+        eci: '02',
+        cavv: 'jGvQIvG/5UhjAREALGYa6Vu/hto=',
+        xid: 'UXZEYlNBeFNpYVFzMjQxODk5RTA='
       }
     }
   end

--- a/test/unit/gateways/payflow_uk_test.rb
+++ b/test/unit/gateways/payflow_uk_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class PayflowUkTest < Test::Unit::TestCase
   def setup
     @gateway = PayflowUkGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
   end
 

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -5,19 +5,19 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def setup
     @gateway = PaymentExpressGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @visa = credit_card
 
-    @solo = credit_card('6334900000000005', :brand => 'maestro')
+    @solo = credit_card('6334900000000005', brand: 'maestro')
 
     @options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :email => 'cody@example.com',
-      :description => 'Store purchase'
+      order_id: generate_unique_id,
+      billing_address: address,
+      email: 'cody@example.com',
+      description: 'Store purchase'
     }
 
     @amount = 100
@@ -74,9 +74,9 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_successful_card_store_with_custom_billing_id
-    @gateway.expects(:ssl_post).returns(successful_store_response(:billing_id => 'my-custom-id'))
+    @gateway.expects(:ssl_post).returns(successful_store_response(billing_id: 'my-custom-id'))
 
-    assert response = @gateway.store(@visa, :billing_id => 'my-custom-id')
+    assert response = @gateway.store(@visa, billing_id: 'my-custom-id')
     assert_success response
     assert response.test?
     assert_equal 'my-custom-id', response.token
@@ -107,14 +107,14 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_purchase_using_merchant_specified_billing_id_token
     @gateway = PaymentExpressGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD',
-      :use_custom_payment_token => true
+      login: 'LOGIN',
+      password: 'PASSWORD',
+      use_custom_payment_token: true
     )
 
-    @gateway.expects(:ssl_post).returns(successful_store_response({:billing_id => 'TEST1234'}))
+    @gateway.expects(:ssl_post).returns(successful_store_response({billing_id: 'TEST1234'}))
 
-    assert response = @gateway.store(@visa, {:billing_id => 'TEST1234'})
+    assert response = @gateway.store(@visa, {billing_id: 'TEST1234'})
     assert_equal 'TEST1234', response.token
 
     @gateway.expects(:ssl_post).returns(successful_billing_id_token_purchase_response)
@@ -158,9 +158,9 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_pass_optional_txn_data
     options = {
-      :txn_data1 => 'Transaction Data 1',
-      :txn_data2 => 'Transaction Data 2',
-      :txn_data3 => 'Transaction Data 3'
+      txn_data1: 'Transaction Data 1',
+      txn_data2: 'Transaction Data 2',
+      txn_data3: 'Transaction Data 3'
     }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
@@ -172,9 +172,9 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_pass_optional_txn_data_truncated_to_255_chars
     options = {
-      :txn_data1 => 'Transaction Data 1-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA',
-      :txn_data2 => 'Transaction Data 2-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA',
-      :txn_data3 => 'Transaction Data 3-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA'
+      txn_data1: 'Transaction Data 1-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA',
+      txn_data2: 'Transaction Data 2-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA',
+      txn_data3: 'Transaction Data 3-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-EXTRA'
     }
 
     truncated_addendum = '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345'
@@ -187,7 +187,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_web
-    options = {:client_type => :web}
+    options = {client_type: :web}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Web<\/ClientType>/, body)
@@ -195,7 +195,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_ivr
-    options = {:client_type => :ivr}
+    options = {client_type: :ivr}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>IVR<\/ClientType>/, body)
@@ -203,7 +203,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_moto
-    options = {:client_type => :moto}
+    options = {client_type: :moto}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>MOTO<\/ClientType>/, body)
@@ -211,7 +211,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_unattended
-    options = {:client_type => :unattended}
+    options = {client_type: :unattended}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Unattended<\/ClientType>/, body)
@@ -219,7 +219,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_internet
-    options = {:client_type => :internet}
+    options = {client_type: :internet}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Internet<\/ClientType>/, body)
@@ -227,7 +227,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_recurring
-    options = {:client_type => :recurring}
+    options = {client_type: :recurring}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Recurring<\/ClientType>/, body)
@@ -235,7 +235,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_unknown_type_omits_element
-    options = {:client_type => :unknown}
+    options = {client_type: :unknown}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_no_match(/<ClientType>/, body)
@@ -243,7 +243,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_ip_as_client_info
-    options = {:ip => '192.168.0.1'}
+    options = {ip: '192.168.0.1'}
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientInfo>192.168.0.1<\/ClientInfo>/, body)
@@ -252,7 +252,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_purchase_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.purchase(@amount, @visa, {:order_id => '16chars---------EXTRA'})
+      @gateway.purchase(@amount, @visa, {order_id: '16chars---------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -260,7 +260,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_authorize_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.authorize(@amount, @visa, {:order_id => '16chars---------EXTRA'})
+      @gateway.authorize(@amount, @visa, {order_id: '16chars---------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -268,7 +268,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_capture_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {:order_id => '16chars---------EXTRA'})
+      @gateway.capture(@amount, 'identification', {order_id: '16chars---------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -276,7 +276,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_refund_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.refund(@amount, 'identification', {:description => 'refund', :order_id => '16chars---------EXTRA'})
+      @gateway.refund(@amount, 'identification', {description: 'refund', order_id: '16chars---------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -284,7 +284,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_purchase_truncates_description_to_50_chars
     stub_comms do
-      @gateway.purchase(@amount, @visa, {:description => '50chars-------------------------------------------EXTRA'})
+      @gateway.purchase(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -292,7 +292,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_authorize_truncates_description_to_50_chars
     stub_comms do
-      @gateway.authorize(@amount, @visa, {:description => '50chars-------------------------------------------EXTRA'})
+      @gateway.authorize(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -300,7 +300,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_capture_truncates_description_to_50_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {:description => '50chars-------------------------------------------EXTRA'})
+      @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -308,7 +308,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_refund_truncates_description_to_50_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {:description => '50chars-------------------------------------------EXTRA'})
+      @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
     end.check_request do |endpoint, data, headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -344,7 +344,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
     # refund
     stub_comms do
-      @gateway.refund(@amount, 'identification', {:description => 'description'}.merge(options))
+      @gateway.refund(@amount, 'identification', {description: 'description'}.merge(options))
     end.check_request do |endpoint, data, headers|
       yield data
     end.respond_with(successful_authorization_response)

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -7,12 +7,12 @@ class PaymentezTest < Test::Unit::TestCase
     @gateway = PaymentezGateway.new(application_code: 'foo', app_key: 'bar')
     @credit_card = credit_card
     @elo_credit_card = credit_card('6362970000457013',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
     @amount = 100
 

--- a/test/unit/gateways/paymill_test.rb
+++ b/test/unit/gateways/paymill_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PaymillTest < Test::Unit::TestCase
   def setup
-    @gateway = PaymillGateway.new(:public_key => 'PUBLIC', :private_key => 'PRIVATE')
+    @gateway = PaymillGateway.new(public_key: 'PUBLIC', private_key: 'PRIVATE')
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -18,20 +18,20 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     CommonPaypalGateway.pem_file = nil
 
     @gateway = CommonPaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
 
     @address = {
-      :address1 => '1234 My Street',
-      :address2 => 'Apt 1',
-      :company => 'Widgets Inc',
-      :city => 'Ottawa',
-      :state => 'ON',
-      :zip => 'K1C2N6',
-      :country => 'Canada',
-      :phone => '(555)555-5555'
+      address1: '1234 My Street',
+      address2: 'Apt 1',
+      company: 'Widgets Inc',
+      city: 'Ottawa',
+      state: 'ON',
+      zip: 'K1C2N6',
+      country: 'Canada',
+      phone: '(555)555-5555'
     }
   end
 
@@ -44,25 +44,25 @@ class PaypalCommonApiTest < Test::Unit::TestCase
   end
 
   def test_add_payment_details_adds_express_only_payment_details_when_necessary
-    options = {:express_request => true}
+    options = {express_request: true}
     @gateway.expects(:add_express_only_payment_details)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_items_details
-    options = {:items => [1]}
+    options = {items: [1]}
     @gateway.expects(:add_payment_details_items_xml)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_address
-    options = {:shipping_address => @address}
+    options = {shipping_address: @address}
     @gateway.expects(:add_address)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_items_details_elements
-    options = {:items => [{:name => 'foo'}]}
+    options = {items: [{name: 'foo'}]}
     request = wrap_xml do |xml|
       @gateway.send(:add_payment_details, xml, 100, 'USD', options)
     end
@@ -71,7 +71,7 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_add_express_only_payment_details_adds_non_blank_fields
     request = wrap_xml do |xml|
-      @gateway.send(:add_express_only_payment_details, xml, {:payment_action => 'Sale', :payment_request_id => ''})
+      @gateway.send(:add_express_only_payment_details, xml, {payment_action: 'Sale', payment_request_id: ''})
     end
     assert_equal 'Sale', REXML::XPath.first(request, '//n2:PaymentAction').text
     assert_nil REXML::XPath.first(request, '//n2:PaymentRequestID')
@@ -85,7 +85,7 @@ class PaypalCommonApiTest < Test::Unit::TestCase
   end
 
   def test_build_request_wrapper_with_request_details
-    result = @gateway.send(:build_request_wrapper, 'Action', :request_details => true) do |xml|
+    result = @gateway.send(:build_request_wrapper, 'Action', request_details: true) do |xml|
       xml.tag! 'n2:TransactionID', 'baz'
     end
     assert_equal 'baz', REXML::XPath.first(REXML::Document.new(result), '//ActionReq/ActionRequest/n2:ActionRequestDetails/n2:TransactionID').text
@@ -118,7 +118,7 @@ class PaypalCommonApiTest < Test::Unit::TestCase
   end
 
   def test_build_do_authorize_request
-    request = REXML::Document.new(@gateway.send(:build_do_authorize, 123, 100, :currency => 'USD'))
+    request = REXML::Document.new(@gateway.send(:build_do_authorize, 123, 100, currency: 'USD'))
     assert_equal '123', REXML::XPath.first(request, '//DoAuthorizationReq/DoAuthorizationRequest/TransactionID').text
     assert_equal '1.00', REXML::XPath.first(request, '//DoAuthorizationReq/DoAuthorizationRequest/Amount').text
   end
@@ -137,10 +137,10 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_build_transaction_search_request
     options = {
-      :start_date => DateTime.new(2012, 2, 21, 0),
-      :end_date => DateTime.new(2012, 3, 21, 0),
-      :receiver => 'foo@example.com',
-      :first_name => 'Robert'
+      start_date: DateTime.new(2012, 2, 21, 0),
+      end_date: DateTime.new(2012, 3, 21, 0),
+      receiver: 'foo@example.com',
+      first_name: 'Robert'
     }
     request = REXML::Document.new(@gateway.send(:build_transaction_search, options))
     assert_match %r{^2012-02-21T\d{2}:00:00Z$}, REXML::XPath.first(request, '//TransactionSearchReq/TransactionSearchRequest/StartDate').text
@@ -152,14 +152,14 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_raise ArgumentError do
       @gateway.reference_transaction(100)
     end
-    @gateway.reference_transaction(100, :reference_id => 'id')
+    @gateway.reference_transaction(100, reference_id: 'id')
   end
 
   def test_build_reference_transaction_gets_ip
     request = REXML::Document.new(@gateway.send(:build_reference_transaction_request,
       100,
-      :reference_id => 'id',
-      :ip => '127.0.0.1'))
+      reference_id: 'id',
+      ip: '127.0.0.1'))
     assert_equal '100', REXML::XPath.first(request, '//n2:PaymentDetails/n2:OrderTotal').text
     assert_equal 'id', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
     assert_equal '127.0.0.1', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -8,9 +8,9 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
 
   def setup
     @gateway = PaypalDigitalGoodsGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
 
     Base.mode = :test
@@ -35,42 +35,42 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
   def test_setup_request_invalid_requests
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        :ip                => '127.0.0.1',
-        :description       => 'Test Title',
-        :return_url        => 'http://return.url',
-        :cancel_return_url => 'http://cancel.url')
+        ip: '127.0.0.1',
+        description: 'Test Title',
+        return_url: 'http://return.url',
+        cancel_return_url: 'http://cancel.url')
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        :ip                => '127.0.0.1',
-        :description       => 'Test Title',
-        :return_url        => 'http://return.url',
-        :cancel_return_url => 'http://cancel.url',
-        :items             => [])
+        ip: '127.0.0.1',
+        description: 'Test Title',
+        return_url: 'http://return.url',
+        cancel_return_url: 'http://cancel.url',
+        items: [])
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        :ip                => '127.0.0.1',
-        :description       => 'Test Title',
-        :return_url        => 'http://return.url',
-        :cancel_return_url => 'http://cancel.url',
-        :items             => [Hash.new])
+        ip: '127.0.0.1',
+        description: 'Test Title',
+        return_url: 'http://return.url',
+        cancel_return_url: 'http://cancel.url',
+        items: [Hash.new])
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        :ip                => '127.0.0.1',
-        :description       => 'Test Title',
-        :return_url        => 'http://return.url',
-        :cancel_return_url => 'http://cancel.url',
-        :items             => [{ :name => 'Charge',
-                                  :number => '1',
-                                  :quantity => '1',
-                                  :amount   => 100,
-                                  :description => 'Description',
-                                  :category => 'Physical' }])
+        ip: '127.0.0.1',
+        description: 'Test Title',
+        return_url: 'http://return.url',
+        cancel_return_url: 'http://cancel.url',
+        items: [{ name: 'Charge',
+                  number: '1',
+                  quantity: '1',
+                  amount: 100,
+                  description: 'Description',
+                  category: 'Physical' }])
     end
   end
 
@@ -78,16 +78,16 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_setup_response)
 
     @gateway.setup_purchase(100,
-      :ip                => '127.0.0.1',
-      :description       => 'Test Title',
-      :return_url        => 'http://return.url',
-      :cancel_return_url => 'http://cancel.url',
-      :items             => [{ :name => 'Charge',
-                                :number => '1',
-                                :quantity => '1',
-                                :amount   => 100,
-                                :description => 'Description',
-                                :category => 'Digital' }])
+      ip: '127.0.0.1',
+      description: 'Test Title',
+      return_url: 'http://return.url',
+      cancel_return_url: 'http://cancel.url',
+      items: [{ name: 'Charge',
+                number: '1',
+                quantity: '1',
+                amount: 100,
+                description: 'Description',
+                category: 'Digital' }])
   end
 
   private

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -14,20 +14,20 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def setup
     @gateway = PaypalExpressGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
 
     @address = {
-      :address1 => '1234 My Street',
-      :address2 => 'Apt 1',
-      :company => 'Widgets Inc',
-      :city => 'Ottawa',
-      :state => 'ON',
-      :zip => 'K1C2N6',
-      :country => 'Canada',
-      :phone => '(555)555-5555'
+      address1: '1234 My Street',
+      address2: 'Apt 1',
+      company: 'Widgets Inc',
+      city: 'Ottawa',
+      state: 'ON',
+      zip: 'K1C2N6',
+      country: 'Canada',
+      phone: '(555)555-5555'
     }
 
     Base.mode = :test
@@ -40,40 +40,40 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_live_redirect_url
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
+    assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_live_redirect_url_without_review
     Base.mode = :production
-    assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
+    assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+    assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
   end
 
   def test_force_sandbox_redirect_url
     Base.mode = :production
 
     gateway = PaypalExpressGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM',
-      :test => true
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM',
+      test: true
     )
 
     assert gateway.test?
     assert_equal TEST_REDIRECT_URL, gateway.redirect_url_for('1234567890')
-    assert_equal TEST_REDIRECT_URL_MOBILE, gateway.redirect_url_for('1234567890', :mobile => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE, gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_test_redirect_url
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
-    assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', :mobile => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
   end
 
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
-    assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false)
-    assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true)
+    assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
+    assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
   end
 
   def test_get_express_details
@@ -111,7 +111,7 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    response = @gateway.authorize(300, :token => 'EC-6WS104951Y388951L', :payer_id => 'FWRVKNRRZ3WUC')
+    response = @gateway.authorize(300, token: 'EC-6WS104951Y388951L', payer_id: 'FWRVKNRRZ3WUC')
     assert response.success?
     assert_not_nil response.authorization
     assert response.test?
@@ -130,13 +130,13 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_includes_description
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :description => 'a description' }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { description: 'a description' }))
 
     assert_equal 'a description', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:OrderDescription').text
   end
 
   def test_includes_order_id
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :order_id => '12345' }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { order_id: '12345' }))
 
     assert_equal '12345', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:InvoiceID').text
   end
@@ -148,7 +148,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_includes_custom_tag_if_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:custom => 'Foo'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {custom: 'Foo'}))
 
     assert_equal 'Foo', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:Custom').text
   end
@@ -167,20 +167,20 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_items_are_included_if_specified_in_build_setup_request
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {
-      :currency => 'GBP',
-      :items => [
+      currency: 'GBP',
+      items: [
         {
-          :name => 'item one',
-          :description => 'item one description',
-          :amount => 10000,
-          :number => 1,
-          :quantity => 3
+          name: 'item one',
+          description: 'item one description',
+          amount: 10000,
+          number: 1,
+          quantity: 3
         },
-        { :name => 'item two',
-          :description => 'item two description',
-          :amount => 20000,
-          :number => 2,
-          :quantity => 4}
+        { name: 'item two',
+          description: 'item two description',
+          amount: 20000,
+          number: 2,
+          quantity: 4}
       ]
     }))
 
@@ -206,7 +206,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_url_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:callback_url => 'http://example.com/update_callback'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_url: 'http://example.com/update_callback'}))
 
     assert_equal 'http://example.com/update_callback', REXML::XPath.first(xml, '//n2:CallbackURL').text
   end
@@ -218,7 +218,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_timeout_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:callback_timeout => 2}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_timeout: 2}))
 
     assert_equal '2', REXML::XPath.first(xml, '//n2:CallbackTimeout').text
   end
@@ -230,7 +230,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_version_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {:callback_version => '53.0'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_version: '53.0'}))
 
     assert_equal '53.0', REXML::XPath.first(xml, '//n2:CallbackVersion').text
   end
@@ -244,17 +244,17 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_flatrate_shipping_options_are_included_if_specified_in_build_setup_request
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0,
       {
-        :currency => 'AUD',
-        :shipping_options => [
+        currency: 'AUD',
+        shipping_options: [
           {
-            :default => true,
-            :name => 'first one',
-            :amount => 1000
+            default: true,
+            name: 'first one',
+            amount: 1000
           },
           {
-            :default => false,
-            :name => 'second one',
-            :amount => 2000
+            default: false,
+            name: 'second one',
+            amount: 2000
           }
         ]
       }))
@@ -273,14 +273,14 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_address_is_included_if_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'Sale', 0,
       {
-        :currency => 'GBP',
-        :address => {
-          :name     => 'John Doe',
-          :address1 => '123 somewhere',
-          :city     => 'Townville',
-          :country  => 'Canada',
-          :zip      => 'k1l4p2',
-          :phone    => '1231231231'
+        currency: 'GBP',
+        address: {
+          name: 'John Doe',
+          address1: '123 somewhere',
+          city: 'Townville',
+          country: 'Canada',
+          zip: 'k1l4p2',
+          phone: '1231231231'
         }
       }))
 
@@ -300,12 +300,12 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_amount_format_for_jpy_currency
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_authorization_response)
-    response = @gateway.authorize(100, :token => 'EC-6WS104951Y388951L', :payer_id => 'FWRVKNRRZ3WUC', :currency => 'JPY')
+    response = @gateway.authorize(100, token: 'EC-6WS104951Y388951L', payer_id: 'FWRVKNRRZ3WUC', currency: 'JPY')
     assert response.success?
   end
 
   def test_removes_fractional_amounts_with_twd_currency
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, {:currency => 'TWD'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, {currency: 'TWD'}))
 
     assert_equal '1', REXML::XPath.first(xml, '//n2:OrderTotal').text
   end
@@ -313,27 +313,27 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_fractional_discounts_are_correctly_calculated_with_jpy_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
       {
-        :items => [
+        items: [
           {
-            :name => 'item one',
-            :description => 'description',
-            :amount => 15000,
-            :number => 1,
-            :quantity => 1
+            name: 'item one',
+            description: 'description',
+            amount: 15000,
+            number: 1,
+            quantity: 1
           },
           {
-            :name => 'Discount',
-            :description => 'Discount',
-            :amount => -750,
-            :number => 2,
-            :quantity => 1
+            name: 'Discount',
+            description: 'Discount',
+            amount: -750,
+            number: 2,
+            quantity: 1
           }
         ],
-        :subtotal => 14250,
-        :currency => 'JPY',
-        :shipping => 0,
-        :handling => 0,
-        :tax => 0
+        subtotal: 14250,
+        currency: 'JPY',
+        shipping: 0,
+        handling: 0,
+        tax: 0
       }))
 
     assert_equal '142', REXML::XPath.first(xml, '//n2:OrderTotal').text
@@ -346,27 +346,27 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_non_fractional_discounts_are_correctly_calculated_with_jpy_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14300,
       {
-        :items => [
+        items: [
           {
-            :name => 'item one',
-            :description => 'description',
-            :amount => 15000,
-            :number => 1,
-            :quantity => 1
+            name: 'item one',
+            description: 'description',
+            amount: 15000,
+            number: 1,
+            quantity: 1
           },
           {
-            :name => 'Discount',
-            :description => 'Discount',
-            :amount => -700,
-            :number => 2,
-            :quantity => 1
+            name: 'Discount',
+            description: 'Discount',
+            amount: -700,
+            number: 2,
+            quantity: 1
           }
         ],
-        :subtotal => 14300,
-        :currency => 'JPY',
-        :shipping => 0,
-        :handling => 0,
-        :tax => 0
+        subtotal: 14300,
+        currency: 'JPY',
+        shipping: 0,
+        handling: 0,
+        tax: 0
       }))
 
     assert_equal '143', REXML::XPath.first(xml, '//n2:OrderTotal').text
@@ -379,27 +379,27 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_fractional_discounts_are_correctly_calculated_with_usd_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
       {
-        :items => [
+        items: [
           {
-            :name => 'item one',
-            :description => 'description',
-            :amount => 15000,
-            :number => 1,
-            :quantity => 1
+            name: 'item one',
+            description: 'description',
+            amount: 15000,
+            number: 1,
+            quantity: 1
           },
           {
-            :name => 'Discount',
-            :description => 'Discount',
-            :amount => -750,
-            :number => 2,
-            :quantity => 1
+            name: 'Discount',
+            description: 'Discount',
+            amount: -750,
+            number: 2,
+            quantity: 1
           }
         ],
-      :subtotal => 14250,
-      :currency => 'USD',
-      :shipping => 0,
-      :handling => 0,
-      :tax => 0
+      subtotal: 14250,
+      currency: 'USD',
+      shipping: 0,
+      handling: 0,
+      tax: 0
       }))
 
     assert_equal '142.50', REXML::XPath.first(xml, '//n2:OrderTotal').text
@@ -416,27 +416,27 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_adds_allow_note_if_specified
-    allow_notes_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :allow_note => true }))
-    do_not_allow_notes_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :allow_note => false }))
+    allow_notes_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { allow_note: true }))
+    do_not_allow_notes_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { allow_note: false }))
 
     assert_equal '1', REXML::XPath.first(allow_notes_xml, '//n2:AllowNote').text
     assert_equal '0', REXML::XPath.first(do_not_allow_notes_xml, '//n2:AllowNote').text
   end
 
   def test_handle_locale_code
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :locale => 'GB' }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { locale: 'GB' }))
 
     assert_equal 'GB', REXML::XPath.first(xml, '//n2:LocaleCode').text
   end
 
   def test_handle_non_standard_locale_code
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :locale => 'IL' }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { locale: 'IL' }))
 
     assert_equal 'he_IL', REXML::XPath.first(xml, '//n2:LocaleCode').text
   end
 
   def test_does_not_include_locale_in_request_unless_provided_in_options
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { :locale => nil }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { locale: nil }))
 
     assert_nil REXML::XPath.first(xml, '//n2:LocaleCode')
   end
@@ -455,20 +455,20 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_items_are_included_if_specified_in_build_sale_or_authorization_request
     xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Sale', 100,
       {
-        :items => [
+        items: [
           {
-            :name => 'item one',
-            :description => 'item one description',
-            :amount => 10000,
-            :number => 1,
-            :quantity => 3
+            name: 'item one',
+            description: 'item one description',
+            amount: 10000,
+            number: 1,
+            quantity: 3
           },
           {
-            :name => 'item two',
-            :description => 'item two description',
-            :amount => 20000,
-            :number => 2,
-            :quantity => 4
+            name: 'item two',
+            description: 'item two description',
+            amount: 20000,
+            number: 2,
+            quantity: 4
           }
         ]
       }))
@@ -549,11 +549,11 @@ class PaypalExpressTest < Test::Unit::TestCase
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
     xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000,
       {
-        :reference_id => 'ref_id',
-        :payment_type => 'Any',
-        :invoice_id   => 'invoice_id',
-        :description  => 'Description',
-        :ip           => '127.0.0.1'
+        reference_id: 'ref_id',
+        payment_type: 'Any',
+        invoice_id: 'invoice_id',
+        description: 'Description',
+        ip: '127.0.0.1'
       }))
 
     assert_equal '124', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
@@ -578,11 +578,11 @@ class PaypalExpressTest < Test::Unit::TestCase
 
     response = @gateway.authorize_reference_transaction(2000,
       {
-        :reference_id => 'ref_id',
-        :payment_type => 'Any',
-        :invoice_id   => 'invoice_id',
-        :description  => 'Description',
-        :ip           => '127.0.0.1'
+        reference_id: 'ref_id',
+        payment_type: 'Any',
+        invoice_id: 'invoice_id',
+        description: 'Description',
+        ip: '127.0.0.1'
       })
 
     assert_equal 'Success', response.params['ack']
@@ -593,7 +593,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_reference_transaction
     @gateway.expects(:ssl_post).returns(successful_reference_transaction_response)
 
-    response = @gateway.reference_transaction(2000, { :reference_id => 'ref_id' })
+    response = @gateway.reference_transaction(2000, { reference_id: 'ref_id' })
 
     assert_equal 'Success', response.params['ack']
     assert_equal 'Success', response.message
@@ -609,8 +609,8 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_error_code_for_single_error
     @gateway.expects(:ssl_post).returns(response_with_error)
     response = @gateway.setup_authorization(100,
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com'
     )
     assert_equal '10736', response.params['error_codes']
   end
@@ -618,8 +618,8 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_ensure_only_unique_error_codes
     @gateway.expects(:ssl_post).returns(response_with_duplicate_errors)
     response = @gateway.setup_authorization(100,
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com'
     )
 
     assert_equal '10736', response.params['error_codes']
@@ -628,22 +628,22 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_error_codes_for_multiple_errors
     @gateway.expects(:ssl_post).returns(response_with_errors)
     response = @gateway.setup_authorization(100,
-      :return_url => 'http://example.com',
-      :cancel_return_url => 'http://example.com'
+      return_url: 'http://example.com',
+      cancel_return_url: 'http://example.com'
     )
 
     assert_equal ['10736', '10002'], response.params['error_codes'].split(',')
   end
 
   def test_allow_guest_checkout
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_guest_checkout => true}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_guest_checkout: true}))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
 
   def test_paypal_chooses_landing_page
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_guest_checkout => true, :paypal_chooses_landing_page=> true}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_guest_checkout: true, paypal_chooses_landing_page: true}))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_nil REXML::XPath.first(xml, '//n2:LandingPage')
@@ -656,7 +656,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_adds_brand_name_if_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:brand_name => 'Acme'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {brand_name: 'Acme'}))
     assert_equal 'Acme', REXML::XPath.first(xml, '//n2:BrandName').text
   end
 
@@ -674,15 +674,15 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_adds_buyer_optin_if_specified
-    allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_buyer_optin => true}))
-    do_not_allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:allow_buyer_optin => false}))
+    allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_buyer_optin: true}))
+    do_not_allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_buyer_optin: false}))
 
     assert_equal '1', REXML::XPath.first(allow_optin_xml, '//n2:BuyerEmailOptInEnable').text
     assert_equal '0', REXML::XPath.first(do_not_allow_optin_xml, '//n2:BuyerEmailOptInEnable').text
   end
 
   def test_add_total_type_if_specified
-    total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {:total_type => 'EstimatedTotal'}))
+    total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {total_type: 'EstimatedTotal'}))
     no_total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
 
     assert_equal 'EstimatedTotal', REXML::XPath.first(total_type_xml, '//n2:TotalType').text
@@ -691,53 +691,52 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_structure_correct
     all_options_enabled = {
-      :allow_guest_checkout => true,
-      :max_amount => 50,
-      :locale => 'AU',
-      :page_style => 'test-gray',
-      :header_image => 'https://example.com/my_business',
-      :header_background_color => 'CAFE00',
-      :header_border_color => 'CAFE00',
-      :background_color => 'CAFE00',
-      :email => 'joe@example.com',
-      :billing_agreement => {:type => 'MerchantInitiatedBilling', :description => '9.99 per month for a year'},
-      :allow_note => true,
-      :allow_buyer_optin => true,
-      :subtotal => 35,
-      :shipping => 10,
-      :handling => 0,
-      :tax => 5,
-      :total_type => 'EstimatedTotal',
-      :items => [
+      allow_guest_checkout: true,
+      max_amount: 50,
+      locale: 'AU',
+      page_style: 'test-gray',
+      header_image: 'https://example.com/my_business',
+      header_background_color: 'CAFE00',
+      header_border_color: 'CAFE00',
+      background_color: 'CAFE00',
+      email: 'joe@example.com',
+      billing_agreement: {type: 'MerchantInitiatedBilling', description: '9.99 per month for a year'},
+      allow_note: true,
+      allow_buyer_optin: true,
+      subtotal: 35,
+      shipping: 10,
+      handling: 0,
+      tax: 5,
+      total_type: 'EstimatedTotal',
+      items: [
         {
-          :name => 'item one',
-          :number => 'number 1',
-          :quantity => 3,
-          :amount => 35,
-          :description => 'one description',
-          :url => 'http://example.com/number_1'
+          name: 'item one',
+          number: 'number 1',
+          quantity: 3,
+          amount: 35,
+          description: 'one description',
+          url: 'http://example.com/number_1'
         }
       ],
-      :address =>
+      address:         {
+        name: 'John Doe',
+          address1: 'Apartment 1',
+          address2: '1 Road St',
+          city: 'First City',
+          state: 'NSW',
+          country: 'AU',
+          zip: '2000',
+          phone: '555 5555'
+      },
+      callback_url: 'http://example.com/update_callback',
+      callback_timeout: 2,
+      callback_version: '53.0',
+      funding_sources: {source: 'BML'},
+      shipping_options: [
         {
-          :name => 'John Doe',
-          :address1 => 'Apartment 1',
-          :address2 => '1 Road St',
-          :city => 'First City',
-          :state => 'NSW',
-          :country => 'AU',
-          :zip => '2000',
-          :phone => '555 5555'
-        },
-      :callback_url => 'http://example.com/update_callback',
-      :callback_timeout => 2,
-      :callback_version => '53.0',
-      :funding_sources => {:source => 'BML'},
-      :shipping_options => [
-        {
-          :default => true,
-          :name => 'first one',
-          :amount => 10
+          default: true,
+          name: 'first one',
+          amount: 10
         }
       ]
     }

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -8,19 +8,19 @@ class PaypalTest < Test::Unit::TestCase
 
     @amount = 100
     @gateway = PaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
 
     @credit_card = credit_card('4242424242424242')
-    @options = { :billing_address => address, :ip => '127.0.0.1' }
-    @recurring_required_fields = {:start_date => Date.today, :frequency => :Month, :period => 'Month', :description => 'A description'}
+    @options = { billing_address: address, ip: '127.0.0.1' }
+    @recurring_required_fields = {start_date: Date.today, frequency: :Month, period: 'Month', description: 'A description'}
   end
 
   def test_no_ip_address
     assert_raise(ArgumentError) do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end
   end
 
@@ -63,7 +63,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_update_recurring_requires_profile_id
     assert_raise(ArgumentError) do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.update_recurring(:amount => 100)
+        @gateway.update_recurring(amount: 100)
       end
     end
   end
@@ -71,7 +71,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_cancel_recurring_requires_profile_id
     assert_raise(ArgumentError) do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.cancel_recurring(nil, :note => 'Note')
+        @gateway.cancel_recurring(nil, note: 'Note')
       end
     end
   end
@@ -87,7 +87,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_suspend_recurring_requires_profile_id
     assert_raise(ArgumentError) do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.suspend_recurring(nil, :note => 'Note')
+        @gateway.suspend_recurring(nil, note: 'Note')
       end
     end
   end
@@ -95,13 +95,13 @@ class PaypalTest < Test::Unit::TestCase
   def test_reactivate_recurring_requires_profile_id
     assert_raise(ArgumentError) do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.reactivate_recurring(nil, :note => 'Note')
+        @gateway.reactivate_recurring(nil, note: 'Note')
       end
     end
   end
 
   def test_successful_purchase_with_auth_signature
-    @gateway = PaypalGateway.new(:login => 'cody', :password => 'test', :pem => 'PEM', :auth_signature => 123)
+    @gateway = PaypalGateway.new(login: 'cody', password: 'test', pem: 'PEM', auth_signature: 123)
     expected_header = {'X-PP-AUTHORIZATION' => 123, 'X-PAYPAL-MESSAGE-PROTOCOL' => 'SOAP11'}
     @gateway.expects(:ssl_post).with(anything, anything, expected_header).returns(successful_purchase_response)
     @gateway.expects(:add_credentials).never
@@ -110,7 +110,7 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_without_auth_signature
-    @gateway = PaypalGateway.new(:login => 'cody', :password => 'test', :pem => 'PEM')
+    @gateway = PaypalGateway.new(login: 'cody', password: 'test', pem: 'PEM')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     @gateway.expects(:add_credentials)
 
@@ -136,7 +136,7 @@ class PaypalTest < Test::Unit::TestCase
 
     ref_id = response.authorization
 
-    gateway2 = PaypalGateway.new(:login => 'cody', :password => 'test', :pem => 'PEM')
+    gateway2 = PaypalGateway.new(login: 'cody', password: 'test', pem: 'PEM')
     gateway2.expects(:ssl_post).returns(successful_reference_purchase_response)
     assert response = gateway2.purchase(@amount, ref_id, @options)
     assert_instance_of Response, response
@@ -198,19 +198,19 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_pem_file_accessor
     PaypalGateway.pem_file = '123456'
-    gateway = PaypalGateway.new(:login => 'test', :password => 'test')
+    gateway = PaypalGateway.new(login: 'test', password: 'test')
     assert_equal '123456', gateway.options[:pem]
   end
 
   def test_passed_in_pem_overrides_class_accessor
     PaypalGateway.pem_file = '123456'
-    gateway = PaypalGateway.new(:login => 'test', :password => 'test', :pem => 'Clobber')
+    gateway = PaypalGateway.new(login: 'test', password: 'test', pem: 'Clobber')
     assert_equal 'Clobber', gateway.options[:pem]
   end
 
   def test_ensure_options_are_transferred_to_express_instance
     PaypalGateway.pem_file = '123456'
-    gateway = PaypalGateway.new(:login => 'test', :password => 'password')
+    gateway = PaypalGateway.new(login: 'test', password: 'password')
     express = gateway.express
     assert_instance_of PaypalExpressGateway, express
     assert_equal 'test', express.options[:login]
@@ -261,9 +261,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_item_total_shipping_handling_and_tax_not_included_unless_all_are_present
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
-      :tax => @amount,
-      :shipping => @amount,
-      :handling => @amount
+      tax: @amount,
+      shipping: @amount,
+      handling: @amount
     )
 
     doc = REXML::Document.new(xml)
@@ -272,10 +272,10 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_item_total_shipping_handling_and_tax
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
-      :tax => @amount,
-      :shipping => @amount,
-      :handling => @amount,
-      :subtotal => 200
+      tax: @amount,
+      shipping: @amount,
+      handling: @amount,
+      subtotal: 200
     )
 
     doc = REXML::Document.new(xml)
@@ -284,18 +284,18 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_use_test_certificate_endpoint
     gateway = PaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
     assert_equal PaypalGateway::URLS[:test][:certificate], gateway.send(:endpoint_url)
   end
 
   def test_should_use_live_certificate_endpoint
     gateway = PaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :pem => 'PEM'
+      login: 'cody',
+      password: 'test',
+      pem: 'PEM'
     )
     gateway.expects(:test?).returns(false)
 
@@ -304,9 +304,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_use_test_signature_endpoint
     gateway = PaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :signature => 'SIG'
+      login: 'cody',
+      password: 'test',
+      signature: 'SIG'
     )
 
     assert_equal PaypalGateway::URLS[:test][:signature], gateway.send(:endpoint_url)
@@ -314,9 +314,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_use_live_signature_endpoint
     gateway = PaypalGateway.new(
-      :login => 'cody',
-      :password => 'test',
-      :signature => 'SIG'
+      login: 'cody',
+      password: 'test',
+      signature: 'SIG'
     )
     gateway.expects(:test?).returns(false)
 
@@ -325,7 +325,7 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_should_raise_argument_when_credentials_not_present
     assert_raises(ArgumentError) do
-      PaypalGateway.new(:login => 'cody', :password => 'test')
+      PaypalGateway.new(login: 'cody', password: 'test')
     end
   end
 
@@ -372,14 +372,14 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_amount_format_for_jpy_currency
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/n2:OrderTotal currencyID=.JPY.>1<\/n2:OrderTotal>/), {}).returns(successful_purchase_response)
-    response = @gateway.purchase(100, @credit_card, @options.merge(:currency => 'JPY'))
+    response = @gateway.purchase(100, @credit_card, @options.merge(currency: 'JPY'))
     assert response.success?
   end
 
   def test_successful_create_profile
     @gateway.expects(:ssl_post).returns(successful_create_profile_paypal_response)
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, @credit_card, :description => 'some description', :start_date => Time.now, :frequency => 12, :period => 'Month')
+      @gateway.recurring(@amount, @credit_card, description: 'some description', start_date: Time.now, frequency: 12, period: 'Month')
     end
     assert_instance_of Response, response
     assert response.success?
@@ -391,7 +391,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_failed_create_profile
     @gateway.expects(:ssl_post).returns(failed_create_profile_paypal_response)
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, @credit_card, :description => 'some description', :start_date => Time.now, :frequency => 12, :period => 'Month')
+      @gateway.recurring(@amount, @credit_card, description: 'some description', start_date: Time.now, frequency: 12, period: 'Month')
     end
     assert_instance_of Response, response
     assert !response.success?
@@ -401,42 +401,42 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_update_recurring_delegation
-    @gateway.expects(:build_change_profile_request).with('I-G7A2FF8V75JY', :amount => 200)
+    @gateway.expects(:build_change_profile_request).with('I-G7A2FF8V75JY', amount: 200)
     @gateway.stubs(:commit)
     assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+      @gateway.update_recurring(profile_id: 'I-G7A2FF8V75JY', amount: 200)
     end
   end
 
   def test_update_recurring_response
     @gateway.expects(:ssl_post).returns(successful_update_recurring_payment_profile_response)
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.update_recurring(:profile_id => 'I-G7A2FF8V75JY', :amount => 200)
+      @gateway.update_recurring(profile_id: 'I-G7A2FF8V75JY', amount: 200)
     end
     assert response.success?
   end
 
   def test_cancel_recurring_delegation
-    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Cancel', :note => 'A Note').returns(:cancel_request)
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Cancel', note: 'A Note').returns(:cancel_request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :cancel_request)
     assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.cancel_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+      @gateway.cancel_recurring('I-G7A2FF8V75JY', note: 'A Note')
     end
   end
 
   def test_suspend_recurring_delegation
-    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Suspend', :note => 'A Note').returns(:request)
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Suspend', note: 'A Note').returns(:request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
     assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.suspend_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+      @gateway.suspend_recurring('I-G7A2FF8V75JY', note: 'A Note')
     end
   end
 
   def test_reactivate_recurring_delegation
-    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Reactivate', :note => 'A Note').returns(:request)
+    @gateway.expects(:build_manage_profile_request).with('I-G7A2FF8V75JY', 'Reactivate', note: 'A Note').returns(:request)
     @gateway.expects(:commit).with('ManageRecurringPaymentsProfileStatus', :request)
     assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.reactivate_recurring('I-G7A2FF8V75JY', :note => 'A Note')
+      @gateway.reactivate_recurring('I-G7A2FF8V75JY', note: 'A Note')
     end
   end
 
@@ -458,17 +458,17 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_bill_outstanding_amoung_delegation
-    @gateway.expects(:build_bill_outstanding_amount).with('I-G7A2FF8V75JY', :amount => 400).returns(:request)
+    @gateway.expects(:build_bill_outstanding_amount).with('I-G7A2FF8V75JY', amount: 400).returns(:request)
     @gateway.expects(:commit).with('BillOutstandingAmount', :request)
     assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', amount: 400)
     end
   end
 
   def test_bill_outstanding_amoung_response
     @gateway.expects(:ssl_post).returns(successful_bill_outstanding_amount)
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', :amount => 400)
+      @gateway.bill_outstanding_amount('I-G7A2FF8V75JY', amount: 400)
     end
     assert response.success?
   end
@@ -481,14 +481,14 @@ class PaypalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.transfer 1000, 'fred@example.com', :receiver_type => 'EmailAddress'
+      @gateway.transfer 1000, 'fred@example.com', receiver_type: 'EmailAddress'
     end.check_request do |endpoint, data, headers|
       assert_match %r{<ReceiverType>EmailAddress</ReceiverType>}, data
       assert_match %r{<ReceiverEmail>fred@example\.com</ReceiverEmail>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.transfer 1000, 'fred@example.com', :receiver_type => 'UserID'
+      @gateway.transfer 1000, 'fred@example.com', receiver_type: 'UserID'
     end.check_request do |endpoint, data, headers|
       assert_match %r{<ReceiverType>UserID</ReceiverType>}, data
       assert_match %r{<ReceiverID>fred@example\.com</ReceiverID>}, data

--- a/test/unit/gateways/payscout_test.rb
+++ b/test/unit/gateways/payscout_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class PayscoutTest < Test::Unit::TestCase
   def setup
     @gateway = PayscoutGateway.new(
-      :username => 'xxx',
-      :password => 'xxx'
+      username: 'xxx',
+      password: 'xxx'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -4,17 +4,17 @@ class PaystationTest < Test::Unit::TestCase
   include CommStub
   def setup
     @gateway = PaystationGateway.new(
-      :paystation_id => 'some_id_number',
-      :gateway_id    => 'another_id_number'
+      paystation_id: 'some_id_number',
+      gateway_id: 'another_id_number'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :customer => 'Joe Bloggs, Customer ID #56',
-      :description => 'Store Purchase'
+      order_id: '1',
+      customer: 'Joe Bloggs, Customer ID #56',
+      description: 'Store Purchase'
     }
   end
 
@@ -41,7 +41,7 @@ class PaystationTest < Test::Unit::TestCase
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
-    assert response = @gateway.store(@credit_card, @options.merge(:token => 'justatest1310263135'))
+    assert response = @gateway.store(@credit_card, @options.merge(token: 'justatest1310263135'))
     assert_success response
     assert response.test?
 
@@ -74,7 +74,7 @@ class PaystationTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
 
-    assert response = @gateway.capture(@amount, '0009062250-01', @options.merge(:credit_card_verification => 123))
+    assert response = @gateway.capture(@amount, '0009062250-01', @options.merge(credit_card_verification: 123))
     assert_success response
   end
 

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -12,7 +12,7 @@ class PayuLatamTest < Test::Unit::TestCase
     @pending_card = credit_card('4097440000000004', verification_value: '222', first_name: 'PENDING', last_name: '')
     @no_cvv_visa_card = credit_card('4097440000000004', verification_value: ' ')
     @no_cvv_amex_card = credit_card('4097440000000004', verification_value: ' ', brand: 'american_express')
-    @cabal_credit_card = credit_card('5896570000000004', :verification_value => '123', :first_name => 'APPROVED', :last_name => '', :brand => 'cabal')
+    @cabal_credit_card = credit_card('5896570000000004', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')
 
     @options = {
       dni_number: '5415668464654',

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -3,25 +3,25 @@ require 'test_helper'
 class PaywayTest < Test::Unit::TestCase
   def setup
     @gateway = PaywayGateway.new(
-      :username => '12341234',
-      :password => 'abcdabcd',
-      :pem      => certificate
+      username: '12341234',
+      password: 'abcdabcd',
+      pem: certificate
     )
 
     @amount = 1000
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :number             => 4564710000000004,
-      :month              => 2,
-      :year               => 2019,
-      :first_name         => 'Bob',
-      :last_name          => 'Smith',
-      :verification_value => '847',
-      :brand              => 'visa'
+      number: 4564710000000004,
+      month: 2,
+      year: 2019,
+      first_name: 'Bob',
+      last_name: 'Smith',
+      verification_value: '847',
+      brand: 'visa'
     )
 
     @options = {
-      :order_id => 'abc'
+      order_id: 'abc'
     }
   end
 
@@ -208,7 +208,7 @@ class PaywayTest < Test::Unit::TestCase
   def test_store
     @gateway.stubs(:ssl_post).returns(successful_response_store)
 
-    response = @gateway.store(@credit_card, :billing_id => 84517)
+    response = @gateway.store(@credit_card, billing_id: 84517)
 
     assert_instance_of Response, response
     assert_success response

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -2,16 +2,16 @@ require 'test_helper'
 
 class PinTest < Test::Unit::TestCase
   def setup
-    @gateway = PinGateway.new(:api_key => 'I_THISISNOTAREALAPIKEY')
+    @gateway = PinGateway.new(api_key: 'I_THISISNOTAREALAPIKEY')
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :email => 'roland@pinpayments.com',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :ip => '127.0.0.1'
+      email: 'roland@pinpayments.com',
+      billing_address: address,
+      description: 'Store Purchase',
+      ip: '127.0.0.1'
     }
   end
 
@@ -130,7 +130,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_successful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_equal 'rf_d2C7M6Mn4z2m3APqarNN6w', response.authorization
@@ -140,7 +140,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_unsuccessful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {:amount => '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_failure response
@@ -262,7 +262,7 @@ class PinTest < Test::Unit::TestCase
     @gateway.send(:add_capture, post, @options)
     assert_equal post[:capture], true
 
-    @gateway.send(:add_capture, post, :capture => false)
+    @gateway.send(:add_capture, post, capture: false)
     assert_equal post[:capture], false
   end
 
@@ -310,7 +310,7 @@ class PinTest < Test::Unit::TestCase
     expected_headers['X-Safe-Card'] = '1'
 
     @gateway.expects(:ssl_request).with(:post, anything, anything, expected_headers).returns(successful_purchase_response)
-    assert @gateway.purchase(@amount, @credit_card, :partner_key => 'MyPartnerKey', :safe_card => '1')
+    assert @gateway.purchase(@amount, @credit_card, partner_key: 'MyPartnerKey', safe_card: '1')
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/plugnpay_test.rb
+++ b/test/unit/gateways/plugnpay_test.rb
@@ -5,14 +5,14 @@ class PlugnpayTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = PlugnpayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     @credit_card = credit_card
     @options = {
-      :billing_address => address,
-      :description => 'Store purchase'
+      billing_address: address,
+      description: 'Store purchase'
     }
     @amount = 100
   end
@@ -69,7 +69,7 @@ class PlugnpayTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = PlugnpayGateway::PlugnpayPostData.new
 
-    @gateway.send(:add_addresses, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'DE', :state => 'Dortmund'})
+    @gateway.send(:add_addresses, result, billing_address: {address1: '164 Waverley Street', country: 'DE', state: 'Dortmund'})
 
     assert_equal result[:state], 'ZZ'
     assert_equal result[:province], 'Dortmund'
@@ -84,7 +84,7 @@ class PlugnpayTest < Test::Unit::TestCase
   def test_add_address
     result = PlugnpayGateway::PlugnpayPostData.new
 
-    @gateway.send(:add_addresses, result, :billing_address => {:address1 => '164 Waverley Street', :country => 'US', :state => 'CO'})
+    @gateway.send(:add_addresses, result, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
 
     assert_equal result[:card_state], 'CO'
     assert_equal result[:card_address1], '164 Waverley Street'

--- a/test/unit/gateways/psigate_test.rb
+++ b/test/unit/gateways/psigate_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class PsigateTest < Test::Unit::TestCase
   def setup
     @gateway = PsigateGateway.new(
-      :login => 'teststore',
-      :password => 'psigate1234'
+      login: 'teststore',
+      password: 'psigate1234'
     )
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
-    @options = { :order_id => '1', :billing_address => address }
+    @options = { order_id: '1', billing_address: address }
   end
 
   def test_successful_authorization

--- a/test/unit/gateways/psl_card_test.rb
+++ b/test/unit/gateways/psl_card_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class PslCardTest < Test::Unit::TestCase
   def setup
     @gateway = PslCardGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @credit_card = credit_card
     @options = {
-      :billing_address => address,
-      :description => 'Store purchase'
+      billing_address: address,
+      description: 'Store purchase'
     }
     @amount = 100
   end

--- a/test/unit/gateways/qbms_test.rb
+++ b/test/unit/gateways/qbms_test.rb
@@ -5,9 +5,9 @@ class QbmsTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = QbmsGateway.new(
-      :login  => 'test',
-      :ticket => 'abc123',
-      :pem    => 'PEM')
+      login: 'test',
+      ticket: 'abc123',
+      pem: 'PEM')
 
     @amount = 100
     @card = credit_card('4111111111111111')
@@ -45,7 +45,7 @@ class QbmsTest < Test::Unit::TestCase
       with(anything, regexp_matches(/12345 Ridiculously Lengthy Roa\<.*445566778\</), anything).
       returns(charge_response)
 
-    options = { :billing_address => address.update(:address1 => '12345 Ridiculously Lengthy Road Name', :zip => '4455667788') }
+    options = { billing_address: address.update(address1: '12345 Ridiculously Lengthy Road Name', zip: '4455667788') }
     assert response = @gateway.purchase(@amount, @card, options)
     assert_success response
   end
@@ -53,7 +53,7 @@ class QbmsTest < Test::Unit::TestCase
   def test_partial_address_is_ok
     @gateway.expects(:ssl_post).returns(charge_response)
 
-    options = { :billing_address => address.update(:address1 => nil, :zip => nil) }
+    options = { billing_address: address.update(address1: nil, zip: nil) }
     assert response = @gateway.purchase(@amount, @card, options)
     assert_success response
   end
@@ -90,17 +90,17 @@ class QbmsTest < Test::Unit::TestCase
     assert_equal 'Y', response.avs_result['street_match']
     assert_equal 'Y', response.avs_result['postal_match']
 
-    @gateway.expects(:ssl_post).returns(authorization_response(:avs_street => 'Fail'))
+    @gateway.expects(:ssl_post).returns(authorization_response(avs_street: 'Fail'))
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'N', response.avs_result['street_match']
     assert_equal 'Y', response.avs_result['postal_match']
 
-    @gateway.expects(:ssl_post).returns(authorization_response(:avs_zip => 'Fail'))
+    @gateway.expects(:ssl_post).returns(authorization_response(avs_zip: 'Fail'))
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'Y', response.avs_result['street_match']
     assert_equal 'N', response.avs_result['postal_match']
 
-    @gateway.expects(:ssl_post).returns(authorization_response(:avs_street => 'Fail', :avs_zip => 'Fail'))
+    @gateway.expects(:ssl_post).returns(authorization_response(avs_street: 'Fail', avs_zip: 'Fail'))
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'N', response.avs_result['street_match']
     assert_equal 'N', response.avs_result['postal_match']
@@ -111,11 +111,11 @@ class QbmsTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'M', response.cvv_result['code']
 
-    @gateway.expects(:ssl_post).returns(authorization_response(:card_security_code_match => 'Fail'))
+    @gateway.expects(:ssl_post).returns(authorization_response(card_security_code_match: 'Fail'))
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'N', response.cvv_result['code']
 
-    @gateway.expects(:ssl_post).returns(authorization_response(:card_security_code_match => 'NotAvailable'))
+    @gateway.expects(:ssl_post).returns(authorization_response(card_security_code_match: 'NotAvailable'))
     assert response = @gateway.authorize(@amount, @card)
     assert_equal 'P', response.cvv_result['code']
   end
@@ -129,7 +129,7 @@ class QbmsTest < Test::Unit::TestCase
   end
 
   def test_failed_signon
-    @gateway.expects(:ssl_post).returns(query_response(:signon_status_code => 2000))
+    @gateway.expects(:ssl_post).returns(query_response(signon_status_code: 2000))
 
     assert response = @gateway.query()
     assert_instance_of Response, response
@@ -137,7 +137,7 @@ class QbmsTest < Test::Unit::TestCase
   end
 
   def test_failed_authorization
-    @gateway.expects(:ssl_post).returns(authorization_response(:status_code => 10301))
+    @gateway.expects(:ssl_post).returns(authorization_response(status_code: 10301))
 
     assert response = @gateway.authorize(@amount, @card)
     assert_instance_of Response, response
@@ -147,7 +147,7 @@ class QbmsTest < Test::Unit::TestCase
   def test_use_test_url_when_overwriting_with_test_option
     ActiveMerchant::Billing::Base.mode = :production
 
-    @gateway = QbmsGateway.new(:login => 'test', :ticket => 'abc123', :test => true)
+    @gateway = QbmsGateway.new(login: 'test', ticket: 'abc123', test: true)
     @gateway.stubs(:parse).returns({})
     @gateway.expects(:ssl_post).with(QbmsGateway.test_url, anything, anything).returns(authorization_response)
     @gateway.authorize(@amount, @card)
@@ -173,9 +173,9 @@ class QbmsTest < Test::Unit::TestCase
 
   def authorization_response(opts = {})
     opts = {
-      :avs_street               => 'Pass',
-      :avs_zip                  => 'Pass',
-      :card_security_code_match => 'Pass',
+      avs_street: 'Pass',
+      avs_zip: 'Pass',
+      card_security_code_match: 'Pass',
     }.merge(opts)
 
     wrap 'CustomerCreditCardAuth', opts, <<-"XML"
@@ -200,9 +200,9 @@ class QbmsTest < Test::Unit::TestCase
 
   def charge_response(opts = {})
     opts = {
-      :avs_street               => 'Pass',
-      :avs_zip                  => 'Pass',
-      :card_security_code_match => 'Pass',
+      avs_street: 'Pass',
+      avs_zip: 'Pass',
+      card_security_code_match: 'Pass',
     }.merge(opts)
 
     wrap 'CustomerCreditCardCharge', opts, <<-"XML"
@@ -236,9 +236,9 @@ class QbmsTest < Test::Unit::TestCase
 
   def wrap(type, opts, xml)
     opts = {
-      :signon_status_code => 0,
-      :request_id         => 'x',
-      :status_code        => 0,
+      signon_status_code: 0,
+      request_id: 'x',
+      status_code: 0,
     }.merge(opts)
 
     <<-"XML"

--- a/test/unit/gateways/quantum_test.rb
+++ b/test/unit/gateways/quantum_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class QuantumTest < Test::Unit::TestCase
   def setup
     @gateway = QuantumGateway.new(
-      :login => '',
-      :password => ''
+      login: '',
+      password: ''
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :billing_address => address,
-      :description => 'Store Purchase'
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/quickpay_test.rb
+++ b/test/unit/gateways/quickpay_test.rb
@@ -8,12 +8,12 @@ class QuickpayTest < Test::Unit::TestCase
   end
 
   def test_v4to7
-    gateway = QuickpayGateway.new(:login => 50000000, :password => 'secret')
+    gateway = QuickpayGateway.new(login: 50000000, password: 'secret')
     assert_instance_of QuickpayV4to7Gateway, gateway
   end
 
   def test_v10
-    gateway = QuickpayGateway.new(:login => 100, :api_key => 'APIKEY')
+    gateway = QuickpayGateway.new(login: 100, api_key: 'APIKEY')
     assert_instance_of QuickpayV10Gateway, gateway
   end
 end

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -4,10 +4,10 @@ class QuickpayV10Test < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = QuickpayV10Gateway.new(:api_key => 'APIKEY')
+    @gateway = QuickpayV10Gateway.new(api_key: 'APIKEY')
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :order_id => '1', :billing_address => address, :customer_ip => '1.1.1.1' }
+    @options = { order_id: '1', billing_address: address, customer_ip: '1.1.1.1' }
   end
 
   def parse(body)

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -9,14 +9,14 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
   def setup
     @gateway = QuickpayGateway.new(
-      :login => merchant_id,
-      :password => 'PASSWORD',
-      :version  => 7
+      login: merchant_id,
+      password: 'PASSWORD',
+      version: 7
     )
 
     @credit_card = credit_card('4242424242424242')
     @amount = 100
-    @options = { :order_id => '1', :billing_address => address }
+    @options = { order_id: '1', billing_address: address }
   end
 
   def test_successful_purchase
@@ -39,14 +39,14 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
   def test_successful_store_for_v6
     @gateway = QuickpayGateway.new(
-      :login => merchant_id,
-      :password => 'PASSWORD',
-      :version => 6
+      login: merchant_id,
+      password: 'PASSWORD',
+      version: 6
     )
     @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
 
     response = stub_comms do
-      @gateway.store(@credit_card, {:order_id => 'fa73664073e23597bbdd', :description => 'Storing Card'})
+      @gateway.store(@credit_card, {order_id: 'fa73664073e23597bbdd', description: 'Storing Card'})
     end.check_request do |endpoint, data, headers|
       assert_equal(expected_store_parameters_v6, CGI::parse(data))
     end.respond_with(successful_store_response_v6)
@@ -61,7 +61,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
     @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
 
     response = stub_comms do
-      @gateway.store(@credit_card, {:order_id => 'ed7546cb4ceb8f017ea4', :description => 'Storing Card'})
+      @gateway.store(@credit_card, {order_id: 'ed7546cb4ceb8f017ea4', description: 'Storing Card'})
     end.check_request do |endpoint, data, headers|
       assert_equal(expected_store_parameters_v7, CGI::parse(data))
     end.respond_with(successful_store_response_v7)
@@ -133,7 +133,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   end
 
   def test_add_testmode_does_not_add_testmode_if_transaction_id_present
-    post_hash = {:transaction => '12345'}
+    post_hash = {transaction: '12345'}
     @gateway.send(:add_testmode, post_hash)
     assert_equal nil, post_hash[:testmode]
   end

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -15,37 +15,37 @@ class RealexTest < Test::Unit::TestCase
     @refund_secret = 'your_refund_secret'
 
     @gateway = RealexGateway.new(
-      :login => @login,
-      :password => @password,
-      :account => @account
+      login: @login,
+      password: @password,
+      account: @account
     )
 
     @gateway_with_account = RealexGateway.new(
-      :login => @login,
-      :password => @password,
-      :account => 'bill_web_cengal'
+      login: @login,
+      password: @password,
+      account: 'bill_web_cengal'
     )
 
     @credit_card = CreditCard.new(
-      :number => '4263971921001307',
-      :month => 8,
-      :year => 2008,
-      :first_name => 'Longbob',
-      :last_name => 'Longsen',
-      :brand => 'visa'
+      number: '4263971921001307',
+      month: 8,
+      year: 2008,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      brand: 'visa'
     )
 
     @options = {
-      :order_id => '1'
+      order_id: '1'
     }
 
     @address = {
-      :name => 'Longbob Longsen',
-      :address1 => '123 Fake Street',
-      :city => 'Belfast',
-      :state => 'Antrim',
-      :country => 'Northern Ireland',
-      :zip => 'BT2 8XX'
+      name: 'Longbob Longsen',
+      address1: '123 Fake Street',
+      city: 'Belfast',
+      state: 'Antrim',
+      country: 'Northern Ireland',
+      zip: 'BT2 8XX'
     }
 
     @amount = 100
@@ -90,12 +90,12 @@ class RealexTest < Test::Unit::TestCase
 
   def test_hash
     gateway = RealexGateway.new(
-      :login => 'thestore',
-      :password => 'mysecret'
+      login: 'thestore',
+      password: 'mysecret'
     )
     Time.stubs(:now).returns(Time.new(2001, 4, 3, 12, 32, 45))
     gateway.expects(:ssl_post).with(anything, regexp_matches(/9af7064afd307c9f988e8dfc271f9257f1fc02f6/)).returns(successful_purchase_response)
-    gateway.purchase(29900, credit_card('5105105105105100'), :order_id => 'ORD453-11')
+    gateway.purchase(29900, credit_card('5105105105105100'), order_id: 'ORD453-11')
   end
 
   def test_successful_purchase
@@ -188,7 +188,7 @@ class RealexTest < Test::Unit::TestCase
 
   def test_purchase_xml
     options = {
-      :order_id => '1'
+      order_id: '1'
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -237,7 +237,7 @@ class RealexTest < Test::Unit::TestCase
 
   def test_verify_xml
     options = {
-      :order_id => '1'
+      order_id: '1'
     }
     @gateway.expects(:new_timestamp).returns('20181026114304')
 
@@ -266,7 +266,7 @@ class RealexTest < Test::Unit::TestCase
 
   def test_auth_xml
     options = {
-      :order_id => '1'
+      order_id: '1'
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -316,7 +316,7 @@ class RealexTest < Test::Unit::TestCase
   end
 
   def test_refund_with_rebate_secret_xml
-    gateway = RealexGateway.new(:login => @login, :password => @password, :account => @account, :rebate_secret => @rebate_secret)
+    gateway = RealexGateway.new(login: @login, password: @password, account: @account, rebate_secret: @rebate_secret)
 
     gateway.expects(:new_timestamp).returns('20090824160201')
 
@@ -339,7 +339,7 @@ class RealexTest < Test::Unit::TestCase
 
   def test_credit_xml
     options = {
-      :order_id => '1'
+      order_id: '1'
     }
 
     @gateway.expects(:new_timestamp).returns('20190717161006')
@@ -370,7 +370,7 @@ class RealexTest < Test::Unit::TestCase
   end
 
   def test_credit_with_refund_secret_xml
-    gateway = RealexGateway.new(:login => @login, :password => @password, :account => @account, :refund_secret => @refund_secret)
+    gateway = RealexGateway.new(login: @login, password: @password, account: @account, refund_secret: @refund_secret)
 
     gateway.expects(:new_timestamp).returns('20190717161006')
 
@@ -404,9 +404,9 @@ class RealexTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
     options = {
-      :order_id => '1',
-      :billing_address => @address,
-      :shipping_address => @address
+      order_id: '1',
+      billing_address: @address,
+      shipping_address: @address
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -421,8 +421,8 @@ class RealexTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<code>28\|123<\/code>/)).returns(successful_purchase_response)
 
     options = {
-      :order_id => '1',
-      :shipping_address => @address
+      order_id: '1',
+      shipping_address: @address
     }
 
     @gateway.authorize(@amount, @credit_card, options)
@@ -432,8 +432,8 @@ class RealexTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<code>28\|123<\/code>/)).returns(successful_purchase_response)
 
     options = {
-      :order_id => '1',
-      :billing_address => @address
+      order_id: '1',
+      billing_address: @address
     }
 
     @gateway.authorize(@amount, @credit_card, options)

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -6,9 +6,9 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def setup
     Base.mode = :test
     @credentials = {
-      :login      => '091952713',
-      :secret_key => 'QIK77hYl6UFcoCYFKcj+ZjJg8Q6I93Dx',
-      :signature_algorithm => 'sha256'
+      login: '091952713',
+      secret_key: 'QIK77hYl6UFcoCYFKcj+ZjJg8Q6I93Dx',
+      signature_algorithm: 'sha256'
     }
     @gateway = RedsysGateway.new(@credentials)
     @credit_card = credit_card('4548812049400004')
@@ -22,17 +22,17 @@ class RedsysSHA256Test < Test::Unit::TestCase
     @credit_card.month = 9
     @credit_card.year = 2017
     @gateway.expects(:ssl_post).with(RedsysGateway.test_url, purchase_request, @headers).returns(successful_purchase_response)
-    @gateway.purchase(100, @credit_card, :order_id => '144742736014')
+    @gateway.purchase(100, @credit_card, order_id: '144742736014')
   end
 
   def test_purchase_payload_with_credit_card_token
     @gateway.expects(:ssl_post).with(RedsysGateway.test_url, purchase_request_with_credit_card_token, @headers).returns(successful_purchase_response)
-    @gateway.purchase(100, '3126bb8b80a79e66eb1ecc39e305288b60075f86', :order_id => '144742884282')
+    @gateway.purchase(100, '3126bb8b80a79e66eb1ecc39e305288b60075f86', order_id: '144742884282')
   end
 
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    res = @gateway.purchase(100, credit_card, :order_id => '144742736014')
+    res = @gateway.purchase(100, credit_card, order_id: '144742736014')
     assert_success res
     assert_equal 'Transaction Approved', res.message
     assert_equal '144742736014|100|978', res.authorization
@@ -42,7 +42,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   # This one is being werid...
   def test_successful_purchase_requesting_credit_card_token
     @gateway.expects(:ssl_post).returns(successful_purchase_response_with_credit_card_token)
-    res = @gateway.purchase(100, 'e55e1d0ef338e281baf1d0b5b68be433260ddea0', :order_id => '144742955848')
+    res = @gateway.purchase(100, 'e55e1d0ef338e281baf1d0b5b68be433260ddea0', order_id: '144742955848')
     assert_success res
     assert_equal 'Transaction Approved', res.message
     assert_equal '144742955848|100|978', res.authorization
@@ -52,7 +52,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    res = @gateway.purchase(100, credit_card, :order_id => '144743314659')
+    res = @gateway.purchase(100, credit_card, order_id: '144743314659')
     assert_failure res
     assert_equal 'SIS0093 ERROR', res.message
   end
@@ -65,7 +65,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_error_purchase
     @gateway.expects(:ssl_post).returns(error_purchase_response)
-    res = @gateway.purchase(100, credit_card, :order_id => '123')
+    res = @gateway.purchase(100, credit_card, order_id: '123')
     assert_failure res
     assert_equal 'SIS0051 ERROR', res.message
   end
@@ -104,7 +104,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
       ),
       anything
     ).returns(successful_authorize_response)
-    response = @gateway.authorize(100, credit_card, :order_id => '144743367273')
+    response = @gateway.authorize(100, credit_card, order_id: '144743367273')
     assert_success response
   end
 
@@ -213,25 +213,25 @@ class RedsysSHA256Test < Test::Unit::TestCase
       includes(CGI.escape('<DS_MERCHANT_CURRENCY>840</DS_MERCHANT_CURRENCY>')),
       anything
     ).returns(successful_purchase_response)
-    @gateway.authorize(100, credit_card, :order_id => '1001', :currency => 'USD')
+    @gateway.authorize(100, credit_card, order_id: '1001', currency: 'USD')
   end
 
   def test_successful_verify
     @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(successful_void_response)
-    response = @gateway.verify(credit_card, :order_id => '144743367273')
+    response = @gateway.verify(credit_card, order_id: '144743367273')
     assert_success response
   end
 
   def test_successful_verify_with_failed_void
     @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(failed_void_response)
-    response = @gateway.verify(credit_card, :order_id => '144743367273')
+    response = @gateway.verify(credit_card, order_id: '144743367273')
     assert_success response
     assert_equal 'Transaction Approved', response.message
   end
 
   def test_unsuccessful_verify
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
-    response = @gateway.verify(credit_card, :order_id => '141278225678')
+    response = @gateway.verify(credit_card, order_id: '141278225678')
     assert_failure response
     assert_equal 'SIS0093 ERROR', response.message
   end
@@ -262,10 +262,10 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_overriding_options
     Base.mode = :production
     gw = RedsysGateway.new(
-      :terminal => 1,
-      :login => '1234',
-      :secret_key => '12345',
-      :test => true
+      terminal: 1,
+      login: '1234',
+      secret_key: '12345',
+      test: true
     )
     assert gw.test?
     assert_equal RedsysGateway.test_url, gw.send(:url)
@@ -274,9 +274,9 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_production_mode
     Base.mode = :production
     gw = RedsysGateway.new(
-      :terminal => 1,
-      :login => '1234',
-      :secret_key => '12345'
+      terminal: 1,
+      login: '1234',
+      secret_key: '12345'
     )
     assert !gw.test?
     assert_equal RedsysGateway.live_url, gw.send(:url)

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -6,9 +6,9 @@ class RedsysTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
     @credentials = {
-      :login      => '091952713',
-      :secret_key => 'qwertyasdf0123456789',
-      :terminal   => '1',
+      login: '091952713',
+      secret_key: 'qwertyasdf0123456789',
+      terminal: '1',
     }
     @gateway = RedsysGateway.new(@credentials)
     @headers = {
@@ -20,12 +20,12 @@ class RedsysTest < Test::Unit::TestCase
 
   def test_purchase_payload
     @gateway.expects(:ssl_post).with(RedsysGateway.test_url, purchase_request, @headers).returns(successful_purchase_response)
-    @gateway.purchase(123, credit_card, :order_id => '1001')
+    @gateway.purchase(123, credit_card, order_id: '1001')
   end
 
   def test_purchase_payload_with_credit_card_token
     @gateway.expects(:ssl_post).with(RedsysGateway.test_url, purchase_request_with_credit_card_token, @headers).returns(successful_purchase_response)
-    @gateway.purchase(123, '77bff3a969d6f97b2ec815448cdcff453971f573', :order_id => '1001')
+    @gateway.purchase(123, '77bff3a969d6f97b2ec815448cdcff453971f573', order_id: '1001')
   end
 
   def test_successful_purchase
@@ -161,7 +161,7 @@ class RedsysTest < Test::Unit::TestCase
       includes(CGI.escape('<DS_MERCHANT_CURRENCY>840</DS_MERCHANT_CURRENCY>')),
       anything
     ).returns(successful_purchase_response)
-    @gateway.authorize(123, credit_card, :order_id => '1001', :currency => 'USD')
+    @gateway.authorize(123, credit_card, order_id: '1001', currency: 'USD')
   end
 
   def test_successful_verify
@@ -210,10 +210,10 @@ class RedsysTest < Test::Unit::TestCase
   def test_overriding_options
     Base.mode = :production
     gw = RedsysGateway.new(
-      :terminal => 1,
-      :login => '1234',
-      :secret_key => '12345',
-      :test => true
+      terminal: 1,
+      login: '1234',
+      secret_key: '12345',
+      test: true
     )
     assert gw.test?
     assert_equal RedsysGateway.test_url, gw.send(:url)
@@ -222,9 +222,9 @@ class RedsysTest < Test::Unit::TestCase
   def test_production_mode
     Base.mode = :production
     gw = RedsysGateway.new(
-      :terminal => 1,
-      :login => '1234',
-      :secret_key => '12345'
+      terminal: 1,
+      login: '1234',
+      secret_key: '12345'
     )
     assert !gw.test?
     assert_equal RedsysGateway.live_url, gw.send(:url)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -6,23 +6,23 @@ class SagePayTest < Test::Unit::TestCase
   def setup
     @gateway = SagePayGateway.new(login: 'X')
 
-    @credit_card = credit_card('4242424242424242', :brand => 'visa')
-    @electron_credit_card = credit_card('4245190000000000', :brand => 'visa')
+    @credit_card = credit_card('4242424242424242', brand: 'visa')
+    @electron_credit_card = credit_card('4245190000000000', brand: 'visa')
     @options = {
-      :billing_address => {
-        :name => 'Tekin Suleyman',
-        :address1 => 'Flat 10 Lapwing Court',
-        :address2 => 'West Didsbury',
-        :city => 'Manchester',
-        :county => 'Greater Manchester',
-        :country => 'GB',
-        :zip => 'M20 2PS'
+      billing_address: {
+        name: 'Tekin Suleyman',
+        address1: 'Flat 10 Lapwing Court',
+        address2: 'West Didsbury',
+        city: 'Manchester',
+        county: 'Greater Manchester',
+        country: 'GB',
+        zip: 'M20 2PS'
       },
-      :order_id => '1',
-      :description => 'Store purchase',
-      :ip => '86.150.65.37',
-      :email => 'tekin@tekin.co.uk',
-      :phone => '0161 123 4567'
+      order_id: '1',
+      description: 'Store purchase',
+      ip: '86.150.65.37',
+      email: 'tekin@tekin.co.uk',
+      phone: '0161 123 4567'
     }
     @amount = 100
   end
@@ -95,15 +95,15 @@ class SagePayTest < Test::Unit::TestCase
     @amount = 100_00 # 100 YEN
     @options[:currency] = 'JPY'
 
-    @gateway.expects(:add_pair).with({}, :Amount, '100', :required => true)
-    @gateway.expects(:add_pair).with({}, :Currency, 'JPY', :required => true)
+    @gateway.expects(:add_pair).with({}, :Amount, '100', required: true)
+    @gateway.expects(:add_pair).with({}, :Currency, 'JPY', required: true)
 
     @gateway.send(:add_amount, {}, @amount, @options)
   end
 
   def test_send_fractional_amount_for_british_pounds
-    @gateway.expects(:add_pair).with({}, :Amount, '1.00', :required => true)
-    @gateway.expects(:add_pair).with({}, :Currency, 'GBP', :required => true)
+    @gateway.expects(:add_pair).with({}, :Amount, '1.00', required: true)
+    @gateway.expects(:add_pair).with({}, :Currency, 'GBP', required: true)
 
     @gateway.send(:add_amount, {}, @amount, @options)
   end

--- a/test/unit/gateways/sage_test.rb
+++ b/test/unit/gateways/sage_test.rb
@@ -5,8 +5,8 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def setup
     @gateway = SageGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
@@ -14,20 +14,20 @@ class SageGatewayTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
 
     @check_options = {
-      :order_id => generate_unique_id,
-      :billing_address => address,
-      :shipping_address => address,
-      :email => 'longbob@example.com',
-      :drivers_license_state => 'CA',
-      :drivers_license_number => '12345689',
-      :date_of_birth => Date.new(1978, 8, 11),
-      :ssn => '078051120'
+      order_id: generate_unique_id,
+      billing_address: address,
+      shipping_address: address,
+      email: 'longbob@example.com',
+      drivers_license_state: 'CA',
+      drivers_license_number: '12345689',
+      date_of_birth: Date.new(1978, 8, 11),
+      ssn: '078051120'
     }
   end
 
@@ -157,7 +157,7 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def test_include_customer_number_for_numeric_values
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:customer => '123'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({customer: '123'}))
     end.check_request do |method, data|
       assert data =~ /T_customer_number=123/
     end.respond_with(successful_authorization_response)
@@ -165,7 +165,7 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def test_dont_include_customer_number_for_numeric_values
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:customer => 'bob@test.com'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({customer: 'bob@test.com'}))
     end.check_request do |method, data|
       assert data !~ /T_customer_number/
     end.respond_with(successful_authorization_response)
@@ -188,7 +188,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_address_with_state
     post = {}
     options = {
-      :billing_address => { :country => 'US', :state => 'CA'}
+      billing_address: { country: 'US', state: 'CA'}
     }
     @gateway.send(:add_addresses, post, options)
 
@@ -199,7 +199,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_address_without_state
     post = {}
     options = {
-      :billing_address => { :country => 'NZ', :state => ''}
+      billing_address: { country: 'NZ', state: ''}
     }
     @gateway.send(:add_addresses, post, options)
 

--- a/test/unit/gateways/sallie_mae_test.rb
+++ b/test/unit/gateways/sallie_mae_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class SallieMaeTest < Test::Unit::TestCase
   def setup
     @gateway = SallieMaeGateway.new(
-      :login => 'FAKEACCOUNT'
+      login: 'FAKEACCOUNT'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -35,7 +35,7 @@ class SallieMaeTest < Test::Unit::TestCase
   end
 
   def test_test_account
-    gateway = SallieMaeGateway.new(:login => 'TEST0')
+    gateway = SallieMaeGateway.new(login: 'TEST0')
     assert gateway.test?
   end
 

--- a/test/unit/gateways/secure_net_test.rb
+++ b/test/unit/gateways/secure_net_test.rb
@@ -5,17 +5,17 @@ class SecureNetTest < Test::Unit::TestCase
 
   def setup
     @gateway = SecureNetGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -5,17 +5,17 @@ class SecurePayAuTest < Test::Unit::TestCase
 
   def setup
     @gateway = SecurePayAuGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -51,13 +51,13 @@ class SecurePayAuTest < Test::Unit::TestCase
 
   def test_localized_currency
     stub_comms do
-      @gateway.purchase(100, @credit_card, @options.merge(:currency => 'CAD'))
+      @gateway.purchase(100, @credit_card, @options.merge(currency: 'CAD'))
     end.check_request do |endpoint, data, headers|
       assert_match %r{<amount>100<\/amount>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
-      @gateway.purchase(100, @credit_card, @options.merge(:currency => 'JPY'))
+      @gateway.purchase(100, @credit_card, @options.merge(currency: 'JPY'))
     end.check_request do |endpoint, data, headers|
       assert_match %r{<amount>1<\/amount>}, data
     end.respond_with(successful_purchase_response)
@@ -166,7 +166,7 @@ class SecurePayAuTest < Test::Unit::TestCase
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
-    assert response = @gateway.store(@credit_card, {:billing_id => 'test3', :amount => 123})
+    assert response = @gateway.store(@credit_card, {billing_id: 'test3', amount: 123})
     assert_instance_of Response, response
     assert_equal 'Successful', response.message
     assert_equal 'test3', response.params['client_id']

--- a/test/unit/gateways/secure_pay_tech_test.rb
+++ b/test/unit/gateways/secure_pay_tech_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class SecurePayTechTest < Test::Unit::TestCase
   def setup
     @gateway = SecurePayTechGateway.new(
-      :login => 'x',
-      :password => 'y'
+      login: 'x',
+      password: 'y'
     )
 
     @amount = 100
     @credit_card = credit_card('4987654321098769')
     @options = {
-      :billing_address => address
+      billing_address: address
     }
   end
 

--- a/test/unit/gateways/secure_pay_test.rb
+++ b/test/unit/gateways/secure_pay_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class SecurePayTest < Test::Unit::TestCase
   def setup
     @gateway = SecurePayGateway.new(
-      :login => 'X',
-      :password => 'Y'
+      login: 'X',
+      password: 'Y'
     )
 
     @credit_card = credit_card
 
     @options = {
-      :order_id => generate_unique_id,
-      :description => 'Store purchase',
-      :billing_address => address
+      order_id: generate_unique_id,
+      description: 'Store purchase',
+      billing_address: address
     }
 
     @amount = 100

--- a/test/unit/gateways/skip_jack_test.rb
+++ b/test/unit/gateways/skip_jack_test.rb
@@ -4,34 +4,34 @@ class SkipJackTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
 
-    @gateway = SkipJackGateway.new(:login => 'X', :password => 'Y')
+    @gateway = SkipJackGateway.new(login: 'X', password: 'Y')
 
     @credit_card = credit_card('4242424242424242')
 
     @billing_address = {
-      :address1 => '123 Any St.',
-      :address2 => 'Apt. B',
-      :city => 'Anytown',
-      :state => 'ST',
-      :country => 'US',
-      :zip => '51511-1234',
-      :phone => '616-555-1212',
-      :fax => '616-555-2121'
+      address1: '123 Any St.',
+      address2: 'Apt. B',
+      city: 'Anytown',
+      state: 'ST',
+      country: 'US',
+      zip: '51511-1234',
+      phone: '616-555-1212',
+      fax: '616-555-2121'
     }
 
     @shipping_address = {
-      :name => 'Stew Packman',
-      :address1 => 'Company',
-      :address2 => '321 No RD',
-      :city => 'Nowhereton',
-      :state => 'ZC',
-      :country => 'MX',
-      :phone => '0123231212'
+      name: 'Stew Packman',
+      address1: 'Company',
+      address2: '321 No RD',
+      city: 'Nowhereton',
+      state: 'ZC',
+      country: 'MX',
+      phone: '0123231212'
     }
 
     @options = {
-      :order_id => 1,
-      :email => 'cody@example.com'
+      order_id: 1,
+      email: 'cody@example.com'
     }
 
     @amount = 100

--- a/test/unit/gateways/so_easy_pay_test.rb
+++ b/test/unit/gateways/so_easy_pay_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class SoEasyPayTest < Test::Unit::TestCase
   def setup
     @gateway = SoEasyPayGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
     }
   end
 
@@ -87,7 +87,7 @@ class SoEasyPayTest < Test::Unit::TestCase
   def test_use_ducktyping_for_credit_card
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 
-    credit_card = stub(:number => '4242424242424242', :verification_value => '123', :name => 'Hans Tester', :year => 2012, :month => 1)
+    credit_card = stub(number: '4242424242424242', verification_value: '123', name: 'Hans Tester', year: 2012, month: 1)
 
     assert_nothing_raised do
       assert_success @gateway.purchase(@amount, credit_card, @options)

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class SpreedlyCoreTest < Test::Unit::TestCase
   def setup
-    @gateway = SpreedlyCoreGateway.new(:login => 'api_login', :password => 'api_secret', :gateway_token => 'token')
+    @gateway = SpreedlyCoreGateway.new(login: 'api_login', password: 'api_secret', gateway_token: 'token')
     @payment_method_token = 'E3eQGR3E0xiosj7FOJRtIKbF8Ch'
 
     @credit_card = credit_card

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -4,7 +4,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = StripePaymentIntentsGateway.new(:login => 'login')
+    @gateway = StripePaymentIntentsGateway.new(login: 'login')
 
     @credit_card = credit_card()
     @threeds_2_card = credit_card('4000000000003220')

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -4,7 +4,7 @@ class StripeTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = StripeGateway.new(:login => 'login')
+    @gateway = StripeGateway.new(login: 'login')
 
     @credit_card = credit_card()
     @threeds_card = credit_card('4000000000003063')
@@ -13,14 +13,14 @@ class StripeTest < Test::Unit::TestCase
     @refund_amount = 200
 
     @options = {
-      :billing_address => address(),
-      :statement_address => statement_address(),
-      :description => 'Test Purchase'
+      billing_address: address(),
+      statement_address: statement_address(),
+      description: 'Test Purchase'
     }
 
     @threeds_options = {
-      :execute_threed => true,
-      :callback_url => 'http://www.example.com/callback'
+      execute_threed: true,
+      callback_url: 'http://www.example.com/callback'
     }
 
     @apple_pay_payment_token = apple_pay_payment_token
@@ -82,7 +82,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@credit_card, :customer => 'cus_3sgheFxeBgTQ3M')
+    assert response = @gateway.store(@credit_card, customer: 'cus_3sgheFxeBgTQ3M')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -94,7 +94,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
     @gateway.expects(:tokenize_apple_pay_token).returns(Response.new(true, nil, token: successful_apple_pay_token_exchange))
 
-    assert response = @gateway.store(@apple_pay_payment_token, :customer => 'cus_3sgheFxeBgTQ3M')
+    assert response = @gateway.store(@apple_pay_payment_token, customer: 'cus_3sgheFxeBgTQ3M')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -106,7 +106,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@emv_credit_card, :customer => 'cus_3sgheFxeBgTQ3M')
+    assert response = @gateway.store(@emv_credit_card, customer: 'cus_3sgheFxeBgTQ3M')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -118,7 +118,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@token_string, :customer => 'cus_3sgheFxeBgTQ3M')
+    assert response = @gateway.store(@token_string, customer: 'cus_3sgheFxeBgTQ3M')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -130,7 +130,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_new_card_response)
     @gateway.expects(:add_payment_token)
 
-    assert response = @gateway.store(@payment_token, :customer => 'cus_3sgheFxeBgTQ3M')
+    assert response = @gateway.store(@payment_token, customer: 'cus_3sgheFxeBgTQ3M')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -142,7 +142,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@credit_card, :customer => 'cus_3sgheFxeBgTQ3M', :email => 'test@test.com')
+    assert response = @gateway.store(@credit_card, customer: 'cus_3sgheFxeBgTQ3M', email: 'test@test.com')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -157,7 +157,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:tokenize_apple_pay_token).returns(Response.new(true, nil, token: successful_apple_pay_token_exchange))
 
-    assert response = @gateway.store(@apple_pay_payment_token, :customer => 'cus_3sgheFxeBgTQ3M', :email => 'test@test.com')
+    assert response = @gateway.store(@apple_pay_payment_token, customer: 'cus_3sgheFxeBgTQ3M', email: 'test@test.com')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -171,7 +171,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_new_card_and_customer_update_with_emv_credit_card
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
 
-    assert response = @gateway.store(@emv_credit_card, :customer => 'cus_3sgheFxeBgTQ3M', :email => 'test@test.com')
+    assert response = @gateway.store(@emv_credit_card, customer: 'cus_3sgheFxeBgTQ3M', email: 'test@test.com')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -185,7 +185,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_new_card_and_customer_update_with_token_string
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
 
-    assert response = @gateway.store(@token_string, :customer => 'cus_3sgheFxeBgTQ3M', :email => 'test@test.com')
+    assert response = @gateway.store(@token_string, customer: 'cus_3sgheFxeBgTQ3M', email: 'test@test.com')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -199,7 +199,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_new_card_and_customer_update_with_payment_token
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
 
-    assert response = @gateway.store(@payment_token, :customer => 'cus_3sgheFxeBgTQ3M', :email => 'test@test.com')
+    assert response = @gateway.store(@payment_token, customer: 'cus_3sgheFxeBgTQ3M', email: 'test@test.com')
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -214,7 +214,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@credit_card, @options.merge(:customer => 'cus_3sgheFxeBgTQ3M', :set_default => true))
+    assert response = @gateway.store(@credit_card, @options.merge(customer: 'cus_3sgheFxeBgTQ3M', set_default: true))
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -229,7 +229,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:tokenize_apple_pay_token).returns(Response.new(true, nil, token: successful_apple_pay_token_exchange))
 
-    assert response = @gateway.store(@apple_pay_payment_token, @options.merge(:customer => 'cus_3sgheFxeBgTQ3M', :set_default => true))
+    assert response = @gateway.store(@apple_pay_payment_token, @options.merge(customer: 'cus_3sgheFxeBgTQ3M', set_default: true))
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -243,7 +243,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_new_default_card_with_emv_credit_card
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
 
-    assert response = @gateway.store(@emv_credit_card, @options.merge(:customer => 'cus_3sgheFxeBgTQ3M', :set_default => true))
+    assert response = @gateway.store(@emv_credit_card, @options.merge(customer: 'cus_3sgheFxeBgTQ3M', set_default: true))
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -258,7 +258,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:add_creditcard)
 
-    assert response = @gateway.store(@token_string, @options.merge(:customer => 'cus_3sgheFxeBgTQ3M', :set_default => true))
+    assert response = @gateway.store(@token_string, @options.merge(customer: 'cus_3sgheFxeBgTQ3M', set_default: true))
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -273,7 +273,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_card_response, successful_new_customer_response)
     @gateway.expects(:add_payment_token)
 
-    assert response = @gateway.store(@payment_token, @options.merge(:customer => 'cus_3sgheFxeBgTQ3M', :set_default => true))
+    assert response = @gateway.store(@payment_token, @options.merge(customer: 'cus_3sgheFxeBgTQ3M', set_default: true))
     assert_instance_of MultiResponse, response
     assert_success response
 
@@ -674,7 +674,7 @@ class StripeTest < Test::Unit::TestCase
       post.include?('refund_application_fee=true')
     end.returns(successful_partially_refunded_response)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_application_fee => true)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_application_fee: true)
     assert_success response
   end
 
@@ -731,7 +731,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_fetch_application_fee_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_application_fee_response).in_sequence(s)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_fee_amount: 100)
     assert_success response
   end
 
@@ -741,7 +741,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_fetch_application_fee_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_application_fee_response).in_sequence(s)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_fee_amount: 100)
     assert_success response
     assert_equal 're_test_refund', response.authorization
   end
@@ -751,7 +751,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_partially_refunded_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(unsuccessful_fetch_application_fee_response).in_sequence(s)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_fee_amount: 100)
     assert_success response
   end
 
@@ -761,7 +761,7 @@ class StripeTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_fetch_application_fee_response).in_sequence(s)
     @gateway.expects(:ssl_request).returns(generic_error_response).in_sequence(s)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_fee_amount: 100)
     assert_success response
   end
 
@@ -769,7 +769,7 @@ class StripeTest < Test::Unit::TestCase
     s = sequence('request')
     @gateway.expects(:ssl_request).returns(generic_error_response).in_sequence(s)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_fee_amount => 100)
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', refund_fee_amount: 100)
     assert_failure response
   end
 
@@ -936,7 +936,7 @@ class StripeTest < Test::Unit::TestCase
   def test_add_creditcard_with_card_token_and_track_data
     post = {}
     credit_card_token = 'card_2iD4AezYnNNzkW'
-    @gateway.send(:add_creditcard, post, credit_card_token, :track_data => 'Tracking data')
+    @gateway.send(:add_creditcard, post, credit_card_token, track_data: 'Tracking data')
     assert_equal 'Tracking data', post[:card][:swipe_data]
   end
 
@@ -962,7 +962,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_application_fee_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:application_fee => 144}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({application_fee: 144}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_purchase_response)
@@ -970,7 +970,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_application_fee_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
-      @gateway.capture(@amount, 'ch_test_charge', @options.merge({:application_fee => 144}))
+      @gateway.capture(@amount, 'ch_test_charge', @options.merge({application_fee: 144}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_capture_response)
@@ -978,7 +978,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_exchange_rate_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:exchange_rate => 0.96251}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({exchange_rate: 0.96251}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_purchase_response)
@@ -986,7 +986,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_exchange_rate_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
-      @gateway.capture(@amount, 'ch_test_charge', @options.merge({:exchange_rate => 0.96251}))
+      @gateway.capture(@amount, 'ch_test_charge', @options.merge({exchange_rate: 0.96251}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_capture_response)
@@ -994,7 +994,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_destination_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid'}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/destination\[account\]=subaccountid/, data)
     end.respond_with(successful_purchase_response)
@@ -1002,7 +1002,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_destination_amount_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({:destination => 'subaccountid', :destination_amount => @amount - 20}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid', destination_amount: @amount - 20}))
     end.check_request do |method, endpoint, data, headers|
       assert_match(/destination\[amount\]=#{@amount - 20}/, data)
     end.respond_with(successful_purchase_response)
@@ -1010,7 +1010,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:description => 'a test customer', :ip => '127.127.127.127', :user_agent => 'some browser', :order_id => '42', :email => 'foo@wonderfullyfakedomain.com', :receipt_email => 'receipt-receiver@wonderfullyfakedomain.com', :referrer =>'http://www.shopify.com'})
+      updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/description=a\+test\+customer/, data)
@@ -1027,7 +1027,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase_without_email_or_order
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:description => 'a test customer', :ip => '127.127.127.127', :user_agent => 'some browser', :referrer =>'http://www.shopify.com'})
+      updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', referrer: 'http://www.shopify.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/description=a\+test\+customer/, data)
@@ -1041,7 +1041,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => '42', :email => 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1053,7 +1053,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => '42', :email => 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.purchase(@amount, @emv_credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1066,7 +1066,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_authorize
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => '42', :email => 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.authorize(@amount, @emv_credit_card, updated_options)
     end.check_request do |method, endpoint, data, headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1096,7 +1096,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = {:card => {}}
+    post = {card: {}}
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:zip], post[:card][:address_zip]
     assert_equal @options[:billing_address][:state], post[:card][:address_state]
@@ -1144,10 +1144,10 @@ class StripeTest < Test::Unit::TestCase
 
   def test_metadata_header
     @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
-      headers && headers['X-Stripe-Client-User-Metadata'] == {:ip => '1.1.1.1'}.to_json
+      headers && headers['X-Stripe-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, @options.merge(:ip => '1.1.1.1'))
+    @gateway.purchase(@amount, @credit_card, @options.merge(ip: '1.1.1.1'))
   end
 
   def test_optional_version_header
@@ -1155,7 +1155,7 @@ class StripeTest < Test::Unit::TestCase
       headers && headers['Stripe-Version'] == '2013-10-29'
     }.returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, @options.merge(:version => '2013-10-29'))
+    @gateway.purchase(@amount, @credit_card, @options.merge(version: '2013-10-29'))
   end
 
   def test_optional_idempotency_key_header
@@ -1163,7 +1163,7 @@ class StripeTest < Test::Unit::TestCase
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response)
 
-    response = @gateway.purchase(@amount, @credit_card, @options.merge(:idempotency_key => 'test123'))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(idempotency_key: 'test123'))
     assert_success response
   end
 
@@ -1172,7 +1172,7 @@ class StripeTest < Test::Unit::TestCase
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response(true))
 
-    response = @gateway.void('ch_test_charge', @options.merge(:idempotency_key => 'test123'))
+    response = @gateway.void('ch_test_charge', @options.merge(idempotency_key: 'test123'))
     assert_success response
   end
 
@@ -1185,12 +1185,12 @@ class StripeTest < Test::Unit::TestCase
       headers && headers['Idempotency-Key'] == 'test123'
     end.returns(successful_authorization_response)
 
-    response = @gateway.verify(@credit_card, @options.merge(:idempotency_key => 'test123'))
+    response = @gateway.verify(@credit_card, @options.merge(idempotency_key: 'test123'))
     assert_success response
   end
 
   def test_initialize_gateway_with_version
-    @gateway = StripeGateway.new(:login => 'login', :version => '2013-12-03')
+    @gateway = StripeGateway.new(login: 'login', version: '2013-12-03')
     @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
       headers && headers['Stripe-Version'] == '2013-12-03'
     }.returns(successful_purchase_response)
@@ -1261,7 +1261,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def generate_options_should_allow_key
-    assert_equal({:key => '12345'}, generate_options({:key => '12345'}))
+    assert_equal({key: '12345'}, generate_options({key: '12345'}))
   end
 
   def test_passing_expand_parameters
@@ -1334,7 +1334,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_new_attributes_are_included_in_update
     stub_comms(@gateway, :ssl_request) do
-      @gateway.send(:update, 'cus_3sgheFxeBgTQ3M', 'card_483etw4er9fg4vF3sQdrt3FG', { :name => 'John Smith', :exp_year => 2021, :exp_month => 6 })
+      @gateway.send(:update, 'cus_3sgheFxeBgTQ3M', 'card_483etw4er9fg4vF3sQdrt3FG', { name: 'John Smith', exp_year: 2021, exp_month: 6 })
     end.check_request do |method, endpoint, data, headers|
       assert data == 'name=John+Smith&exp_year=2021&exp_month=6'
       assert endpoint.include? '/customers/cus_3sgheFxeBgTQ3M/cards/card_483etw4er9fg4vF3sQdrt3FG'
@@ -1517,7 +1517,7 @@ class StripeTest < Test::Unit::TestCase
   def test_webhook_deletion
     @gateway.expects(:ssl_request).twice.returns(webhook_event_creation_response, webhook_event_deletion_response)
     webhook = @gateway.send(:create_webhook_endpoint, @options.merge(@threeds_options), ['source.chargeable'])
-    response = @gateway.send(:delete_webhook_endpoint, @options.merge(:webhook_id => webhook.params['id']))
+    response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook.params['id']))
     assert_equal response.params['id'], webhook.params['id']
     assert_equal true, response.params['deleted']
   end

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -91,7 +91,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => {country: 'US'})
+      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
@@ -99,7 +99,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => {country: 'Blah'})
+      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
     end.check_request do |method, endpoint, data, headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)
@@ -115,7 +115,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_passing_billing_address
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :billing_address => address)
+      @gateway.authorize(@amount, @credit_card, billing_address: address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
       assert_equal('456 My Street', parsed['billing']['address']['street'])
@@ -125,7 +125,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_passing_shipping_name
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, :shipping_address => address)
+      @gateway.authorize(@amount, @credit_card, shipping_address: address)
     end.check_request do |method, endpoint, data, headers|
       parsed = JSON.parse(data)
       assert_equal('Jim', parsed['shipping']['firstName'])

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class TransFirstTest < Test::Unit::TestCase
   def setup
     @gateway = TransFirstGateway.new(
-      :login => 'LOGIN',
-      :password => 'PASSWORD'
+      login: 'LOGIN',
+      password: 'PASSWORD'
     )
 
     @credit_card = credit_card('4242424242424242')
     @check = check
     @options = {
-      :billing_address => address
+      billing_address: address
     }
     @amount = 100
   end

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -28,13 +28,13 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_strip_hyphens_from_zip
     options = {
-      :billing_address => {
-        :name => 'John & Mary Smith',
-        :address1 => '1 Main St.',
-        :city => 'Burlington',
-        :state => 'MA',
-        :zip => '01803-3747',
-        :country => 'US'
+      billing_address: {
+        name: 'John & Mary Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
       }
     }
 

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -4,9 +4,9 @@ class TrustCommerceTest < Test::Unit::TestCase
   include CommStub
   def setup
     @gateway = TrustCommerceGateway.new(
-      :login => 'TestMerchant',
-      :password => 'password',
-      :aggregator_id => 'abc123'
+      login: 'TestMerchant',
+      password: 'password',
+      aggregator_id: 'abc123'
     )
     # Force SSL post
     @gateway.stubs(:tclink?).returns(false)

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -16,90 +16,90 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     # UsaEpayAdvancedGateway.wiredump_device.sync = true
 
     @gateway = UsaEpayAdvancedGateway.new(
-      :login => 'X',
-      :password => 'Y',
-      :software_id => 'Z'
+      login: 'X',
+      password: 'Y',
+      software_id: 'Z'
     )
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
-      :number => '4000100011112224',
-      :month => 12,
-      :year => 12,
-      :brand => 'visa',
-      :verification_value => '123',
-      :first_name => 'Fred',
-      :last_name => 'Flintstone'
+      number: '4000100011112224',
+      month: 12,
+      year: 12,
+      brand: 'visa',
+      verification_value: '123',
+      first_name: 'Fred',
+      last_name: 'Flintstone'
     )
 
     @check = ActiveMerchant::Billing::Check.new(
-      :account_number => '123456789012',
-      :routing_number => '123456789',
-      :account_type => 'checking',
-      :first_name => 'Fred',
-      :last_name => 'Flintstone'
+      account_number: '123456789012',
+      routing_number: '123456789',
+      account_type: 'checking',
+      first_name: 'Fred',
+      last_name: 'Flintstone'
     )
 
     payment_methods = [
       {
-        :name => 'My Visa', # optional
-        :sort => 2, # optional
-        :method => @credit_card
+        name: 'My Visa', # optional
+        sort: 2, # optional
+        method: @credit_card
       },
       {
-        :name => 'My Checking',
-        :method => @check
+        name: 'My Checking',
+        method: @check
       }
     ]
 
     payment_method = {
-      :name => 'My new Visa', # optional
-      :method => @credit_card
+      name: 'My new Visa', # optional
+      method: @credit_card
     }
 
     @customer_options = {
-      :id => 1, # optional: merchant assigned id, usually db id
-      :notes =>  'Note about customer', # optional
-      :data => 'Some Data', # optional
-      :url => 'awesomesite.com', # optional
-      :payment_methods => payment_methods # optional
+      id: 1, # optional: merchant assigned id, usually db id
+      notes: 'Note about customer', # optional
+      data: 'Some Data', # optional
+      url: 'awesomesite.com', # optional
+      payment_methods: payment_methods # optional
     }
 
     @payment_options = {
-      :payment_method => payment_method
+      payment_method: payment_method
     }
 
     @transaction_options = {
-      :payment_method => @credit_card,
-      :recurring => {
-        :schedule => 'monthly',
-        :amount => 4000
+      payment_method: @credit_card,
+      recurring: {
+        schedule: 'monthly',
+        amount: 4000
       }
     }
 
     @standard_transaction_options = {
-      :method_id => 0,
-      :command => 'Sale',
-      :amount => 2000 # 20.00
+      method_id: 0,
+      command: 'Sale',
+      amount: 2000 # 20.00
     }
 
     @get_payment_options = {
-      :method_id => 0
+      method_id: 0
     }
 
     @delete_customer_options = {
-      :customer_number => 299461
+      customer_number: 299461
     }
 
     @custom_options = {
-      :fields => ['Response.StatusCode', 'Response.Status']
+      fields: ['Response.StatusCode', 'Response.Status']
     }
 
     @options = {
-      :client_ip => '127.0.0.1',
-      :billing_address => address,
+      client_ip: '127.0.0.1',
+      billing_address: address,
 
-      :customer_number => 298741,
-      :reference_number => 9999
+      customer_number: 298741,
+      reference_number: 9999
     }
   end
 
@@ -279,7 +279,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
   def test_successful_get_customer_payment_methods
     @gateway.expects(:ssl_post).returns(successful_get_customer_payment_methods_response)
 
-    assert response = @gateway.get_customer_payment_methods(@options.merge!(:customer_number => 298741))
+    assert response = @gateway.get_customer_payment_methods(@options.merge!(customer_number: 298741))
     assert_instance_of Response, response
     assert_success response
     assert response.test?
@@ -305,7 +305,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
   def test_successful_delete_customer_payment_method
     @gateway.expects(:ssl_post).returns(successful_delete_customer_payment_method_response)
 
-    assert response = @gateway.delete_customer_payment_method(@options.merge!(:customer_number => 298741, :method_id => 15))
+    assert response = @gateway.delete_customer_payment_method(@options.merge!(customer_number: 298741, method_id: 15))
     assert_instance_of Response, response
     assert_success response
     assert_equal 'true', response.message
@@ -396,7 +396,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
     @options.merge!(@transaction_options)
 
     response = stub_comms do
-      @gateway.run_check_sale(@options.merge(:payment_method => @check))
+      @gateway.run_check_sale(@options.merge(payment_method: @check))
     end.check_request do |endpoint, data, headers|
       assert_match(/123456789012/, data)
     end.respond_with(successful_transaction_response('runCheckSale'))

--- a/test/unit/gateways/usa_epay_test.rb
+++ b/test/unit/gateways/usa_epay_test.rb
@@ -4,26 +4,26 @@ require 'logger'
 class UsaEpayTest < Test::Unit::TestCase
   def test_transaction_gateway_created
     gateway = UsaEpayGateway.new(
-      :login => 'X'
+      login: 'X'
     )
     assert_kind_of UsaEpayTransactionGateway, gateway
   end
 
   def test_advanced_gateway_created_with_software_id
     gateway = UsaEpayGateway.new(
-      :login => 'X',
-      :password => 'Y',
-      :software_id => 'Z'
+      login: 'X',
+      password: 'Y',
+      software_id: 'Z'
     )
     assert_kind_of UsaEpayAdvancedGateway, gateway
   end
 
   def test_advanced_gateway_created_with_urls
     gateway = UsaEpayGateway.new(
-      :login => 'X',
-      :password => 'Y',
-      :test_url => 'Z',
-      :live_url => 'Z'
+      login: 'X',
+      password: 'Y',
+      test_url: 'Z',
+      live_url: 'Z'
     )
     assert_kind_of UsaEpayAdvancedGateway, gateway
   end

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -4,13 +4,13 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = UsaEpayTransactionGateway.new(:login => 'LOGIN')
+    @gateway = UsaEpayTransactionGateway.new(login: 'LOGIN')
 
     @credit_card = credit_card('4242424242424242')
     @check = check
     @options = {
-      :billing_address  => address,
-      :shipping_address => address
+      billing_address: address,
+      shipping_address: address
     }
     @amount = 100
   end
@@ -21,7 +21,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_request_url_live
-    gateway = UsaEpayTransactionGateway.new(:login => 'LOGIN', :test => false)
+    gateway = UsaEpayTransactionGateway.new(login: 'LOGIN', test: false)
     gateway.expects(:ssl_post).
       with('https://www.usaepay.com/gate', regexp_matches(Regexp.new('^' + Regexp.escape(purchase_request)))).
       returns(successful_purchase_response)
@@ -78,7 +78,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_passing_extra_info
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:invoice => '1337', :description => 'socool'))
+      @gateway.purchase(@amount, @credit_card, @options.merge(invoice: '1337', description: 'socool'))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMinvoice=1337/, data)
       assert_match(/UMdescription=socool/, data)
@@ -89,7 +89,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_passing_extra_test_mode
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:test_mode => true))
+      @gateway.purchase(@amount, @credit_card, @options.merge(test_mode: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_purchase_response)
@@ -98,7 +98,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_email_receipt
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:email => 'bobby@hill.com', :cust_receipt => 'Yes', :cust_receipt_name => 'socool'))
+      @gateway.purchase(@amount, @credit_card, @options.merge(email: 'bobby@hill.com', cust_receipt: 'Yes', cust_receipt_name: 'socool'))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMcustreceipt=Yes/, data)
       assert_match(/UMcustreceiptname=socool/, data)
@@ -109,9 +109,9 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_split_payment
     options = @options.merge(
-      :split_payments => [
-        { :key => 'abc123', :amount => 199, :description => 'Second payee' },
-        { :key => 'def456', :amount => 911, :description => 'Third payee' },
+      split_payments: [
+        { key: 'abc123', amount: 199, description: 'Second payee' },
+        { key: 'def456', amount: 911, description: 'Third payee' },
       ]
     )
     response = stub_comms do
@@ -132,10 +132,10 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_split_payment_with_custom_on_error
     options = @options.merge(
-      :split_payments => [
-        { :key => 'abc123', :amount => 199, :description => 'Second payee' }
+      split_payments: [
+        { key: 'abc123', amount: 199, description: 'Second payee' }
       ],
-      :on_error => 'Continue'
+      on_error: 'Continue'
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
@@ -147,7 +147,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_recurring_fields
     options = @options.merge(
-      :recurring_fields => {
+      recurring_fields: {
         add_customer: true,
         schedule: 'quarterly',
         bill_source_key: 'bill source key',
@@ -173,7 +173,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_custom_fields
     options = @options.merge(
-      :custom_fields => {
+      custom_fields: {
         1 => 'diablo',
         2 => 'mephisto',
         3 => 'baal'
@@ -191,7 +191,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_first_index_guard_on_custom_fields
     num_options = @options.merge(
-      :custom_fields => {
+      custom_fields: {
         0 => 'butcher',
         1 => 'diablo',
         2 => 'mephisto',
@@ -203,7 +203,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     end
 
     str_options = @options.merge(
-      :custom_fields => {
+      custom_fields: {
         '0' => 'butcher',
         '1' => 'diablo',
         '2' => 'mephisto',
@@ -217,10 +217,10 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_line_items
     options = @options.merge(
-      :line_items => [
-        { :sku=> 'abc123', :cost => 119, :quantity => 1 },
-        { :sku => 'def456', :cost => 200, :quantity => 2, :name => 'an item' },
-        { :cost => 300, :qty => 4 }
+      line_items: [
+        { sku: 'abc123', cost: 119, quantity: 1 },
+        { sku: 'def456', cost: 200, quantity: 2, name: 'an item' },
+        { cost: 300, qty: 4 }
       ]
     )
     response = stub_comms do
@@ -252,7 +252,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_authorize_passing_extra_info
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(:invoice => '1337', order_id: 'w00t', :description => 'socool'))
+      @gateway.authorize(@amount, @credit_card, @options.merge(invoice: '1337', order_id: 'w00t', description: 'socool'))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMinvoice=1337/, data)
       assert_match(/UMorderid=w00t/, data)
@@ -264,7 +264,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_authorize_passing_extra_test_mode
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(:test_mode => true))
+      @gateway.authorize(@amount, @credit_card, @options.merge(test_mode: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_authorize_response)
@@ -292,7 +292,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_capture_passing_extra_test_mode
     response = stub_comms do
-      @gateway.capture(@amount, '65074409', @options.merge(:test_mode => true))
+      @gateway.capture(@amount, '65074409', @options.merge(test_mode: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_capture_response)
@@ -329,7 +329,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_refund_passing_extra_test_mode
     response = stub_comms do
-      @gateway.refund(@amount, '65074409', @options.merge(:test_mode => true))
+      @gateway.refund(@amount, '65074409', @options.merge(test_mode: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_refund_response)
@@ -356,7 +356,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_void_passing_extra_info
     response = stub_comms do
-      @gateway.void('65074409', @options.merge(:no_release => true))
+      @gateway.void('65074409', @options.merge(no_release: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMcommand=cc%3Avoid/, data)
       assert_match(/UMtestmode=0/, data)
@@ -366,7 +366,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_void_passing_extra_test_mode
     response = stub_comms do
-      @gateway.refund(@amount, '65074409', @options.merge(:test_mode => true))
+      @gateway.refund(@amount, '65074409', @options.merge(test_mode: true))
     end.check_request do |endpoint, data, headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_void_response)
@@ -419,8 +419,8 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_add_address_with_single_billing_and_shipping_names
     post = {}
     options = {
-      :billing_address  => address(:name => 'Smith'),
-      :shipping_address => address(:name => 'Longsen')
+      billing_address: address(name: 'Smith'),
+      shipping_address: address(name: 'Longsen')
     }
 
     @gateway.send(:add_address, post, @credit_card, options)
@@ -437,13 +437,13 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_add_test_mode_with_true_test_mode_option
     post = {}
-    @gateway.send(:add_test_mode, post, :test_mode => true)
+    @gateway.send(:add_test_mode, post, test_mode: true)
     assert_equal 1, post[:testmode]
   end
 
   def test_add_test_mode_with_false_test_mode_option
     post = {}
-    @gateway.send(:add_test_mode, post, :test_mode => false)
+    @gateway.send(:add_test_mode, post, test_mode: false)
     assert_equal 0, post[:testmode]
   end
 

--- a/test/unit/gateways/verifi_test.rb
+++ b/test/unit/gateways/verifi_test.rb
@@ -5,16 +5,16 @@ class VerifiTest < Test::Unit::TestCase
 
   def setup
     @gateway = VerifiGateway.new(
-      :login => 'l',
-      :password => 'p'
+      login: 'l',
+      password: 'p'
     )
 
     @credit_card = credit_card('4111111111111111')
 
     @options = {
-      :order_id => '37',
-      :email => 'paul@example.com',
-      :billing_address => address
+      order_id: '37',
+      email: 'paul@example.com',
+      billing_address: address
     }
 
     @amount = 100
@@ -67,7 +67,7 @@ class VerifiTest < Test::Unit::TestCase
 
   def test_add_description
     result = {}
-    @gateway.send(:add_invoice_data, result, :description => 'My Purchase is great')
+    @gateway.send(:add_invoice_data, result, description: 'My Purchase is great')
     assert_equal 'My Purchase is great', result[:orderdescription]
   end
 

--- a/test/unit/gateways/viaklix_test.rb
+++ b/test/unit/gateways/viaklix_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class ViaklixTest < Test::Unit::TestCase
   def setup
     @gateway = ViaklixGateway.new(
-      :login => 'LOGIN',
-      :password => 'PIN'
+      login: 'LOGIN',
+      password: 'PIN'
     )
 
     @credit_card = credit_card
     @options = {
-      :order_id => '37',
-      :email => 'paul@domain.com',
-      :description => 'Test Transaction',
-      :billing_address => address
+      order_id: '37',
+      email: 'paul@domain.com',
+      description: 'Test Transaction',
+      billing_address: address
     }
     @amount = 100
   end

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -4,15 +4,15 @@ class WebpayTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = WebpayGateway.new(:login => 'login')
+    @gateway = WebpayGateway.new(login: 'login')
 
     @credit_card = credit_card()
     @amount = 40000
     @refund_amount = 20000
 
     @options = {
-      :billing_address => address(),
-      :description => 'Test Purchase'
+      billing_address: address(),
+      description: 'Test Purchase'
     }
   end
 
@@ -94,7 +94,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_request_always_uses_live_mode_to_determine_test_request
-    @gateway.expects(:ssl_request).returns(successful_partially_refunded_response(:livemode => true))
+    @gateway.expects(:ssl_request).returns(successful_partially_refunded_response(livemode: true))
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge')
     assert_success response
@@ -121,24 +121,24 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_add_customer
     post = {}
-    @gateway.send(:add_customer, post, 'card_token', {:customer => 'test_customer'})
+    @gateway.send(:add_customer, post, 'card_token', {customer: 'test_customer'})
     assert_equal 'test_customer', post[:customer]
   end
 
   def test_doesnt_add_customer_if_card
     post = {}
-    @gateway.send(:add_customer, post, @credit_card, {:customer => 'test_customer'})
+    @gateway.send(:add_customer, post, @credit_card, {customer: 'test_customer'})
     assert !post[:customer]
   end
 
   def test_add_customer_data
     post = {}
-    @gateway.send(:add_customer_data, post, {:description => 'a test customer'})
+    @gateway.send(:add_customer_data, post, {description: 'a test customer'})
     assert_equal 'a test customer', post[:description]
   end
 
   def test_add_address
-    post = {:card => {}}
+    post = {card: {}}
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:zip], post[:card][:address_zip]
     assert_equal @options[:billing_address][:state], post[:card][:address_state]
@@ -159,10 +159,10 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_metadata_header
     @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
-      headers && headers['X-Webpay-Client-User-Metadata'] == {:ip => '1.1.1.1'}.to_json
+      headers && headers['X-Webpay-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, @options.merge(:ip => '1.1.1.1'))
+    @gateway.purchase(@amount, @credit_card, @options.merge(ip: '1.1.1.1'))
   end
 
   private
@@ -342,7 +342,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def successful_partially_refunded_response(options = {})
-    options = {:livemode=>false}.merge!(options)
+    options = {livemode: false}.merge!(options)
     <<-RESPONSE
 {
   "id": "ch_test_charge",

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -259,7 +259,7 @@ class WirecardTest < Test::Unit::TestCase
 
   def test_store_sets_amount_to_amount_from_options
     stub_comms do
-      @gateway.store(@credit_card, :amount => 120)
+      @gateway.store(@credit_card, amount: 120)
     end.check_request do |endpoint, body, headers|
       assert_xml_element_text(body, '//CC_TRANSACTION/Amount', '120')
     end.respond_with(successful_authorization_response)
@@ -285,7 +285,7 @@ class WirecardTest < Test::Unit::TestCase
 
   def test_authorization_with_recurring_transaction_type_initial
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(:recurring => 'Initial'))
+      @gateway.authorize(@amount, @credit_card, @options.merge(recurring: 'Initial'))
     end.check_request do |endpoint, body, headers|
       assert_xml_element_text(body, '//RECURRING_TRANSACTION/Type', 'Initial')
     end.respond_with(successful_authorization_response)
@@ -293,7 +293,7 @@ class WirecardTest < Test::Unit::TestCase
 
   def test_purchase_using_with_recurring_transaction_type_initial
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(:recurring => 'Initial'))
+      @gateway.purchase(@amount, @credit_card, @options.merge(recurring: 'Initial'))
     end.check_request do |endpoint, body, headers|
       assert_xml_element_text(body, '//RECURRING_TRANSACTION/Type', 'Initial')
     end.respond_with(successful_authorization_response)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -5,23 +5,23 @@ class WorldpayTest < Test::Unit::TestCase
 
   def setup
     @gateway = WorldpayGateway.new(
-      :login => 'testlogin',
-      :password => 'testpassword'
+      login: 'testlogin',
+      password: 'testpassword'
     )
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @token = '|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     @elo_credit_card = credit_card('4514 1600 0000 0008',
-      :month => 10,
-      :year => 2020,
-      :first_name => 'John',
-      :last_name => 'Smith',
-      :verification_value => '737',
-      :brand => 'elo'
+      month: 10,
+      year: 2020,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'elo'
     )
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
-    @options = {:order_id => 1}
+    @options = {order_id: 1}
     @store_options = {
       customer: '59424549c291397379f30c5c082dbed8',
       email: 'wow@example.com'
@@ -597,9 +597,9 @@ class WorldpayTest < Test::Unit::TestCase
     ActiveMerchant::Billing::Base.mode = :production
 
     @gateway = WorldpayGateway.new(
-      :login => 'testlogin',
-      :password => 'testpassword',
-      :test => true
+      login: 'testlogin',
+      password: 'testpassword',
+      test: true
     )
 
     stub_comms do

--- a/test/unit/gateways/worldpay_us_test.rb
+++ b/test/unit/gateways/worldpay_us_test.rb
@@ -143,7 +143,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
   def test_passing_billing_address
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/ci_billaddr1=456\+My\+Street/, data)
       assert_match(/ci_billzip=K1C2N6/, data)
@@ -152,7 +152,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
   def test_passing_phone_number
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address)
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
     end.check_request do |endpoint, data, headers|
       assert_match(/ci_phone=%28555%29555-5555/, data)
     end.respond_with(successful_purchase_response)
@@ -160,7 +160,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
   def test_passing_billing_address_without_phone
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, :billing_address => address(:phone => nil))
+      @gateway.purchase(@amount, @credit_card, billing_address: address(phone: nil))
     end.check_request do |endpoint, data, headers|
       assert_no_match(/udf3/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/multi_response_test.rb
+++ b/test/unit/multi_response_test.rb
@@ -35,12 +35,12 @@ class MultiResponseTest < Test::Unit::TestCase
       true,
       '1',
       {'one' => 1},
-      :test => true,
-      :authorization => 'auth1',
-      :avs_result => {:code => 'AVS1'},
-      :cvv_result => 'CVV1',
-      :error_code => :card_declined,
-      :fraud_review => true
+      test: true,
+      authorization: 'auth1',
+      avs_result: {code: 'AVS1'},
+      cvv_result: 'CVV1',
+      error_code: :card_declined,
+      fraud_review: true
     )
     m.process { r1 }
     assert_equal({'one' => 1}, m.params)
@@ -57,11 +57,11 @@ class MultiResponseTest < Test::Unit::TestCase
       true,
       '2',
       {'two' => 2},
-      :test => false,
-      :authorization => 'auth2',
-      :avs_result => {:code => 'AVS2'},
-      :cvv_result => 'CVV2',
-      :fraud_review => false
+      test: false,
+      authorization: 'auth2',
+      avs_result: {code: 'AVS2'},
+      cvv_result: 'CVV2',
+      fraud_review: false
     )
     m.process { r2 }
     assert_equal({'two' => 2}, m.params)
@@ -81,11 +81,11 @@ class MultiResponseTest < Test::Unit::TestCase
       true,
       '1',
       {'one' => 1},
-      :test => true,
-      :authorization => 'auth1',
-      :avs_result => {:code => 'AVS1'},
-      :cvv_result => 'CVV1',
-      :fraud_review => true
+      test: true,
+      authorization: 'auth1',
+      avs_result: {code: 'AVS1'},
+      cvv_result: 'CVV1',
+      fraud_review: true
     )
     m.process { r1 }
     assert_equal({'one' => 1}, m.params)
@@ -101,11 +101,11 @@ class MultiResponseTest < Test::Unit::TestCase
       true,
       '2',
       {'two' => 2},
-      :test => false,
-      :authorization => 'auth2',
-      :avs_result => {:code => 'AVS2'},
-      :cvv_result => 'CVV2',
-      :fraud_review => false
+      test: false,
+      authorization: 'auth2',
+      avs_result: {code: 'AVS2'},
+      cvv_result: 'CVV2',
+      fraud_review: false
     )
     m.process { r2 }
     assert_equal({'one' => 1}, m.params)

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -9,7 +9,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   def setup
     @logger = stubs(:logger)
     @requester = stubs(:requester)
-    @ok = stub(:code => 200, :message => 'OK', :body => 'success')
+    @ok = stub(code: 200, message: 'OK', body: 'success')
   end
 
   def test_eoferror_raises_correctly
@@ -78,7 +78,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   def test_unrecoverable_exception_logged_if_logger_provided
     @logger.expects(:info).once
     assert_raises(ActiveMerchant::ConnectionError) do
-      retry_exceptions :logger => @logger do
+      retry_exceptions logger: @logger do
         raise EOFError
       end
     end
@@ -107,7 +107,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @requester.expects(:post).times(ActiveMerchant::NetworkConnectionRetries::DEFAULT_RETRIES).raises(Errno::ECONNREFUSED)
 
     assert_raises(ActiveMerchant::ConnectionError) do
-      retry_exceptions(:logger => @logger) do
+      retry_exceptions(logger: @logger) do
         @requester.post
       end
     end
@@ -116,7 +116,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   def test_failure_then_success_with_retry_safe_enabled
     @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
 
-    retry_exceptions :retry_safe => true do
+    retry_exceptions retry_safe: true do
       @requester.post
     end
   end
@@ -126,7 +126,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @logger.expects(:info).with(regexp_matches(/success/))
     @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
 
-    retry_exceptions(:logger => @logger, :retry_safe => true) do
+    retry_exceptions(logger: @logger, retry_safe: true) do
       @requester.post
     end
   end
@@ -140,7 +140,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
       raises(EOFError)
 
     assert_raises(ActiveMerchant::ConnectionError) do
-      retry_exceptions :retry_safe => true do
+      retry_exceptions retry_safe: true do
         @requester.post
       end
     end
@@ -161,7 +161,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @requester.expects(:post).raises(OpenSSL::X509::CertificateError)
 
     assert_raises(ActiveMerchant::ClientCertificateError) do
-      retry_exceptions :logger => @logger do
+      retry_exceptions logger: @logger do
         @requester.post
       end
     end
@@ -171,7 +171,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @requester.expects(:post).raises(MyNewError)
 
     assert_raises(ActiveMerchant::ConnectionError) do
-      retry_exceptions :connection_exceptions => {MyNewError => 'my message'} do
+      retry_exceptions connection_exceptions: {MyNewError => 'my message'} do
         @requester.post
       end
     end

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
   def setup
     @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
-      number: '4242424242424242', :brand => 'visa',
+      number: '4242424242424242', brand: 'visa',
       month: default_expiration_date.month, year: default_expiration_date.year,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', eci: '05'
     })

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -4,8 +4,8 @@ class PostsDataTests < Test::Unit::TestCase
   def setup
     @url = 'http://example.com'
     @gateway = SimpleTestGateway.new
-    @ok = stub(:body => '', :code => '200', :message => 'OK')
-    @error = stub(:code => 500, :message => 'Internal Server Error', :body => 'failure')
+    @ok = stub(body: '', code: '200', message: 'OK')
+    @error = stub(code: 500, message: 'Internal Server Error', body: 'failure')
   end
 
   def teardown

--- a/test/unit/rails_compatibility_test.rb
+++ b/test/unit/rails_compatibility_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RailsCompatibilityTest < Test::Unit::TestCase
   def test_should_be_able_to_access_errors_indifferently
-    cc = credit_card('4779139500118580', :first_name => '')
+    cc = credit_card('4779139500118580', first_name: '')
 
     silence_deprecation_warnings do
       assert !cc.valid?

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -2,35 +2,35 @@ require 'test_helper'
 
 class ResponseTest < Test::Unit::TestCase
   def test_response_success
-    assert Response.new(true, 'message', :param => 'value').success?
-    assert !Response.new(false, 'message', :param => 'value').success?
+    assert Response.new(true, 'message', param: 'value').success?
+    assert !Response.new(false, 'message', param: 'value').success?
   end
 
   def test_response_without_avs
-    response = Response.new(true, 'message', :param => 'value')
+    response = Response.new(true, 'message', param: 'value')
     assert response.avs_result.has_key?('code')
   end
 
   def test_response_without_cvv
-    response = Response.new(true, 'message', :param => 'value')
+    response = Response.new(true, 'message', param: 'value')
     assert response.cvv_result.has_key?('code')
   end
 
   def test_get_params
-    response = Response.new(true, 'message', :param => 'value')
+    response = Response.new(true, 'message', param: 'value')
 
     assert_equal ['param'], response.params.keys
   end
 
   def test_avs_result
-    response = Response.new(true, 'message', {}, :avs_result => { :code => 'A', :street_match => 'Y', :zip_match => 'N' })
+    response = Response.new(true, 'message', {}, avs_result: { code: 'A', street_match: 'Y', zip_match: 'N' })
     avs_result = response.avs_result
     assert_equal 'A', avs_result['code']
     assert_equal AVSResult.messages['A'], avs_result['message']
   end
 
   def test_cvv_result
-    response = Response.new(true, 'message', {}, :cvv_result => 'M')
+    response = Response.new(true, 'message', {}, cvv_result: 'M')
     cvv_result = response.cvv_result
     assert_equal 'M', cvv_result['code']
     assert_equal CVVResult.messages['M'], cvv_result['message']


### PR DESCRIPTION
This fixes the RuboCop to-do for [Style/HashSyntax](https://www.rubocop.org/en/stable/cops_style/#stylehashsyntax)
and changes all of the existing hash rockets with symbols to use the
more modern Ruby 1.9 colon hash syntax.

All unit tests:
4450 tests, 71519 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed