### PR TITLE
Ingenico/Global Collect: Add Installments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Cybersource: Conditionally find stored credentials [therufs] #3696 #3697
 * Cybersource: Update logic to send cavv as xid for 3DS2 [douglas] #3699
 * Credorax: Default 3ds_browsercolordepth to 32 when passed as 30 [britth] #3700
+* Ingenico/ GlobalCollect: Add field for installments [cdmackeyfree] #3707
 
 == Version 1.109.0
 * Remove reference to `Billing::Integrations` [pi3r] #3692

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -100,6 +100,7 @@ module ActiveMerchant #:nodoc:
           'invoiceNumber' => options[:invoice]
         }
         add_airline_data(post, options) if options[:airline_data]
+        add_number_of_installments(post, options) if options[:number_of_installments]
       end
 
       def add_airline_data(post, options)
@@ -231,6 +232,10 @@ module ActiveMerchant #:nodoc:
         post['fraudFields'] = fraud_fields unless fraud_fields.empty?
       end
 
+      def add_number_of_installments(post, options)
+        post['order']['additionalInput']['numberOfInstallments'] = options[:number_of_installments] if options[:number_of_installments]
+      end
+        
       def parse(body)
         JSON.parse(body)
       end

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -55,6 +55,13 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_installments
+    options = @options.merge(number_of_installments: 2)
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   # When requires_approval is true (or not present),
   # `purchase` will make both an `auth` and a `capture` call
   def test_successful_purchase_with_requires_approval_true
@@ -227,7 +234,6 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = GlobalCollectGateway.new(merchant_id: '', api_key_id: '', secret_api_key: '')
-
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match %r{MISSING_OR_INVALID_AUTHORIZATION}, response.message

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -85,6 +85,14 @@ class GlobalCollectTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response, successful_capture_response)
   end
 
+  def test_purchase_passes_installments
+    stub_comms do
+      @gateway.purchase(@accepted_amount, @credit_card, @options.merge(number_of_installments: '3'))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"numberOfInstallments\":\"3\"/, data)
+    end.respond_with(successful_authorize_response, successful_capture_response)
+  end
+
   def test_purchase_does_not_run_capture_if_authorize_auto_captured
     response = stub_comms do
       @gateway.purchase(@accepted_amount, @credit_card, @options)


### PR DESCRIPTION
Add the option of sending the number of installments for payments and related tests. Remote tests are failing to result in 502 errors on this gateway (on branch master as well as this one).

Unit:

24 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

22 tests, 33 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
40.9091% passed

Local:

4537 tests, 72200 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed