### PR TITLE
D Local: Handle invalid country code errors

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -93,8 +93,10 @@ module ActiveMerchant #:nodoc:
         post[:country] = lookup_country_code(address[:country])
       end
 
-      def lookup_country_code(country)
-        Country.find(country).code(:alpha2).value
+      def lookup_country_code(country_field)
+        Country.find(country_field).code(:alpha2).value
+      rescue InvalidCountryCodeError
+        nil
       end
 
       def add_payer(post, card, options)

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -70,6 +70,14 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_invalid_country
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(country: 'INVALID')))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/\"country\":null/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
 


### PR DESCRIPTION
Implemented handling similar to other gateways.

Unit:
18 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
27 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed