### PR TITLE
Stripe Payment Intents: Add tests for idempotency_key header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Redsys: Properly escape cardholder name and description fields in 3DS requests [britth] #3537
 * RuboCop: Fix Style/HashSyntax [leila-alderman] #3540
 * Paypal: Fix OrderTotal elements in `add_payment_details` [chinhle23] #3544
+* Stripe Payment Intents: Add tests for "Idempotency-Key" header [fatcatt316] #3542
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -74,6 +74,17 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'canceled', cancel.params['status']
   end
 
+  def test_create_intent_with_optional_idempotency_key_header
+    idempotency_key = 'test123'
+    options = @options.merge(idempotency_key: idempotency_key)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_equal idempotency_key, headers['Idempotency-Key']
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_failed_capture_after_creation
     @gateway.expects(:ssl_request).returns(failed_capture_response)
 


### PR DESCRIPTION
## What Changed?
Add tests for "Idempotency-Key" header for Stripe Payment Intents.

## Why?
This header is tested for Stripe, but had not yet been directly
tested for Stripe Payment Intents.

See documentation at:
https://stripe.com/docs/api/idempotent_requests

CE-394 > CE-431

## Testing
Local
```
ruby -Ilib:test test/unit/gateways/stripe_payment_intents_test.rb

9 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

All local:
```
rake test:local

4455 tests, 71541 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

Remote
```
ruby -Ilib:test test/remote/gateways/remote_stripe_payment_intents_test.rb

32 tests, 139 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.875% passed
```

1 failed test that fails on `master`, too:
* test_create_payment_intent_that_saves_payment_method