### PR TITLE
[Cybersource] Send cavv as xid when xid is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Cybersource: Send cavv as xid is xid is missing [pi3r] #3658
 * Forte: Change default sec_code value to PPD [molbrown] #3653
 * Elavon: Add merchant initiated unscheduled field [leila-alderman] #3647
 * Decidir: Add aggregate data fields [leila-alderman] #3648

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -617,7 +617,10 @@ module ActiveMerchant #:nodoc:
         xml.tag!('directoryServerTransactionID', threeds_2_options[:ds_transaction_id]) if threeds_2_options[:ds_transaction_id]
         xml.tag!('commerceIndicator', options[:commerce_indicator] || ECI_BRAND_MAPPING[card_brand(payment_method).to_sym])
         xml.tag!('eciRaw', threeds_2_options[:eci]) if threeds_2_options[:eci]
-        xml.tag!('xid', threeds_2_options[:xid]) if threeds_2_options[:xid]
+
+        xid = threeds_2_options[:xid] || threeds_2_options[:cavv]
+        xml.tag!('xid', xid) if xid
+
         xml.tag!('veresEnrolled', threeds_2_options[:enrolled]) if threeds_2_options[:enrolled]
         xml.tag!('paresStatus', threeds_2_options[:authentication_response_status]) if threeds_2_options[:authentication_response_status]
       end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -885,6 +885,45 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_adds_cavv_as_xid_for_3ds2
+    cavv = '637574652070757070792026206b697474656e73'
+
+    options_with_normalized_3ds = @options.merge(
+      three_d_secure: {
+        version: '2.0',
+        eci: '05',
+        cavv: cavv,
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        cavv_algorithm: 'vbv'
+      }
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<xid\>#{cavv}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_does_not_add_cavv_as_xid_if_xid_is_present
+    options_with_normalized_3ds = @options.merge(
+      three_d_secure: {
+        version: '2.0',
+        eci: '05',
+        cavv: '637574652070757070792026206b697474656e73',
+        xid: 'this-is-an-xid',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        cavv_algorithm: 'vbv'
+      }
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<xid\>this-is-an-xid/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end


### PR DESCRIPTION
We've been experiencing an error with 3DS 2.0 where Cybersource still
requires an xid even though this field isn't present for 3DS 2.0 transactions.

This is the exact error `<c:missingField>c:xid</c:missingField>`

After discussing with Cybersource and Cardinal it was decided that we
will send the cavv as the xid for 3DS 2.0 until they sort out their api.