### PR TITLE
Adyen: Allow for executeThreeD to be passed as false

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -421,7 +421,7 @@ module ActiveMerchant #:nodoc:
           return unless !options[:execute_threed].nil? || !options[:threed_dynamic].nil?
 
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] } if options[:execute_threed] || options[:threed_dynamic]
-          post[:additionalData] = { executeThreeD: options[:execute_threed] } if options[:execute_threed]
+          post[:additionalData] = { executeThreeD: options[:execute_threed] } if !options[:execute_threed].nil?
         end
       end
 

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -418,10 +418,10 @@ module ActiveMerchant #:nodoc:
             post[:additionalData][:scaExemption] = options[:sca_exemption] if options[:sca_exemption]
           end
         else
-          return unless options[:execute_threed] || options[:threed_dynamic]
+          return unless !options[:execute_threed].nil? || !options[:threed_dynamic].nil?
 
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
-          post[:additionalData] = { executeThreeD: 'true' } if options[:execute_threed]
+          post[:additionalData] = { executeThreeD: options[:execute_threed] } if options[:execute_threed]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -420,7 +420,7 @@ module ActiveMerchant #:nodoc:
         else
           return unless !options[:execute_threed].nil? || !options[:threed_dynamic].nil?
 
-          post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] }
+          post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] } if options[:execute_threed] || options[:threed_dynamic]
           post[:additionalData] = { executeThreeD: options[:execute_threed] } if options[:execute_threed]
         end
       end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -180,6 +180,13 @@ class RemoteAdyenTest < Test::Unit::TestCase
     refute response.params['paRequest'].blank?
   end
 
+  def test_successful_authorize_with_execute_threed_false
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: false, sca_exemption: 'lowValue'))
+    assert response.test?
+    refute response.authorization.blank?
+    assert_equal response.params['resultCode'], 'RedirectShopper'
+  end
+
   def test_successful_authorize_with_3ds_with_idempotency_key
     options = @options.merge(idempotency_key: SecureRandom.hex, execute_threed: true)
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -184,7 +184,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(execute_threed: false, sca_exemption: 'lowValue'))
     assert response.test?
     refute response.authorization.blank?
-    assert_equal response.params['resultCode'], 'RedirectShopper'
+    assert_equal response.params['resultCode'], 'Authorised'
   end
 
   def test_successful_authorize_with_3ds_with_idempotency_key


### PR DESCRIPTION
Passing false to `executeThreeD` is an option for this gateway that some
users may want

CE-550

Unit: 66 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 89 tests, 343 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed