### PR TITLE
Fix broken refund response when force_full_refund_if_unsettled is true

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Elavon: Cleanup inadvertant field removal (avs_address) in #3600 [apfranzen] #3602
 * EBANX: Fix transaction amount for verify transaction [miguelxpn] #3603
 * iATS Payments: Update gateway to accept `email`, `phone`, and `country` fields [naashton] #3607
+* Braintree: Fix response for failed refunds when falling back to voids [jasonwebster] #3608
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -98,10 +98,13 @@ module ActiveMerchant #:nodoc:
 
         commit do
           response = response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
-          return response if response.success?
-          return response unless options[:force_full_refund_if_unsettled]
 
-          void(transaction_id) if response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
+          if !response.success? && options[:force_full_refund_if_unsettled] &&
+              response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
+            void(transaction_id)
+          else
+            response
+          end
         end
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -984,6 +984,19 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert response.success?
   end
 
+  def test_refund_unsettled_payment_other_error_does_not_void
+    Braintree::TransactionGateway.any_instance.
+      expects(:refund).
+      returns(braintree_error_result(message: 'Some error message'))
+
+    Braintree::TransactionGateway.any_instance.
+      expects(:void).
+      never
+
+    response = @gateway.refund(1.00, 'transaction_id', force_full_refund_if_unsettled: true)
+    refute response.success?
+  end
+
   def test_stored_credential_recurring_cit_initial
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(


### PR DESCRIPTION
Before this change, if the `force_full_refund_if_unsettled` option was
set to true, and the refund failed for any reason other than the one
that triggered the `#void` call, the `#refund` method would return
nothing at all. Which is bad. Very bad.