### PR TITLE
Cybersource: do not send 3DS fields if 'cavv` is missing and `commerceIndicator` is inferred

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Fat Zebra: standardized 3DS fields and card on file extra data for Visa scheme rules [montdidier] #3409
+* Cybersource: do not send 3DS fields if 'cavv` is missing and `commerceIndicator` is inferred #3712
 
 == Version 1.110.0
 * FirstData e4 v27+: Strip linebreaks from address [curiousepic] #3693

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -612,6 +612,9 @@ module ActiveMerchant #:nodoc:
       def add_normalized_threeds_2_data(xml, payment_method, options)
         threeds_2_options = options[:three_d_secure]
         cc_brand = card_brand(payment_method).to_sym
+
+        return if threeds_2_options[:cavv].blank? && infer_commerce_indicator?(options, cc_brand)
+
         xid = threeds_2_options[:xid]
 
         xml.tag!('cavv', threeds_2_options[:cavv]) if threeds_2_options[:cavv] && cc_brand != :master
@@ -630,6 +633,10 @@ module ActiveMerchant #:nodoc:
 
         xml.tag!('veresEnrolled', threeds_2_options[:enrolled]) if threeds_2_options[:enrolled]
         xml.tag!('paresStatus', threeds_2_options[:authentication_response_status]) if threeds_2_options[:authentication_response_status]
+      end
+
+      def infer_commerce_indicator?(options, cc_brand)
+        options[:commerce_indicator].blank? && ECI_BRAND_MAPPING[cc_brand].present?
       end
 
       def add_threeds_2_ucaf_data(xml, payment_method, options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -836,7 +836,7 @@ class CyberSourceTest < Test::Unit::TestCase
       stub_comms do
         @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: { cavv: 'anything but empty' }))
       end.check_request do |endpoint, data, headers|
-        assert_match(/commerceIndicator\>#{CyberSourceGateway::ECI_BRAND_MAPPING[brand.to_sym]}/, data)
+        assert_match(/commerceIndicator\>#{CyberSourceGateway::ECI_BRAND_MAPPING[brand.to_sym]}</, data)
       end.respond_with(successful_purchase_response)
     end
   end
@@ -882,14 +882,14 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_, data, _|
-      assert_not_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
-      assert_not_match(/<cavv\>#{options[:three_d_secure][:cavv]}/, data)
-      assert_not_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
-      assert_not_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
-      assert_not_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
-      assert_not_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
-      assert_not_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
-      assert_not_match(/<commerceIndicator\>#{options[:commerce_indicator]}/, data)
+      assert_not_match(/<eciRaw\>#{options[:three_d_secure][:eci]}</, data)
+      assert_not_match(/<cavv\>#{options[:three_d_secure][:cavv]}</, data)
+      assert_not_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}</, data)
+      assert_not_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}</, data)
+      assert_not_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}</, data)
+      assert_not_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}</, data)
+      assert_not_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}</, data)
+      assert_not_match(/<commerceIndicator\>#{options[:commerce_indicator]}</, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -901,12 +901,12 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_, data, _|
-      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
-      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
-      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
-      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
-      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
-      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}</, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}</, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}</, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}</, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}</, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}</, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -915,13 +915,13 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_, data, _|
-      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
-      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
-      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
-      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
-      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
-      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
-      assert_match(/<commerceIndicator\>#{options[:commerce_indicator]}/, data)
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}</, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}</, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}</, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}</, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}</, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}</, data)
+      assert_match(/<commerceIndicator\>#{options[:commerce_indicator]}</, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -930,13 +930,13 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_, data, _|
-      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
-      assert_match(/<cavv\>#{options[:three_d_secure][:cavv]}/, data)
-      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
-      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
-      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
-      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
-      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}</, data)
+      assert_match(/<cavv\>#{options[:three_d_secure][:cavv]}</, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}</, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}</, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}</, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}</, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}</, data)
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -834,7 +834,7 @@ class CyberSourceTest < Test::Unit::TestCase
       @credit_card.brand = brand
 
       stub_comms do
-        @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: {}))
+        @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: { cavv: 'anything but empty' }))
       end.check_request do |endpoint, data, headers|
         assert_match(/commerceIndicator\>#{CyberSourceGateway::ECI_BRAND_MAPPING[brand.to_sym]}/, data)
       end.respond_with(successful_purchase_response)
@@ -874,6 +874,69 @@ class CyberSourceTest < Test::Unit::TestCase
       assert_match(/<cavvAlgorithm\>#{cavv_algorithm}/, data)
       assert_match(/<commerceIndicator\>#{commerce_indicator}/, data)
       assert_match(/<veresEnrolled\>#{enrolled}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_does_not_add_3ds2_fields_via_normalized_hash_when_cavv_and_commerce_indicator_absent
+    options = options_with_normalized_3ds(cavv: nil, commerce_indicator: nil)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_, data, _|
+      assert_not_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
+      assert_not_match(/<cavv\>#{options[:three_d_secure][:cavv]}/, data)
+      assert_not_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
+      assert_not_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
+      assert_not_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
+      assert_not_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
+      assert_not_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
+      assert_not_match(/<commerceIndicator\>#{options[:commerce_indicator]}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_adds_3ds2_fields_via_normalized_hash_when_cavv_and_commerce_indicator_absent_and_commerce_indicator_not_inferred
+    @credit_card.brand = supported_cc_brand_without_inferred_commerce_indicator
+    assert_not_nil @credit_card.brand
+
+    options = options_with_normalized_3ds(cavv: nil, commerce_indicator: nil)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_, data, _|
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_adds_3ds2_fields_via_normalized_hash_when_cavv_absent_and_commerce_indicator_present
+    options = options_with_normalized_3ds(cavv: nil)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_, data, _|
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
+      assert_match(/<commerceIndicator\>#{options[:commerce_indicator]}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_adds_3ds2_fields_via_normalized_hash_when_cavv_present_and_commerce_indicator_absent
+    options = options_with_normalized_3ds(commerce_indicator: nil)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_, data, _|
+      assert_match(/<eciRaw\>#{options[:three_d_secure][:eci]}/, data)
+      assert_match(/<cavv\>#{options[:three_d_secure][:cavv]}/, data)
+      assert_match(/<paSpecificationVersion\>#{options[:three_d_secure][:version]}/, data)
+      assert_match(/<directoryServerTransactionID\>#{options[:three_d_secure][:ds_transaction_id]}/, data)
+      assert_match(/<paresStatus\>#{options[:three_d_secure][:authentication_response_status]}/, data)
+      assert_match(/<cavvAlgorithm\>#{options[:three_d_secure][:cavv_algorithm]}/, data)
+      assert_match(/<veresEnrolled\>#{options[:three_d_secure][:enrolled]}/, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -1066,6 +1129,39 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   private
+
+  def options_with_normalized_3ds(
+    cavv: '637574652070757070792026206b697474656e73',
+    commerce_indicator: 'commerce_indicator'
+  )
+    xid = 'Y2FyZGluYWxjb21tZXJjZWF1dGg='
+    authentication_response_status = 'Y'
+    cavv_algorithm = 2
+    collection_indicator = 2
+    ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
+    eci = '05'
+    enrolled = 'Y'
+    version = '2.0'
+    @options.merge(
+      three_d_secure: {
+        version: version,
+        eci: eci,
+        xid: xid,
+        cavv: cavv,
+        ds_transaction_id: ds_transaction_id,
+        cavv_algorithm: cavv_algorithm,
+        enrolled: enrolled,
+        authentication_response_status: authentication_response_status
+      },
+      commerce_indicator: commerce_indicator,
+      collection_indicator: collection_indicator
+    ).compact
+  end
+
+  def supported_cc_brand_without_inferred_commerce_indicator
+    (ActiveMerchant::Billing::CyberSourceGateway.supported_cardtypes -
+      ActiveMerchant::Billing::CyberSourceGateway::ECI_BRAND_MAPPING.keys).first
+  end
 
   def pre_scrubbed
     <<-PRE_SCRUBBED


### PR DESCRIPTION
### Problem
A merchant can attempt to authorize a non-3DS-authenticated transaction but the liability shift may not occur under the same conditions as it would for a fully 3DS-authenticated transaction.

This is the case, for example, in the `Failed Frictionless Authentication` test with the `4000000000001018` credit card, [here](https://developer.cybersource.com/library/documentation/dev_guides/Payer_Authentication_SO_API/html/index.html#t=Topics%2FTest_Cases_for_3D_Secure_2_x.htm).

If a merchant does not want to attempt to authorize a non-3DS-authenticated transaction, then the call to authorize the transaction through `active_merchant` should not be made and there won't be a problem.

On the other hand, a merchant may want to authorize a non-3DS-authenticated transaction and a corresponding call to `active_merchant` should be made. If no `commerceIndicator` is specified by the caller, `active_merchant` infers a `commerceIndicator` that indicates the authentication has occurred, that is the problem.
In the `4000000000001018` example, `active_merchant` infers `vbv` for the `commerceIndicator`:

```xml
      <ccAuthService run="true">
        <paSpecificationVersion>2.2.0</paSpecificationVersion>
        <directoryServerTransactionID>...</directoryServerTransactionID>
        <commerceIndicator>vbv</commerceIndicator>
        <eciRaw>07</eciRaw>
        <veresEnrolled>Y</veresEnrolled>
      </ccAuthService>
```
As explained by Michael T. from cybersource
> when you pass in “vbv” as the commerceIndicator [the cybersource backend] looks for the presence of a CAVV, since “vbv” means the request was successfully authenticated

and the payment fails with
```xml
    <c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.164">
      ...
      <c:decision>REJECT</c:decision>
      <c:reasonCode>101</c:reasonCode>
      <c:missingField>c:xid</c:missingField>
      ...
      <c:ccAuthReply>
        <c:reasonCode>101</c:reasonCode>
      </c:ccAuthReply>
    </c:replyMessage>
```

### Fix

If the
1. `cavv` is absent and
1. `commerceIndicator` is absent and is inferred by `active_merchant`

then do not add the 3DS fields to the `ccAuthService` xml element.
