### PR TITLE
Cybersource: add `maestro` and `diners_club` to ECI_BRAND_MAPPING

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708
 
 == Version 1.111.0
 * Fat Zebra: standardized 3DS fields and card on file extra data for Visa scheme rules [montdidier] #3409

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -30,9 +30,11 @@ module ActiveMerchant #:nodoc:
       ECI_BRAND_MAPPING = {
         visa: 'vbv',
         master: 'spa',
+        maestro: 'spa',
         american_express: 'aesk',
         jcb: 'js',
         discover: 'pb',
+        diners_club: 'pb',
       }.freeze
       DEFAULT_COLLECTION_INDICATOR = 2
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -830,7 +830,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_adds_3ds_brand_based_commerce_indicator
-    %w(visa master american_express jcb discover).each do |brand|
+    %w(visa maestro master american_express jcb discover diners_club).each do |brand|
       @credit_card.brand = brand
 
       stub_comms do


### PR DESCRIPTION
Cybersource confirmed than the same commerce indicators can be used for 
- `maestro` and `master` 
- `discover` and `diners_club`

This PR updates `ActiveMerchant::Billing::CyberSourceGateway::ECI_BRAND_MAPPING` accordingly