### PR TITLE
iATS Payments: Updating gateway to accept additional fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Remove deprecated `rubyforge_project` attribute and tidy up unit test output [fatcatt316] #3598
 * Elavon: Cleanup inadvertant field removal (avs_address) in #3600 [apfranzen] #3602
 * EBANX: Fix transaction amount for verify transaction [miguelxpn] #3603
+* iATS Payments: Update gateway to accept `email`, `phone`, and `country` fields [naashton] #3607
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -39,7 +39,6 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment)
         add_address(post, options)
-        add_customer_details(post, options)
         add_ip(post, options)
         add_description(post, options)
 
@@ -61,7 +60,6 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment(post, credit_card)
         add_address(post, options)
-        add_customer_details(post, options)
         add_ip(post, options)
         add_description(post, options)
         add_store_defaults(post)
@@ -103,6 +101,9 @@ module ActiveMerchant #:nodoc:
           post[:city] = billing_address[:city]
           post[:state] = billing_address[:state]
           post[:zip_code] = billing_address[:zip]
+          post[:phone] = billing_address[:phone] if billing_address[:phone]
+          post[:email] = billing_address[:email] if billing_address[:email]
+          post[:country] = billing_address[:country] if billing_address[:country]
         end
       end
 
@@ -144,12 +145,6 @@ module ActiveMerchant #:nodoc:
         post[:begin_date] = Time.now.xmlschema
         post[:end_date] = Time.now.xmlschema
         post[:amount] = 0
-      end
-
-      def add_customer_details(post, options)
-        post[:phone] = options[:phone] if options[:phone]
-        post[:email] = options[:email] if options[:email]
-        post[:country] = options[:country] if options[:country]
       end
 
       def expdate(creditcard)

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -28,14 +28,6 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert response.authorization
   end
 
-  def test_successful_purchase_with_customer_details
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@customer_details))
-    assert_success response
-    assert response.test?
-    assert_equal 'Success', response.message
-    assert response.authorization
-  end
-
   def test_failed_purchase
     credit_card = credit_card('4111111111111111')
     assert response = @gateway.purchase(200, credit_card, @options)
@@ -103,13 +95,6 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert unstore = @gateway.unstore(store.authorization, @options)
     assert_success unstore
     assert_equal 'Success', unstore.message
-  end
-
-  def test_successful_store_with_customer_details
-    assert store = @gateway.store(@credit_card, @options.merge(@customer_details))
-    assert_success store
-    assert store.authorization
-    assert_equal 'Success', store.message
   end
 
   def test_failed_store

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -12,13 +12,23 @@ class IatsPaymentsTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card
     @check = check
+    @address = {
+      name:     'Jim Smith',
+      address1: '456 My Street',
+      address2: 'Apt 1',
+      company:  'Widgets Inc',
+      city:     'Ottawa',
+      state:    'ON',
+      zip:      'K1C2N6',
+      country:  'CA',
+      phone:    '555-555-5555',
+      fax:      '(555)555-6666',
+      email:    'jimsmith@example.com'
+    }
     @options = {
       ip: '71.65.249.145',
       order_id: generate_unique_id,
-      billing_address: address,
-      phone: '5555555555',
-      email: 'test@example.com',
-      country: 'US',
+      billing_address: @address,
       description: 'Store purchase'
     }
   end
@@ -41,11 +51,11 @@ class IatsPaymentsTest < Test::Unit::TestCase
       assert_match(/<city>#{@options[:billing_address][:city]}<\/city>/, data)
       assert_match(/<state>#{@options[:billing_address][:state]}<\/state>/, data)
       assert_match(/<zipCode>#{@options[:billing_address][:zip]}<\/zipCode>/, data)
+      assert_match(/<phone>#{@options[:billing_address][:phone]}<\/phone>/, data)
+      assert_match(/<country>#{@options[:billing_address][:country]}<\/country>/, data)
       assert_match(/<total>1.00<\/total>/, data)
       assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
-      assert_match(/<phone>#{@options[:phone]}<\/phone>/, data)
-      assert_match(/<email>#{@options[:email]}<\/email>/, data)
-      assert_match(/<country>#{@options[:country]}<\/country>/, data)
+      assert_match(/<email>#{@options[:billing_address][:email]}<\/email>/, data)
       assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
       assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'
     end.respond_with(successful_purchase_response)
@@ -85,10 +95,10 @@ class IatsPaymentsTest < Test::Unit::TestCase
       assert_match(/<city>#{@options[:billing_address][:city]}<\/city>/, data)
       assert_match(/<state>#{@options[:billing_address][:state]}<\/state>/, data)
       assert_match(/<zipCode>#{@options[:billing_address][:zip]}<\/zipCode>/, data)
+      assert_match(/<phone>#{@options[:billing_address][:phone]}<\/phone>/, data)
+      assert_match(/<country>#{@options[:billing_address][:country]}<\/country>/, data)
       assert_match(/<total>1.00<\/total>/, data)
-      assert_match(/<phone>#{@options[:phone]}<\/phone>/, data)
-      assert_match(/<email>#{@options[:email]}<\/email>/, data)
-      assert_match(/<country>#{@options[:country]}<\/country>/, data)
+      assert_match(/<email>#{@options[:billing_address][:email]}<\/email>/, data)
       assert_match(/<comment>#{@options[:description]}<\/comment>/, data)
       assert_equal endpoint, 'https://www.uk.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessACHEFT'
       assert_equal headers['Content-Type'], 'application/soap+xml; charset=utf-8'


### PR DESCRIPTION
Changing previous update to include the fields, `phone`, `country`, and
`email` in `add_address` for `purchase` and `store` methods

CE-291

Unit: 17 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 12 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed