### PR TITLE
Worldpay: exclude empty inst_id

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -217,7 +217,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def order_tag_attributes(options)
-        { 'orderCode' => options[:order_id], 'installationId' => options[:inst_id] || @options[:inst_id] }.reject { |_, v| !v }
+        { 'orderCode' => options[:order_id], 'installationId' => options[:inst_id] || @options[:inst_id] }.reject { |_, v| !v.present? }
       end
 
       def build_capture_request(money, authorization, options)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -649,6 +649,11 @@ class WorldpayTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_empty_inst_id_is_stripped
+    @gateway.expects(:ssl_post).with { |_, request, _| request !~ /installationId/ }.returns(successful_authorize_response)
+    @gateway.authorize(@amount, @credit_card, @options.merge({ inst_id: '' }))
+  end
+
   def test_3ds_name_coersion
     @options[:execute_threed] = true
     response = stub_comms do

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -650,8 +650,11 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   def test_empty_inst_id_is_stripped
-    @gateway.expects(:ssl_post).with { |_, request, _| request !~ /installationId/ }.returns(successful_authorize_response)
-    @gateway.authorize(@amount, @credit_card, @options.merge({ inst_id: '' }))
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ inst_id: '' }))
+    end.check_request do |_, data, _|
+      assert_not_match(/installationId/, data)
+    end.respond_with(successful_authorize_response)
   end
 
   def test_3ds_name_coersion


### PR DESCRIPTION
Exclude empty `inst_id` as per recommendation from Worldpay:

> \<order orderCode="c12999949615176.2" installationId=""\>
> If there is not installation ID, you should not be including this data. You can instead just submit:
> \<order orderCode="c12999949615176.2"\>
> The response with NMTOKEN must be a name token usually means a value is missing. Anything with "" and nothing is in the middle of the quotes typically will produce this error.