### PR TITLE
RuboCop: Fix Style/SpecialGlobalVars

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -882,13 +882,6 @@ Style/SingleLineMethods:
   Exclude:
     - 'test/unit/gateways/paypal/paypal_common_api_test.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: .
-# SupportedStyles: use_perl_names, use_english_names
-Style/SpecialGlobalVars:
-  EnforcedStyle: use_perl_names
-
 # Offense count: 27
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Forte: Use underscore for unused arguments in test [wsmoak] #3605
 * Add Alia card type [therufs] #3673
 * Element: Fix unit tests [leila-alderman] #3676
+* RuboCop: Fix Style/SpecialGlobalVars [leila-alderman] #3669
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'active_merchant/version'
 
 begin

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'active_merchant/version'
 
 Gem::Specification.new do |s|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'bundler/setup'
 


### PR DESCRIPTION
Fixed the RuboCop to-do for [Style/SpecialGlobalVars](https://docs.rubocop.org/rubocop/cops_style.html#stylespecialglobalvars).

All unit tests:
4517 tests, 72070 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed