### PR TITLE
Stripe Payment Intents: Utilize execute_threed flag to determine success

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,9 @@
 * Vantiv Express: Implement true verify [leila-alderman] #3617
 * Litle: Pass expiration data for basis payment method [therufs] #3606
 * Stripe Payment Intents: Error handling and backwards compatibility within refund [britth] #3627
-* HPS: Prevent errors when account_type or account_holder_type nil are nil [britth] #3628
+* HPS: Prevent errors when account_type or account_holder_type are nil [britth] #3628
 * D Local: Handle invalid country code errors [curiousepic] #3626
+* Stripe Payment Intents: Utilize execute_threed flag to determine success [britth] #3625
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -647,7 +647,7 @@ module ActiveMerchant #:nodoc:
         add_expand_parameters(parameters, options) if parameters
         response = api_request(method, url, parameters, options)
         response['webhook_id'] = options[:webhook_id] if options[:webhook_id]
-        success = success_from(response)
+        success = success_from(response, options)
 
         card = card_from_response(response)
         avs_code = AVS_CODE_TRANSLATOR["line1: #{card["address_line1_check"]}, zip: #{card["address_zip_check"]}"]
@@ -681,7 +681,7 @@ module ActiveMerchant #:nodoc:
         success ? 'Transaction approved' : response.fetch('error', {'message' => 'No error details'})['message']
       end
 
-      def success_from(response)
+      def success_from(response, options)
         !response.key?('error') && response['status'] != 'failed'
       end
 

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -295,6 +295,16 @@ module ActiveMerchant #:nodoc:
 
         options.merge(idempotency_key: "#{options[:idempotency_key]}-#{suffix}")
       end
+
+      def success_from(response, options)
+        if response['status'] == 'requires_action' && !options[:execute_threed]
+          response['error'] = {}
+          response['error']['message'] = 'Received unexpected 3DS authentication response. Use the execute_threed option to initiate a proper 3DS flow.'
+          return false
+        end
+
+        super(response, options)
+      end
     end
   end
 end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -180,7 +180,8 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'USD',
       customer: @customer,
       confirm: true,
-      return_url: 'https://www.example.com'
+      return_url: 'https://www.example.com',
+      execute_threed: true
     }
 
     assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
@@ -254,6 +255,19 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert response = @gateway.authorize(@amount, @three_ds_credit_card, options)
     assert_failure response
+  end
+
+  def test_purchase_fails_on_unexpected_3ds_initiation
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      confirm: true,
+      return_url: 'https://www.example.com'
+    }
+
+    assert response = @gateway.purchase(100, @three_ds_credit_card, options)
+    assert_failure response
+    assert_match 'Received unexpected 3DS authentication response', response.message
   end
 
   def test_create_payment_intent_with_shipping_address


### PR DESCRIPTION
Currently Stripe Payment Intents will return a successful response
if a user tries to initiate a purchase or auth and the api responds
with a status of `required_action` (i.e. if additional steps are
required to authenticate with 3ds and proceed with the transaction).
In other adapters that implement 3DS, we use an `execute_threed` flag
to either signify that we should hit a 3DS specific endpoint, or
classify a response as success/failure depending on whether or not
3DS was requested. For Stripe, there's no separate 3DS endpoint; rather,
if a transaction requires 3DS the response will just signify that in the
status field and by having redirect urls. This PR updates to use the
presence of an `execute_threed` option to either classify the response
as a failure should that field not be present and authentication was
required, or default to the normal success determination

Questions:
This will have potential impacts on backwards compatibility. Would it be
better to have a flag specifically saying you do not want to request 3DS
instead of the normal execute_threed flag. That would go against all other
implementations though...

Remote:
37 tests, 177 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
10 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed