### PR TITLE
PayU Latam - Improve error response

### DIFF
--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -392,10 +392,12 @@ module ActiveMerchant #:nodoc:
           if response['transactionResponse']
             response_message = response['transactionResponse']['responseMessage']
             response_code = response['transactionResponse']['responseCode'] || response['transactionResponse']['pendingReason']
+
+            response_message = response_code + ' | ' + response['transactionResponse']['paymentNetworkResponseErrorMessage'] unless response['transactionResponse']['paymentNetworkResponseErrorMessage'].nil?
           end
           return response_code if success
 
-          response['error'] || response_message || response_code || 'FAILED'
+          response_message || response['error'] || response_code || 'FAILED'
         end
       end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -237,6 +237,19 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     assert_equal 'DECLINED', response.params['transactionResponse']['state']
   end
 
+  # Published API does not currently provide a way to request a CONTACT_THE_ENTITY
+  # def test_failed_purchase_correct_message_when_payment_network_response_error_present
+  #   response = @gateway.purchase(@amount, @credit_card, @options)
+  #   assert_failure response
+  #   assert_equal 'CONTACT_THE_ENTITY | Contactar con entidad emisora', response.message
+  #   assert_equal 'Contactar con entidad emisora', response.params['transactionResponse']['paymentNetworkResponseErrorMessage']
+
+  #   response = @gateway.purchase(@amount, @credit_card, @options)
+  #   assert_failure response
+  #   assert_equal 'CONTACT_THE_ENTITY', response.message
+  #   assert_nil response.params['transactionResponse']['paymentNetworkResponseErrorMessage']
+  # end
+
   def test_failed_purchase_with_cabal_card
     response = @gateway.purchase(@amount, @invalid_cabal_card, @options)
     assert_failure response
@@ -395,14 +408,14 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 499))
 
     assert_failure verify
-    assert_equal 'The order value is less than minimum allowed. Minimum value allowed 5 ARS', verify.message
+    assert_equal 'INVALID_TRANSACTION | [The given payment value [4.99] is inferior than minimum configured value [5]]', verify.message
   end
 
   def test_failed_verify_with_specified_language
     verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 499, language: 'es'))
 
     assert_failure verify
-    assert_equal 'The order value is less than minimum allowed. Minimum value allowed 5 ARS', verify.message
+    assert_equal 'INVALID_TRANSACTION | [El valor recibido [4,99] es inferior al valor mínimo configurado [5]]', verify.message
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -76,6 +76,22 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal 'DECLINED', response.params['transactionResponse']['state']
   end
 
+  def test_failed_purchase_correct_message_when_payment_network_response_error_present
+    @gateway.expects(:ssl_post).returns(failed_purchase_response_when_payment_network_response_error_expected)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'CONTACT_THE_ENTITY | Contactar con entidad emisora', response.message
+    assert_equal 'Contactar con entidad emisora', response.params['transactionResponse']['paymentNetworkResponseErrorMessage']
+
+    @gateway.expects(:ssl_post).returns(failed_purchase_response_when_payment_network_response_error_not_expected)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'CONTACT_THE_ENTITY', response.message
+    assert_nil response.params['transactionResponse']['paymentNetworkResponseErrorMessage']
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -554,6 +570,60 @@ class PayuLatamTest < Test::Unit::TestCase
         "authorizationCode": null,
         "pendingReason": null,
         "responseCode": "ANTIFRAUD_REJECTED",
+        "errorCode": null,
+        "responseMessage": null,
+        "transactionDate": null,
+        "transactionTime": null,
+        "operationDate": null,
+        "referenceQuestionnaire": null,
+        "extraParameters": null
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_response_when_payment_network_response_error_expected
+    <<-RESPONSE
+    {
+      "code": "SUCCESS",
+      "error": null,
+      "transactionResponse": {
+        "orderId": 7354347,
+        "transactionId": "15b6cec0-9eec-4564-b6b9-c846b868203e",
+        "state": "DECLINED",
+        "paymentNetworkResponseCode": "290",
+        "paymentNetworkResponseErrorMessage": "Contactar con entidad emisora",
+        "trazabilityCode": null,
+        "authorizationCode": null,
+        "pendingReason": null,
+        "responseCode": "CONTACT_THE_ENTITY",
+        "errorCode": null,
+        "responseMessage": null,
+        "transactionDate": null,
+        "transactionTime": null,
+        "operationDate": null,
+        "referenceQuestionnaire": null,
+        "extraParameters": null
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_response_when_payment_network_response_error_not_expected
+    <<-RESPONSE
+    {
+      "code": "SUCCESS",
+      "error": null,
+      "transactionResponse": {
+        "orderId": 7354347,
+        "transactionId": "15b6cec0-9eec-4564-b6b9-c846b868203e",
+        "state": "DECLINED",
+        "paymentNetworkResponseCode": null,
+        "paymentNetworkResponseErrorMessage": null,
+        "trazabilityCode": null,
+        "authorizationCode": null,
+        "pendingReason": null,
+        "responseCode": "CONTACT_THE_ENTITY",
         "errorCode": null,
         "responseMessage": null,
         "transactionDate": null,


### PR DESCRIPTION
Add additional error detail when paymentNetworkResponseErrorMessage
might be more useful.

CE-482

Unit:
33 tests, 131 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 77 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
82.8571% passed

@curiousepic