### PR TITLE
iATs Payments: Upgrade to v3 and add GSFs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * ePay: Send unique order ids for remote tests [curiousepic] #3593
 * Checkout V2: Send more informative error messages for 4xx errors [britth] #3601
 * Elavon: Add ssl_dynamic_dba field [apfranzen] #3600
+* iATS Payments: Update gateway to v3 and add support for additional GSFs [naashton] #3599 
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -14,12 +14,12 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'iATS Payments'
 
       ACTIONS = {
-        purchase: 'ProcessCreditCardV1',
-        purchase_check: 'ProcessACHEFTV1',
-        refund: 'ProcessCreditCardRefundWithTransactionIdV1',
-        refund_check: 'ProcessACHEFTRefundWithTransactionIdV1',
-        store: 'CreateCreditCardCustomerCodeV1',
-        unstore: 'DeleteCustomerCodeV1'
+        purchase: 'ProcessCreditCard',
+        purchase_check: 'ProcessACHEFT',
+        refund: 'ProcessCreditCardRefundWithTransactionId',
+        refund_check: 'ProcessACHEFTRefundWithTransactionId',
+        store: 'CreateCreditCardCustomerCode',
+        unstore: 'DeleteCustomerCode'
       }
 
       def initialize(options={})
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment)
         add_address(post, options)
+        add_customer_details(post, options)
         add_ip(post, options)
         add_description(post, options)
 
@@ -60,6 +61,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment(post, credit_card)
         add_address(post, options)
+        add_customer_details(post, options)
         add_ip(post, options)
         add_description(post, options)
         add_store_defaults(post)
@@ -144,6 +146,12 @@ module ActiveMerchant #:nodoc:
         post[:amount] = 0
       end
 
+      def add_customer_details(post, options)
+        post[:phone] = options[:phone] if options[:phone]
+        post[:email] = options[:email] if options[:email]
+        post[:country] = options[:country] if options[:country]
+      end
+
       def expdate(creditcard)
         year  = sprintf('%.4i', creditcard.year)
         month = sprintf('%.2i', creditcard.month)
@@ -178,12 +186,12 @@ module ActiveMerchant #:nodoc:
 
       def endpoints
         {
-          purchase: 'ProcessLink.asmx',
-          purchase_check: 'ProcessLink.asmx',
-          refund: 'ProcessLink.asmx',
-          refund_check: 'ProcessLink.asmx',
-          store: 'CustomerLink.asmx',
-          unstore: 'CustomerLink.asmx'
+          purchase: 'ProcessLinkv3.asmx',
+          purchase_check: 'ProcessLinkv3.asmx',
+          refund: 'ProcessLinkv3.asmx',
+          refund_check: 'ProcessLinkv3.asmx',
+          store: 'CustomerLinkv3.asmx',
+          unstore: 'CustomerLinkv3.asmx'
         }
       end
 

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -13,10 +13,23 @@ class IatsPaymentsTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store purchase'
     }
+    @customer_details = {
+      phone: '5555555555',
+      email: 'test@example.com',
+      country: 'US'
+    }
   end
 
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Success', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_customer_details
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@customer_details))
     assert_success response
     assert response.test?
     assert_equal 'Success', response.message
@@ -71,11 +84,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
 
-    # This is a dubious test. Basically testing that the refund failed b/c
-    # the original purchase hadn't yet cleared. No way to test immediate failure
-    # due to the delay in original tx processing, even for text txs.
-    assert_failure refund
-    assert_equal 'REJECT: 3', refund.message
+    assert_success refund
+    assert_equal 'Success', refund.message
   end
 
   def test_failed_check_refund
@@ -93,6 +103,13 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert unstore = @gateway.unstore(store.authorization, @options)
     assert_success unstore
     assert_equal 'Success', unstore.message
+  end
+
+  def test_successful_store_with_customer_details
+    assert store = @gateway.store(@credit_card, @options.merge(@customer_details))
+    assert_success store
+    assert store.authorization
+    assert_equal 'Success', store.message
   end
 
   def test_failed_store

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -539,7 +539,7 @@ class CheckoutV2Test < Test::Unit::TestCase
 
   def error_4xx_response
     mock_response = Net::HTTPUnauthorized.new('1.1', '401', 'Unauthorized')
-    mock_response.stubs(:body).returns("")
+    mock_response.stubs(:body).returns('')
 
     ActiveMerchant::ResponseError.new(mock_response)
   end

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -16,6 +16,9 @@ class IatsPaymentsTest < Test::Unit::TestCase
       ip: '71.65.249.145',
       order_id: generate_unique_id,
       billing_address: address,
+      phone: '5555555555',
+      email: 'test@example.com',
+      country: 'US',
       description: 'Store purchase'
     }
   end
@@ -40,7 +43,10 @@ class IatsPaymentsTest < Test::Unit::TestCase
       assert_match(/<zipCode>#{@options[:billing_address][:zip]}<\/zipCode>/, data)
       assert_match(/<total>1.00<\/total>/, data)
       assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
-      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+      assert_match(/<phone>#{@options[:phone]}<\/phone>/, data)
+      assert_match(/<email>#{@options[:email]}<\/email>/, data)
+      assert_match(/<country>#{@options[:country]}<\/country>/, data)
+      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
       assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'
     end.respond_with(successful_purchase_response)
 
@@ -66,7 +72,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @check, @options)
     end.check_request do |endpoint, data, headers|
-      assert_match(/<ProcessACHEFTV1/, data)
+      assert_match(/<ProcessACHEFT/, data)
       assert_match(/<agentCode>login<\/agentCode>/, data)
       assert_match(/<password>password<\/password>/, data)
       assert_match(/<customerIPAddress>#{@options[:ip]}<\/customerIPAddress>/, data)
@@ -80,8 +86,11 @@ class IatsPaymentsTest < Test::Unit::TestCase
       assert_match(/<state>#{@options[:billing_address][:state]}<\/state>/, data)
       assert_match(/<zipCode>#{@options[:billing_address][:zip]}<\/zipCode>/, data)
       assert_match(/<total>1.00<\/total>/, data)
+      assert_match(/<phone>#{@options[:phone]}<\/phone>/, data)
+      assert_match(/<email>#{@options[:email]}<\/email>/, data)
+      assert_match(/<country>#{@options[:country]}<\/country>/, data)
       assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
-      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessACHEFTV1'
+      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessACHEFT'
       assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'
     end.respond_with(successful_check_purchase_response)
 
@@ -121,13 +130,13 @@ class IatsPaymentsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.refund(@amount, 'ref|check', @options)
     end.check_request do |endpoint, data, headers|
-      assert_match(/<ProcessACHEFTRefundWithTransactionIdV1/, data)
+      assert_match(/<ProcessACHEFTRefundWithTransactionId/, data)
       assert_match(/<agentCode>login<\/agentCode>/, data)
       assert_match(/<password>password<\/password>/, data)
       assert_match(/<customerIPAddress>#{@options[:ip]}<\/customerIPAddress>/, data)
       assert_match(/<total>-1.00<\/total>/, data)
       assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
-      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessACHEFTRefundWithTransactionIdV1'
+      assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessACHEFTRefundWithTransactionId'
       assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'
     end.respond_with(successful_check_refund_response)
 
@@ -215,7 +224,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match(/<agentCode>login<\/agentCode>/, data)
       assert_match(/<password>password<\/password>/, data)
-      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -231,7 +240,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLink.asmx?op=ProcessCreditCardV1'
+      assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -268,8 +277,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
   <soap12:Body>
-    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessCreditCardV1Result>
+    <ProcessCreditCardResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardResult>
         <IATSRESPONSE>
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -281,8 +290,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A6DE6F24</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessCreditCardV1Result>
-    </ProcessCreditCardV1Response>
+      </ProcessCreditCardResult>
+    </ProcessCreditCardResponse>
   </soap12:Body>
 </soap12:Envelope>
     XML
@@ -293,8 +302,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessCreditCardV1Result>
+    <ProcessCreditCardResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -306,8 +315,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A6DE6F24</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessCreditCardV1Result>
-    </ProcessCreditCardV1Response>
+      </ProcessCreditCardResult>
+    </ProcessCreditCardResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -318,8 +327,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessACHEFTV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessACHEFTV1Result>
+    <ProcessACHEFTResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessACHEFTResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -329,8 +338,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A7F8B8B3</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessACHEFTV1Result>
-    </ProcessACHEFTV1Response>
+      </ProcessACHEFTResult>
+    </ProcessACHEFTResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -341,8 +350,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessACHEFTV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessACHEFTV1Result>
+    <ProcessACHEFTResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessACHEFTResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -352,8 +361,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID />
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessACHEFTV1Result>
-    </ProcessACHEFTV1Response>
+      </ProcessACHEFTResult>
+    </ProcessACHEFTResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -364,8 +373,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessCreditCardV1Result>
+    <ProcessCreditCardResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -377,8 +386,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A6DEA654</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessCreditCardV1Result>
-    </ProcessCreditCardV1Response>
+      </ProcessCreditCardResult>
+    </ProcessCreditCardResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -389,8 +398,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessACHEFTRefundWithTransactionIdV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessACHEFTRefundWithTransactionIdV1Result>
+    <ProcessACHEFTRefundWithTransactionIdResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessACHEFTRefundWithTransactionIdResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -400,8 +409,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A7F8B8B3</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessACHEFTRefundWithTransactionIdV1Result>
-    </ProcessACHEFTRefundWithTransactionIdV1Response>
+      </ProcessACHEFTRefundWithTransactionIdResult>
+    </ProcessACHEFTRefundWithTransactionIdResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -412,8 +421,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessACHEFTRefundWithTransactionIdV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessACHEFTRefundWithTransactionIdV1Result>
+    <ProcessACHEFTRefundWithTransactionIdResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessACHEFTRefundWithTransactionIdResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -425,8 +434,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID></TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessACHEFTRefundWithTransactionIdV1Result>
-    </ProcessACHEFTRefundWithTransactionIdV1Response>
+      </ProcessACHEFTRefundWithTransactionIdResult>
+    </ProcessACHEFTRefundWithTransactionIdResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -437,8 +446,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>
-    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
-      <ProcessCreditCardV1Result>
+    <ProcessCreditCardResponse xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardResult>
         <IATSRESPONSE xmlns="">
           <STATUS>Success</STATUS>
           <ERRORS />
@@ -450,8 +459,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
             <TRANSACTIONID>A6DEA654</TRANSACTIONID>
           </PROCESSRESULT>
         </IATSRESPONSE>
-      </ProcessCreditCardV1Result>
-    </ProcessCreditCardV1Response>
+      </ProcessCreditCardResult>
+    </ProcessCreditCardResponse>
   </soap:Body>
 </soap:Envelope>
     XML
@@ -462,8 +471,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
       <?xml version="1.0" encoding="UTF-8"?>
       <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <soap:Body>
-          <CreateCreditCardCustomerCodeV1Response xmlns="https://www.iatspayments.com/NetGate/">
-            <CreateCreditCardCustomerCodeV1Result>
+          <CreateCreditCardCustomerCodeResponse xmlns="https://www.iatspayments.com/NetGate/">
+            <CreateCreditCardCustomerCodeResult>
               <IATSRESPONSE xmlns="">
                 <STATUS>Success</STATUS>
                 <ERRORS />
@@ -472,8 +481,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
                   <CUSTOMERCODE>A12181132</CUSTOMERCODE>
                 </PROCESSRESULT>
               </IATSRESPONSE>
-            </CreateCreditCardCustomerCodeV1Result>
-          </CreateCreditCardCustomerCodeV1Response>
+            </CreateCreditCardCustomerCodeResult>
+          </CreateCreditCardCustomerCodeResponse>
         </soap:Body>
       </soap:Envelope>
     XML
@@ -484,8 +493,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
       <?xml version="1.0" encoding="UTF-8"?>
       <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <soap:Body>
-          <CreateCreditCardCustomerCodeV1Response xmlns="https://www.iatspayments.com/NetGate/">
-            <CreateCreditCardCustomerCodeV1Result>
+          <CreateCreditCardCustomerCodeResponse xmlns="https://www.iatspayments.com/NetGate/">
+            <CreateCreditCardCustomerCodeResult>
               <IATSRESPONSE xmlns="">
                 <STATUS>Success</STATUS>
                 <ERRORS />
@@ -494,8 +503,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
                   <CUSTOMERCODE />
                 </PROCESSRESULT>
               </IATSRESPONSE>
-            </CreateCreditCardCustomerCodeV1Result>
-          </CreateCreditCardCustomerCodeV1Response>
+            </CreateCreditCardCustomerCodeResult>
+          </CreateCreditCardCustomerCodeResponse>
         </soap:Body>
       </soap:Envelope>
     XML
@@ -506,8 +515,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
       <?xml version="1.0" encoding="UTF-8"?>
       <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <soap:Body>
-          <DeleteCustomerCodeV1Response xmlns="https://www.iatspayments.com/NetGate/">
-            <DeleteCustomerCodeV1Result>
+          <DeleteCustomerCodeResponse xmlns="https://www.iatspayments.com/NetGate/">
+            <DeleteCustomerCodeResult>
               <IATSRESPONSE xmlns="">
                 <STATUS>Success</STATUS>
                 <ERRORS />
@@ -516,8 +525,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
                   <CUSTOMERCODE>"A12181132" is deleted</CUSTOMERCODE>
                 </PROCESSRESULT>
               </IATSRESPONSE>
-            </DeleteCustomerCodeV1Result>
-          </DeleteCustomerCodeV1Response>
+            </DeleteCustomerCodeResult>
+          </DeleteCustomerCodeResponse>
         </soap:Body>
       </soap:Envelope>
     XML
@@ -528,16 +537,16 @@ class IatsPaymentsTest < Test::Unit::TestCase
       <?xml version="1.0" encoding="UTF-8"?>
       <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <soap:Body>
-          <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
-            <ProcessCreditCardV1Result>
+          <ProcessCreditCardResponse xmlns="https://www.iatspayments.com/NetGate/">
+            <ProcessCreditCardResult>
               <IATSRESPONSE xmlns="">
                 <STATUS>Failure</STATUS>
                 <ERRORS>Server Error</ERRORS>
                 <PROCESSRESULT>
                 </PROCESSRESULT>
               </IATSRESPONSE>
-            </ProcessCreditCardV1Result>
-          </ProcessCreditCardV1Response>
+            </ProcessCreditCardResult>
+          </ProcessCreditCardResponse>
         </soap:Body>
       </soap:Envelope>
     XML
@@ -549,8 +558,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
       opened
       starting SSL for www.iatspayments.com:443...
       SSL established
-      <- "POST /NetGate/ProcessLink.asmx?op=ProcessCreditCardV1 HTTP/1.1\r\nContent-Type: application/soap+xml; charset=utf-8\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.iatspayments.com\r\nContent-Length: 779\r\n\r\n"
-      <- "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><ProcessCreditCardV1 xmlns=\"https://www.iatspayments.com/NetGate/\"><agentCode>TEST88</agentCode><password>TEST88</password><invoiceNum>63b5dd7098e8e3a9ff9a6f0992fdb6d5</invoiceNum><total>1.00</total><firstName>Longbob</firstName><lastName>Longsen</lastName><creditCardNum>4222222222222220</creditCardNum><creditCardExpiry>09/17</creditCardExpiry><cvv2>123</cvv2><mop>VISA</mop><address>456 My Street</address><city>Ottawa</city><state>ON</state><zipCode>K1C2N6</zipCode><comment>Store purchase</comment></ProcessCreditCardV1></soap12:Body></soap12:Envelope>"
+      <- "POST /NetGate/ProcessLink.asmx?op=ProcessCreditCard HTTP/1.1\r\nContent-Type: application/soap+xml; charset=utf-8\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.iatspayments.com\r\nContent-Length: 779\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><ProcessCreditCard xmlns=\"https://www.iatspayments.com/NetGate/\"><agentCode>TEST88</agentCode><password>TEST88</password><invoiceNum>63b5dd7098e8e3a9ff9a6f0992fdb6d5</invoiceNum><total>1.00</total><firstName>Longbob</firstName><lastName>Longsen</lastName><creditCardNum>4222222222222220</creditCardNum><creditCardExpiry>09/17</creditCardExpiry><cvv2>123</cvv2><mop>VISA</mop><address>456 My Street</address><city>Ottawa</city><state>ON</state><zipCode>K1C2N6</zipCode><comment>Store purchase</comment></ProcessCreditCard></soap12:Body></soap12:Envelope>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Cache-Control: private, max-age=0\r\n"
       -> "Content-Type: application/soap+xml; charset=utf-8\r\n"
@@ -562,7 +571,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
       -> "Via: 1.1 sjc1-10\r\n"
       -> "\r\n"
       reading 719 bytes...
-      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessCreditCardV1Response xmlns=\"https://www.iatspayments.com/NetGate/\"><ProcessCreditCardV1Result><IATSRESPONSE xmlns=\"\"><STATUS>Success</STATUS><ERRORS /><PROCESSRESULT><AUTHORIZATIONRESULT> OK: 678594:\n</AUTHORIZATIONRESULT><CUSTOMERCODE /><SETTLEMENTBATCHDATE> 09/28/2016\n</SETTLEMENTBATCHDATE><SETTLEMENTDATE> 09/29/2016\n</SETTLEMENTDATE><TRANSACTIONID>A92E3B72\n</TRANSACTIONID></PROCESSRESULT></IATSRESPONSE></ProcessCreditCardV1Result></ProcessCreditCardV1Response></soap:Body></soap:Envelope>"
+      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessCreditCardResponse xmlns=\"https://www.iatspayments.com/NetGate/\"><ProcessCreditCardResult><IATSRESPONSE xmlns=\"\"><STATUS>Success</STATUS><ERRORS /><PROCESSRESULT><AUTHORIZATIONRESULT> OK: 678594:\n</AUTHORIZATIONRESULT><CUSTOMERCODE /><SETTLEMENTBATCHDATE> 09/28/2016\n</SETTLEMENTBATCHDATE><SETTLEMENTDATE> 09/29/2016\n</SETTLEMENTDATE><TRANSACTIONID>A92E3B72\n</TRANSACTIONID></PROCESSRESULT></IATSRESPONSE></ProcessCreditCardResult></ProcessCreditCardResponse></soap:Body></soap:Envelope>"
       read 719 bytes
       Conn close
     XML
@@ -574,8 +583,8 @@ class IatsPaymentsTest < Test::Unit::TestCase
       opened
       starting SSL for www.iatspayments.com:443...
       SSL established
-      <- "POST /NetGate/ProcessLink.asmx?op=ProcessCreditCardV1 HTTP/1.1\r\nContent-Type: application/soap+xml; charset=utf-8\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.iatspayments.com\r\nContent-Length: 779\r\n\r\n"
-      <- "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><ProcessCreditCardV1 xmlns=\"https://www.iatspayments.com/NetGate/\"><agentCode>[FILTERED]</agentCode><password>[FILTERED]</password><invoiceNum>63b5dd7098e8e3a9ff9a6f0992fdb6d5</invoiceNum><total>1.00</total><firstName>Longbob</firstName><lastName>Longsen</lastName><creditCardNum>[FILTERED]</creditCardNum><creditCardExpiry>09/17</creditCardExpiry><cvv2>[FILTERED]</cvv2><mop>VISA</mop><address>456 My Street</address><city>Ottawa</city><state>ON</state><zipCode>K1C2N6</zipCode><comment>Store purchase</comment></ProcessCreditCardV1></soap12:Body></soap12:Envelope>"
+      <- "POST /NetGate/ProcessLink.asmx?op=ProcessCreditCard HTTP/1.1\r\nContent-Type: application/soap+xml; charset=utf-8\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.iatspayments.com\r\nContent-Length: 779\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><ProcessCreditCard xmlns=\"https://www.iatspayments.com/NetGate/\"><agentCode>[FILTERED]</agentCode><password>[FILTERED]</password><invoiceNum>63b5dd7098e8e3a9ff9a6f0992fdb6d5</invoiceNum><total>1.00</total><firstName>Longbob</firstName><lastName>Longsen</lastName><creditCardNum>[FILTERED]</creditCardNum><creditCardExpiry>09/17</creditCardExpiry><cvv2>[FILTERED]</cvv2><mop>VISA</mop><address>456 My Street</address><city>Ottawa</city><state>ON</state><zipCode>K1C2N6</zipCode><comment>Store purchase</comment></ProcessCreditCard></soap12:Body></soap12:Envelope>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Cache-Control: private, max-age=0\r\n"
       -> "Content-Type: application/soap+xml; charset=utf-8\r\n"
@@ -587,7 +596,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
       -> "Via: 1.1 sjc1-10\r\n"
       -> "\r\n"
       reading 719 bytes...
-      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessCreditCardV1Response xmlns=\"https://www.iatspayments.com/NetGate/\"><ProcessCreditCardV1Result><IATSRESPONSE xmlns=\"\"><STATUS>Success</STATUS><ERRORS /><PROCESSRESULT><AUTHORIZATIONRESULT> OK: 678594:\n</AUTHORIZATIONRESULT><CUSTOMERCODE /><SETTLEMENTBATCHDATE> 09/28/2016\n</SETTLEMENTBATCHDATE><SETTLEMENTDATE> 09/29/2016\n</SETTLEMENTDATE><TRANSACTIONID>A92E3B72\n</TRANSACTIONID></PROCESSRESULT></IATSRESPONSE></ProcessCreditCardV1Result></ProcessCreditCardV1Response></soap:Body></soap:Envelope>"
+      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessCreditCardResponse xmlns=\"https://www.iatspayments.com/NetGate/\"><ProcessCreditCardResult><IATSRESPONSE xmlns=\"\"><STATUS>Success</STATUS><ERRORS /><PROCESSRESULT><AUTHORIZATIONRESULT> OK: 678594:\n</AUTHORIZATIONRESULT><CUSTOMERCODE /><SETTLEMENTBATCHDATE> 09/28/2016\n</SETTLEMENTBATCHDATE><SETTLEMENTDATE> 09/29/2016\n</SETTLEMENTDATE><TRANSACTIONID>A92E3B72\n</TRANSACTIONID></PROCESSRESULT></IATSRESPONSE></ProcessCreditCardResult></ProcessCreditCardResponse></soap:Body></soap:Envelope>"
       read 719 bytes
       Conn close
     XML


### PR DESCRIPTION
Upgrade the iATs gateway to version 3 following the examples found
https://www.iatspayments.com/netgate/ProcessLinkv3.asmx and
https://www.iatspayments.com/netgate/CustomerLinkv3.asmx

Additionally, add support for phone, email, and country fields

CE-291

Unit: 17 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 14 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed