### PR TITLE
EBANX: Fix declines if order id is bigger than 40 chars

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -171,7 +171,7 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, money, options)
         post[:payment][:amount_total] = amount(money)
         post[:payment][:currency_code] = (options[:currency] || currency(money))
-        post[:payment][:merchant_payment_code] = options[:order_id]
+        post[:payment][:merchant_payment_code] = Digest::MD5.hexdigest(options[:order_id])
         post[:payment][:instalments] = options[:instalments] || 1
       end
 

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -229,4 +229,12 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:integration_key], transcript)
   end
+
+  def test_successful_purchase_with_long_order_id
+    options = @options.update(order_id: SecureRandom.hex(50))
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
 end


### PR DESCRIPTION
Finished in 39.908368 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed