### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - "lib/active_merchant/billing/gateways/paypal_express.rb"
     - "vendor/**/*"
   ExtraDetails: false
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 # Active Merchant gateways are not amenable to length restrictions
 Metrics/ClassLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ cache: bundler
 
 rvm:
 - 2.5
-- 2.4
-- 2.3
+- 2.6
+- 2.7
 
 gemfile:
-- gemfiles/Gemfile.rails52
-- gemfiles/Gemfile.rails51
 - gemfiles/Gemfile.rails50
-- gemfiles/Gemfile.rails42
+- gemfiles/Gemfile.rails51
+- gemfiles/Gemfile.rails52
+- gemfiles/Gemfile.rails60
 - gemfiles/Gemfile.rails_master
 
 jobs:
@@ -19,13 +19,6 @@ jobs:
       rvm: 2.5
       gemfile: Gemfile
       script: bundle exec rubocop --parallel
-
-matrix:
-  exclude:
-    - rvm: 2.3
-      gemfile: 'gemfiles/Gemfile.rails_master'
-    - rvm: 2.4
-      gemfile: 'gemfiles/Gemfile.rails_master'
 
 notifications:
   email:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Elavon: Add merchant initiated unscheduled field [leila-alderman] #3647
 * Decidir: Add aggregate data fields [leila-alderman] #3648
 * Vantiv: Vantiv(Element): add option to send terminal id in transactions [cdmackeyfree] #3654
+* Update supported Ruby and Rails versions [leila-alderman] #3656
 
 == Version 1.107.4 (Jun 2, 2020)
 * Elavon: Implement true verify action [leila-alderman] #3610

--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ Functionality or APIs that are deprecated will be marked as such. Deprecated fun
 
 ## Ruby and Rails compatibility policies
 
-Because Active Merchant is a payment library, it needs to take security seriously. For this reason, Active Merchant guarantees compatibility only with actively supported versions of Ruby and Rails. At the time of this writing, that means that Ruby 2.3+ and Rails 4.2+ are supported.
+Because Active Merchant is a payment library, it needs to take security seriously. For this reason, Active Merchant guarantees compatibility only with actively supported versions of Ruby and Rails. At the time of this writing, that means that Ruby 2.5+ and Rails 5.0+ are supported.

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = 'tobi@leetsoft.com'
   s.homepage = 'http://activemerchant.org/'
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.5'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: '2.3.0'
+    version: '2.5.0'
 
 dependencies:
   cache_directories:

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -1,0 +1,3 @@
+eval_gemfile '../Gemfile'
+
+gem 'activesupport', '~> 6.0.0'

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -488,7 +488,7 @@ module ActiveMerchant
 
       def add_swipe_data(xml, credit_card)
         TRACKS.each do |key, regex|
-          if regex.match(credit_card.track_data)
+          if regex.match?(credit_card.track_data)
             @valid_track_data = true
             xml.payment do
               xml.trackData do

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -382,9 +382,9 @@ module ActiveMerchant #:nodoc:
           end
         elsif message == 'Missing ACCOUNT_ID'
           message = 'The merchant login ID or password is invalid'
-        elsif message =~ /Approved/
+        elsif /Approved/.match?(message)
           message = 'This transaction has been approved'
-        elsif message =~  /Expired/
+        elsif /Expired/.match?(message)
           message = 'The credit card has expired'
         end
         message

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -204,12 +204,10 @@ module ActiveMerchant #:nodoc:
 
       def check_customer_exists(customer_vault_id)
         commit do
-          begin
-            @braintree_gateway.customer.find(customer_vault_id)
-            ActiveMerchant::Billing::Response.new(true, 'Customer found', {exists: true}, authorization: customer_vault_id)
-          rescue Braintree::NotFoundError
-            ActiveMerchant::Billing::Response.new(true, 'Customer not found', {exists: false})
-          end
+          @braintree_gateway.customer.find(customer_vault_id)
+          ActiveMerchant::Billing::Response.new(true, 'Customer found', {exists: true}, authorization: customer_vault_id)
+        rescue Braintree::NotFoundError
+          ActiveMerchant::Billing::Response.new(true, 'Customer not found', {exists: false})
         end
       end
 

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -206,7 +206,7 @@ module ActiveMerchant #:nodoc:
 
       def generate_signature(body)
         key = OpenSSL::PKey::RSA.new(@options[:private_key])
-        hex = key.sign(OpenSSL::Digest.new('sha256'), body).unpack('H*').first
+        hex = key.sign(OpenSSL::Digest.new('sha256'), body).unpack1('H*')
 
         "#{@options[:signing_key]} RS256-hex #{hex}"
       end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -913,7 +913,7 @@ module ActiveMerchant #:nodoc:
         if node.has_elements?
           node.elements.each { |e| parse_element(reply, e) }
         else
-          if node.parent.name =~ /item/
+          if /item/.match?(node.parent.name)
             parent = node.parent.name
             parent += '_' + node.parent.attributes['id'] if node.parent.attributes['id']
             parent += '_'

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -255,7 +255,7 @@ module ActiveMerchant #:nodoc:
             (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
           end
 
-        xml.tag! 'Ecommerce_Flag', eci.to_s =~ /^[0-9]+$/ ? eci.to_s.rjust(2, '0') : eci
+        xml.tag! 'Ecommerce_Flag', /^[0-9]+$/.match?(eci.to_s) ? eci.to_s.rjust(2, '0') : eci
       end
 
       def add_credit_card_verification_strings(xml, credit_card, options)

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -229,7 +229,7 @@ module ActiveMerchant #:nodoc:
                 (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
               end
 
-        xml.tag! 'Ecommerce_Flag', eci.to_s =~ /^[0-9]+$/ ? eci.to_s.rjust(2, '0') : eci
+        xml.tag! 'Ecommerce_Flag', /^[0-9]+$/.match?(eci.to_s) ? eci.to_s.rjust(2, '0') : eci
       end
 
       def add_credit_card_verification_strings(xml, credit_card, options)

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
 
         success = false
         authorization = (raw['TransactionId'] || parameters[:transactionId])
-        if raw[:container] =~ /Exception|Error/
+        if /Exception|Error/.match?(raw[:container])
           message = (raw['Message'] || raw['Error']['Message'])
         elsif raw['Error'] && !raw['Error'].empty?
           message = (raw['Error']['ResponseText'] || raw['Error']['ResponseCode'])

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -222,7 +222,7 @@ module ActiveMerchant #:nodoc:
 
       def get_url(uri)
         url = (test? ? test_url : live_url)
-        if uri =~ /^customervault/
+        if /^customervault/.match?(uri)
           "#{url}#{uri}"
         else
           "#{url}cardpayments/v1/accounts/#{@options[:account_number]}/#{uri}"

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -357,7 +357,7 @@ module ActiveMerchant #:nodoc:
 
         success_regex = /^(000\.000\.|000\.100\.1|000\.[36])/
 
-        if success_regex =~ response['result']['code']
+        if success_regex.match?(response['result']['code'])
           true
         else
           false

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
           node.xpath('.//*').each { |e| parse_element(payment_result_response, e) }
         when node.xpath('.//*').to_a.any?
           node.xpath('.//*').each { |e| parse_element(response, e) }
-        when node_name.to_s =~ /amt$/
+        when /amt$/.match?(node_name.to_s)
           # *Amt elements don't put the value in the #text - instead they use a Currency attribute
           response[node_name] = node.attributes['Currency'].to_s
         when node_name == :ext_data

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
             name: creditcard.name
           )
         elsif creditcard.kind_of?(String)
-          if creditcard =~ /^card_/
+          if /^card_/.match?(creditcard)
             post[:card_token] = get_card_token(creditcard)
           else
             post[:customer_token] = creditcard

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -253,7 +253,7 @@ module ActiveMerchant #:nodoc:
         if node.has_elements?
           node.elements.each { |e| parse_element(reply, e) }
         else
-          if node.parent.name =~ /item/
+          if /item/.match?(node.parent.name)
             parent = node.parent.name + (node.parent.attributes['id'] ? '_' + node.parent.attributes['id'] : '')
             reply[(parent + '_' + node.name).to_sym] = node.text
           else

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -310,7 +310,7 @@ module ActiveMerchant
 
         version = three_d_secure.fetch(:version, '')
         xml.tag! 'mpi' do
-          if version =~ /^2/
+          if /^2/.match?(version)
             xml.tag! 'authentication_value', three_d_secure[:cavv]
             xml.tag! 'ds_trans_id', three_d_secure[:ds_transaction_id]
           else

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -565,7 +565,7 @@ module ActiveMerchant #:nodoc:
 
       def clean_order_id(order_id)
         cleansed = order_id.gsub(/[^\da-zA-Z]/, '')
-        if cleansed =~ /^\d{4}/
+        if /^\d{4}/.match?(cleansed)
           cleansed[0..11]
         else
           '%04d%s' % [rand(0..9999), cleansed[0...8]]

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
       def parse(response, action)
         result = {}
         document = REXML::Document.new(response)
-        response_element = document.root.get_elements("//[@xsi:type='tns:#{action}Response']").first
+        response_element = document.root.get_elements("//*[@xsi:type='tns:#{action}Response']").first
         response_element.elements.each do |element|
           result[element.name.underscore] = element.text
         end

--- a/lib/active_merchant/billing/gateways/transact_pro.rb
+++ b/lib/active_merchant/billing/gateways/transact_pro.rb
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
-        if body =~ /^ID:/
+        if /^ID:/.match?(body)
           body.split('~').reduce(Hash.new) { |h, v|
             m = v.match('(.*?):(.*)')
             h.merge!(m[1].underscore.to_sym => m[2])
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def split_authorization(authorization)
-        if authorization =~ /|/
+        if /|/.match?(authorization)
           identifier, amount = authorization.split('|')
           [identifier, amount.to_i]
         else

--- a/lib/active_merchant/billing/gateways/trexle.rb
+++ b/lib/active_merchant/billing/gateways/trexle.rb
@@ -137,7 +137,7 @@ module ActiveMerchant #:nodoc:
             name: creditcard.name
           )
         elsif creditcard.kind_of?(String)
-          if creditcard =~ /^token_/
+          if /^token_/.match?(creditcard)
             post[:card_token] = creditcard
           else
             post[:customer_token] = creditcard

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -406,7 +406,7 @@ module ActiveMerchant #:nodoc:
       def add_three_d_secure(three_d_secure, xml)
         xml.info3DSecure do
           xml.threeDSVersion three_d_secure[:version]
-          if three_d_secure[:version] =~ /^2/
+          if /^2/.match?(three_d_secure[:version])
             xml.dsTransactionId three_d_secure[:ds_transaction_id]
           else
             xml.xid three_d_secure[:xid]

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -73,52 +73,50 @@ module ActiveMerchant
       headers['connection'] ||= 'close'
 
       retry_exceptions(max_retries: max_retries, logger: logger, tag: tag) do
-        begin
-          info "connection_http_method=#{method.to_s.upcase} connection_uri=#{endpoint}", tag
+        info "connection_http_method=#{method.to_s.upcase} connection_uri=#{endpoint}", tag
 
-          result = nil
+        result = nil
 
-          realtime = Benchmark.realtime do
-            http.start unless http.started?
-            @ssl_connection = http.ssl_connection
-            info "connection_ssl_version=#{ssl_connection[:version]} connection_ssl_cipher=#{ssl_connection[:cipher]}", tag
+        realtime = Benchmark.realtime do
+          http.start unless http.started?
+          @ssl_connection = http.ssl_connection
+          info "connection_ssl_version=#{ssl_connection[:version]} connection_ssl_cipher=#{ssl_connection[:cipher]}", tag
 
-            result =
-              case method
-              when :get
-                raise ArgumentError, 'GET requests do not support a request body' if body
+          result =
+            case method
+            when :get
+              raise ArgumentError, 'GET requests do not support a request body' if body
 
-                http.get(endpoint.request_uri, headers)
-              when :post
+              http.get(endpoint.request_uri, headers)
+            when :post
+              debug body
+              http.post(endpoint.request_uri, body, RUBY_184_POST_HEADERS.merge(headers))
+            when :put
+              debug body
+              http.put(endpoint.request_uri, body, headers)
+            when :patch
+              debug body
+              http.patch(endpoint.request_uri, body, headers)
+            when :delete
+              # It's kind of ambiguous whether the RFC allows bodies
+              # for DELETE requests. But Net::HTTP's delete method
+              # very unambiguously does not.
+              if body
                 debug body
-                http.post(endpoint.request_uri, body, RUBY_184_POST_HEADERS.merge(headers))
-              when :put
-                debug body
-                http.put(endpoint.request_uri, body, headers)
-              when :patch
-                debug body
-                http.patch(endpoint.request_uri, body, headers)
-              when :delete
-                # It's kind of ambiguous whether the RFC allows bodies
-                # for DELETE requests. But Net::HTTP's delete method
-                # very unambiguously does not.
-                if body
-                  debug body
-                  req = Net::HTTP::Delete.new(endpoint.request_uri, headers)
-                  req.body = body
-                  http.request(req)
-                else
-                  http.delete(endpoint.request_uri, headers)
-                end
+                req = Net::HTTP::Delete.new(endpoint.request_uri, headers)
+                req.body = body
+                http.request(req)
               else
-                raise ArgumentError, "Unsupported request method #{method.to_s.upcase}"
+                http.delete(endpoint.request_uri, headers)
               end
-          end
-
-          info '--> %d %s (%d %.4fs)' % [result.code, result.message, result.body ? result.body.length : 0, realtime], tag
-          debug result.body
-          result
+            else
+              raise ArgumentError, "Unsupported request method #{method.to_s.upcase}"
+            end
         end
+
+        info '--> %d %s (%d %.4fs)' % [result.code, result.message, result.body ? result.body.length : 0, realtime], tag
+        debug result.body
+        result
       end
     ensure
       info 'connection_request_total_time=%.4fs' % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start], tag

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -21,18 +21,16 @@ module ActiveMerchant
       connection_errors = DEFAULT_CONNECTION_ERRORS.merge(options[:connection_exceptions] || {})
 
       retry_network_exceptions(options) do
-        begin
-          yield
-        rescue Errno::ECONNREFUSED => e
-          raise ActiveMerchant::RetriableConnectionError.new('The remote server refused the connection', e)
-        rescue OpenSSL::X509::CertificateError => e
-          NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
-          raise ActiveMerchant::ClientCertificateError, 'The remote server did not accept the provided SSL certificate'
-        rescue Zlib::BufError
-          raise ActiveMerchant::InvalidResponseError, 'The remote server replied with an invalid response'
-        rescue *connection_errors.keys => e
-          raise ActiveMerchant::ConnectionError.new(derived_error_message(connection_errors, e.class), e)
-        end
+        yield
+      rescue Errno::ECONNREFUSED => e
+        raise ActiveMerchant::RetriableConnectionError.new('The remote server refused the connection', e)
+      rescue OpenSSL::X509::CertificateError => e
+        NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
+        raise ActiveMerchant::ClientCertificateError, 'The remote server did not accept the provided SSL certificate'
+      rescue Zlib::BufError
+        raise ActiveMerchant::InvalidResponseError, 'The remote server replied with an invalid response'
+      rescue *connection_errors.keys => e
+        raise ActiveMerchant::ConnectionError.new(derived_error_message(connection_errors, e.class), e)
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,12 +131,12 @@ module ActiveMerchant
       yield
     rescue AssertionClass => e
       path = File.expand_path(__FILE__)
-      raise AssertionClass, e.message, (e.backtrace.reject { |line| File.expand_path(line) =~ /#{path}/ })
+      raise AssertionClass, e.message, (e.backtrace.reject { |line| File.expand_path(line).match?(/#{path}/) })
     end
   end
 
   module Fixtures
-    HOME_DIR = RUBY_PLATFORM =~ /mswin32/ ? ENV['HOMEPATH'] : ENV['HOME'] unless defined?(HOME_DIR)
+    HOME_DIR = RUBY_PLATFORM.match?('mswin32') ? ENV['HOMEPATH'] : ENV['HOME'] unless defined?(HOME_DIR)
     LOCAL_CREDENTIALS = File.join(HOME_DIR.to_s, '.active_merchant/fixtures.yml') unless defined?(LOCAL_CREDENTIALS)
     DEFAULT_CREDENTIALS = File.join(File.dirname(__FILE__), 'fixtures.yml') unless defined?(DEFAULT_CREDENTIALS)
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -290,7 +290,7 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
     end.check_request do |endpoint, data, headers|
-      if endpoint =~ /authorise/
+      if /authorise/.match?(endpoint)
         assert_match(/"overwriteBrand":true/, data)
         assert_match(/"selectedBrand":"maestro"/, data)
       end

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -330,7 +330,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({third_party_payout: true}))
     end.check_request do |endpoint, data, headers|
-      if /storeDetailAndSubmitThirdParty/ =~ endpoint
+      if /storeDetailAndSubmitThirdParty/.match?(endpoint)
         assert_match(%r{/storeDetailAndSubmitThirdParty}, endpoint)
         assert_match(/dateOfBirth=1990-10-11&/, data)
         assert_match(/entityType=NaturalPerson&/, data)

--- a/test/unit/gateways/digitzs_test.rb
+++ b/test/unit/gateways/digitzs_test.rb
@@ -39,7 +39,7 @@ class DigitzsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"cardSplit"/
+      if /"cardSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)
       end
@@ -53,7 +53,7 @@ class DigitzsTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
     end.check_request do |endpoint, data, headers|
-      if data =~ /"tokenSplit"/
+      if /"tokenSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)
       end

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -69,9 +69,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
-        assert_no_match %r{extraTaxes}, data
-      end
+      assert_no_match %r{extraTaxes}, data if /charges/.match?(endpoint)
     end.respond_with(successful_charge_response, successful_token_response)
 
     assert_success response
@@ -102,7 +100,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
+      if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_no_match %r{propina}, data
         assert_match %r{iac}, data
@@ -139,7 +137,7 @@ class KushkiTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |endpoint, data, headers|
-      if /charges/ =~ endpoint
+      if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_match %r{propina}, data
       end

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -309,7 +309,7 @@ class MercadoPagoTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /payment_method_id/
+      if /payment_method_id/.match?(data)
         assert_match(/"foo":"bar"/, data)
         assert_match(/"baz":"quux"/, data)
       end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -511,7 +511,7 @@ class StripeTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_method, endpoint, data, _headers|
-      if %r{/charges} =~ endpoint
+      if %r{/charges}.match?(endpoint)
         assert_match('level3[merchant_reference]=123', data)
         assert_match('level3[customer_reference]=456', data)
         assert_match('level3[shipping_address_zip]=98765', data)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -237,12 +237,8 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.void(authorization, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<orderInquiry .*?>) =~ data
-        assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data)
-      end
-      if %r(<orderModification .*?>) =~ data
-        assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
+      assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_void_inquiry_response, successful_void_response)
     assert_success response
     assert_equal 'SUCCESS', response.message
@@ -301,12 +297,8 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.refund(@amount, authorization, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<orderInquiry .*?>) =~ data
-        assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data)
-      end
-      if %r(<orderModification .*?>) =~ data
-        assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
+      assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_refund_inquiry_response('CAPTURED'), successful_refund_response)
     assert_success response
   end
@@ -325,9 +317,7 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{response.authorization}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.capture(@amount, authorization, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<orderModification .*?>) =~ data
-        assert_tag_with_attributes('orderModification', {'orderCode' => response.authorization}, data)
-      end
+      assert_tag_with_attributes('orderModification', {'orderCode' => response.authorization}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end
@@ -384,7 +374,7 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.capture(@amount, 'bogus', @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /capture/
+      if /capture/.match?(data)
         t = Time.now
         assert_tag_with_attributes 'date',
           {'dayOfMonth' => t.day.to_s, 'month' => t.month.to_s, 'year' => t.year.to_s},
@@ -534,7 +524,7 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(instalments: 3))
     end.check_request do |endpoint, data, headers|
-      unless /<capture>/ =~ data
+      unless /<capture>/.match?(data)
         assert_match %r(<instalments>3</instalments>), data
         assert_no_match %r(cpf), data
       end
@@ -543,7 +533,7 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(instalments: 3, cpf: 12341234))
     end.check_request do |endpoint, data, headers|
-      unless /<capture>/ =~ data
+      unless /<capture>/.match?(data)
         assert_match %r(<instalments>3</instalments>), data
         assert_match %r(<cpf>12341234</cpf>), data
       end
@@ -623,7 +613,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.refund(@amount, @options[:order_id], @options)
     end.check_request do |endpoint, data, headers|
-      if data =~ /<refund>/
+      if /<refund>/.match?(data)
         request_hash = Hash.from_xml(data)
         assert_equal 'credit', request_hash['paymentService']['modify']['orderModification']['refund']['amount']['debitCreditIndicator']
       end
@@ -664,9 +654,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if /<submit>/ =~ data
-        assert_match %r{<cardHolderName>3D</cardHolderName>}, data
-      end
+      assert_match %r{<cardHolderName>3D</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end
@@ -677,9 +665,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if /<submit>/ =~ data
-        assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data
-      end
+      assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
 
@@ -687,9 +673,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if /<submit>/ =~ data
-        assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data
-      end
+      assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
 
@@ -697,9 +681,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      if /<submit>/ =~ data
-        assert_match %r{<cardHolderName>3D</cardHolderName>}, data
-      end
+      assert_match %r{<cardHolderName>3D</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end
@@ -800,9 +782,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<order .*?>) =~ data
-        assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
     assert_success response
@@ -813,9 +793,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.verify(@token, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<order .*?>) =~ data
-        assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
     assert_success response
@@ -894,9 +872,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<order .*?>) =~ data
-        assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
     assert_success response
@@ -908,9 +884,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.verify(@token, @options)
     end.check_request do |endpoint, data, headers|
-      if %r(<order .*?>) =~ data
-        assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
-      end
+      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
     assert_success response


### PR DESCRIPTION
Updated the supported Ruby and Rails versions included in Travis CI to
remove versions that have officially been moved to end of life while
still maintaining support for Rails versions 5.0 and 5.1 for now.

 - Removed Ruby versions 2.3 and 2.4
 - Added Ruby versions 2.6 and 2.7
 - Removed Rails version 4.2
 - Added Rails version 6.0

In addition, several RuboCop changes were made as a result of updating
the target Ruby version from 2.3 to 2.5:
 - a few unneeded `begin` statements were removed
 - the `=~` operator was replaced with `.match?` where appropriate
 - a chained method of `.unpack.first` was replaced with `.unpack1`

All unit tests:
4510 tests, 72041 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed

Authorize.net remote tests:
70 tests, 242 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Realex remote tests:
27 tests, 138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed