### PR TITLE
Realex: Update remote tests (gateway fixtures)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Borgun: Support `passengerItineraryData` [therufs] #3572
 * Ingenico GlobalCollect: support optional `requires_approval` field [fatcatt316] #3571
 * CenPOS: Update failing remote tests [britth] #3575
+* Realex: Update remote tests [britth] #3576
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RemoteRealexTest < Test::Unit::TestCase
   def setup
-    @gateway = RealexGateway.new(fixtures(:realex_with_account))
+    @gateway = RealexGateway.new(fixtures(:realex))
 
     # Replace the card numbers with the test account numbers from Realex
     @visa              = card_fixtures(:realex_visa)


### PR DESCRIPTION
Currently, remote realex tests are failing when using the
:realex_with_account fixtures. They all pass with no other
updates when using just the :realex fixtures. Update the
gateway to use the :realex set of fixtures.

To test, ensure remote tests are passing for you.

Remote:
27 tests, 138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
31 tests, 981 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed