### PR TITLE
Decidir: Handle unique error response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Ixopay: Properly support three-decimal currencies [chinhle23] #3589
 * Kushki: support `auth` and `capture` [therufs] #3591
 * PaymentExpress: Update references to Windcave to reflect rebranding [britth] #3595
+* Decidir: Improve handling of error responses from the gateway [naashton] #3594
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
-  s.metadata['allowed_push_host'] = "https://rubygems.org"
+  s.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -266,6 +266,11 @@ module ActiveMerchant #:nodoc:
           error_code ||= error['type']
         elsif response['error_type']
           error_code = response['error_type'] if response['validation_errors']
+        elsif error = response.dig('error')
+          validation_errors = error.dig('validation_errors', 0)
+          code = validation_errors['code'] if validation_errors && validation_errors['code']
+          param = validation_errors['param'] if validation_errors && validation_errors['param']
+          error_code = "#{error['error_type']} | #{code} | #{param}" if error['error_type']
         end
 
         error_code || STANDARD_ERROR_CODE[:processing_error]

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -209,7 +209,6 @@ module ActiveMerchant #:nodoc:
         if ['void', 'refund'].include?(action)
           base_url + 'v1/' + ENDPOINT[action] + '/' + params[:ticketNumber].to_s
         else
-          #require 'pry-byebug'; byebug
           base_url + 'card/v1/' + ENDPOINT[action]
         end
       end

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -67,7 +67,7 @@ class RemoteKushkiTest < Test::Unit::TestCase
     }
     response = @gateway.authorize(@amount, @credit_card, options)
     assert_failure response
-    assert_equal "220", response.responses.last.error_code
+    assert_equal '220', response.responses.last.error_code
     assert_equal 'Monto de la transacción es diferente al monto de la venta inicial', response.message
   end
 
@@ -91,7 +91,7 @@ class RemoteKushkiTest < Test::Unit::TestCase
 
     capture = @gateway.capture(@amount, auth.authorization, options)
     assert_failure capture
-    assert_equal "K012", capture.error_code
+    assert_equal 'K012', capture.error_code
     assert_equal 'Monto de captura inválido.', capture.message
   end
 

--- a/test/remote/gateways/remote_optimal_payment_test.rb
+++ b/test/remote/gateways/remote_optimal_payment_test.rb
@@ -98,7 +98,6 @@ class RemoteOptimalPaymentTest < Test::Unit::TestCase
     assert_not_nil response.authorization
     assert_equal 'ERROR', response.params['decision']
 
-
     assert stored_purchase = @gateway.stored_purchase(@amount, response.authorization)
     assert_failure stored_purchase
     assert_equal 'ERROR', stored_purchase.params['decision']

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -86,6 +86,14 @@ class DecidirTest < Test::Unit::TestCase
     end
   end
 
+  def test_failed_purchase_error_response
+    @gateway_for_purchase.expects(:ssl_request).returns(unique_error_response)
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match 'invalid_request_error | invalid_param | payment_type', response.error_code
+  end
+
   def test_successful_authorize
     @gateway_for_auth.expects(:ssl_request).returns(successful_authorize_response)
 
@@ -462,5 +470,11 @@ class DecidirTest < Test::Unit::TestCase
     %(
       {"error_type":"not_found_error","entity_name":"","id":""}
     )
+  end
+
+  def unique_error_response
+    %{
+      {\"error\":{\"error_type\":\"invalid_request_error\",\"validation_errors\":[{\"code\":\"invalid_param\",\"param\":\"payment_type\"}]}}
+    }
   end
 end


### PR DESCRIPTION
Decidir, in some odd cases, is returning a json response that was not
being caught by the `error_code_from` method

CE-378

Unit: 33 tests, 143 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 21 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed