### PR TITLE
Mercado-Pago: Notification url GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Cybersource: pass reconciliation_id [therufs] #3688
 * RuboCop: Fix Layout/HeredocIndentation [leila-alderman] #3685
 * RuboCop: Fix Gemspec/OrderedDependencies [leila-alderman] #3679
+* Mercado-Pago: Notification url GSF [cdmackeyfree] #3678
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -98,6 +98,7 @@ module ActiveMerchant #:nodoc:
         add_processing_mode(post, options)
         add_net_amount(post, options)
         add_taxes(post, options)
+        add_notification_url(post, options)
         post[:binary_mode] = (options[:binary_mode].nil? ? true : options[:binary_mode])
         post
       end
@@ -201,6 +202,10 @@ module ActiveMerchant #:nodoc:
 
       def add_net_amount(post, options)
         post[:net_amount] = Float(options[:net_amount]) if options[:net_amount]
+      end
+
+      def add_notification_url(post, options)
+        post[:notification_url] = options[:notification_url] if options[:notification_url]
       end
 
       def add_taxes(post, options)

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -7,7 +7,7 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @colombian_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_colombia))
 
     @amount = 500
-    @credit_card = credit_card('4509953566233704')
+    @credit_card = credit_card('5031433215406351')
     @colombian_card = credit_card('4013540682746260')
     @elo_credit_card = credit_card('5067268650517446',
       month: 10,
@@ -16,7 +16,7 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
       last_name: 'Smith',
       verification_value: '737'
     )
-    @cabal_credit_card = credit_card('6035227716427021',
+    @cabal_credit_card = credit_card('6042012045809847',
       month: 10,
       year: 2020,
       first_name: 'John',
@@ -30,7 +30,8 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
       last_name: 'Smith',
       verification_value: '123'
     )
-    @declined_card = credit_card('4000300011112220')
+    @declined_card = credit_card('5031433215406351',
+      first_name: 'OTHE')
     @options = {
       billing_address: address,
       shipping_address: address,
@@ -106,6 +107,12 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     response = @colombian_gateway.purchase(amount, @colombian_card, @options)
     assert_success response
     assert_equal 'accredited', response.message
+  end
+
+  def test_successful_purchase_with_notification_url
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(notification_url: 'https://www.spreedly.com/'))
+    assert_success response
+    assert_equal 'https://www.spreedly.com/', response.params['notification_url']
   end
 
   def test_failed_purchase

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -295,6 +295,16 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_equal '4141491|1.0', response.authorization
   end
 
+  def test_successful_purchase_with_notification_url
+    response = stub_comms do
+      @gateway.purchase(@amount, credit_card, @options.merge(notification_url: 'www.mercado-pago.com'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r("notification_url":"www.mercado-pago.com"), data) if endpoint =~ /payments/
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_includes_deviceid_header
     @options[:device_id] = '1a2b3c'
     @gateway.expects(:ssl_post).with(anything, anything, {'Content-Type' => 'application/json'}).returns(successful_purchase_response)


### PR DESCRIPTION
Add notification_url GSF, also update Mercado-Pago test card values

Unit:
Finished in 0.033803 seconds.
37 tests, 171 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote 
 Finished in 67.755391 seconds.
31 tests, 85 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
83.871% passed
0.46 tests/s, 1.25 assertions/s

All Unit tests:
  Finished in 11.617083 seconds.
4517 tests, 72070 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
388.82 tests/s, 6203.79 assertions/s

Tests unrelated to this work are still failing, so that should be addressed in another ticket
