### PR TITLE
Adyen: Correctly parse error messages for 3DS2 auths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Worldpay: Fix response for failed refunds when falling back to voids [jasonwebster] #3609
 * iATS Payments: Add support for Customer Code payment method [molbrown] #3611
 * HPS: Add Google Pay support [MSmedal] #3597
+* Adyen: Parse appropriate message for 3DS2 authorization calls [britth] #3619
 
 == Version 1.107.1 (Apr 1, 2020)
 * Add `allowed_push_host` to gemspec [mdeloupy]

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -549,7 +549,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(action, response)
-        return authorize_message_from(response) if action.to_s == 'authorise' || action.to_s == 'authorise3d'
+        return authorize_message_from(response) if %w(authorise authorise3d authorise3ds2).include?(action.to_s)
 
         response['response'] || response['message'] || response['result']
       end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -225,6 +225,15 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_authorise3ds2
+    @gateway.expects(:ssl_post).returns(failed_authorize_3ds2_response)
+
+    response = @gateway.send(:commit, 'authorise3ds2', {}, {})
+
+    assert_equal '3D Not Authenticated', response.message
+    assert_failure response
+  end
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934')
@@ -996,6 +1005,26 @@ class AdyenTest < Test::Unit::TestCase
       "refusalReason": "Expired Card",
       "resultCode": "Refused"
     }
+    RESPONSE
+  end
+
+  def failed_authorize_3ds2_response
+    <<-RESPONSE
+    {
+      "additionalData":
+      {
+        "threeds2.threeDS2Result.dsTransID": "1111-abc-234",
+        "threeds2.threeDS2Result.eci":"07",
+        "threeds2.threeDS2Result.threeDSServerTransID":"222-cde-321",
+        "threeds2.threeDS2Result.transStatusReason":"01",
+        "threeds2.threeDS2Result.messageVersion":"2.1.0",
+        "threeds2.threeDS2Result.authenticationValue":"ABCDEFG",
+        "threeds2.threeDS2Result.transStatus":"N"
+       },
+       "pspReference":"8514775559925128",
+       "refusalReason":"3D Not Authenticated",
+       "resultCode":"Refused"
+     }
     RESPONSE
   end
 


### PR DESCRIPTION
When 3DS2 fails, Adyen will return an error under refusalReason.
Previously, we were checking for this value with the `authorise`
and the `authorise3d` endpoints, but not for `authorise3ds2`.
Updates message_from to properly check for the refusal reason when
present for 3DS2 txns.

Unit:
66 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
89 tests, 343 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed