### PR TITLE
Cybersource: Ensure Partner Solution Id placement conforms to schema

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708
+* Cybersource: Ensure Partner Solution Id placement conforms to schema [britth] #3715
 
 == Version 1.111.0
 * Fat Zebra: standardized 3DS fields and card on file extra data for Visa scheme rules [montdidier] #3409

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -123,6 +123,32 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_authorize_with_solution_id
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_authorize_with_solution_id_and_stored_creds
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: '',
+      initial_transaction: true,
+      network_transaction_id: ''
+    }
+    @options[:commerce_indicator] = 'internet'
+
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
   def test_successful_authorization_with_issuer_additional_data
     @options[:issuer_additional_data] = @issuer_additional_data
 
@@ -200,6 +226,18 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(void)
   end
 
+  def test_successful_void_with_solution_id
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_successful_response(void)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
   def test_successful_tax_calculation
     assert response = @gateway.calculate_tax(@credit_card, @options)
     assert response.params['totalTaxAmount']
@@ -274,6 +312,32 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
+  def test_successful_purchase_with_solution_id
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_purchase_with_solution_id_and_stored_creds
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: '',
+      initial_transaction: true,
+      network_transaction_id: ''
+    }
+    @options[:commerce_indicator] = 'internet'
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_equal 'Invalid account number', response.message
@@ -304,6 +368,18 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.capture(@amount, auth.authorization)
     assert_successful_response(response)
     assert !response.authorization.blank?
+  end
+
+  def test_successful_capture_with_solution_id
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    assert response = @gateway.capture(@amount, auth.authorization, @options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
   end
 
   def test_successful_authorization_and_failed_capture
@@ -338,6 +414,18 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(@amount, response.authorization)
     assert_successful_response(response)
+  end
+
+  def test_successful_refund_with_solution_id
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_successful_response(refund)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
   end
 
   def test_successful_validate_pinless_debit_card

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1110,6 +1110,27 @@ class CyberSourceTest < Test::Unit::TestCase
     CyberSourceGateway.application_id = nil
   end
 
+  def test_partner_solution_id_position_follows_schema
+    partner_id = 'partner_id'
+    CyberSourceGateway.application_id = partner_id
+
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: '',
+      initial_transaction: true,
+      network_transaction_id: ''
+    }
+    @options[:commerce_indicator] = 'internet'
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match("<subsequentAuth/>\n<partnerSolutionID>#{partner_id}</partnerSolutionID>\n<subsequentAuthFirst>true</subsequentAuthFirst>\n<subsequentAuthTransactionID/>\n<subsequentAuthStoredCredential/>", data)
+    end.respond_with(successful_capture_response)
+  ensure
+    CyberSourceGateway.application_id = nil
+  end
+
   def test_missing_field
     @gateway.expects(:ssl_post).returns(missing_field_response)
 


### PR DESCRIPTION
The Cybersource XML request must follow the defined [xsd schema format](https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.167.xsd) 
or else it will result in an XML parse error. Currently, if someone
tries to use stored credential fields in addition to the partner
solution id, they will receive an XML parse error from the gateway. The 
schema requires `subsequentAuth` to come before the solution id and 
for the other stored credential fields to come after solution id. This PR 
updates the request building methods to ensure that these fields are 
added in the right order, also adding remote tests for this behavior.

Remote:
89 tests, 457 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.382% passed
(pre-existing failures)

Unit:
96 tests, 463 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed