### PR TITLE
Cybersource: Add fields to override stored creds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Cybersource: Add fields to override stored creds [leila-alderman] #3689
 
 == Version 1.109.0
 * Remove reference to `Billing::Integrations` [pi3r] #3692
@@ -26,7 +27,6 @@
 * RuboCop: Fix Style/TrailingUnderscoreVariable [leila-alderman] #3663
 * RuboCop: Fix Style/WordArray [leila-alderman] #3664
 * RuboCop: Fix Style/SymbolArray [leila-alderman] #3665
-
 * Mercado-Pago: Notification url GSF [cdmackeyfree] #3678
 * Credorax: Update logic for setting 3ds_homephonecountry [britth] #3691
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -831,12 +831,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_stored_credential_options(xml, options={})
-        return unless options[:stored_credential]
+        return unless options[:stored_credential] || options[:stored_credential_overrides]
 
-        xml.tag! 'subsequentAuth', 'true' if options[:stored_credential][:initiator] == 'merchant'
-        xml.tag! 'subsequentAuthFirst', 'true' if options[:stored_credential][:initial_transaction]
-        xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id] if options[:stored_credential][:initiator] == 'merchant'
-        xml.tag! 'subsequentAuthStoredCredential', 'true' if options[:stored_credential][:initiator] == 'cardholder' && !options[:stored_credential][:initial_transaction] || options[:stored_credential][:initiator] == 'merchant' && options[:stored_credential][:reason_type] == 'unscheduled'
+        stored_credential_subsequent_auth = 'true' if options[:stored_credential][:initiator] == 'merchant'
+        stored_credential_subsequent_auth_first = 'true' if options[:stored_credential][:initial_transaction]
+        stored_credential_transaction_id = options[:stored_credential][:network_transaction_id] if options[:stored_credential][:initiator] == 'merchant'
+        stored_credential_subsequent_auth_stored_cred = 'true' if options[:stored_credential][:initiator] == 'cardholder' && !options[:stored_credential][:initial_transaction] || options[:stored_credential][:initiator] == 'merchant' && options[:stored_credential][:reason_type] == 'unscheduled'
+
+        xml.subsequentAuth options.dig(:stored_credential_overrides, :subsequent_auth) || stored_credential_subsequent_auth
+        xml.subsequentAuthFirst options.dig(:stored_credential_overrides, :subsequent_auth_first) || stored_credential_subsequent_auth_first
+        xml.subsequentAuthTransactionID options.dig(:stored_credential_overrides, :subsequent_auth_transaction_id) || stored_credential_transaction_id
+        xml.subsequentAuthStoredCredential options.dig(:stored_credential_overrides, :subsequent_auth_stored_credential) || stored_credential_subsequent_auth_stored_cred
       end
 
       def add_partner_solution_id(xml)


### PR DESCRIPTION
Added four new fields to allow for directly overriding the standard
stored credential fields for the Cybersource gateway. These four new
fields are all held within the `stored_credential_overrides` hash:

```
    @options[:stored_credential_overrides] = {
      subsequent_auth: 'true',
      subsequent_auth_first: 'false',
      subsequent_auth_stored_credential: 'true',
      subsequent_auth_transaction_id: '54321'
    }
```

CE-698

Unit:
87 tests, 410 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
81 tests, 407 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.8272% passed

All unit tests:
4523 tests, 72134 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed

Unrelated, previously failing remote tests:
 - test_successful_validate_pinless_debit_card
 - test_successful_tax_calculation
 - test_successful_pinless_debit_card_puchase
 - test_successful_3ds_validate_purchase_request
 - test_successful_3ds_validate_authorize_request