### PR TITLE
Element(Vantiv) : Add terminal id field to transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Forte: Change default sec_code value to PPD [molbrown] #3653
 * Elavon: Add merchant initiated unscheduled field [leila-alderman] #3647
 * Decidir: Add aggregate data fields [leila-alderman] #3648
+* Vantiv: Vantiv(Element): add option to send terminal id in transactions [cdmackeyfree] #3654
 
 == Version 1.107.4 (Jun 2, 2020)
 * Elavon: Implement true verify action [leila-alderman] #3610

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -193,7 +193,7 @@ module ActiveMerchant #:nodoc:
 
       def add_terminal(xml, options)
         xml.terminal do
-          xml.TerminalID '01'
+          xml.TerminalID options[:terminal_id] || '01'
           xml.CardPresentCode options[:card_present_code] || 'UseDefault'
           xml.CardholderPresentCode 'UseDefault'
           xml.CardInputCode 'UseDefault'

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -56,6 +56,12 @@ class RemoteElementTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_terminal_id
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(terminal_id: '02'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_authorize_and_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -147,6 +147,11 @@ class ElementTest < Test::Unit::TestCase
     assert_equal 'Present', response.params['terminal']['cardpresentcode']
   end
 
+  def test_successful_purchase_with_terminal_id
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(terminal_id: '02'))
+    assert_equal '02', response.params['terminal']['terminalid']
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
Give the option to send through a specific terminal id via transactions to the Element(Vantiv) gateway and corrected a few Rubocop errors manually

CE-506

Unit: 
19 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Remote
21 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed