### PR TITLE
Fix rubocop offense (trailing spaces)

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -235,7 +235,7 @@ module ActiveMerchant #:nodoc:
       def add_number_of_installments(post, options)
         post['order']['additionalInput']['numberOfInstallments'] = options[:number_of_installments] if options[:number_of_installments]
       end
-        
+
       def parse(body)
         JSON.parse(body)
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Remove trailing spaces, which will allow [others branches to pass CI](https://travis-ci.org/github/activemerchant/active_merchant/jobs/714608258#L290) =)