### PR TITLE
Stripe, Stripe PI: Update supported country list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * RuboCop: Fix Style/SpecialGlobalVars [leila-alderman] #3669
 * RuboCop: Fix Style/StringLiteralsInInterpolation [leila-alderman] #3670
 * PayU Latam: Fix store method [ccarruitero] #2590
+* Stripe, Stripe Payment Intents: Update supported countries [britth] #3684
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
 
       DEFAULT_API_VERSION = '2015-04-07'
 
-      self.supported_countries = %w(AT AU BE BR CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MX NL NO NZ PL PT SE SG SI SK US)
+      self.supported_countries = %w(AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT MX NL NO NZ PL PT RO SE SG SI SK US)
       self.default_currency = 'USD'
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro]

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
     # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
     # For the legacy API, see the Stripe gateway
     class StripePaymentIntentsGateway < StripeGateway
-      self.supported_countries = %w(AT AU BE BR CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MX NL NO NZ PL PT SE SG SI SK US)
+      self.supported_countries = %w(AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT MX NL NO NZ PL PT RO SE SG SI SK US)
 
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze


### PR DESCRIPTION
Support added for 5 additional countries: [Czech Republic, Romania, Bulgaria, Cyprus, and Malta](https://stripe.com/blog/stripe-launches-in-five-more-european-countries)

Stripe PI
Remote:
41 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
13 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

remote:

Stripe
Remote:
71 tests, 325 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
138 tests, 738 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed