### PR TITLE
Stripe PI: Implement verify action

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * DLocal: Handle nil address1 [molbrown] #3661
 * Braintree: Add travel and lodging fields [leila-alderman] #3668
 * Stripe: strict_encode64 api key [britth] #3672
+* Stripe PI: Implement verify action [leila-alderman] #3662
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -592,6 +592,24 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal store1.params['id'], store2.params['id']
   end
 
+  def test_successful_verify
+    options = {
+      customer: @customer
+    }
+    assert verify = @gateway.verify(@visa_payment_method, options)
+
+    assert_equal 'succeeded', verify.params['status']
+  end
+
+  def test_failed_verify
+    options = {
+      customer: @customer
+    }
+    assert verify = @gateway.verify(@declined_payment_method, options)
+
+    assert_equal 'Your card was declined.', verify.message
+  end
+
   def test_moto_enabled_card_requires_action_when_not_marked
     options = {
       currency: 'GBP',
@@ -631,7 +649,6 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'GBP',
       customer: @customer,
       confirmation_method: 'manual',
-      capture_method: 'manual',
       return_url: 'https://www.example.com/return',
       confirm: true
     }

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -158,6 +158,13 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_match(/payment_intent has a status of requires_action/, refund.message)
   end
 
+  def test_successful_verify
+    @gateway.expects(:ssl_request).returns(successful_verify_response)
+    assert verify = @gateway.verify(@visa_token)
+    assert_success verify
+    assert_equal 'succeeded', verify.params['status']
+  end
+
   private
 
   def successful_create_intent_response
@@ -346,6 +353,40 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   def failed_service_response
     <<-RESPONSE
       {"error": {"message": "Error while communicating with one of our backends.  Sorry about that!  We have been notified of the problem.  If you have any questions, we can help at https://support.stripe.com/.", "type": "api_error"  }}
+    RESPONSE
+  end
+
+  def successful_verify_response
+    <<-RESPONSE
+      {
+        "id": "seti_1Gsw0aAWOtgoysog0XjSBPVX",
+        "object": "setup_intent",
+        "application": null,
+        "cancellation_reason": null,
+        "client_secret": "seti_1Gsw0aAWOtgoysog0XjSBPVX_secret_HRpfHkvewAdYQJgee27ihJfm4E4zWmW",
+        "created": 1591903456,
+        "customer": "cus_GkjsDZC58SgUcY",
+        "description": null,
+        "last_setup_error": null,
+        "livemode": false,
+        "mandate": null,
+        "metadata": {
+        },
+        "next_action": null,
+        "on_behalf_of": null,
+        "payment_method": "pm_1Gsw0aAWOtgoysog304wX4J9",
+        "payment_method_options": {
+          "card": {
+            "request_three_d_secure": "automatic"
+          }
+        },
+        "payment_method_types": [
+          "card"
+        ],
+        "single_use_mandate": null,
+        "status": "succeeded",
+        "usage": "off_session"
+      }
     RESPONSE
   end
 end


### PR DESCRIPTION
Added the `verify` action to the Stripe Payment Intents gateway using
the [SetupIntents endpoint](https://stripe.com/docs/api/setup_intents/create).

CE-554

Unit:
13 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
41 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
ÿ7 tests, 72072 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed