### PR TITLE
CheckoutV2: Use status as message for 3DS txns in progress

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * SafeCharge: Adds four supported countries [carrigan] #3550
 * Ixopay: Support stored credentials [leila-alderman] #3549
 * BlueSnap: Adds localized currency support [carrigan] #3552
+* CheckoutV2: Use status as message for 3DS txns in progress [britth] #3545
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
         elsif response['error_type']
           response['error_type'] + ': ' + response['error_codes'].first
         else
-          response['response_summary'] || response['response_code'] || 'Unable to read error message'
+          response['response_summary'] || response['response_code'] || response['status'] || 'Unable to read error message'
         end
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -8,6 +8,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @credit_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2025')
     @expired_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2010')
     @declined_card = credit_card('42424242424242424', verification_value: '234', month: '6', year: '2025')
+    @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
 
     @options = {
       order_id: '1',
@@ -180,6 +181,14 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
     assert capture = @gateway.capture(nil, auth.authorization)
     assert_success capture
+  end
+
+  def test_direct_3ds_authorize
+    auth = @gateway.authorize(@amount, @threeds_card, @options.merge(execute_threed: true))
+
+    assert_equal 'Pending', auth.message
+    assert_equal 'Y', auth.params['3ds']['enrolled']
+    assert auth.params['_links']['redirect']
   end
 
   def test_failed_authorize


### PR DESCRIPTION
The response from Checkout direct 3DS requests often includes
the message "Unable to parse error message" because while the
transaction is pending, the existing fields we try to parse a
message from are not present. This PR updates the message_from
field to also check in the status field for a possible message
before using the default.

Remote:
32 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
27 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed