### PR TITLE
Default executeThreeD to false if it's not set

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -413,8 +413,12 @@ module ActiveMerchant #:nodoc:
             post[:threeDS2RequestData] = { deviceChannel: device_channel, notificationURL: three_ds_2_options[:notification_url] }
           end
 
-          post[:additionalData][:executeThreeD] = options[:execute_threed] || false
+          if options.has_key?(:execute_threed)
+            post[:additionalData][:executeThreeD] = options[:execute_threed]
+          end
+          
           post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
+          post[:additionalData][:executeThreeD] = false if options[:threed_dynamic] == false && options[:execute_threed].nil?
 
         else
           return unless options[:execute_threed] || options[:threed_dynamic]

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -413,10 +413,9 @@ module ActiveMerchant #:nodoc:
             post[:threeDS2RequestData] = { deviceChannel: device_channel, notificationURL: three_ds_2_options[:notification_url] }
           end
 
-          if options.has_key?(:execute_threed)
-            post[:additionalData][:executeThreeD] = options[:execute_threed]
-            post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
-          end
+          post[:additionalData][:executeThreeD] = options[:execute_threed] || false
+          post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
+
         else
           return unless options[:execute_threed] || options[:threed_dynamic]
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -215,7 +215,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response.test?
     refute response.authorization.blank?
 
-    assert_equal response.params['resultCode'], 'IdentifyShopper'
+    assert_equal response.params['resultCode'], 'Authorised'
     refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
     refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
     refute response.params['additionalData']['threeds2.threeDSMethodURL'].blank?
@@ -260,7 +260,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, three_ds_app_based_options)
     assert response.test?
     refute response.authorization.blank?
-    assert_equal response.params['resultCode'], 'IdentifyShopper'
+    assert_equal response.params['resultCode'], 'Authorised'
     refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
     refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
     refute response.params['additionalData']['threeds2.threeDS2DirectoryServerInformation.algorithm'].blank?

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -210,12 +210,22 @@ class RemoteAdyenTest < Test::Unit::TestCase
     refute response.params['paRequest'].blank?
   end
 
+  def test_successful_authorize_with_execute_threed_default_to_false
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(threed_dynamic: false, sca_exemption: 'transactionRiskAnalysis'))
+    assert response.test?
+    refute response.authorization.blank?
+    assert_equal response.params['resultCode'], 'RedirectShopper'
+    refute response.params['issuerUrl'].blank?
+    refute response.params['md'].blank?
+    refute response.params['paRequest'].blank?
+  end
+
   def test_successful_authorize_with_3ds2_browser_client_data
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @normalized_3ds_2_options)
     assert response.test?
     refute response.authorization.blank?
 
-    assert_equal response.params['resultCode'], 'Authorised'
+    assert_equal response.params['resultCode'], 'IdentifyShopper'
     refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
     refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
     refute response.params['additionalData']['threeds2.threeDSMethodURL'].blank?
@@ -260,7 +270,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, three_ds_app_based_options)
     assert response.test?
     refute response.authorization.blank?
-    assert_equal response.params['resultCode'], 'Authorised'
+    assert_equal response.params['resultCode'], 'IdentifyShopper'
     refute response.params['additionalData']['threeds2.threeDS2Token'].blank?
     refute response.params['additionalData']['threeds2.threeDSServerTransID'].blank?
     refute response.params['additionalData']['threeds2.threeDS2DirectoryServerInformation.algorithm'].blank?

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -367,6 +367,15 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_execute_threed_defaults_to_false
+    stub_comms do
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options)
+    end.check_request do |endpoint, data, headers|
+      refute JSON.parse(data)['additionalData']['scaExemption']
+      assert_false JSON.parse(data)['additionalData']['executeThreeD']
+    end.respond_with(successful_authorize_response)
+  end
+  
   def test_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({execute_threed: false}))

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -369,7 +369,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_execute_threed_defaults_to_false
     stub_comms do
-      @gateway.authorize(@amount, '123', @normalized_3ds_2_options)
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({threed_dynamic: false}))
     end.check_request do |endpoint, data, headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       assert_false JSON.parse(data)['additionalData']['executeThreeD']


### PR DESCRIPTION
This seems like what we want to do, but the output of the remote test for `test_successful_authorize_with_3ds2_app_based_request` and `test_successful_authorize_with_3ds2_browser_client_data` is a bit concerning as I'm not sure how it will affect downstream users. 

`bundle exec rake test:remote TEST=test/remote/gateways/remote_adyen_test.rb`

The ticket states that Adyen does not have a default behavior if the field is passed as null, but passing in false seems to completely change the response for these requests.

I think the alternative here, implementing it as a GSF and allowing the individual users to decide whether or not they want to explicitly set `executeThreeD` to false, may be safer. 