### PR TITLE
Adyen: Fix stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * PayJunctionv2: Fix billing address fields [leila-alderman] #3557
 * Adyen: Fail unexpected 3DS responses [curiousepic] #3546
 * Merchant Warrior: Add support for setting soft descriptors [daBayrus] #3558
+* Adyen: Fix stored credentials [chinhle23] #3560 
 
 == Version 1.105.0 (Feb 20, 2020)
 * Credorax: Fix `3ds_transtype` setting in post [chinhle23] #3531


### PR DESCRIPTION
ECS-1016

https://docs.adyen.com/checkout/tokenization
`shopperInteraction` possible values:
* `Ecommerce`: Transactions where shoppers enter their card details.
* `ContAuth`: Transactions using previously stored card details, which
  include the card number and card expiry date.

`recurringProcessingModel` possible values:
* `Subscription`: A series of transactions with fixed or variable amounts,
  following a fixed time interval.
* `CardOnFile`: Transactions where a shopper stores card details, and
  transactions where the shopper purchases from your website or app at a
  later time using the previously stored card details
* `UnscheduledCardOnFile`: Contracts that occur on a non-fixed schedule
  using stored card details.

Initial merchant initiated recurring stored credential transactions was
incorrectly setting `shopperInteraction` to `Ecommerce` and setting
`recurringProcessingModel` to `CardOnFile` and thus triggering 3DS responding
with `resultCode` equal to `RedirectShopper` on 3DS-enabled cards.

This change corrects the setting of the `shopperInteraction` and
`recurringProcessingModel` fields for merchant initiated stored credential
transactions.

Unit:
65 tests, 311 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
89 tests, 343 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4471 tests, 71631 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed