### PR TITLE
Borgun: support airline data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Stripe Payment Intents: Early return failed `payment_methods` response [chinhle23] #3570
+* Borgun: Support `passengerItineraryData` [therufs] #3572
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/test/remote/gateways/remote_borgun_test.rb
+++ b/test/remote/gateways/remote_borgun_test.rb
@@ -54,6 +54,27 @@ class RemoteBorgunTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_airline_data
+    passenger_itinerary_data = {
+      'MessageNumber' => '1111111',
+      'TrDate' => '20120222',
+      'TrTime' => '151515',
+      'PassengerName' => 'Jane Doe',
+      'ServiceClassCode_1' => '100',
+      'FlightNumber_1' => '111111',
+      'TravelDate_1' => '20120222',
+      'DepartureAirport_1' => 'KEF',
+      'CarrierCode_1' => 'CC',
+      'TravelAgencyCode' => 'A7654321',
+      'TravelAgencyName' => 'Spreedly Inc',
+      'TicketNumber' => '900.123.222'
+    }
+
+    options = @options.merge(passenger_itinerary_data: passenger_itinerary_data)
+    auth = @gateway.authorize(@amount, @credit_card, options)
+    assert_success auth
+  end
+
   def test_successful_authorize_and_capture_usd
     auth = @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'USD'))
     assert_success auth

--- a/test/unit/gateways/borgun_test.rb
+++ b/test/unit/gateways/borgun_test.rb
@@ -56,6 +56,23 @@ class BorgunTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_authorize_airline_data
+    # itinerary data abbreviated for brevity
+    passenger_itinerary_data = {
+      'MessageNumber' => '1111111',
+      'TrDate' => '20120222',
+      'TrTime' => '151515',
+      'PassengerName' => 'Jane Doe'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, {passenger_itinerary_data: passenger_itinerary_data})
+    end.check_request do |endpoint, data, headers|
+      assert_match('PassengerItineraryData', data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_refund
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
Support passing airline data fields pursuant to https://docs.borgun.com/paymentgateways/bgateway/#sending-passenger-itinerary. 

Some fields are required; we don't validate those, but the adapter will pass generated error messages back to the user. Of particular note, the English documentation above says that Version is required, but requests that include Version as part of PassengerItineraryData are rejected. The documentation for the corresponding Icelandic implementation of the API does not appear to include Version (https://docs.borgun.is/formats/mci10/ section A1). 

CE-385

Remote: 21 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 9 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed 