### PR TITLE
Elavon: add ssl_dynamic_dba field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * CyberSource: Added support for MerchantInformation CyberSource-specific fields [apfranzen] #3592
 * ePay: Send unique order ids for remote tests [curiousepic] #3593
 * Checkout V2: Send more informative error messages for 4xx errors [britth] #3601
+* Elavon: Add ssl_dynamic_dba field [apfranzen] #3600
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -47,6 +47,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(form, options)
         add_test_mode(form, options)
         add_ip(form, options)
+        add_ssl_dynamic_dba(form, options)
         commit(:purchase, money, form, options)
       end
 
@@ -60,6 +61,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(form, options)
         add_test_mode(form, options)
         add_ip(form, options)
+        add_ssl_dynamic_dba(form, options)
         commit(:authorize, money, form, options)
       end
 
@@ -209,7 +211,6 @@ module ActiveMerchant #:nodoc:
         billing_address = options[:billing_address] || options[:address]
 
         if billing_address
-          form[:avs_address]    = truncate(billing_address[:address1], 30)
           form[:address2]       = truncate(billing_address[:address2], 30)
           form[:avs_zip]        = truncate(billing_address[:zip].to_s.gsub(/[^a-zA-Z0-9]/, ''), 9)
           form[:city]           = truncate(billing_address[:city], 30)
@@ -247,6 +248,10 @@ module ActiveMerchant #:nodoc:
 
       def add_ip(form, options)
         form[:cardholder_ip] = options[:ip] if options.has_key?(:ip)
+      end
+
+      def add_ssl_dynamic_dba(form, options)
+        form[:dynamic_dba] = options[:dba] if options.has_key?(:dba)
       end
 
       def message_from(response)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -122,6 +122,28 @@ class ElavonTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_dynamic_dba
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(dba: 'MANYMAG*BAKERS MONTHLY'))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = CGI.parse(data)
+      assert_equal ['MANYMAG*BAKERS MONTHLY'], parsed['ssl_dynamic_dba']
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
+  def test_successful_authorization_with_dynamic_dba
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(dba: 'MANYMAG*BAKERS MONTHLY'))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = CGI.parse(data)
+      assert_equal ['MANYMAG*BAKERS MONTHLY'], parsed['ssl_dynamic_dba']
+    end.respond_with(successful_authorization_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_multi_currency
     response = stub_comms(@multi_currency_gateway) do
       @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR'))


### PR DESCRIPTION
CE-505

Unit:
33 tests, 157 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
TBD: Remote tests were unreliable at time of comitting. Please try running when reviewing.