### PR TITLE
 Ignore IPv6 unsupported addresses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Realex: Ignore IPv6 unsupported addresses [elfassy] #3622
 
 == Version 1.107.2 (May 7, 2020)
 * Cybersource: Send a specific card brand commerceIndicator for 3DS [pi3r] #3620

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -230,13 +230,14 @@ module ActiveMerchant
       def add_address_and_customer_info(xml, options)
         billing_address = options[:billing_address] || options[:address]
         shipping_address = options[:shipping_address]
+        ipv4_address = ipv4?(options[:ip]) ? options[:ip] : nil
 
-        return unless billing_address || shipping_address || options[:customer] || options[:invoice] || options[:ip]
+        return unless billing_address || shipping_address || options[:customer] || options[:invoice] || ipv4_address
 
         xml.tag! 'tssinfo' do
           xml.tag! 'custnum', options[:customer] if options[:customer]
           xml.tag! 'prodid', options[:invoice] if options[:invoice]
-          xml.tag! 'custipaddress', options[:ip] if options[:ip]
+          xml.tag! 'custipaddress', options[:ip] if ipv4_address
 
           if billing_address
             xml.tag! 'address', 'type' => 'billing' do
@@ -368,6 +369,11 @@ module ActiveMerchant
 
       def sanitize_order_id(order_id)
         order_id.to_s.gsub(/[^a-zA-Z0-9\-_]/, '')
+      end
+
+      def ipv4?(ip_address)
+        return false if ip_address.nil?
+        !!ip_address[/\A\d+\.\d+\.\d+\.\d+\z/]
       end
     end
   end

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -188,7 +188,8 @@ class RealexTest < Test::Unit::TestCase
 
   def test_purchase_xml
     options = {
-      order_id: '1'
+      order_id: '1',
+      ip: '123.456.789.0',
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -212,7 +213,43 @@ class RealexTest < Test::Unit::TestCase
   </card>
   <autosettle flag="1"/>
   <sha1hash>3499d7bc8dbacdcfba2286bd74916d026bae630f</sha1hash>
+  <tssinfo>
+    <custipaddress>123.456.789.0</custipaddress>
+  </tssinfo>
 </request>
+    SRC
+
+    assert_xml_equal valid_purchase_request_xml, @gateway.build_purchase_or_authorization_request(:purchase, @amount, @credit_card, options)
+  end
+
+  def test_purchase_xml_with_ipv6
+    options = {
+      order_id: '1',
+      ip: '2a02:c7d:da18:ac00:6d10:4f13:1795:4890',
+    }
+
+    @gateway.expects(:new_timestamp).returns('20090824160201')
+
+    valid_purchase_request_xml = <<~SRC
+      <request timestamp="20090824160201" type="auth">
+        <merchantid>your_merchant_id</merchantid>
+        <account>your_account</account>
+        <orderid>1</orderid>
+        <amount currency="EUR">100</amount>
+        <card>
+          <number>4263971921001307</number>
+          <expdate>0808</expdate>
+          <chname>Longbob Longsen</chname>
+          <type>VISA</type>
+          <issueno></issueno>
+          <cvn>
+            <number></number>
+            <presind></presind>
+          </cvn>
+        </card>
+        <autosettle flag="1"/>
+        <sha1hash>3499d7bc8dbacdcfba2286bd74916d026bae630f</sha1hash>
+      </request>
     SRC
 
     assert_xml_equal valid_purchase_request_xml, @gateway.build_purchase_or_authorization_request(:purchase, @amount, @credit_card, options)


### PR DESCRIPTION
# Why

When customer try to complete the checkout with Realex, the following error appears after they enter the payment details.

example error
```
The line number 21 which contains ' [custipaddress] 2a02:c7d:da18:ac00:6d10:4f13:1795:4890 [/custipaddress] ' does not conform to the schema.
```
closes https://github.com/activemerchant/active_merchant/issues/3569

# What
Ignore IPs that don't match the ipv4 standard
