### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,11 @@ AllCops:
     - "lib/active_merchant/billing/gateways/paypal_express.rb"
     - "vendor/**/*"
   ExtraDetails: false
-  TargetRubyVersion: 2.3
+  # This setting disables any new cops in updated versions of RuboCop.
+  # To complete cleaning up the AM code, this should be removed to enable
+  # the cops added to newer versions of RuboCop.
+  NewCops: disable
+  TargetRubyVersion: 2.5
 
 # Active Merchant gateways are not amenable to length restrictions
 Metrics/ClassLength:
@@ -24,7 +28,7 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/DotPosition:
@@ -33,6 +37,6 @@ Layout/DotPosition:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,14 +20,14 @@ Gemspec/OrderedDependencies:
 # SupportedHashRocketStyles: key, separator, table
 # SupportedColonStyles: key, separator, table
 # SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # Offense count: 392
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # Offense count: 232
@@ -63,7 +63,7 @@ Lint/FormatParameterMismatch:
     - 'test/unit/credit_card_formatting_test.rb'
 
 # Offense count: 2
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'lib/active_merchant/billing/gateways/mastercard.rb'
     - 'lib/active_merchant/billing/gateways/trust_commerce.rb'
@@ -186,7 +186,7 @@ Naming/PredicateName:
 # Offense count: 14
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'lib/active_merchant/billing/gateways/blue_snap.rb'
     - 'lib/active_merchant/billing/gateways/cyber_source.rb'
@@ -228,28 +228,6 @@ Naming/VariableNumber:
     - 'test/unit/gateways/merchant_ware_version_four_test.rb'
     - 'test/unit/gateways/orbital_test.rb'
     - 'test/unit/gateways/paypal/paypal_common_api_test.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/opp.rb'
-    - 'test/unit/gateways/payu_latam_test.rb'
-
-# Offense count: 11
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'lib/active_merchant/billing/compatibility.rb'
-    - 'lib/active_merchant/billing/gateways/card_connect.rb'
-    - 'lib/active_merchant/billing/gateways/firstdata_e4.rb'
-    - 'lib/active_merchant/billing/gateways/merchant_ware.rb'
-    - 'lib/active_merchant/billing/gateways/merchant_ware_version_four.rb'
-    - 'lib/active_merchant/billing/gateways/orbital.rb'
-    - 'lib/active_merchant/billing/gateways/quickbooks.rb'
-    - 'lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb'
-    - 'lib/active_merchant/billing/gateways/realex.rb'
-    - 'test/unit/gateways/nab_transact_test.rb'
 
 # Offense count: 2
 # Configuration parameters: EnforcedStyle.
@@ -338,13 +316,6 @@ Style/BlockComments:
 # FunctionalMethods: let, let!, subject, watch
 # IgnoredMethods: lambda, proc, it
 Style/BlockDelimiters:
-  Enabled: false
-
-# Offense count: 440
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: braces, no_braces, context_dependent
-Style/BracesAroundHashParameters:
   Enabled: false
 
 # Offense count: 2
@@ -544,21 +515,11 @@ Style/For:
 Style/FormatString:
   Enabled: false
 
-# Offense count: 22
+# Offense count: ~100
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: annotated, template, unannotated
 Style/FormatStringToken:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/redsys.rb'
-    - 'lib/active_merchant/connection.rb'
-    - 'lib/active_merchant/network_connection_retries.rb'
-    - 'test/remote/gateways/remote_balanced_test.rb'
-    - 'test/remote/gateways/remote_openpay_test.rb'
-    - 'test/unit/gateways/balanced_test.rb'
-    - 'test/unit/gateways/elavon_test.rb'
-    - 'test/unit/gateways/exact_test.rb'
-    - 'test/unit/gateways/firstdata_e4_test.rb'
-    - 'test/unit/gateways/safe_charge_test.rb'
+  Enabled: false
 
 # Offense count: 679
 # Cop supports --auto-correct.
@@ -955,6 +916,6 @@ Style/ZeroLengthPredicate:
 # Offense count: 9321
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 2602
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,22 @@ sudo: false
 cache: bundler
 
 rvm:
+- 2.7
+- 2.6
 - 2.5
-- 2.4
-- 2.3
 
 gemfile:
-- gemfiles/Gemfile.rails52
-- gemfiles/Gemfile.rails51
 - gemfiles/Gemfile.rails50
-- gemfiles/Gemfile.rails42
+- gemfiles/Gemfile.rails51
+- gemfiles/Gemfile.rails52
+- gemfiles/Gemfile.rails60
 - gemfiles/Gemfile.rails_master
 
 jobs:
   include:
-      rvm: 2.5
+      rvm: 2.7
       gemfile: Gemfile
       script: bundle exec rubocop --parallel
-
-matrix:
-  exclude:
-    - rvm: 2.3
-      gemfile: 'gemfiles/Gemfile.rails_master'
-    - rvm: 2.4
-      gemfile: 'gemfiles/Gemfile.rails_master'
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', platforms: :jruby
-gem 'rubocop', '~> 0.60.0', require: false
+gem 'rubocop', '~> 0.83.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ Functionality or APIs that are deprecated will be marked as such. Deprecated fun
 
 ## Ruby and Rails compatibility policies
 
-Because Active Merchant is a payment library, it needs to take security seriously. For this reason, Active Merchant guarantees compatibility only with actively supported versions of Ruby and Rails. At the time of this writing, that means that Ruby 2.3+ and Rails 4.2+ are supported.
+Because Active Merchant is a payment library, it needs to take security seriously. For this reason, Active Merchant guarantees compatibility only with actively supported versions of Ruby and Rails. At the time of this writing, that means that Ruby 2.5+ and Rails 5.0+ are supported.

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = 'tobi@leetsoft.com'
   s.homepage = 'http://activemerchant.org/'
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.5'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: '2.3.0'
+    version: '2.5.0'
 
 dependencies:
   cache_directories:

--- a/gemfiles/Gemfile.rails42
+++ b/gemfiles/Gemfile.rails42
@@ -1,3 +1,0 @@
-eval_gemfile '../Gemfile'
-
-gem 'activesupport', '~> 4.2.0'

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -1,0 +1,3 @@
+eval_gemfile '../Gemfile'
+
+gem 'activesupport', '~> 6.0.0'

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -7,8 +7,8 @@ module ActiveMerchant #:nodoc:
     # You may use Check in place of CreditCard with any gateway that supports it.
     class Check < Model
       attr_accessor :first_name, :last_name,
-        :bank_name, :routing_number, :account_number,
-        :account_holder_type, :account_type, :number
+                    :bank_name, :routing_number, :account_number,
+                    :account_holder_type, :account_type, :number
 
       # Used for Canadian bank accounts
       attr_accessor :institution_number, :transit_number

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -113,6 +113,6 @@ module ActiveMerchant
       end
     end
 
-    Compatibility::Model.send(:include, Rails::Model)
+    Compatibility::Model.include Rails::Model
   end
 end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -488,7 +488,7 @@ module ActiveMerchant
 
       def add_swipe_data(xml, credit_card)
         TRACKS.each do |key, regex|
-          if regex.match(credit_card.track_data)
+          if regex.match?(credit_card.track_data)
             @valid_track_data = true
             xml.payment do
               xml.trackData do

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -394,8 +394,8 @@ module ActiveMerchant #:nodoc:
         success = response[:result_code] == 'Ok'
 
         Response.new(success, message, response,
-          test: test_mode,
-          authorization: response[:subscription_id]
+                     test: test_mode,
+                     authorization: response[:subscription_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # ==== Customer Information Manager (CIM)

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -72,8 +72,8 @@ module ActiveMerchant #:nodoc:
         authorization = response[:unique_id]
 
         Response.new(success, message, response,
-          authorization: authorization,
-          test: (response[:mode] != 'LIVE')
+                     authorization: authorization,
+                     test: (response[:mode] != 'LIVE')
         )
       end
 

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -90,10 +90,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(success?(response),
-          response['message'],
-          response,
-          test: test?,
-          authorization: response['code_auth'])
+                     response['message'],
+                     response,
+                     test: test?,
+                     authorization: response['code_auth'])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -414,10 +414,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post((use_profile_api ? SECURE_PROFILE_URL : self.live_url), data))
         response[:customer_vault_id] = response[:customerCode] if response[:customerCode]
         build_response(success?(response), message_from(response), response,
-          test: test? || response[:authCode] == 'TEST',
-          authorization: authorization_from(response),
-          cvv_result: CVD_CODES[response[:cvdId]],
-          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
+                       test: test? || response[:authCode] == 'TEST',
+                       authorization: authorization_from(response),
+                       cvv_result: CVD_CODES[response[:cvdId]],
+                       avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -343,8 +343,8 @@ module ActiveMerchant #:nodoc:
         message = parsed[:status]
 
         Response.new(success, message, parsed,
-          test: test?,
-          authorization: parsed[:rebill_id])
+                     test: test?,
+                     authorization: parsed[:rebill_id])
       end
 
       def parse(body)
@@ -363,10 +363,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(parsed)
         success = parsed[:response_code] == '1'
         Response.new(success, message, parsed,
-          test: test?,
-          authorization: (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
-          avs_result: { code: parsed[:avs_result_code] },
-          cvv_result: parsed[:card_code]
+                     test: test?,
+                     authorization: (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
+                     avs_result: { code: parsed[:avs_result_code] },
+                     cvv_result: parsed[:card_code]
         )
       end
 
@@ -382,9 +382,9 @@ module ActiveMerchant #:nodoc:
           end
         elsif message == 'Missing ACCOUNT_ID'
           message = 'The merchant login ID or password is invalid'
-        elsif message =~ /Approved/
+        elsif /Approved/.match?(message)
           message = 'This transaction has been approved'
-        elsif message =~  /Expired/
+        elsif /Expired/.match?(message)
           message = 'The credit card has expired'
         end
         message

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -157,16 +157,16 @@ module ActiveMerchant #:nodoc:
           }, options)[:credit_card]
 
           result = @braintree_gateway.customer.update(vault_id,
-            first_name: creditcard.first_name,
-            last_name: creditcard.last_name,
-            email: scrub_email(options[:email]),
-            phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
-              options[:billing_address][:phone]),
-            credit_card: credit_card_params
-          )
+                                                      first_name: creditcard.first_name,
+                                                      last_name: creditcard.last_name,
+                                                      email: scrub_email(options[:email]),
+                                                      phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+                                                        options[:billing_address][:phone]),
+                                                      credit_card: credit_card_params
+                                                     )
           Response.new(result.success?, message_from_result(result),
-            braintree_customer: (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
-            customer_vault_id: (result.customer.id if result.success?)
+                       braintree_customer: (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
+                       customer_vault_id: (result.customer.id if result.success?)
           )
         end
       end
@@ -203,12 +203,10 @@ module ActiveMerchant #:nodoc:
 
       def check_customer_exists(customer_vault_id)
         commit do
-          begin
-            @braintree_gateway.customer.find(customer_vault_id)
-            ActiveMerchant::Billing::Response.new(true, 'Customer found', {exists: true}, authorization: customer_vault_id)
-          rescue Braintree::NotFoundError
-            ActiveMerchant::Billing::Response.new(true, 'Customer not found', {exists: false})
-          end
+          @braintree_gateway.customer.find(customer_vault_id)
+          ActiveMerchant::Billing::Response.new(true, 'Customer found', {exists: true}, authorization: customer_vault_id)
+        rescue Braintree::NotFoundError
+          ActiveMerchant::Billing::Response.new(true, 'Customer not found', {exists: false})
         end
       end
 
@@ -239,12 +237,12 @@ module ActiveMerchant #:nodoc:
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           Response.new(result.success?, message_from_result(result),
-            {
-              braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
-              customer_vault_id: (result.customer.id if result.success?),
-              credit_card_token: (result.customer.credit_cards[0].token if result.success?)
-            },
-            authorization: (result.customer.id if result.success?)
+                       {
+                         braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
+                         customer_vault_id: (result.customer.id if result.success?),
+                         credit_card_token: (result.customer.credit_cards[0].token if result.success?)
+                       },
+                       authorization: (result.customer.id if result.success?)
           )
         end
       end
@@ -335,8 +333,8 @@ module ActiveMerchant #:nodoc:
 
       def commit(&block)
         yield
-      rescue Braintree::BraintreeError => ex
-        Response.new(false, ex.class.to_s)
+      rescue Braintree::BraintreeError => e
+        Response.new(false, e.class.to_s)
       end
 
       def message_from_result(result)

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -143,8 +143,8 @@ module ActiveMerchant #:nodoc:
       def unstore(authorization, options = {})
         account_id, profile_id = authorization.split('|')
         commit('profile', {},
-          verb: :delete,
-          path: "/#{profile_id}/#{account_id}/#{@options[:merchant_id]}")
+               verb: :delete,
+               path: "/#{profile_id}/#{account_id}/#{@options[:merchant_id]}")
       end
 
       def supports_scrubbing?

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -206,7 +206,7 @@ module ActiveMerchant #:nodoc:
 
       def generate_signature(body)
         key = OpenSSL::PKey::RSA.new(@options[:private_key])
-        hex = key.sign(OpenSSL::Digest.new('sha256'), body).unpack('H*').first
+        hex = key.sign(OpenSSL::Digest.new('sha256'), body).unpack1('H*')
 
         "#{@options[:signing_key]} RS256-hex #{hex}"
       end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -879,11 +879,11 @@ module ActiveMerchant #:nodoc:
         authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: authorization,
-          fraud_review: in_fraud_review?(response),
-          avs_result: { code: response[:avsCode] },
-          cvv_result: response[:cvCode]
+                     test: test?,
+                     authorization: authorization,
+                     fraud_review: in_fraud_review?(response),
+                     avs_result: { code: response[:avsCode] },
+                     cvv_result: response[:cvCode]
         )
       end
 
@@ -913,7 +913,7 @@ module ActiveMerchant #:nodoc:
         if node.has_elements?
           node.elements.each { |e| parse_element(reply, e) }
         else
-          if node.parent.name =~ /item/
+          if /item/.match?(node.parent.name)
             parent = node.parent.name
             parent += '_' + node.parent.attributes['id'] if node.parent.attributes['id']
             parent += '_'

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -235,23 +235,23 @@ module ActiveMerchant
             # a predefined one
             xml.tag! :ExtendedPolicy do
               xml.tag! :cv2_policy,
-                notprovided: POLICY_REJECT,
-                notchecked: POLICY_REJECT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_REJECT
+                       notprovided: POLICY_REJECT,
+                       notchecked: POLICY_REJECT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_REJECT
               xml.tag! :postcode_policy,
-                notprovided: POLICY_ACCEPT,
-                notchecked: POLICY_ACCEPT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_ACCEPT
+                       notprovided: POLICY_ACCEPT,
+                       notchecked: POLICY_ACCEPT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_ACCEPT
               xml.tag! :address_policy,
-                notprovided: POLICY_ACCEPT,
-                notchecked: POLICY_ACCEPT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_ACCEPT
+                       notprovided: POLICY_ACCEPT,
+                       notchecked: POLICY_ACCEPT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_ACCEPT
             end
           end
         end
@@ -261,8 +261,8 @@ module ActiveMerchant
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request))
 
         Response.new(response[:status] == '1', response[:reason], response,
-          test: test?,
-          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
+                     test: test?,
+                     authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
         )
       end
 

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -146,10 +146,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(action, parameters), 'Content-Type' => 'text/xml'))
 
         Response.new(success?(response), message_from(response[:result_message]), response,
-          test: test?,
-          authorization: authorization_from(response, parameters),
-          avs_result: { code: response[:avs_response_code] },
-          cvv_result: response[:cvv_response_code]
+                     test: test?,
+                     authorization: authorization_from(response, parameters),
+                     avs_result: { code: response[:avs_response_code] },
+                     cvv_result: response[:cvv_response_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -274,10 +274,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters, options)))
 
         Response.new(response['result'] == '0', message_from(response), response,
-          test: @options[:test] || test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response']
+                     test: @options[:test] || test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response['avs_response'] },
+                     cvv_result: response['cvv2_response']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -319,7 +319,6 @@ module ActiveMerchant #:nodoc:
           xml['soap'].Envelope('xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                                'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
                                'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/') do
-
             xml['soap'].Body do
               yield(xml)
             end

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -175,16 +175,16 @@ module ActiveMerchant #:nodoc:
 
         if action == :authorize
           Response.new response['accept'].to_i == 1,
-            response['errortext'],
-            response,
-            test: test?,
-            authorization: response['tid']
+                       response['errortext'],
+                       response,
+                       test: test?,
+                       authorization: response['tid']
         else
           Response.new response['result'] == 'true',
-            messages(response['epay'], response['pbs']),
-            response,
-            test: test?,
-            authorization: params[:transaction]
+                       messages(response['epay'], response['pbs']),
+                       response,
+                       test: test?,
+                       authorization: params[:transaction]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -280,10 +280,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          test: test?,
-          authorization: response['transactionid'],
-          avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse']
+                     test: test?,
+                     authorization: response['transactionid'],
+                     avs_result: { code: response['avsresponse'] },
+                     cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -112,11 +112,11 @@ module ActiveMerchant #:nodoc:
         response = parse(raw_response)
 
         Response.new(success?(response),
-          message_from(response[:ewaytrxnerror]),
-          response,
-          authorization: response[:ewaytrxnnumber],
-          test: test?
-        )
+                     message_from(response[:ewaytrxnerror]),
+                     response,
+                     authorization: response[:ewaytrxnnumber],
+                     test: test?
+                    )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -223,8 +223,8 @@ module ActiveMerchant #:nodoc:
         response = parse(raw)
 
         EwayResponse.new(response[:success], response[:message], response,
-          test: test?,
-          authorization: response[:auth_code]
+                         test: test?,
+                         authorization: response[:auth_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -159,10 +159,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, build_request(action, request), POST_HEADERS))
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2]
+                     test: test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response[:avs] },
+                     cvv_result: response[:cvv2]
         )
       rescue ResponseError => e
         case e.response.code

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -122,10 +122,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          test: test?,
-          authorization: response['transactionid'],
-          avs_result: {code: response['avsresponse']},
-          cvv_result: response['cvvresponse']
+                     test: test?,
+                     authorization: response['transactionid'],
+                     avs_result: {code: response['avsresponse']},
+                     cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -255,7 +255,7 @@ module ActiveMerchant #:nodoc:
             (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
           end
 
-        xml.tag! 'Ecommerce_Flag', eci.to_s =~ /^[0-9]+$/ ? eci.to_s.rjust(2, '0') : eci
+        xml.tag! 'Ecommerce_Flag', /^[0-9]+$/.match?(eci.to_s) ? eci.to_s.rjust(2, '0') : eci
       end
 
       def add_credit_card_verification_strings(xml, credit_card, options)
@@ -354,11 +354,11 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
-          avs_result: {code: response[:avs]},
-          cvv_result: response[:cvv2],
-          error_code: standard_error_code(response)
+                     test: test?,
+                     authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
+                     avs_result: {code: response[:avs]},
+                     cvv_result: response[:cvv2],
+                     error_code: standard_error_code(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -229,7 +229,7 @@ module ActiveMerchant #:nodoc:
                 (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
               end
 
-        xml.tag! 'Ecommerce_Flag', eci.to_s =~ /^[0-9]+$/ ? eci.to_s.rjust(2, '0') : eci
+        xml.tag! 'Ecommerce_Flag', /^[0-9]+$/.match?(eci.to_s) ? eci.to_s.rjust(2, '0') : eci
       end
 
       def add_credit_card_verification_strings(xml, credit_card, options)
@@ -361,11 +361,11 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
-          avs_result: {code: response[:avs]},
-          cvv_result: response[:cvv2],
-          error_code: standard_error_code(response)
+                     test: test?,
+                     authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
+                     avs_result: {code: response[:avs]},
+                     cvv_result: response[:cvv2],
+                     error_code: standard_error_code(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -220,10 +220,10 @@ module ActiveMerchant #:nodoc:
         success = success?(response)
 
         Response.new(success,
-          success ? 'Approved' : "Declined (Reason: #{response[:reason_code]} - #{response[:error_msg]} - #{response[:sys_err_msg]})",
-          response,
-          test: test?,
-          authorization: response[:order_id])
+                     success ? 'Approved' : "Declined (Reason: #{response[:reason_code]} - #{response[:error_msg]} - #{response[:sys_err_msg]})",
+                     response,
+                     test: test?,
+                     authorization: response[:order_id])
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, parameters)
         response = parse(ssl_post(url(action), post_data(action, parameters),
-          { 'Content-Type' => 'application/soap+xml; charset=utf-8'}))
+                                  { 'Content-Type' => 'application/soap+xml; charset=utf-8'}))
 
         Response.new(
           success_from(response),

--- a/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       def redirect_url_for(token, options = {})
         options = {review: true}.update(options)
-        url  = "#{redirect_url}?token=#{token}"
+        url = "#{redirect_url}?token=#{token}"
         url += '&useraction=commit' unless options[:review]
         url
       end

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -173,10 +173,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(response['response'] == '1', message_from(response), response,
-          authorization: response['transactionid'],
-          test: test?,
-          cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] }
+                     authorization: response['transactionid'],
+                     test: test?,
+                     cvv_result: response['cvvresponse'],
+                     avs_result: { code: response['avsresponse'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/instapay.rb
+++ b/lib/active_merchant/billing/gateways/instapay.rb
@@ -141,9 +141,9 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
 
         Response.new(response[:success], response[:message], response,
-          authorization: response[:transaction_id],
-          avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result]
+                     authorization: response[:transaction_id],
+                     avs_result: { code: response[:avs_result] },
+                     cvv_result: response[:cvv_result]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -377,21 +377,21 @@ module ActiveMerchant #:nodoc:
       def commit(request, options)
         requires!(options, :action)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request,
-          {'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
-           'Content-Type' => 'text/xml; charset=utf-8' }))
+                                  {'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
+                                   'Content-Type' => 'text/xml; charset=utf-8' }))
 
         success = response[:transaction_result][:status_code] == '0'
         message = response[:transaction_result][:message]
         authorization = success ? [options[:order_id], response[:transaction_output_data][:cross_reference], response[:transaction_output_data][:auth_code]].compact.join(';') : nil
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: authorization,
-          avs_result: {
-            street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
-            postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ],
-          },
-          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: {
+                       street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
+                       postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ],
+                     },
+                     cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -388,10 +388,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(payload), 'Content-Type' => 'text/xml'))
 
         Response.new(successful?(response), response[:error_message], response,
-          test: test?,
-          authorization: response[:xid],
-          avs_result: { code: response[:avs_response] },
-          cvv_result: response[:cvv_response])
+                     test: test?,
+                     authorization: response[:xid],
+                     avs_result: { code: response[:avs_response] },
+                     cvv_result: response[:cvv_response])
       end
 
       def post_data(payload)

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -286,8 +286,8 @@ module ActiveMerchant #:nodoc:
         response =
           begin
             parse(ssl_post(url, request, headers(request)))
-          rescue StandardError => error
-            parse(error.response.body)
+          rescue StandardError => e
+            parse(e.response.body)
           end
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -285,13 +285,13 @@ module ActiveMerchant #:nodoc:
 
         success = success?(response)
         Response.new(success,
-          success ? 'APPROVED' : message_from(response),
-          response,
-          test: test?,
-          authorization: authorization_from(response, money, token),
-          avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2]
-        )
+                     success ? 'APPROVED' : message_from(response),
+                     response,
+                     test: test?,
+                     authorization: authorization_from(response, money, token),
+                     avs_result: { code: response[:avs] },
+                     cvv_result: response[:cvv2]
+                    )
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -296,14 +296,14 @@ module ActiveMerchant #:nodoc:
 
         success = success?(response)
         Response.new(success,
-          success ? 'APPROVED' : message_from(response),
-          response,
-          test: test?,
-          authorization: authorization_from(response, money, token),
-          avs_result: AVSResult.new(code: response[:avs]),
-          cvv_result: CVVResult.new(response[:cvv2]),
-          error_code: success ? nil : error_code_from(response)
-        )
+                     success ? 'APPROVED' : message_from(response),
+                     response,
+                     test: test?,
+                     authorization: authorization_from(response, money, token),
+                     avs_result: AVSResult.new(code: response[:avs]),
+                     cvv_result: CVVResult.new(response[:cvv2]),
+                     error_code: success ? nil : error_code_from(response)
+                    )
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -264,10 +264,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(money, creditcard, options)))
 
         Response.new(successful?(response), response[:message], response,
-          test: test?,
-          authorization: response[:ordernum],
-          avs_result: { code: response[:avs].to_s[2, 1] },
-          cvv_result: response[:avs].to_s[3, 1]
+                     test: test?,
+                     authorization: response[:ordernum],
+                     avs_result: { code: response[:avs].to_s[2, 1] },
+                     cvv_result: response[:avs].to_s[3, 1]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -166,10 +166,10 @@ module ActiveMerchant #:nodoc:
           end
 
         Response.new(response['error_code'] == '000', message_from(response), response,
-          authorization: response['transaction_id'],
-          test: test?,
-          cvv_result: response['cvv2_result'],
-          avs_result: { code: response['avs_result'] }
+                     authorization: response['transaction_id'],
+                     test: test?,
+                     cvv_result: response['cvv2_result'],
+                     avs_result: { code: response['avs_result'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -266,7 +266,7 @@ module ActiveMerchant #:nodoc:
 
         document = REXML::Document.new(http_response.body)
 
-        node     = REXML::XPath.first(document, '//soap:Fault')
+        node = REXML::XPath.first(document, '//soap:Fault')
 
         node.elements.each do |element|
           response[element.name] = element.text
@@ -291,8 +291,8 @@ module ActiveMerchant #:nodoc:
       def commit(action, request, v4 = false)
         begin
           data = ssl_post(url(v4), request,
-            'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action, v4)
+                          'Content-Type' => 'text/xml; charset=utf-8',
+                          'SOAPAction'   => soap_action(action, v4)
           )
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
@@ -300,10 +300,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(response[:success], response[:message], response,
-          test: test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response['AVSResponse'] },
-          cvv_result: response['CVResponse']
+                     test: test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response['AVSResponse'] },
+                     cvv_result: response['CVResponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -262,8 +262,8 @@ module ActiveMerchant #:nodoc:
       def commit(action, request)
         begin
           data = ssl_post(url, request,
-            'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action)
+                          'Content-Type' => 'text/xml; charset=utf-8',
+                          'SOAPAction'   => soap_action(action)
           )
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
@@ -271,10 +271,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(response[:success], response[:message], response,
-          test: test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response['AvsResponse'] },
-          cvv_result: response['CvResponse']
+                     test: test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response['AvsResponse'] },
+                     cvv_result: response['CvResponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -303,11 +303,11 @@ module ActiveMerchant #:nodoc:
         message = success ? 'Success' : message_from(response)
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result],
-          error_code: success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]])
+                     test: test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response[:avs_result] },
+                     cvv_result: response[:cvv_result],
+                     error_code: success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -176,11 +176,11 @@ module ActiveMerchant #:nodoc:
         test_mode = test? || message =~ /TESTMODE/
 
         Response.new(success?(response), message, response,
-          test: test_mode,
-          authorization: response[:transaction_id],
-          fraud_review: fraud_review?(response),
-          avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code]
+                     test: test_mode,
+                     authorization: response[:transaction_id],
+                     fraud_review: fraud_review?(response),
+                     avs_result: { code: response[:avs_result_code] },
+                     cvv_result: response[:card_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -282,11 +282,11 @@ module ActiveMerchant #:nodoc:
         cvv_result_code = 'P' if cvv_result_code == 'Unsupported'
 
         Response.new(success?(response), response[:Message], response,
-          test: test?,
-          authorization: response[:TransactionNo],
-          fraud_review: fraud_review?(response),
-          avs_result: { code: avs_response_code },
-          cvv_result: cvv_result_code
+                     test: test?,
+                     authorization: response[:TransactionNo],
+                     fraud_review: fraud_review?(response),
+                     avs_result: { code: avs_response_code },
+                     cvv_result: cvv_result_code
         )
       end
 

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -114,10 +114,9 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
         xml.tag! 'env:Envelope',
-          { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-            'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/',
-            'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' } do
-
+                 { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+                   'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/',
+                   'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' } do
           xml.tag! 'env:Body' do
             xml.tag! action, { 'xmlns' => xmlns(action) } do
               xml.tag! 'clientId', @options[:login]
@@ -147,15 +146,15 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, params)
         data = ssl_post(url(action), build_request(action, params),
-          { 'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction' => "#{xmlns(action)}#{action}" }
+                        { 'Content-Type' => 'text/xml; charset=utf-8',
+                          'SOAPAction' => "#{xmlns(action)}#{action}" }
         )
 
         response = parse(action, data)
         Response.new(successful?(action, response), message_from(action, response), response,
-          test: test?,
-          authorization: authorization_from(action, response),
-          avs_result: { code: response[:avs_code] }
+                     test: test?,
+                     authorization: authorization_from(action, response),
+                     avs_result: { code: response[:avs_code] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -114,10 +114,10 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          test: test?,
-          authorization: response['transactionid'],
-          avs_result: {code: response['avsresponse']},
-          cvv_result: response['cvvresponse']
+                     test: test?,
+                     authorization: response['transactionid'],
+                     avs_result: {code: response['avsresponse']},
+                     cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -234,16 +234,16 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
         Response.new(success?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization_from(action, response)
+                     test: test?,
+                     authorization: authorization_from(action, response)
         )
       end
 
       def commit_periodic(action, request)
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, build_periodic_request(action, request)))
         Response.new(success?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization_from(action, response)
+                     test: test?,
+                     authorization: authorization_from(action, response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -145,7 +145,7 @@ module ActiveMerchant
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
         Response.new(response['status'] == 'approved', message_from(response), response,
-          authorization: authorization_from(response, action)
+                     authorization: authorization_from(response, action)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
 
         success = false
         authorization = (raw['TransactionId'] || parameters[:transactionId])
-        if raw[:container] =~ /Exception|Error/
+        if /Exception|Error/.match?(raw[:container])
           message = (raw['Message'] || raw['Error']['Message'])
         elsif raw['Error'] && !raw['Error'].empty?
           message = (raw['Error']['ResponseText'] || raw['Error']['ResponseCode'])

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -222,7 +222,7 @@ module ActiveMerchant #:nodoc:
 
       def get_url(uri)
         url = (test? ? test_url : live_url)
-        if uri =~ /^customervault/
+        if /^customervault/.match?(uri)
           "#{url}#{uri}"
         else
           "#{url}cardpayments/v1/accounts/#{@options[:account_number]}/#{uri}"

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -194,10 +194,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(success?(response), message_from(response), response,
-          test: test_response?(response),
-          authorization: response[:trans_id],
-          avs_result: { code: response[:avs_code]},
-          cvv_result: response[:cvv2_code]
+                     test: test_response?(response),
+                     authorization: response[:trans_id],
+                     avs_result: { code: response[:avs_code]},
+                     cvv_result: response[:cvv2_code]
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code =~ /^[67]\d\d$/

--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -201,10 +201,10 @@ module ActiveMerchant #:nodoc:
         authorization = authorization_from(success, parameters, raw)
 
         Response.new(success, raw['responsetext'], raw,
-          test: test?,
-          authorization: authorization,
-          avs_result: { code: raw['avsresponse']},
-          cvv_result: raw['cvvresponse']
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: { code: raw['avsresponse']},
+                     cvv_result: raw['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -185,11 +185,11 @@ module ActiveMerchant #:nodoc:
         success = !error?(response)
 
         Response.new(success,
-          (success ? response['error_code'] : response['description']),
-          response,
-          test: test?,
-          authorization: response['id']
-        )
+                     (success ? response['error_code'] : response['description']),
+                     response,
+                     test: test?,
+                     authorization: response['id']
+                    )
       end
 
       def http_request(method, resource, parameters={}, options={})

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
         # debit
         options[:registrationId] = payment if payment.is_a?(String)
         execute_dbpa(options[:risk_workflow] ? 'PA.CP' : 'DB',
-          money, payment, options)
+                     money, payment, options)
       end
 
       def authorize(money, payment, options={})
@@ -357,7 +357,7 @@ module ActiveMerchant #:nodoc:
 
         success_regex = /^(000\.000\.|000\.100\.1|000\.[36])/
 
-        if success_regex =~ response['result']['code']
+        if success_regex&.match?(response['result']['code'])
           true
         else
           false

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -122,10 +122,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, "txnMode=#{action}&txnRequest=#{txnRequest}"))
 
         Response.new(successful?(response), message_from(response), hash_from_xml(response),
-          test: test?,
-          authorization: authorization_from(response),
-          avs_result: { code: avs_result_from(response) },
-          cvv_result: cvv_result_from(response)
+                     test: test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: avs_result_from(response) },
+                     cvv_result: cvv_result_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -621,12 +621,12 @@ module ActiveMerchant #:nodoc:
           end
 
         Response.new(success?(response, message_type), message_from(response), response,
-          {
-            authorization: authorization_string(response[:tx_ref_num], response[:order_id]),
-            test: self.test?,
-            avs_result: OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
-            cvv_result: OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
-          }
+                     {
+                       authorization: authorization_string(response[:tx_ref_num], response[:order_id]),
+                       test: self.test?,
+                       avs_result: OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
+                       cvv_result: OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
+                     }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -122,14 +122,14 @@ module ActiveMerchant #:nodoc:
         test_mode = test? || message =~ /TESTMODE/
 
         Response.new(success?(response), message, response,
-          test: test_mode,
-          authorization: response['TrackingNumber'],
-          fraud_review: fraud_review?(response),
-          avs_result: {
-            postal_match: AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
-            street_match: AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
-          },
-          cvv_result: CVV2_CODES[response['CVV2ResponseCode']]
+                     test: test_mode,
+                     authorization: response['TrackingNumber'],
+                     fraud_review: fraud_review?(response),
+                     avs_result: {
+                       postal_match: AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
+                       street_match: AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
+                     },
+                     cvv_result: CVV2_CODES[response['CVV2ResponseCode']]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -253,9 +253,9 @@ module ActiveMerchant #:nodoc:
         xml   = REXML::Document.new(body)
 
         response_action = action.gsub(/tx/, 'rx')
-        root  = REXML::XPath.first(xml.root, response_action)
+        root = REXML::XPath.first(xml.root, response_action)
         # we might have gotten an error
-        root  = REXML::XPath.first(xml.root, 'errorrx') if root.nil?
+        root = REXML::XPath.first(xml.root, 'errorrx') if root.nil?
         root.attributes.each do |name, value|
           hash[name.to_sym] = value
         end
@@ -265,8 +265,8 @@ module ActiveMerchant #:nodoc:
       def commit(action, request, authorization = nil)
         response = parse(action, ssl_post(self.live_url, request))
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization || response[:tid]
+                     test: test?,
+                     authorization: authorization || response[:tid]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -183,14 +183,14 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(success,
-          response_message(response),
-          response,
-          test: test?,
-          avs_result: {code: response['AVS_RESULT_CODE']},
-          cvv_result: response['VERIFICATION_RESULT_CODE'],
-          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]),
-          authorization: response['TRANSACTION_ID']
-        )
+                     response_message(response),
+                     response,
+                     test: test?,
+                     avs_result: {code: response['AVS_RESULT_CODE']},
+                     cvv_result: response['VERIFICATION_RESULT_CODE'],
+                     error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]),
+                     authorization: response['TRANSACTION_ID']
+                    )
       end
 
       def response_error(raw_response)

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -338,8 +338,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(action, parameters)))
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: response[:transaction_id] || parameters[:transaction_id]
+                     test: test?,
+                     authorization: response[:transaction_id] || parameters[:transaction_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -69,8 +69,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
         Response.new(successful?(response), message_from(response), response,
-          test: test_response?(response),
-          authorization: authorization_from(response)
+                     test: test_response?(response),
+                     authorization: authorization_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -386,11 +386,11 @@ module ActiveMerchant #:nodoc:
         }
         response = parse(ssl_post(url, request, headers))
         Response.new(success?(response),
-          message_from(response),
-          response,
-          test: test?,
-          authorization: build_authorization(response)
-        )
+                     message_from(response),
+                     response,
+                     test: test?,
+                     authorization: build_authorization(response)
+                    )
       end
 
       def build_authorization(response)

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
           node.xpath('.//*').each { |e| parse_element(payment_result_response, e) }
         when node.xpath('.//*').to_a.any?
           node.xpath('.//*').each { |e| parse_element(response, e) }
-        when node_name.to_s =~ /amt$/
+        when /amt$/.match?(node_name.to_s)
           # *Amt elements don't put the value in the #text - instead they use a Currency attribute
           response[node_name] = node.attributes['Currency'].to_s
         when node_name == :ext_data

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -302,8 +302,8 @@ module ActiveMerchant #:nodoc:
 
         # Return a response
         PaymentExpressResponse.new(response[:success] == APPROVED, message_from(response), response,
-          test: response[:test_mode] == '1',
-          authorization: authorization_from(action, response)
+                                   test: response[:test_mode] == '1',
+                                   authorization: authorization_from(action, response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -116,11 +116,11 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
         test_mode = (test? || message =~ /TESTMODE/)
         Response.new(success?(response), message, response,
-          test: test_mode,
-          authorization: response['transactionid'],
-          fraud_review: fraud_review?(response),
-          avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse']
+                     test: test_mode,
+                     authorization: response['transactionid'],
+                     fraud_review: fraud_review?(response),
+                     avs_result: { code: response['avsresponse'] },
+                     cvv_result: response['cvvresponse']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -178,8 +178,8 @@ module ActiveMerchant #:nodoc:
         message  = message_from(response)
 
         PaystationResponse.new(success?(response), message, response,
-          test: (response[:tm]&.casecmp('t')&.zero?),
-          authorization: response[:paystation_transaction_id]
+                               test: response[:tm]&.casecmp('t')&.zero?,
+                               authorization: response[:paystation_transaction_id]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -193,8 +193,8 @@ module ActiveMerchant
         success = (params[:summary_code] ? (params[:summary_code] == '0') : (params[:response_code] == '00'))
 
         Response.new(success, message, params,
-          test: (@options[:merchant].to_s == 'TEST'),
-          authorization: post[:order_number]
+                     test: (@options[:merchant].to_s == 'TEST'),
+                     authorization: post[:order_number]
         )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
             name: creditcard.name
           )
         elsif creditcard.kind_of?(String)
-          if creditcard =~ /^card_/
+          if /^card_/.match?(creditcard)
             post[:card_token] = get_card_token(creditcard)
           else
             post[:customer_token] = creditcard

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -179,10 +179,10 @@ module ActiveMerchant
         message = success ? 'Success' : message_from(response)
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: response[:orderid],
-          avs_result: { code: response[:avs_code] },
-          cvv_result: response[:cvvresp]
+                     test: test?,
+                     authorization: response[:orderid],
+                     avs_result: { code: response[:avs_code] },
+                     cvv_result: response[:cvvresp]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -103,10 +103,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(money, creditcard, options)))
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: build_authorization(response),
-          avs_result: { code: response[:avsresult] },
-          cvv_result: response[:cardidresult]
+                     test: test?,
+                     authorization: build_authorization(response),
+                     avs_result: { code: response[:avsresult] },
+                     cvv_result: response[:cardidresult]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -260,10 +260,10 @@ module ActiveMerchant
         response = parse(ssl_post(self.live_url, post_data(request)))
 
         Response.new(response[:ResponseCode] == APPROVED, response[:Message], response,
-          test: test?,
-          authorization: response[:CrossReference],
-          cvv_result: CVV_CODE[response[:AVSCV2Check]],
-          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] }
+                     test: test?,
+                     authorization: response[:CrossReference],
+                     cvv_result: CVV_CODE[response[:AVSCV2Check]],
+                     avs_result: { code: AVS_CODE[response[:AVSCV2Check]] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -143,11 +143,11 @@ module ActiveMerchant #:nodoc:
         message = (response[:status_message] || '').strip
 
         Response.new(success?(response), message, response,
-          test: test?,
-          authorization: response[:credit_card_trans_id],
-          fraud_review: fraud_review?(response),
-          avs_result: { code: avs_result(response) },
-          cvv_result: cvv_result(response)
+                     test: test?,
+                     authorization: response[:credit_card_trans_id],
+                     fraud_review: fraud_review?(response),
+                     avs_result: { code: avs_result(response) },
+                     cvv_result: cvv_result(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -216,10 +216,10 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: authorization,
-          avs_result: { code: response[:AVSResponseCode] },
-          cvv_result: response[:CVV2ResponseCode]
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: { code: response[:AVSResponseCode] },
+                     cvv_result: response[:CVV2ResponseCode]
         )
       end
 
@@ -253,7 +253,7 @@ module ActiveMerchant #:nodoc:
         if node.has_elements?
           node.elements.each { |e| parse_element(reply, e) }
         else
-          if node.parent.name =~ /item/
+          if /item/.match?(node.parent.name)
             parent = node.parent.name + (node.parent.attributes['id'] ? '_' + node.parent.attributes['id'] : '')
             reply[(parent + '_' + node.name).to_sym] = node.text
           else

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -154,8 +154,8 @@ module ActiveMerchant
         end
 
         Response.new(success, message_from(success, response), response,
-          test: test?,
-          authorization: authorization_from(response)
+                     test: test?,
+                     authorization: authorization_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -165,8 +165,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: response[:transaction]
+                     test: test?,
+                     authorization: response[:transaction]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -310,7 +310,7 @@ module ActiveMerchant
 
         version = three_d_secure.fetch(:version, '')
         xml.tag! 'mpi' do
-          if version =~ /^2/
+          if /^2/.match?(version)
             xml.tag! 'authentication_value', three_d_secure[:cavv]
             xml.tag! 'ds_trans_id', three_d_secure[:ds_transaction_id]
           else

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -565,7 +565,7 @@ module ActiveMerchant #:nodoc:
 
       def clean_order_id(order_id)
         cleansed = order_id.gsub(/[^\da-zA-Z]/, '')
-        if cleansed =~ /^\d{4}/
+        if /^\d{4}/.match?(cleansed)
           cleansed[0..11]
         else
           '%04d%s' % [rand(0..9999), cleansed[0...8]]

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -261,10 +261,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, post_data(action, params)), source)
 
         Response.new(success?(response), response[:message], response,
-          test: test?,
-          authorization: authorization_from(response, source),
-          avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result]
+                     test: test?,
+                     authorization: authorization_from(response, source),
+                     avs_result: { code: response[:avs_result] },
+                     cvv_result: response[:cvv_result]
         )
       end
 
@@ -382,7 +382,7 @@ module ActiveMerchant #:nodoc:
           end
 
           Response.new(success, message, response,
-            authorization: response[:guid]
+                       authorization: response[:guid]
           )
         end
 

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -347,13 +347,13 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url_for(action), post_data(action, parameters)))
 
         Response.new(response['Status'] == APPROVED, message_from(response), response,
-          test: test?,
-          authorization: authorization_from(response, parameters, action),
-          avs_result: {
-            street_match: AVS_CODE[response['AddressResult']],
-            postal_match: AVS_CODE[response['PostCodeResult']],
-          },
-          cvv_result: CVV_CODE[response['CV2Result']]
+                     test: test?,
+                     authorization: authorization_from(response, parameters, action),
+                     avs_result: {
+                       street_match: AVS_CODE[response['AddressResult']],
+                       postal_match: AVS_CODE[response['PostCodeResult']],
+                     },
+                     cvv_result: CVV_CODE[response['CV2Result']]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/sallie_mae.rb
+++ b/lib/active_merchant/billing/gateways/sallie_mae.rb
@@ -121,8 +121,8 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(self.live_url, parameters.to_post_data) || '')
         Response.new(successful?(response), message_from(response), response,
-          test: test?,
-          authorization: response['refcode']
+                     test: test?,
+                     authorization: response['refcode']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -80,10 +80,10 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
 
         Response.new(success?(response), message_from(response), response,
-          test: test?,
-          authorization: build_authorization(response),
-          avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code_response_code]
+                     test: test?,
+                     authorization: build_authorization(response),
+                     avs_result: { code: response[:avs_result_code] },
+                     cvv_result: response[:card_code_response_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -57,11 +57,11 @@ module ActiveMerchant #:nodoc:
         message = message_from(response)
 
         Response.new(success?(response), message, response,
-          test: test?,
-          authorization: response[:transaction_id],
-          fraud_review: fraud_review?(response),
-          avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code]
+                     test: test?,
+                     authorization: response[:transaction_id],
+                     fraud_review: fraud_review?(response),
+                     avs_result: { code: response[:avs_result_code] },
+                     cvv_result: response[:card_code]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -184,8 +184,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
         Response.new(success?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization_from(response)
+                     test: test?,
+                     authorization: authorization_from(response)
         )
       end
 
@@ -241,8 +241,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, my_request))
 
         Response.new(success?(response), message_from(response), response,
-          test: test?,
-          authorization: authorization_from(response)
+                     test: test?,
+                     authorization: authorization_from(response)
         )
       end
 

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -85,8 +85,8 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(action, post)))
 
         Response.new(response[:result_code] == 1, message_from(response), response,
-          test: test?,
-          authorization: response[:merchant_transaction_reference]
+                     test: test?,
+                     authorization: response[:merchant_transaction_reference]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -186,12 +186,12 @@ module ActiveMerchant #:nodoc:
         success = !response.key?('error')
 
         Response.new(success,
-          (success ? 'Transaction approved' : response['error']['message']),
-          response,
-          test: test?,
-          authorization: (success ? response['id'] : response['error']['charge']),
-          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']])
-        )
+                     (success ? 'Transaction approved' : response['error']['message']),
+                     response,
+                     test: test?,
+                     authorization: (success ? response['id'] : response['error']['charge']),
+                     error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']])
+                    )
       end
 
       def headers(options = {})
@@ -259,7 +259,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def test?
-        (@options[:secret_key]&.include?('_test_'))
+        @options[:secret_key]&.include?('_test_')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -264,10 +264,10 @@ module ActiveMerchant #:nodoc:
 
         # Pass along the original transaction id in the case an update transaction
         Response.new(response[:success], message_from(response, action), response,
-          test: test?,
-          authorization: response[:szTransactionFileName] || parameters[:szTransactionId],
-          avs_result: { code: response[:szAVSResponseCode] },
-          cvv_result: response[:szCVV2ResponseCode]
+                     test: test?,
+                     authorization: response[:szTransactionFileName] || parameters[:szTransactionId],
+                     avs_result: { code: response[:szAVSResponseCode] },
+                     cvv_result: response[:szCVV2ResponseCode]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -227,10 +227,10 @@ module ActiveMerchant #:nodoc:
         parameters[:amount] = localized_amount(money, parameters[:currency] || default_currency) if money
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
         Response.new(response['response'] == '1', message_from(response), response,
-          authorization: (response['transactionid'] || response['customer_vault_id']),
-          test: test?,
-          cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] }
+                     authorization: (response['transactionid'] || response['customer_vault_id']),
+                     test: test?,
+                     cvv_result: response['cvvresponse'],
+                     avs_result: { code: response['avsresponse'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
       def parse(response, action)
         result = {}
         document = REXML::Document.new(response)
-        response_element = document.root.get_elements("//[@xsi:type='tns:#{action}Response']").first
+        response_element = document.root.get_elements("//*[@xsi:type='tns:#{action}Response']").first
         response_element.elements.each do |element|
           result[element.name.underscore] = element.text
         end
@@ -162,10 +162,10 @@ module ActiveMerchant #:nodoc:
         response_string = ssl_post(test? ? self.test_url : self.live_url, soap, headers)
         response = parse(response_string, soap_action)
         return Response.new(response['errorcode'] == '000',
-          response['errormessage'],
-          response,
-          test: test?,
-          authorization: response['transaction_id'])
+                            response['errormessage'],
+                            response,
+                            test: test?,
+                            authorization: response['transaction_id'])
       end
 
       def build_soap(request)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -654,15 +654,15 @@ module ActiveMerchant #:nodoc:
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
 
         Response.new(success,
-          message_from(success, response),
-          response,
-          test: response_is_test?(response),
-          authorization: authorization_from(success, url, method, response),
-          avs_result: { code: avs_code },
-          cvv_result: cvc_code,
-          emv_authorization: emv_authorization_from_response(response),
-          error_code: success ? nil : error_code_from(response)
-        )
+                     message_from(success, response),
+                     response,
+                     test: response_is_test?(response),
+                     authorization: authorization_from(success, url, method, response),
+                     avs_result: { code: avs_code },
+                     cvv_result: cvc_code,
+                     emv_authorization: emv_authorization_from_response(response),
+                     error_code: success ? nil : error_code_from(response)
+                    )
       end
 
       def authorization_from(success, url, method, response)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -121,7 +121,7 @@ module ActiveMerchant #:nodoc:
 
           if charge_id.nil?
             error_message = "No associated charge for #{intent['id']}"
-            error_message <<  "; payment_intent has a status of #{intent['status']}" if intent.try(:[], 'status') && intent.try(:[], 'status') != 'succeeded'
+            error_message << "; payment_intent has a status of #{intent['status']}" if intent.try(:[], 'status') && intent.try(:[], 'status') != 'succeeded'
             return Response.new(false, error_message, intent)
           end
         else

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -105,12 +105,12 @@ module ActiveMerchant #:nodoc:
               success = (result == 'accepted' || (test? && result == 'test-accepted'))
 
               Response.new(success,
-                success ?
-                TRANSACTION_APPROVED_MSG :
-                TRANSACTION_DECLINED_MSG,
-                response,
-                test: test?
-              )
+                           success ?
+                           TRANSACTION_APPROVED_MSG :
+                           TRANSACTION_DECLINED_MSG,
+                           response,
+                           test: test?
+                          )
             else
               build_error_response(message, response)
             end

--- a/lib/active_merchant/billing/gateways/transact_pro.rb
+++ b/lib/active_merchant/billing/gateways/transact_pro.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
       def add_payment_cc(post, credit_card)
         post[:cc] = credit_card.number
         post[:cvv] = credit_card.verification_value if credit_card.verification_value?
-        year  = sprintf('%.4i', credit_card.year)
+        year = sprintf('%.4i', credit_card.year)
         month = sprintf('%.2i', credit_card.month)
         post[:expire] = "#{month}/#{year[2..3]}"
       end
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        if body =~ /^ID:/
+        if /^ID:/.match?(body)
           body.split('~').reduce(Hash.new) { |h, v|
             m = v.match('(.*?):(.*)')
             h.merge!(m[1].underscore.to_sym => m[2])
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def split_authorization(authorization)
-        if authorization =~ /|/
+        if /|/.match?(authorization)
           identifier, amount = authorization.split('|')
           [identifier, amount.to_i]
         else

--- a/lib/active_merchant/billing/gateways/trexle.rb
+++ b/lib/active_merchant/billing/gateways/trexle.rb
@@ -137,7 +137,7 @@ module ActiveMerchant #:nodoc:
             name: creditcard.name
           )
         elsif creditcard.kind_of?(String)
-          if creditcard =~ /^token_/
+          if /^token_/.match?(creditcard)
             post[:card_token] = creditcard
           else
             post[:customer_token] = creditcard

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -444,10 +444,10 @@ module ActiveMerchant #:nodoc:
         success = SUCCESS_TYPES.include?(data['status'])
         message = message_from(data)
         Response.new(success, message, data,
-          test: test?,
-          authorization: authorization_from(action, data),
-          cvv_result: data['cvv'],
-          avs_result: { code: data['avs'] }
+                     test: test?,
+                     authorization: authorization_from(action, data),
+                     cvv_result: data['cvv'],
+                     avs_result: { code: data['avs'] }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -1033,12 +1033,12 @@ module ActiveMerchant #:nodoc:
         soap = Builder::XmlMarkup.new
         soap.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         soap.tag! 'SOAP-ENV:Envelope',
-          'xmlns:SOAP-ENV' => 'http://schemas.xmlsoap.org/soap/envelope/',
-          'xmlns:ns1' => 'urn:usaepay',
-          'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-          'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-          'xmlns:SOAP-ENC' => 'http://schemas.xmlsoap.org/soap/encoding/',
-          'SOAP-ENV:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/' do
+                  'xmlns:SOAP-ENV' => 'http://schemas.xmlsoap.org/soap/envelope/',
+                  'xmlns:ns1' => 'urn:usaepay',
+                  'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+                  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                  'xmlns:SOAP-ENC' => 'http://schemas.xmlsoap.org/soap/encoding/',
+                  'SOAP-ENV:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/' do
           soap.tag! 'SOAP-ENV:Body' do
             send("build_#{action}", soap, options)
           end
@@ -1336,7 +1336,7 @@ module ActiveMerchant #:nodoc:
         when payment_method[:method].kind_of?(ActiveMerchant::Billing::CreditCard)
           build_tag soap, :string, 'CardNumber', payment_method[:method].number
           build_tag soap, :string, 'CardExpiration',
-            "#{"%02d" % payment_method[:method].month}#{payment_method[:method].year.to_s[-2..-1]}"
+                    "#{"%02d" % payment_method[:method].month}#{payment_method[:method].year.to_s[-2..-1]}"
           if options[:billing_address]
             build_tag soap, :string, 'AvsStreet', options[:billing_address][:address1]
             build_tag soap, :string, 'AvsZip', options[:billing_address][:zip]
@@ -1520,8 +1520,8 @@ module ActiveMerchant #:nodoc:
 
         begin
           soap = ssl_post(url, request, 'Content-Type' => 'text/xml')
-        rescue ActiveMerchant::ResponseError => error
-          soap = error.response.body
+        rescue ActiveMerchant::ResponseError => e
+          soap = e.response.body
         end
 
         build_response(action, soap)

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -320,11 +320,11 @@ module ActiveMerchant #:nodoc:
         error_code = nil
         error_code = (STANDARD_ERROR_CODE_MAPPING[response[:error_code]] || STANDARD_ERROR_CODE[:processing_error]) unless approved
         Response.new(approved, message_from(response), response,
-          test: test?,
-          authorization: response[:ref_num],
-          cvv_result: response[:cvv2_result_code],
-          avs_result: { code: response[:avs_result_code] },
-          error_code: error_code
+                     test: test?,
+                     authorization: response[:ref_num],
+                     cvv_result: response[:cvv2_result_code],
+                     avs_result: { code: response[:avs_result_code] },
+                     error_code: error_code
         )
       end
 

--- a/lib/active_merchant/billing/gateways/verifi.rb
+++ b/lib/active_merchant/billing/gateways/verifi.rb
@@ -195,10 +195,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, post_data(trx_type, post)))
 
         Response.new(response[:response].to_i == SUCCESS, message_from(response), response,
-          test: test?,
-          authorization: response[:transactionid],
-          avs_result: { code: response[:avsresponse] },
-          cvv_result: response[:cvvresponse]
+                     test: test?,
+                     authorization: response[:transactionid],
+                     avs_result: { code: response[:avsresponse] },
+                     cvv_result: response[:cvvresponse]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -137,10 +137,10 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters)))
 
         Response.new(response['result'] == APPROVED, message_from(response), response,
-          test: @options[:test] || test?,
-          authorization: authorization_from(response),
-          avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response']
+                     test: @options[:test] || test?,
+                     authorization: authorization_from(response),
+                     avs_result: { code: response['avs_response'] },
+                     cvv_result: response['cvv2_response']
         )
       end
 

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -180,10 +180,10 @@ module ActiveMerchant #:nodoc:
         authorization = response[:GuWID]
 
         Response.new(success, message, response,
-          test: test?,
-          authorization: authorization,
-          avs_result: { code: avs_code(response, options) },
-          cvv_result: response[:CVCResponseCode]
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: { code: avs_code(response, options) },
+                     cvv_result: response[:CVCResponseCode]
         )
       rescue ResponseError => e
         if e.response.code == '401'

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -406,7 +406,7 @@ module ActiveMerchant #:nodoc:
       def add_three_d_secure(three_d_secure, xml)
         xml.info3DSecure do
           xml.threeDSVersion three_d_secure[:version]
-          if three_d_secure[:version] =~ /^2/
+          if /^2/.match?(three_d_secure[:version])
             xml.dsTransactionId three_d_secure[:ds_transaction_id]
           else
             xml.xid three_d_secure[:xid]

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -35,14 +35,14 @@ module ActiveMerchant #:nodoc:
           commit(:post, "orders/#{CGI.escape(authorization)}/capture", {'captureAmount' => money}, options, 'capture')
         else
           Response.new(false,
-            'FAILED',
-            'FAILED',
-            test: test?,
-            authorization: false,
-            avs_result: {},
-            cvv_result: {},
-            error_code: false
-          )
+                       'FAILED',
+                       'FAILED',
+                       test: test?,
+                       authorization: false,
+                       avs_result: {},
+                       cvv_result: {},
+                       error_code: false
+                      )
         end
       end
 
@@ -172,14 +172,14 @@ module ActiveMerchant #:nodoc:
         end
 
         Response.new(success,
-          success ? 'SUCCESS' : response['message'],
-          response,
-          test: test?,
-          authorization: authorization,
-          avs_result: {},
-          cvv_result: {},
-          error_code: success ? nil : response['customCode']
-        )
+                     success ? 'SUCCESS' : response['message'],
+                     response,
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: {},
+                     cvv_result: {},
+                     error_code: success ? nil : response['customCode']
+                    )
       end
 
       def test?

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -73,52 +73,50 @@ module ActiveMerchant
       headers['connection'] ||= 'close'
 
       retry_exceptions(max_retries: max_retries, logger: logger, tag: tag) do
-        begin
-          info "connection_http_method=#{method.to_s.upcase} connection_uri=#{endpoint}", tag
+        info "connection_http_method=#{method.to_s.upcase} connection_uri=#{endpoint}", tag
 
-          result = nil
+        result = nil
 
-          realtime = Benchmark.realtime do
-            http.start unless http.started?
-            @ssl_connection = http.ssl_connection
-            info "connection_ssl_version=#{ssl_connection[:version]} connection_ssl_cipher=#{ssl_connection[:cipher]}", tag
+        realtime = Benchmark.realtime do
+          http.start unless http.started?
+          @ssl_connection = http.ssl_connection
+          info "connection_ssl_version=#{ssl_connection[:version]} connection_ssl_cipher=#{ssl_connection[:cipher]}", tag
 
-            result =
-              case method
-              when :get
-                raise ArgumentError, 'GET requests do not support a request body' if body
+          result =
+            case method
+            when :get
+              raise ArgumentError, 'GET requests do not support a request body' if body
 
-                http.get(endpoint.request_uri, headers)
-              when :post
+              http.get(endpoint.request_uri, headers)
+            when :post
+              debug body
+              http.post(endpoint.request_uri, body, RUBY_184_POST_HEADERS.merge(headers))
+            when :put
+              debug body
+              http.put(endpoint.request_uri, body, headers)
+            when :patch
+              debug body
+              http.patch(endpoint.request_uri, body, headers)
+            when :delete
+              # It's kind of ambiguous whether the RFC allows bodies
+              # for DELETE requests. But Net::HTTP's delete method
+              # very unambiguously does not.
+              if body
                 debug body
-                http.post(endpoint.request_uri, body, RUBY_184_POST_HEADERS.merge(headers))
-              when :put
-                debug body
-                http.put(endpoint.request_uri, body, headers)
-              when :patch
-                debug body
-                http.patch(endpoint.request_uri, body, headers)
-              when :delete
-                # It's kind of ambiguous whether the RFC allows bodies
-                # for DELETE requests. But Net::HTTP's delete method
-                # very unambiguously does not.
-                if body
-                  debug body
-                  req = Net::HTTP::Delete.new(endpoint.request_uri, headers)
-                  req.body = body
-                  http.request(req)
-                else
-                  http.delete(endpoint.request_uri, headers)
-                end
+                req = Net::HTTP::Delete.new(endpoint.request_uri, headers)
+                req.body = body
+                http.request(req)
               else
-                raise ArgumentError, "Unsupported request method #{method.to_s.upcase}"
+                http.delete(endpoint.request_uri, headers)
               end
-          end
-
-          info '--> %d %s (%d %.4fs)' % [result.code, result.message, result.body ? result.body.length : 0, realtime], tag
-          debug result.body
-          result
+            else
+              raise ArgumentError, "Unsupported request method #{method.to_s.upcase}"
+            end
         end
+
+        info '--> %d %s (%d %.4fs)' % [result.code, result.message, result.body ? result.body.length : 0, realtime], tag
+        debug result.body
+        result
       end
     ensure
       info 'connection_request_total_time=%.4fs' % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start], tag

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -21,18 +21,16 @@ module ActiveMerchant
       connection_errors = DEFAULT_CONNECTION_ERRORS.merge(options[:connection_exceptions] || {})
 
       retry_network_exceptions(options) do
-        begin
-          yield
-        rescue Errno::ECONNREFUSED => e
-          raise ActiveMerchant::RetriableConnectionError.new('The remote server refused the connection', e)
-        rescue OpenSSL::X509::CertificateError => e
-          NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
-          raise ActiveMerchant::ClientCertificateError, 'The remote server did not accept the provided SSL certificate'
-        rescue Zlib::BufError
-          raise ActiveMerchant::InvalidResponseError, 'The remote server replied with an invalid response'
-        rescue *connection_errors.keys => e
-          raise ActiveMerchant::ConnectionError.new(derived_error_message(connection_errors, e.class), e)
-        end
+        yield
+      rescue Errno::ECONNREFUSED => e
+        raise ActiveMerchant::RetriableConnectionError.new('The remote server refused the connection', e)
+      rescue OpenSSL::X509::CertificateError => e
+        NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
+        raise ActiveMerchant::ClientCertificateError, 'The remote server did not accept the provided SSL certificate'
+      rescue Zlib::BufError
+        raise ActiveMerchant::InvalidResponseError, 'The remote server replied with an invalid response'
+      rescue *connection_errors.keys => e
+        raise ActiveMerchant::ConnectionError.new(derived_error_message(connection_errors, e.class), e)
       end
     end
 

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -80,9 +80,9 @@ class SSLVerify
     end
 
     return :success
-  rescue OpenSSL::SSL::SSLError => ex
-    return :fail, ex.inspect
-  rescue Net::HTTPBadResponse, Errno::ETIMEDOUT, EOFError, SocketError, Errno::ECONNREFUSED, Timeout::Error => ex
-    return :error, ex.inspect
+  rescue OpenSSL::SSL::SSLError => e
+    return :fail, e.inspect
+  rescue Net::HTTPBadResponse, Errno::ETIMEDOUT, EOFError, SocketError, Errno::ECONNREFUSED, Timeout::Error => e
+    return :error, e.inspect
   end
 end

--- a/lib/support/ssl_version.rb
+++ b/lib/support/ssl_version.rb
@@ -75,12 +75,12 @@ class SSLVersion
     return :success
   rescue Net::HTTPBadResponse
     return :success # version negotiation succeeded
-  rescue OpenSSL::SSL::SSLError => ex
-    return :fail, ex.inspect
-  rescue Interrupt => ex
+  rescue OpenSSL::SSL::SSLError => e
+    return :fail, e.inspect
+  rescue Interrupt => e
     print_summary
-    raise ex
-  rescue StandardError => ex
-    return :error, ex.inspect
+    raise e
+  rescue StandardError => e
+    return :error, e.inspect
   end
 end

--- a/script/generate
+++ b/script/generate
@@ -4,7 +4,7 @@ require 'thor'
 
 require File.expand_path('../../generators/active_merchant_generator', __FILE__)
 
-Dir[File.expand_path('../..', __FILE__) + '/generators/*/*.rb'].each do |generator|
+Dir[File.expand_path('../..', __FILE__) + '/generators/*/*.rb'].sort.each do |generator|
   require generator
 end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -7,69 +7,69 @@ class RemoteAdyenTest < Test::Unit::TestCase
     @amount = 100
 
     @credit_card = credit_card('4111111111111111',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'visa'
-    )
+                               month: 10,
+                               year: 2020,
+                               first_name: 'John',
+                               last_name: 'Smith',
+                               verification_value: '737',
+                               brand: 'visa'
+                              )
 
     @avs_credit_card = credit_card('4400000000000008',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'visa'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'visa'
+                                  )
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'elo'
+                                  )
 
     @three_ds_enrolled_card = credit_card('4917610000000000', month: 10, year: 2020, verification_value: '737', brand: :visa)
 
     @cabal_credit_card = credit_card('6035 2277 1642 7021',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'cabal'
-    )
+                                     month: 10,
+                                     year: 2020,
+                                     first_name: 'John',
+                                     last_name: 'Smith',
+                                     verification_value: '737',
+                                     brand: 'cabal'
+                                    )
 
     @invalid_cabal_credit_card = credit_card('6035 2200 0000 0006',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'cabal'
-    )
+                                             month: 10,
+                                             year: 2020,
+                                             first_name: 'John',
+                                             last_name: 'Smith',
+                                             verification_value: '737',
+                                             brand: 'cabal'
+                                            )
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
-      month: 10,
-      year: 2030,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'unionpay'
-    )
+                                        month: 10,
+                                        year: 2030,
+                                        first_name: 'John',
+                                        last_name: 'Smith',
+                                        verification_value: '737',
+                                        brand: 'unionpay'
+                                       )
 
     @invalid_unionpay_credit_card = credit_card('8171 9999 1234 0000 921',
-      month: 10,
-      year: 2030,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'unionpay'
-    )
+                                                month: 10,
+                                                year: 2030,
+                                                first_name: 'John',
+                                                last_name: 'Smith',
+                                                verification_value: '737',
+                                                brand: 'unionpay'
+                                               )
 
     @declined_card = credit_card('4000300011112220')
 
@@ -84,20 +84,20 @@ class RemoteAdyenTest < Test::Unit::TestCase
     )
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      month: '08',
-      year: '2018',
-      source: :apple_pay,
-      verification_value: nil
-    )
+                                                       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+                                                       month: '08',
+                                                       year: '2018',
+                                                       source: :apple_pay,
+                                                       verification_value: nil
+                                                      )
 
     @google_pay_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      month: '08',
-      year: '2018',
-      source: :google_pay,
-      verification_value: nil
-    )
+                                                        payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+                                                        month: '08',
+                                                        year: '2018',
+                                                        source: :google_pay,
+                                                        verification_value: nil
+                                                       )
 
     @options = {
       reference: '345123',
@@ -271,13 +271,13 @@ class RemoteAdyenTest < Test::Unit::TestCase
   # with rule set in merchant account to skip 3DS for cards of this brand
   def test_successful_authorize_with_3ds_dynamic_rule_broken
     mastercard_threed = credit_card('5212345678901234',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'mastercard'
-    )
+                                    month: 10,
+                                    year: 2020,
+                                    first_name: 'John',
+                                    last_name: 'Smith',
+                                    verification_value: '737',
+                                    brand: 'mastercard'
+                                   )
     assert response = @gateway.authorize(@amount, mastercard_threed, @options.merge(threed_dynamic: true))
     assert response.test?
     refute response.authorization.blank?

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -83,9 +83,9 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
     }.update(options)
 
     ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
-      payment_instrument_name: defaults[:payment_instrument_name],
-      payment_network: defaults[:payment_network],
-      transaction_identifier: defaults[:transaction_identifier]
-    )
+                                                      payment_instrument_name: defaults[:payment_instrument_name],
+                                                      payment_network: defaults[:payment_network],
+                                                      transaction_identifier: defaults[:transaction_identifier]
+                                                     )
   end
 end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -679,9 +679,9 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_authorize_and_capture_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil
+                                                  )
     auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
     assert_equal 'This transaction has been approved', auth.message
@@ -692,9 +692,9 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_refund_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil
+                                                  )
 
     purchase = @gateway.purchase(@amount, credit_card, @options)
     assert_success purchase
@@ -708,9 +708,9 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_credit_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil
+                                                  )
 
     response = @gateway.credit(@amount, credit_card, @options)
     assert_success response
@@ -720,10 +720,10 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_network_tokenization_transcript_scrubbing
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+                                                  )
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -101,9 +101,9 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
     }
 
     @avs_credit_card = credit_card('4400000000000008',
-      month: 8,
-      year: 2018,
-      verification_value: 737)
+                                   month: 8,
+                                   year: 2018,
+                                   verification_value: 737)
 
     @avs_address = @options.clone
     @avs_address.update(billing_address: {
@@ -159,24 +159,24 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_unusual_address
     response = @gateway.purchase(@amount,
-      @credit_card,
-      @options_with_alternate_address)
+                                 @credit_card,
+                                 @options_with_alternate_address)
     assert_success response
     assert_equal '[capture-received]', response.message
   end
 
   def test_successful_purchase_with_house_number_and_street
     response = @gateway.purchase(@amount,
-      @credit_card,
-      @options.merge(street: 'Top Level Drive', house_number: '100'))
+                                 @credit_card,
+                                 @options.merge(street: 'Top Level Drive', house_number: '100'))
     assert_success response
     assert_equal '[capture-received]', response.message
   end
 
   def test_successful_purchase_with_no_address
     response = @gateway.purchase(@amount,
-      @credit_card,
-      @options_with_no_address)
+                                 @credit_card,
+                                 @options_with_no_address)
     assert_success response
     assert_equal '[capture-received]', response.message
   end

--- a/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
+++ b/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
@@ -6,9 +6,9 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def setup
     @gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus))
     @amount = 100
-    @credit_card     = credit_card('4000100011112224', verification_value: '987')
-    @mastercard      = credit_card('5399999999999999', brand: 'mastercard')
-    @declined_card   = credit_card('1111111111111111')
+    @credit_card = credit_card('4000100011112224', verification_value: '987')
+    @mastercard = credit_card('5399999999999999', brand: 'mastercard')
+    @declined_card = credit_card('1111111111111111')
     @credit_card_d3d = credit_card('4000000000000002', verification_value: '111')
     @options = {
       order_id: generate_unique_id[0...30],

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -390,7 +390,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_email
     assert response = @gateway.purchase(@amount, @credit_card,
-      email: 'customer@example.com'
+                                        email: 'customer@example.com'
     )
     assert_success response
     transaction = response.params['braintree_transaction']
@@ -482,9 +482,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_purchase_using_specified_payment_method_token
     assert response = @gateway.store(
       credit_card('4111111111111111',
-        first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012
-      ),
+                  first_name: 'Old First', last_name: 'Old Last',
+                  month: 9, year: 2012
+                 ),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -517,8 +517,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       country_name: 'Mexico'
     }
     assert response = @gateway.purchase(@amount, @credit_card,
-      billing_address: billing_address,
-      shipping_address: shipping_address
+                                        billing_address: billing_address,
+                                        shipping_address: shipping_address
     )
     assert_success response
     transaction = response.params['braintree_transaction']
@@ -541,7 +541,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_purchase_with_three_d_secure_pass_thru
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
     response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params
+                                 three_d_secure: three_d_secure_params
     )
     assert_success response
   end
@@ -549,7 +549,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_purchase_with_some_three_d_secure_pass_thru_fields
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id' }
     response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params
+                                 three_d_secure: three_d_secure_params
     )
     assert_success response
   end
@@ -579,10 +579,10 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_apple_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+                                                  )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -594,13 +594,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_android_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: '2024',
-      source: :android_pay,
-      transaction_id: '123456789',
-      eci: '05'
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   month: '01',
+                                                   year: '2024',
+                                                   source: :android_pay,
+                                                   transaction_id: '123456789',
+                                                   eci: '05'
+                                                  )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -612,13 +612,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_authorize_and_capture_with_google_pay_card
     credit_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: '2024',
-      source: :google_pay,
-      transaction_id: '123456789',
-      eci: '05'
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   month: '01',
+                                                   year: '2024',
+                                                   source: :google_pay,
+                                                   transaction_id: '123456789',
+                                                   eci: '05'
+                                                  )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -730,9 +730,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_update
     assert response = @gateway.store(
       credit_card('4111111111111111',
-        first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012
-      ),
+                  first_name: 'Old First', last_name: 'Old Last',
+                  month: 9, year: 2012
+                 ),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -752,9 +752,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.update(
       customer_vault_id,
       credit_card('5105105105105100',
-        first_name: 'New First', last_name: 'New Last',
-        month: 10, year: 2014
-      ),
+                  first_name: 'New First', last_name: 'New Last',
+                  month: 10, year: 2014
+                 ),
       email: 'new@example.com',
       phone: '987-765-5432'
     )

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -7,37 +7,37 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     @gateway = CardStreamGateway.new(fixtures(:card_stream))
 
     @amex = credit_card('374245455400001',
-      month: '12',
-      year: Time.now.year + 1,
-      verification_value: '4887',
-      brand: :american_express
-    )
+                        month: '12',
+                        year: Time.now.year + 1,
+                        verification_value: '4887',
+                        brand: :american_express
+                       )
 
     @mastercard = credit_card('5301250070000191',
-      month: '12',
-      year: Time.now.year + 1,
-      verification_value: '419',
-      brand: :master
-    )
+                              month: '12',
+                              year: Time.now.year + 1,
+                              verification_value: '419',
+                              brand: :master
+                             )
 
     @visacreditcard = credit_card('4929421234600821',
-      month: '12',
-      year: Time.now.year + 1,
-      verification_value: '356',
-      brand: :visa
-    )
+                                  month: '12',
+                                  year: Time.now.year + 1,
+                                  verification_value: '356',
+                                  brand: :visa
+                                 )
 
     @visadebitcard = credit_card('4539791001730106',
-      month: '12',
-      year: Time.now.year + 1,
-      verification_value: '289',
-      brand: :visa
-    )
+                                 month: '12',
+                                 year: Time.now.year + 1,
+                                 verification_value: '289',
+                                 brand: :visa
+                                )
 
     @declined_card = credit_card('4000300011112220',
-      month: '9',
-      year: Time.now.year + 1
-    )
+                                 month: '9',
+                                 year: Time.now.year + 1
+                                )
 
     @amex_options = {
       billing_address: {
@@ -115,10 +115,10 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     }
 
     @three_ds_enrolled_card = credit_card('4012001037141112',
-      month: '12',
-      year: '2020',
-      brand: :visa
-    )
+                                          month: '12',
+                                          year: '2020',
+                                          brand: :visa
+                                         )
   end
 
   def test_successful_visacreditcard_authorization_and_capture

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -11,12 +11,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
 
     @network_token = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               '2025',
-      source:             :network_token,
-      verification_value: nil
-    )
+                                                      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+                                                      month:              '10',
+                                                      year:               '2025',
+                                                      source:             :network_token,
+                                                      verification_value: nil
+                                                     )
 
     @options = {
       order_id: '1',

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -5,7 +5,7 @@ class RemoteClearhausTest < Test::Unit::TestCase
     @gateway = ClearhausGateway.new(fixtures(:clearhaus))
 
     @amount = 100
-    @credit_card   = credit_card('4111111111111111')
+    @credit_card = credit_card('4111111111111111')
     @declined_card = credit_card('4200000000000000')
     @options = {}
   end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -11,35 +11,35 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     @declined_card = credit_card('801111111111111')
     @pinless_debit_card = credit_card('4002269999999999')
     @elo_credit_card = credit_card('5067310000000010',
-      verification_value: '321',
-      month: '12',
-      year: (Time.now.year + 2).to_s,
-      brand: :elo
-    )
+                                   verification_value: '321',
+                                   month: '12',
+                                   year: (Time.now.year + 2).to_s,
+                                   brand: :elo
+                                  )
     @three_ds_unenrolled_card = credit_card('4000000000000051',
-      verification_value: '321',
-      month: '12',
-      year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+                                            verification_value: '321',
+                                            month: '12',
+                                            year: (Time.now.year + 2).to_s,
+                                            brand: :visa
+                                           )
     @three_ds_enrolled_card = credit_card('4000000000000002',
-      verification_value: '321',
-      month: '12',
-      year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+                                          verification_value: '321',
+                                          month: '12',
+                                          year: (Time.now.year + 2).to_s,
+                                          brand: :visa
+                                         )
     @three_ds_invalid_card = credit_card('4000000000000010',
-      verification_value: '321',
-      month: '12',
-      year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+                                         verification_value: '321',
+                                         month: '12',
+                                         year: (Time.now.year + 2).to_s,
+                                         brand: :visa
+                                        )
     @three_ds_enrolled_mastercard = credit_card('5200000000001005',
-      verification_value: '321',
-      month: '12',
-      year: (Time.now.year + 2).to_s,
-      brand: :master
-    )
+                                                verification_value: '321',
+                                                month: '12',
+                                                year: (Time.now.year + 2).to_s,
+                                                brand: :master
+                                               )
 
     @amount = 100
 
@@ -95,10 +95,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_network_tokenization_transcript_scrubbing
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+                                                  )
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)
@@ -336,10 +336,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_network_tokenization_authorize_and_capture
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+                                                  )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_successful_response(auth)
@@ -509,7 +509,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
 
     assert response = @gateway.update(response.authorization, nil,
-      {order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
+                                      {order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
 
     assert_successful_response(response)
   end

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -74,42 +74,42 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
 
   def test_fully_loaded_purchase
     response = @gateway.purchase(@amount, @credit_card,
-      redirect_url: 'http://awesomesauce.com',
-      ip: '0.0.0.0',
-      application_id: 'Woohoo',
-      partner_id: 'Woohoo',
-      transaction_type: 'Purchase',
-      description: 'Description',
-      order_id: 'orderid1',
-      invoice: 'I1234',
-      currency: 'AUD',
-      email: 'jim@example.com',
-      billing_address: {
-        title:    'Mr.',
-        name:     'Jim Awesome Smith',
-        company:  'Awesome Co',
-        address1: '1234 My Street',
-        address2: 'Apt 1',
-        city:     'Ottawa',
-        state:    'ON',
-        zip:      'K1C2N6',
-        country:  'CA',
-        phone:    '(555)555-5555',
-        fax:      '(555)555-6666'
-      },
-      shipping_address: {
-        title:    'Ms.',
-        name:     'Baker',
-        company:  'Elsewhere Inc.',
-        address1: '4321 Their St.',
-        address2: 'Apt 2',
-        city:     'Chicago',
-        state:    'IL',
-        zip:      '60625',
-        country:  'US',
-        phone:    '1115555555',
-        fax:      '1115556666'
-      }
+                                 redirect_url: 'http://awesomesauce.com',
+                                 ip: '0.0.0.0',
+                                 application_id: 'Woohoo',
+                                 partner_id: 'Woohoo',
+                                 transaction_type: 'Purchase',
+                                 description: 'Description',
+                                 order_id: 'orderid1',
+                                 invoice: 'I1234',
+                                 currency: 'AUD',
+                                 email: 'jim@example.com',
+                                 billing_address: {
+                                   title:    'Mr.',
+                                   name:     'Jim Awesome Smith',
+                                   company:  'Awesome Co',
+                                   address1: '1234 My Street',
+                                   address2: 'Apt 1',
+                                   city:     'Ottawa',
+                                   state:    'ON',
+                                   zip:      'K1C2N6',
+                                   country:  'CA',
+                                   phone:    '(555)555-5555',
+                                   fax:      '(555)555-6666'
+                                 },
+                                 shipping_address: {
+                                   title:    'Ms.',
+                                   name:     'Baker',
+                                   company:  'Elsewhere Inc.',
+                                   address1: '4321 Their St.',
+                                   address2: 'Apt 2',
+                                   city:     'Chicago',
+                                   state:    'IL',
+                                   zip:      '60625',
+                                   country:  'US',
+                                   phone:    '1115555555',
+                                   fax:      '1115556666'
+                                 }
     )
     assert_success response
   end

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -5,9 +5,9 @@ class EwayTest < Test::Unit::TestCase
     @gateway = EwayGateway.new(fixtures(:eway))
     @credit_card_success = credit_card('4444333322221111')
     @credit_card_fail = credit_card('1234567812345678',
-      month: Time.now.month,
-      year: Time.now.year - 1
-    )
+                                    month: Time.now.month,
+                                    year: Time.now.year - 1
+                                   )
 
     @params = {
       order_id: '1230123',

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -27,9 +27,9 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokenization
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: nil
+                                                   )
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -28,9 +28,9 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokenization
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: nil
+                                                   )
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -284,11 +284,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing_with_cryptogram
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, credit_card, @options)
     end
@@ -301,11 +301,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -313,10 +313,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -324,11 +324,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -336,10 +336,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -347,11 +347,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_android_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -359,10 +359,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_android_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -370,11 +370,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_android_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -382,10 +382,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_android_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -393,11 +393,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -405,10 +405,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -416,11 +416,11 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_google_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -428,10 +428,10 @@ class RemoteHpsTest < Test::Unit::TestCase
 
   def test_successful_auth_with_google_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -101,11 +101,11 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_successful_recurring_payment
     assert response = @gateway.recurring(2400, @credit_card,
-      order_id: generate_unique_id,
-      installments: 12,
-      startdate: 'immediate',
-      periodicity: :monthly,
-      billing_address: address
+                                         order_id: generate_unique_id,
+                                         installments: 12,
+                                         startdate: 'immediate',
+                                         periodicity: :monthly,
+                                         billing_address: address
     )
 
     assert_success response

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -114,17 +114,17 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_unsuccessful_authorization
     assert response = @gateway.authorize(60060, @credit_card2,
-      {
-        order_id: '6',
-        billing_address: {
-          name: 'Joe Green',
-          address1: '6 Main St.',
-          city: 'Derry',
-          state: 'NH',
-          zip: '03038',
-          country: 'US'
-        },
-      }
+                                         {
+                                           order_id: '6',
+                                           billing_address: {
+                                             name: 'Joe Green',
+                                             address1: '6 Main St.',
+                                             city: 'Derry',
+                                             state: 'NH',
+                                             zip: '03038',
+                                             country: 'US'
+                                           },
+                                         }
     )
     assert_failure response
     assert_equal 'Insufficient Funds', response.message

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -10,26 +10,26 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @credit_card = credit_card('4509953566233704')
     @colombian_card = credit_card('4013540682746260')
     @elo_credit_card = credit_card('5067268650517446',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737'
+                                  )
     @cabal_credit_card = credit_card('6035227716427021',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737'
-    )
+                                     month: 10,
+                                     year: 2020,
+                                     first_name: 'John',
+                                     last_name: 'Smith',
+                                     verification_value: '737'
+                                    )
     @naranja_credit_card = credit_card('5895627823453005',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '123'
-    )
+                                       month: 10,
+                                       year: 2020,
+                                       first_name: 'John',
+                                       last_name: 'Smith',
+                                       verification_value: '123'
+                                      )
     @declined_card = credit_card('4000300011112220')
     @options = {
       billing_address: address,

--- a/test/remote/gateways/remote_merchant_ware_version_four_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_version_four_test.rb
@@ -70,8 +70,8 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
     assert purchase.authorization
 
     assert reference_purchase = @gateway.purchase(@amount,
-      purchase.authorization,
-      @reference_purchase_options)
+                                                  purchase.authorization,
+                                                  @reference_purchase_options)
     assert_success reference_purchase
     assert_not_nil reference_purchase.authorization
   end

--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -10,7 +10,7 @@ class RemoteMigsTest < Test::Unit::TestCase
 
     @amount = 100
     @declined_amount = 105
-    @visa   = credit_card('4987654321098769', month: 5, year: 2021, brand: 'visa')
+    @visa = credit_card('4987654321098769', month: 5, year: 2021, brand: 'visa')
     @master = credit_card('5123456789012346', month: 5, year: 2021, brand: 'master')
     @amex   = credit_card('371449635311004',  month: 5, year: 2021, brand: 'american_express')
     @diners = credit_card('30123456789019',   month: 5, year: 2021, brand: 'diners_club')

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -57,8 +57,8 @@ class NetRegistryTest < Test::Unit::TestCase
       assert_match(/\A\d{6}\z/, response.authorization)
 
       response = @gateway.capture(@amount,
-        response.authorization,
-        credit_card: @valid_creditcard)
+                                  response.authorization,
+                                  credit_card: @valid_creditcard)
       assert_success response
       assert_equal 'approved', response.params['status']
     end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -10,13 +10,13 @@ class RemoteNmiTest < Test::Unit::TestCase
       account_number: '123123123'
     )
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: '2024',
-      source: :apple_pay,
-      eci: '5',
-      transaction_id: '123456789'
-    )
+                                                       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                       month: '01',
+                                                       year: '2024',
+                                                       source: :apple_pay,
+                                                       eci: '5',
+                                                       transaction_id: '123456789'
+                                                      )
     @options = {
       order_id: generate_unique_id,
       billing_address: address,

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -6,9 +6,9 @@ class RemoteOgoneTest < Test::Unit::TestCase
   def setup
     @gateway = OgoneGateway.new(fixtures(:ogone))
     @amount = 100
-    @credit_card     = credit_card('4000100011112224')
-    @mastercard      = credit_card('5399999999999999', brand: 'mastercard')
-    @declined_card   = credit_card('1111111111111111')
+    @credit_card = credit_card('4000100011112224')
+    @mastercard = credit_card('5399999999999999', brand: 'mastercard')
+    @declined_card = credit_card('1111111111111111')
     @credit_card_d3d = credit_card('4000000000000002', verification_value: '111')
     @options = {
       order_id: generate_unique_id[0...30],

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -4,7 +4,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
   def setup
     @gateway = OmiseGateway.new(fixtures(:omise))
     @amount  = 8888
-    @credit_card   = credit_card('4242424242424242')
+    @credit_card = credit_card('4242424242424242')
     @declined_card = credit_card('4255555555555555')
     @invalid_cvc   = credit_card('4111111111160001', {verification_value: ''})
     @options = {

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -81,12 +81,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_visa_network_tokenization_credit_card_with_eci
     network_card = network_tokenization_credit_card('4788250000028291',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: '111',
-      brand: 'visa',
-      eci: '5'
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: '111',
+                                                    brand: 'visa',
+                                                    eci: '5'
+                                                   )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -95,11 +95,11 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_master_card_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: '111',
-      brand: 'master'
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: '111',
+                                                    brand: 'master'
+                                                   )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -108,11 +108,11 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: '111',
-      brand: 'american_express'
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: '111',
+                                                    brand: 'american_express'
+                                                   )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -121,11 +121,11 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_discover_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: '111',
-      brand: 'discover'
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: '111',
+                                                    brand: 'discover'
+                                                   )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -5,8 +5,8 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
     @gateway = PayGateXmlGateway.new(fixtures(:pay_gate_xml))
 
     @amount = 245000
-    @credit_card    = credit_card('4000000000000002')
-    @declined_card  = credit_card('4000000000000036')
+    @credit_card = credit_card('4000000000000002')
+    @declined_card = credit_card('4000000000000036')
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_pay_junction_test.rb
+++ b/test/remote/gateways/remote_pay_junction_test.rb
@@ -72,7 +72,7 @@ class PayJunctionTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'capture', response.params['posture'], 'Should be a capture'
     assert_equal auth.authorization, response.authorization,
-      'Should maintain transaction ID across request'
+                 'Should maintain transaction ID across request'
   end
 
   def test_successful_credit
@@ -94,7 +94,7 @@ class PayJunctionTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'void', response.params['posture'], 'Should be a capture'
     assert_equal purchase.authorization, response.authorization,
-      'Should maintain transaction ID across request'
+                 'Should maintain transaction ID across request'
   end
 
   def test_successful_instant_purchase
@@ -111,16 +111,16 @@ class PayJunctionTest < Test::Unit::TestCase
     assert_equal 'capture', response.params['posture'], 'Should be captured funds'
     assert_equal 'charge', response.params['transaction_action']
     assert_not_equal purchase.authorization, response.authorization,
-      'Should have recieved new transaction ID'
+                     'Should have recieved new transaction ID'
 
     assert_success response
   end
 
   def test_successful_recurring
     assert response = @gateway.recurring(AMOUNT, @credit_card,
-      periodicity: :monthly,
-      payments: 12,
-      order_id: generate_unique_id[0..15]
+                                         periodicity: :monthly,
+                                         payments: 12,
+                                         order_id: generate_unique_id[0..15]
     )
 
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -383,11 +383,11 @@ class RemotePayflowTest < Test::Unit::TestCase
   def test_recurring_with_initial_authorization
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(1000, @credit_card,
-        periodicity: :monthly,
-        initial_transaction: {
-          type: :purchase,
-          amount: 500
-        }
+                         periodicity: :monthly,
+                         initial_transaction: {
+                           type: :purchase,
+                           amount: 500
+                         }
       )
     end
 

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -7,13 +7,13 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111', verification_value: '666')
     @elo_credit_card = credit_card('6362970000457013',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'elo'
+                                  )
     @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {
       billing_address: address,

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -233,8 +233,8 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
 
     response = @gateway.transfer([@amount, 'joe@example.com'],
-      [600, 'jane@example.com', {note: 'Thanks for taking care of that'}],
-      subject: 'Your money')
+                                 [600, 'jane@example.com', {note: 'Thanks for taking care of that'}],
+                                 subject: 'Your money')
     assert_success response
   end
 

--- a/test/remote/gateways/remote_payway_test.rb
+++ b/test/remote/gateways/remote_payway_test.rb
@@ -9,42 +9,42 @@ class PaywayTest < Test::Unit::TestCase
     @gateway = ActiveMerchant::Billing::PaywayGateway.new(fixtures(:payway))
 
     @visa = credit_card('4564710000000004',
-      month: 2,
-      year: 2019,
-      verification_value: '847'
-    )
+                        month: 2,
+                        year: 2019,
+                        verification_value: '847'
+                       )
 
     @mastercard = credit_card('5163200000000008',
-      month: 8,
-      year: 2020,
-      verification_value: '070',
-      brand: 'master'
-    )
+                              month: 8,
+                              year: 2020,
+                              verification_value: '070',
+                              brand: 'master'
+                             )
 
     @expired = credit_card('4564710000000012',
-      month: 2,
-      year: 2005,
-      verification_value: '963'
-    )
+                           month: 2,
+                           year: 2005,
+                           verification_value: '963'
+                          )
 
     @low = credit_card('4564710000000020',
-      month: 5,
-      year: 2020,
-      verification_value: '234'
-    )
+                       month: 5,
+                       year: 2020,
+                       verification_value: '234'
+                      )
 
     @stolen_mastercard = credit_card('5163200000000016',
-      month: 12,
-      year: 2019,
-      verification_value: '728',
-      brand: 'master'
-    )
+                                     month: 12,
+                                     year: 2019,
+                                     verification_value: '728',
+                                     brand: 'master'
+                                    )
 
     @invalid = credit_card('4564720000000037',
-      month: 9,
-      year: 2019,
-      verification_value: '030'
-    )
+                           month: 9,
+                           year: 2019,
+                           verification_value: '030'
+                          )
   end
 
   def test_successful_visa

--- a/test/remote/gateways/remote_psl_card_test.rb
+++ b/test/remote/gateways/remote_psl_card_test.rb
@@ -25,7 +25,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_visa_purchase
     response = @gateway.purchase(@accept_amount, @visa,
-      billing_address: @visa_address
+                                 billing_address: @visa_address
     )
     assert_success response
     assert response.test?
@@ -33,7 +33,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_visa_debit_purchase
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address
+                                 billing_address: @visa_debit_address
     )
     assert_success response
   end
@@ -42,15 +42,15 @@ class RemotePslCardTest < Test::Unit::TestCase
   def test_visa_debit_purchase_should_not_send_debit_info_if_present
     @visa_debit.start_month = '07'
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address
+                                 billing_address: @visa_debit_address
     )
     assert_success response
   end
 
   def test_successful_visa_purchase_specifying_currency
     response = @gateway.purchase(@accept_amount, @visa,
-      billing_address: @visa_address,
-      currency: 'GBP'
+                                 billing_address: @visa_address,
+                                 currency: 'GBP'
     )
     assert_success response
     assert response.test?
@@ -58,7 +58,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_solo_purchase
     response = @gateway.purchase(@accept_amount, @solo,
-      billing_address: @solo_address
+                                 billing_address: @solo_address
     )
     assert_success response
     assert response.test?
@@ -66,7 +66,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_referred_purchase
     response = @gateway.purchase(@referred_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
+                                 billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -74,7 +74,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_declined_purchase
     response = @gateway.purchase(@declined_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
+                                 billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -82,7 +82,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_declined_keep_card_purchase
     response = @gateway.purchase(@keep_card_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
+                                 billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -90,7 +90,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_authorization
     response = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address
+                                  billing_address: @visa_address
     )
     assert_success response
     assert response.test?
@@ -101,7 +101,7 @@ class RemotePslCardTest < Test::Unit::TestCase
       login: ''
     )
     response = @gateway.authorize(@accept_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
+                                  billing_address: @uk_maestro_address
     )
     assert_failure response
     assert response.test?
@@ -109,7 +109,7 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_authorization_and_capture
     authorization = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address
+                                       billing_address: @visa_address
     )
     assert_success authorization
     assert authorization.test?

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -19,18 +19,18 @@ class RemoteRealexTest < Test::Unit::TestCase
     @mastercard_coms_error = card_fixtures(:realex_mastercard_coms_error)
 
     @apple_pay = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                  payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                  verification_value: nil,
+                                                  eci: '05',
+                                                  source: :apple_pay
+                                                 )
 
     @declined_apple_pay = network_tokenization_credit_card('4000120000001154',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                           payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                           verification_value: nil,
+                                                           eci: '05',
+                                                           source: :apple_pay
+                                                          )
     @amount = 10000
   end
 
@@ -41,12 +41,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase
     [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex Purchase',
-        billing_address: {
-          zip: '90210',
-          country: 'US'
-        }
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex Purchase',
+                                   billing_address: {
+                                     zip: '90210',
+                                     country: 'US'
+                                   }
       )
       assert_not_nil response
       assert_success response
@@ -62,8 +62,8 @@ class RemoteRealexTest < Test::Unit::TestCase
       password: 'invalid'
     )
     response = gateway.purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Invalid login test'
+                                order_id: generate_unique_id,
+                                description: 'Invalid login test'
     )
 
     assert_not_nil response
@@ -75,8 +75,8 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_with_invalid_account
     response = RealexGateway.new(fixtures(:realex_with_account).merge(account: 'invalid')).purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex purchase with invalid account'
+                                                                                                    order_id: generate_unique_id,
+                                                                                                    description: 'Test Realex purchase with invalid account'
     )
 
     assert_not_nil response
@@ -96,8 +96,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_declined
     [@visa_declined, @mastercard_declined].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex purchase declined'
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex purchase declined'
       )
       assert_not_nil response
       assert_failure response
@@ -154,8 +154,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_referral_b
     [@visa_referral_b, @mastercard_referral_b].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex Referral B'
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex Referral B'
       )
       assert_not_nil response
       assert_failure response
@@ -168,8 +168,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_referral_a
     [@visa_referral_a, @mastercard_referral_a].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex Rqeferral A'
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex Rqeferral A'
       )
       assert_not_nil response
       assert_failure response
@@ -181,8 +181,8 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_coms_error
     [@visa_coms_error, @mastercard_coms_error].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex coms error'
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex coms error'
       )
       assert_not_nil response
       assert_failure response
@@ -196,8 +196,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.month = 13
 
     response = @gateway.purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex expiry month error'
+                                 order_id: generate_unique_id,
+                                 description: 'Test Realex expiry month error'
     )
     assert_not_nil response
     assert_failure response
@@ -210,8 +210,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.year = 2005
 
     response = @gateway.purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex expiry year error'
+                                 order_id: generate_unique_id,
+                                 description: 'Test Realex expiry year error'
     )
     assert_not_nil response
     assert_failure response
@@ -225,8 +225,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.last_name = ''
 
     response = @gateway.purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'test_chname_error'
+                                 order_id: generate_unique_id,
+                                 description: 'test_chname_error'
     )
     assert_not_nil response
     assert_failure response
@@ -239,8 +239,8 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa_cvn = @visa.clone
     @visa_cvn.verification_value = '111'
     response = @gateway.purchase(@amount, @visa_cvn,
-      order_id: generate_unique_id,
-      description: 'test_cvn'
+                                 order_id: generate_unique_id,
+                                 description: 'test_cvn'
     )
     assert_not_nil response
     assert_success response
@@ -249,9 +249,9 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_customer_number
     response = @gateway.purchase(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'test_cust_num',
-      customer: 'my customer id'
+                                 order_id: generate_unique_id,
+                                 description: 'test_cust_num',
+                                 customer: 'my customer id'
     )
     assert_not_nil response
     assert_success response
@@ -260,12 +260,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_authorize
     response = @gateway.authorize(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex Purchase',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                  order_id: generate_unique_id,
+                                  description: 'Test Realex Purchase',
+                                  billing_address: {
+                                    zip: '90210',
+                                    country: 'US'
+                                  }
     )
 
     assert_not_nil response
@@ -279,12 +279,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     auth_response = @gateway.authorize(@amount, @visa,
-      order_id: order_id,
-      description: 'Test Realex Purchase',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                       order_id: order_id,
+                                       description: 'Test Realex Purchase',
+                                       billing_address: {
+                                         zip: '90210',
+                                         country: 'US'
+                                       }
     )
     assert auth_response.test?
 
@@ -301,12 +301,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     auth_response = @gateway.authorize(@amount * 115, @visa,
-      order_id: order_id,
-      description: 'Test Realex Purchase',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                       order_id: order_id,
+                                       description: 'Test Realex Purchase',
+                                       billing_address: {
+                                         zip: '90210',
+                                         country: 'US'
+                                       }
     )
     assert auth_response.test?
 
@@ -323,12 +323,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     order_id = generate_unique_id
 
     purchase_response = @gateway.purchase(@amount, @visa,
-      order_id: order_id,
-      description: 'Test Realex Purchase',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                          order_id: order_id,
+                                          description: 'Test Realex Purchase',
+                                          billing_address: {
+                                            zip: '90210',
+                                            country: 'US'
+                                          }
     )
     assert purchase_response.test?
 
@@ -346,12 +346,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(rebate_secret: 'rebate'))
 
     purchase_response = gateway_with_refund_password.purchase(@amount, @visa,
-      order_id: order_id,
-      description: 'Test Realex Purchase',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                                              order_id: order_id,
+                                                              description: 'Test Realex Purchase',
+                                                              billing_address: {
+                                                                zip: '90210',
+                                                                country: 'US'
+                                                              }
     )
     assert purchase_response.test?
 
@@ -365,9 +365,9 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_verify
     response = @gateway.verify(@visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex verify'
-    )
+                               order_id: generate_unique_id,
+                               description: 'Test Realex verify'
+                              )
 
     assert_not_nil response
     assert_success response
@@ -378,9 +378,9 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_verify_declined
     response = @gateway.verify(@visa_declined,
-      order_id: generate_unique_id,
-      description: 'Test Realex verify declined'
-    )
+                               order_id: generate_unique_id,
+                               description: 'Test Realex verify declined'
+                              )
 
     assert_not_nil response
     assert_failure response
@@ -393,12 +393,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(refund_secret: 'refund'))
 
     credit_response = gateway_with_refund_password.credit(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex Credit',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                                          order_id: generate_unique_id,
+                                                          description: 'Test Realex Credit',
+                                                          billing_address: {
+                                                            zip: '90210',
+                                                            country: 'US'
+                                                          }
     )
 
     assert_not_nil credit_response
@@ -409,12 +409,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_failed_credit
     credit_response = @gateway.credit(@amount, @visa,
-      order_id: generate_unique_id,
-      description: 'Test Realex Credit',
-      billing_address: {
-        zip: '90210',
-        country: 'US'
-      }
+                                      order_id: generate_unique_id,
+                                      description: 'Test Realex Credit',
+                                      billing_address: {
+                                        zip: '90210',
+                                        country: 'US'
+                                      }
     )
 
     assert_not_nil credit_response
@@ -426,12 +426,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_maps_avs_and_cvv_response_codes
     [@visa, @mastercard].each do |card|
       response = @gateway.purchase(@amount, card,
-        order_id: generate_unique_id,
-        description: 'Test Realex Purchase',
-        billing_address: {
-          zip: '90210',
-          country: 'US'
-        }
+                                   order_id: generate_unique_id,
+                                   description: 'Test Realex Purchase',
+                                   billing_address: {
+                                     zip: '90210',
+                                     country: 'US'
+                                   }
       )
       assert_not_nil response
       assert_success response
@@ -443,12 +443,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @visa_declined,
-        order_id: generate_unique_id,
-        description: 'Test Realex Purchase',
-        billing_address: {
-          zip: '90210',
-          country: 'US'
-        }
+                        order_id: generate_unique_id,
+                        description: 'Test Realex Purchase',
+                        billing_address: {
+                          zip: '90210',
+                          country: 'US'
+                        }
       )
     end
     clean_transcript = @gateway.scrub(transcript)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -132,8 +132,8 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success capture
 
     assert refund = @gateway.refund(@amount, capture.authorization,
-      description: 'Crediting trx',
-      order_id: generate_unique_id
+                                    description: 'Crediting trx',
+                                    order_id: generate_unique_id
     )
     assert_success refund
   end
@@ -159,8 +159,8 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success purchase
 
     assert refund = @gateway.refund(@amount, purchase.authorization,
-      description: 'Crediting trx',
-      order_id: generate_unique_id
+                                    description: 'Crediting trx',
+                                    order_id: generate_unique_id
     )
 
     assert_success refund

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -165,7 +165,7 @@ class RemoteSageTest < Test::Unit::TestCase
     assert response = @gateway.store(@visa, @options)
     assert_success response
     assert response.authorization,
-      'Store card authorization should not be nil'
+           'Store card authorization should not be nil'
     assert_not_nil response.message
   end
 
@@ -177,14 +177,14 @@ class RemoteSageTest < Test::Unit::TestCase
 
   def test_unstore_visa
     assert auth = @gateway.store(@visa, @options).authorization,
-      'Unstore card authorization should not be nil'
+           'Unstore card authorization should not be nil'
     assert response = @gateway.unstore(auth, @options)
     assert_success response
   end
 
   def test_failed_unstore_visa
     assert auth = @gateway.store(@visa, @options).authorization,
-      'Unstore card authorization should not be nil'
+           'Unstore card authorization should not be nil'
     assert response = @gateway.unstore(auth, @options)
     assert_success response
   end

--- a/test/remote/gateways/remote_secure_pay_test.rb
+++ b/test/remote/gateways/remote_secure_pay_test.rb
@@ -5,9 +5,9 @@ class RemoteSecurePayTest < Test::Unit::TestCase
     @gateway = SecurePayGateway.new(fixtures(:secure_pay))
 
     @credit_card = credit_card('4111111111111111',
-      month: '7',
-      year: '2014'
-    )
+                               month: '7',
+                               year: '2014'
+                              )
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_skipjack_test.rb
+++ b/test/remote/gateways/remote_skipjack_test.rb
@@ -7,8 +7,8 @@ class RemoteSkipJackTest < Test::Unit::TestCase
     @gateway = SkipJackGateway.new(fixtures(:skip_jack))
 
     @credit_card = credit_card('4445999922225',
-      verification_value: '999'
-    )
+                               verification_value: '999'
+                              )
 
     @amount = 100
 

--- a/test/remote/gateways/remote_stripe_android_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_android_pay_test.rb
@@ -16,11 +16,11 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_android_pay_raw_cryptogram
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -32,11 +32,11 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
 
   def test_successful_auth_with_android_pay_raw_cryptogram
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -102,11 +102,11 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -118,10 +118,10 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -133,11 +133,11 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -149,10 +149,10 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -11,15 +11,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     @three_ds_moto_enabled = 'pm_card_authenticationRequiredOnSetup'
     @three_ds_authentication_required = 'pm_card_authenticationRequired'
     @three_ds_credit_card = credit_card('4000000000003220',
-      verification_value: '737',
-      month: 10,
-      year: 2020
-    )
+                                        verification_value: '737',
+                                        month: 10,
+                                        year: 2020
+                                       )
     @visa_card = credit_card('4242424242424242',
-      verification_value: '737',
-      month: 10,
-      year: 2020
-    )
+                             verification_value: '737',
+                             month: 10,
+                             year: 2020
+                            )
     @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
   end
 
@@ -543,7 +543,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     refund = @gateway.refund(@amount - 20, intent_id)
     assert_failure refund
-    assert_match /has a status of requires_action/, refund.message
+    assert_match(/has a status of requires_action/, refund.message)
   end
 
   def test_successful_store_purchase_and_unstore

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -8,13 +8,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111')
     @elo_credit_card = credit_card('4514 1600 0000 0008',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'elo'
+                                  )
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,8 @@ require 'comm_stub'
 require 'active_support/core_ext/integer/time'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/time/acts_like'
+require 'active_support/core_ext/array/extract_options'
+require 'active_support/core_ext/kernel/singleton_class'
 
 ActiveMerchant::Billing::Base.mode = :test
 
@@ -136,7 +138,7 @@ module ActiveMerchant
   end
 
   module Fixtures
-    HOME_DIR = RUBY_PLATFORM =~ /mswin32/ ? ENV['HOMEPATH'] : ENV['HOME'] unless defined?(HOME_DIR)
+    HOME_DIR = RUBY_PLATFORM.match?(/mswin32/) ? ENV['HOMEPATH'] : ENV['HOME'] unless defined?(HOME_DIR)
     LOCAL_CREDENTIALS = File.join(HOME_DIR.to_s, '.active_merchant/fixtures.yml') unless defined?(LOCAL_CREDENTIALS)
     DEFAULT_CREDENTIALS = File.join(File.dirname(__FILE__), 'fixtures.yml') unless defined?(DEFAULT_CREDENTIALS)
 
@@ -214,10 +216,10 @@ module ActiveMerchant
       }.update(options)
 
       ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
-        payment_instrument_name: defaults[:payment_instrument_name],
-        payment_network: defaults[:payment_network],
-        transaction_identifier: defaults[:transaction_identifier]
-      )
+                                                        payment_instrument_name: defaults[:payment_instrument_name],
+                                                        payment_network: defaults[:payment_network],
+                                                        transaction_identifier: defaults[:transaction_identifier]
+                                                       )
     end
 
     def address(options = {})

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -11,50 +11,50 @@ class AdyenTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card('4111111111111111',
-      month: 8,
-      year: 2018,
-      first_name: 'Test',
-      last_name: 'Card',
-      verification_value: '737',
-      brand: 'visa'
-    )
+                               month: 8,
+                               year: 2018,
+                               first_name: 'Test',
+                               last_name: 'Card',
+                               verification_value: '737',
+                               brand: 'visa'
+                              )
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'elo'
+                                  )
 
     @cabal_credit_card = credit_card('6035 2277 1642 7021',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'cabal'
-    )
+                                     month: 10,
+                                     year: 2020,
+                                     first_name: 'John',
+                                     last_name: 'Smith',
+                                     verification_value: '737',
+                                     brand: 'cabal'
+                                    )
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
-      month: 10,
-      year: 2030,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'unionpay'
-    )
+                                        month: 10,
+                                        year: 2030,
+                                        first_name: 'John',
+                                        last_name: 'Smith',
+                                        verification_value: '737',
+                                        brand: 'unionpay'
+                                       )
 
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
     @apple_pay_card = network_tokenization_credit_card('4111111111111111',
-      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      month: '08',
-      year: '2018',
-      source: :apple_pay,
-      verification_value: nil
-    )
+                                                       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+                                                       month: '08',
+                                                       year: '2018',
+                                                       source: :apple_pay,
+                                                       verification_value: nil
+                                                      )
 
     @amount = 100
 
@@ -290,7 +290,7 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
     end.check_request do |endpoint, data, headers|
-      if endpoint =~ /authorise/
+      if /authorise/.match?(endpoint)
         assert_match(/"overwriteBrand":true/, data)
         assert_match(/"selectedBrand":"maestro"/, data)
       end

--- a/test/unit/gateways/authorize_net_arb_test.rb
+++ b/test/unit/gateways/authorize_net_arb_test.rb
@@ -19,15 +19,15 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
     response = @gateway.recurring(@amount, @credit_card,
-      billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
-      interval: {
-        length: 10,
-        unit: :days
-      },
-      duration: {
-        start_date: Time.now.strftime('%Y-%m-%d'),
-        occurrences: 30
-      }
+                                  billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+                                  interval: {
+                                    length: 10,
+                                    unit: :days
+                                  },
+                                  duration: {
+                                    start_date: Time.now.strftime('%Y-%m-%d'),
+                                    occurrences: 30
+                                  }
     )
 
     assert_instance_of Response, response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -1103,8 +1103,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_includes_shipping_name_when_different_from_billing_name
     card = credit_card('4242424242424242',
-      first_name: 'billing',
-      last_name: 'name')
+                       first_name: 'billing',
+                       last_name: 'name')
 
     options = {
       order_id: 'a' * 21,
@@ -1126,8 +1126,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_includes_shipping_name_when_passed_as_options
     card = credit_card('4242424242424242',
-      first_name: 'billing',
-      last_name: 'name')
+                       first_name: 'billing',
+                       last_name: 'name')
 
     shipping_address = address(first_name: 'shipping', last_name: 'lastname')
     shipping_address.delete(:name)
@@ -1151,9 +1151,9 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_truncation
     card = credit_card('4242424242424242',
-      first_name: 'a' * 51,
-      last_name: 'a' * 51
-    )
+                       first_name: 'a' * 51,
+                       last_name: 'a' * 51
+                      )
 
     options = {
       order_id: 'a' * 21,
@@ -1226,8 +1226,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_apple_pay_authorization_with_network_tokenization
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)
@@ -1246,8 +1246,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_failed_apple_pay_authorization_with_network_tokenization_not_supported
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -9,9 +9,9 @@ class BanwireTest < Test::Unit::TestCase
       currency: 'MXN')
 
     @credit_card = credit_card('5204164299999999',
-      month: 11,
-      year: 2012,
-      verification_value: '999')
+                               month: 11,
+                               year: 2012,
+                               verification_value: '999')
     @amount = 100
 
     @options = {
@@ -22,10 +22,10 @@ class BanwireTest < Test::Unit::TestCase
     }
 
     @amex_credit_card = credit_card('375932134599999',
-      month: 3,
-      year: 2017,
-      first_name: 'Banwire',
-      last_name: 'Test Card')
+                                    month: 3,
+                                    year: 2017,
+                                    first_name: 'Banwire',
+                                    last_name: 'Test Card')
     @amex_options = {
       order_id: '2',
       email: 'test@email.com',

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -153,8 +153,8 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_successful_authorize_with_house_number_and_street
     response = stub_comms do
       @gateway.authorize(@amount,
-        @credit_card,
-        @options_with_house_number_and_street)
+                         @credit_card,
+                         @options_with_house_number_and_street)
     end.check_request do |endpoint, data, headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)
@@ -168,8 +168,8 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_successful_authorize_with_shipping_house_number_and_street
     response = stub_comms do
       @gateway.authorize(@amount,
-        @credit_card,
-        @options_with_shipping_house_number_and_shipping_street)
+                         @credit_card,
+                         @options_with_shipping_house_number_and_shipping_street)
     end.check_request do |endpoint, data, headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)
@@ -330,7 +330,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({third_party_payout: true}))
     end.check_request do |endpoint, data, headers|
-      if /storeDetailAndSubmitThirdParty/ =~ endpoint
+      if /storeDetailAndSubmitThirdParty/.match?(endpoint)
         assert_match(%r{/storeDetailAndSubmitThirdParty}, endpoint)
         assert_match(/dateOfBirth=1990-10-11&/, data)
         assert_match(/entityType=NaturalPerson&/, data)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -221,7 +221,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_message_from
     assert_equal 'CVV does not match', @gateway.send(:parse, 'STATUS=2&CVV2=N&AVS=A&MESSAGE=FAILURE').message
     assert_equal 'Street address matches, but postal code does not match.',
-      @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
+                 @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
   end
 
   # Recurring Billing Unit Tests
@@ -230,11 +230,11 @@ class BluePayTest < Test::Unit::TestCase
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
       @gateway.recurring(@amount, @credit_card,
-        billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
-        rebill_start_date: '1 MONTH',
-        rebill_expression: '14 DAYS',
-        rebill_cycles: '24',
-        rebill_amount: @amount * 4
+                         billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
+                         rebill_start_date: '1 MONTH',
+                         rebill_expression: '14 DAYS',
+                         rebill_cycles: '24',
+                         rebill_amount: @amount * 4
       )
     end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -860,11 +860,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
       returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      transaction_id: '123',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   brand: 'visa',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -893,12 +893,12 @@ class BraintreeBlueTest < Test::Unit::TestCase
       returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram',
-      source: :android_pay,
-      transaction_id: '1234567890'
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   source: :android_pay,
+                                                   transaction_id: '1234567890'
+                                                  )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -927,12 +927,12 @@ class BraintreeBlueTest < Test::Unit::TestCase
       returns(braintree_result(id: 'transaction_id'))
 
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram',
-      source: :google_pay,
-      transaction_id: '1234567890'
-    )
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   source: :google_pay,
+                                                   transaction_id: '1234567890'
+                                                  )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -10,11 +10,11 @@ class CardStreamTest < Test::Unit::TestCase
     )
 
     @visacreditcard = credit_card('4929421234600821',
-      month: '12',
-      year: '2014',
-      verification_value: '356',
-      brand: :visa
-    )
+                                  month: '12',
+                                  year: '2014',
+                                  verification_value: '356',
+                                  brand: :visa
+                                 )
 
     @visacredit_options = {
       billing_address: {
@@ -41,16 +41,16 @@ class CardStreamTest < Test::Unit::TestCase
     }
 
     @amex = credit_card('374245455400001',
-      month: '12',
-      year: 2014,
-      verification_value: '4887',
-      brand: :american_express
-    )
+                        month: '12',
+                        year: 2014,
+                        verification_value: '4887',
+                        brand: :american_express
+                       )
 
     @declined_card = credit_card('4000300011112220',
-      month: '9',
-      year: '2014'
-    )
+                                 month: '9',
+                                 year: '2014'
+                                )
   end
 
   def test_successful_visacreditcard_authorization

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -559,11 +559,11 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_auth_with_network_tokenization_for_visa
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      transaction_id: '123',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   brand: 'visa',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card, @options)
@@ -577,11 +577,11 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokenization_for_visa
     credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'visa',
-      transaction_id: '123',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   brand: 'visa',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
@@ -601,11 +601,11 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     credit_card = network_tokenization_credit_card('5555555555554444',
-      brand: 'master',
-      transaction_id: '123',
-      eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+                                                   brand: 'master',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram'
+                                                  )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
@@ -619,11 +619,11 @@ class CyberSourceTest < Test::Unit::TestCase
     end.returns(successful_purchase_response)
 
     credit_card = network_tokenization_credit_card('378282246310005',
-      brand: 'american_express',
-      transaction_id: '123',
-      eci: '05',
-      payment_cryptogram: Base64.encode64('111111111100cryptogram')
-    )
+                                                   brand: 'american_express',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: Base64.encode64('111111111100cryptogram')
+                                                  )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response

--- a/test/unit/gateways/digitzs_test.rb
+++ b/test/unit/gateways/digitzs_test.rb
@@ -39,7 +39,7 @@ class DigitzsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"cardSplit"/
+      if /"cardSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)
       end
@@ -53,7 +53,7 @@ class DigitzsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"tokenSplit"/
+      if /"tokenSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)
       end

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -27,7 +27,7 @@ class EpayTest < Test::Unit::TestCase
     assert response = @gateway.authorize(100, @credit_card)
     assert_failure response
     assert_equal 'The payment was declined. Try again in a moment or try with another credit card.',
-      response.message
+                 response.message
   end
 
   def test_successful_3ds_purchase
@@ -52,7 +52,7 @@ class EpayTest < Test::Unit::TestCase
     assert response = @gateway.authorize(100, @credit_card)
     assert_failure response
     assert_equal 'The payment was declined of unknown reasons. For more information contact the bank. E.g. try with another credit card.<br />Denied - Call your bank for information',
-      response.message
+                 response.message
   end
 
   def test_failed_response_on_purchase

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -154,42 +154,42 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_with_all_options
     response = stub_comms do
       @gateway.purchase(200, @credit_card,
-        transaction_type: 'CustomTransactionType',
-        redirect_url: 'http://awesomesauce.com',
-        ip: '0.0.0.0',
-        application_id: 'Woohoo',
-        partner_id: 'SomePartner',
-        description: 'The Really Long Description More Than Sixty Four Characters Gets Truncated',
-        order_id: 'orderid1',
-        invoice: 'I1234',
-        currency: 'INR',
-        email: 'jim@example.com',
-        billing_address: {
-          title: 'Mr.',
-          name: 'Jim Awesome Smith',
-          company: 'Awesome Co',
-          address1: '1234 My Street',
-          address2: 'Apt 1',
-          city: 'Ottawa',
-          state: 'ON',
-          zip: 'K1C2N6',
-          country: 'CA',
-          phone: '(555)555-5555',
-          fax: '(555)555-6666'
-        },
-        shipping_address: {
-          title: 'Ms.',
-          name: 'Baker',
-          company: 'Elsewhere Inc.',
-          address1: '4321 Their St.',
-          address2: 'Apt 2',
-          city: 'Chicago',
-          state: 'IL',
-          zip: '60625',
-          country: 'US',
-          phone: '1115555555',
-          fax: '1115556666'
-        }
+                        transaction_type: 'CustomTransactionType',
+                        redirect_url: 'http://awesomesauce.com',
+                        ip: '0.0.0.0',
+                        application_id: 'Woohoo',
+                        partner_id: 'SomePartner',
+                        description: 'The Really Long Description More Than Sixty Four Characters Gets Truncated',
+                        order_id: 'orderid1',
+                        invoice: 'I1234',
+                        currency: 'INR',
+                        email: 'jim@example.com',
+                        billing_address: {
+                          title: 'Mr.',
+                          name: 'Jim Awesome Smith',
+                          company: 'Awesome Co',
+                          address1: '1234 My Street',
+                          address2: 'Apt 1',
+                          city: 'Ottawa',
+                          state: 'ON',
+                          zip: 'K1C2N6',
+                          country: 'CA',
+                          phone: '(555)555-5555',
+                          fax: '(555)555-6666'
+                        },
+                        shipping_address: {
+                          title: 'Ms.',
+                          name: 'Baker',
+                          company: 'Elsewhere Inc.',
+                          address1: '4321 Their St.',
+                          address2: 'Apt 2',
+                          city: 'Chicago',
+                          state: 'IL',
+                          zip: '60625',
+                          country: 'US',
+                          phone: '1115555555',
+                          fax: '1115556666'
+                        }
       )
     end.check_request do |endpoint, data, headers|
       assert_match(%r{"TransactionType":"CustomTransactionType"}, data)

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -51,7 +51,7 @@ class ExactTest < Test::Unit::TestCase
   def test_expdate
     assert_equal('%02d%s' % [@credit_card.month,
                              @credit_card.year.to_s[-2..-1]],
-      @gateway.send(:expdate, @credit_card))
+                 @gateway.send(:expdate, @credit_card))
   end
 
   def test_soap_fault

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -64,7 +64,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     options_with_specified_currency = @options.merge({currency: 'GBP'})
     @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
     assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014',
-      options_with_specified_currency)
+                                        options_with_specified_currency)
     assert_success response
     assert_equal 'GBP', response.params['currency']
   end

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -29,7 +29,7 @@ class GatewayTest < Test::Unit::TestCase
     assert_nothing_raised do
       Gateway.supported_countries = all_country_codes
       assert Gateway.supported_countries == all_country_codes,
-        'List of supported countries not properly set'
+             'List of supported countries not properly set'
     end
   end
 

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -247,11 +247,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -261,11 +261,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -275,10 +275,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -288,10 +288,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -301,11 +301,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -315,11 +315,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -329,10 +329,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -342,10 +342,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :apple_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :apple_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -355,11 +355,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -369,11 +369,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -383,10 +383,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -396,10 +396,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -409,11 +409,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -423,11 +423,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -437,10 +437,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -450,10 +450,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :android_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :android_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -463,11 +463,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -477,11 +477,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -491,10 +491,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -504,10 +504,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -517,11 +517,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -531,11 +531,11 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -545,10 +545,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -558,10 +558,10 @@ class HpsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      source: :google_pay
-    )
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+                                                   verification_value: nil,
+                                                   source: :google_pay
+                                                  )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -69,9 +69,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
-        assert_no_match %r{extraTaxes}, data
-      end
+      assert_no_match %r{extraTaxes}, data if /charges/.match?(endpoint)
     end.respond_with(successful_charge_response, successful_token_response)
 
     assert_success response
@@ -102,7 +100,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
+      if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_no_match %r{propina}, data
         assert_match %r{iac}, data
@@ -139,7 +137,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
+      if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_match %r{propina}, data
       end

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -7,26 +7,26 @@ class MercadoPagoTest < Test::Unit::TestCase
     @gateway = MercadoPagoGateway.new(access_token: 'access_token')
     @credit_card = credit_card
     @elo_credit_card = credit_card('5067268650517446',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737'
+                                  )
     @cabal_credit_card = credit_card('6035227716427021',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737'
-    )
+                                     month: 10,
+                                     year: 2020,
+                                     first_name: 'John',
+                                     last_name: 'Smith',
+                                     verification_value: '737'
+                                    )
     @naranja_credit_card = credit_card('5895627823453005',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '123'
-    )
+                                       month: 10,
+                                       year: 2020,
+                                       first_name: 'John',
+                                       last_name: 'Smith',
+                                       verification_value: '123'
+                                      )
     @amount = 100
 
     @options = {
@@ -309,7 +309,7 @@ class MercadoPagoTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /payment_method_id/
+      if /payment_method_id/.match?(data)
         assert_match(/"foo":"bar"/, data)
         assert_match(/"baz":"quux"/, data)
       end

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -90,9 +90,9 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_purchase_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_purchase_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: nil
+                                                   )
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
     assert_equal '101965-0_10;0bbb277b543a17b6781243889a689573', response.authorization
@@ -240,9 +240,9 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_authorize_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_authorization_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+                                                    payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+                                                    verification_value: nil
+                                                   )
     assert response = @gateway.authorize(100, @credit_card, @options)
     assert_success response
     assert_equal '109232-0_10;d88d9f5f3472898832c54d6b5572757e', response.authorization

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -369,7 +369,7 @@ class NmiTest < Test::Unit::TestCase
 
   def test_supported_countries
     assert_equal 1,
-      (['US'] | NmiGateway.supported_countries).size
+                 (['US'] | NmiGateway.supported_countries).size
   end
 
   def test_supported_card_types
@@ -605,7 +605,7 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/ccnumber=#{@credit_card.number}/, data)
       assert_match(/cvv=#{@credit_card.verification_value}/, data)
       assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/,
-        data)
+                   data)
 
       test_level3_options(data) if options.any?
     end.respond_with(successful_validate_response)

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -144,7 +144,7 @@ class OmiseTest < Test::Unit::TestCase
 
   def test_add_customer_with_card_id
     result = {}
-    customer_id   = 'cust_test_4zjzcgm8kpdt4xdhdw2'
+    customer_id = 'cust_test_4zjzcgm8kpdt4xdhdw2'
     result[:card] = 'card_test_4zguktjcxanu3dw171a'
     @gateway.send(:add_customer, result, {customer_id: customer_id})
     assert_equal customer_id, result[:customer]

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -203,97 +203,97 @@ class OppTest < Test::Unit::TestCase
 
   def successful_response(type, id)
     OppMockResponse.new(200,
-      JSON.generate({
-        'id' => id,
-        'paymentType' => type,
-        'paymentBrand' => 'VISA',
-        'amount' => '1.00',
-        'currency' => 'EUR',
-        'descriptor' => '5410.9959.0306 OPP_Channel',
-        'result' => {
-          'code' => '000.100.110',
-          'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
-        },
-        'card' => {
-          'bin' => '420000',
-          'last4Digits' => '0000',
-          'holder' => 'Longbob Longsen',
-          'expiryMonth' => '05',
-          'expiryYear' => '2018'
-        },
-        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
-        'timestamp' => '2015-06-20 19:31:01+0000',
-        'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      })
-    )
+                        JSON.generate({
+                          'id' => id,
+                          'paymentType' => type,
+                          'paymentBrand' => 'VISA',
+                          'amount' => '1.00',
+                          'currency' => 'EUR',
+                          'descriptor' => '5410.9959.0306 OPP_Channel',
+                          'result' => {
+                            'code' => '000.100.110',
+                            'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
+                          },
+                          'card' => {
+                            'bin' => '420000',
+                            'last4Digits' => '0000',
+                            'holder' => 'Longbob Longsen',
+                            'expiryMonth' => '05',
+                            'expiryYear' => '2018'
+                          },
+                          'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+                          'timestamp' => '2015-06-20 19:31:01+0000',
+                          'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
+                        })
+                       )
   end
 
   def successful_store_response(id)
     OppMockResponse.new(200,
-      JSON.generate({
-        'id' => id,
-        'result' => {
-          'code' => '000.100.110',
-          'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
-        },
-        'card' => {
-          'bin' => '420000',
-          'last4Digits' => '0000',
-          'holder' => 'Longbob Longsen',
-          'expiryMonth' => '05',
-          'expiryYear' => '2018'
-        },
-        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
-        'timestamp' => '2015-06-20 19:31:01+0000',
-        'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      })
-    )
+                        JSON.generate({
+                          'id' => id,
+                          'result' => {
+                            'code' => '000.100.110',
+                            'description' => "Request successfully processed in 'Merchant in Integrator Test Mode'"
+                          },
+                          'card' => {
+                            'bin' => '420000',
+                            'last4Digits' => '0000',
+                            'holder' => 'Longbob Longsen',
+                            'expiryMonth' => '05',
+                            'expiryYear' => '2018'
+                          },
+                          'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+                          'timestamp' => '2015-06-20 19:31:01+0000',
+                          'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
+                        })
+                       )
   end
 
   def failed_response(type, id, code='100.100.101')
     OppMockResponse.new(400,
-      JSON.generate({
-        'id' => id,
-        'paymentType' => type,
-        'paymentBrand' => 'VISA',
-        'result' => {
-          'code' => code,
-          'description' => 'invalid creditcard, bank account number or bank name'
-        },
-        'card' => {
-          'bin' => '444444',
-          'last4Digits' => '4444',
-          'holder' => 'Longbob Longsen',
-          'expiryMonth' => '05',
-          'expiryYear' => '2018'
-        },
-        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
-        'timestamp' => '2015-06-20 20:40:26+0000',
-        'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      })
-    )
+                        JSON.generate({
+                          'id' => id,
+                          'paymentType' => type,
+                          'paymentBrand' => 'VISA',
+                          'result' => {
+                            'code' => code,
+                            'description' => 'invalid creditcard, bank account number or bank name'
+                          },
+                          'card' => {
+                            'bin' => '444444',
+                            'last4Digits' => '4444',
+                            'holder' => 'Longbob Longsen',
+                            'expiryMonth' => '05',
+                            'expiryYear' => '2018'
+                          },
+                          'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+                          'timestamp' => '2015-06-20 20:40:26+0000',
+                          'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
+                        })
+                       )
   end
 
   def failed_store_response(id, code='100.100.101')
     OppMockResponse.new(400,
-      JSON.generate({
-        'id' => id,
-        'result' => {
-          'code' => code,
-          'description' => 'invalid creditcard, bank account number or bank name'
-        },
-        'card' => {
-          'bin' => '444444',
-          'last4Digits' => '4444',
-          'holder' => 'Longbob Longsen',
-          'expiryMonth' => '05',
-          'expiryYear' => '2018'
-        },
-        'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
-        'timestamp' => '2015-06-20 20:40:26+0000',
-        'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      })
-    )
+                        JSON.generate({
+                          'id' => id,
+                          'result' => {
+                            'code' => code,
+                            'description' => 'invalid creditcard, bank account number or bank name'
+                          },
+                          'card' => {
+                            'bin' => '444444',
+                            'last4Digits' => '4444',
+                            'holder' => 'Longbob Longsen',
+                            'expiryMonth' => '05',
+                            'expiryYear' => '2018'
+                          },
+                          'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
+                          'timestamp' => '2015-06-20 20:40:26+0000',
+                          'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
+                        })
+                       )
   end
 
   class OppMockResponse

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -274,8 +274,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_truncates_name
     card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+                       first_name: 'John',
+                       last_name: 'Jacob Jingleheimer Smith-Jones')
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: address)
@@ -351,7 +351,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card,
-          billing_address: address_with_invalid_chars)
+                                      billing_address: address_with_invalid_chars)
       end
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Main Street</, data)
@@ -363,8 +363,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_truncates_by_byte_length
     card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+                       first_name: 'John',
+                       last_name: 'Jacob Jingleheimer Smith-Jones')
 
     long_address = address(
       address1: '456 Stréêt Name is Really Long',
@@ -401,7 +401,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card,
-          billing_address: long_address)
+                                      billing_address: long_address)
       end
     end.check_request do |endpoint, data, headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
@@ -669,12 +669,12 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         assert_deprecation_warning do
           @gateway.add_customer_profile(credit_card,
-            managed_billing: {
-              start_date: '10-10-2014',
-              end_date: '10-10-2015',
-              max_dollar_value: 1500,
-              max_transactions: 12
-            })
+                                        managed_billing: {
+                                          start_date: '10-10-2014',
+                                          end_date: '10-10-2015',
+                                          max_dollar_value: 1500,
+                                          max_transactions: 12
+                                        })
         end
       end
     end.check_request do |endpoint, data, headers|
@@ -959,7 +959,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     assert_deprecation_warning do
       response = @gateway.add_customer_profile(credit_card,
-        billing_address: address)
+                                               billing_address: address)
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/pac_net_raven_test.rb
+++ b/test/unit/gateways/pac_net_raven_test.rb
@@ -338,15 +338,15 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
     @gateway.stubs(timestamp: '2013-10-08T14:31:54.Z')
 
     assert_equal "PymtType=cc_preauth&RAPIVersion=2&UserName=user&Timestamp=2013-10-08T14%3A31%3A54.Z&RequestID=wouykiikdvqbwwxueppby&Signature=7794efc8c0d39f0983edc10f778e6143ba13531d&CardNumber=4242424242424242&Expiry=09#{@credit_card.year.to_s[-2..-1]}&CVV2=123&Currency=USD&BillingStreetAddressLineOne=Address+1&BillingStreetAddressLineFour=Address+2&BillingPostalCode=ZIP123",
-      @gateway.send(:post_data, 'cc_preauth', {
-        'CardNumber' => @credit_card.number,
-        'Expiry' => @gateway.send(:expdate, @credit_card),
-        'CVV2' => @credit_card.verification_value,
-        'Currency' => 'USD',
-        'BillingStreetAddressLineOne' => 'Address 1',
-        'BillingStreetAddressLineFour' => 'Address 2',
-        'BillingPostalCode' => 'ZIP123'
-      })
+                 @gateway.send(:post_data, 'cc_preauth', {
+                   'CardNumber' => @credit_card.number,
+                   'Expiry' => @gateway.send(:expdate, @credit_card),
+                   'CVV2' => @credit_card.verification_value,
+                   'Currency' => 'USD',
+                   'BillingStreetAddressLineOne' => 'Address 1',
+                   'BillingStreetAddressLineFour' => 'Address 2',
+                   'BillingPostalCode' => 'ZIP123'
+                 })
   end
 
   def test_signature_for_cc_preauth_action

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -5,8 +5,8 @@ class PayGateTest < Test::Unit::TestCase
     @gateway = PayGateXmlGateway.new(fixtures(:pay_gate_xml))
 
     @amount = 245000
-    @credit_card    = credit_card('4000000000000002')
-    @declined_card  = credit_card('4000000000000036')
+    @credit_card = credit_card('4000000000000002')
+    @declined_card = credit_card('4000000000000036')
 
     # May need to generate a unique order id as server responds with duplicate order detected
     @options = {

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -10,8 +10,8 @@ class PayboxDirectTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card('1111222233334444',
-      brand: 'visa'
-    )
+                               brand: 'visa'
+                              )
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -309,8 +309,8 @@ class PayflowTest < Test::Unit::TestCase
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
-          periodicity: :monthly,
-          initial_transaction: { }
+                           periodicity: :monthly,
+                           initial_transaction: { }
         )
       end
     end
@@ -320,8 +320,8 @@ class PayflowTest < Test::Unit::TestCase
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
-          periodicity: :monthly,
-          initial_transaction: { amount: :purchase }
+                           periodicity: :monthly,
+                           initial_transaction: { amount: :purchase }
         )
       end
     end

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -7,13 +7,13 @@ class PaymentezTest < Test::Unit::TestCase
     @gateway = PaymentezGateway.new(application_code: 'foo', app_key: 'bar')
     @credit_card = credit_card
     @elo_credit_card = credit_card('6362970000457013',
-      month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo'
-    )
+                                   month: 10,
+                                   year: 2020,
+                                   first_name: 'John',
+                                   last_name: 'Smith',
+                                   verification_value: '737',
+                                   brand: 'elo'
+                                  )
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -191,9 +191,9 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_build_reference_transaction_gets_ip
     request = REXML::Document.new(@gateway.send(:build_reference_transaction_request,
-      100,
-      reference_id: 'id',
-      ip: '127.0.0.1'))
+                                                100,
+                                                reference_id: 'id',
+                                                ip: '127.0.0.1'))
     assert_equal '100', REXML::XPath.first(request, '//n2:PaymentDetails/n2:OrderTotal').text
     assert_equal 'id', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
     assert_equal '127.0.0.1', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -35,42 +35,42 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
   def test_setup_request_invalid_requests
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        ip: '127.0.0.1',
-        description: 'Test Title',
-        return_url: 'http://return.url',
-        cancel_return_url: 'http://cancel.url')
+                              ip: '127.0.0.1',
+                              description: 'Test Title',
+                              return_url: 'http://return.url',
+                              cancel_return_url: 'http://cancel.url')
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        ip: '127.0.0.1',
-        description: 'Test Title',
-        return_url: 'http://return.url',
-        cancel_return_url: 'http://cancel.url',
-        items: [])
+                              ip: '127.0.0.1',
+                              description: 'Test Title',
+                              return_url: 'http://return.url',
+                              cancel_return_url: 'http://cancel.url',
+                              items: [])
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        ip: '127.0.0.1',
-        description: 'Test Title',
-        return_url: 'http://return.url',
-        cancel_return_url: 'http://cancel.url',
-        items: [Hash.new])
+                              ip: '127.0.0.1',
+                              description: 'Test Title',
+                              return_url: 'http://return.url',
+                              cancel_return_url: 'http://cancel.url',
+                              items: [Hash.new])
     end
 
     assert_raise ArgumentError do
       @gateway.setup_purchase(100,
-        ip: '127.0.0.1',
-        description: 'Test Title',
-        return_url: 'http://return.url',
-        cancel_return_url: 'http://cancel.url',
-        items: [{ name: 'Charge',
-                  number: '1',
-                  quantity: '1',
-                  amount: 100,
-                  description: 'Description',
-                  category: 'Physical' }])
+                              ip: '127.0.0.1',
+                              description: 'Test Title',
+                              return_url: 'http://return.url',
+                              cancel_return_url: 'http://cancel.url',
+                              items: [{ name: 'Charge',
+                                        number: '1',
+                                        quantity: '1',
+                                        amount: 100,
+                                        description: 'Description',
+                                        category: 'Physical' }])
     end
   end
 
@@ -78,16 +78,16 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_setup_response)
 
     @gateway.setup_purchase(100,
-      ip: '127.0.0.1',
-      description: 'Test Title',
-      return_url: 'http://return.url',
-      cancel_return_url: 'http://cancel.url',
-      items: [{ name: 'Charge',
-                number: '1',
-                quantity: '1',
-                amount: 100,
-                description: 'Description',
-                category: 'Digital' }])
+                            ip: '127.0.0.1',
+                            description: 'Test Title',
+                            return_url: 'http://return.url',
+                            cancel_return_url: 'http://cancel.url',
+                            items: [{ name: 'Charge',
+                                      number: '1',
+                                      quantity: '1',
+                                      amount: 100,
+                                      description: 'Description',
+                                      category: 'Digital' }])
   end
 
   private

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -243,21 +243,21 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_flatrate_shipping_options_are_included_if_specified_in_build_setup_request
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0,
-      {
-        currency: 'AUD',
-        shipping_options: [
-          {
-            default: true,
-            name: 'first one',
-            amount: 1000
-          },
-          {
-            default: false,
-            name: 'second one',
-            amount: 2000
-          }
-        ]
-      }))
+                                            {
+                                              currency: 'AUD',
+                                              shipping_options: [
+                                                {
+                                                  default: true,
+                                                  name: 'first one',
+                                                  amount: 1000
+                                                },
+                                                {
+                                                  default: false,
+                                                  name: 'second one',
+                                                  amount: 2000
+                                                }
+                                              ]
+                                            }))
 
     assert_equal 'true', REXML::XPath.first(xml, '//n2:FlatRateShippingOptions/n2:ShippingOptionIsDefault').text
     assert_equal 'first one', REXML::XPath.first(xml, '//n2:FlatRateShippingOptions/n2:ShippingOptionName').text
@@ -272,17 +272,17 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_address_is_included_if_specified
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'Sale', 0,
-      {
-        currency: 'GBP',
-        address: {
-          name: 'John Doe',
-          address1: '123 somewhere',
-          city: 'Townville',
-          country: 'Canada',
-          zip: 'k1l4p2',
-          phone: '1231231231'
-        }
-      }))
+                                            {
+                                              currency: 'GBP',
+                                              address: {
+                                                name: 'John Doe',
+                                                address1: '123 somewhere',
+                                                city: 'Townville',
+                                                country: 'Canada',
+                                                zip: 'k1l4p2',
+                                                phone: '1231231231'
+                                              }
+                                            }))
 
     assert_equal 'John Doe', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:ShipToAddress/n2:Name').text
     assert_equal '123 somewhere', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:ShipToAddress/n2:Street1').text
@@ -312,29 +312,29 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_fractional_discounts_are_correctly_calculated_with_jpy_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -750,
-            number: 2,
-            quantity: 1
-          }
-        ],
-        subtotal: 14250,
-        currency: 'JPY',
-        shipping: 0,
-        handling: 0,
-        tax: 0
-      }))
+                                            {
+                                              items: [
+                                                {
+                                                  name: 'item one',
+                                                  description: 'description',
+                                                  amount: 15000,
+                                                  number: 1,
+                                                  quantity: 1
+                                                },
+                                                {
+                                                  name: 'Discount',
+                                                  description: 'Discount',
+                                                  amount: -750,
+                                                  number: 2,
+                                                  quantity: 1
+                                                }
+                                              ],
+                                              subtotal: 14250,
+                                              currency: 'JPY',
+                                              shipping: 0,
+                                              handling: 0,
+                                              tax: 0
+                                            }))
 
     assert_equal '142', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '142', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -345,29 +345,29 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_non_fractional_discounts_are_correctly_calculated_with_jpy_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14300,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -700,
-            number: 2,
-            quantity: 1
-          }
-        ],
-        subtotal: 14300,
-        currency: 'JPY',
-        shipping: 0,
-        handling: 0,
-        tax: 0
-      }))
+                                            {
+                                              items: [
+                                                {
+                                                  name: 'item one',
+                                                  description: 'description',
+                                                  amount: 15000,
+                                                  number: 1,
+                                                  quantity: 1
+                                                },
+                                                {
+                                                  name: 'Discount',
+                                                  description: 'Discount',
+                                                  amount: -700,
+                                                  number: 2,
+                                                  quantity: 1
+                                                }
+                                              ],
+                                              subtotal: 14300,
+                                              currency: 'JPY',
+                                              shipping: 0,
+                                              handling: 0,
+                                              tax: 0
+                                            }))
 
     assert_equal '143', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '143', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -378,29 +378,29 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_fractional_discounts_are_correctly_calculated_with_usd_currency
     xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -750,
-            number: 2,
-            quantity: 1
-          }
-        ],
-      subtotal: 14250,
-      currency: 'USD',
-      shipping: 0,
-      handling: 0,
-      tax: 0
-      }))
+                                            {
+                                              items: [
+                                                {
+                                                  name: 'item one',
+                                                  description: 'description',
+                                                  amount: 15000,
+                                                  number: 1,
+                                                  quantity: 1
+                                                },
+                                                {
+                                                  name: 'Discount',
+                                                  description: 'Discount',
+                                                  amount: -750,
+                                                  number: 2,
+                                                  quantity: 1
+                                                }
+                                              ],
+                                            subtotal: 14250,
+                                            currency: 'USD',
+                                            shipping: 0,
+                                            handling: 0,
+                                            tax: 0
+                                            }))
 
     assert_equal '142.50', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '142.50', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -454,24 +454,24 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_items_are_included_if_specified_in_build_sale_or_authorization_request
     xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Sale', 100,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'item one description',
-            amount: 10000,
-            number: 1,
-            quantity: 3
-          },
-          {
-            name: 'item two',
-            description: 'item two description',
-            amount: 20000,
-            number: 2,
-            quantity: 4
-          }
-        ]
-      }))
+                                            {
+                                              items: [
+                                                {
+                                                  name: 'item one',
+                                                  description: 'item one description',
+                                                  amount: 10000,
+                                                  number: 1,
+                                                  quantity: 3
+                                                },
+                                                {
+                                                  name: 'item two',
+                                                  description: 'item two description',
+                                                  amount: 20000,
+                                                  number: 2,
+                                                  quantity: 4
+                                                }
+                                              ]
+                                            }))
 
     assert_equal 'item one', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name').text
     assert_equal 'item one description', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Description').text
@@ -548,13 +548,13 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_build_reference_transaction_test
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
     xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000,
-      {
-        reference_id: 'ref_id',
-        payment_type: 'Any',
-        invoice_id: 'invoice_id',
-        description: 'Description',
-        ip: '127.0.0.1'
-      }))
+                                            {
+                                              reference_id: 'ref_id',
+                                              payment_type: 'Any',
+                                              invoice_id: 'invoice_id',
+                                              description: 'Description',
+                                              ip: '127.0.0.1'
+                                            }))
 
     assert_equal '124', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
     assert_equal 'ref_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
@@ -577,13 +577,13 @@ class PaypalExpressTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_reference_transaction_response)
 
     response = @gateway.authorize_reference_transaction(2000,
-      {
-        reference_id: 'ref_id',
-        payment_type: 'Any',
-        invoice_id: 'invoice_id',
-        description: 'Description',
-        ip: '127.0.0.1'
-      })
+                                                        {
+                                                          reference_id: 'ref_id',
+                                                          payment_type: 'Any',
+                                                          invoice_id: 'invoice_id',
+                                                          description: 'Description',
+                                                          ip: '127.0.0.1'
+                                                        })
 
     assert_equal 'Success', response.params['ack']
     assert_equal 'Success', response.message
@@ -609,18 +609,18 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_error_code_for_single_error
     @gateway.expects(:ssl_post).returns(response_with_error)
     response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+                                            return_url: 'http://example.com',
+                                            cancel_return_url: 'http://example.com'
+                                           )
     assert_equal '10736', response.params['error_codes']
   end
 
   def test_ensure_only_unique_error_codes
     @gateway.expects(:ssl_post).returns(response_with_duplicate_errors)
     response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+                                            return_url: 'http://example.com',
+                                            cancel_return_url: 'http://example.com'
+                                           )
 
     assert_equal '10736', response.params['error_codes']
   end
@@ -628,9 +628,9 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_error_codes_for_multiple_errors
     @gateway.expects(:ssl_post).returns(response_with_errors)
     response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+                                            return_url: 'http://example.com',
+                                            cancel_return_url: 'http://example.com'
+                                           )
 
     assert_equal ['10736', '10002'], response.params['error_codes'].split(',')
   end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -261,9 +261,9 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_item_total_shipping_handling_and_tax_not_included_unless_all_are_present
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
-      tax: @amount,
-      shipping: @amount,
-      handling: @amount
+                        tax: @amount,
+                        shipping: @amount,
+                        handling: @amount
     )
 
     doc = REXML::Document.new(xml)
@@ -272,10 +272,10 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_item_total_shipping_handling_and_tax
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
-      tax: @amount,
-      shipping: @amount,
-      handling: @amount,
-      subtotal: 200
+                        tax: @amount,
+                        shipping: @amount,
+                        handling: @amount,
+                        subtotal: 200
     )
 
     doc = REXML::Document.new(xml)

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -4,7 +4,7 @@ class RealexTest < Test::Unit::TestCase
   class ActiveMerchant::Billing::RealexGateway
     # For the purposes of testing, lets redefine some protected methods as public.
     public :build_purchase_or_authorization_request, :build_refund_request, :build_void_request,
-      :build_capture_request, :build_verify_request, :build_credit_request
+           :build_capture_request, :build_verify_request, :build_credit_request
   end
 
   def setup

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -317,8 +317,8 @@ class SagePayTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, capture.authorization,
-        order_id: generate_unique_id,
-        description: 'Refund txn'
+                      order_id: generate_unique_id,
+                      description: 'Refund txn'
       )
     end.respond_with(successful_refund_response)
     assert_success refund

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -8,7 +8,7 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     @credit_card = credit_card
     @check = check
     @amount = 103
-    @existing_transaction  = 'LKA3RchoqYO0njAfhHVw60ohjrC'
+    @existing_transaction = 'LKA3RchoqYO0njAfhHVw60ohjrC'
     @not_found_transaction = 'AdyQXaG0SVpSoMPdmFlvd3aA3uz'
   end
 

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -146,7 +146,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, 'pi_123')
     assert_failure refund
-    assert_match /Error while communicating with one of our backends/, refund.params.dig('error', 'message')
+    assert_match(/Error while communicating with one of our backends/, refund.params.dig('error', 'message'))
   end
 
   def test_failed_refund_due_to_pending_3ds_auth
@@ -155,7 +155,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount, 'pi_123')
     assert_failure refund
     assert_equal 'requires_action', refund.params['status']
-    assert_match /payment_intent has a status of requires_action/, refund.message
+    assert_match(/payment_intent has a status of requires_action/, refund.message)
   end
 
   private

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -511,7 +511,7 @@ class StripeTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_method, endpoint, data, _headers|
-      if %r{/charges} =~ endpoint
+      if %r{/charges}.match?(endpoint)
         assert_match('level3[merchant_reference]=123', data)
         assert_match('level3[customer_reference]=456', data)
         assert_match('level3[shipping_address_zip]=98765', data)
@@ -950,10 +950,10 @@ class StripeTest < Test::Unit::TestCase
   def test_add_creditcard_pads_eci_value
     post = {}
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram',
-      verification_value: nil,
-      eci: '7'
-    )
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   verification_value: nil,
+                                                   eci: '7'
+                                                  )
 
     @gateway.send(:add_creditcard, post, credit_card, {})
 
@@ -1365,10 +1365,10 @@ class StripeTest < Test::Unit::TestCase
     end.returns(successful_authorization_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram',
-      verification_value: nil,
-      eci: '05'
-    )
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   verification_value: nil,
+                                                   eci: '05'
+                                                  )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1386,11 +1386,11 @@ class StripeTest < Test::Unit::TestCase
     end.returns(successful_authorization_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1408,10 +1408,10 @@ class StripeTest < Test::Unit::TestCase
     end.returns(successful_authorization_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram',
-      verification_value: nil,
-      eci: '05'
-    )
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   verification_value: nil,
+                                                   eci: '05'
+                                                  )
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1429,11 +1429,11 @@ class StripeTest < Test::Unit::TestCase
     end.returns(successful_authorization_response)
 
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram',
-      verification_value: nil,
-      eci: '05',
-      source: :android_pay
-    )
+                                                   payment_cryptogram: '111111111100cryptogram',
+                                                   verification_value: nil,
+                                                   eci: '05',
+                                                   source: :android_pay
+                                                  )
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response


### PR DESCRIPTION
Updated the supported Ruby and Rails versions to remove versions that
have officially been moved to end of life while maintaining support for
versions 5.0 and 5.1 for Rails.

 - Removed Ruby versions 2.3 and 2.4
 - Added Ruby versions 2.6 and 2.7
 - Removed Rails version 4.2
 - Added Rails version 6.0

In addition, the following changes were made as part of this update:

 - RuboCop target Ruby version was updated to 2.5, which necessitated
 some RuboCop fixes in various files
 - The RuboCop version was upgraded to 0.83, which necessitated even
 more RuboCop fixes in various files
 - [Fix an REXML error](https://github.com/kbeckman/omniauth-wsfed/pull/30)
for the So Easy Pay gateway
 - Add in missing Active Support core extensions to the test helper file

All unit tests:
4497 tests, 71905 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed