### PR TITLE
WorldPay: Fix handling of `state` field for 3DS transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -429,7 +429,7 @@ module ActiveMerchant #:nodoc:
         xml.cardHolderName card_holder_name
         xml.cvc payment_method.verification_value
 
-        add_address(xml, (options[:billing_address] || options[:address]))
+        add_address(xml, (options[:billing_address] || options[:address]), options)
       end
 
       def add_stored_credential_options(xml, options={})
@@ -485,7 +485,7 @@ module ActiveMerchant #:nodoc:
         xml.authenticatedShopperID options[:customer] if options[:customer]
       end
 
-      def add_address(xml, address)
+      def add_address(xml, address, options)
         return unless address
 
         address = address_with_defaults(address)
@@ -500,7 +500,7 @@ module ActiveMerchant #:nodoc:
             xml.address2 address[:address2] if address[:address2]
             xml.postalCode address[:zip]
             xml.city address[:city]
-            xml.state address[:state]
+            xml.state address[:state] unless address[:country] != 'US' && options[:execute_threed]
             xml.countryCode address[:country]
             xml.telephoneNumber address[:phone] if address[:phone]
           end


### PR DESCRIPTION
ECS-1287

WorldPay Support states: "for 3DS transactions, state should only be
populated when Billing or Shipping address is domiciled within the
United States."

Unfortunately, this change cannot be tested in WorldPay's sandbox,
because 3DS transactions will succeed whether `state` is sent or not for
non-US countries.

Unit:
73 tests, 485 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
57 tests, 239 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.2281% passed
(the same tests fail on master)

All unit tests:
4523 tests, 72104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed