### PR TITLE
Checkout V2: Purchase using Network Token

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -102,13 +102,21 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method, options)
         post[:source] = {}
-        post[:source][:type] = 'card'
-        post[:source][:name] = payment_method.name
-        post[:source][:number] = payment_method.number
-        post[:source][:cvv] = payment_method.verification_value
+        if payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :network_token
+          post[:source][:type] = 'network_token'
+          post[:source][:token] = payment_method.number
+          post[:source][:token_type] = payment_method.brand == 'visa' ? 'vts' : 'mdes'
+          post[:source][:cryptogram] = payment_method.payment_cryptogram
+          post[:source][:eci] = options[:eci] || '05'
+        else
+          post[:source][:type] = 'card'
+          post[:source][:name] = payment_method.name
+          post[:source][:number] = payment_method.number
+          post[:source][:cvv] = payment_method.verification_value
+          post[:source][:stored] = 'true' if options[:card_on_file] == true
+        end
         post[:source][:expiry_year] = format(payment_method.year, :four_digits)
         post[:source][:expiry_month] = format(payment_method.month, :two_digits)
-        post[:source][:stored] = 'true' if options[:card_on_file] == true
       end
 
       def add_customer_data(post, options)

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       attr_accessor :payment_cryptogram, :eci, :transaction_id
       attr_writer :source
 
-      SOURCES = %i(apple_pay android_pay google_pay)
+      SOURCES = %i(apple_pay android_pay google_pay network_token)
 
       def source
         if defined?(@source) && SOURCES.include?(@source)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -10,6 +10,14 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @declined_card = credit_card('42424242424242424', verification_value: '234', month: '6', year: '2025')
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
 
+    @network_token = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month:              '10',
+      year:               '2025',
+      source:             :network_token,
+      verification_value: nil
+    )
+
     @options = {
       order_id: '1',
       billing_address: address,
@@ -56,6 +64,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_network_token
+    response = @gateway.purchase(100, @network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_not_nil response.params['source']['payment_account_reference']
   end
 
   def test_successful_purchase_with_additional_options

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -41,6 +41,17 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Y', response.cvv_result['code']
   end
 
+  def test_successful_purchase_using_network_token
+    network_token = network_tokenization_credit_card({source: :network_token})
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
   def test_successful_authorize_includes_avs_result
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
@@ -351,6 +362,12 @@ class CheckoutV2Test < Test::Unit::TestCase
        }
       }
     )
+  end
+
+  def successful_purchase_with_network_token_response
+    purchase_response = JSON.parse(successful_purchase_response)
+    purchase_response['source']['payment_account_reference'] = '2FCFE326D92D4C27EDD699560F484'
+    purchase_response.to_json
   end
 
   def failed_purchase_response

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -16,6 +16,9 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     @tokenized_google_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :google_pay
     })
+    @existing_network_token = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      source: :network_token
+    })
     @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :bogus_pay
     })
@@ -43,5 +46,6 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     assert_equal @tokenized_android_pay_card.source, :android_pay
     assert_equal @tokenized_google_pay_card.source, :google_pay
     assert_equal @tokenized_bogus_pay_card.source, :apple_pay
+    assert_equal @existing_network_token.source, :network_token
   end
 end


### PR DESCRIPTION
Make Purchase call on Checkout V2 gateway using a network token. Add
`use_network_token` to the response to indicate NT was used for the
transaction