### PR TITLE
FirstdataE4V27Gateway: Fix strip_line_breaks method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Cybersource: Add fields to override stored creds [leila-alderman] #3689
 * FirstData e4 v27+: Strip linebreaks from address [curiousepic] #3693
 * Adyen: Change shopper_email to email and shopper_ip to ip [rikterbeek] #3675
+* FirstData e4 v27+ Fix strip_line_breaks method [carrigan] #3695
 
 == Version 1.109.0
 * Remove reference to `Billing::Integrations` [pi3r] #3692

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -304,7 +304,7 @@ module ActiveMerchant #:nodoc:
       def strip_line_breaks(address)
         return unless address.is_a?(Hash)
 
-        Hash[address.map { |k, s| [k, s.tr("\r\n", ' ').strip] }]
+        Hash[address.map { |k, s| [k, s&.tr("\r\n", ' ')&.strip] }]
       end
 
       def add_invoice(xml, options)

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -170,10 +170,10 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
   def test_requests_scrub_newline_and_return_characters_from_verification_string_components
     stub_comms do
-      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "456 My\nStreet", address2: "Apt 1\r", city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' })})
+      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "456 My\nStreet", address2: nil, city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' })})
       @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
     end.check_request do |endpoint, data, headers|
-      assert_match '<Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
+      assert_match '<Address><Address1>456 My Street</Address1><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
## Why?

The recently added strip_line_breaks method added the requirement that all values in the shipping hash be strings. It is often the case though that nil values are supplied, especially for fields like address2. 

## What Changed?

This fix changes the function to allow for nil values.

No test changes were made since the function is already under test with test_requests_scrub_newline_and_return_characters_from_verification_string_components

## Test Suite

4533 tests, 72185 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed
692 files inspected, no offenses detected