### PR TITLE
Stripe: strict_encode64 api key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * DLocal: Handle nil address1 [molbrown] #3661
 * Braintree: Add travel and lodging fields [leila-alderman] #3668
+* Stripe: strict_encode64 api key [britth] #3672
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -613,7 +613,7 @@ module ActiveMerchant #:nodoc:
         idempotency_key = options[:idempotency_key]
 
         headers = {
-          'Authorization' => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
+          'Authorization' => 'Basic ' + Base64.strict_encode64(key.to_s + ':').strip,
           'User-Agent' => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'Stripe-Version' => api_version(options),
           'X-Stripe-Client-User-Agent' => stripe_client_user_agent(options),


### PR DESCRIPTION
Stripe API keys can be up to 255 characters now, and these longer
keys ended up with line breaks when encoded in the headers, causing
the error: `ArgumentError: header field value cannot include CR/LF`.
Use strict_encode64 to prevent these characters from being added.

Stripe:

Remote:
71 tests, 324 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.5915% passed
(test_successful_store_with_existing_account failure - looks to be related to test data - `Account ... already has the maximum 200 external accounts attached.` - and also fails on master)

Unit:
138 tests, 738 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe PI
Remote:
39 tests, 183 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.4359% passed
(test_transcript_scrubbing failure - cvv string showing up elsewhere in transcript, but not actual cvv though)

Unit:
12 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed