### PR TITLE
SafeCharge: Adds four supported countries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,7 @@
 * Authorize.net: Trim down supported countries [fatcatt316] #3511
 * Stripe: Add support for `statement_descriptor_suffix` field [carrigan] #3528
 * Stripe: Add connected account support [carrigan] #3535
+* SafeCharge: Adds four supported countries [carrigan] #3550
 
 == Version 1.103.0 (Dec 2, 2019)
 * Quickbooks: Mark transactions that returned `AuthorizationFailed` as failures [britth] #3447

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://process.sandbox.safecharge.com/service.asmx/Process'
       self.live_url = 'https://process.safecharge.com/service.asmx/Process'
 
-      self.supported_countries = ['AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'GR', 'ES', 'FI', 'FR', 'HR', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK', 'GB', 'US']
+      self.supported_countries = ['AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'GR', 'ES', 'FI', 'FR', 'GI', 'HK', 'HR', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MT', 'MX', 'NL', 'NO', 'PL', 'PT', 'RO', 'SE', 'SG', 'SI', 'SK', 'GB', 'US']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master]
 


### PR DESCRIPTION
## Why?

- The SafeCharge gateway was missing four countries in its `supported_countries` list.

## What Changed?

Adds four supported countries to the SafeCharge gateway:
- Gibraltar (GI)
- Hong Kong (HK)
- Mexico (MX)
- Singapore (SG)

## Test Results

```
4455 tests, 71541 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed

695 files inspected, no offenses detected
```