### PR TITLE
iVeri: Fix `verify` action

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Iridium: Localize zero-decimal currencies [chinhle23] #3587
+* iVeri: Fix `verify` action [chinhle23] #3588
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -60,7 +60,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options={})
-        authorize(0, credit_card, options)
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
       end
 
       def verify_credentials

--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -124,6 +124,10 @@ class RemoteIveriTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
+    assert_equal 'Authorisation', response.responses[0].params['transaction_command']
+    assert_equal '0', response.responses[0].params['result_status']
+    assert_equal 'Void', response.responses[1].params['transaction_command']
+    assert_equal '0', response.responses[1].params['result_status']
     assert_equal 'Succeeded', response.message
   end
 

--- a/test/unit/gateways/iveri_test.rb
+++ b/test/unit/gateways/iveri_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class IveriTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = IveriGateway.new(app_id: '123', cert_id: '321')
     @credit_card = credit_card('4242424242424242')
@@ -100,20 +102,19 @@ class IveriTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    @gateway.expects(:ssl_post).returns(successful_verify_response)
-
-    response = @gateway.verify(@credit_card, @options)
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
-    assert_equal '{F4337D04-B526-4A7E-A400-2A6DEADDCF57}|{5D5F8BF7-2D9D-42C3-AF32-08C5E62CD45E}|c0006d1d739905afc9e70beaf4194ea3', response.authorization
-    assert response.test?
+    assert_equal 'Succeeded', response.message
   end
 
   def test_failed_verify
-    @gateway.expects(:ssl_post).returns(failed_verify_response)
-
-    response = @gateway.verify(credit_card('2121212121212121'), @options)
+    response = stub_comms do
+      @gateway.verify(credit_card('2121212121212121'), @options)
+    end.respond_with(failed_authorize_response, successful_void_response)
     assert_failure response
-    assert_equal '4', response.error_code
+    assert_equal 'Denied', response.message
   end
 
   def test_successful_verify_credentials
@@ -490,44 +491,6 @@ Conn close
     &lt;DistributorName&gt;Nedbank&lt;/DistributorName&gt;
     &lt;CCNumber&gt;4242........4242&lt;/CCNumber&gt;
     &lt;PAN&gt;4242........4242&lt;/PAN&gt;
-  &lt;/Transaction&gt;
-&lt;/V_XML&gt;</ExecuteResult></ExecuteResponse></soap:Body></soap:Envelope>
-    XML
-  end
-
-  def failed_verify_response
-    <<-XML
-<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><ExecuteResponse xmlns="http://iveri.com/"><ExecuteResult>&lt;V_XML Version="2.0" Direction="Response"&gt;
-  &lt;Transaction ApplicationID="{D10A603D-4ADE-405B-93F1-826DFC0181E8}" Command="Authorisation" Mode="Test" RequestID="{A700FAE2-2A76-407D-A540-B41668E2B703}"&gt;
-    &lt;Result Status="-1" Code="4" Description="Denied" Source="NBPostilionBICISONBSouthAfrica" AppServer="105IVERIAPPPR02" DBServer="105iveridbpr01" Gateway="Nedbank" AcquirerCode="05" AcquirerDescription="Do not Honour" /&gt;
-    &lt;Amount&gt;0&lt;/Amount&gt;
-    &lt;Currency&gt;ZAR&lt;/Currency&gt;
-    &lt;ExpiryDate&gt;092018&lt;/ExpiryDate&gt;
-    &lt;MerchantReference&gt;e955afb03f224284b09ad6ae7e9b4683&lt;/MerchantReference&gt;
-    &lt;Terminal&gt;Default&lt;/Terminal&gt;
-    &lt;TransactionIndex&gt;{2A378547-AEA4-48E1-8A3E-29F9BBEA954D}&lt;/TransactionIndex&gt;
-    &lt;MerchantName&gt;iVeri Payment Technology&lt;/MerchantName&gt;
-    &lt;MerchantUSN&gt;7771777&lt;/MerchantUSN&gt;
-    &lt;Acquirer&gt;NBPostilionBICISONBSouthAfrica&lt;/Acquirer&gt;
-    &lt;AcquirerReference&gt;70418:04078337&lt;/AcquirerReference&gt;
-    &lt;AcquirerDate&gt;20170418&lt;/AcquirerDate&gt;
-    &lt;AcquirerTime&gt;161716&lt;/AcquirerTime&gt;
-    &lt;DisplayAmount&gt;R 0.00&lt;/DisplayAmount&gt;
-    &lt;BIN&gt;2&lt;/BIN&gt;
-    &lt;Association&gt;Unknown Association&lt;/Association&gt;
-    &lt;CardType&gt;Unknown CardType&lt;/CardType&gt;
-    &lt;Issuer&gt;Unknown&lt;/Issuer&gt;
-    &lt;Jurisdiction&gt;Local&lt;/Jurisdiction&gt;
-    &lt;PANMode&gt;Keyed,CVV&lt;/PANMode&gt;
-    &lt;ReconReference&gt;04078337&lt;/ReconReference&gt;
-    &lt;CardHolderPresence&gt;CardNotPresent&lt;/CardHolderPresence&gt;
-    &lt;MerchantAddress&gt;MERCHANT ADDRESS&lt;/MerchantAddress&gt;
-    &lt;MerchantCity&gt;Sandton&lt;/MerchantCity&gt;
-    &lt;MerchantCountryCode&gt;ZA&lt;/MerchantCountryCode&gt;
-    &lt;MerchantCountry&gt;South Africa&lt;/MerchantCountry&gt;
-    &lt;DistributorName&gt;Nedbank&lt;/DistributorName&gt;
-    &lt;CCNumber&gt;2121........2121&lt;/CCNumber&gt;
-    &lt;PAN&gt;2121........2121&lt;/PAN&gt;
   &lt;/Transaction&gt;
 &lt;/V_XML&gt;</ExecuteResult></ExecuteResponse></soap:Body></soap:Envelope>
     XML


### PR DESCRIPTION
ECS-1124

iVeri now requires an amount other than `0` for the `authorize` action.

Unit:
15 tests, 62 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
19 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4461 tests, 71591 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed