### PR TITLE
DLocal: Handle nil address1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* DLocal: Handle nil address1 [molbrown] #3661
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -125,11 +125,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse_street(address)
+        return unless address[:address1]
+
         street = address[:address1].split(/\s+/).keep_if { |x| x !~ /\d/ }.join(' ')
         street.empty? ? nil : street
       end
 
       def parse_house_number(address)
+        return unless address[:address1]
+
         house = address[:address1].split(/\s+/).keep_if { |x| x =~ /\d/ }.join(' ')
         house.empty? ? nil : house
       end

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -85,6 +85,14 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_passing_nil_address_1
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(address1: nil)))
+    end.check_request do |method, endpoint, data, headers|
+      refute_match(/"street\"/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_passing_country_as_string
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)


### PR DESCRIPTION
Recent address parsing addition in 6419a3474fb87a0d02d75d8312de61e823e8beec
did not account for nil address1. Adds handling to not attempt parsing
when there is no address1.

Unit:
22 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
28 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-1267