### PR TITLE
Update logic to send cavv as xid for 3DS2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Change shopper_email to email and shopper_ip to ip [rikterbeek] #3675
 * FirstData e4 v27+ Fix strip_line_breaks method [carrigan] #3695
 * Cybersource: Conditionally find stored credentials [therufs] #3696 #3697
+* Cybersource: Update logic to send cavv as xid for 3DS2 [douglas] #3699
 * Credorax: Default 3ds_browsercolordepth to 32 when passed as 30 [britth] #3700
 
 == Version 1.109.0

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -927,6 +927,43 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_send_xid_for_3ds_1_regardless_of_cc_brand
+    options_with_normalized_3ds = @options.merge(
+      three_d_secure: {
+        eci: '05',
+        cavv: '637574652070757070792026206b697474656e73',
+        xid: 'this-is-an-xid',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        cavv_algorithm: 'vbv'
+      }
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @elo_credit_card, options_with_normalized_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<xid\>this-is-an-xid/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_dont_send_cavv_as_xid_in_3ds2_for_mastercard
+    options_with_normalized_3ds = @options.merge(
+      three_d_secure: {
+        version: '2.0',
+        eci: '05',
+        cavv: '637574652070757070792026206b697474656e73',
+        xid: 'this-is-an-xid',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        cavv_algorithm: 'vbv'
+      }
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<xid\>this-is-an-xid/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_adds_cavv_as_xid_for_3ds2
     cavv = '637574652070757070792026206b697474656e73'
 
@@ -941,7 +978,7 @@ class CyberSourceTest < Test::Unit::TestCase
     )
 
     stub_comms do
-      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+      @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
     end.check_request do |endpoint, data, headers|
       assert_match(/<xid\>#{cavv}/, data)
     end.respond_with(successful_purchase_response)
@@ -960,7 +997,7 @@ class CyberSourceTest < Test::Unit::TestCase
     )
 
     stub_comms do
-      @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
+      @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
     end.check_request do |endpoint, data, headers|
       assert_match(/<xid\>this-is-an-xid/, data)
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
### What are you trying to accomplish?

Update logic to send `cavv` as `xid` for 3DS2 according to `Cybersource` recommendations.

### Context

Pierre (@pi3r) was talking with Cybersource about an error that we had related to the `xid` field and we got this response from them:

```
1.x
  if xid is present, send it
  do not send the cavv in the xid XML element
2.x
  if xid is present, send it
  else if cavv is present, send cavv in the xid XML element for all card brands except :master
```

So this change intends to make the code behave in the recommended way.

### What should reviewers focus on?

Is there anything that I'm missing? Any improvement suggestion?
