### PR TITLE
[Cybersource] Set a default collectionIndicator

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -34,6 +34,7 @@ module ActiveMerchant #:nodoc:
         jcb: 'js',
         discover: 'pb',
       }.freeze
+      DEFAULT_COLLECTION_INDICATOR = 2
 
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :dankort, :maestro, :elo]
       self.supported_countries = %w(US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB PK)
@@ -626,7 +627,7 @@ module ActiveMerchant #:nodoc:
 
         xml.tag! 'ucaf' do
           xml.tag!('authenticationData', options[:three_d_secure][:cavv])
-          xml.tag!('collectionIndicator', options[:collection_indicator]) if options[:collection_indicator]
+          xml.tag!('collectionIndicator', options[:collection_indicator] || DEFAULT_COLLECTION_INDICATOR)
         end
       end
 
@@ -660,7 +661,7 @@ module ActiveMerchant #:nodoc:
         when :master
           xml.tag! 'ucaf' do
             xml.tag!('authenticationData', payment_method.payment_cryptogram)
-            xml.tag!('collectionIndicator', '2')
+            xml.tag!('collectionIndicator', DEFAULT_COLLECTION_INDICATOR)
           end
           xml.tag! 'ccAuthService', {'run' => 'true'} do
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -867,6 +867,24 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_adds_mastercard_3ds2_default_collection_indicator
+    options_with_normalized_3ds = @options.merge(
+      three_d_secure: {
+        version: '2.0',
+        eci: '05',
+        cavv: '637574652070757070792026206b697474656e73',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        cavv_algorithm: 'vbv'
+      },
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<collectionIndicator\>2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end


### PR DESCRIPTION
For mastercard cards, we need to always be passing a collectionIndicator for the request to succeed.

I decided to use `2` as the default collectionIndicator, as it was already the one used for tokenized card and
it seems to match our usecase from all the pther choices:

- 0: UCAF collection is not supported at your web
site.
- 1: UCAF collection is supported at your web
site, and the UCAF was populated.
- 2: UCAF collection is supported at your web
site and the UCAF was populated. This value
indicates a successful Mastercard Identity
Check transaction.
- 5: UCAF collection is supported at your web
site, and the UCAF was populated based on the
risk assessment that the issuer performed. This
value is supported only for Masterpass
transactions.
- 6: UCAF collection is supported at your web
site, and the UCAF was populated based on the
risk assessment that you performed. This value
is supported only for Masterpass transactions.