### PR TITLE
Credorax: Default 3ds_browsercolordepth to 32 when passed as 30

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Change shopper_email to email and shopper_ip to ip [rikterbeek] #3675
 * FirstData e4 v27+ Fix strip_line_breaks method [carrigan] #3695
 * Cybersource: Conditionally find stored credentials [therufs] #3696 #3697
+* Credorax: Default 3ds_browsercolordepth to 32 when passed as 30 [britth] #3700
 
 == Version 1.109.0
 * Remove reference to `Billing::Integrations` [pi3r] #3692

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -333,7 +333,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds_browsertz'] = browser_info[:timezone]
           post[:'3ds_browserscreenwidth'] = browser_info[:width]
           post[:'3ds_browserscreenheight'] = browser_info[:height]
-          post[:'3ds_browsercolordepth'] = browser_info[:depth]
+          post[:'3ds_browsercolordepth'] = browser_info[:depth].to_s == '30' ? '32' : browser_info[:depth]
           post[:d6] = browser_info[:language]
           post[:'3ds_browserjavaenabled'] = browser_info[:java]
           post[:'3ds_browseracceptheader'] = browser_info[:accept_header]

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -274,6 +274,21 @@ class CredoraxTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_adds_correct_3ds_browsercolordepth_when_color_depth_is_30
+    @normalized_3ds_2_options[:three_ds_2][:browser_info][:depth] = 30
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @normalized_3ds_2_options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/3ds_browsercolordepth=32/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '8a82944a5351570601535955efeb513c;006596;02617cf5f02ccaed239b6521748298c5;purchase', response.authorization
+    assert response.test?
+  end
+
   def test_adds_3d2_secure_fields_with_3ds_transtype_specified
     options_with_3ds = @normalized_3ds_2_options.merge(three_ds_transtype: '03')
 


### PR DESCRIPTION
Credorax does not accept the value 30 (deep color) as an input for browser depth. 
Instead we should default to 32 when this value is returned.

Unit:
69 tests, 327 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
40 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed