### PR TITLE
Stripe Payment Intents: Updates for idempotency key support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Ixopay: Support stored credentials [leila-alderman] #3549
 * BlueSnap: Adds localized currency support [carrigan] #3552
 * CheckoutV2: Use status as message for 3DS txns in progress [britth] #3545
+* Stripe Payment Intents: Prevent idempotency key errors for compound actions [britth] #3554
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -52,7 +52,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'GBP',
       customer: @customer,
-      idempotency_key: SecureRandom.uuid
+      idempotency_key: SecureRandom.hex
     }
     assert purchase1 = @gateway.purchase(@amount, @visa_payment_method, options)
     assert_equal 'succeeded', purchase1.params['status']
@@ -64,11 +64,27 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal purchase1.params['charges']['data'][0]['id'], purchase2.params['charges']['data'][0]['id']
   end
 
+  def test_credit_card_purchases_with_same_idempotency_key
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      idempotency_key: SecureRandom.hex
+    }
+    assert purchase1 = @gateway.purchase(@amount, @visa_card, options)
+    assert_equal 'succeeded', purchase1.params['status']
+    assert purchase1.params.dig('charges', 'data')[0]['captured']
+
+    assert purchase2 = @gateway.purchase(@amount, @visa_card, options)
+    assert purchase2.success?
+    assert_equal purchase1.authorization, purchase2.authorization
+    assert_equal purchase1.params['charges']['data'][0]['id'], purchase2.params['charges']['data'][0]['id']
+  end
+
   def test_purchases_with_same_idempotency_key_different_options
     options = {
       currency: 'GBP',
       customer: @customer,
-      idempotency_key: SecureRandom.uuid
+      idempotency_key: SecureRandom.hex
     }
     assert purchase = @gateway.purchase(@amount, @visa_payment_method, options)
     assert_equal 'succeeded', purchase.params['status']
@@ -76,6 +92,22 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     options[:currency] = 'USD'
     assert purchase = @gateway.purchase(@amount, @visa_payment_method, options)
+    refute purchase.success?
+    assert_match(/^Keys for idempotent requests can only be used with the same parameters they were first used with/, purchase.message)
+  end
+
+  def test_credit_card_purchases_with_same_idempotency_key_different_options
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      idempotency_key: SecureRandom.hex
+    }
+    assert purchase = @gateway.purchase(@amount, @visa_card, options)
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+
+    options[:currency] = 'USD'
+    assert purchase = @gateway.purchase(@amount, @visa_card, options)
     refute purchase.success?
     assert_match(/^Keys for idempotent requests can only be used with the same parameters they were first used with/, purchase.message)
   end
@@ -418,6 +450,31 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'requested_by_customer', cancel_response.params['cancellation_reason']
   end
 
+  def test_create_a_payment_intent_and_void_requires_unique_idempotency_key
+    idempotency_key = SecureRandom.hex
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      return_url: 'https://www.example.com',
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      idempotency_key: idempotency_key
+    }
+    assert create_response = @gateway.create_intent(@amount, @three_ds_payment_method, options)
+    assert_equal 'requires_confirmation', create_response.params['status']
+    intent_id = create_response.params['id']
+
+    assert get_response = @gateway.show_intent(intent_id, options)
+    assert_equal 'requires_confirmation', get_response.params['status']
+
+    assert_failure cancel_response = @gateway.void(intent_id, cancellation_reason: 'requested_by_customer', idempotency_key: idempotency_key)
+    assert_match(/^Keys for idempotent requests can only be used for the same endpoint they were first used for/, cancel_response.message)
+
+    assert cancel_response = @gateway.void(intent_id, cancellation_reason: 'requested_by_customer', idempotency_key: "#{idempotency_key}-auto-void")
+    assert_equal 'canceled', cancel_response.params['status']
+    assert_equal 'requested_by_customer', cancel_response.params['cancellation_reason']
+  end
+
   def test_failed_void_after_capture
     options = {
       currency: 'GBP',
@@ -468,6 +525,24 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert unstore = @gateway.unstore(store.authorization)
     assert_nil unstore.params['customer']
+  end
+
+  def test_successful_store_with_idempotency_key
+    idempotency_key = SecureRandom.hex
+
+    options = {
+      currency: 'GBP',
+      idempotency_key: idempotency_key
+    }
+
+    assert store1 = @gateway.store(@visa_card, options)
+    assert store1.success?
+    assert store1.params['customer'].start_with?('cus_')
+
+    assert store2 = @gateway.store(@visa_card, options)
+    assert store2.success?
+    assert_equal store1.authorization, store2.authorization
+    assert_equal store1.params['id'], store2.params['id']
   end
 
   def test_moto_enabled_card_requires_action_when_not_marked


### PR DESCRIPTION
Stripe Payment Intents supports the use of an idempotency key, but
that key can only be used against a single endpoint. Because the
Stripe PI flow can touch multiple different endpoints, we need to
ensure that it is slightly different across the different types
of requests to prevent errors. For instance, if the payment method
provided is a credit card, the adapter hits the payment method endpoint
to create that object before hitting the payment intent endpoint to
create the intent. This PR adds a method to add a suffix aligning to
request endpoints other than /payment_intents (e.g. a post to /payment_methods
would be <provided-key-pm> or a post to /payment_intents/intent-id/capture
would be <provided-key-capture>) to ensure that keys are unique but stable
across a request type. Also adds a remote test to ensure idempotency key
behavior remains as expected when a credit card payment type is used.

Unit:
9 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 167 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed