### PR TITLE
Stripe: Provide error when attempting an authorize with ACH

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * CyberSource: Fix invalid and missing field tests [curiousepic] #3634
 * CyberSource: Pass stored credentials with purchase [curiousepic] #3636
 * Mercado Pago: Add payment_method_option_id field [schwarzgeist] #3635
+* Stripe: Provide error when attempting an authorize with ACH [britth] #3633
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -80,6 +80,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize(money, payment, options = {})
+        if ach?(payment)
+          direct_bank_error = 'Direct bank account transactions are not supported for authorize.'
+          return Response.new(false, direct_bank_error)
+        end
+
         MultiResponse.run do |r|
           if payment.is_a?(ApplePayPaymentToken)
             r.process { tokenize_apple_pay_token(payment) }

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -180,6 +180,23 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'Direct bank account transactions are not supported. Bank accounts must be stored and verified before use.', response.message
   end
 
+  def test_unsuccessful_echeck_auth_with_verified_account
+    customer_id = @verified_bank_account[:customer_id]
+    bank_account_id = @verified_bank_account[:bank_account_id]
+
+    payment = [customer_id, bank_account_id].join('|')
+
+    response = @gateway.authorize(@amount, payment, @options)
+    assert_failure response
+    assert_equal 'You cannot pass capture=false for this payment type.', response.message
+  end
+
+  def test_unsuccessful_direct_bank_account_auth
+    response = @gateway.authorize(@amount, @check, @options)
+    assert_failure response
+    assert_equal 'Direct bank account transactions are not supported for authorize.', response.message
+  end
+
   def test_authorization_and_capture
     assert authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization


### PR DESCRIPTION
Currently, the Stripe adapter can be used to attempt an authorize
with a check object. However, this causes an application error,
because if you pass a check directly in an authorize, we don't try
to tokenize it in any way before processing, so it errors out with
a NoMethodError (we're trying to process it as though it's a credit
card, and in this case, there's no `month` method on the check,
causing an error). Additionally, ACH simply does not seem to be
supported by Stripe for revenue transfers where funds aren't captured - 
after storing a check as you'd have to do for a purchase, you'll
end up with an error related to capture being false if you attempt
the auth. This PR updates the logic in authorize to check if the
payment method is a check before processing the auth, and if so, we
return an error the way we do for purchases when the check has not
been previously stored. Also adds a test showing that auths fail
anyway if attempted using a stored check, but don't result in any
unexpected application errors.

Further reading: https://stripe.com/docs/ach

Unit:
138 tests, 738 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
71 tests, 325 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed