### PR TITLE
Implement change to formatting of VerificationStr1 to strip control characters

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -262,7 +262,7 @@ module ActiveMerchant #:nodoc:
         address = options[:billing_address] || options[:address]
         if address
           address_values = []
-          [:address1, :zip, :city, :state, :country].each { |part| address_values << address[part].to_s }
+          [:address1, :zip, :city, :state, :country].each { |part| address_values << address[part].to_s.tr("\r\n"," ").strip }
           xml.tag! 'VerificationStr1', address_values.join('|')
         end
 

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -165,6 +165,15 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_requests_scrub_newline_and_return_characters_from_verification_string_components
+    stub_comms do
+      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "123 My\nStreet", address2: "K1C2N6\r", city: "Ottawa\r\n" })})
+      @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<VerificationStr1>123 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>', data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_tax_fields_are_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(tax1_amount: 830, tax1_number: 'Br59a'))


### PR DESCRIPTION
This pull request implements a change to strip out \r  and \n characters from address components in the VerificationStr1.
This is to conform with tighter verification on VerificationStr1 values introduced by FirstData in May 2020.