### PR TITLE
Paypal: Fix OrderTotal elements in `add_payment_details`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Adyen: Fix some remote tests [curiousepic] #3541
 * Redsys: Properly escape cardholder name and description fields in 3DS requests [britth] #3537
 * RuboCop: Fix Style/HashSyntax [leila-alderman] #3540
+* Paypal: Fix OrderTotal elements in `add_payment_details` [chinhle23] #3544
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -586,7 +586,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'n2:OrderTotal', localized_amount(money, currency_code), 'currencyID' => currency_code
 
           # All of the values must be included together and add up to the order total
-          if [:subtotal, :shipping, :handling, :tax].all?{ |o| options.has_key?(o) }
+          if [:subtotal, :shipping, :handling, :tax].all?{ |o| options[o].present? }
             xml.tag! 'n2:ItemTotal', localized_amount(options[:subtotal], currency_code), 'currencyID' => currency_code
             xml.tag! 'n2:ShippingTotal', localized_amount(options[:shipping], currency_code),'currencyID' => currency_code
             xml.tag! 'n2:HandlingTotal', localized_amount(options[:handling], currency_code),'currencyID' => currency_code

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -64,6 +64,32 @@ class PaypalTest < Test::Unit::TestCase
     assert response.params['transaction_id']
   end
 
+  def test_successful_purchase_with_order_total_elements
+    order_total_elements = {
+      :subtotal => @amount/4,
+      :shipping => @amount/4,
+      :handling => @amount/4,
+      :tax => @amount/4
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @params.merge(order_total_elements))
+    assert_success response
+    assert response.params['transaction_id']
+  end
+
+  def test_successful_purchase_with_non_fractional_currency_when_any_order_total_element_is_nil
+    order_total_elements = {
+      :subtotal => @amount/4,
+      :shipping => @amount/4,
+      :handling => nil,
+      :tax => @amount/4
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @params.merge(order_total_elements).merge(:currency => 'JPY'))
+    assert_success response
+    assert response.params['transaction_id']
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @params)
     assert_failure response

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -69,6 +69,40 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_equal 'foo', REXML::XPath.first(request, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name').text
   end
 
+  def test_add_payment_details_adds_order_total_elements
+    options = {
+      :subtotal => 25,
+      :shipping => 5,
+      :handling => 2,
+      :tax => 1
+    }
+    request = wrap_xml do |xml|
+      @gateway.send(:add_payment_details, xml, 100, 'USD', options)
+    end
+
+    assert_equal '25', REXML::XPath.first(request, '//n2:PaymentDetails/n2:ItemTotal').text
+    assert_equal '5', REXML::XPath.first(request, '//n2:PaymentDetails/n2:ShippingTotal').text
+    assert_equal '2', REXML::XPath.first(request, '//n2:PaymentDetails/n2:HandlingTotal').text
+    assert_equal '1', REXML::XPath.first(request, '//n2:PaymentDetails/n2:TaxTotal').text
+  end
+
+  def test_add_payment_details_does_not_add_order_total_elements_when_any_element_is_nil
+    options = {
+      :subtotal => nil,
+      :shipping => 5,
+      :handling => 2,
+      :tax => 1
+    }
+    request = wrap_xml do |xml|
+      @gateway.send(:add_payment_details, xml, 100, 'USD', options)
+    end
+
+    assert_equal nil, REXML::XPath.first(request, '//n2:PaymentDetails/n2:ItemTotal')
+    assert_equal nil, REXML::XPath.first(request, '//n2:PaymentDetails/n2:ShippingTotal')
+    assert_equal nil, REXML::XPath.first(request, '//n2:PaymentDetails/n2:HandlingTotal')
+    assert_equal nil, REXML::XPath.first(request, '//n2:PaymentDetails/n2:TaxTotal')
+  end
+
   def test_add_express_only_payment_details_adds_non_blank_fields
     request = wrap_xml do |xml|
       @gateway.send(:add_express_only_payment_details, xml, {payment_action: 'Sale', payment_request_id: ''})


### PR DESCRIPTION
ECS-986

Possible `nil` or blank values in the `subtotal`, `shipping`, `handling`,
or `tax` fields will cause the `localized_amount` method to break causing
`NoMethodError`.

This change requires for the affected fields to have a value before being
evaluated.

Unit:
19 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
29 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4452 tests, 71527 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed