### PR TITLE
RuboCop: Fix Gemspec/OrderedDependencies

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: Include, TreatCommentsAsGroupSeparators.
-# Include: **/*.gemspec
-Gemspec/OrderedDependencies:
-  Exclude:
-    - 'activemerchant.gemspec'
-
 # Offense count: 1828
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Diners Club: support 16 digit card numbers [therufs] #3682
 * Cybersource: pass reconciliation_id [therufs] #3688
 * RuboCop: Fix Layout/HeredocIndentation [leila-alderman] #3685
+* RuboCop: Fix Gemspec/OrderedDependencies [leila-alderman] #3679
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |s|
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
   s.add_dependency('activesupport', '>= 4.2')
-  s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
+  s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('nokogiri', '~> 1.4')
 
+  s.add_development_dependency('mocha', '~> 1')
+  s.add_development_dependency('pry')
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')
-  s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('thor')
-  s.add_development_dependency('pry')
 end


### PR DESCRIPTION
Fixes the RuboCop to-do for [Gemspec/OrderedDependencies](https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecordereddependencies).

This cop ensures that the dependencies listed in the Gemspec are listed
in alphabetical order.

All unit tests:
4522 tests, 72123 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed