### PR TITLE
Elavon: Cleanup inadvertent field removal (avs_address) in #3600

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,8 +11,9 @@
 * ePay: Send unique order ids for remote tests [curiousepic] #3593
 * Checkout V2: Send more informative error messages for 4xx errors [britth] #3601
 * Elavon: Add ssl_dynamic_dba field [apfranzen] #3600
-* iATS Payments: Update gateway to v3 and add support for additional GSFs [naashton] #3599 
+* iATS Payments: Update gateway to v3 and add support for additional GSFs [naashton] #3599
 * Remove deprecated `rubyforge_project` attribute and tidy up unit test output [fatcatt316] #3598
+* Elavon: Cleanup inadvertant field removal (avs_address) in #3600 [apfranzen] #3602
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -211,6 +211,7 @@ module ActiveMerchant #:nodoc:
         billing_address = options[:billing_address] || options[:address]
 
         if billing_address
+          form[:avs_address]    = truncate(billing_address[:address1], 30)
           form[:address2]       = truncate(billing_address[:address2], 30)
           form[:avs_zip]        = truncate(billing_address[:zip].to_s.gsub(/[^a-zA-Z0-9]/, ''), 9)
           form[:city]           = truncate(billing_address[:city], 30)


### PR DESCRIPTION
CE-505

Unit:
33 tests, 157 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
27 tests, 120 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2963% passed