### PR TITLE
Mercado Pago: Add payment_method_option_id field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * CyberSource: Stored Credential fixes [curiousepic] #3624
 * CyberSource: Fix invalid and missing field tests [curiousepic] #3634
 * CyberSource: Pass stored credentials with purchase [curiousepic] #3636
+* Mercado Pago: Add payment_method_option_id field [schwarzgeist] #3635
 
 == Version 1.107.3 (May 8, 2020)
 * Realex: Ignore IPv6 unsupported addresses [elfassy] #3622

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -113,6 +113,7 @@ module ActiveMerchant #:nodoc:
 
         post[:processing_mode] = options[:processing_mode]
         post[:merchant_account_id] = options[:merchant_account_id] if options[:merchant_account_id]
+        post[:payment_method_option_id] = options[:payment_method_option_id] if options[:payment_method_option_id]
         add_merchant_services(post, options)
       end
 

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -42,7 +42,8 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
       processing_mode: 'gateway',
       merchant_account_id: fixtures(:mercado_pago)[:merchant_account_id],
       fraud_scoring: true,
-      fraud_manual_review: true
+      fraud_manual_review: true,
+      payment_method_option_id: '123abc'
     }
   end
 


### PR DESCRIPTION
CE-562, CE-593

Unit:
38 tests, 174 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
32 tests, 82 assertions, 8 failures, 1 errors,
0 pendings, 0 omissions, 0 notifications
71.875% passed

All Unit Tests:
4501 tests, 71919 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed