### PR TITLE
Element: Add card_present_code field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Mercado Pago: Add payment_method_option_id field [schwarzgeist] #3635
 * Stripe: Provide error when attempting an authorize with ACH [britth] #3633
 * EBANX: Send original order id as merchant_payment_code metadata [miguelxpn] #3637 
+* Element: Add card_present_code field [schwarzgeist] #3623
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -194,7 +194,7 @@ module ActiveMerchant #:nodoc:
       def add_terminal(xml, options)
         xml.terminal do
           xml.TerminalID '01'
-          xml.CardPresentCode 'UseDefault'
+          xml.CardPresentCode options[:card_present_code] || 'UseDefault'
           xml.CardholderPresentCode 'UseDefault'
           xml.CardInputCode 'UseDefault'
           xml.CVVPresenceCode 'UseDefault'

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -50,6 +50,12 @@ class RemoteElementTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_card_present_code
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(card_present_code: 'Present'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -142,6 +142,11 @@ class ElementTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_purchase_with_card_present_code
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(card_present_code: 'Present'))
+    assert_equal 'Present', response.params['terminal']['cardpresentcode']
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
CE-376, CE-584

Remote:
20 tests, 57 assertions, 1 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
95% passed

Unit:
20 tests, 53 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

Remote test failure seems to be pending an update with an updated
value containing an actual CardPresentCode value. This
modification to remote unit tests may need to be removed.