### PR TITLE
Braintree: Add travel and lodging fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * DLocal: Handle nil address1 [molbrown] #3661
+* Braintree: Add travel and lodging fields [leila-alderman] #3668
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -859,6 +859,31 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success auth
   end
 
+  def test_authorize_with_travel_data
+    assert auth = @gateway.authorize(@amount, @credit_card,
+      travel_data: {
+        travel_package: 'flight',
+        departure_date: '2050-07-22',
+        lodging_check_in_date: '2050-07-22',
+        lodging_check_out_date: '2050-07-25',
+        lodging_name: 'Best Hotel Ever'
+      }
+    )
+    assert_success auth
+  end
+
+  def test_authorize_with_lodging_data
+    assert auth = @gateway.authorize(@amount, @credit_card,
+      lodging_data: {
+        folio_number: 'ABC123',
+        check_in_date: '2050-12-22',
+        check_out_date: '2050-12-25',
+        room_rate: '80.00'
+      }
+    )
+    assert_success auth
+  end
+
   def test_successful_validate_on_store_with_verification_merchant_account
     card = credit_card('4111111111111111', verification_value: '101')
     assert response = @gateway.store(card, verify_card: true, verification_merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id])

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -719,7 +719,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     )
 
     Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(has_entries(recurring: true)).
+      with(has_entries(transaction_source: 'recurring')).
       returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), recurring: true)
@@ -837,6 +837,46 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Decline', transaction['risk_data']['decision']
     assert_equal true, transaction['risk_data']['device_data_captured']
     assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
+  end
+
+  def test_successful_purchase_with_travel_data
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:industry][:industry_type] == Braintree::Transaction::IndustryType::TravelAndCruise) &&
+        (params[:industry][:data][:travel_package] == 'flight') &&
+        (params[:industry][:data][:departure_date] == '2050-07-22') &&
+        (params[:industry][:data][:lodging_check_in_date] == '2050-07-22') &&
+        (params[:industry][:data][:lodging_check_out_date] == '2050-07-25') &&
+        (params[:industry][:data][:lodging_name] == 'Best Hotel Ever')
+    end.returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'),
+      travel_data: {
+        travel_package: 'flight',
+        departure_date: '2050-07-22',
+        lodging_check_in_date: '2050-07-22',
+        lodging_check_out_date: '2050-07-25',
+        lodging_name: 'Best Hotel Ever'
+      }
+    )
+  end
+
+  def test_successful_purchase_with_lodging_data
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:industry][:industry_type] == Braintree::Transaction::IndustryType::Lodging) &&
+        (params[:industry][:data][:folio_number] == 'ABC123') &&
+        (params[:industry][:data][:check_in_date] == '2050-12-22') &&
+        (params[:industry][:data][:check_out_date] == '2050-12-25') &&
+        (params[:industry][:data][:room_rate] == '80.00')
+    end.returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'),
+      lodging_data: {
+        folio_number: 'ABC123',
+        check_in_date: '2050-12-22',
+        check_out_date: '2050-12-25',
+        room_rate: '80.00'
+      }
+    )
   end
 
   def test_apple_pay_card


### PR DESCRIPTION
Added the [industry-specific fields for travel and lodging](https://developers.braintreepayments.com/guides/amex-direct-industry-specific/ruby#travel/cruise-industry-parameters)
to the Braintree gateway.

In addition, the (rather large) `create_transaction_parameters` method
was refactored to pull out many new methods as the main method was
getting sufficiently unweildy to cause RuboCop to complain about it.

While doing this refactoring, I discovered that [the recurring parameter
is now deprecated](https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#recurring),
so I removed its use while still allowing the existing parameter to be
passed into Active Merchant in order to keep this from being a breaking
change.

CE-470

Unit:
80 tests, 183 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
82 tests, 439 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4519 tests, 72072 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed