### PR TITLE
[Cybersource] Set authorization on the response when in Fraud Review

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -903,8 +903,7 @@ module ActiveMerchant #:nodoc:
 
         success = success?(response)
         message = message_from(response)
-
-        authorization = success ? authorization_from(response, action, amount, options) : nil
+        authorization = success || in_fraud_review?(response) ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
           test: test?,

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -442,6 +442,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     assert_failure(response = @gateway.authorize(@amount, @credit_card, @options))
     assert response.fraud_review?
+    assert_equal(response.authorization, "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};authorize;100;USD;")
   end
 
   def test_successful_credit_to_subscription_request


### PR DESCRIPTION
We use the `authorization` as a reference when voiding/refunding a transaction. `authorization` isn't set when the transaction is in review which prevents later void/refund. 