### PR TITLE
Realex: Remove support for network tokenization

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -146,11 +146,7 @@ module ActiveMerchant
           add_card(xml, credit_card)
           xml.tag! 'autosettle', 'flag' => auto_settle_flag(action)
           add_signed_digest(xml, timestamp, @options[:login], sanitize_order_id(options[:order_id]), amount(money), (options[:currency] || currency(money)), credit_card.number)
-          if credit_card.is_a?(NetworkTokenizationCreditCard)
-            add_network_tokenization_card(xml, credit_card)
-          else
-            add_three_d_secure(xml, options)
-          end
+          add_three_d_secure(xml, options)
           add_comments(xml, options)
           add_address_and_customer_info(xml, options)
         end
@@ -289,18 +285,6 @@ module ActiveMerchant
           xml.tag! 'cvn' do
             xml.tag! 'number', credit_card.verification_value
             xml.tag! 'presind', (options['presind'] || (credit_card.verification_value? ? 1 : nil))
-          end
-        end
-      end
-
-      def add_network_tokenization_card(xml, payment)
-        xml.tag! 'mpi' do
-          xml.tag! 'cavv', payment.payment_cryptogram
-          xml.tag! 'eci', payment.eci
-        end
-        xml.tag! 'supplementarydata' do
-          xml.tag! 'item', 'type' => 'mobile' do
-            xml.tag! 'field01', payment.source.to_s.gsub('_', '-')
           end
         end
       end

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -18,19 +18,6 @@ class RemoteRealexTest < Test::Unit::TestCase
     @mastercard_referral_a = card_fixtures(:realex_mastercard_referral_a)
     @mastercard_coms_error = card_fixtures(:realex_mastercard_coms_error)
 
-    @apple_pay = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
-
-    @declined_apple_pay = network_tokenization_credit_card('4000120000001154',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil,
-      eci: '05',
-      source: :apple_pay
-    )
     @amount = 10000
   end
 
@@ -86,13 +73,6 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_match %r{no such}i, response.message
   end
 
-  def test_realex_purchase_with_apple_pay
-    response = @gateway.purchase(1000, @apple_pay, order_id: generate_unique_id, description: 'Test Realex with ApplePay')
-    assert_success response
-    assert response.test?
-    assert_equal 'Successful', response.message
-  end
-
   def test_realex_purchase_declined
     [@visa_declined, @mastercard_declined].each do |card|
       response = @gateway.purchase(@amount, card,
@@ -105,14 +85,6 @@ class RemoteRealexTest < Test::Unit::TestCase
       assert_equal '101', response.params['result']
       assert_equal response.params['message'], response.message
     end
-  end
-
-  def test_realex_purchase_with_apple_pay_declined
-    response = @gateway.purchase(1101, @declined_apple_pay, order_id: generate_unique_id, description: 'Test Realex with ApplePay')
-    assert_failure response
-    assert response.test?
-    assert_equal '101', response.params['result']
-    assert_match %r{DECLINED}i, response.message
   end
 
   def test_realex_purchase_with_three_d_secure_1


### PR DESCRIPTION
## Why?

Discussions with the Realex support team have revealed that these fields are not actually supported.

## What Changed?

This pull request removes support for network tokenized cards on the Realex gateway.

## Test Suite

```
4503 tests, 71981 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```