### PR TITLE
Fix Style/DoubleNegation linting error

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -374,7 +374,7 @@ module ActiveMerchant
       def ipv4?(ip_address)
         return false if ip_address.nil?
 
-        !!ip_address[/\A\d+\.\d+\.\d+\.\d+\z/]
+        !ip_address.match(/\A\d+\.\d+\.\d+\.\d+\z/).nil?
       end
     end
   end


### PR DESCRIPTION
## Why?

A linting error was recently introduced:

```
lib/active_merchant/billing/gateways/realex.rb:377:9: C: Style/DoubleNegation: Avoid the use of double negation (!!). (https://github.com/rubocop-hq/ruby-style-guide#no-bang-bang)
        !!ip_address[/\A\d+\.\d+\.\d+\.\d+\z/]
```

## What Changed?

Fixes a Style/DoubleNegation linting error was introduced in the Realex gateway by changing the statement to `!statement.nil?` from `!!statement`.

## Test Suite

```
4493 tests, 71886 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
692 files inspected, no offenses detected
```