### PR TITLE
Add pry-byebug development dependency

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('pry')
+  s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('thor')


### PR DESCRIPTION
### What are you trying to accomplish?

### What are you trying to accomplish?

While debugging recent PRs we (@bbraschi  and I) noticed that it was not possible to do step-by-step debugging and stack navigation, so this PR adds it.

### How did you accomplish this and why did you choose this approach?

Just added `pry-byebug` as a development dependency.

### How can this PR be tophatted:

Just running the tests with a breakpoint set `require 'pry'; binding.pry` and then use the commands `step` and `continue`.

### What should reviewers focus on?

Any other way of doing this? Any suggestions?