### PR TITLE
Iridium: Localize zero-decimal currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Iridium: Localize zero-decimal currencies [chinhle23] #3587
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -291,7 +291,8 @@ module ActiveMerchant #:nodoc:
         order_id, cross_reference, _ = authorization.split(';')
         build_request(options) do |xml|
           if money
-            details = {'CurrencyCode' => currency_code(options[:currency] || default_currency), 'Amount' => amount(money)}
+            currency = options[:currency] || currency(money)
+            details = {'CurrencyCode' => currency_code(currency), 'Amount' => localized_amount(money, currency)}
           else
             details = {'CurrencyCode' => currency_code(default_currency), 'Amount' => '0'}
           end
@@ -327,8 +328,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_purchase_data(xml, type, money, options)
+        currency = options[:currency] || currency(money)
         requires!(options, :order_id)
-        xml.tag! 'TransactionDetails', {'Amount' => amount(money), 'CurrencyCode' => currency_code(options[:currency] || currency(money))} do
+        xml.tag! 'TransactionDetails', {'Amount' => localized_amount(money, currency), 'CurrencyCode' => currency_code(currency)} do
           xml.tag! 'MessageDetails', {'TransactionType' => type}
           xml.tag! 'OrderID', options[:order_id]
           xml.tag! 'TransactionControl' do

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class IridiumTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     Base.mode = :test
 
@@ -107,6 +109,14 @@ class IridiumTest < Test::Unit::TestCase
     assert_nothing_raised do
       assert_success @gateway.purchase(@amount, credit_card, @options)
     end
+  end
+
+  def test_nonfractional_currency_handling
+    stub_comms do
+      @gateway.authorize(14200, @credit_card, @options.merge(currency: 'JPY'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<TransactionDetails Amount=\"142\"/, data)
+    end.respond_with(successful_authorize_response)
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
ECS-1119

Iridium (PayVector) requires the transaction amount to be sent in "minor
currency". This change ensures that zero-decimal currencies are properly
sent (i.e. 14200 JPY is sent as 142)

A new remote test was not written because Iridium (PayVector) does not
return the amount in the response.

Unit:
13 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
21 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4462 tests, 71592 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed