### PR TITLE
Paypal: Fix RuboCop Style/HashSyntax violations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * RuboCop: Fix Style/HashSyntax [leila-alderman] #3540
 * Paypal: Fix OrderTotal elements in `add_payment_details` [chinhle23] #3544
 * Stripe Payment Intents: Add tests for "Idempotency-Key" header [fatcatt316] #3542
+* Paypal: Fix RuboCop Style/HashSyntax violations chinhle23] #3547
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -66,10 +66,10 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_order_total_elements
     order_total_elements = {
-      :subtotal => @amount/4,
-      :shipping => @amount/4,
-      :handling => @amount/4,
-      :tax => @amount/4
+      subtotal: @amount/4,
+      shipping: @amount/4,
+      handling: @amount/4,
+      tax: @amount/4
     }
 
     response = @gateway.purchase(@amount, @credit_card, @params.merge(order_total_elements))
@@ -79,13 +79,13 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_non_fractional_currency_when_any_order_total_element_is_nil
     order_total_elements = {
-      :subtotal => @amount/4,
-      :shipping => @amount/4,
-      :handling => nil,
-      :tax => @amount/4
+      subtotal: @amount/4,
+      shipping: @amount/4,
+      handling: nil,
+      tax: @amount/4
     }
 
-    response = @gateway.purchase(@amount, @credit_card, @params.merge(order_total_elements).merge(:currency => 'JPY'))
+    response = @gateway.purchase(@amount, @credit_card, @params.merge(order_total_elements).merge(currency: 'JPY'))
     assert_success response
     assert response.params['transaction_id']
   end

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -71,10 +71,10 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_add_payment_details_adds_order_total_elements
     options = {
-      :subtotal => 25,
-      :shipping => 5,
-      :handling => 2,
-      :tax => 1
+      subtotal: 25,
+      shipping: 5,
+      handling: 2,
+      tax: 1
     }
     request = wrap_xml do |xml|
       @gateway.send(:add_payment_details, xml, 100, 'USD', options)
@@ -88,10 +88,10 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_add_payment_details_does_not_add_order_total_elements_when_any_element_is_nil
     options = {
-      :subtotal => nil,
-      :shipping => 5,
-      :handling => 2,
-      :tax => 1
+      subtotal: nil,
+      shipping: 5,
+      handling: 2,
+      tax: 1
     }
     request = wrap_xml do |xml|
       @gateway.send(:add_payment_details, xml, 100, 'USD', options)


### PR DESCRIPTION
Exposed after commit [3540](https://github.com/activemerchant/active_merchant/pull/3540)

Unit:
19 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
29 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4455 tests, 71541 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed

RuboCop:
695 files inspected, no offenses detected