### PR TITLE
HPS: Prevent NoMethodError when account_type or account_holder_type nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Vantiv Express: Implement true verify [leila-alderman] #3617
 * Litle: Pass expiration data for basis payment method [therufs] #3606
 * Stripe Payment Intents: Error handling and backwards compatibility within refund [britth] #3627
+* HPS: Prevent errors when account_type or account_holder_type nil are nil [britth] #3628
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -201,9 +201,9 @@ module ActiveMerchant #:nodoc:
           xml.hps :RoutingNumber, check.routing_number
           xml.hps :AccountNumber, check.account_number
           xml.hps :CheckNumber, check.number
-          xml.hps :AccountType, check.account_type.upcase
+          xml.hps :AccountType, check.account_type&.upcase
         end
-        xml.hps :CheckType, check.account_holder_type.upcase
+        xml.hps :CheckType, check.account_holder_type&.upcase
       end
 
       def add_details(xml, options)

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -48,6 +48,30 @@ class HpsTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_check_purchase_does_not_raise_no_method_error_when_account_type_missing
+    check = @check.dup
+    check.account_type = nil
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@check_amount, check, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<hps:CheckSale><hps:Block1><hps:CheckAction>SALE<\/hps:CheckAction>/, data)
+    end.respond_with(successful_check_purchase_response)
+
+    assert_success response
+  end
+
+  def test_check_purchase_does_not_raise_no_method_error_when_account_holder_type_missing
+    check = @check.dup
+    check.account_holder_type = nil
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@check_amount, check, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<hps:CheckSale><hps:Block1><hps:CheckAction>SALE<\/hps:CheckAction>/, data)
+    end.respond_with(successful_check_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_charge_response)
 


### PR DESCRIPTION
For check payment methods, the HPS adapter attempts to upcase the
account_type and account_holder_type fields when adding them to
the request. If either of these is missing, a NoMethodError is raised.
This PR makes an update to safely call upcase in these instances
to prevent such errors.

Remote (same failures on master):
50 tests, 125 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90% passed

Unit:
54 tests, 267 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed