### PR TITLE
Optimal Payment: Add store method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * CyberSource: Fix `void` for `purchase` transactions [chinhle23] #3581
 * Checkout V2: Begin to add support for using network tokens for transactions. [arbianchi] #3580
 * Opp: Update remote test fixtures [ccarruitero] #3582
+* Optimal Payment: Add support for store [britth] #3585
 
 == Version 1.106.0 (Mar 10, 2020)
 * PayJunctionV2: Send billing address in `auth` and `purchase` transactions [naashton] #3538

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -65,6 +65,10 @@ module ActiveMerchant #:nodoc:
         commit('ccVerification', 0, options)
       end
 
+      def store(credit_card, options = {})
+        verify(credit_card, options)
+      end
+
       def supports_scrubbing?
         true
       end

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -7,6 +7,7 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     @amount = 100
     @declined_amount = 5
     @credit_card = credit_card('4387751111011')
+    @expired_card = credit_card('4387751111011', month: 12, year: 2019)
 
     @options = {
       order_id: '1',
@@ -55,6 +56,52 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     response = @gateway.verify(@credit_card, @options)
     assert_success response
     assert_equal 'no_error', response.message
+  end
+
+  def test_stored_data_auth_and_capture_after_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'no_error', response.message
+
+    assert auth = @gateway.stored_authorize(@amount, response.authorization)
+    assert_success auth
+    assert_equal 'no_error', auth.message
+    assert auth.authorization
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
+  def test_stored_data_purchase_after_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'no_error', response.message
+
+    assert stored_purchase = @gateway.stored_purchase(@amount, response.authorization)
+    assert_success stored_purchase
+  end
+
+  def test_stored_data_auth_after_failed_store
+    response = @gateway.store(@expired_card, @options)
+    assert_failure response
+    assert_not_nil response.authorization
+    assert_equal 'ERROR', response.params['decision']
+
+    assert auth = @gateway.stored_authorize(@amount, response.authorization)
+    assert_failure auth
+    assert_equal 'ERROR', auth.params['decision']
+  end
+
+  def test_stored_data_purchase_after_failed_store
+    response = @gateway.store(@expired_card, @options)
+    assert_failure response
+    assert_not_nil response.authorization
+    assert_equal 'ERROR', response.params['decision']
+
+
+    assert stored_purchase = @gateway.stored_purchase(@amount, response.authorization)
+    assert_failure stored_purchase
+    assert_equal 'ERROR', stored_purchase.params['decision']
   end
 
   def test_authorize_and_capture


### PR DESCRIPTION
Add support for store on Optimal Payment, which calls verify with
the cc and any options passed. You can use the authorization value
returned from the successful transaction to issue a purchase or auth,
which will utilize that same payment method.

Remote:
18 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
19 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed