### PR TITLE
FirstData e4 v27+: Strip linebreaks from address

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -287,6 +287,8 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, options)
         if (address = options[:billing_address] || options[:address])
+          address = strip_line_breaks(address)
+
           xml.tag! 'Address' do
             xml.tag! 'Address1', address[:address1]
             xml.tag! 'Address2', address[:address2] if address[:address2]
@@ -297,6 +299,12 @@ module ActiveMerchant #:nodoc:
           end
           xml.tag! 'ZipCode', address[:zip]
         end
+      end
+
+      def strip_line_breaks(address)
+        return unless address.is_a?(Hash)
+
+        Hash[address.map { |k, s| [k, s.tr("\r\n", ' ').strip] }]
       end
 
       def add_invoice(xml, options)

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -168,6 +168,15 @@ class FirstdataE4V27Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_requests_scrub_newline_and_return_characters_from_verification_string_components
+    stub_comms do
+      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "456 My\nStreet", address2: "Apt 1\r", city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' })})
+      @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
+    end.check_request do |endpoint, data, headers|
+      assert_match '<Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_tax_fields_are_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(tax1_amount: 830, tax1_number: 'Br59a'))


### PR DESCRIPTION
These characters cause an error for 3DS auth.

Unit:
32 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed