### PR TITLE
RuboCop: Fix Style/TrailingCommaInHashLiteral

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -877,13 +877,6 @@ Style/TrailingCommaInArrayLiteral:
     - 'test/unit/gateways/netaxept_test.rb'
     - 'test/unit/gateways/usa_epay_transaction_test.rb'
 
-# Offense count: 160
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
 # Offense count: 34
 # Cop supports --auto-correct.
 Style/ZeroLengthPredicate:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Orbital: Add cardIndicators field [meagabeth] #3734
 * Openpay: Add Colombia to supported countries [molbrown] #3740
 * Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
+* RuboCop: Fix Style/TrailingCommaInHashLiteral [leila-alderman] #3718
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -190,7 +190,7 @@ module ActiveMerchant #:nodoc:
         'contactless' => 'Data was read by a Contactless EMV kernel. Issuer script results are not available.',
         'contactless_magstripe' => 'Contactless data was read with a non-EMV protocol.',
         'contact' => 'Data was read using the EMV protocol. Issuer script results may follow.',
-        'contact_quickchip' => 'Data was read by the Quickchip EMV kernel. Issuer script results are not available.',
+        'contact_quickchip' => 'Data was read by the Quickchip EMV kernel. Issuer script results are not available.'
       }
 
       # Returns the ciphertext of the card's encrypted PIN.

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -329,7 +329,7 @@ module ActiveMerchant #:nodoc:
           54 => 3, # 6 * 2 - 9
           55 => 5, # etc ...
           56 => 7,
-          57 => 9,
+          57 => 9
         }.freeze
 
         # Checks the validity of a card number by use of the Luhn Algorithm.

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
         pickup_card: 'pick_up_card',
         config_error: 'config_error',
         test_mode_live_card: 'test_mode_live_card',
-        unsupported_feature: 'unsupported_feature',
+        unsupported_feature: 'unsupported_feature'
       }
 
       cattr_reader :implementations

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
         '132' => STANDARD_ERROR_CODE[:incorrect_address],
         '133' => STANDARD_ERROR_CODE[:incorrect_address],
         '134' => STANDARD_ERROR_CODE[:incorrect_address],
-        '135' => STANDARD_ERROR_CODE[:incorrect_address],
+        '135' => STANDARD_ERROR_CODE[:incorrect_address]
       }
 
       def initialize(options={})
@@ -243,7 +243,7 @@ module ActiveMerchant #:nodoc:
         splits = []
         split_data.each do |split|
           amount = {
-            value: split['amount']['value'],
+            value: split['amount']['value']
           }
           amount[:currency] = split['amount']['currency'] if split['amount']['currency']
 

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -54,7 +54,7 @@ module ActiveMerchant
         '37' => STANDARD_ERROR_CODE[:invalid_expiry_date],
         '378' => STANDARD_ERROR_CODE[:invalid_cvc],
         '38' => STANDARD_ERROR_CODE[:expired_card],
-        '384' => STANDARD_ERROR_CODE[:config_error],
+        '384' => STANDARD_ERROR_CODE[:config_error]
       }
 
       MARKET_TYPE = {
@@ -1059,7 +1059,7 @@ module ActiveMerchant
           card_type: parts[51] || '',
           split_tender_id: parts[52] || '',
           requested_amount: parts[53] || '',
-          balance_on_card: parts[54] || '',
+          balance_on_card: parts[54] || ''
         }
       end
     end

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -928,7 +928,7 @@ module ActiveMerchant #:nodoc:
             'card_type' => direct_response_fields[51] || '',
             'split_tender_id' => direct_response_fields[52] || '',
             'requested_amount' => direct_response_fields[53] || '',
-            'balance_on_card' => direct_response_fields[54] || '',
+            'balance_on_card' => direct_response_fields[54] || ''
           }
         )
       end

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
           'Authorization' => 'Basic ' + Base64.encode64(@options[:login].to_s + ':').strip,
           'User-Agent' => "Balanced/v1.1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'Accept' => 'application/vnd.api+json;revision=1.1',
-          'X-Balanced-User-Agent' => @@ua,
+          'X-Balanced-User-Agent' => @@ua
         }
       end
     end

--- a/lib/active_merchant/billing/gateways/bambora_apac.rb
+++ b/lib/active_merchant/billing/gateways/bambora_apac.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
         '05' => STANDARD_ERROR_CODE[:card_declined],
         '06' => STANDARD_ERROR_CODE[:processing_error],
         '14' => STANDARD_ERROR_CODE[:invalid_number],
-        '54' => STANDARD_ERROR_CODE[:expired_card],
+        '54' => STANDARD_ERROR_CODE[:expired_card]
       }
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/bank_frick.rb
+++ b/lib/active_merchant/billing/gateways/bank_frick.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
         'authonly'  => 'CC.PA',
         'capture'   => 'CC.CP',
         'refund'    => 'CC.RF',
-        'void'      => 'CC.RV',
+        'void'      => 'CC.RV'
       }
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -58,7 +58,7 @@ module ActiveMerchant
         'line1: N, zip: M, name: N' => 'W',
         'line1: N, zip: N, name: U' => 'N',
         'line1: N, zip: N, name: M' => 'K',
-        'line1: N, zip: N, name: N' => 'N',
+        'line1: N, zip: N, name: N' => 'N'
       }
 
       BANK_ACCOUNT_TYPE_MAPPING = {
@@ -476,7 +476,7 @@ module ActiveMerchant
       def headers
         {
           'Content-Type' => 'application/xml',
-          'Authorization' => ('Basic ' + Base64.strict_encode64("#{@options[:api_username]}:#{@options[:api_password]}").strip),
+          'Authorization' => ('Basic ' + Base64.strict_encode64("#{@options[:api_username]}:#{@options[:api_password]}").strip)
         }
       end
 

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
 
       def headers
         {
-          'Authorization' => 'Basic ' + Base64.strict_encode64(@options[:username].to_s + ':' + @options[:password].to_s),
+          'Authorization' => 'Basic ' + Base64.strict_encode64(@options[:username].to_s + ':' + @options[:password].to_s)
         }
       end
 

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -234,7 +234,7 @@ module ActiveMerchant #:nodoc:
             phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone]),
             id: options[:customer],
-            device_data: options[:device_data],
+            device_data: options[:device_data]
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
           Response.new(result.success?, message_from_result(result),
@@ -258,7 +258,7 @@ module ActiveMerchant #:nodoc:
             cvv: credit_card.verification_value,
             expiration_month: credit_card.month.to_s.rjust(2, '0'),
             expiration_year: credit_card.year.to_s,
-            device_data: options[:device_data],
+            device_data: options[:device_data]
           }
           if options[:billing_address]
             address = map_address(options[:billing_address])
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
           company: address[:company],
           locality: address[:city],
           region: address[:state],
-          postal_code: scrub_zip(address[:zip]),
+          postal_code: scrub_zip(address[:zip])
         }
 
         mapped[:country_code_alpha2] = (address[:country] || address[:country_code_alpha2]) if address[:country] || address[:country_code_alpha2]
@@ -508,7 +508,7 @@ module ActiveMerchant #:nodoc:
         customer_details = {
           'id' => transaction.customer_details.id,
           'email' => transaction.customer_details.email,
-          'phone' => transaction.customer_details.phone,
+          'phone' => transaction.customer_details.phone
         }
 
         billing_details = {
@@ -518,7 +518,7 @@ module ActiveMerchant #:nodoc:
           'locality'         => transaction.billing_details.locality,
           'region'           => transaction.billing_details.region,
           'postal_code'      => transaction.billing_details.postal_code,
-          'country_name'     => transaction.billing_details.country_name,
+          'country_name'     => transaction.billing_details.country_name
         }
 
         shipping_details = {
@@ -528,7 +528,7 @@ module ActiveMerchant #:nodoc:
           'locality'         => transaction.shipping_details.locality,
           'region'           => transaction.shipping_details.region,
           'postal_code'      => transaction.shipping_details.postal_code,
-          'country_name'     => transaction.shipping_details.country_name,
+          'country_name'     => transaction.shipping_details.country_name
         }
         credit_card_details = {
           'masked_number'       => transaction.credit_card_details.masked_number,
@@ -578,7 +578,7 @@ module ActiveMerchant #:nodoc:
           options: {
             store_in_vault: options[:store] ? true : false,
             submit_for_settlement: options[:submit_for_settlement],
-            hold_in_escrow: options[:hold_in_escrow],
+            hold_in_escrow: options[:hold_in_escrow]
           }
         }
 

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -312,7 +312,7 @@ module ActiveMerchant #:nodoc:
           Version: '4.5.4',
           SoftwareName: 'Active Merchant',
           SoftwareVersion: ActiveMerchant::VERSION.to_s,
-          Command: command,
+          Command: command
         }
 
         seed = SecureRandom.hex(32).upcase

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -250,7 +250,7 @@ module ActiveMerchant #:nodoc:
         '257' => STANDARD_ERROR_CODE[:invalid_cvc],
         '333' => STANDARD_ERROR_CODE[:expired_card],
         '1' => STANDARD_ERROR_CODE[:card_declined],
-        '99' => STANDARD_ERROR_CODE[:processing_error],
+        '99' => STANDARD_ERROR_CODE[:processing_error]
       }
 
       def authorization_from(request, response)

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -194,7 +194,7 @@ module ActiveMerchant #:nodoc:
       def headers
         {
           'Authorization' => @options[:secret_key],
-          'Content-Type' => 'application/json;charset=UTF-8',
+          'Content-Type' => 'application/json;charset=UTF-8'
         }
       end
 

--- a/lib/active_merchant/billing/gateways/culqi.rb
+++ b/lib/active_merchant/billing/gateways/culqi.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
         refund: 'SingleCallGenericReverse',
         tokenize: 'SingleCallTokenServlet',
         invalidate: 'SingleCallInvalidateToken',
-        tokenpay: 'SingleCallTokenTransaction',
+        tokenpay: 'SingleCallTokenTransaction'
       }
 
       def commit(action, params)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         american_express: 'aesk',
         jcb: 'js',
         discover: 'pb',
-        diners_club: 'pb',
+        diners_club: 'pb'
       }.freeze
       DEFAULT_COLLECTION_INDICATOR = 2
 

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
         76 => STANDARD_ERROR_CODE[:call_issuer],
         91 => STANDARD_ERROR_CODE[:call_issuer],
         96 => STANDARD_ERROR_CODE[:processing_error],
-        97 => STANDARD_ERROR_CODE[:processing_error],
+        97 => STANDARD_ERROR_CODE[:processing_error]
       }
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
         post[:data][:attributes] = {
           tokenType: 'card',
           customerId: options[:customer_id],
-          label: 'Credit Card',
+          label: 'Credit Card'
         }
         add_payment(post, payment, options)
         add_address(post, options)

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -209,7 +209,7 @@ module ActiveMerchant #:nodoc:
         credit_card_refund: %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
         void_transaction: %w(ReferenceNumber TransactionID),
         credit_card_settle: %w(ReferenceNumber TransactionAmount OriginalTransactionAmount OriginalTransactionID ClientIpAddress),
-        system_check: %w(SystemCheck),
+        system_check: %w(SystemCheck)
       }
     end
   end

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
           'InvoiceReference' => truncate(options[:order_id], 50),
           'InvoiceNumber' => truncate(options[:invoice] || options[:order_id], 12),
           'InvoiceDescription' => truncate(options[:description], 64),
-          'CurrencyCode' => currency_code,
+          'CurrencyCode' => currency_code
         }
       end
 
@@ -558,7 +558,7 @@ module ActiveMerchant #:nodoc:
         'V6150' => 'Invalid Refund Amount',
         'V6151' => 'Refund amount greater than original transaction',
         'V6152' => 'Original transaction already refunded for total amount',
-        'V6153' => 'Card type not support by merchant',
+        'V6153' => 'Card type not support by merchant'
       }
     end
   end

--- a/lib/active_merchant/billing/gateways/ezic.rb
+++ b/lib/active_merchant/billing/gateways/ezic.rb
@@ -187,7 +187,7 @@ module ActiveMerchant
 
       def headers
         {
-          'User-Agent' => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'User-Agent' => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
         }
       end
     end

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
         'Bank Declined Transaction' => STANDARD_ERROR_CODE[:card_declined],
         'Insufficient Funds' => STANDARD_ERROR_CODE[:card_declined],
         'Transaction Declined - Bank Error' => STANDARD_ERROR_CODE[:processing_error],
-        'No Reply from Bank' => STANDARD_ERROR_CODE[:processing_error],
+        'No Reply from Bank' => STANDARD_ERROR_CODE[:processing_error]
       }
 
       def error_code_from(succeeded, response)

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -134,7 +134,7 @@ module ActiveMerchant #:nodoc:
         'purchase' => '1',
         'refund' => '2',
         'authorize' => '4',
-        'capture' => '5',
+        'capture' => '5'
       }
 
       def commit(action, post)

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -232,7 +232,7 @@ module ActiveMerchant #:nodoc:
             source: card_or_token.source,
             cavv: card_or_token.payment_cryptogram,
             eci: card_or_token.eci,
-            xid: card_or_token.transaction_id,
+            xid: card_or_token.transaction_id
           })
         elsif options[:three_d_secure]
           options[:three_d_secure][:source] ||= card_brand(card_or_token)

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
         '05' => STANDARD_ERROR_CODE[:card_declined],
         '06' => STANDARD_ERROR_CODE[:processing_error],
         '14' => STANDARD_ERROR_CODE[:invalid_number],
-        '54' => STANDARD_ERROR_CODE[:expired_card],
+        '54' => STANDARD_ERROR_CODE[:expired_card]
       }
 
       def initialize(options={})
@@ -121,7 +121,7 @@ module ActiveMerchant #:nodoc:
       def commit(action, &block)
         headers = {
           'Content-Type' => 'text/xml; charset=utf-8',
-          'SOAPAction' => "http://www.ippayments.com.au/interface/api/dts/#{action}",
+          'SOAPAction' => "http://www.ippayments.com.au/interface/api/dts/#{action}"
         }
         response = parse(ssl_post(commit_url, new_submit_xml(action, &block), headers))
 

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         'YER' => '886',
         'ZAR' => '710',
         'ZMK' => '894',
-        'ZWD' => '716',
+        'ZWD' => '716'
       }
 
       AVS_CODE = {
@@ -389,7 +389,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization,
           avs_result: {
             street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
-            postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ],
+            postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ]
           },
           cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
         )

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -364,7 +364,7 @@ module ActiveMerchant #:nodoc:
             dlstate: options[:telecheck_dlstate],
             void: options[:telecheck_void],
             accounttype: options[:telecheck_accounttype],
-            ssn: options[:telecheck_ssn],
+            ssn: options[:telecheck_ssn]
           }
         }
 

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -105,7 +105,7 @@ module ActiveMerchant
           billing: {},
           device: {},
           shipping: {},
-          transaction: {},
+          transaction: {}
         }
       end
 
@@ -190,7 +190,7 @@ module ActiveMerchant
       def headers
         {
           'Authorization' => 'Basic ' + Base64.encode64("merchant.#{@options[:userid]}:#{@options[:password]}").strip.delete("\r\n"),
-          'Content-Type' => 'application/json',
+          'Content-Type' => 'application/json'
         }
       end
 

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -196,7 +196,7 @@ module ActiveMerchant #:nodoc:
           street: address[:address1],
           city: address[:city],
           zip: address[:zip],
-          state: address[:state],
+          state: address[:state]
         }
         mapped[:country] = country.code(:alpha2).value unless country.blank?
 

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -243,7 +243,7 @@ module ActiveMerchant #:nodoc:
           city: address[:city],
           state: address[:state],
           postcode: address[:zip],
-          country: address[:country],
+          country: address[:country]
         }
       end
 
@@ -260,7 +260,7 @@ module ActiveMerchant #:nodoc:
 
         if options[:registrationId]
           post[:card] = {
-            cvv: payment.verification_value,
+            cvv: payment.verification_value
           }
         else
           post[:paymentBrand] = payment.brand.upcase
@@ -269,7 +269,7 @@ module ActiveMerchant #:nodoc:
             number: payment.number,
             expiryMonth: '%02d' % payment.month,
             expiryYear: payment.year,
-            cvv: payment.verification_value,
+            cvv: payment.verification_value
           }
         end
       end

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -325,7 +325,7 @@ module ActiveMerchant #:nodoc:
           'master'          => 'MC',
           'american_express' => 'AM',
           'discover'        => 'DI',
-          'diners_club'     => 'DC', }[key]
+          'diners_club'     => 'DC' }[key]
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -981,7 +981,7 @@ module ActiveMerchant #:nodoc:
           'R'  => 'Issuer does not participate in AVS',
           'UK' => 'Unknown',
           'X'  => 'Zip Match/Zip 4 Match/Address Match',
-          'Z'  => 'Zip Match/Locale no match',
+          'Z'  => 'Zip Match/Locale no match'
         }
 
         # Map vendor's AVS result code to a postal match code

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
 
       STANDARD_ERROR_CODE_MAPPING = {
         'refused' => STANDARD_ERROR_CODE[:card_declined],
-        'processing_error' => STANDARD_ERROR_CODE[:processing_error],
+        'processing_error' => STANDARD_ERROR_CODE[:processing_error]
       }
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
       # transaction_id that can be used later to postauthorize (capture) the funds.
       def authorize(money, payment_source, options = {})
         parameters = {
-          transaction_amount: amount(money),
+          transaction_amount: amount(money)
         }
 
         add_payment_source(parameters, payment_source)
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
       # Execute authorization and capture in a single step.
       def purchase(money, payment_source, options = {})
         parameters = {
-          transaction_amount: amount(money),
+          transaction_amount: amount(money)
         }
 
         add_payment_source(parameters, payment_source)

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
         authorize:  '3',
         cancel:     '4',
         failure:    '5',
-        capture:    '6',
+        capture:    '6'
       }
 
       SOAP_ACTIONS = {
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         credit: { name: 'Credit5', url: 'pxorder/pxorder.asmx', xmlns: 'http://external.payex.com/PxOrder/' },
         create_agreement: { name: 'CreateAgreement3', url: 'pxagreement/pxagreement.asmx', xmlns: 'http://external.payex.com/PxAgreement/' },
         delete_agreement: { name: 'DeleteAgreement', url: 'pxagreement/pxagreement.asmx', xmlns: 'http://external.payex.com/PxAgreement/' },
-        autopay: { name: 'AutoPay3', url: 'pxagreement/pxagreement.asmx', xmlns: 'http://external.payex.com/PxAgreement/' },
+        autopay: { name: 'AutoPay3', url: 'pxagreement/pxagreement.asmx', xmlns: 'http://external.payex.com/PxAgreement/' }
       }
 
       def initialize(options = {})
@@ -231,7 +231,7 @@ module ActiveMerchant #:nodoc:
           description: options[:description] || options[:order_id],
           orderId: options[:order_id],
           purchaseOperation: is_auth ? 'AUTHORIZATION' : 'SALE',
-          currency: (options[:currency] || default_currency),
+          currency: (options[:currency] || default_currency)
         }
         hash_fields = %i[accountNumber agreementRef price productNumber description orderId purchaseOperation currency]
         add_request_hash(properties, hash_fields)
@@ -278,7 +278,7 @@ module ActiveMerchant #:nodoc:
       def send_cancel(transaction_number)
         properties = {
           accountNumber: @options[:account],
-          transactionNumber: transaction_number,
+          transactionNumber: transaction_number
         }
         hash_fields = %i[accountNumber transactionNumber]
         add_request_hash(properties, hash_fields)
@@ -310,7 +310,7 @@ module ActiveMerchant #:nodoc:
       def send_delete_agreement(authorization)
         properties = {
           accountNumber: @options[:account],
-          agreementRef: authorization,
+          agreementRef: authorization
         }
         hash_fields = %i[accountNumber agreementRef]
         add_request_hash(properties, hash_fields)

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -42,7 +42,7 @@ module ActiveMerchant #:nodoc:
         discover: 'Discover',
         american_express: 'Amex',
         jcb: 'JCB',
-        diners_club: 'DinersClub',
+        diners_club: 'DinersClub'
       }
 
       TRANSACTIONS = {

--- a/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_express_response.rb
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
            'state'      => @params['state'],
            'country'    => @params['country'],
            'zip'        => @params['zip'],
-           'phone'      => phone, }
+           'phone'      => phone }
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
         parsed = JSON.parse(raw_response)
         options = {
           authorization: authorization_from(parsed),
-          test: (parsed['mode'] == 'test'),
+          test: (parsed['mode'] == 'test')
         }
 
         succeeded = (parsed['data'] == []) || (parsed['data']['response_code'].to_i == 20000)

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -31,7 +31,7 @@ module ActiveMerchant
         'W' => '9-digit zip/postal code matches billing information, street address does not',
         'X' => 'Street address and 9-digit zip/postal code matches billing information',
         'Y' => 'Street address and 5-digit zip/postal code matches billing information',
-        'Z' => '5-digit zip/postal code matches billing information, street address does not',
+        'Z' => '5-digit zip/postal code matches billing information, street address does not'
       }
 
       AVS_ERRORS = %w(A E N R W Z)

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -163,7 +163,7 @@ module ActiveMerchant #:nodoc:
           SubTotal: amount(money),
           Tax1: options[:tax1],
           Tax2: options[:tax2],
-          ShippingTotal: options[:shipping_total],
+          ShippingTotal: options[:shipping_total]
         }
 
         if creditcard

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
         purchase: 'CustomerCreditCardCharge',
         refund: 'CustomerCreditCardTxnVoidOrRefund',
         void: 'CustomerCreditCardTxnVoid',
-        query: 'MerchantAccountQuery',
+        query: 'MerchantAccountQuery'
       }
 
       # Creates a new QbmsGateway
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
         if status_code != 0
           return {
             status_code: status_code,
-            status_message: signon.attributes['statusMessage'],
+            status_message: signon.attributes['statusMessage']
           }
         end
 
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
 
         results = {
           status_code: response.attributes['statusCode'].to_i,
-          status_message: response.attributes['statusMessage'],
+          status_message: response.attributes['statusMessage']
         }
 
         response.elements.each do |e|

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -280,7 +280,7 @@ module ActiveMerchant #:nodoc:
         '12' => STANDARD_ERROR_CODE[:card_declined],
         '06' => STANDARD_ERROR_CODE[:processing_error],
         '01' => STANDARD_ERROR_CODE[:call_issuer],
-        '04' => STANDARD_ERROR_CODE[:pickup_card],
+        '04' => STANDARD_ERROR_CODE[:pickup_card]
       }
 
       def error_code_from(succeeded, response)

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -351,7 +351,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(response, parameters, action),
           avs_result: {
             street_match: AVS_CODE[response['AddressResult']],
-            postal_match: AVS_CODE[response['PostCodeResult']],
+            postal_match: AVS_CODE[response['PostCodeResult']]
           },
           cvv_result: CVV_CODE[response['CV2Result']]
         )

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
         'W' => '9-digit zip/postal code matches billing information, street address does not',
         'X' => 'Street address and 9-digit zip/postal code matches billing information',
         'Y' => 'Street address and 5-digit zip/postal code matches billing information',
-        'Z' => '5-digit zip/postal code matches billing information, street address does not',
+        'Z' => '5-digit zip/postal code matches billing information, street address does not'
       }
 
       CHANGE_STATUS_ERROR_MESSAGES = {

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
 
       BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {
         'personal' => 'individual',
-        'business' => 'company',
+        'business' => 'company'
       }
 
       MINIMUM_AUTHORIZE_AMOUNTS = {
@@ -755,7 +755,7 @@ module ActiveMerchant #:nodoc:
             currency: 'usd',
             routing_number: bank_account.routing_number,
             name: bank_account.name,
-            account_holder_type: account_holder_type,
+            account_holder_type: account_holder_type
           }
         }
 

--- a/lib/active_merchant/billing/gateways/telr.rb
+++ b/lib/active_merchant/billing/gateways/telr.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
         'Y' => 'M',
         'N' => 'N',
         'X' => 'P',
-        'E' => 'U',
+        'E' => 'U'
       }
 
       AVS_CODE_TRANSLATOR = {

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
         purchase_echeck: 'ACHDebit',
         refund: 'CreditCardCredit',
         refund_echeck: 'ACHVoidTransaction',
-        void: 'CreditCardAutoRefundorVoid',
+        void: 'CreditCardAutoRefundorVoid'
       }
 
       ENDPOINTS = {

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
         'R1' => 'The transaction was declined or returned, because the cardholder requested that payment of all recurring or installment payment transactions for a specific merchant account be stopped/ Reserved for client-specific use (declined)',
         'Q1' => 'Card Authentication failed/ Reserved for client-specific use (declined)',
         'XA' => 'Forward to Issuer/ Reserved for client-specific use (declined)',
-        'XD' => 'Forward to Issuer/ Reserved for client-specific use (declined)',
+        'XD' => 'Forward to Issuer/ Reserved for client-specific use (declined)'
       }
 
       EXTENDED_RESPONSE_MESSAGES = {
@@ -179,7 +179,7 @@ module ActiveMerchant #:nodoc:
         refund_echeck: 16,
         void_echeck: 16,
 
-        wallet_sale: 14,
+        wallet_sale: 14
       }
 
       def initialize(options={})

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, creditcard_or_billing_id, options = {})
         parameters = {
-          amount: amount(money),
+          amount: amount(money)
         }
 
         add_order_id(parameters, options)
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
       # to process a purchase are an amount in cents or a money object and a creditcard object or billingid string.
       def purchase(money, creditcard_or_billing_id, options = {})
         parameters = {
-          amount: amount(money),
+          amount: amount(money)
         }
 
         add_order_id(parameters, options)
@@ -188,7 +188,7 @@ module ActiveMerchant #:nodoc:
         transaction_id, = split_authorization(authorization)
         parameters = {
           amount: amount(money),
-          transid: transaction_id,
+          transid: transaction_id
         }
         add_aggregator(parameters, options)
         add_custom_fields(parameters, options)
@@ -239,7 +239,7 @@ module ActiveMerchant #:nodoc:
         action = (VOIDABLE_ACTIONS - ['preauth']).include?(original_action) ? 'void' : 'reversal'
 
         parameters = {
-          transid: transaction_id,
+          transid: transaction_id
         }
 
         add_aggregator(parameters, options)
@@ -285,7 +285,7 @@ module ActiveMerchant #:nodoc:
           cycle: cycle,
           verify: options[:verify] || 'y',
           billingid: options[:billingid] || nil,
-          payments: options[:payments] || nil,
+          payments: options[:payments] || nil
         }
 
         add_creditcard(parameters, creditcard)
@@ -300,7 +300,7 @@ module ActiveMerchant #:nodoc:
       def store(creditcard, options = {})
         parameters = {
           verify: options[:verify] || 'y',
-          billingid: options[:billingid] || options[:billing_id] || nil,
+          billingid: options[:billingid] || options[:billing_id] || nil
         }
 
         add_creditcard(parameters, creditcard)
@@ -314,7 +314,7 @@ module ActiveMerchant #:nodoc:
       # unstore() the information will be removed and a Response object will be returned indicating the success of the action.
       def unstore(identification, options = {})
         parameters = {
-          billingid: identification,
+          billingid: identification
         }
 
         add_custom_fields(parameters, options)

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
         COMMON_ADDRESS_OPTIONS,
         {
           address1: [:string, 'Street'],
-          address2: [:string, 'Street2'],
+          address2: [:string, 'Street2']
         }
       ].inject(:merge) #:nodoc
 
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
         COMMON_ADDRESS_OPTIONS,
         {
           address1: [:string, 'Address'],
-          address2: [:string, 'Address2'],
+          address2: [:string, 'Address2']
         },
         {
           card_number: [:string, 'CardNumber'],
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
           account: [:string, 'Account'],
           routing: [:string, 'Routing'],
           check_format: [:string, 'CheckFormat'],
-          record_type: [:string, 'RecordType'],
+          record_type: [:string, 'RecordType']
         }
       ].inject(:merge) #:nodoc
 
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
         comments: [:string, 'Comments'],
         allow_partial_auth: [:boolean, 'AllowPartialAuth'],
         currency: [:string, 'Currency'],
-        non_tax: [:boolean, 'NonTax'],
+        non_tax: [:boolean, 'NonTax']
       } #:nodoc:
 
       TRANSACTION_DETAIL_MONEY_OPTIONS = {

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -279,7 +279,7 @@ module ActiveMerchant #:nodoc:
 
           {
             quantity: 'qty',
-            unit: 'um',
+            unit: 'um'
           }.each do |key, umkey|
             post["line#{index}#{umkey}"] = line_item[key.to_sym] if line_item.has_key?(key.to_sym)
           end

--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -139,7 +139,7 @@ module ActiveMerchant #:nodoc:
 
       ACCOUNT_TYPES = {
         'checking' => '1',
-        'savings' => '2',
+        'savings' => '2'
       }
 
       def add_check(post, payment_method)
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         'refund' => 'ns_credit',
         'authorize' => 'ns_quicksale_cc',
         'capture' => 'ns_quicksale_cc',
-        'void' => 'ns_void',
+        'void' => 'ns_void'
       }
 
       def commit(action, options, post)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -106,7 +106,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: {reason_type: 'unscheduled'}
     }
 
     @normalized_3ds_2_options = {
@@ -260,7 +260,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       order_id: '123',
       stored_credential: {reason_type: 'unscheduled'},
       three_ds_2: {
-        channel: 'app',
+        channel: 'app'
       }
     }
 

--- a/test/remote/gateways/remote_allied_wallet_test.rb
+++ b/test/remote/gateways/remote_allied_wallet_test.rb
@@ -9,7 +9,7 @@ class RemoteAlliedWalletTest < Test::Unit::TestCase
     @declined_card = credit_card('4242424242424242', verification_value: '555')
 
     @options = {
-      billing_address: address,
+      billing_address: address
     }
   end
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -31,7 +31,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       shipping: {
         amount: '300',
         name: 'shipping name',
-        description: 'shipping description',
+        description: 'shipping description'
       },
       tax_exempt: 'false',
       po_number: '123'

--- a/test/remote/gateways/remote_bambora_apac_test.rb
+++ b/test/remote/gateways/remote_bambora_apac_test.rb
@@ -9,7 +9,7 @@ class RemoteBamboraApacTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase',
+      description: 'Store Purchase'
     }
   end
 

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -12,7 +12,7 @@ class RemoteBanwireTest < Test::Unit::TestCase
 
     @declined_card = credit_card('4000300011112220')
     @options = {
-      billing_address: address,
+      billing_address: address
     }
   end
 

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -256,7 +256,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
       order_id: '123',
       stored_credential: {reason_type: 'unscheduled'},
       three_ds_2: {
-        channel: 'app',
+        channel: 'app'
       }
     }
 

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -416,7 +416,7 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
       'number'       => credit_card.number,
       'expiry_month' => '01',
       'expiry_year'  => (Time.now.year + 1) % 100,
-      'cvd'          => credit_card.verification_value,
+      'cvd'          => credit_card.verification_value
     }.to_json
 
     response = http.request(request)

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -78,7 +78,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
       order_id: generate_unique_id,
       merchant_name: 'merchant',
       dynamic_descriptor: 'product',
-      ip: '1.1.1.1',
+      ip: '1.1.1.1'
     }
 
     @visacredit_reference_options = {

--- a/test/remote/gateways/remote_cardknox_test.rb
+++ b/test/remote/gateways/remote_cardknox_test.rb
@@ -33,7 +33,7 @@ class RemoteCardknoxTest < Test::Unit::TestCase
         zip: '46112',
         country: 'US',
         phone: '(555)555-5555',
-        fax: '(555)555-6666',
+        fax: '(555)555-6666'
       }
     }
 

--- a/test/remote/gateways/remote_cenpos_test.rb
+++ b/test/remote/gateways/remote_cenpos_test.rb
@@ -17,7 +17,7 @@ class RemoteCenposTest < Test::Unit::TestCase
         name:     'Jim Smith',
         address1: 'D8320',
         zip:      'D5284'
-      },
+      }
     }
   end
 

--- a/test/remote/gateways/remote_citrus_pay_test.rb
+++ b/test/remote/gateways/remote_citrus_pay_test.rb
@@ -34,7 +34,7 @@ class RemoteCitrusPayTest < Test::Unit::TestCase
   def test_successful_purchase_with_more_options
     more_options = @options.merge({
       ip: '127.0.0.1',
-      email: 'joe@example.com',
+      email: 'joe@example.com'
     })
 
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(more_options))

--- a/test/remote/gateways/remote_clearhaus_test.rb
+++ b/test/remote/gateways/remote_clearhaus_test.rb
@@ -84,7 +84,7 @@ class RemoteClearhausTest < Test::Unit::TestCase
   def test_successful_purchase_with_more_options
     options = {
       order_id: '1',
-      ip: '127.0.0.1',
+      ip: '127.0.0.1'
     }
 
     response = @gateway.purchase(@amount, @credit_card, @options.merge(options))

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -34,7 +34,7 @@ class RemoteConektaTest < Test::Unit::TestCase
         country: 'Mexico',
         zip: '5555',
         name: 'Mario Reyes',
-        phone: '12345678',
+        phone: '12345678'
       },
       carrier: 'Estafeta',
       email: 'bob@something.com',
@@ -143,7 +143,7 @@ class RemoteConektaTest < Test::Unit::TestCase
         city: 'Wanaque',
         state: 'NJ',
         country: 'USA',
-        zip: '01085',
+        zip: '01085'
       },
       line_items: [
         {

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -565,7 +565,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
         merchantDescriptor: {
           name: 'Test Name',
           address1: '123 Main Dr',
-          locality: 'Durham',
+          locality: 'Durham'
         }
       }
     }

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -122,12 +122,12 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
       billing_address: {
         address1: 'The Billing Address 1 Cannot Be More Than Fifty Characters.',
         address2: 'The Billing Address 2 Cannot Be More Than Fifty Characters.',
-        city: 'TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart',
+        city: 'TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart'
       },
       shipping_address: {
         address1: 'The Shipping Address 1 Cannot Be More Than Fifty Characters.',
         address2: 'The Shipping Address 2 Cannot Be More Than Fifty Characters.',
-        city: 'TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart',
+        city: 'TheCityCannotBeMoreThanFiftyCharactersOrItAllFallsApart'
       }
     }
     @credit_card.first_name = 'FullNameOnACardMustBeLessThanFiftyCharacters'

--- a/test/remote/gateways/remote_global_transport_test.rb
+++ b/test/remote/gateways/remote_global_transport_test.rb
@@ -9,7 +9,7 @@ class RemoteGlobalTransportTest < Test::Unit::TestCase
     @options = {
       email: 'john@example.com',
       order_id: '1',
-      billing_address: address,
+      billing_address: address
     }
   end
 

--- a/test/remote/gateways/remote_ipp_test.rb
+++ b/test/remote/gateways/remote_ipp_test.rb
@@ -9,7 +9,7 @@ class RemoteIppTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase',
+      description: 'Store Purchase'
     }
   end
 

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -1048,7 +1048,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test_apple_pay_purchase
     options = {
-      order_id: transaction_id,
+      order_id: transaction_id
     }
     decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {
@@ -1066,7 +1066,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   def test_android_pay_purchase
     options = {
-      order_id: transaction_id,
+      order_id: transaction_id
     }
     decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -123,7 +123,7 @@ class RemoteLitleTest < Test::Unit::TestCase
           state: 'NH',
           zip: '03038',
           country: 'US'
-        },
+        }
       }
     )
     assert_failure response
@@ -207,7 +207,7 @@ class RemoteLitleTest < Test::Unit::TestCase
         state: 'NH',
         zip: '03038',
         country: 'US'
-      },
+      }
     })
     assert_failure response
     assert_equal 'Insufficient Funds', response.message

--- a/test/remote/gateways/remote_mercury_certification_test.rb
+++ b/test/remote/gateways/remote_mercury_certification_test.rb
@@ -108,7 +108,7 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
   def options(order_id=nil, other={})
     {
       order_id: order_id,
-      description: 'ActiveMerchant',
+      description: 'ActiveMerchant'
     }.merge(other)
   end
 end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -95,7 +95,7 @@ class RemoteNmiTest < Test::Unit::TestCase
     options = @options.merge({
       customer_id: '234',
       vendor_id: '456',
-      recurring: true,
+      recurring: true
     })
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response

--- a/test/remote/gateways/remote_opp_test.rb
+++ b/test/remote/gateways/remote_opp_test.rb
@@ -25,7 +25,7 @@ class RemoteOppTest < Test::Unit::TestCase
         city:     'Test',
         state:    'TE',
         zip:      'AB12CD',
-        country:  'GB',
+        country:  'GB'
       },
       shipping_address: {
         name:     'Muton DeMicelis',
@@ -33,7 +33,7 @@ class RemoteOppTest < Test::Unit::TestCase
         city:     'Munich',
         state:    'Bov',
         zip:      '81675',
-        country:  'DE',
+        country:  'DE'
       },
       customer: {
         merchant_customer_id:  'your merchant/customer id',
@@ -46,13 +46,13 @@ class RemoteOppTest < Test::Unit::TestCase
         company_name:  'JJ Ltd.',
         identification_doctype:  'PASSPORT',
         identification_docid:  'FakeID2342431234123',
-        ip:  ip,
-      },
+        ip:  ip
+      }
     }
 
     @minimal_request_options = {
       order_id: "Order #{time}",
-      description: 'Store Purchase - Books',
+      description: 'Store Purchase - Books'
     }
 
     @complete_request_options['customParameters[SHOPPER_test124TestName009]'] = 'customParameters_test'

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -37,7 +37,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       address2: address[:address2],
       city: address[:city],
       state: address[:state],
-      zip: address[:zip],
+      zip: address[:zip]
     }
 
     @level_3_options_visa = {
@@ -205,12 +205,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       card: {
         number: '4112344112344113',
         verification_value: '411',
-        brand: 'visa',
+        brand: 'visa'
       },
       three_d_secure: {
         eci: '5',
         cavv: 'AAABAIcJIoQDIzAgVAkiAAAAAAA=',
-        xid: 'AAABAIcJIoQDIzAgVAkiAAAAAAA=',
+        xid: 'AAABAIcJIoQDIzAgVAkiAAAAAAA='
       },
       address: {
         address1: '55 Forever Ave',
@@ -218,19 +218,19 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         city: 'Concord',
         state: 'NH',
         zip: '03301',
-        country: 'US',
-      },
+        country: 'US'
+      }
     },
     {
       card: {
         number: '5112345112345114',
         verification_value: '823',
-        brand: 'master',
+        brand: 'master'
       },
       three_d_secure: {
         eci: '6',
         cavv: 'Asju1ljfl86bAAAAAACm9zU6aqY=',
-        xid: 'Asju1ljfl86bAAAAAACm9zU6aqY=',
+        xid: 'Asju1ljfl86bAAAAAACm9zU6aqY='
       },
       address: {
         address1: 'Byway Street',
@@ -238,19 +238,19 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         city: 'Portsmouth',
         state: 'MA',
         zip: '',
-        country: 'US',
-      },
+        country: 'US'
+      }
     },
     {
       card: {
         number: '371144371144376',
         verification_value: '1234',
-        brand: 'american_express',
+        brand: 'american_express'
       },
       three_d_secure: {
         eci: '5',
         cavv: 'AAABBWcSNIdjeUZThmNHAAAAAAA=',
-        xid: 'AAABBWcSNIdjeUZThmNHAAAAAAA=',
+        xid: 'AAABBWcSNIdjeUZThmNHAAAAAAA='
       },
       address: {
         address1: '4 Northeastern Blvd',
@@ -258,8 +258,8 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         city: 'Salem',
         state: 'NH',
         zip: '03105',
-        country: 'US',
-      },
+        country: 'US'
+      }
     }
   ].each do |fixture|
     define_method("test_successful_#{fixture[:card][:brand]}_authorization_with_3ds") do

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -13,7 +13,7 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
       billing_address: address,
       email: 'john.doe@example.com',
       ip: '127.0.0.1',
-      description: 'Store Purchase',
+      description: 'Store Purchase'
     }
   end
 

--- a/test/remote/gateways/remote_payex_test.rb
+++ b/test/remote/gateways/remote_payex_test.rb
@@ -9,7 +9,7 @@ class RemotePayexTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220')
 
     @options = {
-      order_id: '1234',
+      order_id: '1234'
     }
   end
 

--- a/test/remote/gateways/remote_qbms_test.rb
+++ b/test/remote/gateways/remote_qbms_test.rb
@@ -11,7 +11,7 @@ class QbmsTest < Test::Unit::TestCase
     @card    = credit_card('4111111111111111')
 
     @options = {
-      billing_address: address,
+      billing_address: address
     }
   end
 

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -123,7 +123,7 @@ class RemoteRealexTest < Test::Unit::TestCase
         eci: '05',
         cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
         xid: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY=',
-        version: '1.0.2',
+        version: '1.0.2'
       },
       order_id: generate_unique_id,
       description: 'Test Realex with 3DS'
@@ -141,7 +141,7 @@ class RemoteRealexTest < Test::Unit::TestCase
         eci: '05',
         cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
         ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
-        version: '2.1.0',
+        version: '2.1.0'
       },
       order_id: generate_unique_id,
       description: 'Test Realex with 3DS'

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -8,7 +8,7 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     @declined_card = credit_card
     @threeds2_credit_card = credit_card('4918019199883839')
     @options = {
-      order_id: generate_order_id,
+      order_id: generate_order_id
     }
   end
 

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -71,7 +71,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   def test_successful_purchase_with_card_and_address
     options = {
       email: 'joebob@example.com',
-      billing_address: address,
+      billing_address: address
     }
 
     assert response = @gateway.purchase(@amount, @credit_card, options)
@@ -124,7 +124,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   def test_successful_authorize_with_card_and_address
     options = {
       email: 'joebob@example.com',
-      billing_address: address,
+      billing_address: address
     }
 
     assert response = @gateway.authorize(@amount, @credit_card, options)
@@ -194,7 +194,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
   def test_successful_store_with_address
     options = {
       email: 'joebob@example.com',
-      billing_address: address,
+      billing_address: address
     }
 
     assert response = @gateway.store(@credit_card, options)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -26,7 +26,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_authorization_and_void
     options = {
       currency: 'GBP',
-      customer: @customer,
+      customer: @customer
     }
     assert authorization = @gateway.authorize(@amount, @visa_payment_method, options)
 
@@ -40,7 +40,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_successful_purchase
     options = {
       currency: 'GBP',
-      customer: @customer,
+      customer: @customer
     }
     assert purchase = @gateway.purchase(@amount, @visa_payment_method, options)
 
@@ -115,7 +115,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     options = {
       currency: 'GBP',
-      customer: @customer,
+      customer: @customer
     }
     assert purchase = @gateway.purchase(@amount, @declined_payment_method, options)
 
@@ -166,7 +166,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_create_payment_intent_with_credit_card
     options = {
       currency: 'USD',
-      customer: @customer,
+      customer: @customer
     }
 
     assert response = @gateway.create_intent(@amount, @three_ds_credit_card, options)
@@ -250,7 +250,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'USD',
       customer: @customer,
-      off_session: true,
+      off_session: true
     }
 
     assert response = @gateway.authorize(@amount, @three_ds_credit_card, options)
@@ -334,7 +334,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       customer: @customer,
       return_url: 'https://www.example.com',
       confirmation_method: 'manual',
-      capture_method: 'manual',
+      capture_method: 'manual'
     }
     assert create_response = @gateway.create_intent(@amount, @three_ds_payment_method, options)
     assert_equal 'requires_confirmation', create_response.params['status']
@@ -436,7 +436,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'XPF',
       customer: @customer,
       confirmation_method: 'manual',
-      capture_method: 'manual',
+      capture_method: 'manual'
     }
     assert create_response = @gateway.create_intent(amount, @visa_payment_method, options)
     intent_id = create_response.params['id']
@@ -562,7 +562,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
   def test_successful_store_purchase_and_unstore
     options = {
-      currency: 'GBP',
+      currency: 'GBP'
     }
     assert store = @gateway.store(@visa_card, options)
     assert store.params['customer'].start_with?('cus_')
@@ -613,7 +613,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_moto_enabled_card_requires_action_when_not_marked
     options = {
       currency: 'GBP',
-      confirm: true,
+      confirm: true
     }
     assert purchase = @gateway.purchase(@amount, @three_ds_moto_enabled, options)
 
@@ -624,7 +624,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'GBP',
       confirm: true,
-      moto: true,
+      moto: true
     }
     assert purchase = @gateway.purchase(@amount, @three_ds_moto_enabled, options)
 
@@ -636,7 +636,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'GBP',
       confirm: true,
-      moto: true,
+      moto: true
     }
     assert purchase = @gateway.purchase(@amount, @three_ds_authentication_required, options)
 

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -13,7 +13,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     @check = check({
       bank_name: 'STRIPE TEST BANK',
       account_number: '000123456789',
-      routing_number: '110000000',
+      routing_number: '110000000'
     })
     @verified_bank_account = fixtures(:stripe_verified_bank_account)
 
@@ -109,7 +109,7 @@ class RemoteStripeTest < Test::Unit::TestCase
         'product_description' => 'A totes different item',
         'tax_amount' => 10,
         'unit_cost' => 50,
-        'quantity' => 1,
+        'quantity' => 1
       }
     ]
 

--- a/test/remote/gateways/remote_tns_test.rb
+++ b/test/remote/gateways/remote_tns_test.rb
@@ -36,7 +36,7 @@ class RemoteTnsTest < Test::Unit::TestCase
   def test_successful_purchase_with_more_options
     more_options = @options.merge({
       ip: '127.0.0.1',
-      email: 'joe@example.com',
+      email: 'joe@example.com'
     })
 
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(more_options))

--- a/test/remote/gateways/remote_trans_first_transaction_express_test.rb
+++ b/test/remote/gateways/remote_trans_first_transaction_express_test.rb
@@ -15,7 +15,7 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
       city: 'Broomfield',
       state: 'CO',
       zip: '85284',
-      phone: '(333) 444-5555',
+      phone: '(333) 444-5555'
     })
 
     @options = {
@@ -58,12 +58,12 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     options = @options.dup
     options[:shipping_address] = {
       address1: '450 Main',
-      zip: '85284',
+      zip: '85284'
     }
 
     options[:billing_address] = {
       address1: '450 Main',
-      zip: '85284',
+      zip: '85284'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)
@@ -81,13 +81,13 @@ class RemoteTransFirstTransactionExpressTest < Test::Unit::TestCase
     options[:shipping_address] = {
       address1: '450 Main',
       address2: '',
-      zip: '85284',
+      zip: '85284'
     }
 
     options[:billing_address] = {
       address1: '450 Main',
       address2: '',
-      zip: '85284',
+      zip: '85284'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -42,7 +42,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
 
     @options = {
       client_ip: '127.0.0.1',
-      billing_address: address,
+      billing_address: address
     }
 
     @transaction_options = {

--- a/test/remote/gateways/remote_world_net_test.rb
+++ b/test/remote/gateways/remote_world_net_test.rb
@@ -8,7 +8,7 @@ class RemoteWorldNetTest < Test::Unit::TestCase
     @declined_amount = 101
     @credit_card = credit_card('3779810000000005')
     @options = {
-      order_id: generate_order_id,
+      order_id: generate_order_id
     }
     @refund_options = {
       operator: 'mr.nobody',
@@ -28,7 +28,7 @@ class RemoteWorldNetTest < Test::Unit::TestCase
       email: 'joe@example.com',
       billing_address: address,
       description: 'Store Purchase',
-      ip: '127.0.0.1',
+      ip: '127.0.0.1'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -679,27 +679,27 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         shopper_account_creation_date: {
           day_of_month: shopper_account_creation_date.strftime('%d'),
           month: shopper_account_creation_date.strftime('%m'),
-          year: shopper_account_creation_date.strftime('%Y'),
+          year: shopper_account_creation_date.strftime('%Y')
         },
         shopper_account_modification_date: {
           day_of_month: shopper_account_modification_date.strftime('%d'),
           month: shopper_account_modification_date.strftime('%m'),
-          year: shopper_account_modification_date.strftime('%Y'),
+          year: shopper_account_modification_date.strftime('%Y')
         },
         shopper_account_password_change_date: {
           day_of_month: shopper_account_password_change_date.strftime('%d'),
           month: shopper_account_password_change_date.strftime('%m'),
-          year: shopper_account_password_change_date.strftime('%Y'),
+          year: shopper_account_password_change_date.strftime('%Y')
         },
         shopper_account_shipping_address_first_use_date: {
           day_of_month: shopper_account_shipping_address_first_use_date.strftime('%d'),
           month: shopper_account_shipping_address_first_use_date.strftime('%m'),
-          year: shopper_account_shipping_address_first_use_date.strftime('%Y'),
+          year: shopper_account_shipping_address_first_use_date.strftime('%Y')
         },
         shopper_account_payment_account_first_use_date: {
           day_of_month: shopper_account_payment_account_first_use_date.strftime('%d'),
           month: shopper_account_payment_account_first_use_date.strftime('%m'),
-          year: shopper_account_payment_account_first_use_date.strftime('%Y'),
+          year: shopper_account_payment_account_first_use_date.strftime('%Y')
         }
       },
       transaction_risk_data: {
@@ -718,7 +718,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         transaction_risk_data_pre_order_date: {
           day_of_month: transaction_risk_data_pre_order_date.strftime('%d'),
           month: transaction_risk_data_pre_order_date.strftime('%m'),
-          year: transaction_risk_data_pre_order_date.strftime('%Y'),
+          year: transaction_risk_data_pre_order_date.strftime('%Y')
         }
       }
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,7 +168,7 @@ module ActiveMerchant
       exp_date = default_expiration_date.strftime('%y%m')
 
       defaults = {
-        track_data: "%B#{number}^LONGSEN/L. ^#{exp_date}1200000000000000**123******?",
+        track_data: "%B#{number}^LONGSEN/L. ^#{exp_date}1200000000000000**123******?"
       }.update(options)
 
       Billing::CreditCard.new(defaults)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -108,7 +108,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_purchase_meets_minimum_requirements
     params = {
-      amount: '1.01',
+      amount: '1.01'
     }
 
     @gateway.send(:add_creditcard, params, @credit_card)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -650,7 +650,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       with(has_entries(three_d_secure_pass_thru: {
         cavv: 'cavv',
         eci_flag: 'eci',
-        xid: 'xid',
+        xid: 'xid'
       })).
       returns(braintree_result)
 
@@ -1247,7 +1247,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
         cvv: '123',
         expiration_month: '09',
         expiration_year: (Time.now.year + 1).to_s,
-        cardholder_name: 'Longbob Longsen',
+        cardholder_name: 'Longbob Longsen'
       }
     }
   end

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -93,7 +93,7 @@ class Cashnet < Test::Unit::TestCase
 
   def test_action_meets_minimum_requirements
     params = {
-      amount: '1.01',
+      amount: '1.01'
     }
 
     @gateway.send(:add_creditcard, params, @credit_card)

--- a/test/unit/gateways/efsnet_test.rb
+++ b/test/unit/gateways/efsnet_test.rb
@@ -56,7 +56,7 @@ class EfsnetTest < Test::Unit::TestCase
       transaction_amount: '1.01',
       account_number: '4242424242424242',
       expiration_month: '12',
-      expiration_year: '2029',
+      expiration_year: '2029'
     }
 
     assert data = @gateway.send(:post_data, :credit_card_authorize, params)
@@ -68,7 +68,7 @@ class EfsnetTest < Test::Unit::TestCase
       order_id: 'order1',
       transaction_amount: '1.01',
       original_transaction_amount: '1.01',
-      original_transaction_id: '1',
+      original_transaction_id: '1'
     }
 
     assert data = @gateway.send(:post_data, :credit_card_settle, params)

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -296,7 +296,7 @@ class FatZebraTest < Test::Unit::TestCase
         rrn: '000000000000',
         cvv_match: 'U',
         metadata: {
-        },
+        }
       },
       test: true,
       errors: []
@@ -328,8 +328,8 @@ class FatZebraTest < Test::Unit::TestCase
         rrn: '000000000000',
         cvv_match: 'U',
         metadata: {
-          'foo' => 'bar',
-        },
+          'foo' => 'bar'
+        }
       },
       test: true,
       errors: []
@@ -391,7 +391,7 @@ class FatZebraTest < Test::Unit::TestCase
         metadata: {
         },
         standalone: false,
-        rrn: '000000000002',
+        rrn: '000000000002'
       },
       errors: [],
       test: true

--- a/test/unit/gateways/global_transport_test.rb
+++ b/test/unit/gateways/global_transport_test.rb
@@ -9,7 +9,7 @@ class GlobalTransportTest < Test::Unit::TestCase
 
     @options = {
       order_id: '1',
-      billing_address: address,
+      billing_address: address
     }
   end
 

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -101,7 +101,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
 
   def test_purchase_meets_minimum_requirements
     params = {
-      amount: '1.01',
+      amount: '1.01'
     }
 
     @gateway.send(:add_creditcard, params, @credit_card)
@@ -193,7 +193,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
       card_code: 'N',
       avs_result_code: 'A',
       response_reason_code: '27',
-      response_reason_text: 'Failure.',
+      response_reason_text: 'Failure.'
     }
     assert_equal 'CVV does not match', @gateway.message_from(result)
 

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -133,7 +133,7 @@ class MonerisTest < Test::Unit::TestCase
       amount: '1.01',
       pan: '4242424242424242',
       expdate: '0303',
-      crypt_type: 7,
+      crypt_type: 7
     }
 
     assert data = @gateway.send(:post_data, 'preauth', params)
@@ -147,7 +147,7 @@ class MonerisTest < Test::Unit::TestCase
       amount: '1.01',
       pan: '4242424242424242',
       expdate: '0303',
-      crypt_type: 7,
+      crypt_type: 7
     }
 
     assert data = @gateway.send(:post_data, 'purchase', params)
@@ -161,7 +161,7 @@ class MonerisTest < Test::Unit::TestCase
       amount: '1.01',
       pan: '4242424242424242',
       expdate: '0303',
-      crypt_type: 7,
+      crypt_type: 7
     }
 
     assert data = @gateway.send(:post_data, 'preauth', params)

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -27,7 +27,7 @@ class OppTest < Test::Unit::TestCase
         city:     'Istambul',
         state:    'IS',
         zip:      'H12JK2354',
-        country:  'TR',
+        country:  'TR'
       },
       shipping_address: {
         name:     '',
@@ -35,7 +35,7 @@ class OppTest < Test::Unit::TestCase
         city:     'Moskau',
         state:    'MO',
         zip:      'MO2342432',
-        country:  'RU',
+        country:  'RU'
       },
       customer: {
         merchant_customer_id:  "merchantCustomerId #{ip}",
@@ -48,13 +48,13 @@ class OppTest < Test::Unit::TestCase
         company_name:  'No such deal Ltd.',
         identification_doctype:  'PASSPORT',
         identification_docid:  'FakeID2342431234123',
-        ip:  ip,
-      },
+        ip:  ip
+      }
     }
 
     @minimal_request_options = {
       order_id: "Order #{time}",
-      description: 'Store Purchase - Books',
+      description: 'Store Purchase - Books'
     }
 
     @complete_request_options['customParameters[SHOPPER_test124TestName009]'] = 'customParameters_test'

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -44,7 +44,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
       order_id: '1',
       description: 'Store Purchase',
       billing_address: {
-        zip: 'K1C2N6',
+        zip: 'K1C2N6'
       }
     }
     credit_card = CreditCard.new(

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -27,7 +27,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       address2: address[:address2],
       city: address[:city],
       state: address[:state],
-      zip: address[:zip],
+      zip: address[:zip]
     }
 
     @level_3 = {
@@ -94,7 +94,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       three_d_secure: {
         eci: '5',
         xid: 'TESTXID',
-        cavv: 'TESTCAVV',
+        cavv: 'TESTCAVV'
       }
     }
   end

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -14,7 +14,7 @@ class PayGateTest < Test::Unit::TestCase
       billing_address: address,
       email: 'john.doe@example.com',
       ip: '127.0.0.1',
-      description: 'Store Purchase',
+      description: 'Store Purchase'
     }
   end
 

--- a/test/unit/gateways/payex_test.rb
+++ b/test/unit/gateways/payex_test.rb
@@ -11,7 +11,7 @@ class PayexTest < Test::Unit::TestCase
     @amount = 1000
 
     @options = {
-      order_id: '1234',
+      order_id: '1234'
     }
   end
 

--- a/test/unit/gateways/qbms_test.rb
+++ b/test/unit/gateways/qbms_test.rb
@@ -175,7 +175,7 @@ class QbmsTest < Test::Unit::TestCase
     opts = {
       avs_street: 'Pass',
       avs_zip: 'Pass',
-      card_security_code_match: 'Pass',
+      card_security_code_match: 'Pass'
     }.merge(opts)
 
     wrap 'CustomerCreditCardAuth', opts, <<-"XML"
@@ -202,7 +202,7 @@ class QbmsTest < Test::Unit::TestCase
     opts = {
       avs_street: 'Pass',
       avs_zip: 'Pass',
-      card_security_code_match: 'Pass',
+      card_security_code_match: 'Pass'
     }.merge(opts)
 
     wrap 'CustomerCreditCardCharge', opts, <<-"XML"
@@ -238,7 +238,7 @@ class QbmsTest < Test::Unit::TestCase
     opts = {
       signon_status_code: 0,
       request_id: 'x',
-      status_code: 0,
+      status_code: 0
     }.merge(opts)
 
     <<-"XML"

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -189,7 +189,7 @@ class RealexTest < Test::Unit::TestCase
   def test_purchase_xml
     options = {
       order_id: '1',
-      ip: '123.456.789.0',
+      ip: '123.456.789.0'
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -225,7 +225,7 @@ class RealexTest < Test::Unit::TestCase
   def test_purchase_xml_with_ipv6
     options = {
       order_id: '1',
-      ip: '2a02:c7d:da18:ac00:6d10:4f13:1795:4890',
+      ip: '2a02:c7d:da18:ac00:6d10:4f13:1795:4890'
     }
 
     @gateway.expects(:new_timestamp).returns('20090824160201')
@@ -489,7 +489,7 @@ class RealexTest < Test::Unit::TestCase
         cavv: '1234',
         eci: '1234',
         xid: '1234',
-        version: '1.0.2',
+        version: '1.0.2'
       }
     }
 
@@ -504,7 +504,7 @@ class RealexTest < Test::Unit::TestCase
         cavv: '1234',
         eci: '1234',
         xid: '1234',
-        version: '1.0.2',
+        version: '1.0.2'
       }
     }
 
@@ -548,7 +548,7 @@ class RealexTest < Test::Unit::TestCase
         cavv: '1234',
         eci: '1234',
         ds_transaction_id: '1234',
-        version: '2.1.0',
+        version: '2.1.0'
       }
     }
 

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -8,7 +8,7 @@ class RedsysTest < Test::Unit::TestCase
     @credentials = {
       login: '091952713',
       secret_key: 'qwertyasdf0123456789',
-      terminal: '1',
+      terminal: '1'
     }
     @gateway = RedsysGateway.new(@credentials)
     @headers = {

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -14,7 +14,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     @options = {
       currency: 'GBP',
-      confirmation_method: 'manual',
+      confirmation_method: 'manual'
     }
   end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -31,7 +31,7 @@ class StripeTest < Test::Unit::TestCase
     @check = check({
       bank_name: 'STRIPE TEST BANK',
       account_number: '000123456789',
-      routing_number: '110000000',
+      routing_number: '110000000'
     })
   end
 

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -32,7 +32,7 @@ class WirecardTest < Test::Unit::TestCase
       city:      'Ottawa',
       zip:       'K12 P2A',
       country:   'CA',
-      state:     nil,
+      state:     nil
     }
 
     @address_avs = {
@@ -40,7 +40,7 @@ class WirecardTest < Test::Unit::TestCase
       city:      'London',
       zip:       'W8 2TE',
       country:   'GB',
-      state:     'London',
+      state:     'London'
     }
   end
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -612,7 +612,7 @@ class WorldpayTest < Test::Unit::TestCase
       'payment_service_merchant_code' => 'XXXXXXXXXXXXXXX',
       'payment_service_version' => '1.4',
       'reply' => true,
-      'risk_score_value' => '1',
+      'risk_score_value' => '1'
     }, response.params)
   end
 
@@ -979,7 +979,7 @@ class WorldpayTest < Test::Unit::TestCase
         cavv: 'cavv',
         xid: xid,
         ds_transaction_id: ds_transaction_id,
-        version: version,
+        version: version
       }
     }
   end
@@ -1022,27 +1022,27 @@ class WorldpayTest < Test::Unit::TestCase
         shopper_account_creation_date: {
           day_of_month: shopper_account_creation_date.strftime('%d'),
           month: shopper_account_creation_date.strftime('%m'),
-          year: shopper_account_creation_date.strftime('%Y'),
+          year: shopper_account_creation_date.strftime('%Y')
         },
         shopper_account_modification_date: {
           day_of_month: shopper_account_modification_date.strftime('%d'),
           month: shopper_account_modification_date.strftime('%m'),
-          year: shopper_account_modification_date.strftime('%Y'),
+          year: shopper_account_modification_date.strftime('%Y')
         },
         shopper_account_password_change_date: {
           day_of_month: shopper_account_password_change_date.strftime('%d'),
           month: shopper_account_password_change_date.strftime('%m'),
-          year: shopper_account_password_change_date.strftime('%Y'),
+          year: shopper_account_password_change_date.strftime('%Y')
         },
         shopper_account_shipping_address_first_use_date: {
           day_of_month: shopper_account_shipping_address_first_use_date.strftime('%d'),
           month: shopper_account_shipping_address_first_use_date.strftime('%m'),
-          year: shopper_account_shipping_address_first_use_date.strftime('%Y'),
+          year: shopper_account_shipping_address_first_use_date.strftime('%Y')
         },
         shopper_account_payment_account_first_use_date: {
           day_of_month: shopper_account_payment_account_first_use_date.strftime('%d'),
           month: shopper_account_payment_account_first_use_date.strftime('%m'),
-          year: shopper_account_payment_account_first_use_date.strftime('%Y'),
+          year: shopper_account_payment_account_first_use_date.strftime('%Y')
         }
       },
       transaction_risk_data: {
@@ -1061,7 +1061,7 @@ class WorldpayTest < Test::Unit::TestCase
         transaction_risk_data_pre_order_date: {
           day_of_month: transaction_risk_data_pre_order_date.strftime('%d'),
           month: transaction_risk_data_pre_order_date.strftime('%m'),
-          year: transaction_risk_data_pre_order_date.strftime('%Y'),
+          year: transaction_risk_data_pre_order_date.strftime('%Y')
         }
       }
     }


### PR DESCRIPTION
Fixes the RuboCop to-do for [Style/TrailingCommaInHashLiteral](https://docs.rubocop.org/rubocop/0.85/cops_style.html#styletrailingcommainhashliteral).

All unit tests:
4534 tests, 72191 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed