### PR TITLE
fix card expiration date format for Pagar.me Gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
       def add_credit_card(post, credit_card)
         post[:card_number] = credit_card.number
         post[:card_holder_name] = credit_card.name
-        post[:card_expiration_date] = "#{credit_card.month}/#{credit_card.year}"
+        post[:card_expiration_date] = expdate(credit_card)
         post[:card_cvv] = credit_card.verification_value
       end
 

--- a/test/remote/gateways/remote_pagarme_test.rb
+++ b/test/remote/gateways/remote_pagarme_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'active_support/duration'
 
 class RemotePagarmeTest < Test::Unit::TestCase
   def setup
@@ -6,14 +7,21 @@ class RemotePagarmeTest < Test::Unit::TestCase
 
     @amount = 1000
 
+    exp_date = Time.now + 1.year
+
     @credit_card = credit_card('4242424242424242', {
       first_name: 'Richard',
-      last_name: 'Deschamps'
+      last_name: 'Deschamps',
+      year: exp_date.year,
+      month: exp_date.month,
+      verification_value: 123
     })
 
     @declined_card = credit_card('4242424242424242', {
       first_name: 'Richard',
       last_name: 'Deschamps',
+      year: exp_date.year,
+      month: exp_date.month,
       verification_value: '688'
     })
 


### PR DESCRIPTION
fix #2534

```
$ rake test TEST=test/unit/gateways/pagarme_test.rb 
Started
................
Finished in 0.028124156 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
16 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
568.91 tests/s, 4231.24 assertions/s

```
```
$ rake test TEST=test/remote/gateways/remote_pagarme_test.rb 
Started
......F
=======================================================================================================================================================================================
     148: 
     149:     response = gateway.purchase(@amount, @credit_card, @options)
     150:     assert_failure response
  => 151:     assert_match %r{401 Authorization Required}, response.message
     152:   end
     153: 
     154:   def test_transcript_scrubbing
/home/pavle/tmp/active_merchant/test/remote/gateways/remote_pagarme_test.rb:151:in `test_invalid_login'
Failure: test_invalid_login(RemotePagarmeTest):
  </401 Authorization Required/> was expected to be =~
  <"Invalid environment">.
=======================================================================================================================================================================================
........
Finished in 16.44644862 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
15 tests, 46 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.91 tests/s, 2.80 assertions/s

```

Failing in remote test is unrelated to the change.
