### PR TITLE
Ixopay: Properly support three-decimal currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Iridium: Localize zero-decimal currencies [chinhle23] #3587
 * iVeri: Fix `verify` action [chinhle23] #3588
+* Ixopay: Properly support three-decimal currencies [chinhle23] #3589
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -8,6 +8,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w(AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW)
       self.default_currency = 'EUR'
+      self.currencies_with_three_decimal_places = %w(BHD IQD JOD KWD LWD OMR TND)
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :maestro]
 
       self.homepage_url = 'https://www.ixopay.com'

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -350,6 +350,18 @@ class IxopayTest < Test::Unit::TestCase
     assert_equal 'FINISHED', response.message
   end
 
+  def test_three_decimal_currency_handling
+    response = stub_comms do
+      @gateway.authorize(14200, @credit_card, @options.merge(currency: 'KWD'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<amount>14.200<\/amount>/, data)
+      assert_match(/<currency>KWD<\/currency>/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal 'FINISHED', response.message
+  end
+
   private
 
   def mock_response_error


### PR DESCRIPTION
ECS-1133

Ixopay requires three-decimal currencies (i.e. KWD) amount to be sent with
three decimal values. For example, amount = 1000 KWD is currently sent as
10.00 KWD, when it should be 1.000 KWD. This change corrects this.

A new remote test was not written because Ixopay does not return the amount
in the response.

Unit:
29 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
23 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4463 tests, 71612 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed