### PR TITLE
Update BIN ranges for Alelo and Maestro cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,8 @@
 * PayJunctionv2: Fix billing address fields [leila-alderman] #3557
 * Adyen: Fail unexpected 3DS responses [curiousepic] #3546
 * Merchant Warrior: Add support for setting soft descriptors [daBayrus] #3558
-* Adyen: Fix stored credentials [chinhle23] #3560 
+* Adyen: Fix stored credentials [chinhle23] #3560
+* Update BIN ranges for Alelo and Maestro cards [leila-alderman] #3559
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -13,7 +13,12 @@ module ActiveMerchant #:nodoc:
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11}$/ },
         'jcb'                => ->(num) { num =~ /^35(28|29|[3-8]\d)\d{12}$/ },
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
-        'maestro'            => ->(num) { (12..19).cover?(num&.size) && in_bin_range?(num.slice(0, 6), MAESTRO_RANGES) },
+        'maestro'            => lambda { |num|
+          (12..19).cover?(num&.size) && (
+            in_bin_range?(num.slice(0, 6), MAESTRO_RANGES) ||
+            MAESTRO_BINS.any? { |bin| num.slice(0, bin.size) == bin }
+          )
+        },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
         'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
@@ -65,6 +70,10 @@ module ActiveMerchant #:nodoc:
         (510000..559999),
       ]
 
+      MAESTRO_BINS = Set.new(
+        ['500033', '581149']
+      )
+
       # https://www.mastercard.us/content/dam/mccom/global/documents/mastercard-rules.pdf, page 73
       MAESTRO_RANGES = [
         (561200..561269),
@@ -111,7 +120,7 @@ module ActiveMerchant #:nodoc:
         405886..405886, 430471..430471, 438061..438061, 438064..438064, 470063..470066,
         496067..496067, 506699..506704, 506706..506706, 506713..506714, 506716..506716,
         506749..506750, 506752..506752, 506754..506756, 506758..506762, 506764..506767,
-        506770..506771, 509015..509019, 509880..509882, 509884..509885, 509987..509988
+        506770..506771, 509015..509019, 509880..509882, 509884..509885, 509987..509992
       ]
 
       CABAL_RANGES = [

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -12,6 +12,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
       5612590000000000 5817500000000000 5818000000000000
       6390000000000000 6390700000000000 6390990000000000
       6761999999999999 6763000000000000 6799999999999999
+      5000330000000000 5811499999999999
     ]
   end
 
@@ -146,6 +147,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'alelo', CreditCard.brand?('5067700000000028')
     assert_equal 'alelo', CreditCard.brand?('5067600000000036')
     assert_equal 'alelo', CreditCard.brand?('5067600000000044')
+    assert_equal 'alelo', CreditCard.brand?('5099920000000000')
   end
 
   def test_should_detect_naranja_card


### PR DESCRIPTION
Updated the BIN ranges for the Alelo and Maestro cards to accurately
reflect ranges for those cards.

CE-363
CE-364
CE-438

All unit tests:
4479 tests, 71674 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed