### PR TITLE
iATS Payments: Add support for Customer Code payment method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * iATS Payments: Update gateway to accept `email`, `phone`, and `country` fields [naashton] #3607
 * Braintree: Fix response for failed refunds when falling back to voids [jasonwebster] #3608
 * Worldpay: Fix response for failed refunds when falling back to voids [jasonwebster] #3609
+* iATS Payments: Add support for Customer Code payment method [molbrown] #3611
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -97,6 +97,21 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert_equal 'Success', unstore.message
   end
 
+  def test_successful_store_and_purchase_and_refund
+    assert store = @gateway.store(@credit_card, @options)
+    assert_success store
+    assert store.authorization
+    assert_equal 'Success', store.message
+
+    assert purchase = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success purchase
+    assert purchase.authorization
+    assert_equal 'Success', purchase.message
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+  end
+
   def test_failed_store
     credit_card = credit_card('4111')
     assert store = @gateway.store(credit_card, @options)

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -199,6 +199,18 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_customer_code
+    response = stub_comms do
+      @gateway.purchase(@amount, 'CustomerCode', @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<customerCode>CustomerCode</customerCode>}, data)
+    end.respond_with(successful_purchase_response)
+
+    assert response
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_failed_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)


### PR DESCRIPTION
iats_payments gateway has had support for store, but not using stored
payment methods. Adds ability to purchase with a CustomerCode.

Unit:
18 tests, 178 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
13 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-1177