### PR TITLE
First Data E4 v27: Correctly tag stored credentials intiation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Ingenico GlobalCollect: support optional `requires_approval` field [fatcatt316] #3571
 * CenPOS: Update failing remote tests [britth] #3575
 * Realex: Update remote tests [britth] #3576
+* FirstData e4 v27: Properly tag stored credential initiation field in request [britth] #3578
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -319,7 +319,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'StoredCredentials' do
           xml.tag! 'Indicator', stored_credential_indicator(xml, card, options)
           if initiator = options.dig(:stored_credential, :initiator)
-            xml.tag! initiator == 'merchant' ? 'M' : 'C'
+            xml.tag! 'Initiation', initiator == 'merchant' ? 'M' : 'C'
           end
           if reason_type = options.dig(:stored_credential, :reason_type)
             xml.tag! 'Schedule', reason_type == 'unscheduled' ? 'U' : 'S'

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -91,6 +91,7 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
     assert_match(/Transaction Normal/, response.message)
     assert_success response
     assert_equal '1', response.params['stored_credentials_indicator']
+    assert_equal 'C', response.params['stored_credentials_initiation']
     assert_equal 'U', response.params['stored_credentials_schedule']
     assert_not_nil response.params['stored_credentials_transaction_id']
   end

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -73,6 +73,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
       assert_match(/Indicator>1</, data)
       assert_match(/Schedule>U</, data)
       assert_match(/TransactionId>new</, data)
+      assert_match(/Initiation>C/, data)
     end.respond_with(successful_purchase_response_with_stored_credentials)
 
     assert_success response


### PR DESCRIPTION
Some transactions on this gateway that used stored credentials
appeared successful to start, but were ultimately rejected because
the initation value was missing. That seems to match up with remote
test behavior seen before updating this branch, as current stored
credentials remote tests appear to pass, despite not tagging the value
as expected. This PR updates add_stored_credentials to pass along
the appropriate value ('M' or 'C') into an XML field called `Initiation`,
per [docs](https://support.payeezy.com/hc/en-us/articles/206601408-First-Data-Payeezy-Gateway-Web-Service-API-Reference-Guide#3.13). 

Unit:
31 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed