### PR TITLE
Credorax: Only send 3ds_homephonecountry when phone number is present

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * RuboCop: Fix Layout/HeredocIndentation [leila-alderman] #3685
 * RuboCop: Fix Gemspec/OrderedDependencies [leila-alderman] #3679
 * Mercado-Pago: Notification url GSF [cdmackeyfree] #3678
+* Credorax: Update logic for setting 3ds_homephonecountry [britth] #3691
 
 == Version 1.108.0 (Jun 9, 2020)
 * Cybersource: Send cavv as xid is xid is missing [pi3r] #3658

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -238,6 +238,10 @@ module ActiveMerchant #:nodoc:
             normalized_value = normalize(value)
             next if normalized_value.nil?
 
+            if key == :'3ds_homephonecountry'
+              next unless options[:billing_address] && options[:billing_address][:phone]
+            end
+
             post[key] = normalized_value unless post[key]
           end
         end


### PR DESCRIPTION
Credorax 3DS requires the field 3ds_homephonecountry for 3DS requests
where the phone number is present. However, if the phone number is not
present, you'll get an error if you still send this field. We originally
allowed users to pass optional fields by adding an `optional` key to the
three_ds_2 options hash (#3515). This PR updates the method to check for
this specific key and only set it if phone is present. I don't love this,
but unsure if there's a better way to do this given that we support the
field as an arbitrary one passed in this optional hash - other ideas
welcome!

Remote:
40 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
68 tests, 321 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed