### PR TITLE
Pass 3DS options to NMI.

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -36,6 +36,7 @@ module ActiveMerchant #:nodoc:
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
         add_level3_fields(post, options)
+        add_3ds_auth(post, options)
 
         commit('sale', post)
       end
@@ -49,6 +50,7 @@ module ActiveMerchant #:nodoc:
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
         add_level3_fields(post, options)
+        add_3ds_auth(post, options)
 
         commit('auth', post)
       end
@@ -136,6 +138,16 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def add_3ds_auth(post, options)
+        if options[:three_d_secure]
+          post[:cardholder_auth] = options.dig(:three_d_secure, :status) == 'Y' ? 'verified' : 'attempted'
+          post[:eci] = options.dig(:three_d_secure, :eci)
+          post[:cavv] = options.dig(:three_d_secure, :cavv)
+          post[:xid] = options.dig(:three_d_secure, :xid)
+          post[:three_ds_version] = options.dig(:three_d_secure, :version)
+        end
+      end
 
       def add_level3_fields(post, options)
         add_fields_to_post_if_present(post, options, %i[tax shipping ponumber])

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -24,6 +24,15 @@ class RemoteNmiTest < Test::Unit::TestCase
     @level3_options = {
       tax: 5.25, shipping: 10.51, ponumber: 1002
     }
+    @additional_options_3ds = @options.merge(
+      execute_threed: true,
+      three_d_secure: {
+        version: '1.0.2',
+        eci: '06',
+        cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+        xid: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY='
+      }
+    )
   end
 
   def test_invalid_login
@@ -126,6 +135,14 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, authorization.authorization)
     assert_success capture
     assert_equal 'Succeeded', capture.message
+  end
+
+  def test_successful_authorize_and_capture_with_3ds
+    assert authorization = @gateway.authorize(@amount, @credit_card, @additional_options_3ds)
+    assert_success authorization
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
   end
 
   def test_failed_capture


### PR DESCRIPTION
3DS1 only for now.

Unit:
45 tests, 342 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed