### PR TITLE
Remove reference to `Billing::Integrations`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Remove reference to `Billing::Integrations` [pi3r] #3692
 * DLocal: Handle nil address1 [molbrown] #3661
 * Braintree: Add travel and lodging fields [leila-alderman] #3668
 * Stripe: strict_encode64 api key [britth] #3672

--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -39,19 +39,6 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      # Return the matching integration module
-      # You can then get the notification from the module
-      # * <tt>bogus</tt>: Bogus - Does nothing (for testing)
-      # * <tt>chronopay</tt>: Chronopay
-      # * <tt>paypal</tt>: Paypal
-      #
-      #   chronopay = ActiveMerchant::Billing::Base.integration('chronopay')
-      #   notification = chronopay.notification(raw_post)
-      #
-      def self.integration(name)
-        Billing::Integrations.const_get(name.to_s.downcase.camelize)
-      end
-
       # A check to see if we're in test mode
       def self.test?
         mode == :test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -322,36 +322,6 @@ Test::Unit::TestCase.class_eval do
   end
 end
 
-module ActionViewHelperTestHelper
-  def self.included(base)
-    base.send(:include, ActiveMerchant::Billing::Integrations::ActionViewHelper)
-    base.send(:include, ActionView::Helpers::FormHelper)
-    base.send(:include, ActionView::Helpers::FormTagHelper)
-    base.send(:include, ActionView::Helpers::UrlHelper)
-    base.send(:include, ActionView::Helpers::TagHelper)
-    base.send(:include, ActionView::Helpers::CaptureHelper)
-    base.send(:include, ActionView::Helpers::TextHelper)
-    base.send(:attr_accessor, :output_buffer)
-  end
-
-  def setup
-    @controller = Class.new do
-      attr_reader :url_for_options
-      def url_for(options, *parameters_for_method_reference)
-        @url_for_options = options
-      end
-    end
-    @controller = @controller.new
-    @output_buffer = ''
-  end
-
-  protected
-
-  def protect_against_forgery?
-    false
-  end
-end
-
 class MockResponse
   attr_reader   :code, :body, :message
   attr_accessor :headers


### PR DESCRIPTION
This is a remnant of when all offsites gateway were extracted to
`OffsitPayments`. The namespace `Billing::Integrations` doesn't
exist anymore.

References https://github.com/activemerchant/active_merchant/issues/3503#issuecomment-647739812

```
irb(main):001:0> require 'activemerchant'
=> true
irb(main):002:0> ActiveMerchant
=> ActiveMerchant
irb(main):003:0> ActiveMerchant::Billing
=> ActiveMerchant::Billing
irb(main):004:0> ActiveMerchant::Billing::Integrations
Traceback (most recent call last):
        4: from /opt/rubies/2.6.5/bin/irb:23:in `<main>'
        3: from /opt/rubies/2.6.5/bin/irb:23:in `load'
        2: from /opt/rubies/2.6.5/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):4
NameError (uninitialized constant ActiveMerchant::Billing::Integrations)
```