### PR TITLE
Clean up output of rake test:local

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * ePay: Send unique order ids for remote tests [curiousepic] #3593
 * Checkout V2: Send more informative error messages for 4xx errors [britth] #3601
 * Elavon: Add ssl_dynamic_dba field [apfranzen] #3600
+* Remove deprecated `rubyforge_project` attribute and tidy up unit test output [fatcatt316] #3598
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ namespace :test do
   Rake::TestTask.new(:units) do |t|
     t.pattern = 'test/unit/**/*_test.rb'
     t.libs << 'test'
-    t.verbose = true
+    t.verbose = false
   end
 
   desc 'Run all tests that do not require network access'

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.author = 'Tobias Luetke'
   s.email = 'tobi@leetsoft.com'
   s.homepage = 'http://activemerchant.org/'
-  s.rubyforge_project = 'activemerchant'
 
   s.required_ruby_version = '>= 2.3'
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -580,7 +580,7 @@ module ActiveMerchant #:nodoc:
         xml = ssl_post(url, request, headers(options))
         raw = parse(action, xml)
         if options[:execute_threed]
-          raw[:cookie] = @cookie
+          raw[:cookie] = @cookie if defined?(@cookie)
           raw[:session_id] = options[:session_id]
           raw[:is3DSOrder] = true
         end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -733,8 +733,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_passes_transaction_source
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
-      (params[:transaction_source] == 'recurring')
-      (params[:recurring] == nil)
+      (params[:transaction_source] == 'recurring') && (params[:recurring] == nil)
     end.returns(braintree_result)
     @gateway.purchase(100, credit_card('41111111111111111111'), transaction_source: 'recurring', recurring: true)
   end

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -190,7 +190,6 @@ class CardStreamTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(28400, @amex, @visacredit_descriptor_options.merge(currency: 'JPY', order_id: '1234567890'))
     end.check_request do |endpoint, data, headers|
-      puts data
       assert_match(/item1GrossValue=284&/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -539,7 +539,7 @@ class CheckoutV2Test < Test::Unit::TestCase
 
   def error_4xx_response
     mock_response = Net::HTTPUnauthorized.new('1.1', '401', 'Unauthorized')
-    mock_response.stubs(:body).returns("")
+    mock_response.stubs(:body).returns('')
 
     ActiveMerchant::ResponseError.new(mock_response)
   end

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -280,7 +280,6 @@ class CredoraxTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
     end.check_request do |endpoint, data, headers|
-      p data
       assert_match(/3ds_channel=02/, data)
       assert_match(/3ds_transtype=03/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -962,7 +962,7 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   def risk_data
-    return @risk_data if @risk_data
+    return @risk_data if defined?(@risk_data)
 
     authentication_time = Time.now
     shopper_account_creation_date = Date.today


### PR DESCRIPTION
## What Changed?
This PR cleans up some of `rake test:local` output. Try it out on `master`, and then on this branch to see the difference!

- [x] Removes two `puts` statements
- [x] Removes EOL'd `rubyforge_project` property.
  * RubyForge was closed down in 2013.
  * rubygems/rubygems#2436 deprecated the `rubyforge_project` property.
- [x] Sets `verbose` to `false` for the `test:local`
- [x] Checks if variable is defined before using it to set another in Worldpay
- [x] Fix a BraintreeBlue test
- [x] Fix Rubocop issue in a checkout_v2 test

## Why?
Someone pointed out that the test output was
a bit cluttered, which can make it harder to tell
what's happening.

RubyForge closed down in 2013. There are actually **two other** open PRs to remove this property:
* #3293 (which was actually approved but not merged)
* #3275 

## Testing

### Local 
```
rake test:local results:
4472 tests, 71664 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```

### Remote tests of changed gateways
Worldpay
```
ruby -Ilib:test test/remote/gateways/remote_worldpay_test.rb
57 tests, 243 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4912% passed

Same two tests fail on `master`
```

## Questions for Reviewer
1. Any reason not to do any of these changes?