### PR TITLE
CyberSource: Fix `void` for `purchase` transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -325,7 +325,8 @@ module ActiveMerchant #:nodoc:
         options[:order_id] = order_id
 
         xml = Builder::XmlMarkup.new indent: 2
-        if action == 'capture'
+        case action
+        when 'capture', 'purchase'
           add_mdd_fields(xml, options)
           add_void_service(xml, request_id, request_token)
         else

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -7,7 +7,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     @gateway = CyberSourceGateway.new({nexus: 'NC'}.merge(fixtures(:cyber_source)))
 
-    @credit_card = credit_card('4111111111111111', verification_value: '321')
+    @credit_card = credit_card('4111111111111111', verification_value: '987')
     @declined_card = credit_card('801111111111111')
     @pinless_debit_card = credit_card('4002269999999999')
     @elo_credit_card = credit_card('5067310000000010',
@@ -141,6 +141,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Invalid account number', response.message
     assert_equal false, response.success?
+  end
+
+  def test_purchase_and_void
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+    assert void = @gateway.void(purchase.authorization, @options)
+    assert_successful_response(void)
   end
 
   def test_authorize_and_void

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -451,22 +451,34 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_card_credit_response)
   end
 
+  def test_successful_void_purchase_request
+    purchase = '1000;1842651133440156177166;AP4JY+Or4xRonEAOERAyMzQzOTEzMEM0MFZaNUZCBgDH3fgJ8AEGAMfd+AnwAwzRpAAA7RT/;purchase;100;USD;'
+
+    stub_comms do
+      @gateway.void(purchase, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<voidService run=\"true\"), data)
+    end.respond_with(successful_void_response)
+  end
+
   def test_successful_void_capture_request
-    @gateway.stubs(:ssl_post).returns(successful_capture_response, successful_auth_reversal_response)
-    assert response_capture = @gateway.capture(@amount, '1846925324700976124593')
-    assert response_capture.success?
-    assert response_capture.test?
-    assert response_auth_reversal = @gateway.void(response_capture.authorization, @options)
-    assert response_auth_reversal.success?
+    capture = '1000;1842651133440156177166;AP4JY+Or4xRonEAOERAyMzQzOTEzMEM0MFZaNUZCBgDH3fgJ8AEGAMfd+AnwAwzRpAAA7RT/;capture;100;USD;'
+
+    stub_comms do
+      @gateway.void(capture, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<voidService run=\"true\"), data)
+    end.respond_with(successful_void_response)
   end
 
   def test_successful_void_authorization_request
-    @gateway.stubs(:ssl_post).returns(successful_authorization_response, successful_void_response)
-    assert response = @gateway.authorize(@amount, @credit_card, @options)
-    assert response.success?
-    assert response.test?
-    assert response_void = @gateway.void(response.authorization, @options)
-    assert response_void.success?
+    authorization = '1000;1842651133440156177166;AP4JY+Or4xRonEAOERAyMzQzOTEzMEM0MFZaNUZCBgDH3fgJ8AEGAMfd+AnwAwzRpAAA7RT/;authorize;100;USD;'
+
+    stub_comms do
+      @gateway.void(authorization, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<ccAuthReversalService run=\"true\"), data)
+    end.respond_with(successful_auth_reversal_response)
   end
 
   def test_successful_void_with_issuer_additional_data


### PR DESCRIPTION
ECS-1080

Voiding `purchase` transactions were failing due to `<ccAuthReversalService run=\"true\">`
being sent in the request instead of the required `<voidService run=\"true\">`.

This change corrects this issue.

Unit:
76 tests, 340 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
75 tests, 385 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed

All unit tests:
4460 tests, 71572 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed

The 5 remote failures seem to be previously existing and unrelated:

 - test_successful_3ds_validate_authorize_request
 - test_successful_3ds_validate_purchase_request
 - test_successful_pinless_debit_card_puchase
 - test_successful_tax_calculation
 - test_successful_validate_pinless_debit_card