### PR TITLE
Forte: Change default sec_code value to PPD

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
         post[:echeck][:routing_number] = payment.routing_number
         post[:echeck][:account_type] = payment.account_type
         post[:echeck][:check_number] = payment.number
-        post[:echeck][:sec_code] = options[:sec_code] || "WEB"
+        post[:echeck][:sec_code] = options[:sec_code] || "PPD"
       end
 
       def add_credit_card(post, payment)

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -43,18 +43,18 @@ class RemoteForteTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @check, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
-    assert_equal 'WEB', response.params['echeck']['sec_code']
+    assert_equal 'PPD', response.params['echeck']['sec_code']
   end
 
   def test_successful_purchase_with_echeck_with_more_options
     options = {
-      sec_code: "PPD"
+      sec_code: "WEB"
     }
 
     response = @gateway.purchase(@amount, @check, options)
     assert_success response
     assert_equal 'APPROVED', response.message
-    assert_equal 'PPD', response.params['echeck']['sec_code']
+    assert_equal 'WEB', response.params['echeck']['sec_code']
   end
 
   def test_failed_purchase_with_echeck


### PR DESCRIPTION
The sec_code field for echeck transactions was recently added to the
Forte gateway in 1c4b10818a780d0c80e4554e0843741193c6584a. After
customer issues and digging into Forte value definitions, it has become
clear that 'PPD' should be the default value when none is specified.
Forte currently assigns PPD to a transaction where no sec_code is specified,
so we should follow that pattern here.

Forte will soon be requiring a sec_code is sent on any echeck
transaction, which is why a default is being set.

Remote:
22 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
20 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CE-532