### PR TITLE
CyberSource: Stored Credential fixes

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -816,15 +816,10 @@ module ActiveMerchant #:nodoc:
 
       def add_stored_credential_options(xml, options={})
         return unless options[:stored_credential]
-
-        if options[:stored_credential][:initial_transaction]
-          xml.tag! 'subsequentAuthFirst', 'true'
-        elsif options[:stored_credential][:reason_type] == 'unscheduled'
-          xml.tag! 'subsequentAuth', 'true'
-          xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
-        else
-          xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
-        end
+        xml.tag! 'subsequentAuth', 'true' if options[:stored_credential][:initiator] == 'merchant'
+        xml.tag! 'subsequentAuthFirst', 'true' if options[:stored_credential][:initial_transaction]
+        xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id] if options[:stored_credential][:initiator] == 'merchant'
+        xml.tag! 'subsequentAuthStoredCredential', 'true' if options[:stored_credential][:initiator] == 'cardholder' && !options[:stored_credential][:initial_transaction] ||  options[:stored_credential][:initiator] == 'merchant' && options[:stored_credential][:reason_type] == 'unscheduled'
       end
 
       def add_partner_solution_id(xml)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -664,18 +664,19 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
-  def test_successful_first_unscheduled_cof_transaction
+  def test_successful_first_cof_authorize
     @options[:stored_credential] = {
       initiator: 'cardholder',
-      reason_type: 'unscheduled',
+      reason_type: '',
       initial_transaction: true,
       network_transaction_id: ''
     }
+    @options[:commerce_indicator] = 'internet'
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)
   end
 
-  def test_successful_subsequent_unscheduled_cof_transaction
+  def test_successful_subsequent_unscheduled_cof_authorize
     @options[:stored_credential] = {
       initiator: 'merchant',
       reason_type: 'unscheduled',
@@ -686,21 +687,32 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
-  def test_successful_first_recurring_cof_transaction
+  def test_successful_recurring_cof_authorize
     @options[:stored_credential] = {
-      initiator: 'cardholder',
+      initiator: 'merchant',
       reason_type: 'recurring',
-      initial_transaction: true,
+      initial_transaction: false,
       network_transaction_id: ''
     }
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(response)
   end
 
-  def test_successful_subsequent_recurring_cof_transaction
+  def test_successful_subsequent_recurring_cof_authorize
     @options[:stored_credential] = {
       initiator: 'merchant',
       reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_subsequent_installment_cof_authorize
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'installment',
       initial_transaction: false,
       network_transaction_id: '016150703802094'
     }


### PR DESCRIPTION
The initial implementation of Stored Credentials had some discrepancies
with CyberSource's API documentation. This change adds the
subsequentAuthStoredCredential field to appropriate transactions, and
corrects some behavior around the other fields. Tests were changed
significantly to verify the new behavior.

Docs used to guide the logic are here: https://developer.cybersource.com/library/documentation/sbc/credit_cards/html/Topics/Merchant-Initiated_Transactions_MITs_and_Credentials-on-File_COF_Transactions.htm
Currently, "Industry Practice" designations are not supported. 

Remote (5 known failures):
77 tests, 393 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.5065% passed

Unit:
80 tests, 377 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed