### PR TITLE
Payu Latam: Prevent blank country in billing_address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Vantiv: Vantiv(Element): add option to send terminal id in transactions [cdmackeyfree] #3654
 * Update supported Ruby and Rails versions [leila-alderman] #3656
 * CI: Drop unused sudo: false Travis directive [olleolleolle] #3616
+* PayU Latam: Prevent blank country in billing_address [britth] #3657
 
 == Version 1.107.4 (Jun 2, 2020)
 * Elavon: Implement true verify action [leila-alderman] #3610

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
         billing_address[:street2] = address[:address2]
         billing_address[:city] = address[:city]
         billing_address[:state] = address[:state]
-        billing_address[:country] = address[:country]
+        billing_address[:country] = address[:country] unless address[:country].blank?
         billing_address[:postalCode] = address[:zip] if @options[:payment_country] == 'MX'
         billing_address[:phone] = address[:phone]
         billing_address

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -74,6 +74,13 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_blank_billing_address_country
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: { address1: 'Viamonte', country: '', zip: '10001' }))
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert response.test?
+  end
+
   def test_successful_purchase_with_buyer
     gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(account_id: '512327', payment_country: 'BR'))
 

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -285,6 +285,34 @@ class PayuLatamTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_request_with_blank_billing_address_fields
+    options = {
+      dni_number: '5415668464654',
+      dni_type: 'TI',
+      merchant_buyer_id: '1',
+      currency: 'ARS',
+      order_id: generate_unique_id,
+      description: 'Active Merchant Transaction',
+      billing_address: address(
+        address1: 'Viamonte',
+        address2: nil,
+        city: 'Plata',
+        state: 'Buenos Aires',
+        country: '',
+        zip: '64000',
+        phone: '7563126'
+      )
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"merchantBuyerId":"1"/, data)
+      assert_match(/"street2":null/, data)
+      refute_match(/"country"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_brazil_required_fields
     gateway = PayuLatamGateway.new(merchant_id: 'merchant_id', account_id: 'account_id', api_login: 'api_login', api_key: 'api_key', payment_country: 'BR')
 


### PR DESCRIPTION
In PayU Latam requests, passing in certain billing_address fields
as empty strings (specifically `country`) will result in an error.
This PR updates the logic to not pass a billing_address country field
that's blank.

Remote:
34 tests, 83 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.0588% passed
unrelated failure, also on master: `test_well_formed_refund_fails_as_expected`

Unit:
32 tests, 122 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed