### PR TITLE
Litle: pass expiration data for basis payment method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 
 == HEAD
 * Elavon: Implement true verify action [leila-alderman] #3610
-* Vanitv Express: Implement true verify [leila-alderman] #3617
+* Vantiv Express: Implement true verify [leila-alderman] #3617
+* Litle: Pass expiration data for basis payment method [therufs] #3606
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -263,6 +263,7 @@ module ActiveMerchant #:nodoc:
         if payment_method.is_a?(String)
           doc.token do
             doc.litleToken(payment_method)
+            doc.expDate(format_exp_date(options[:basis_expiration_month], options[:basis_expiration_year])) if options[:basis_expiration_month] && options[:basis_expiration_year]
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.card do
@@ -416,7 +417,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def exp_date(payment_method)
-        "#{format(payment_method.month, :two_digits)}#{format(payment_method.year, :two_digits)}"
+        format_exp_date(payment_method.month, payment_method.year)
+      end
+
+      def format_exp_date(month, year)
+        "#{format(month, :two_digits)}#{format(year, :two_digits)}"
       end
 
       def parse(kind, xml)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -7,7 +7,7 @@ class RemoteLitleTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       month: '01',
-      year: '2012',
+      year: '2024',
       brand: 'visa',
       number: '4457010000000009',
       verification_value: '349'
@@ -472,7 +472,7 @@ class RemoteLitleTest < Test::Unit::TestCase
   def test_unsuccessful_void
     assert void = @gateway.void('123456789012345360;authorization;100')
     assert_failure void
-    assert_equal 'No transaction found with specified litleTxnId', void.message
+    assert_equal 'No transaction found with specified Transaction Id', void.message
   end
 
   def test_partial_refund
@@ -528,19 +528,19 @@ class RemoteLitleTest < Test::Unit::TestCase
   def test_capture_unsuccessful
     assert capture_response = @gateway.capture(10010, '123456789012345360')
     assert_failure capture_response
-    assert_equal 'No transaction found with specified litleTxnId', capture_response.message
+    assert_equal 'No transaction found with specified Transaction Id', capture_response.message
   end
 
   def test_refund_unsuccessful
     assert credit_response = @gateway.refund(10010, '123456789012345360')
     assert_failure credit_response
-    assert_equal 'No transaction found with specified litleTxnId', credit_response.message
+    assert_equal 'No transaction found with specified Transaction Id', credit_response.message
   end
 
   def test_void_unsuccessful
     assert void_response = @gateway.void('123456789012345360')
     assert_failure void_response
-    assert_equal 'No transaction found with specified litleTxnId', void_response.message
+    assert_equal 'No transaction found with specified Transaction Id', void_response.message
   end
 
   def test_store_successful
@@ -583,6 +583,18 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal store_response.params['litleToken'], token
 
     assert response = @gateway.purchase(10010, token)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_purchase_with_token_and_date_successful
+    assert store_response = @gateway.store(@credit_card1, order_id: '50')
+    assert_success store_response
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(10010, token, {basis_expiration_month: '01', basis_expiration_year: '2024'})
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -153,6 +153,14 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_passing_basis_date
+    stub_comms do
+      @gateway.purchase(@amount, 'token', {basis_expiration_month: '04', basis_expiration_year: '2027'})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<expDate>0427<\/expDate>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_add_applepay_order_source
     stub_comms do
       @gateway.purchase(@amount, @decrypted_apple_pay)


### PR DESCRIPTION
Litle (Vantiv Ecommerce) allows (and may require) expiration date information to be sent when a `litleToken` is used as the payment method.

Tests currently in extreme disarray. 