### PR TITLE
Ixopay: Support stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Rubocop corrections for space around operators [cdmackeyfree] #3543
 * Fat Zebra: Add `is_billing` in post for `store` call [chinhle23] #3551
 * SafeCharge: Adds four supported countries [carrigan] #3550
+* Ixopay: Support stored credentials [leila-alderman] #3549
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -14,6 +14,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
       email: 'test@example.com',
       description: 'Store Purchase',
       ip: '192.168.1.1',
+      stored_credential: stored_credential(:initial)
     }
 
     @extra_data = {extra_data: { customData1: 'some data', customData2: 'Can be anything really' }}


### PR DESCRIPTION
Implemented support for stored credentials on the Ixopay gateway.

Ixopay is slightly unusual in that it does not return a true
`network_transaction_id` and therefore this value cannot be sent on
subsequent transactions.

See [Ixopay's documentation on recurring transactions](https://gateway.ixopay.com/documentation/gateway#transaction-types)
as well as [an example recurring debit transaction](https://gateway.ixopay.com/documentation/direct-pci-enabled-api?xml#transactionwithcard-request-debit).

CE-161

Unit:
28 tests, 138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
23 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4458 tests, 71557 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed