### PR TITLE
Forte: Use underscore for unused argument in test

### DIFF
--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -157,7 +157,7 @@ class ForteTest < Test::Unit::TestCase
     @gateway = ForteGateway.new(location_id: ' improperly-padded ', account_id: '  account_id  ', api_key: 'api_key', secret: 'secret')
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |type, url, parameters, headers|
+    end.check_request do |type, url, parameters, _headers|
       URI.parse(url)
     end.respond_with(MockedResponse.new(successful_purchase_response))
     assert_success response

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -157,7 +157,7 @@ class ForteTest < Test::Unit::TestCase
     @gateway = ForteGateway.new(location_id: ' improperly-padded ', account_id: '  account_id  ', api_key: 'api_key', secret: 'secret')
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |type, url, parameters, _headers|
+    end.check_request do |_type, url, _parameters, _headers|
       URI.parse(url)
     end.respond_with(MockedResponse.new(successful_purchase_response))
     assert_success response


### PR DESCRIPTION
Working with the Forte gateway in a fork, I received this error from Codacy:

```
test/unit/gateways/forte_test.rb
Unused block argument - `headers`. If it's necessary, use `_` or `_headers` as an argument name to indicate that it won't be used.
end.check_request do |type, url, parameters, headers|
```

This will mark the `headers` argument as unused so that the quality review will pass.