### PR TITLE
fix opp tests

### DIFF
--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -13,8 +13,7 @@ module ActiveMerchant #:nodoc:
       # == Usage
       #
       #   gateway = ActiveMerchant::Billing::OppGateway.new(
-      #      user_id: 'merchant user id',
-      #      password: 'password',
+      #      access_token: 'access_token',
       #      entity_id: 'entity id',
       #   )
       #

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -633,8 +633,7 @@ openpay:
   merchant_id: 'mzdtln0bmtms6o3kck8f'
 
 opp:
-  user_id: '8a8294174b7ecb28014b9699220015cc'
-  password: 'sy6KJsT8'
+  access_token: 'OGE4Mjk0MTc0YjdlY2IyODAxNGI5Njk5MjIwMDE1Y2N8c3k2S0pzVDg='
   entity_id: '8a8294174d0a8edd014d242337942575'
 
 optimal_payment:


### PR DESCRIPTION
This fix the tests for opp by updating fixtures credentials.
Credentials required for opp gateway was updated in https://github.com/activemerchant/active_merchant/commit/8c0e5d3b745abc11cde06766907934b3824266ed, but not fixtures

```
$ rake test TEST=test/unit/gateways/opp_test.rb 
..............
Finished in 0.056895137 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
246.07 tests/s, 1283.06 assertions/s
```

```
$ rake test TEST=test/remote/gateways/remote_opp_test.rb 
...............
Finished in 24.366227315 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.62 tests/s, 1.97 assertions/s
```