### PR TITLE
Litle: Omit checkNum when nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708
 * Cybersource: Ensure Partner Solution Id placement conforms to schema [britth] #3715
 * Adyen: Adyen: Pass `subMerchantId` as `additionalData` [naashton] #3714
+* Litle: Omit checkNum when nil [leila-alderman] #3719
 
 == Version 1.111.0
 * Fat Zebra: standardized 3DS fields and card on file extra data for Visa scheme rules [montdidier] #3409

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -274,7 +274,7 @@ module ActiveMerchant #:nodoc:
             doc.accType(payment_method.account_type.capitalize)
             doc.accNum(payment_method.account_number)
             doc.routingNum(payment_method.routing_number)
-            doc.checkNum(payment_method.number)
+            doc.checkNum(payment_method.number) if payment_method.number
           end
         else
           doc.card do

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -161,6 +161,21 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_does_not_pass_empty_checknum
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      number: nil,
+      account_type: 'checking'
+    )
+    stub_comms do
+      @gateway.purchase(@amount, check)
+    end.check_request do |endpoint, data, headers|
+      assert_not_match(/<checkNum\/>/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_add_applepay_order_source
     stub_comms do
       @gateway.purchase(@amount, @decrypted_apple_pay)


### PR DESCRIPTION
ACH transactions in which the `checkNum` was `nil` were previously
sending an empty `checkNum` node, which caused failures against the
Litle gateway.

This adds a check so that the `checkNum` node is created only when there
is a value for this field.

ECS-1350

Unit:
46 tests, 201 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
43 tests, 188 assertions, 13 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
69.7674% passed

Many remote tests are currently failing [due to previously noted
changes to the gateway's responses](https://github.com/activemerchant/active_merchant/issues/3618).

All unit tests:
4544 tests, 72251 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed