### PR TITLE
Realex: Change 3DSecure v1 message_version to a valid format

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -316,6 +316,7 @@ module ActiveMerchant
           else
             xml.tag! 'cavv', three_d_secure[:cavv]
             xml.tag! 'xid', three_d_secure[:xid]
+            version = '1'
           end
           xml.tag! 'eci', three_d_secure[:eci]
           xml.tag! 'message_version', version

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -533,7 +533,7 @@ class RealexTest < Test::Unit::TestCase
           <cavv>1234</cavv>
           <xid>1234</xid>
           <eci>1234</eci>
-          <message_version>1.0.2</message_version>
+          <message_version>1</message_version>
         </mpi>
       </request>
     SRC


### PR DESCRIPTION
Major/minor versions (ex: 1.0.2) in the `message_version` tag is not accepted for 3D Secure v1 for the Realex gateway. For a valid 3D Secure v1 request `message_version` must be either 1 or blank.