### PR TITLE
Stripe Payment Intents: Handle errors in refund process

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Elavon: Implement true verify action [leila-alderman] #3610
 * Vantiv Express: Implement true verify [leila-alderman] #3617
 * Litle: Pass expiration data for basis payment method [therufs] #3606
+* Stripe Payment Intents: Handle errors and intents without an associated charge in refund [britth] #3627
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622


### PR DESCRIPTION
The Stripe PI refund method first makes an API call to check for
the associated charge id of the payment intent to be refunded. If
this payment intent does not have an associated charge, or if there
is some sort of error (whether service availability, etc), subsequent
steps in the refund process will raise errors due to the way we try
to parse out the charge id. This PR updates refund to check for any
errors resulting from the initial get request. If there are any, we
stop the process and simply return a failed response with that error.
Next we try to parse out the charge id from the response. If it's nil,
we again simply send back a failed response with appropriate message
and halt processing. Otherwise, we use that charge_id to call the stripe
refund method as before.

This PR also incorporates updates from PR #3352 (thanks @Ligator!), to make 
refund backwards compatible if you pass in a charge id rather than an intent id.

Remote:
38 tests, 181 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
12 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed