### PR TITLE
Fix broken refund response when force_full_refund_if_unsettled is true

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * EBANX: Fix transaction amount for verify transaction [miguelxpn] #3603
 * iATS Payments: Update gateway to accept `email`, `phone`, and `country` fields [naashton] #3607
 * Braintree: Fix response for failed refunds when falling back to voids [jasonwebster] #3608
+* Worldpay: Fix response for failed refunds when falling back to voids [jasonwebster] #3609
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -94,10 +94,12 @@ module ActiveMerchant #:nodoc:
           r.process { refund_request(money, authorization, options) }
         end
 
-        return response if response.success?
-        return response unless options[:force_full_refund_if_unsettled]
-
-        void(authorization, options) if response.params['last_event'] == 'AUTHORISED'
+        if !response.success? && options[:force_full_refund_if_unsettled] &&
+          response.params['last_event'] == 'AUTHORISED'
+          void(authorization, options)
+        else
+          response
+        end
       end
 
       # Credits only function on a Merchant ID/login/profile flagged for Payouts

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -288,6 +288,14 @@ class WorldpayTest < Test::Unit::TestCase
     assert 'cancel', response.responses.last.params['action']
   end
 
+  def test_refund_failure_with_force_full_refund_if_unsettled_does_not_force_void
+    response = stub_comms do
+      @gateway.refund(@amount, @options[:order_id], @options.merge(force_full_refund_if_unsettled: true))
+    end.respond_with("total garbage")
+
+    assert_failure response
+  end
+
   def test_refund_using_order_id_embedded_with_token
     response = stub_comms do
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"


### PR DESCRIPTION
For Worldpay this time. Turns out this gateway had the exact same
problem I fixed in 284dcdd7af1f7764c4ddda1f1ab48369aae0673e for Braintree.

Previously, if the `force_full_refund_if_unsettled` option was
set to true, and the refund failed for any reason other than the one
that triggered the `#void` call, the `#refund` method would return
nothing at all, which is bad, because the caller would never know why
their request failed.