### PR TITLE
PayJunctionv2: Fix billing address fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Adyen: Add tests for voiding with idempotency keys [jknipp] #3553
 * Fat Zebra: Fix `store` call [chinhle23] #3556
 * Update README to include Adyen [haolime] #3452
+* PayJunctionv2: Fix billing address fields [leila-alderman] #3557
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -113,19 +113,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        if (address = options[:billing_address])
-          post[:billing] = {}
-          post[:billing][:firstName] = address[:first_name] if address[:first_name]
-          post[:billing][:lastName] = address[:last_name] if address[:last_name]
-          post[:billing][:companyName] = address[:company] if address[:company]
-          post[:billing][:phone] = address[:phone_number] if address[:phone_number]
-
-          post[:billing][:address] = {}
-          post[:billing][:address][:address] = address[:address1] if address[:address1]
-          post[:billing][:address][:city] = address[:city] if address[:city]
-          post[:billing][:address][:state] = address[:state] if address[:state]
-          post[:billing][:address][:country] = address[:country] if address[:country]
-          post[:billing][:address][:zip] = address[:zip] if address[:zip]
+        if address = options[:billing_address]
+          post[:billingFirstName] = address[:first_name] if address[:first_name]
+          post[:billingLastName] = address[:last_name] if address[:last_name]
+          post[:billingCompanyName] = address[:company] if address[:company]
+          post[:billingPhone] = address[:phone_number] if address[:phone_number]
+          post[:billingAddress] = address[:address1] if address[:address1]
+          post[:billingCity] = address[:city] if address[:city]
+          post[:billingState] = address[:state] if address[:state]
+          post[:billingCountry] = address[:country] if address[:country]
+          post[:billingZip] = address[:zip] if address[:zip]
         end
       end
 

--- a/test/remote/gateways/remote_pay_junction_v2_test.rb
+++ b/test/remote/gateways/remote_pay_junction_v2_test.rb
@@ -25,6 +25,13 @@ class RemotePayJunctionV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'Approved', response.message
     assert response.test?
+
+    assert_match @options[:billing_address][:company], response.params['billing']['companyName']
+    assert_match @options[:billing_address][:address1], response.params['billing']['address']['address']
+    assert_match @options[:billing_address][:city], response.params['billing']['address']['city']
+    assert_match @options[:billing_address][:state], response.params['billing']['address']['state']
+    assert_match @options[:billing_address][:country], response.params['billing']['address']['country']
+    assert_match @options[:billing_address][:zip], response.params['billing']['address']['zip']
   end
 
   def test_successful_purchase_sans_options

--- a/test/unit/gateways/pay_junction_v2_test.rb
+++ b/test/unit/gateways/pay_junction_v2_test.rb
@@ -209,16 +209,15 @@ class PayJunctionV2Test < Test::Unit::TestCase
   def test_add_address
     post = {card: {billingAddress: {}}}
     @gateway.send(:add_address, post, @options)
-    # Billing Address
-    assert_equal @options[:billing_address][:first_name], post[:billing][:firstName]
-    assert_equal @options[:billing_address][:last_name], post[:billing][:lastName]
-    assert_equal @options[:billing_address][:company], post[:billing][:companyName]
-    assert_equal @options[:billing_address][:phone_number], post[:billing][:phone]
-    assert_equal @options[:billing_address][:address1], post[:billing][:address][:address]
-    assert_equal @options[:billing_address][:city], post[:billing][:address][:city]
-    assert_equal @options[:billing_address][:state], post[:billing][:address][:state]
-    assert_equal @options[:billing_address][:country], post[:billing][:address][:country]
-    assert_equal @options[:billing_address][:zip], post[:billing][:address][:zip]
+    assert_equal @options[:billing_address][:first_name], post[:billingFirstName]
+    assert_equal @options[:billing_address][:last_name], post[:billingLastName]
+    assert_equal @options[:billing_address][:company], post[:billingCompanyName]
+    assert_equal @options[:billing_address][:phone_number], post[:billingPhone]
+    assert_equal @options[:billing_address][:address1], post[:billingAddress]
+    assert_equal @options[:billing_address][:city], post[:billingCity]
+    assert_equal @options[:billing_address][:state], post[:billingState]
+    assert_equal @options[:billing_address][:country], post[:billingCountry]
+    assert_equal @options[:billing_address][:zip], post[:billingZip]
   end
 
   def test_scrub


### PR DESCRIPTION
The billing address fields were recently added to the PayJunctionv2
gateway but were mapped to incorrect fields for the gateway.

This update corrects these fields to send the data in the correctly
named fields according to [PayJunction's documentation](https://developer.payjunction.com/hc/en-us/articles/216477407-POST-transactions).

In addition, new remote test assertions were added to ensure that the
gateway is correctly receiving and returning the billing address fields
in the response.

CE-437

Unit:
19 tests, 87 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
20 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4464 tests, 71595 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed