### PR TITLE
Acapture(OPP): Update gateway credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Realex: Update remote tests [britth] #3576
 * FirstData e4 v27: Properly tag stored credential initiation field in request [britth] #3578
 * Orbital: Fix stored credentials [chinhle23] #3579
+* Acapture(Opp): Update gateway credentials [molbrown] #3574
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/test/remote/gateways/remote_opp_test.rb
+++ b/test/remote/gateways/remote_opp_test.rb
@@ -210,6 +210,6 @@ class RemoteOppTest < Test::Unit::TestCase
 
     assert_scrubbed(@valid_card.number, transcript)
     assert_scrubbed(@valid_card.verification_value, transcript)
-    assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:access_token], transcript)
   end
 end

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -194,11 +194,11 @@ class OppTest < Test::Unit::TestCase
   private
 
   def pre_scrubbed
-    'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=4200000000000000&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=123&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=sy6KJsT8&authentication.userId=8a8294174b7ecb28014b9699220015cc'
+    'paymentType=DB&amount=1.00&currency=EUR&descriptor=&merchantInvoiceId=&merchantTransactionId=50b5c1763c20c456a6208f7831dd0a04&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=4200000000000000&card.expiryMonth=05&card.expiryYear=2022&card.cvv=123&customParameters[SHOPPER_pluginId]=activemerchant&authentication.entityId=5c6602174b7ecb28014b96992'
   end
 
   def post_scrubbed
-    'paymentType=DB&amount=1.00&currency=EUR&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2018&      card.cvv=[FILTERED]&billing.street1=456+My+Street&billing.street2=Apt+1&billing.city=Ottawa&billing.state=ON&billing.postcode=K1C2N6&billing.country=CA&authentication.entityId=8a8294174b7ecb28014b9699220015ca&authentication.password=[FILTERED]&authentication.userId=8a8294174b7ecb28014b9699220015cc'
+    'paymentType=DB&amount=1.00&currency=EUR&descriptor=&merchantInvoiceId=&merchantTransactionId=50b5c1763c20c456a6208f7831dd0a04&paymentBrand=VISA&card.holder=Longbob+Longsen&card.number=[FILTERED]&card.expiryMonth=05&card.expiryYear=2022&card.cvv=[FILTERED]&customParameters[SHOPPER_pluginId]=activemerchant&authentication.entityId=5c6602174b7ecb28014b96992'
   end
 
   def successful_response(type, id)


### PR DESCRIPTION
Acapture notified us that they will be deprecating the user_id/password
request authentication method in favor of an access_token header. This
change includes:
- Adding the access_token required credentials and removing the old
user_id and password fields. The entity_id field will continue to be
used.
- Updating request building logic around those changes, introducing the
Bearer token header.
- Updating the scrub method.

ECS-863

Remote:
15 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
14 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed