### PR TITLE
Adyen: Fail unexpected 3DS responses

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -471,7 +471,7 @@ module ActiveMerchant #:nodoc:
           raw_response = e.response.body
           response = parse(raw_response)
         end
-        success = success_from(action, response)
+        success = success_from(action, response, options)
         Response.new(
           success,
           message_from(action, response),
@@ -520,7 +520,12 @@ module ActiveMerchant #:nodoc:
         headers
       end
 
-      def success_from(action, response)
+      def success_from(action, response, options)
+        if ['RedirectShopper', 'ChallengeShopper'].include?(response.dig('resultCode')) && !options[:execute_threed] && !options[:threed_dynamic]
+          response['refusalReason'] = 'Received unexpected 3DS authentication response. Use the execute_threed and/or threed_dynamic options to initiate a proper 3DS flow.'
+          return false
+        end
+
         case action.to_s
         when 'authorise', 'authorise3d'
           ['Authorised', 'Received', 'RedirectShopper'].include?(response['resultCode'])

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -264,6 +264,16 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal response.params['resultCode'], 'Authorised'
   end
 
+  # Fail in situations where neither execute_threed nor dynamic_threed is
+  # present, but the account is set to dynamic 3ds and it is triggered. This
+  # test assumes a Dynamic 3DS rule set for the Adyen test account to always
+  # perform 3ds auth for an amount of 8484
+  def test_purchase_fails_on_unexpected_3ds_initiation
+    response = @gateway.purchase(8484, @three_ds_enrolled_card, @options)
+    assert_failure response
+    assert_match 'Received unexpected 3DS authentication response', response.message
+  end
+
   def test_successful_purchase_with_auth_data_via_threeds1_standalone
     eci = '05'
     cavv = '3q2+78r+ur7erb7vyv66vv\/\/\/\/8='

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -149,6 +149,13 @@ class AdyenTest < Test::Unit::TestCase
     refute response.params['paRequest'].blank?
   end
 
+  def test_failed_authorize_with_unexpected_3ds
+    @gateway.expects(:ssl_post).returns(successful_authorize_with_3ds_response)
+    response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options)
+    assert_failure response
+    assert_match 'Received unexpected 3DS authentication response', response.message
+  end
+
   def test_successful_authorize_with_recurring_contract_type
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))


### PR DESCRIPTION
There are certain situations where the initiator of a transaction is not
expecting or prepared to complete a 3DS challenge flow, yet an authorize
transaction triggers a 3DS auth response from Adyen.

Previously, if a 3DS flow was not expected, a Purchase was initiated,
and the auth step received a 3ds authentication response, the adapter
would assume the auth step succeeded, and perform the capture, for which
Adyen's response is not sufficient to indicate the money was actually
moved. This means the Purchase would be assumed to succeed when in fact
it was stalled at the 3DS auth step.

This change recognizes these situations and fails the transaction with a
meaningful message.

Remote:
82 tests, 276 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
59 tests, 279 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed