### PR TITLE
Cybersource additions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Cybersource: Send a specific card brand commerceIndicator for 3DS [pi3r]
+* Cybersource: Send application_id as partnerSolutionID [pi3r]
 * Iridium: Localize zero-decimal currencies [chinhle23] #3587
 * iVeri: Fix `verify` action [chinhle23] #3588
 * Ixopay: Properly support three-decimal currencies [chinhle23] #3589

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Cybersource: Send a specific card brand commerceIndicator for 3DS [pi3r]
 * Iridium: Localize zero-decimal currencies [chinhle23] #3587
 * iVeri: Fix `verify` action [chinhle23] #3588
 * Ixopay: Properly support three-decimal currencies [chinhle23] #3589

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -471,6 +471,8 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
         xml.tag! 'clientLibraryVersion', VERSION
         xml.tag! 'clientEnvironment', RUBY_PLATFORM
+        xml.tag!('partnerSolutionID', application_id) if application_id
+
         add_merchant_descriptor(xml, options)
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -840,6 +840,19 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_adds_application_id_as_partner_solution_id
+    partner_id = 'partner_id'
+    CyberSourceGateway.application_id = partner_id
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match("<partnerSolutionID>#{partner_id}</partnerSolutionID>", data)
+    end.respond_with(successful_capture_response)
+  ensure
+    CyberSourceGateway.application_id = nil
+  end
+
   private
 
   def pre_scrubbed

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -729,13 +729,25 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success validation
   end
 
+  def test_adds_3ds_brand_based_commerce_indicator
+    %w(visa master american_express jcb discover).each do |brand|
+      @credit_card.brand = brand
+
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: {}))
+      end.check_request do |endpoint, data, headers|
+        assert_match(/commerceIndicator\>#{CyberSourceGateway::ECI_BRAND_MAPPING[brand.to_sym]}/, data)
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
   def test_adds_3ds2_fields_via_normalized_hash
     version = '2.0'
     eci = '05'
     cavv = '637574652070757070792026206b697474656e73'
     cavv_algorithm = 2
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
-    commerce_indicator = 'vbv'
+    commerce_indicator = 'commerce_indicator'
     authentication_response_status = 'Y'
     enrolled = 'Y'
     options_with_normalized_3ds = @options.merge(
@@ -771,7 +783,7 @@ class CyberSourceTest < Test::Unit::TestCase
     cavv = '637574652070757070792026206b697474656e73'
     cavv_algorithm = 1
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
-    commerce_indicator = 'spa'
+    commerce_indicator = 'commerce_indicator'
     collection_indicator = 2
     options_with_normalized_3ds = @options.merge(
       three_d_secure: {


### PR DESCRIPTION
1. Send a specific card brand commerceIndicator for 3DS to comply with following doc

![image](https://user-images.githubusercontent.com/330573/81224913-6c2e1280-8fb6-11ea-9731-a2b9b81e6323.png)

2. Pass application_id as partnerSolutionID
