### PR TITLE
Decidir: Improving the response message when encountering errors

### DIFF
--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         56 => STANDARD_ERROR_CODE[:card_declined],
         57 => STANDARD_ERROR_CODE[:card_declined],
         76 => STANDARD_ERROR_CODE[:call_issuer],
-        91 => STANDARD_ERROR_CODE[:invalid_number],
+        91 => STANDARD_ERROR_CODE[:call_issuer],
         96 => STANDARD_ERROR_CODE[:processing_error],
         97 => STANDARD_ERROR_CODE[:processing_error],
       }

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
         message = nil
         if error = response.dig('status_details', 'error')
           message = error.dig('reason', 'description')
-          if detail = error.dig('type')
+          if detail = error['type']
             message += ' | ' + detail
           end
         elsif response['error_type']

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -37,6 +37,7 @@ module ActiveMerchant #:nodoc:
         56 => STANDARD_ERROR_CODE[:card_declined],
         57 => STANDARD_ERROR_CODE[:card_declined],
         76 => STANDARD_ERROR_CODE[:call_issuer],
+        91 => STANDARD_ERROR_CODE[:invalid_number],
         96 => STANDARD_ERROR_CODE[:processing_error],
         97 => STANDARD_ERROR_CODE[:processing_error],
       }
@@ -239,9 +240,11 @@ module ActiveMerchant #:nodoc:
         return response['message'] if response['message']
 
         message = nil
-
         if error = response.dig('status_details', 'error')
           message = error.dig('reason', 'description')
+          if detail = error.dig('type')
+            message += ' | ' + detail
+          end
         elsif response['error_type']
           message = response['validation_errors'].map { |errors| "#{errors['code']}: #{errors['param']}" }.join(', ') if response['validation_errors']
           message ||= response['error_type']

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -241,10 +241,7 @@ module ActiveMerchant #:nodoc:
 
         message = nil
         if error = response.dig('status_details', 'error')
-          message = error.dig('reason', 'description')
-          if detail = error['type']
-            message += ' | ' + detail
-          end
+          message = "#{error.dig('reason', 'description')} | #{error['type']}"
         elsif response['error_type']
           message = response['validation_errors'].map { |errors| "#{errors['code']}: #{errors['param']}" }.join(', ') if response['validation_errors']
           message ||= response['error_type']

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -95,7 +95,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'TARJETA INVALIDA', response.message
+    assert_equal 'EMISOR FUERA LINEA | invalid_card', response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
   end
 
@@ -121,7 +121,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'TARJETA INVALIDA', response.message
+    assert_equal 'EMISOR FUERA LINEA | invalid_card', response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
   end
 
@@ -196,7 +196,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway_for_auth.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{TARJETA INVALIDA}, response.message
+    assert_match %r{EMISOR FUERA LINEA | invalid_card}, response.message
   end
 
   def test_invalid_login

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -95,8 +95,8 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'EMISOR FUERA LINEA | invalid_card', response.message
-    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+    assert_equal 'COMERCIO INVALIDO | invalid_card', response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
   end
 
   def test_failed_purchase_with_invalid_field
@@ -121,7 +121,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'EMISOR FUERA LINEA | invalid_card', response.message
+    assert_equal 'TARJETA INVALIDA | invalid_number', response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
   end
 
@@ -196,7 +196,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway_for_auth.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{EMISOR FUERA LINEA | invalid_card}, response.message
+    assert_match %r{TARJETA INVALIDA | invalid_number}, response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -67,7 +67,7 @@ class DecidirTest < Test::Unit::TestCase
 
     response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'TARJETA INVALIDA', response.message
+    assert_equal 'TARJETA INVALIDA | invalid_number', response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
   end
 
@@ -104,7 +104,7 @@ class DecidirTest < Test::Unit::TestCase
     assert_failure response
 
     assert_equal 7719358, response.authorization
-    assert_equal 'TARJETA INVALIDA', response.message
+    assert_equal 'TARJETA INVALIDA | invalid_number', response.message
     assert response.test?
   end
 
@@ -235,7 +235,7 @@ class DecidirTest < Test::Unit::TestCase
     response = @gateway_for_auth.verify(@credit_card, @options)
     assert_failure response
 
-    assert_equal 'TARJETA INVALIDA', response.message
+    assert_equal 'TARJETA INVALIDA | invalid_number', response.message
     assert response.test?
   end
 


### PR DESCRIPTION
Appending error type to error description to provide a better response
message when a transaction is declined or rejected.

Decidir also changed the error message returned which resulted in some
of the remote tests failing and included a new error code (91) that was
not in the STANDARD_ERROR_CODE_MAPPING array.

CE-444

Unit: 32 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 21 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed