### PR TITLE
Fat Zebra: Fix `store` call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * CheckoutV2: Use status as message for 3DS txns in progress [britth] #3545
 * Stripe Payment Intents: Prevent idempotency key errors for compound actions [britth] #3554
 * Adyen: Add tests for voiding with idempotency keys [jknipp] #3553
+* Fat Zebra: Fix `store` call [chinhle23] #3556
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_creditcard(post, creditcard)
-        post[:is_billing] = options[:is_billing] if options[:is_billing]
+        post[:is_billing] = true if options[:recurring]
 
         commit(:post, 'credit_cards', post)
       end

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -142,7 +142,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   def test_successful_store_without_cvv
     credit_card = @credit_card
     credit_card.verification_value = nil
-    assert card = @gateway.store(credit_card, is_billing: true)
+    assert card = @gateway.store(credit_card, recurring: true)
 
     assert_success card
     assert_not_nil card.authorization

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -174,7 +174,7 @@ class FatZebraTest < Test::Unit::TestCase
     credit_card.verification_value = nil
     @gateway.expects(:ssl_request).returns(successful_no_cvv_tokenize_response)
 
-    assert response = @gateway.store(credit_card, is_billing: true)
+    assert response = @gateway.store(credit_card, recurring: true)
     assert_success response
     assert_equal 'ep3c05nzsqvft15wsf1z|credit_cards', response.authorization
   end


### PR DESCRIPTION
Related to https://github.com/activemerchant/active_merchant/pull/3551

Use the existing `recurring` flag to set the `is_billing` requirement
from the gateway. `recurring` set to true will allow `store` calls to succeed
without a CVV.

Unit:
20 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4464 tests, 71595 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed