### PR TITLE
Add Alia cardtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * RuboCop: Fix Style/WordArray [leila-alderman] #3664
 * RuboCop: Fix Style/SymbolArray [leila-alderman] #3665
 * Forte: Use underscore for unused arguments in test [wsmoak] #3605
+* Add Alia card type [therufs] #3673
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -23,6 +23,7 @@ module ActiveMerchant #:nodoc:
     # * Cabal
     # * Naranja
     # * UnionPay
+    # * Alia
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -98,6 +99,7 @@ module ActiveMerchant #:nodoc:
       # * +'cabal'+
       # * +'naranja'+
       # * +'union_pay'+
+      # * +'alia'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
         },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
+        'alia'               => ->(num) { num =~ /^(504997|505878|601030|601073|505874)\d{10}$/ },
         'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
         'cabal'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 8), CABAL_RANGES) },
         'unionpay'           => ->(num) { (16..19).cover?(num&.size) && in_bin_range?(num.slice(0, 8), UNIONPAY_RANGES) },

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w[CL CO EC MX PE]
       self.default_currency = 'USD'
       self.money_format = :dollars
-      self.supported_cardtypes = %i[visa master american_express discover diners_club]
+      self.supported_cardtypes = %i[visa master american_express discover diners_club alia]
 
       def initialize(options={})
         requires!(options, :public_merchant_id, :private_merchant_id)

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[MX EC CO BR CL PE]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express diners_club elo]
+      self.supported_cardtypes = %i[visa master american_express diners_club elo alia]
 
       self.homepage_url = 'https://secure.paymentez.com/'
       self.display_name = 'Paymentez'

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -67,7 +67,7 @@ class RemoteKushkiTest < Test::Unit::TestCase
     }
     response = @gateway.authorize(@amount, @credit_card, options)
     assert_failure response
-    assert_equal '220', response.responses.last.error_code
+    assert_equal 'K220', response.responses.last.error_code
     assert_equal 'Monto de la transacción es diferente al monto de la venta inicial', response.message
   end
 

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -187,7 +187,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert capture = @gateway.capture(@amount - 1, auth.authorization)
-    assert_failure capture # Paymentez explicitly does not support partial capture; only GREATER than auth capture
+    assert_success capture
+    assert_equal 'Response by mock', capture.message
   end
 
   def test_failed_capture

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -131,6 +131,14 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'sodexo', CreditCard.brand?('6060694495764400')
   end
 
+  def test_should_detect_alia_card
+    assert_equal 'alia', CreditCard.brand?('5049970000000000')
+    assert_equal 'alia', CreditCard.brand?('5058780000000000')
+    assert_equal 'alia', CreditCard.brand?('6010300000000000')
+    assert_equal 'alia', CreditCard.brand?('6010730000000000')
+    assert_equal 'alia', CreditCard.brand?('5058740000000000')
+  end
+
   def test_should_detect_vr_card
     assert_equal 'vr', CreditCard.brand?('6370364495764400')
   end


### PR DESCRIPTION
No Alia test card numbers seem to be available, so no tests were written.

Paymentez and Kushki both had some changed resposes; I updated these.
Paymentez does specifically call out that they now support partial
capture for some transactions:
https://paymentez.github.io/api-doc/#payment-methods-cards-capture

Unit tests:
4521 tests, 72082 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Kushki remote:
13 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Paymentez remote:
26 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CE-640