### PR TITLE
Elavon: Implement true verify action

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Elavon: Implement true verify action [leila-alderman] #3610
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
           response = response_from_result(@braintree_gateway.transaction.refund(transaction_id, money))
 
           if !response.success? && options[:force_full_refund_if_unsettled] &&
-              response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
+             response.message =~ /#{ERROR_CODES[:cannot_refund_if_unsettled]}/
             void(transaction_id)
           else
             response

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -644,6 +644,7 @@ module ActiveMerchant #:nodoc:
 
       def add_auth_network_tokenization(xml, payment_method, options)
         return unless network_tokenization?(payment_method)
+
         brand = card_brand(payment_method).to_sym
 
         case brand

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -26,6 +26,7 @@ module ActiveMerchant #:nodoc:
         void: 'CCDELETE',
         store: 'CCGETTOKEN',
         update: 'CCUPDATETOKEN',
+        verify: 'CCVERIFY'
       }
 
       def initialize(options = {})
@@ -74,6 +75,7 @@ module ActiveMerchant #:nodoc:
           add_invoice(form, options)
           add_creditcard(form, options[:credit_card])
           add_currency(form, money, options)
+          add_address(form, options)
           add_customer_data(form, options)
           add_test_mode(form, options)
         else
@@ -113,10 +115,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+        form = {}
+        add_creditcard(form, credit_card)
+        add_address(form, options)
+        add_test_mode(form, options)
+        add_ip(form, options)
+        commit(:verify, 0, form, options)
       end
 
       def store(creditcard, options = {})

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -373,6 +373,7 @@ module ActiveMerchant
 
       def ipv4?(ip_address)
         return false if ip_address.nil?
+
         !!ip_address[/\A\d+\.\d+\.\d+\.\d+\z/]
       end
     end

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if !response.success? && options[:force_full_refund_if_unsettled] &&
-          response.params['last_event'] == 'AUTHORISED'
+           response.params['last_event'] == 'AUTHORISED'
           void(authorization, options)
         else
           response

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -40,7 +40,7 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_equal 'APPROVAL', auth.message
     assert auth.authorization
 
-    assert capture = @gateway.capture(@amount, auth.authorization, credit_card: @credit_card)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(credit_card: @credit_card))
     assert_success capture
   end
 
@@ -70,7 +70,6 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response
     assert_equal 'APPROVAL', response.message
-    assert_success response.responses.last, 'The void should succeed'
   end
 
   def test_failed_verify

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -216,22 +216,14 @@ class ElavonTest < Test::Unit::TestCase
   def test_successful_verify
     response = stub_comms do
       @gateway.verify(@credit_card)
-    end.respond_with(successful_authorization_response, successful_void_response)
+    end.respond_with(successful_verify_response)
     assert_success response
-  end
-
-  def test_successful_verify_failed_void
-    response = stub_comms do
-      @gateway.verify(@credit_card, @options)
-    end.respond_with(successful_authorization_response, failed_void_response)
-    assert_success response
-    assert_equal 'APPROVED', response.message
   end
 
   def test_unsuccessful_verify
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
-    end.respond_with(failed_authorization_response, successful_void_response)
+    end.respond_with(failed_verify_response)
     assert_failure response
     assert_equal 'The Credit Card Number supplied in the authorization request appears to be invalid.', response.message
   end
@@ -419,6 +411,23 @@ class ElavonTest < Test::Unit::TestCase
     ssl_txn_time=08/21/2012 05:37:19 PM"
   end
 
+  def successful_verify_response
+    "ssl_card_number=41**********9990
+    ssl_exp_date=0921
+    ssl_card_short_description=VISA
+    ssl_result=0
+    ssl_result_message=APPROVAL
+    ssl_transaction_type=CARDVERIFICATION
+    ssl_txn_id=010520ED3-56D114FC-B7D0-4ACF-BB3E-B1F0DA5A1EC7
+    ssl_approval_code=401169
+    ssl_cvv2_response=M
+    ssl_avs_response=M
+    ssl_account_balance=0.00
+    ssl_txn_time=05/01/2020 11:30:56 AM
+    ssl_card_type=CREDITCARD
+    ssl_partner_app_id=VM"
+  end
+
   def failed_purchase_response
     "errorCode=5000
     errorName=Credit Card Number Invalid
@@ -435,6 +444,12 @@ class ElavonTest < Test::Unit::TestCase
     "errorCode=5040
     errorName=Invalid Transaction ID
     errorMessage=The transaction ID is invalid for this transaction type"
+  end
+
+  def failed_verify_response
+    "errorCode=5000
+    errorName=Credit Card Number Invalid
+    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
   end
 
   def invalid_login_response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -291,7 +291,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_refund_failure_with_force_full_refund_if_unsettled_does_not_force_void
     response = stub_comms do
       @gateway.refund(@amount, @options[:order_id], @options.merge(force_full_refund_if_unsettled: true))
-    end.respond_with("total garbage")
+    end.respond_with('total garbage')
 
     assert_failure response
   end


### PR DESCRIPTION
Previously, the `verify` action for the Elavon gateway was implemented
as a $1 authorization followed by a void action.

This change implements a true verify action using the `ccverify` action.
This update means that customers will no longer see potentially
confusing holds on their accounts.

CE-553

Unit:
32 tests, 153 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
27 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4471 tests, 71666 assertions, 0 failures, 0 errors, 0 pendings, 2
omissions, 0 notifications
100% passed