### PR TITLE
Explicitly require "extract_options" from Braintree Blue

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -1,4 +1,5 @@
 require 'active_merchant/billing/gateways/braintree/braintree_common'
+require 'active_support/core_ext/array/extract_options'
 
 begin
   require 'braintree'

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'active_support/core_ext/kernel/singleton_class'
 
 class MetricsGlobalTest < Test::Unit::TestCase
   include CommStub


### PR DESCRIPTION
Since this commit in Rails https://github.com/rails/rails/commit/d9539281bd6c314786b9f05ff6cba1d89509b174,
`extract_options` is no longer required automatically, since this class uses it, lets require it. 

We're also requiring the `singleton_class` when `class_eval` is used.

This fixes the tests on Rails master.