### PR TITLE
DLocal: Fix address field names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Update supported Ruby and Rails versions [leila-alderman] #3656
 * CI: Drop unused sudo: false Travis directive [olleolleolle] #3616
 * PayU Latam: Prevent blank country in billing_address [britth] #3657
+* DLocal: Fix address field names [molbrown] #3651
 
 == Version 1.107.4 (Jun 2, 2020)
 * Elavon: Implement true verify action [leila-alderman] #3610

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -118,10 +118,20 @@ module ActiveMerchant #:nodoc:
         address_object = {}
         address_object[:state] = address[:state] if address[:state]
         address_object[:city] = address[:city] if address[:city]
-        address_object[:zip_code] = address[:zip_code] if address[:zip_code]
-        address_object[:street] = address[:street] if address[:street]
-        address_object[:number] = address[:number] if address[:number]
+        address_object[:zip_code] = address[:zip] if address[:zip]
+        address_object[:street] = address[:street] || parse_street(address) if parse_street(address)
+        address_object[:number] = address[:number] || parse_house_number(address) if parse_house_number(address)
         address_object
+      end
+
+      def parse_street(address)
+        street = address[:address1].split(/\s+/).keep_if { |x| x !~ /\d/ }.join(' ')
+        street.empty? ? nil : street
+      end
+
+      def parse_house_number(address)
+        house = address[:address1].split(/\s+/).keep_if { |x| x =~ /\d/ }.join(' ')
+        house.empty? ? nil : house
       end
 
       def add_card(post, card, action, options={})

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -110,6 +110,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was paid', response.message
   end
 
+  def test_successful_purchase_partial_address
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: address(address1: 'My Street', country: 'Brazil')))
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @credit_card, @options.merge(description: '300'))
     assert_failure response

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -62,6 +62,29 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal 'D-15104-be03e883-3e6b-497d-840e-54c8b6209bc3', response.authorization
   end
 
+  def test_passing_billing_address
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"state\":\"ON\"/, data)
+      assert_match(/"city\":\"Ottawa\"/, data)
+      assert_match(/"zip_code\":\"K1C2N6\"/, data)
+      assert_match(/"street\":\"My Street\"/, data)
+      assert_match(/"number\":\"456\"/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_passing_incomplete_billing_address
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(address1: 'Just a Street')))
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/"state\":\"ON\"/, data)
+      assert_match(/"city\":\"Ottawa\"/, data)
+      assert_match(/"zip_code\":\"K1C2N6\"/, data)
+      assert_match(/"street\":\"Just a Street\"/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_passing_country_as_string
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)


### PR DESCRIPTION
DLocal was previously only passing state and country in the billing
address due to checking for incorrect address fields. DLocal also
separates number and street fields, so adds address parser for address1.

Unit:
20 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
27 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-1267