### PR TITLE
ePay: Send unique order ids for remote tests

### DIFF
--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -8,8 +8,8 @@ class RemoteEpayTest < Test::Unit::TestCase
     @credit_card = credit_card('3333333333333000')
     @credit_card_declined = credit_card('3333333333333102')
     @amount = 100
-    @options_xid = {order_id: '1', three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: nil }}
-    @options_ds_transaction_id = {order_id: '1', three_d_secure: { eci: '7', xid: nil, cavv: '456', version: '2', ds_transaction_id: '798' }}
+    @options_xid = {order_id: generate_unique_id, three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: nil }}
+    @options_ds_transaction_id = {order_id: generate_unique_id, three_d_secure: { eci: '7', xid: nil, cavv: '456', version: '2', ds_transaction_id: '798' }}
   end
 
   def test_successful_purchase_xid


### PR DESCRIPTION
A number of remote tests were failing due to the gateway rejecting non-
unique order ids.

Remote:
15 tests, 27 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
16 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed