### PR TITLE
Cybersource: Update supported countries list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * RuboCop: Fix Style/StringLiteralsInInterpolation [leila-alderman] #3670
 * PayU Latam: Fix store method [ccarruitero] #2590
 * Stripe, Stripe Payment Intents: Update supported countries [britth] #3684
+* Cybersource: Update supported countries [britth] #3683
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       DEFAULT_COLLECTION_INDICATOR = 2
 
       self.supported_cardtypes = %i[visa master american_express discover diners_club jcb dankort maestro elo]
-      self.supported_countries = %w(US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB PK)
+      self.supported_countries = %w(US AE BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB PK)
 
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(JPY)


### PR DESCRIPTION
Adds UAE to supported countries list

Remote:
80 tests, 403 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.75% passed (5 known unrelated failures)

Unit:
86 tests, 402 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed