### PR TITLE
RuboCop: Fix Style/StringLiteralsInInterpolation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -882,27 +882,6 @@ Style/SingleLineMethods:
   Exclude:
     - 'test/unit/gateways/paypal/paypal_common_api_test.rb'
 
-# Offense count: 27
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/banwire.rb'
-    - 'lib/active_merchant/billing/gateways/cams.rb'
-    - 'lib/active_merchant/billing/gateways/checkout_v2.rb'
-    - 'lib/active_merchant/billing/gateways/credorax.rb'
-    - 'lib/active_merchant/billing/gateways/digitzs.rb'
-    - 'lib/active_merchant/billing/gateways/ebanx.rb'
-    - 'lib/active_merchant/billing/gateways/merchant_one.rb'
-    - 'lib/active_merchant/billing/gateways/micropayment.rb'
-    - 'lib/active_merchant/billing/gateways/pagarme.rb'
-    - 'lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb'
-    - 'lib/active_merchant/billing/gateways/stripe.rb'
-    - 'lib/active_merchant/billing/gateways/usa_epay_advanced.rb'
-    - 'lib/active_merchant/billing/gateways/worldpay.rb'
-    - 'test/unit/gateways/eway_managed_test.rb'
-
 # Offense count: 7
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Add Alia card type [therufs] #3673
 * Element: Fix unit tests [leila-alderman] #3676
 * RuboCop: Fix Style/SpecialGlobalVars [leila-alderman] #3669
+* RuboCop: Fix Style/StringLiteralsInInterpolation [leila-alderman] #3670
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         post[:card_num] = creditcard.number
         post[:card_name] = creditcard.name
         post[:card_type] = card_brand(creditcard)
-        post[:card_exp] = "#{sprintf("%02d", creditcard.month)}/#{creditcard.year.to_s[-2, 2]}"
+        post[:card_exp] = "#{sprintf('%02d', creditcard.month)}/#{creditcard.year.to_s[-2, 2]}"
         post[:card_ccv2] = creditcard.verification_value
       end
 

--- a/lib/active_merchant/billing/gateways/cams.rb
+++ b/lib/active_merchant/billing/gateways/cams.rb
@@ -167,7 +167,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(post, payment)
         post[:ccnumber] = payment.number
-        post[:ccexp] = "#{payment.month.to_s.rjust(2, "0")}#{payment.year.to_s[-2..-1]}"
+        post[:ccexp] = "#{payment.month.to_s.rjust(2, '0')}#{payment.year.to_s[-2..-1]}"
         post[:cvv] = payment.verification_value
       end
 

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -413,7 +413,7 @@ module ActiveMerchant #:nodoc:
           success_from(response),
           message_from(response),
           response,
-          authorization: "#{response["Z1"]};#{response["Z4"]};#{response["A1"]};#{action}",
+          authorization: "#{response['Z1']};#{response['Z4']};#{response['A1']};#{action}",
           avs_result: AVSResult.new(code: response['Z9']),
           cvv_result: CVVResult.new(response['Z14']),
           test: test?

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response)
         if customer_id = response.try(:[], 'data').try(:[], 'attributes').try(:[], 'customerId')
-          "#{customer_id}|#{response.try(:[], "data").try(:[], "id")}"
+          "#{customer_id}|#{response.try(:[], 'data').try(:[], 'id')}"
         else
           response.try(:[], 'data').try(:[], 'id')
         end

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -258,7 +258,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(action, parameters, response)
         if action == :store
-          "#{response.try(:[], "token")}|#{CARD_BRAND[parameters[:payment_type_code].to_sym]}"
+          "#{response.try(:[], 'token')}|#{CARD_BRAND[parameters[:payment_type_code].to_sym]}"
         else
           response.try(:[], 'payment').try(:[], 'hash')
         end

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
       def add_creditcard(post, creditcard)
         post['cvv'] = creditcard.verification_value
         post['ccnumber'] = creditcard.number
-        post['ccexp'] = "#{sprintf("%02d", creditcard.month)}#{creditcard.year.to_s[-2, 2]}"
+        post['ccexp'] = "#{sprintf('%02d', creditcard.month)}#{creditcard.year.to_s[-2, 2]}"
       end
 
       def commit(action, money, parameters={})

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response, request_params)
         session_id = response['sessionId'] || request_params[:sessionId]
-        "#{session_id}|#{response["transactionId"]}"
+        "#{session_id}|#{response['transactionId']}"
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
           when 'refunded'
             'Transação estornada'
           else
-            "Transação com status '#{response["status"]}'"
+            "Transação com status '#{response['status']}'"
           end
         elsif failure_from(response)
           'Transação recusada'

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -24,11 +24,11 @@ module ActiveMerchant
           r.process {
             post = authorization_params(money, credit_card_or_reference, options)
             add_autocapture(post, false)
-            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/authorize"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params['id']}/authorize"), post)
           }
           r.process {
             post = capture_params(money, credit_card_or_reference, options)
-            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/capture"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params['id']}/capture"), post)
           }
         end
       end
@@ -42,7 +42,7 @@ module ActiveMerchant
           r.process { create_payment(money, options) }
           r.process {
             post = authorization_params(money, credit_card_or_reference, options)
-            commit(synchronized_path("/payments/#{r.responses.last.params["id"]}/authorize"), post)
+            commit(synchronized_path("/payments/#{r.responses.last.params['id']}/authorize"), post)
           }
         end
       end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -655,7 +655,7 @@ module ActiveMerchant #:nodoc:
         success = success_from(response, options)
 
         card = card_from_response(response)
-        avs_code = AVS_CODE_TRANSLATOR["line1: #{card["address_line1_check"]}, zip: #{card["address_zip_check"]}"]
+        avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
 
         Response.new(success,

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -1336,7 +1336,7 @@ module ActiveMerchant #:nodoc:
         when payment_method[:method].kind_of?(ActiveMerchant::Billing::CreditCard)
           build_tag soap, :string, 'CardNumber', payment_method[:method].number
           build_tag soap, :string, 'CardExpiration',
-            "#{"%02d" % payment_method[:method].month}#{payment_method[:method].year.to_s[-2..-1]}"
+            "#{'%02d' % payment_method[:method].month}#{payment_method[:method].year.to_s[-2..-1]}"
           if options[:billing_address]
             build_tag soap, :string, 'AvsStreet', options[:billing_address][:address1]
             build_tag soap, :string, 'AvsZip', options[:billing_address][:zip]
@@ -1432,7 +1432,7 @@ module ActiveMerchant #:nodoc:
       def build_card_expiration(options)
         month = options[:payment_method].month
         year  = options[:payment_method].year
-        "#{"%02d" % month}#{year.to_s[-2..-1]}" unless month.nil? || year.nil?
+        "#{'%02d' % month}#{year.to_s[-2..-1]}" unless month.nil? || year.nil?
       end
 
       def build_check_data(soap, options)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -663,7 +663,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def required_status_message(raw, success_criteria)
-        "A transaction status of #{success_criteria.collect { |c| "'#{c}'" }.join(" or ")} is required." if !success_criteria.include?(raw[:last_event])
+        "A transaction status of #{success_criteria.collect { |c| "'#{c}'" }.join(' or ')} is required." if !success_criteria.include?(raw[:last_event])
       end
 
       def authorization_from(action, raw, options)

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -322,8 +322,8 @@ class EwayManagedTest < Test::Unit::TestCase
         <QueryCustomerResult>
           <CCName>#{@credit_card.first_name} #{@credit_card.last_name}</CCName>
           <CCNumber>#{@credit_card.number}</CCNumber>
-          <CCExpiryMonth>#{sprintf("%.2i", @credit_card.month)}</CCExpiryMonth>
-          <CCExpiryYear>#{sprintf("%.4i", @credit_card.year)[-2..-1]}</CCExpiryYear>
+          <CCExpiryMonth>#{sprintf('%.2i', @credit_card.month)}</CCExpiryMonth>
+          <CCExpiryYear>#{sprintf('%.4i', @credit_card.year)[-2..-1]}</CCExpiryYear>
         </QueryCustomerResult>
         </QueryCustomerResponse>
       </soap12:Body>
@@ -364,8 +364,8 @@ class EwayManagedTest < Test::Unit::TestCase
       <URL></URL>
       <CCNumber>#{@credit_card.number}</CCNumber>
       <CCNameOnCard>#{@credit_card.first_name} #{@credit_card.last_name}</CCNameOnCard>
-      <CCExpiryMonth>#{sprintf("%.2i", @credit_card.month)}</CCExpiryMonth>
-      <CCExpiryYear>#{sprintf("%.4i", @credit_card.year)[-2..-1]}</CCExpiryYear>
+      <CCExpiryMonth>#{sprintf('%.2i', @credit_card.month)}</CCExpiryMonth>
+      <CCExpiryYear>#{sprintf('%.4i', @credit_card.year)[-2..-1]}</CCExpiryYear>
     </CreateCustomer>
   </soap12:Body>
 </soap12:Envelope>


### PR DESCRIPTION
Fixed the RuboCop to-do for [Style/StringLiteralsInInterpolation](https://docs.rubocop.org/rubocop/cops_style.html#stylestringliteralsininterpolation).

All unit tests:
4517 tests, 72070 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed