### PR TITLE
Fat Zebra: Add `is_billing` in post for `store` call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Stripe Payment Intents: Add tests for "Idempotency-Key" header [fatcatt316] #3542
 * Paypal: Fix RuboCop Style/HashSyntax violations [chinhle23] #3547
 * Rubocop corrections for space around operators [cdmackeyfree] #3543
+* Fat Zebra: Add `is_billing` in post for `store` call [chinhle23] #3551
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -79,6 +79,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_creditcard(post, creditcard)
+        post[:is_billing] = options[:is_billing] if options[:is_billing]
 
         commit(:post, 'credit_cards', post)
       end


### PR DESCRIPTION
ECS-890

Per Fat Zebra support, `is_billing` set to true is required for
successful tokenization of cards without CVV.

-Fixed a remote test and removed a `puts` statement

Unit:
20 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4457 tests, 71551 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed