### PR TITLE
CheckoutV2: Send appropriate error messages for 4xx errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Decidir: Improve handling of error responses from the gateway [naashton] #3594
 * CyberSource: Added support for MerchantInformation CyberSource-specific fields [apfranzen] #3592
 * ePay: Send unique order ids for remote tests [curiousepic] #3593
+* Checkout V2: Send more informative error messages for 4xx errors [britth] #3601
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
         rescue ResponseError => e
           raise unless e.response.code.to_s =~ /4\d\d/
 
-          response = parse(e.response.body)
+          response = parse(e.response.body, error: e.response)
         end
 
         succeeded = success_from(response)
@@ -224,13 +224,16 @@ module ActiveMerchant #:nodoc:
         response['source'] && response['source']['cvv_check'] ? CVVResult.new(response['source']['cvv_check']) : nil
       end
 
-      def parse(body)
+      def parse(body, error: nil)
         JSON.parse(body)
       rescue JSON::ParserError
-        {
+        response = {
+          'error_type' => error&.code,
           'message' => 'Invalid JSON response received from Checkout.com Unified Payments Gateway. Please contact Checkout.com if you continue to receive this message.',
           'raw_response' => scrub(body)
         }
+        response['error_codes'] = [error&.message] if error&.message
+        response
       end
 
       def success_from(response)
@@ -243,7 +246,7 @@ module ActiveMerchant #:nodoc:
         elsif response['error_type']
           response['error_type'] + ': ' + response['error_codes'].first
         else
-          response['response_summary'] || response['response_code'] || response['status'] || 'Unable to read error message'
+          response['response_summary'] || response['response_code'] || response['status'] || response['message'] || 'Unable to read error message'
         end
       end
 


### PR DESCRIPTION
When we're unable to parse an error message from the returned body
of a checkout response, we send the generic message `Unable to read
error message`. This causes confusion, and in a lot of cases there
is more information we could be providing to help inform users of the
problem. Specifically, when there's a 4xx error, we attempt to parse
the response body, but can ultimately get a ParserError which will end
up setting the AM message to a generic error message. We've seen with
401 errors, the body is simply an empty string, so this default happens
everytime and customers have to dig to figure out exactly what happened.
This PR updates the logic to instead set an error type and code when
rescuing the ParserError (if available). That leads us to present a more
informative error in such cases (e.g. `401: Unavailable`). It also updates
the default condition in `message_from` to check for the value from the
response['message'] field if present before setting the message to `Unable
to read...`, which notes that there's an issue with the JSON (which also
seems more informative).

Remote:
33 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
29 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed