### PR TITLE
Paypal Express: support for "Order"  PaymentAction

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
@@ -60,6 +60,22 @@ module ActiveMerchant #:nodoc:
       def note
         @params['note_text']
       end
+
+      def payment_info
+        (@params['PaymentInfo']||{})
+      end
+
+      def transaction_id
+        payment_info['TransactionID']
+      end
+
+      def payment_status
+        payment_info['PaymentStatus']
+      end
+
+      def pending_reason
+        payment_info['PendingReason']
+      end
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -38,6 +38,12 @@ module ActiveMerchant #:nodoc:
         commit 'SetExpressCheckout', build_setup_request('Authorization', money, options)
       end
 
+      def setup_order(money, options = {})
+        requires!(options, :return_url, :cancel_return_url)
+
+        commit 'SetExpressCheckout', build_setup_request('Order', money, options)
+      end
+
       def setup_purchase(money, options = {})
         requires!(options, :return_url, :cancel_return_url)
 
@@ -52,6 +58,12 @@ module ActiveMerchant #:nodoc:
         requires!(options, :token, :payer_id)
 
         commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Authorization', money, options)
+      end
+
+      def order(money, options = {})
+        requires!(options, :token, :payer_id)
+
+        commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Order', money, options)
       end
 
       def purchase(money, options = {})

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -17,10 +17,11 @@ module ActiveMerchant
       end
 
       def redirect_url_for(token, options = {})
-        options = {review: true, mobile: false}.update(options)
+        options = {review: true, mobile: false, order: false}.update(options)
 
         cmd  = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
-        url  = "#{redirect_url}?cmd=#{cmd}&token=#{token}"
+        url  = "#{redirect_url}?cmd=#{cmd}"
+        url += options[:order] ? "&order_id=#{token}" : "&token=#{token}"
         url += '&useraction=commit' unless options[:review]
 
         url

--- a/test/remote/gateways/remote_paypal_express_test.rb
+++ b/test/remote/gateways/remote_paypal_express_test.rb
@@ -48,6 +48,13 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert !response.params['token'].blank?
   end
 
+  def test_setup_order
+    response = @gateway.setup_order(500, @options)
+    assert response.success?
+    assert response.test?
+    assert_not_nil response,token
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.setup_authorization(500, @options)

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -4,13 +4,21 @@ require 'nokogiri'
 class PaypalExpressTest < Test::Unit::TestCase
   TEST_REDIRECT_URL        = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
   TEST_REDIRECT_URL_MOBILE = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
+  TEST_REDIRECT_URL_ORDER  = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&order_id=1234567890'
+  TEST_REDIRECT_URL_MOBILE_ORDER = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&order_id=1234567890'
   LIVE_REDIRECT_URL        = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=1234567890'
   LIVE_REDIRECT_URL_MOBILE = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&token=1234567890'
+  LIVE_REDIRECT_URL_ORDER = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&order_id=1234567890'
+  LIVE_REDIRECT_URL_MOBILE_ORDER = 'https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&order_id=1234567890'
 
   TEST_REDIRECT_URL_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL}&useraction=commit"
   LIVE_REDIRECT_URL_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL}&useraction=commit"
   TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_MOBILE}&useraction=commit"
   LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE}&useraction=commit"
+  TEST_REDIRECT_URL_ORDER_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_ORDER}&useraction=commit"
+  LIVE_REDIRECT_URL_ORDER_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_ORDER}&useraction=commit"
+  TEST_REDIRECT_URL_MOBILE_ORDER_WITHOUT_REVIEW = "#{TEST_REDIRECT_URL_MOBILE_ORDER}&useraction=commit"
+  LIVE_REDIRECT_URL_MOBILE_ORDER_WITHOUT_REVIEW = "#{LIVE_REDIRECT_URL_MOBILE_ORDER}&useraction=commit"
 
   def setup
     @gateway = PaypalExpressGateway.new(
@@ -41,12 +49,16 @@ class PaypalExpressTest < Test::Unit::TestCase
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal LIVE_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
+    assert_equal LIVE_REDIRECT_URL_ORDER, @gateway.redirect_url_for('1234567890', :order => true)
+    assert_equal LIVE_REDIRECT_URL_MOBILE_ORDER, @gateway.redirect_url_for('1234567890', :mobile => true, :order => true)
   end
 
   def test_live_redirect_url_without_review
     Base.mode = :production
     assert_equal LIVE_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
     assert_equal LIVE_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
+    assert_equal LIVE_REDIRECT_URL_ORDER_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :order => true)
+    assert_equal LIVE_REDIRECT_URL_MOBILE_ORDER_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', :review => false, :mobile => true, :order => true)
   end
 
   def test_force_sandbox_redirect_url
@@ -62,18 +74,24 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert gateway.test?
     assert_equal TEST_REDIRECT_URL, gateway.redirect_url_for('1234567890')
     assert_equal TEST_REDIRECT_URL_MOBILE, gateway.redirect_url_for('1234567890', mobile: true)
+    assert_equal TEST_REDIRECT_URL_ORDER, gateway.redirect_url_for('1234567890', :order => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE_ORDER, gateway.redirect_url_for('1234567890', :mobile => true, :order => true)
   end
 
   def test_test_redirect_url
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL, @gateway.redirect_url_for('1234567890')
     assert_equal TEST_REDIRECT_URL_MOBILE, @gateway.redirect_url_for('1234567890', mobile: true)
+    assert_equal TEST_REDIRECT_URL_ORDER, @gateway.redirect_url_for('1234567890', :order => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE_ORDER, @gateway.redirect_url_for('1234567890', :mobile => true, :order => true)
   end
 
   def test_test_redirect_url_without_review
     assert_equal :test, Base.mode
     assert_equal TEST_REDIRECT_URL_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false)
     assert_equal TEST_REDIRECT_URL_MOBILE_WITHOUT_REVIEW, @gateway.redirect_url_for('1234567890', review: false, mobile: true)
+    assert_equal TEST_REDIRECT_URL_ORDER, @gateway.redirect_url_for('1234567890', :order => true)
+    assert_equal TEST_REDIRECT_URL_MOBILE_ORDER, @gateway.redirect_url_for('1234567890', :mobile => true, :order => true)
   end
 
   def test_get_express_details
@@ -114,6 +132,24 @@ class PaypalExpressTest < Test::Unit::TestCase
     response = @gateway.authorize(300, token: 'EC-6WS104951Y388951L', payer_id: 'FWRVKNRRZ3WUC')
     assert response.success?
     assert_not_nil response.authorization
+    assert response.test?
+  end
+
+  def test_setup_order
+    @gateway.expects(:ssl_post).returns(successful_setup_order_response)
+    response = @gateway.setup_order(16900, :return_url => "http://www.mysite.com/cart/payment_confirmation", :cancel_return_url => "http://www.mysite.com/cart")
+    assert response.success?
+    assert_not_nil response.token
+    assert response.test?
+  end
+
+  def test_order
+    @gateway.expects(:ssl_post).returns(successful_order_response)
+    response = @gateway.order(16900, :token => 'EC-9GL04947RL8867642', :payer_id => 'FM3RWNZH2RUVQ')
+    assert response.success?
+    assert_not_nil response.transaction_id
+    assert_equal 'Pending', response.payment_status
+    assert_equal 'order', response.pending_reason
     assert response.test?
   end
 
@@ -1135,6 +1171,95 @@ class PaypalExpressTest < Test::Unit::TestCase
             <Version xmlns="urn:ebay:apis:eBLBaseComponents">2.000000</Version>
             <Build xmlns="urn:ebay:apis:eBLBaseComponents">543066</Build>
           </SetExpressCheckoutResponse>
+        </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_setup_order_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cc="urn:ebay:apis:CoreComponentTypes"
+      xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"
+      xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext"
+      xmlns:ed="urn:ebay:apis:EnhancedDataTypes" xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+        <SOAP-ENV:Header>
+          <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+          <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+            <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+              <Username xsi:type="xs:string"></Username>
+              <Password xsi:type="xs:string"></Password>
+              <Signature xsi:type="xs:string"></Signature>
+              <Subject xsi:type="xs:string"></Subject>
+            </Credentials>
+          </RequesterCredentials>
+        </SOAP-ENV:Header>
+        <SOAP-ENV:Body id="_0">
+          <SetExpressCheckoutResponse xmlns="urn:ebay:api:PayPalAPI">
+            <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2017-03-28T15:49:52Z</Timestamp>
+            <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+            <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">29968f61cda43</CorrelationID>
+            <Version xmlns="urn:ebay:apis:eBLBaseComponents">124</Version>
+            <Build xmlns="urn:ebay:apis:eBLBaseComponents">31704689</Build>
+            <Token xsi:type="ebl:ExpressCheckoutTokenType">EC-9GL04947RL8867642</Token>
+          </SetExpressCheckoutResponse>
+        </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_order_response
+    <<-RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+      xmlns:cc="urn:ebay:apis:CoreComponentTypes" xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"
+      xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext" xmlns:ed="urn:ebay:apis:EnhancedDataTypes"
+      xmlns:ebl="urn:ebay:apis:eBLBaseComponents" xmlns:ns="urn:ebay:api:PayPalAPI">
+        <SOAP-ENV:Header>
+          <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+          <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+            <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+              <Username xsi:type="xs:string"></Username>
+              <Password xsi:type="xs:string"></Password>
+              <Signature xsi:type="xs:string"></Signature>
+              <Subject xsi:type="xs:string"></Subject>
+            </Credentials>
+          </RequesterCredentials>
+        </SOAP-ENV:Header>
+        <SOAP-ENV:Body id="_0">
+          <DoExpressCheckoutPaymentResponse xmlns="urn:ebay:api:PayPalAPI">
+            <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2017-03-28T17:32:49Z</Timestamp>
+            <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+            <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">fee07610312c9</CorrelationID>
+            <Version xmlns="urn:ebay:apis:eBLBaseComponents">124</Version>
+            <Build xmlns="urn:ebay:apis:eBLBaseComponents">31704689</Build>
+            <DoExpressCheckoutPaymentResponseDetails xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:DoExpressCheckoutPaymentResponseDetailsType">
+              <Token xsi:type="ebl:ExpressCheckoutTokenType">EC-0J1915405U175562M</Token>
+              <PaymentInfo xsi:type="ebl:PaymentInfoType">
+                <TransactionID>O-8JU15276WT352522F</TransactionID>
+                <ParentTransactionID xsi:type="ebl:TransactionId"></ParentTransactionID>
+                <ReceiptID></ReceiptID>
+                <TransactionType xsi:type="ebl:PaymentTransactionCodeType">cart</TransactionType>
+                <PaymentType xsi:type="ebl:PaymentCodeType">none</PaymentType>
+                <PaymentDate xsi:type="xs:dateTime">2017-03-28T17:32:48Z</PaymentDate>
+                <GrossAmount xsi:type="cc:BasicAmountType" currencyID="USD">169.00</GrossAmount>
+                <TaxAmount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</TaxAmount>
+                <ExchangeRate xsi:type="xs:string"></ExchangeRate>
+                <PaymentStatus xsi:type="ebl:PaymentStatusCodeType">Pending</PaymentStatus>
+                <PendingReason xsi:type="ebl:PendingStatusCodeType">order</PendingReason>
+                <ReasonCode xsi:type="ebl:ReversalReasonCodeType">none</ReasonCode>
+                <ProtectionEligibility xsi:type="xs:string">None</ProtectionEligibility>
+                <SellerDetails xsi:type="ebl:SellerDetailsType">
+                  <SecureMerchantAccountID xsi:type="ebl:UserIDType">JS9N52U8XTF7G</SecureMerchantAccountID>
+                </SellerDetails>
+              </PaymentInfo>
+              <SuccessPageRedirectRequested xsi:type="xs:string">false</SuccessPageRedirectRequested>
+              <CoupledPaymentInfo xsi:type="ebl:CoupledPaymentInfoType"></CoupledPaymentInfo>
+            </DoExpressCheckoutPaymentResponseDetails>
+          </DoExpressCheckoutPaymentResponse>
         </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>
     RESPONSE


### PR DESCRIPTION
Paypal Express supports 3 different payment actions, but active merchant only includes 2: Sale and Authorization. 
This is adding support for the 3rd payment action "Order". 

You can find detailed info from paypal in the following sources:
https://developer.paypal.com/docs/archive/express-checkout/integration-guide/ECSettlements/#order-payment-action
https://www.paypal.com/uk/smarthelp/article/what-are-the-differences-between-the-express-checkout-payment-actions-ts1501

There was an original pull request from @whitby3001 that got never included and was closed by David, but it's still relevant.
https://github.com/activemerchant/active_merchant/pull/2383