### PR TITLE
Element: Fix unit tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * RuboCop: Fix Style/SymbolArray [leila-alderman] #3665
 * Forte: Use underscore for unused arguments in test [wsmoak] #3605
 * Add Alia card type [therufs] #3673
+* Element: Fix unit tests [leila-alderman] #3676
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658


### PR DESCRIPTION
A couple of unit tests for the Element gateway were previously
implemented as remote tests, which I discovered last night when the
Element gateway was down and the unit test file failed.

To ensure that the unit test file is not dependent on the gateway being
up, these two tests using remote calls to the gateway have been replaced
with actual unit tests that stub out the communication with the gateway.

Unit:
19 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
21 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4520 tests, 72098 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed