### PR TITLE
Monei json api

### DIFF
--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -8,36 +8,33 @@ module ActiveMerchant #:nodoc:
     # gateway please go to http://www.monei.net
     #
     # === Setup
-    # In order to set-up the gateway you need four paramaters: sender_id, channel_id, login and pwd.
+    # In order to set-up the gateway you need only one paramater: the api_key
     # Request that data to Monei.
     class MoneiGateway < Gateway
-      self.test_url = 'https://test.monei-api.net/payment/ctpe'
-      self.live_url = 'https://monei-api.net/payment/ctpe'
+      self.live_url = self.test_url = 'https://api.monei.net/v1/payments'
 
       self.supported_countries = %w[AD AT BE BG CA CH CY CZ DE DK EE ES FI FO FR GB GI GR HU IE IL IS IT LI LT LU LV MT NL NO PL PT RO SE SI SK TR US VA]
       self.default_currency = 'EUR'
+      self.money_format = :cents
       self.supported_cardtypes = %i[visa master maestro jcb american_express]
 
-      self.homepage_url = 'http://www.monei.net/'
-      self.display_name = 'Monei'
+      self.homepage_url = 'https://monei.com/'
+      self.display_name = 'MONEI'
 
       # Constructor
       #
       # options - Hash containing the gateway credentials, ALL MANDATORY
-      #           :sender_id  Sender ID
-      #           :channel_id Channel ID
-      #           :login      User login
-      #           :pwd        User password
+      #           :api_key      Account's API KEY
       #
       def initialize(options = {})
-        requires!(options, :sender_id, :channel_id, :login, :pwd)
+        requires!(options, :api_key)
         super
       end
 
       # Public: Performs purchase operation
       #
       # money       - Amount of purchase
-      # credit_card - Credit card
+      # payment_method - Credit card
       # options     - Hash containing purchase options
       #               :order_id         Merchant created id for the purchase
       #               :billing_address  Hash with billing address information
@@ -45,14 +42,14 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object
-      def purchase(money, credit_card, options = {})
-        execute_new_order(:purchase, money, credit_card, options)
+      def purchase(money, payment_method, options = {})
+        execute_new_order(:purchase, money, payment_method, options)
       end
 
       # Public: Performs authorization operation
       #
       # money       - Amount to authorize
-      # credit_card - Credit card
+      # payment_method - Credit card
       # options     - Hash containing authorization options
       #               :order_id         Merchant created id for the authorization
       #               :billing_address  Hash with billing address information
@@ -60,8 +57,8 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object
-      def authorize(money, credit_card, options = {})
-        execute_new_order(:authorize, money, credit_card, options)
+      def authorize(money, payment_method, options = {})
+        execute_new_order(:authorize, money, payment_method, options)
       end
 
       # Public: Performs capture operation on previous authorization
@@ -109,7 +106,7 @@ module ActiveMerchant #:nodoc:
 
       # Public: Verifies credit card. Does this by doing a authorization of 1.00 Euro and then voiding it.
       #
-      # credit_card - Credit card
+      # payment_method - Credit card
       # options     - Hash containing authorization options
       #               :order_id         Merchant created id for the authorization
       #               :billing_address  Hash with billing address information
@@ -117,113 +114,115 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object of Authorization operation
-      def verify(credit_card, options = {})
+      def verify(payment_method, options = {})
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
+          r.process { authorize(100, payment_method, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
+      end
+
+      def store(payment_method, options = {})
+        execute_new_order(:store, 0, payment_method, options)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: )\w+), '\1[FILTERED]').
+          gsub(%r(("number":")\d+), '\1[FILTERED]').
+          gsub(%r(("cvc":")\d+), '\1[FILTERED]').
+          gsub(%r(("cavv":")[\w=]+), '\1[FILTERED]')
       end
 
       private
 
       # Private: Execute purchase or authorize operation
-      def execute_new_order(action, money, credit_card, options)
-        request = build_request do |xml|
-          add_identification_new_order(xml, options)
-          add_payment(xml, action, money, options)
-          add_account(xml, credit_card)
-          add_customer(xml, credit_card, options)
-          add_three_d_secure(xml, options)
-        end
-
-        commit(request)
+      def execute_new_order(action, money, payment_method, options)
+        request = build_request
+        add_identification_new_order(request, options)
+        add_transaction(request, action, money, options)
+        add_payment(request, payment_method)
+        add_customer(request, payment_method, options)
+        add_3ds_authenticated_data(request, options)
+        add_browser_info(request, options)
+        commit(request, action, options)
       end
 
       # Private: Execute operation that depends on authorization code from previous purchase or authorize operation
       def execute_dependant(action, money, authorization, options)
-        request = build_request do |xml|
-          add_identification_authorization(xml, authorization, options)
-          add_payment(xml, action, money, options)
-        end
+        request = build_request
 
-        commit(request)
+        add_identification_authorization(request, authorization, options)
+        add_transaction(request, action, money, options)
+
+        commit(request, action, options)
       end
 
-      # Private: Build XML wrapping code yielding to code to fill the transaction information
+      # Private: Build request object
       def build_request
-        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-          xml.Request(version: '1.0') do
-            xml.Header { xml.Security(sender: @options[:sender_id]) }
-            xml.Transaction(mode: test? ? 'CONNECTOR_TEST' : 'LIVE', response: 'SYNC', channel: @options[:channel_id]) do
-              xml.User(login: @options[:login], pwd: @options[:pwd])
-              yield xml
-            end
-          end
-        end
-        builder.to_xml
+        request = {}
+        request[:livemode] = test? ? 'false' : 'true'
+        request
       end
 
-      # Private: Add identification part to XML for new orders
-      def add_identification_new_order(xml, options)
+      # Private: Add identification part to request for new orders
+      def add_identification_new_order(request, options)
         requires!(options, :order_id)
-        xml.Identification do
-          xml.TransactionID options[:order_id]
+        request[:orderId] = options[:order_id]
+      end
+
+      # Private: Add identification part to request for orders that depend on authorization from previous operation
+      def add_identification_authorization(request, authorization, options)
+        options[:paymentId] = authorization
+        request[:orderId] = options[:order_id] if options[:order_id]
+      end
+
+      # Private: Add payment part to request
+      def add_transaction(request, action, money, options)
+        request[:transactionType] = translate_payment_code(action)
+        request[:description] = options[:description] || options[:order_id]
+        unless money.nil?
+          request[:amount] = amount(money).to_i
+          request[:currency] = options[:currency] || currency(money)
         end
       end
 
-      # Private: Add identification part to XML for orders that depend on authorization from previous operation
-      def add_identification_authorization(xml, authorization, options)
-        xml.Identification do
-          xml.ReferenceID authorization
-          xml.TransactionID options[:order_id]
+      # Private: Add payment method to request
+      def add_payment(request, payment_method)
+        if payment_method.is_a? String
+          request[:paymentToken] = payment_method
+        else
+          request[:paymentMethod] = {}
+          request[:paymentMethod][:card] = {}
+          request[:paymentMethod][:card][:number] = payment_method.number
+          request[:paymentMethod][:card][:expMonth] = format(payment_method.month, :two_digits)
+          request[:paymentMethod][:card][:expYear] = format(payment_method.year, :two_digits)
+          request[:paymentMethod][:card][:cvc] = payment_method.verification_value.to_s
         end
       end
 
-      # Private: Add payment part to XML
-      def add_payment(xml, action, money, options)
-        code = tanslate_payment_code(action)
-
-        xml.Payment(code: code) do
-          xml.Presentation do
-            xml.Amount amount(money)
-            xml.Currency options[:currency] || currency(money)
-            xml.Usage options[:description] || options[:order_id]
-          end unless money.nil?
-        end
-      end
-
-      # Private: Add account part to XML
-      def add_account(xml, credit_card)
-        xml.Account do
-          xml.Holder credit_card.name
-          xml.Number credit_card.number
-          xml.Brand credit_card.brand.upcase
-          xml.Expiry(month: credit_card.month, year: credit_card.year)
-          xml.Verification credit_card.verification_value
-        end
-      end
-
-      # Private: Add customer part to XML
-      def add_customer(xml, credit_card, options)
+      # Private: Add customer part to request
+      def add_customer(request, payment_method, options)
         requires!(options, :billing_address)
-        address = options[:billing_address]
-        xml.Customer do
-          xml.Name do
-            xml.Given credit_card.first_name
-            xml.Family credit_card.last_name
-          end
-          xml.Address do
-            xml.Street address[:address1].to_s
-            xml.Zip address[:zip].to_s
-            xml.City address[:city].to_s
-            xml.State address[:state].to_s if address.has_key? :state
-            xml.Country address[:country].to_s
-          end
-          xml.Contact do
-            xml.Email options[:email] || 'noemail@monei.net'
-            xml.Ip options[:ip] || '0.0.0.0'
-          end
-        end
+        address = options[:billing_address] || options[:address]
+
+        request[:customer] = {}
+        request[:customer][:email] = options[:email] || 'support@monei.net'
+        request[:customer][:name] = address[:name].to_s
+
+        request[:billingDetails] = {}
+        request[:billingDetails][:address] = {}
+        request[:billingDetails][:address][:line1] = address[:address1].to_s
+        request[:billingDetails][:address][:city] = address[:city].to_s
+        request[:billingDetails][:address][:state] = address[:state].to_s if address.has_key? :state
+        request[:billingDetails][:address][:zip] = address[:zip].to_s
+        request[:billingDetails][:address][:country] = address[:country].to_s
+
+        request[:sessionDetails] = {}
+        request[:sessionDetails][:ip] = options[:ip] if options[:ip]
       end
 
       # Private : Convert ECI to ResultIndicator
@@ -245,92 +244,170 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      # Private : Add the 3DSecure infos to XML
-      def add_three_d_secure(xml, options)
-        if options[:three_d_secure]
-          xml.Authentication(type: '3DSecure') do
-            xml.ResultIndicator eci_to_result_indicator options[:three_d_secure][:eci]
-            xml.Parameter(name: 'VERIFICATION_ID') { xml.text options[:three_d_secure][:cavv] }
-            xml.Parameter(name: 'XID') { xml.text options[:three_d_secure][:xid] }
-          end
+      # Private: add the already validated 3DSecure info to request
+      def add_3ds_authenticated_data(request, options)
+        if options[:three_d_secure] && options[:three_d_secure][:eci] && options[:three_d_secure][:xid]
+          add_3ds1_authenticated_data(request, options)
+        elsif options[:three_d_secure]
+          add_3ds2_authenticated_data(request, options)
         end
       end
 
-      # Private: Parse XML response from Monei servers
-      def parse(body)
-        xml = Nokogiri::XML(body)
-        {
-          unique_id: xml.xpath('//Response/Transaction/Identification/UniqueID').text,
-          status: translate_status_code(xml.xpath('//Response/Transaction/Processing/Status/@code').text),
-          reason: translate_status_code(xml.xpath('//Response/Transaction/Processing/Reason/@code').text),
-          message: xml.xpath('//Response/Transaction/Processing/Return').text
+      def add_3ds1_authenticated_data(request, options)
+        three_d_secure_options = options[:three_d_secure]
+        request[:paymentMethod][:card][:auth] = {
+          cavv: three_d_secure_options[:cavv],
+          cavvAlgorithm: three_d_secure_options[:cavv_algorithm],
+          eci: three_d_secure_options[:eci],
+          xid: three_d_secure_options[:xid],
+          directoryResponse: three_d_secure_options[:enrolled],
+          authenticationResponse: three_d_secure_options[:authentication_response_status]
         }
       end
 
-      # Private: Send XML transaction to Monei servers and create AM response
-      def commit(xml)
-        url = (test? ? test_url : live_url)
+      def add_3ds2_authenticated_data(request, options)
+        three_d_secure_options = options[:three_d_secure]
+        # If the transaction was authenticated in a frictionless flow, send the transStatus from the ARes.
+        if three_d_secure_options[:authentication_response_status].nil?
+          authentication_response = three_d_secure_options[:directory_response_status]
+        else
+          authentication_response = three_d_secure_options[:authentication_response_status]
+        end
+        request[:paymentMethod][:card][:auth] = {
+          threeDSVersion: three_d_secure_options[:version],
+          eci: three_d_secure_options[:eci],
+          cavv: three_d_secure_options[:cavv],
+          dsTransID: three_d_secure_options[:ds_transaction_id],
+          directoryResponse: three_d_secure_options[:directory_response_status],
+          authenticationResponse: authentication_response
+        }
+      end
 
-        response = parse(ssl_post(url, post_data(xml), 'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8'))
+      def add_browser_info(request, options)
+        request[:sessionDetails][:ip] = options[:ip] if options[:ip]
+        request[:sessionDetails][:userAgent] = options[:user_agent] if options[:user_agent]
+      end
+
+      # Private: Parse JSON response from Monei servers
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def json_error(raw_response)
+        msg = 'Invalid response received from the MONEI API. Please contact support@monei.net if you continue to receive this message.'
+        msg += " (The raw response returned by the API was #{raw_response.inspect})"
+        {
+          'status' => 'error',
+          'message' => msg
+        }
+      end
+
+      def response_error(raw_response)
+        parse(raw_response)
+      rescue JSON::ParserError
+        json_error(raw_response)
+      end
+
+      def api_request(url, parameters, options = {})
+        raw_response = response = nil
+        begin
+          raw_response = ssl_post(url, post_data(parameters), options)
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = response_error(raw_response)
+        rescue JSON::ParserError
+          response = json_error(raw_response)
+        end
+        response
+      end
+
+      # Private: Send transaction to Monei servers and create AM response
+      def commit(request, action, options)
+        url = (test? ? test_url : live_url)
+        endpoint = translate_action_endpoint(action, options)
+        headers = {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'Authorization': @options[:api_key],
+          'User-Agent': 'MONEI/Shopify/0.1.0'
+        }
+
+        response = api_request(url + endpoint, params(request, action), headers)
+        success = success_from(response)
 
         Response.new(
-          success_from(response),
-          message_from(response),
+          success,
+          message_from(response, success),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization_from(response, action),
           test: test?,
-          error_code: error_code_from(response)
+          error_code: error_code_from(response, success)
         )
       end
 
       # Private: Decide success from servers response
       def success_from(response)
-        response[:status] == :success || response[:status] == :new
+        %w[
+          SUCCEEDED
+          AUTHORIZED
+          REFUNDED
+          PARTIALLY_REFUNDED
+          CANCELED
+        ].include? response['status']
       end
 
       # Private: Get message from servers response
-      def message_from(response)
-        response[:message]
+      def message_from(response, success)
+        success ? 'Transaction approved' : response.fetch('statusMessage', response.fetch('message', 'No error details'))
       end
 
       # Private: Get error code from servers response
-      def error_code_from(response)
-        success_from(response) ? nil : STANDARD_ERROR_CODE[:card_declined]
+      def error_code_from(response, success)
+        success ? nil : STANDARD_ERROR_CODE[:card_declined]
       end
 
       # Private: Get authorization code from servers response
-      def authorization_from(response)
-        response[:unique_id]
+      def authorization_from(response, action)
+        case action
+        when :store
+          return response['paymentToken']
+        else
+          return response['id']
+        end
       end
 
       # Private: Encode POST parameters
-      def post_data(xml)
-        "load=#{CGI.escape(xml)}"
+      def post_data(params)
+        params.clone.to_json
       end
 
-      # Private: Translate Monei status code to native ruby symbols
-      def translate_status_code(code)
-        {
-          '00' => :success,
-          '40' => :neutral,
-          '59' => :waiting_bank,
-          '60' => :rejected_bank,
-          '64' => :waiting_risk,
-          '65' => :rejected_risk,
-          '70' => :rejected_validation,
-          '80' => :waiting,
-          '90' => :new
-        }[code]
+      # Private: generate request params depending on action
+      def params(request, action)
+        request[:generatePaymentToken] = true if action == :store
+        request
       end
 
       # Private: Translate AM operations to Monei operations codes
-      def tanslate_payment_code(action)
+      def translate_payment_code(action)
         {
-          purchase: 'CC.DB',
-          authorize: 'CC.PA',
-          capture: 'CC.CP',
-          refund: 'CC.RF',
-          void: 'CC.RV'
+          purchase: 'SALE',
+          store: 'SALE',
+          authorize: 'AUTH',
+          capture: 'CAPTURE',
+          refund: 'REFUND',
+          void: 'CANCEL'
+        }[action]
+      end
+
+      # Private: Translate AM operations to Monei endpoints
+      def translate_action_endpoint(action, options)
+        {
+          purchase: '',
+          store: '',
+          authorize: '',
+          capture: "/#{options[:paymentId]}/capture",
+          refund: "/#{options[:paymentId]}/refund",
+          void: "/#{options[:paymentId]}/cancel"
         }[action]
       end
     end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -554,10 +554,7 @@ modern_payments:
 
 # Working credentials, no need to replace
 monei:
-  sender_id: 8a829417488d34c401489a5cd1350977
-  channel_id: 8a829417488d34c401489a5de5dd097b
-  login: 8a829417488d34c401489a5cd1360979
-  pwd: GyNSEAp2
+  api_key: pk_test_3cb2d54b7ee145fa92d683c01816ad15
 
 # Working credentials, no need to replace
 moneris:

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -7,58 +7,142 @@ class RemoteMoneiTest < Test::Unit::TestCase
     )
 
     @amount = 100
-    @credit_card = credit_card('4000100011112224')
-    @declined_card = credit_card('5453010000059675')
+    @credit_card = credit_card('4548812049400004', month: 12, year: 2034, verification_value: '123')
+    @declined_card = credit_card('5453010000059675', month: 12, year: 2034, verification_value: '123')
+
+    @three_ds_declined_card = credit_card('4444444444444505', month: 12, year: 2034, verification_value: '123')
+    @three_ds_2_enrolled_card = credit_card('4444444444444406', month: 12, year: 2034, verification_value: '123')
 
     @options = {
-      order_id: '1',
       billing_address: address,
       description: 'Store Purchase'
     }
   end
 
+  def random_order_id
+    SecureRandom.hex(16)
+  end
+
   def test_successful_purchase
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.purchase(@amount, @credit_card, options)
 
     assert_success response
-    assert_equal 'Request successfully processed in \'Merchant in Connector Test Mode\'', response.message
+    assert_equal 'Transaction approved', response.message
   end
 
   def test_successful_purchase_with_3ds
     options = @options.merge!({
+      order_id: random_order_id,
       three_d_secure: {
         eci: '05',
         cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
         xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
-      }
+      },
+      ip: '77.110.174.153',
+      user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36'
     })
     response = @gateway.purchase(@amount, @credit_card, options)
 
     assert_success response
-    assert_equal 'Request successfully processed in \'Merchant in Connector Test Mode\'', response.message
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_purchase_with_3ds_v2
+    options = @options.merge!({
+      order_id: random_order_id,
+      three_d_secure: {
+        eci: '05',
+        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+        ds_transaction_id: '7eac9571-3533-4c38-addd-00cf34af6a52'
+      },
+      ip: '77.110.174.153',
+      user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36'
+    })
+    response = @gateway.purchase(@amount, @three_ds_2_enrolled_card, options)
+
+    assert_success response
+    assert_equal 'Transaction approved', response.message
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(@amount, @declined_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.purchase(@amount, @declined_card, options)
     assert_failure response
-    assert_equal 'invalid cc number/brand combination', response.message
+    assert_equal 'Card rejected: invalid card number', response.message
   end
 
   def test_failed_purchase_with_3ds
     options = @options.merge!({
+      order_id: random_order_id,
       three_d_secure: {
         eci: '05',
         cavv: 'INVALID_Verification_ID',
         xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
-      }
+      },
+      ip: '77.110.174.153',
+      user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36'
     })
-    response = @gateway.purchase(@amount, @credit_card, options)
+    response = @gateway.purchase(@amount, @three_ds_declined_card, options)
     assert_failure response
-    assert_equal 'Invalid 3DSecure Verification_ID. Must have Base64 encoding a Length of 28 digits', response.message
+    assert_equal 'Invalid 3DSecure Verification ID', response.message
+  end
+
+  def test_successful_store
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.store(@credit_card, options)
+
+    assert_success response
+    assert(!response.params['paymentToken'].nil?)
+    assert_equal response.authorization, response.params['paymentToken']
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_store_with_3ds_v2
+    options = @options.merge!({
+      order_id: random_order_id,
+      three_d_secure: {
+        eci: '05',
+        cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
+        ds_transaction_id: '7eac9571-3533-4c38-addd-00cf34af6a52'
+      },
+      ip: '77.110.174.153',
+      user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36'
+    })
+    response = @gateway.store(@three_ds_2_enrolled_card, options)
+
+    assert_success response
+    assert(!response.params['paymentToken'].nil?)
+    assert_equal response.authorization, response.params['paymentToken']
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_store_and_purchase
+    options = @options.merge({ order_id: random_order_id })
+    stored = @gateway.store(@credit_card, options)
+    assert_success stored
+
+    options = @options.merge({ order_id: random_order_id })
+    assert purchase = @gateway.purchase(@amount, stored.authorization, options)
+    assert_success purchase
+  end
+
+  def test_successful_store_authorize_and_capture
+    options = @options.merge({ order_id: random_order_id })
+    stored = @gateway.store(@credit_card, options)
+    assert_success stored
+
+    options = @options.merge({ order_id: random_order_id })
+    authorize = @gateway.authorize(@amount, stored.authorization, options)
+    assert_success authorize
+
+    assert capture = @gateway.capture(@amount, authorize.authorization)
+    assert_success capture
   end
 
   def test_successful_authorize_and_capture
-    auth = @gateway.authorize(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount, auth.authorization)
@@ -66,12 +150,14 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    response = @gateway.authorize(@amount, @declined_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.authorize(@amount, @declined_card, options)
     assert_failure response
   end
 
   def test_partial_capture
-    auth = @gateway.authorize(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount - 1, auth.authorization)
@@ -79,7 +165,8 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_multi_partial_capture
-    auth = @gateway.authorize(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount - 1, auth.authorization)
@@ -95,7 +182,8 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    purchase = @gateway.purchase(@amount, @credit_card, options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
@@ -103,7 +191,8 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_partial_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    purchase = @gateway.purchase(@amount, @credit_card, options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount - 1, purchase.authorization)
@@ -111,7 +200,8 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_multi_partial_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    purchase = @gateway.purchase(@amount, @credit_card, options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount - 1, purchase.authorization)
@@ -127,7 +217,8 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    auth = @gateway.authorize(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
@@ -140,26 +231,26 @@ class RemoteMoneiTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = @gateway.verify(@credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.verify(@credit_card, options)
     assert_success response
-    assert_equal 'Request successfully processed in \'Merchant in Connector Test Mode\'', response.message
+    assert_equal 'Transaction approved', response.message
   end
 
   def test_failed_verify
-    response = @gateway.verify(@declined_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = @gateway.verify(@declined_card, options)
     assert_failure response
 
-    assert_equal 'invalid cc number/brand combination', response.message
+    assert_equal 'Card rejected: invalid card number', response.message
   end
 
   def test_invalid_login
     gateway = MoneiGateway.new(
-      sender_id: 'mother',
-      channel_id: 'there is no other',
-      login: 'like mother',
-      pwd: 'so treat Her right'
+      api_key: 'invalid'
     )
-    response = gateway.purchase(@amount, @credit_card, @options)
+    options = @options.merge({ order_id: random_order_id })
+    response = gateway.purchase(@amount, @credit_card, options)
     assert_failure response
   end
 end

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -24,7 +24,7 @@ class MoneiTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    assert_equal '8a829449488d79090148996c441551fb', response.authorization
+    assert_equal '067574158f1f42499c31404752d52d06', response.authorization
     assert response.test?
   end
 
@@ -128,10 +128,14 @@ class MoneiTest < Test::Unit::TestCase
   end
 
   def test_3ds_request
+    authentication_eci = '05'
+    authentication_cavv = 'AAACAgSRBklmQCFgMpEGAAAAAAA='
+    authentication_xid = 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+
     three_d_secure_options = {
-      eci: '05',
-      cavv: 'AAACAgSRBklmQCFgMpEGAAAAAAA=',
-      xid: 'CAACCVVUlwCXUyhQNlSXAAAAAAA='
+      eci: authentication_eci,
+      cavv: authentication_cavv,
+      xid: authentication_xid
     }
     options = @options.merge!({
       three_d_secure: three_d_secure_options
@@ -139,298 +143,247 @@ class MoneiTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      body = CGI.unescape data
-      assert_match %r{<Authentication type="3DSecure">}, body
-      assert_match %r{<ResultIndicator>05</ResultIndicator>}, body
-      assert_match %r{<Parameter name="VERIFICATION_ID">#{three_d_secure_options[:cavv]}</Parameter>}, body
-      assert_match %r{<Parameter name="XID">#{three_d_secure_options[:xid]}</Parameter>}, body
+      assert_match(/\"eci\":\"#{authentication_eci}\"/, data)
+      assert_match(/\"cavv\":\"#{authentication_cavv}\"/, data)
+      assert_match(/\"xid\":\"#{authentication_xid}\"/, data)
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_scrub
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_scrubs_auth_data
+    assert_equal @gateway.scrub(pre_scrubbed_with_auth), post_scrubbed_with_auth
+  end
+
+  def test_supports_scrubbing?
+    assert @gateway.supports_scrubbing?
   end
 
   private
 
   def successful_purchase_response
-    return <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014698a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>7621.0198.1858</ShortID>
-                  <UniqueID>8a829449488d79090148996c441551fb</UniqueID>
-                  <TransactionID>1</TransactionID>
-              </Identification>
-              <Payment code="CC.DB">
-                  <Clearing>
-                      <Amount>1.00</Amount>
-                      <Currency>EUR</Currency>
-                      <Descriptor>7621.0198.1858 DEFAULT Store Purchase</Descriptor>
-                      <FxRate>1.0</FxRate>
-                      <FxSource>INTERN</FxSource>
-                      <FxDate>2014-09-21 18:14:42</FxDate>
-                  </Clearing>
-              </Payment>
-              <Processing code="CC.DB.90.00">
-                  <Timestamp>2014-09-21 18:14:42</Timestamp>
-                  <Result>ACK</Result>
-                  <Status code="90">NEW</Status>
-                  <Reason code="00">Successful Processing</Reason>
-                  <Return code="000.100.112">Request successfully processed in 'Merchant in Connector Test Mode'</Return>
-                  <Risk score="0" />
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "id": "067574158f1f42499c31404752d52d06",
+      "amount": 110,
+      "currency": "EUR",
+      "orderId": "1",
+      "accountId": "00000000-aaaa-bbbb-cccc-dddd123456789",
+      "status": "SUCCEEDED",
+      "statusMessage": "Transaction Approved",
+      "signature": "3dc52e4dbcc15cee5bb03cb7e3ab90708bf8b8a21818c0262ac05ec0c01780d0"
+    }
+    RESPONSE
   end
 
   def failed_purchase_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82943746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>9086.6774.0834</ShortID>
-                  <UniqueID>8a82944a488d36c101489972b0ee6ace</UniqueID>
-                  <TransactionID>1</TransactionID>
-              </Identification>
-              <Payment code="CC.DB" />
-              <Processing code="CC.DB.70.40">
-                  <Timestamp>2014-09-21 18:21:43</Timestamp>
-                  <Result>NOK</Result>
-                  <Status code="70">REJECTED_VALIDATION</Status>
-                  <Reason code="40">Account Validation</Reason>
-                  <Return code="100.100.700">invalid cc number/brand combination</Return>
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "status": "error",
+      "message": "Card number declined by processor"
+    }
+    RESPONSE
   end
 
   def successful_authorize_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746487806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>6853.2944.1442</ShortID>
-                  <UniqueID>8a82944a488d36c101489976f0cc6b1c</UniqueID>
-                  <TransactionID>1</TransactionID>
-              </Identification>
-              <Payment code="CC.PA">
-                  <Clearing>
-                      <Amount>1.00</Amount>
-                      <Currency>EUR</Currency>
-                      <Descriptor>6853.2944.1442 DEFAULT Store Purchase</Descriptor>
-                      <FxRate>1.0</FxRate>
-                      <FxSource>INTERN</FxSource>
-                      <FxDate>2014-09-21 18:26:22</FxDate>
-                  </Clearing>
-              </Payment>
-              <Processing code="CC.PA.90.00">
-                  <Timestamp>2014-09-21 18:26:22</Timestamp>
-                  <Result>ACK</Result>
-                  <Status code="90">NEW</Status>
-                  <Reason code="00">Successful Processing</Reason>
-                  <Return code="000.100.112">Request successfully processed in 'Merchant in Connector Test Mode'</Return>
-                  <Risk score="0" />
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "id": "067574158f1f42499c31404752d52d06",
+      "amount": 110,
+      "currency": "EUR",
+      "orderId": "1",
+      "accountId": "00000000-aaaa-bbbb-cccc-dddd123456789",
+      "status": "AUTHORIZED",
+      "statusMessage": "Transaction Approved",
+      "signature": "3dc52e4dbcc15cee5bb03cb7e3ab90708bf8b8a21818c0262ac05ec0c01780d0"
+    }
+    RESPONSE
   end
 
   def failed_authorize_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>4727.2856.0290</ShortID>
-                  <UniqueID>8a829449488d79090148998943a853f6</UniqueID>
-                  <TransactionID>1</TransactionID>
-              </Identification>
-              <Payment code="CC.PA" />
-              <Processing code="CC.PA.70.40">
-                  <Timestamp>2014-09-21 18:46:22</Timestamp>
-                  <Result>NOK</Result>
-                  <Status code="70">REJECTED_VALIDATION</Status>
-                  <Reason code="40">Account Validation</Reason>
-                  <Return code="100.100.700">invalid cc number/brand combination</Return>
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "status": "error",
+      "message": "Card number declined by processor"
+    }
+    RESPONSE
   end
 
   def successful_capture_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>1269.8369.2962</ShortID>
-                  <UniqueID>8a82944a488d36c10148998d9b316cc6</UniqueID>
-                  <TransactionID />
-                  <ReferenceID>8a829449488d79090148998d97f05439</ReferenceID>
-              </Identification>
-              <Payment code="CC.CP">
-                  <Clearing>
-                      <Amount>1.00</Amount>
-                      <Currency>EUR</Currency>
-                      <Descriptor>1269.8369.2962 DEFAULT Store Purchase</Descriptor>
-                      <FxRate>1.0</FxRate>
-                      <FxSource>INTERN</FxSource>
-                      <FxDate>2014-09-21 18:51:07</FxDate>
-                  </Clearing>
-              </Payment>
-              <Processing code="CC.CP.90.00">
-                  <Timestamp>2014-09-21 18:51:07</Timestamp>
-                  <Result>ACK</Result>
-                  <Status code="90">NEW</Status>
-                  <Reason code="00">Successful Processing</Reason>
-                  <Return code="000.100.112">Request successfully processed in 'Merchant in Connector Test Mode'</Return>
-                  <Risk score="0" />
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "id": "067574158f1f42499c31404752d52d06",
+      "amount": 110,
+      "currency": "EUR",
+      "orderId": "1",
+      "accountId": "00000000-aaaa-bbbb-cccc-dddd123456789",
+      "status": "SUCCEEDED",
+      "statusMessage": "Transaction Approved",
+      "signature": "3dc52e4dbcc15cee5bb03cb7e3ab90708bf8b8a21818c0262ac05ec0c01780d0"
+    }
+    RESPONSE
   end
 
   def failed_capture_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>0239.0447.7858</ShortID>
-                  <UniqueID>8a82944a488d36c10148998fc4b66cfc</UniqueID>
-                  <TransactionID />
-                  <ReferenceID />
-              </Identification>
-              <Payment code="CC.CP" />
-              <Processing code="CC.CP.70.20">
-                  <Timestamp>2014-09-21 18:53:29</Timestamp>
-                  <Result>NOK</Result>
-                  <Status code="70">REJECTED_VALIDATION</Status>
-                  <Reason code="20">Format Error</Reason>
-                  <Return code="200.100.302">invalid Request/Transaction/Payment/Presentation tag (not present or [partially] empty)</Return>
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "status": "error",
+      "message": "Card number declined by processor"
+    }
+    RESPONSE
   end
 
   def successful_refund_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>3009.2986.8450</ShortID>
-                  <UniqueID>8a829449488d790901489992a493546f</UniqueID>
-                  <TransactionID />
-                  <ReferenceID>8a82944a488d36c101489992a10f6d21</ReferenceID>
-              </Identification>
-              <Payment code="CC.RF">
-                  <Clearing>
-                      <Amount>1.00</Amount>
-                      <Currency>EUR</Currency>
-                      <Descriptor>3009.2986.8450 DEFAULT Store Purchase</Descriptor>
-                      <FxRate>1.0</FxRate>
-                      <FxSource>INTERN</FxSource>
-                      <FxDate>2014-09-21 18:56:37</FxDate>
-                  </Clearing>
-              </Payment>
-              <Processing code="CC.RF.90.00">
-                  <Timestamp>2014-09-21 18:56:37</Timestamp>
-                  <Result>ACK</Result>
-                  <Status code="90">NEW</Status>
-                  <Reason code="00">Successful Processing</Reason>
-                  <Return code="000.100.112">Request successfully processed in 'Merchant in Connector Test Mode'</Return>
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "id": "067574158f1f42499c31404752d52d06",
+      "amount": 110,
+      "currency": "EUR",
+      "orderId": "1",
+      "accountId": "00000000-aaaa-bbbb-cccc-dddd123456789",
+      "status": "REFUNDED",
+      "statusMessage": "Transaction Approved",
+      "signature": "3dc52e4dbcc15cee5bb03cb7e3ab90708bf8b8a21818c0262ac05ec0c01780d0"
+    }
+    RESPONSE
   end
 
   def failed_refund_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>5070.8829.8658</ShortID>
-                  <UniqueID>8a829449488d790901489994b2c65481</UniqueID>
-                  <TransactionID />
-                  <ReferenceID />
-              </Identification>
-              <Payment code="CC.RF" />
-              <Processing code="CC.RF.70.20">
-                  <Timestamp>2014-09-21 18:58:52</Timestamp>
-                  <Result>NOK</Result>
-                  <Status code="70">REJECTED_VALIDATION</Status>
-                  <Reason code="20">Format Error</Reason>
-                  <Return code="200.100.302">invalid Request/Transaction/Payment/Presentation tag (not present or [partially] empty)</Return>
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "status": "error",
+      "message": "Card number declined by processor"
+    }
+    RESPONSE
   end
 
   def successful_void_response
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>4587.6991.6578</ShortID>
-                  <UniqueID>8a82944a488d36c1014899957fff6d49</UniqueID>
-                  <TransactionID />
-                  <ReferenceID>8a829449488d7909014899957cb45486</ReferenceID>
-              </Identification>
-              <Payment code="CC.RV">
-                  <Clearing>
-                      <Amount>1.00</Amount>
-                      <Currency>EUR</Currency>
-                      <Descriptor>4587.6991.6578 DEFAULT Store Purchase</Descriptor>
-                      <FxRate>1.0</FxRate>
-                      <FxSource>INTERN</FxSource>
-                      <FxDate>2014-09-21 18:59:44</FxDate>
-                  </Clearing>
-              </Payment>
-              <Processing code="CC.RV.90.00">
-                  <Timestamp>2014-09-21 18:59:44</Timestamp>
-                  <Result>ACK</Result>
-                  <Status code="90">NEW</Status>
-                  <Reason code="00">Successful Processing</Reason>
-                  <Return code="000.100.112">Request successfully processed in 'Merchant in Connector Test Mode'</Return>
-                  <Risk score="0" />
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "id": "067574158f1f42499c31404752d52d06",
+      "amount": 110,
+      "currency": "EUR",
+      "orderId": "1",
+      "accountId": "00000000-aaaa-bbbb-cccc-dddd123456789",
+      "status": "CANCELED",
+      "statusMessage": "Transaction Approved",
+      "signature": "3dc52e4dbcc15cee5bb03cb7e3ab90708bf8b8a21818c0262ac05ec0c01780d0"
+    }
+    RESPONSE
   end
 
   def failed_void_response
-    <<~XML
-      <Response version="1.0">
-          <Transaction mode="CONNECTOR_TEST" channel="8a82941746287806014628a0e3240575" response="SYNC">
-              <Identification>
-                  <ShortID>5843.9770.9986</ShortID>
-                  <UniqueID>8a829449488d7909014899965cd354b6</UniqueID>
-                  <TransactionID />
-                  <ReferenceID />
-              </Identification>
-              <Payment code="CC.RV" />
-              <Processing code="CC.RV.70.30">
-                  <Timestamp>2014-09-21 19:00:41</Timestamp>
-                  <Result>NOK</Result>
-                  <Status code="70">REJECTED_VALIDATION</Status>
-                  <Reason code="30">Reference Error</Reason>
-                  <Return code="700.400.530">reversal needs at least one successful transaction of type (CP or DB or RB or PA)</Return>
-                  <Risk score="0" />
-              </Processing>
-          </Transaction>
-      </Response>
-    XML
+    <<-RESPONSE
+    {
+      "status": "error",
+      "message": "Card number declined by processor"
+    }
+    RESPONSE
+  end
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      <- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: pk_test_3cb2d54b7ee145fa92d683c01816ad15\r\nUser-Agent: MONEI/Shopify/0.1.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.monei.net\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"livemode\":\"false\",\"orderId\":\"66e0d04361fb7b401bec3b078744c21e\",\"transactionType\":\"AUTH\",\"description\":\"Store Purchase\",\"amount\":100,\"currency\":\"EUR\",\"paymentMethod\":{\"card\":{\"number\":\"5453010000059675\",\"expMonth\":\"12\",\"expYear\":\"34\",\"cvc\":\"123\"}},\"customer\":{\"email\":\"support@monei.net\",\"name\":\"Jim Smith\"},\"billingDetails\":{\"address\":{\"line1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"country\":\"CA\"}},\"sessionDetails\":{}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1069\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Mon, 05 Jul 2021 15:59:36 GMT\r\n"
+      -> "x-amzn-RequestId: 75b637ff-f230-4522-b6c5-bc5b95495a55\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: CAPf6EPXjoEFdxA=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-60e32c65-625fbe465afdff1666fa4da9;Sampled=0\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 508a0f3451a34ff5e6a3963c94ef304d.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MAD51-C3\r\n"
+      -> "X-Amz-Cf-Id: SH_5SGGltcCwOgNwn4cnuZAYCa8__JZuUe5lj_Dnvkhigu2yB8M-SQ==\r\n"
+      -> "\r\n"
+      reading 1069 bytes...
+      -> "{\"id\":\"cdc503654e76e29051bce6054e4b4d47dfb63edc\",\"amount\":100,\"currency\":\"EUR\",\"orderId\":\"66e0d04361fb7b401bec3b078744c21e\",\"description\":\"Store Purchase\",\"accountId\":\"00000000-aaaa-bbbb-cccc-dddd123456789\",\"authorizationCode\":\"++++++\",\"livemode\":false,\"status\":\"FAILED\",\"statusCode\":\"E501\",\"statusMessage\":\"Card rejected: invalid card number\",\"customer\":{\"name\":\"Jim Smith\",\"email\":\"support@monei.net\"},\"billingDetails\":{\"address\":{\"zip\":\"K1C2N6\",\"country\":\"CA\",\"state\":\"ON\",\"city\":\"Ottawa\",\"line1\":\"456 My Street\"}},\"sessionDetails\":{\"deviceType\":\"desktop\"},\"traceDetails\":{\"deviceType\":\"desktop\",\"sourceVersion\":\"0.1.0\",\"countryCode\":\"ES\",\"ip\":\"217.61.227.107\",\"userAgent\":\"MONEI/Shopify/0.1.0\",\"source\":\"MONEI/Shopify\",\"lang\":\"en\"},\"createdAt\":1625500773,\"updatedAt\":1625500776,\"paymentMethod\":{\"method\":\"card\",\"card\":{\"country\":\"US\",\"last4\":\"9675\",\"threeDSecure\":false,\"expiration\":2048544000,\"type\":\"credit\",\"brand\":\"mastercard\"}},\"nextAction\":{\"type\":\"COMPLETE\",\"redirectUrl\":\"https://secure.monei.com/payments/cdc503654e76e29051bce6054e4b4d47dfb63edc/receipt\"}}"
+      read 1069 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def pre_scrubbed_with_auth
+    <<-PRE_SCRUBBED_WITH_AUTH
+      <- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: pk_test_3cb2d54b7ee145fa92d683c01816ad15\r\nUser-Agent: MONEI/Shopify/0.1.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.monei.net\r\nContent-Length: 1063\r\n\r\n"
+      <- "{\"livemode\":\"false\",\"orderId\":\"851925032d391d67e3fbf70b06aa182d\",\"transactionType\":\"SALE\",\"description\":\"Store Purchase\",\"amount\":100,\"currency\":\"EUR\",\"paymentMethod\":{\"card\":{\"number\":\"4444444444444406\",\"expMonth\":\"12\",\"expYear\":\"34\",\"cvc\":\"123\",\"auth\":{\"threeDSVersion\":null,\"eci\":\"05\",\"cavv\":\"AAACAgSRBklmQCFgMpEGAAAAAAA=\",\"dsTransID\":\"7eac9571-3533-4c38-addd-00cf34af6a52\",\"directoryResponse\":null,\"authenticationResponse\":null,\"notificationUrl\":\"https://example.com/notification\"}}},\"customer\":{\"email\":\"support@monei.net\",\"name\":\"Jim Smith\"},\"billingDetails\":{\"address\":{\"line1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"country\":\"CA\"}},\"sessionDetails\":{\"ip\":\"77.110.174.153\",\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36\",\"browserAccept\":\"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json\",\"browserColorDepth\":\"100\",\"lang\":\"US\",\"browserScreenHeight\":\"1000\",\"browserScreenWidth\":\"500\",\"browserTimezoneOffset\":\"-120\"}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 253\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Mon, 05 Jul 2021 15:59:59 GMT\r\n"
+      -> "x-amzn-RequestId: ac5a5ec8-6dd4-4254-a28a-8e9fa652ba90\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: CAPj7FFfDoEFXOQ=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-60e32c7f-690a46280dc8da307f679795;Sampled=0\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 1868e2f5b79bbf25cd21cd4b652be313.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MAD51-C3\r\n"
+      -> "X-Amz-Cf-Id: RVunC63Qvaswh2fcVB5n0p0BB_1zxbMOx68nuq5m6GKhWUFPpfAgVQ==\r\n"
+      -> "\r\n"
+      reading 253 bytes...
+      -> "{\"id\":\"e1310ab50f7cf1dcf87f1ae75b2ed0fbd2a4d05f\",\"amount\":100,\"currency\":\"EUR\",\"orderId\":\"851925032d391d67e3fbf70b06aa182d\",\"accountId\":\"00000000-aaaa-bbbb-cccc-dddd123456789\",\"liveMode\":false,\"status\":\"SUCCEEDED\",\"statusMessage\":\"Transaction Approved\"}"
+      read 253 bytes
+      Conn close
+    PRE_SCRUBBED_WITH_AUTH
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      <- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\n\Authorization: [FILTERED]\r\nUser-Agent: MONEI/Shopify/0.1.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.monei.net\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"livemode\":\"false\",\"orderId\":\"66e0d04361fb7b401bec3b078744c21e\",\"transactionType\":\"AUTH\",\"description\":\"Store Purchase\",\"amount\":100,\"currency\":\"EUR\",\"paymentMethod\":{\"card\":{\"number\":\"[FILTERED]\",\"expMonth\":\"12\",\"expYear\":\"34\",\"cvc\":\"[FILTERED]\"}},\"customer\":{\"email\":\"support@monei.net\",\"name\":\"Jim Smith\"},\"billingDetails\":{\"address\":{\"line1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"country\":\"CA\"}},\"sessionDetails\":{}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1069\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Mon, 05 Jul 2021 15:59:36 GMT\r\n"
+      -> "x-amzn-RequestId: 75b637ff-f230-4522-b6c5-bc5b95495a55\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: CAPf6EPXjoEFdxA=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-60e32c65-625fbe465afdff1666fa4da9;Sampled=0\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 508a0f3451a34ff5e6a3963c94ef304d.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MAD51-C3\r\n"
+      -> "X-Amz-Cf-Id: SH_5SGGltcCwOgNwn4cnuZAYCa8__JZuUe5lj_Dnvkhigu2yB8M-SQ==\r\n"
+      -> "\r\n"
+      reading 1069 bytes...
+      -> "{\"id\":\"cdc503654e76e29051bce6054e4b4d47dfb63edc\",\"amount\":100,\"currency\":\"EUR\",\"orderId\":\"66e0d04361fb7b401bec3b078744c21e\",\"description\":\"Store Purchase\",\"accountId\":\"00000000-aaaa-bbbb-cccc-dddd123456789\",\"authorizationCode\":\"++++++\",\"livemode\":false,\"status\":\"FAILED\",\"statusCode\":\"E501\",\"statusMessage\":\"Card rejected: invalid card number\",\"customer\":{\"name\":\"Jim Smith\",\"email\":\"support@monei.net\"},\"billingDetails\":{\"address\":{\"zip\":\"K1C2N6\",\"country\":\"CA\",\"state\":\"ON\",\"city\":\"Ottawa\",\"line1\":\"456 My Street\"}},\"sessionDetails\":{\"deviceType\":\"desktop\"},\"traceDetails\":{\"deviceType\":\"desktop\",\"sourceVersion\":\"0.1.0\",\"countryCode\":\"ES\",\"ip\":\"217.61.227.107\",\"userAgent\":\"MONEI/Shopify/0.1.0\",\"source\":\"MONEI/Shopify\",\"lang\":\"en\"},\"createdAt\":1625500773,\"updatedAt\":1625500776,\"paymentMethod\":{\"method\":\"card\",\"card\":{\"country\":\"US\",\"last4\":\"9675\",\"threeDSecure\":false,\"expiration\":2048544000,\"type\":\"credit\",\"brand\":\"mastercard\"}},\"nextAction\":{\"type\":\"COMPLETE\",\"redirectUrl\":\"https://secure.monei.com/payments/cdc503654e76e29051bce6054e4b4d47dfb63edc/receipt\"}}"
+      read 1069 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def post_scrubbed_with_auth
+    <<-POST_SCRUBBED_WITH_AUTH
+      <- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: [FILTERED]\r\nUser-Agent: MONEI/Shopify/0.1.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.monei.net\r\nContent-Length: 1063\r\n\r\n"
+      <- "{\"livemode\":\"false\",\"orderId\":\"851925032d391d67e3fbf70b06aa182d\",\"transactionType\":\"SALE\",\"description\":\"Store Purchase\",\"amount\":100,\"currency\":\"EUR\",\"paymentMethod\":{\"card\":{\"number\":\"[FILTERED]\",\"expMonth\":\"12\",\"expYear\":\"34\",\"cvc\":\"[FILTERED]\",\"auth\":{\"threeDSVersion\":null,\"eci\":\"05\",\"cavv\":\"[FILTERED]\",\"dsTransID\":\"7eac9571-3533-4c38-addd-00cf34af6a52\",\"directoryResponse\":null,\"authenticationResponse\":null,\"notificationUrl\":\"https://example.com/notification\"}}},\"customer\":{\"email\":\"support@monei.net\",\"name\":\"Jim Smith\"},\"billingDetails\":{\"address\":{\"line1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\",\"country\":\"CA\"}},\"sessionDetails\":{\"ip\":\"77.110.174.153\",\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36\",\"browserAccept\":\"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json\",\"browserColorDepth\":\"100\",\"lang\":\"US\",\"browserScreenHeight\":\"1000\",\"browserScreenWidth\":\"500\",\"browserTimezoneOffset\":\"-120\"}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 253\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Mon, 05 Jul 2021 15:59:59 GMT\r\n"
+      -> "x-amzn-RequestId: ac5a5ec8-6dd4-4254-a28a-8e9fa652ba90\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: CAPj7FFfDoEFXOQ=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-60e32c7f-690a46280dc8da307f679795;Sampled=0\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 1868e2f5b79bbf25cd21cd4b652be313.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MAD51-C3\r\n"
+      -> "X-Amz-Cf-Id: RVunC63Qvaswh2fcVB5n0p0BB_1zxbMOx68nuq5m6GKhWUFPpfAgVQ==\r\n"
+      -> "\r\n"
+      reading 253 bytes...
+      -> "{\"id\":\"e1310ab50f7cf1dcf87f1ae75b2ed0fbd2a4d05f\",\"amount\":100,\"currency\":\"EUR\",\"orderId\":\"851925032d391d67e3fbf70b06aa182d\",\"accountId\":\"00000000-aaaa-bbbb-cccc-dddd123456789\",\"liveMode\":false,\"status\":\"SUCCEEDED\",\"statusMessage\":\"Transaction Approved\"}"
+      read 253 bytes
+      Conn close
+    POST_SCRUBBED_WITH_AUTH
   end
 end


### PR DESCRIPTION
This PR moves from our old (unused) XML API to our new one in JSON, for [MONEI gateway](https://monei.net/)

Biggest difference from before: we are now requesting "API KEY" as credential.
The API core is the same, you'll find almost no changes in the remote tests.
Unit tests were now replaced with JSON responses.

Also, we replaced the API URL so it matches the "homepage_url".

Unit test result:
```
> rake test TEST=test/unit/gateways/monei_test.rb
Loaded suite /Library/Ruby/Gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader
Started
..............
Finished in 0.139572 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------
100.31 tests/s, 401.23 assertions/s
```

Remote test result:
```
> rake test TEST=test/remote/gateways/remote_monei_test.rb
Loaded suite /Library/Ruby/Gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader
Started
..................
Finished in 27.320396 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------
18 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------
0.38 tests/s, 0.89 assertions/s
```

Please let me know if you need anything else to move forward. We had a deadline for a customer that needed to begin operating today... so I hope you understand <3