### PR TITLE
Elavon: Add Level 3 fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * HPS: Prevent errors when account_type or account_holder_type are nil [britth] #3628
 * D Local: Handle invalid country code errors [curiousepic] #3626
 * Stripe Payment Intents: Utilize execute_threed flag to determine success [britth] #3625
+* Elavon: Add Level 3 fields [leila-alderman] #3632
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -49,6 +49,7 @@ module ActiveMerchant #:nodoc:
         add_test_mode(form, options)
         add_ip(form, options)
         add_ssl_dynamic_dba(form, options)
+        add_level_3_fields(form, options) if options[:level_3_data]
         commit(:purchase, money, form, options)
       end
 
@@ -63,6 +64,7 @@ module ActiveMerchant #:nodoc:
         add_test_mode(form, options)
         add_ip(form, options)
         add_ssl_dynamic_dba(form, options)
+        add_level_3_fields(form, options) if options[:level_3_data]
         commit(:authorize, money, form, options)
       end
 
@@ -259,6 +261,46 @@ module ActiveMerchant #:nodoc:
         form[:dynamic_dba] = options[:dba] if options.has_key?(:dba)
       end
 
+      def add_level_3_fields(form, options)
+        level_3_data = options[:level_3_data]
+        form[:customer_code] = level_3_data[:customer_code] if level_3_data[:customer_code]
+        form[:salestax] = level_3_data[:salestax] if level_3_data[:salestax]
+        form[:salestax_indicator] = level_3_data[:salestax_indicator] if level_3_data[:salestax_indicator]
+        form[:level3_indicator] = level_3_data[:level3_indicator] if level_3_data[:level3_indicator]
+        form[:ship_to_zip] = level_3_data[:ship_to_zip] if level_3_data[:ship_to_zip]
+        form[:ship_to_country] = level_3_data[:ship_to_country] if level_3_data[:ship_to_country]
+        form[:shipping_amount] = level_3_data[:shipping_amount] if level_3_data[:shipping_amount]
+        form[:ship_from_postal_code] = level_3_data[:ship_from_postal_code] if level_3_data[:ship_from_postal_code]
+        form[:discount_amount] = level_3_data[:discount_amount] if level_3_data[:discount_amount]
+        form[:duty_amount] = level_3_data[:duty_amount] if level_3_data[:duty_amount]
+        form[:national_tax_indicator] = level_3_data[:national_tax_indicator] if level_3_data[:national_tax_indicator]
+        form[:national_tax_amount] = level_3_data[:national_tax_amount] if level_3_data[:national_tax_amount]
+        form[:order_date] = level_3_data[:order_date] if level_3_data[:order_date]
+        form[:other_tax] = level_3_data[:other_tax] if level_3_data[:other_tax]
+        form[:summary_commodity_code] = level_3_data[:summary_commodity_code] if level_3_data[:summary_commodity_code]
+        form[:merchant_vat_number] = level_3_data[:merchant_vat_number] if level_3_data[:merchant_vat_number]
+        form[:customer_vat_number] = level_3_data[:customer_vat_number] if level_3_data[:customer_vat_number]
+        form[:freight_tax_amount] = level_3_data[:freight_tax_amount] if level_3_data[:freight_tax_amount]
+        form[:vat_invoice_number] = level_3_data[:vat_invoice_number] if level_3_data[:vat_invoice_number]
+        form[:tracking_number] = level_3_data[:tracking_number] if level_3_data[:tracking_number]
+        form[:shipping_company] = level_3_data[:shipping_company] if level_3_data[:shipping_company]
+        form[:other_fees] = level_3_data[:other_fees] if level_3_data[:other_fees]
+        add_line_items(form, level_3_data) if level_3_data[:line_items]
+      end
+
+      def add_line_items(form, level_3_data)
+        items = []
+        level_3_data[:line_items].each do |line_item|
+          item = {}
+          line_item.each do |key, value|
+            prefixed_key = "ssl_line_Item_#{key}"
+            item[prefixed_key.to_sym] = value
+          end
+          items << item
+        end
+        form[:LineItemProducts] = { product: items }
+      end
+
       def message_from(response)
         success?(response) ? response['result_message'] : response['errorMessage']
       end
@@ -288,7 +330,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data_string(key, value, options)
-        if custom_field?(key, options)
+        if custom_field?(key, options) || key == :LineItemProducts
           "#{key}=#{CGI.escape(value.to_s)}"
         else
           "ssl_#{key}=#{CGI.escape(value.to_s)}"

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -233,6 +233,75 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_level_3_fields
+    level_3_data = {
+      customer_code: 'bob',
+      salestax: '3.45',
+      salestax_indicator: 'Y',
+      level3_indicator: 'Y',
+      ship_to_zip: '12345',
+      ship_to_country: 'US',
+      shipping_amount: '1234',
+      ship_from_postal_code: '54321',
+      discount_amount: '5',
+      duty_amount: '2',
+      national_tax_indicator: '0',
+      national_tax_amount: '10',
+      order_date: '280810',
+      other_tax: '3',
+      summary_commodity_code: '123',
+      merchant_vat_number: '222',
+      customer_vat_number: '333',
+      freight_tax_amount: '4',
+      vat_invoice_number: '26',
+      tracking_number: '45',
+      shipping_company: 'UFedzon',
+      other_fees: '2',
+      line_items: [
+        {
+          description: 'thing',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: 'state',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        },
+        {
+          description: 'thing2',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: 'state',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        }
+      ]
+    }
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(level_3_data: level_3_data))
+
+    assert_success response
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -316,6 +316,112 @@ class ElavonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_level_3_fields_in_request
+    level_3_data = {
+      customer_code: 'bob',
+      salestax: '3.45',
+      salestax_indicator: 'Y',
+      level3_indicator: 'Y',
+      ship_to_zip: '12345',
+      ship_to_country: 'US',
+      shipping_amount: '1234',
+      ship_from_postal_code: '54321',
+      discount_amount: '5',
+      duty_amount: '2',
+      national_tax_indicator: '0',
+      national_tax_amount: '10',
+      order_date: '280810',
+      other_tax: '3',
+      summary_commodity_code: '123',
+      merchant_vat_number: '222',
+      customer_vat_number: '333',
+      freight_tax_amount: '4',
+      vat_invoice_number: '26',
+      tracking_number: '45',
+      shipping_company: 'UFedzon',
+      other_fees: '2',
+      line_items: [
+        {
+          description: 'thing',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: 'state',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        },
+        {
+          description: 'thing2',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: 'state',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        }
+      ]
+    }
+
+    options = @options.merge(level_3_data: level_3_data)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/ssl_customer_code=bob/, data)
+      assert_match(/ssl_salestax=3.45/, data)
+      assert_match(/ssl_salestax_indicator=Y/, data)
+      assert_match(/ssl_level3_indicator=Y/, data)
+      assert_match(/ssl_ship_to_zip=12345/, data)
+      assert_match(/ssl_ship_to_country=US/, data)
+      assert_match(/ssl_shipping_amount=1234/, data)
+      assert_match(/ssl_ship_from_postal_code=54321/, data)
+      assert_match(/ssl_discount_amount=5/, data)
+      assert_match(/ssl_duty_amount=2/, data)
+      assert_match(/ssl_national_tax_indicator=0/, data)
+      assert_match(/ssl_national_tax_amount=10/, data)
+      assert_match(/ssl_order_date=280810/, data)
+      assert_match(/ssl_other_tax=3/, data)
+      assert_match(/ssl_summary_commodity_code=123/, data)
+      assert_match(/ssl_merchant_vat_number=222/, data)
+      assert_match(/ssl_customer_vat_number=333/, data)
+      assert_match(/ssl_freight_tax_amount=4/, data)
+      assert_match(/ssl_vat_invoice_number=26/, data)
+      assert_match(/ssl_tracking_number=45/, data)
+      assert_match(/ssl_shipping_company=UFedzon/, data)
+      assert_match(/ssl_other_fees=2/, data)
+      assert_match(/ssl_line_Item_description/, data)
+      assert_match(/ssl_line_Item_product_code/, data)
+      assert_match(/ssl_line_Item_commodity_code/, data)
+      assert_match(/ssl_line_Item_quantity/, data)
+      assert_match(/ssl_line_Item_unit_of_measure/, data)
+      assert_match(/ssl_line_Item_unit_cost/, data)
+      assert_match(/ssl_line_Item_discount_indicator/, data)
+      assert_match(/ssl_line_Item_tax_indicator/, data)
+      assert_match(/ssl_line_Item_discount_amount/, data)
+      assert_match(/ssl_line_Item_tax_rate/, data)
+      assert_match(/ssl_line_Item_tax_amount/, data)
+      assert_match(/ssl_line_Item_tax_type/, data)
+      assert_match(/ssl_line_Item_extended_total/, data)
+      assert_match(/ssl_line_Item_total/, data)
+      assert_match(/ssl_line_Item_alternative_tax/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_transcript_scrubbing
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrub), post_scrub


### PR DESCRIPTION
Adds support for Level 2 and Level 3 fields for the Elavon gateway.

CE-543

Unit:
33 tests, 192 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
28 tests, 123 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4499 tests, 71947 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed