### PR TITLE
Ingenico/GlobalCollect: Add support for 'requires_approval' field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Stripe Payment Intents: Early return failed `payment_methods` response [chinhle23] #3570
 * Borgun: Support `passengerItineraryData` [therufs] #3572
+* Ingenico GlobalCollect: support optional `requires_approval` field [fatcatt316] #3571
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -7,10 +7,10 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://eu.sandbox.api-ingenico.com'
       self.live_url = 'https://api.globalcollect.com'
 
-      self.supported_countries = ['AD', 'AE', 'AG', 'AI', 'AL', 'AM', 'AO', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC', 'EE', 'EG', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY', 'HK', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE', 'IL', 'IM', 'IN', 'IS', 'IT', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PL', 'PN', 'PS', 'PT', 'PW', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SR', 'ST', 'SV', 'SZ', 'TC', 'TD', 'TG', 'TH', 'TJ', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'US', 'UY', 'UZ', 'VC', 'VE', 'VG', 'VI', 'VN', 'WF', 'WS', 'ZA', 'ZM', 'ZW']
+      self.supported_countries = %w[AD AE AG AI AL AM AO AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BW BY BZ CA CC CD CF CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HN HR HT HU ID IE IL IM IN IS IT JM JO JP KE KG KH KI KM KN KR KW KY KZ LA LB LC LI LK LR LS LT LU LV MA MC MD ME MF MG MH MK MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PL PN PS PT PW QA RE RO RS RU RW SA SB SC SE SG SH SI SJ SK SL SM SN SR ST SV SZ TC TD TG TH TJ TL TM TN TO TR TT TV TW TZ UA UG US UY UZ VC VE VG VI VN WF WS ZA ZM ZW]
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :naranja, :cabal]
+      self.supported_cardtypes = %i[visa master american_express discover naranja cabal]
 
       def initialize(options={})
         requires!(options, :merchant_id, :api_key_id, :secret_api_key)
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options={})
         MultiResponse.run do |r|
           r.process { authorize(money, payment, options) }
-          r.process { capture(money, r.authorization, options) } unless capture_requested?(r)
+          r.process { capture(money, r.authorization, options) } if should_request_capture?(r, options[:requires_approval])
         end
       end
 
@@ -32,7 +32,6 @@ module ActiveMerchant #:nodoc:
         add_address(post, payment, options)
         add_creator_info(post, options)
         add_fraud_fields(post, options)
-
         commit(:authorize, post)
       end
 
@@ -161,6 +160,8 @@ module ActiveMerchant #:nodoc:
           'skipFraudService' => 'true',
           'authorizationMode' => pre_authorization
         }
+        post['cardPaymentMethodSpecificInput']['requiresApproval'] = options[:requires_approval] unless options[:requires_approval].nil?
+
         post['cardPaymentMethodSpecificInput']['card'] = {
           'cvv' => payment.verification_value,
           'cardNumber' => payment.number,
@@ -283,7 +284,7 @@ module ActiveMerchant #:nodoc:
 
       def headers(action, post, authorization = nil)
         {
-          'Content-Type'  => content_type,
+          'Content-Type' => content_type,
           'Authorization' => auth_digest(action, post, authorization),
           'Date' => date
         }
@@ -314,18 +315,16 @@ POST
       end
 
       def message_from(succeeded, response)
-        if succeeded
-          'Succeeded'
+        return 'Succeeded' if succeeded
+
+        if errors = response['errors']
+          errors.first.try(:[], 'message')
+        elsif response['error_message']
+          response['error_message']
+        elsif response['status']
+          'Status: ' + response['status']
         else
-          if errors = response['errors']
-            errors.first.try(:[], 'message')
-          elsif response['error_message']
-            response['error_message']
-          elsif response['status']
-            'Status: ' + response['status']
-          else
-            'No message available'
-          end
+          'No message available'
         end
       end
 
@@ -340,19 +339,28 @@ POST
       end
 
       def error_code_from(succeeded, response)
-        unless succeeded
-          if errors = response['errors']
-            errors.first.try(:[], 'code')
-          elsif status = response.try(:[], 'statusOutput').try(:[], 'statusCode')
-            status.to_s
-          else
-            'No error code available'
-          end
+        return if succeeded
+
+        if errors = response['errors']
+          errors.first.try(:[], 'code')
+        elsif status = response.try(:[], 'statusOutput').try(:[], 'statusCode')
+          status.to_s
+        else
+          'No error code available'
         end
       end
 
       def nestable_hash
         Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+      end
+
+      # Capture hasn't already been requested,
+      # and
+      # 'requires_approval' is not true
+      #   true = payment requires approval before the funds will be captured using the Approve payment or Capture payment API
+      #   false = payment does not require approval, and the funds will be captured automatically
+      def should_request_capture?(response, requires_approval)
+        !capture_requested?(response) && requires_approval != true
       end
 
       def capture_requested?(response)


### PR DESCRIPTION
## What changed?

Add support for optional "requiresApproval"
gateway-specific field for Ingenico/GlobalCollect gateway.

If `requires_approval` is sent in as the boolean `true`, then a purchase
will **not** request capture.

If `requires_approval` is not sent, or is sent in as `false`,
then a purchase **will** request capture.

## Why?

Please see [Ingenico/GlobalCollect's documentation](https://epayments-api.developer-ingenico.com/s2sapi/v1/en_US/ruby/payments/create.html?paymentPlatform=GLOBALCOLLECT#payments-create-payload)

**Note:** you have to click on `Group: cardPaymentMethodSpecificInput`
in order to get to info about the `requiresApproval` field.

```
requiresApproval

Description
	•	true = the payment requires approval before the funds will be captured using the Approve payment or Capture payment API
	•	false = the payment does not require approval, and the funds will be captured automatically

```

CE-456

## Testing

Unit
```
ruby -Ilib:test test/unit/gateways/global_collect_test.rb

23 tests, 102 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

All local
```
rake test:local

4449 tests, 71520 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

Remote
```
ruby -Ilib:test test/remote/gateways/remote_global_collect_test.rb

21 tests, 54 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

## Questions for Reviewers
1. It seems like there are at least two ways to parse the documentation (linked above) about `requiresApproval`. Does your interpretation jive with what I've done here?
2. Any other tests you would like to see added?