### PR TITLE
RuboCop: Fix Layout/SpaceAroundEqualsInParameterDefault

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,13 +22,6 @@ Layout/AlignHash:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
-# Offense count: 649
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
-
 # Offense count: 1186
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Adyen: Safely add execute_threeds: false [curiousepic] #3756
+* RuboCop: Fix Layout/SpaceAroundEqualsInParameterDefault [leila-alderman] #3720
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -50,7 +50,7 @@ require 'active_merchant/version'
 require 'active_merchant/country'
 
 module ActiveMerchant
-  def self.deprecated(message, caller=Kernel.caller[1])
+  def self.deprecated(message, caller = Kernel.caller[1])
     warning = caller + ': ' + message
     if respond_to?(:logger) && logger.present?
       logger.warn(warning)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -29,13 +29,13 @@ module ActiveMerchant #:nodoc:
         '135' => STANDARD_ERROR_CODE[:incorrect_address]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password, :merchant_account)
         @username, @password, @merchant_account = options.values_at(:username, :password, :merchant_account)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         if options[:execute_threed] || options[:threed_dynamic]
           authorize(money, payment, options)
         else
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         requires!(options, :order_id)
         post = init_post(options)
         add_invoice(post, money, options)
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         commit('authorise', post, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = init_post(options)
         add_invoice_for_modification(post, money, options)
         add_reference(post, authorization, options)
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = init_post(options)
         add_invoice_for_modification(post, money, options)
         add_original_reference(post, authorization, options)
@@ -78,13 +78,13 @@ module ActiveMerchant #:nodoc:
         commit('refund', post, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = init_post(options)
         add_reference(post, authorization, options)
         commit('cancel', post, options)
       end
 
-      def adjust(money, authorization, options={})
+      def adjust(money, authorization, options = {})
         post = init_post(options)
         add_invoice_for_modification(post, money, options)
         add_reference(post, authorization, options)
@@ -92,7 +92,7 @@ module ActiveMerchant #:nodoc:
         commit('adjustAuthorisation', post, options)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         requires!(options, :order_id)
         post = init_post(options)
         add_invoice(post, 0, options)
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def unstore(options={})
+      def unstore(options = {})
         requires!(options, :shopper_reference, :recurring_detail_reference)
         post = {}
 
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
         commit('disable', post, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(0, credit_card, options) }
           options[:idempotency_key] = nil
@@ -271,7 +271,7 @@ module ActiveMerchant #:nodoc:
         post[:shopperReference] = options[:shopper_reference] if options[:shopper_reference]
       end
 
-      def add_shopper_interaction(post, payment, options={})
+      def add_shopper_interaction(post, payment, options = {})
         if  (options.dig(:stored_credential, :initial_transaction) && options.dig(:stored_credential, :initiator) == 'cardholder') ||
             (payment.respond_to?(:verification_value) && payment.verification_value && options.dig(:stored_credential, :initial_transaction).nil?) ||
             payment.is_a?(NetworkTokenizationCreditCard)

--- a/lib/active_merchant/billing/gateways/allied_wallet.rb
+++ b/lib/active_merchant/billing/gateways/allied_wallet.rb
@@ -12,12 +12,12 @@ module ActiveMerchant #:nodoc:
       self.supported_cardtypes = %i[visa master american_express discover
                                     diners_club jcb maestro]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :site_id, :merchant_id, :token)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
         commit(:purchase, post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization, :capture)
@@ -44,14 +44,14 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization, :void)
 
         commit(:void, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization, :refund)
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -94,7 +94,7 @@ module ActiveMerchant
       PAYMENT_METHOD_NOT_SUPPORTED_ERROR = '155'
       INELIGIBLE_FOR_ISSUING_CREDIT_ERROR = '54'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :login, :password)
         super
       end
@@ -111,7 +111,7 @@ module ActiveMerchant
         end
       end
 
-      def authorize(amount, payment, options={})
+      def authorize(amount, payment, options = {})
         if payment.is_a?(String)
           commit(:cim_authorize, options) do |xml|
             add_cim_auth_purchase(xml, 'profileTransAuthOnly', amount, payment, options)
@@ -123,7 +123,7 @@ module ActiveMerchant
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         if auth_was_for_cim?(authorization)
           cim_capture(amount, authorization, options)
         else
@@ -131,7 +131,7 @@ module ActiveMerchant
         end
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         response =
           if auth_was_for_cim?(authorization)
             cim_refund(amount, authorization, options)
@@ -149,7 +149,7 @@ module ActiveMerchant
         end
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         if auth_was_for_cim?(authorization)
           cim_void(authorization, options)
         else
@@ -157,7 +157,7 @@ module ActiveMerchant
         end
       end
 
-      def credit(amount, payment, options={})
+      def credit(amount, payment, options = {})
         raise ArgumentError, 'Reference credits are not supported. Please supply the original credit card or use the #refund method.' if payment.is_a?(String)
 
         commit(:credit) do |xml|
@@ -595,7 +595,7 @@ module ActiveMerchant
         end
       end
 
-      def add_shipping_address(xml, options, root_node='shipTo')
+      def add_shipping_address(xml, options, root_node = 'shipTo')
         address = options[:shipping_address] || options[:address]
         return unless address
 
@@ -619,7 +619,7 @@ module ActiveMerchant
         end
       end
 
-      def add_ship_from_address(xml, options, root_node='shipFrom')
+      def add_ship_from_address(xml, options, root_node = 'shipFrom')
         address = options[:ship_from_address]
         return unless address
 

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
       #   +:interval => { :unit => :months, :length => 3 }+ (REQUIRED)
       # * <tt>:duration</tt> -- A hash containing keys for the <tt>:start_date</tt> the subscription begins (also the date the
       #   initial billing occurs) and the total number of billing <tt>:occurrences</tt> or payments for the subscription. (REQUIRED)
-      def recurring(money, creditcard, options={})
+      def recurring(money, creditcard, options = {})
         requires!(options, :interval, :duration, :billing_address)
         requires!(options[:interval], :length, %i[unit days months])
         requires!(options[:duration], :start_date, :occurrences)
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>:subscription_id</tt> -- A string containing the <tt>:subscription_id</tt> of the recurring payment already in place
       #   for a given credit card. (REQUIRED)
-      def update_recurring(options={})
+      def update_recurring(options = {})
         requires!(options, :subscription_id)
         request = build_recurring_request(:update, options)
         recurring_commit(:update, request)

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -23,33 +23,33 @@ module ActiveMerchant #:nodoc:
       PAYMENT_CODE_REFUND = 'CC.RF'
       PAYMENT_CODE_REBILL = 'CC.RB'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :sender, :login, :password, :channel)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         payment_code = payment.respond_to?(:number) ? PAYMENT_CODE_DEBIT : PAYMENT_CODE_REBILL
         commit(payment_code, money, payment, options)
       end
 
-      def authorize(money, authorization, options={})
+      def authorize(money, authorization, options = {})
         commit(PAYMENT_CODE_PREAUTHORIZATION, money, authorization, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         commit(PAYMENT_CODE_CAPTURE, money, authorization, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit(PAYMENT_CODE_REFUND, money, authorization, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit(PAYMENT_CODE_REVERSAL, nil, authorization, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         commit('refunds', "debits/#{reference_identifier_from(identifier)}/refunds", post)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         post = {}
 
         post[:number] = credit_card.number
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
         post[:meta] = options[:meta]
       end
 
-      def commit(entity_name, path, post, method=:post)
+      def commit(entity_name, path, post, method = :post)
         raw_response =
           begin
             parse(

--- a/lib/active_merchant/billing/gateways/bambora_apac.rb
+++ b/lib/active_merchant/billing/gateways/bambora_apac.rb
@@ -21,12 +21,12 @@ module ActiveMerchant #:nodoc:
         '54' => STANDARD_ERROR_CODE[:expired_card]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         commit('SubmitSingleCapture') do |xml|
           xml.Capture do
             xml.Receipt authorization
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit('SubmitSingleRefund') do |xml|
           xml.Refund do
             xml.Receipt authorization
@@ -72,7 +72,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit('SubmitSingleVoid') do |xml|
           xml.Void do
             xml.Receipt authorization
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def store(payment, options={})
+      def store(payment, options = {})
         commit('TokeniseCreditCard') do |xml|
           xml.TokeniseCreditCard do
             xml.CardNumber payment.number

--- a/lib/active_merchant/billing/gateways/bank_frick.rb
+++ b/lib/active_merchant/billing/gateways/bank_frick.rb
@@ -27,12 +27,12 @@ module ActiveMerchant #:nodoc:
         'void'      => 'CC.RV'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :sender, :channel, :userid, :userpwd)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -42,7 +42,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         commit('authonly', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         post[:authorization] = authorization
         add_invoice(post, money, options)
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         post[:authorization] = authorization
         add_invoice(post, money, options)
@@ -68,14 +68,14 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:authorization] = authorization
 
         commit('void', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def verify(source, options={})
+      def verify(source, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, source, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -410,7 +410,7 @@ module ActiveMerchant #:nodoc:
         recurring_post(post_data(params, false))
       end
 
-      def post(data, use_profile_api=nil)
+      def post(data, use_profile_api = nil)
         response = parse(ssl_post((use_profile_api ? SECURE_PROFILE_URL : self.live_url), data))
         response[:customer_vault_id] = response[:customerCode] if response[:customerCode]
         build_response(success?(response), message_from(response), response,

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -332,7 +332,7 @@ module ActiveMerchant #:nodoc:
         parse(ssl_post(url, post_data(action, fields)))
       end
 
-      def parse_recurring(response_fields, opts={}) # expected status?
+      def parse_recurring(response_fields, opts = {}) # expected status?
         parsed = {}
         response_fields.each do |k, v|
           mapped_key = REBILL_FIELD_MAP.include?(k) ? REBILL_FIELD_MAP[k] : k

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -70,12 +70,12 @@ module ActiveMerchant
 
       STATE_CODE_COUNTRIES = %w(US CA)
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_username, :api_password)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         payment_method_details = PaymentMethodDetails.new(payment_method)
 
         commit(:purchase, :post, payment_method_details) do |doc|
@@ -87,13 +87,13 @@ module ActiveMerchant
         end
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         commit(:authorize) do |doc|
           add_auth_purchase(doc, money, payment_method, options)
         end
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         commit(:capture, :put) do |doc|
           add_authorization(doc, authorization)
           add_order(doc, options)
@@ -101,7 +101,7 @@ module ActiveMerchant
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit(:refund, :put) do |doc|
           add_authorization(doc, authorization)
           add_amount(doc, money, options)
@@ -109,14 +109,14 @@ module ActiveMerchant
         end
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit(:void, :put) do |doc|
           add_authorization(doc, authorization)
           add_order(doc, options)
         end
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         authorize(0, payment_method, options)
       end
 

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -16,12 +16,12 @@ module ActiveMerchant #:nodoc:
 
       self.homepage_url = 'https://www.borgun.is/'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :processor, :merchant_id, :username, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         post[:TransType] = '1'
         add_invoice(post, money, options)
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         post[:TransType] = '5'
         add_invoice(post, money, options)
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         commit('authonly', post, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         post[:TransType] = '1'
         add_invoice(post, money, options)
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         post[:TransType] = '3'
         add_invoice(post, money, options)
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         # TransType, TrAmount, and currency must match original values from auth or purchase.
         _, _, _, _, _, transtype, tramount, currency = split_authorization(authorization)
@@ -125,7 +125,7 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(action, post, options={})
+      def commit(action, post, options = {})
         post[:Version] = '1000'
         post[:Processor] = @options[:processor]
         post[:MerchantID] = @options[:merchant_id]
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def build_request(action, post, options={})
+      def build_request(action, post, options = {})
         mode = action == 'void' ? 'cancel' : 'get'
         xml = Builder::XmlMarkup.new indent: 18
         xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')

--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -12,12 +12,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.bpoint.com.au/bpoint'
       self.display_name = 'BPoint'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password, :merchant_number)
         super
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         options[:crn1] ||= 'DEFAULT'
         request_body = soap_request do |xml|
           add_token(xml, credit_card, options)
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def purchase(amount, credit_card, options={})
+      def purchase(amount, credit_card, options = {})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
             add_purchase(payment_xml, amount, credit_card, options)
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def authorize(amount, credit_card, options={})
+      def authorize(amount, credit_card, options = {})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
             add_authorize(payment_xml, amount, credit_card, options)
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
             add_capture(payment_xml, amount, authorization, options)
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
             add_refund(payment_xml, amount, authorization, options)
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
             add_void(payment_xml, authorization, options)
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
         commit(request_body)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options.merge(amount: 100)) }

--- a/lib/active_merchant/billing/gateways/braintree.rb
+++ b/lib/active_merchant/billing/gateways/braintree.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
 
       self.abstract_class = true
 
-      def self.new(options={})
+      def self.new(options = {})
         if options.has_key?(:login)
           BraintreeOrangeGateway.new(options)
         else

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -464,7 +464,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def customer_hash(customer, include_credit_cards=false)
+      def customer_hash(customer, include_credit_cards = false)
         hash = {
           'email' => customer.email,
           'phone' => customer.phone,

--- a/lib/active_merchant/billing/gateways/bridge_pay.rb
+++ b/lib/active_merchant/billing/gateways/bridge_pay.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'USD'
       self.supported_cardtypes = %i[visa master american_express discover diners_club jcb]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :user_name, :password)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = initialize_required_fields('Sale')
 
         # Allow the same amount in multiple transactions.
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = initialize_required_fields('Auth')
 
         add_invoice(post, amount, options)
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = initialize_required_fields('Force')
 
         add_invoice(post, amount, options)
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = initialize_required_fields('Return')
 
         add_invoice(post, amount, options)
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = initialize_required_fields('Void')
 
         add_reference(post, authorization)
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def store(creditcard, options={})
+      def store(creditcard, options = {})
         post = initialize_required_fields('')
         post[:transaction] = 'Create'
         post[:CardNumber] = creditcard.number

--- a/lib/active_merchant/billing/gateways/cams.rb
+++ b/lib/active_merchant/billing/gateways/cams.rb
@@ -67,12 +67,12 @@ module ActiveMerchant #:nodoc:
         '894' => STANDARD_ERROR_CODE[:processing_error]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
 
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
         commit('auth', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, money, options)
@@ -103,20 +103,20 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, money, options)
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
         commit('void', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         post = {}
         add_invoice(post, 0, options)
         add_payment(post, credit_card)
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def add_address(post, creditcard, options={})
+      def add_address(post, creditcard, options = {})
         post[:firstname] = creditcard.first_name
         post[:lastname]  = creditcard.last_name
 

--- a/lib/active_merchant/billing/gateways/card_save.rb
+++ b/lib/active_merchant/billing/gateways/card_save.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.cardsave.net/'
       self.display_name = 'CardSave'
 
-      def initialize(options={})
+      def initialize(options = {})
         super
         @test_url = 'https://gw1.cardsaveonlinepayments.com:4430/'
         @live_url = 'https://gw1.cardsaveonlinepayments.com:4430/'

--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         commit('CANCEL', post)
       end
 
-      def verify(creditcard, options={})
+      def verify(creditcard, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, creditcard, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -282,7 +282,7 @@ module ActiveMerchant #:nodoc:
         add_pair(post, :threeDSRequired, options[:threeds_required] || @threeds_required ? 'Y' : 'N')
       end
 
-      def add_remote_address(post, options={})
+      def add_remote_address(post, options = {})
         add_pair(post, :remoteAddress, options[:ip] || '1.1.1.1')
       end
 

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         }
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key)
         super
       end
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
       # - check
       # - cardknox token, which is returned in the the authorization string "ref_num;token;command"
 
-      def purchase(amount, source, options={})
+      def purchase(amount, source, options = {})
         post = {}
         add_amount(post, amount, options)
         add_invoice(post, options)
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
         commit(:purchase, source_type(source), post)
       end
 
-      def authorize(amount, source, options={})
+      def authorize(amount, source, options = {})
         post = {}
         add_amount(post, amount)
         add_invoice(post, options)
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
         commit(:capture, source_type(authorization), post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_amount(post, amount)
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
         commit(:void, source_type(authorization), post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/cardprocess.rb
+++ b/lib/active_merchant/billing/gateways/cardprocess.rb
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:user_id</tt> -- The CardProcess user ID
       # * <tt>:password</tt> -- The CardProcess password
       # * <tt>:entity_id</tt> -- The CardProcess channel or entity ID for any transactions
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :user_id, :password, :entity_id)
         super
         # This variable exists purely to allow remote tests to force error codes;

--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :password, :user_id)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         commit('Sale', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         commit('Auth', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         commit('SpecialForce', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_void_required_elements(post)
         add_reference(post, authorization)
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         commit('Void', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
         commit('SpecialReturn', post)
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         commit('Credit', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/checkout.rb
+++ b/lib/active_merchant/billing/gateways/checkout.rb
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -159,7 +159,7 @@ module ActiveMerchant #:nodoc:
         xml.trackid(trackid) if trackid
       end
 
-      def commit(action, amount=nil, options={}, &builder)
+      def commit(action, amount = nil, options = {}, &builder)
         response = parse_xml(ssl_post(live_url, build_xml(action, &builder)))
         Response.new(
           (response[:responsecode] == '0'),

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def verify_payment(authorization, option={})
+      def verify_payment(authorization, option = {})
         commit(:verify_payment, authorization)
       end
 

--- a/lib/active_merchant/billing/gateways/clearhaus.rb
+++ b/lib/active_merchant/billing/gateways/clearhaus.rb
@@ -36,20 +36,20 @@ module ActiveMerchant #:nodoc:
         50000 => 'Clearhaus error'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key)
         options[:private_key] = options[:private_key].strip if options[:private_key]
         super
       end
 
-      def purchase(amount, payment, options={})
+      def purchase(amount, payment, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(amount, payment, options) }
           r.process { capture(amount, r.authorization, options) }
         end
       end
 
-      def authorize(amount, payment, options={})
+      def authorize(amount, payment, options = {})
         post = {}
         add_invoice(post, amount, options)
 
@@ -69,14 +69,14 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
 
         commit("/authorizations/#{authorization}/captures", post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_amount(post, amount, options)
 
@@ -87,14 +87,14 @@ module ActiveMerchant #:nodoc:
         commit("/authorizations/#{authorization}/voids", options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(0, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         post = {}
         add_payment(post, credit_card)
 

--- a/lib/active_merchant/billing/gateways/creditcall.rb
+++ b/lib/active_merchant/billing/gateways/creditcall.rb
@@ -41,12 +41,12 @@ module ActiveMerchant #:nodoc:
         'partialmatched;partialmatch' => 'C'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :terminal_id, :transaction_key)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         multi_response = MultiResponse.run do |r|
           r.process { authorize(money, payment_method, options) }
           r.process { capture(money, r.authorization, options) }
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         request = build_xml_request do |xml|
           add_transaction_details(xml, money, nil, 'Auth', options)
           add_terminal_details(xml, options)
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_transaction_details(xml, money, authorization, 'Conf', options)
           add_terminal_details(xml, options)
@@ -85,7 +85,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_transaction_details(xml, money, authorization, 'Refund', options)
           add_terminal_details(xml, options)
@@ -94,7 +94,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         request = build_xml_request do |xml|
           add_transaction_details(xml, nil, authorization, 'Void', options)
           add_terminal_details(xml, options)
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
         builder.to_xml
       end
 
-      def add_transaction_details(xml, amount, authorization, type, options={})
+      def add_transaction_details(xml, amount, authorization, type, options = {})
         xml.TransactionDetails do
           xml.MessageType type
           xml.Amount(unit: 'Minor') { xml.text(amount) } if amount
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_terminal_details(xml, options={})
+      def add_terminal_details(xml, options = {})
         xml.TerminalDetails do
           xml.TerminalID @options[:terminal_id]
           xml.TransactionKey @options[:transaction_key]
@@ -161,7 +161,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_card_details(xml, payment_method, options={})
+      def add_card_details(xml, payment_method, options = {})
         xml.CardDetails do
           xml.Manual(type: manual_type(options)) do
             xml.PAN payment_method.number

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -120,12 +120,12 @@ module ActiveMerchant #:nodoc:
         'R3' => 'Revocation of all Authorisations Order'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :cipher_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -141,7 +141,7 @@ module ActiveMerchant #:nodoc:
         commit(:purchase, post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -158,7 +158,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -170,7 +170,7 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_customer_data(post, options)
         reference_action = add_reference(post, authorization)
@@ -182,7 +182,7 @@ module ActiveMerchant #:nodoc:
         commit(:void, post, reference_action)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -214,7 +214,7 @@ module ActiveMerchant #:nodoc:
         commit(:credit, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -372,7 +372,7 @@ module ActiveMerchant #:nodoc:
         post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
       end
 
-      def build_i8(eci, cavv=nil, xid=nil)
+      def build_i8(eci, cavv = nil, xid = nil)
         "#{eci}:#{cavv || 'none'}:#{xid || 'none'}"
       end
 

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -26,12 +26,12 @@ module ActiveMerchant #:nodoc:
         'discover' => 'O'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key, :company_number, :merchant_number)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         requires!(options, :order_id)
         post = {}
         add_terminal_number(post, options)
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         payment.is_a?(String) ? commit('purchaseWithToken', post) : commit('purchase', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         requires!(options, :order_id)
         post = {}
         add_money(post, money)
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         payment.is_a?(String) ? commit('preAuthorizationWithToken', post) : commit('preAuthorization', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         requires!(options, :order_id)
         post = {}
         add_invoice(post, money, options)
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         commit('completion', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         requires!(options, :order_id)
         post = {}
         add_invoice(post, money, options)
@@ -86,7 +86,7 @@ module ActiveMerchant #:nodoc:
         commit('refundWithoutCard', post)
       end
 
-      def credit(money, payment, options={})
+      def credit(money, payment, options = {})
         requires!(options, :order_id)
         post = {}
         add_terminal_number(post, options)
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
         payment.is_a?(String) ? commit('refundWithToken', post) : commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:InputType] = 'I'
         post[:LanguageCode] = 'E'
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         requires!(options, :order_id)
         post = {}
         add_terminal_number(post, options)
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
         commit('verifyAccount', post)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         requires!(options, :email)
         post = {
           LanguageCode: 'E',

--- a/lib/active_merchant/billing/gateways/culqi.rb
+++ b/lib/active_merchant/billing/gateways/culqi.rb
@@ -20,16 +20,16 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master diners_club american_express]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :terminal_id, :secret_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         authorize(amount, payment_method, options)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         if payment_method.is_a?(String)
           action = :tokenpay
         else
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         action = :capture
         post = {}
         add_credentials(post)
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         action = :void
         post = {}
         add_credentials(post)
@@ -67,7 +67,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         action = :refund
         post = {}
         add_credentials(post)
@@ -78,7 +78,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(1000, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         response.message.include? 'Transaction not found'
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         action = :tokenize
         post = {}
         post[:partnerid] = options[:partner_id] if options[:partner_id]
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def invalidate(authorization, options={})
+      def invalidate(authorization, options = {})
         action = :invalidate
         post = {}
         post[:partnerid] = options[:partner_id] if options[:partner_id]

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -512,7 +512,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_purchase_data(xml, money = 0, include_grand_total = false, options={})
+      def add_purchase_data(xml, money = 0, include_grand_total = false, options = {})
         xml.tag! 'purchaseTotals' do
           xml.tag! 'currency', options[:currency] || currency(money)
           xml.tag!('grandTotalAmount', localized_amount(money.to_i, options[:currency] || default_currency)) if include_grand_total
@@ -851,7 +851,7 @@ module ActiveMerchant #:nodoc:
         country_code&.code(:alpha2)
       end
 
-      def add_stored_credential_subsequent_auth(xml, options={})
+      def add_stored_credential_subsequent_auth(xml, options = {})
         return unless options[:stored_credential] || options[:stored_credential_overrides]
 
         stored_credential_subsequent_auth = 'true' if options.dig(:stored_credential, :initiator) == 'merchant'
@@ -861,7 +861,7 @@ module ActiveMerchant #:nodoc:
         xml.subsequentAuth override_subsequent_auth.nil? ? stored_credential_subsequent_auth : override_subsequent_auth
       end
 
-      def add_stored_credential_options(xml, options={})
+      def add_stored_credential_options(xml, options = {})
         return unless options[:stored_credential] || options[:stored_credential_overrides]
 
         stored_credential_subsequent_auth_first = 'true' if options.dig(:stored_credential, :initial_transaction)

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -11,33 +11,33 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://dlocal.com/'
       self.display_name = 'dLocal'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :login, :trans_key, :secret_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment, 'purchase', options)
 
         commit('purchase', post, options)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment, 'authorize', options)
 
         commit('authorize', post, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         post[:authorization_id] = authorization
         add_invoice(post, money, options) if money
         commit('capture', post, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         post[:payment_id] = authorization
         post[:notification_url] = options[:notification_url]
@@ -45,13 +45,13 @@ module ActiveMerchant #:nodoc:
         commit('refund', post, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:authorization_id] = authorization
         commit('void', post, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -138,7 +138,7 @@ module ActiveMerchant #:nodoc:
         house.empty? ? nil : house
       end
 
-      def add_card(post, card, action, options={})
+      def add_card(post, card, action, options = {})
         post[:card] = {}
         post[:card][:holder_name] = card.name
         post[:card][:expiration_month] = card.month
@@ -155,7 +155,7 @@ module ActiveMerchant #:nodoc:
         JSON.parse(body)
       end
 
-      def commit(action, parameters, options={})
+      def commit(action, parameters, options = {})
         url = url(action, parameters, options)
         post = post_data(action, parameters)
         begin
@@ -202,7 +202,7 @@ module ActiveMerchant #:nodoc:
         code&.to_s
       end
 
-      def url(action, parameters, options={})
+      def url(action, parameters, options = {})
         "#{(test? ? test_url : live_url)}/#{endpoint(action, parameters, options)}/"
       end
 
@@ -221,7 +221,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def headers(post, options={})
+      def headers(post, options = {})
         timestamp = Time.now.utc.iso8601
         headers = {
           'Content-Type' => 'application/json',

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -42,13 +42,13 @@ module ActiveMerchant #:nodoc:
         97 => STANDARD_ERROR_CODE[:processing_error]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key)
         super
         @options[:preauth_mode] ||= false
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         raise ArgumentError, 'Purchase is not supported on Decidir gateways configured with the preauth_mode option' if @options[:preauth_mode]
 
         post = {}
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'payments', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         raise ArgumentError, 'Authorize is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
 
         post = {}
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'payments', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         raise ArgumentError, 'Capture is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
 
         post = {}
@@ -72,18 +72,18 @@ module ActiveMerchant #:nodoc:
         commit(:put, "payments/#{authorization}", post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_amount(post, money, options)
         commit(:post, "payments/#{authorization}/refunds", post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         commit(:post, "payments/#{authorization}/refunds", post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         raise ArgumentError, 'Verify is not supported on Decidir gateways unless the preauth_mode option is enabled' unless @options[:preauth_mode]
 
         MultiResponse.run(:use_first_response) do |r|
@@ -225,7 +225,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def commit(method, endpoint, parameters, options={})
+      def commit(method, endpoint, parameters, options = {})
         url = "#{(test? ? test_url : live_url)}/#{endpoint}"
 
         begin

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -11,19 +11,19 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express discover]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :secret_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         MultiResponse.run(false) do |r|
           r.process { authorize(amount, payment_method, options) }
           r.process { capture(amount, r.authorization, options) }
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_amount(post, amount)
         add_invoice(post, amount, options)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_amount(post, amount)
         add_reference(post, authorization)
@@ -44,14 +44,14 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
 
         commit(:void, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_amount(post, amount)
         add_reference(post, authorization)
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -14,19 +14,19 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://digitzs.com'
       self.display_name = 'Digitzs'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :app_key, :api_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         MultiResponse.run do |r|
           r.process { commit('auth/token', app_token_request(options)) }
           r.process { commit('payments', purchase_request(money, payment, options), options.merge({ app_token: app_token_from(r) })) }
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         MultiResponse.run do |r|
           r.process { commit('auth/token', app_token_request(options)) }
           r.process { commit('payments', refund_request(money, authorization, options), options.merge({ app_token: app_token_from(r) })) }
@@ -206,7 +206,7 @@ module ActiveMerchant #:nodoc:
         JSON.parse(body)
       end
 
-      def commit(action, parameters, options={})
+      def commit(action, parameters, options = {})
         url = (test? ? test_url : live_url)
         response = parse(ssl_post(url + "/#{action}", parameters.to_json, headers(options)))
 

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -46,12 +46,12 @@ module ActiveMerchant #:nodoc:
         'cl' => 5000
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :integration_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = { payment: {} }
         add_integration_key(post)
         add_operation(post)
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
         commit(:purchase, post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = { payment: {} }
         add_integration_key(post)
         add_operation(post)
@@ -80,7 +80,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_integration_key(post)
         post[:hash] = authorization
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_integration_key(post)
         add_operation(post)
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_integration_key(post)
         add_authorization(post, authorization)
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
         commit(:void, post)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         post = {}
         add_integration_key(post)
         add_payment_details(post, credit_card)
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
         commit(:store, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(VERIFY_AMOUNT_PER_COUNTRY[customer_country(options)], credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -17,12 +17,12 @@ module ActiveMerchant #:nodoc:
       SERVICE_TEST_URL = 'https://certservices.elementexpress.com/express.asmx'
       SERVICE_LIVE_URL = 'https://services.elementexpress.com/express.asmx'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_id, :account_token, :application_id, :acceptor_id, :application_name, :application_version)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         action = payment.is_a?(Check) ? 'CheckSale' : 'CreditCardSale'
 
         request = build_soap_request do |xml|
@@ -38,7 +38,7 @@ module ActiveMerchant #:nodoc:
         commit(action, request, money)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         request = build_soap_request do |xml|
           xml.CreditCardAuthorization(xmlns: 'https://transaction.elementexpress.com') do
             add_credentials(xml)
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         commit('CreditCardAuthorization', request, money)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         trans_id, = split_authorization(authorization)
         options[:trans_id] = trans_id
 
@@ -67,7 +67,7 @@ module ActiveMerchant #:nodoc:
         commit('CreditCardAuthorizationCompletion', request, money)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         trans_id, = split_authorization(authorization)
         options[:trans_id] = trans_id
 
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
         commit('CreditCardReturn', request, money)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         trans_id, trans_amount = split_authorization(authorization)
         options.merge!({trans_id: trans_id, trans_amount: trans_amount, reversal_type: 'Full'})
 
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
         commit('PaymentAccountCreate', request, nil)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         request = build_soap_request do |xml|
           xml.CreditCardAVSOnly(xmlns: 'https://transaction.elementexpress.com') do
             add_credentials(xml)

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -38,7 +38,7 @@ module ActiveMerchant #:nodoc:
         commit(purchase_url(post[:CVN]), money, post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
 
         add_customer_id(post)

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -49,7 +49,7 @@ module ActiveMerchant #:nodoc:
         commit('CreateCustomer', post)
       end
 
-      def update(billing_id, creditcard, options={})
+      def update(billing_id, creditcard, options = {})
         post = {}
 
         # Handle our required fields
@@ -80,7 +80,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:order_id</tt> -- The order number, passed to eWay as the "Invoice Reference"
       # * <tt>:invoice</tt> -- The invoice number, passed to eWay as the "Invoice Reference" unless :order_id is also given
       # * <tt>:description</tt> -- A description of the payment, passed to eWay as the "Invoice Description"
-      def purchase(money, billing_id, options={})
+      def purchase(money, billing_id, options = {})
         post = {}
         post[:managedCustomerID] = billing_id.to_s
         post[:amount] = money

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
       #                                      (default: "https://github.com/activemerchant/active_merchant")
       #
       # Returns an ActiveMerchant::Billing::Response object where authorization is the Transaction ID on success
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         params = {}
         add_metadata(params, options)
         add_invoice(params, amount, options)
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
         commit(url_for('Transaction'), params)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         params = {}
         add_metadata(params, options)
         add_invoice(params, amount, options)
@@ -251,7 +251,7 @@ module ActiveMerchant #:nodoc:
           payment_method.first_name.present? && payment_method.last_name.present?
       end
 
-      def add_address(params, address, options={})
+      def add_address(params, address, options = {})
         return unless address
 
         params['Title'] = address[:title]

--- a/lib/active_merchant/billing/gateways/ezic.rb
+++ b/lib/active_merchant/billing/gateways/ezic.rb
@@ -10,12 +10,12 @@ module ActiveMerchant
       self.homepage_url = 'http://www.ezic.com/'
       self.display_name = 'Ezic'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_id)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
 
         add_account_id(post)
@@ -26,7 +26,7 @@ module ActiveMerchant
         commit('S', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
 
         add_account_id(post)
@@ -37,7 +37,7 @@ module ActiveMerchant
         commit('A', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
 
         add_account_id(post)
@@ -48,7 +48,7 @@ module ActiveMerchant
         commit('D', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
 
         add_account_id(post)
@@ -59,7 +59,7 @@ module ActiveMerchant
         commit('R', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
 
         add_account_id(post)
@@ -69,7 +69,7 @@ module ActiveMerchant
         commit('U', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, "purchases/#{CGI.escape(txn_id)}/capture", post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         txn_id, = authorization.to_s.split('|')
         post = {}
 
@@ -69,13 +69,13 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'refunds', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         txn_id, endpoint = authorization.to_s.split('|')
 
         commit(:post, "#{endpoint}/void?id=#{txn_id}", {})
       end
 
-      def store(creditcard, options={})
+      def store(creditcard, options = {})
         post = {}
 
         add_creditcard(post, creditcard)
@@ -147,7 +147,7 @@ module ActiveMerchant #:nodoc:
         post[:metadata] = options.fetch(:metadata, {})
       end
 
-      def commit(method, uri, parameters=nil)
+      def commit(method, uri, parameters = nil)
         response =
           begin
             parse(ssl_request(method, get_url(uri), parameters.to_json, headers))

--- a/lib/active_merchant/billing/gateways/first_giving.rb
+++ b/lib/active_merchant/billing/gateways/first_giving.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(action, post=nil)
+      def commit(action, post = nil)
         url = (test? ? self.test_url : self.live_url) + action
 
         begin

--- a/lib/active_merchant/billing/gateways/first_pay.rb
+++ b/lib/active_merchant/billing/gateways/first_pay.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://1stpaygateway.net/'
       self.display_name = '1stPayGateway.Net'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :transaction_center_id, :gateway_id)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment, options)
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment, options)
@@ -38,19 +38,19 @@ module ActiveMerchant #:nodoc:
         commit('auth', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_reference(post, 'settle', money, authorization)
         commit('settle', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_reference(post, 'credit', money, authorization)
         commit('credit', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, 'void', nil, authorization)
         commit('void', post)

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -19,19 +19,19 @@ module ActiveMerchant #:nodoc:
         'diners_club' => 'DINERS'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password, :account_id)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         MultiResponse.run do |r|
           r.process { authorize(amount, payment_method, options) }
           r.process { capture(amount, r.authorization, options) }
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit('ProcessAuthorise', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -49,7 +49,7 @@ module ActiveMerchant #:nodoc:
         commit('ProcessCapture', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)

--- a/lib/active_merchant/billing/gateways/flo2cash_simple.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_simple.rb
@@ -3,7 +3,7 @@ module ActiveMerchant #:nodoc:
     class Flo2cashSimpleGateway < Flo2cashGateway
       self.display_name = 'Flo2Cash Simple'
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -15,12 +15,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.forte.net'
       self.display_name = 'Forte'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key, :secret, :location_id, :account_id)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, post)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization) || ''
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         commit(:put, post)
       end
 
-      def credit(money, payment_method, options={})
+      def credit(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_amount(post, money, options)
         post[:original_transaction_id] = transaction_id_from(authorization)
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization)
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         commit(:put, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -12,19 +12,19 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express discover naranja cabal]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :api_key_id, :secret_api_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         MultiResponse.run do |r|
           r.process { authorize(money, payment, options) }
           r.process { capture(money, r.authorization, options) } if should_request_capture?(r, options[:requires_approval])
         end
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = nestable_hash
         add_order(post, money, options)
         add_payment(post, payment, options)
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = nestable_hash
         add_order(post, money, options, capture: true)
         add_customer_data(post, options)
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post, authorization)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = nestable_hash
         add_amount(post, money, options)
         add_refund_customer_data(post, options)
@@ -51,13 +51,13 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post, authorization)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = nestable_hash
         add_creator_info(post, options)
         commit(:void, post, authorization)
       end
 
-      def verify(payment, options={})
+      def verify(payment, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, payment, options) }
           r.process { void(r.authorization, options) }
@@ -142,7 +142,7 @@ module ActiveMerchant #:nodoc:
         post['shoppingCartExtension']['extensionID'] = options[:extension_ID] if options[:extension_ID]
       end
 
-      def add_amount(post, money, options={})
+      def add_amount(post, money, options = {})
         post['amountOfMoney'] = {
           'amount' => amount(money),
           'currencyCode' => options[:currency] || currency(money)

--- a/lib/active_merchant/billing/gateways/global_transport.rb
+++ b/lib/active_merchant/billing/gateways/global_transport.rb
@@ -20,12 +20,12 @@ module ActiveMerchant #:nodoc:
       #           :global_password  - Your Global password
       #           :term_type        - 3 character field assigned by Global Transport after
       #                             - your application is certified.
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :global_user_name, :global_password, :term_type)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment_method(post, payment_method)
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         commit('Sale', post, options)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment_method(post, payment_method)
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
         commit('Auth', post, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_invoice(post, money, options)
         add_auth(post, authorization)
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
         commit('Force', post, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_invoice(post, money, options)
         add_auth(post, authorization)
@@ -59,14 +59,14 @@ module ActiveMerchant #:nodoc:
         commit('Return', post, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_auth(post, authorization)
 
         commit('Void', post, options)
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         post = {}
         add_payment_method(post, payment_method)
         add_address(post, options)

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -14,12 +14,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master discover diners_club]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :login, :password)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
         commit('purchase', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
         commit('authorize', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -194,7 +194,7 @@ module ActiveMerchant #:nodoc:
         [tranid, member]
       end
 
-      def escape(string, max_length=250)
+      def escape(string, max_length = 250)
         return '' unless string
 
         string = string[0...max_length] if max_length

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -25,12 +25,12 @@ module ActiveMerchant #:nodoc:
         google_pay:       'GooglePayApp'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :secret_api_key)
         super
       end
 
-      def authorize(money, card_or_token, options={})
+      def authorize(money, card_or_token, options = {})
         commit('CreditAuth') do |xml|
           add_amount(xml, money)
           add_allow_dup(xml)
@@ -42,14 +42,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(money, transaction_id, options={})
+      def capture(money, transaction_id, options = {})
         commit('CreditAddToBatch', transaction_id) do |xml|
           add_amount(xml, money)
           add_reference(xml, transaction_id)
         end
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         if payment_method.is_a?(Check)
           commit_check_sale(money, payment_method, options)
         else
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def refund(money, transaction_id, options={})
+      def refund(money, transaction_id, options = {})
         commit('CreditReturn') do |xml|
           add_amount(xml, money)
           add_allow_dup(xml)
@@ -67,7 +67,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def verify(card_or_token, options={})
+      def verify(card_or_token, options = {})
         commit('CreditAccountVerify') do |xml|
           add_card_or_token_customer_data(xml, card_or_token, options)
           add_descriptor_name(xml, options)
@@ -75,7 +75,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def void(transaction_id, options={})
+      def void(transaction_id, options = {})
         if options[:check_void]
           commit('CheckVoid') do |xml|
             add_reference(xml, transaction_id)

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         unstore: 'DeleteCustomerCode'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         if options[:login]
           ActiveMerchant.deprecated("The 'login' option is deprecated in favor of 'agent_code' and will be removed in a future version.")
           options[:agent_code] = options[:login]
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         commit(determine_purchase_type(payment), post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         transaction_id, payment_type = split_authorization(authorization)
         post[:transaction_id] = transaction_id

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
         post[:orderdescription] = options[:description]
       end
 
-      def add_payment_source(params, source, options={})
+      def add_payment_source(params, source, options = {})
         case determine_funding_source(source)
         when :vault       then add_customer_vault_id(params, source)
         when :credit_card then add_creditcard(params, source, options)

--- a/lib/active_merchant/billing/gateways/ipp.rb
+++ b/lib/active_merchant/billing/gateways/ipp.rb
@@ -21,13 +21,13 @@ module ActiveMerchant #:nodoc:
         '54' => STANDARD_ERROR_CODE[:expired_card]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         ActiveMerchant.deprecated('IPP gateway is now named Bambora Asia-Pacific')
         requires!(options, :username, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         commit('SubmitSinglePayment') do |xml|
           xml.Transaction do
             xml.CustRef options[:order_id]
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         commit('SubmitSingleCapture') do |xml|
           xml.Capture do
             xml.Receipt authorization
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit('SubmitSingleRefund') do |xml|
           xml.Refund do
             xml.Receipt authorization

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -251,16 +251,16 @@ module ActiveMerchant #:nodoc:
         commit(build_reference_request('COLLECTION', money, authorization, options), options)
       end
 
-      def credit(money, authorization, options={})
+      def credit(money, authorization, options = {})
         ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, authorization, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit(build_reference_request('REFUND', money, authorization, options), options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit(build_reference_request('VOID', nil, authorization, options), options)
       end
 

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.iveri.com'
       self.display_name = 'iVeri'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :app_id, :cert_id)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = build_vxml_request('Debit', options) do |xml|
           add_auth_purchase_params(xml, money, payment_method, options)
         end
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = build_vxml_request('Authorisation', options) do |xml|
           add_auth_purchase_params(xml, money, payment_method, options)
         end
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = build_vxml_request('Debit', options) do |xml|
           add_authorization(xml, authorization, options)
         end
@@ -42,7 +42,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = build_vxml_request('Credit', options) do |xml|
           add_amount(xml, money, options)
           add_authorization(xml, authorization, options)
@@ -51,7 +51,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = build_vxml_request('Void', options) do |xml|
           add_authorization(xml, authorization, options)
         end
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -14,13 +14,13 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.ixopay.com'
       self.display_name = 'Ixopay'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password, :secret, :api_key)
         @secret = options[:secret]
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         request = build_xml_request do |xml|
           add_card_data(xml, payment_method)
           add_debit(xml, money, options)
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         request = build_xml_request do |xml|
           add_card_data(xml, payment_method)
           add_preauth(xml, money, options)
@@ -38,7 +38,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_capture(xml, money, authorization, options)
         end
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_refund(xml, money, authorization, options)
         end
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         request = build_xml_request do |xml|
           add_void(xml, authorization)
         end
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -12,26 +12,26 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover diners_club alia]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :public_merchant_id, :private_merchant_id)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         MultiResponse.run() do |r|
           r.process { tokenize(amount, payment_method, options) }
           r.process { charge(amount, r.authorization, options) }
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         MultiResponse.run() do |r|
           r.process { tokenize(amount, payment_method, options) }
           r.process { preauthorize(amount, r.authorization, options) }
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         action = 'capture'
 
         post = {}
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         action = 'refund'
 
         post = {}
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
         commit(action, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         action = 'void'
 
         post = {}

--- a/lib/active_merchant/billing/gateways/latitude19.rb
+++ b/lib/active_merchant/billing/gateways/latitude19.rb
@@ -51,12 +51,12 @@ module ActiveMerchant #:nodoc:
         'jcb' => 'JC'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_number, :configuration_id, :secret)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         if payment_method.is_a?(String)
           auth_or_sale('sale', payment_method, amount, nil, options)
         else
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         if payment_method.is_a?(String)
           auth_or_sale('auth', payment_method, amount, nil, options)
         else
@@ -80,7 +80,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         post[:method] = 'deposit'
         add_request_id(post)
@@ -96,7 +96,7 @@ module ActiveMerchant #:nodoc:
         commit('v1/', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         method, pgwTID = split_authorization(authorization)
         case method
         when 'auth'
@@ -109,7 +109,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         if payment_method.is_a?(String)
           refundWithCard(payment_method, amount, nil, options)
         else
@@ -121,7 +121,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def verify(payment_method, options={}, action=nil)
+      def verify(payment_method, options = {}, action = nil)
         if payment_method.is_a?(String)
           verifyOnly(action, payment_method, nil, options)
         else
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def store(payment_method, options={})
+      def store(payment_method, options = {})
         verify(payment_method, options, 'store')
       end
 
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def get_session(options={})
+      def get_session(options = {})
         post = {}
         post[:method] = 'getSession'
         add_request_id(post)
@@ -213,7 +213,7 @@ module ActiveMerchant #:nodoc:
         commit('session', post)
       end
 
-      def get_token(authorization, payment_method, options={})
+      def get_token(authorization, payment_method, options = {})
         post = {}
         post[:method] = 'tokenize'
         add_request_id(post)
@@ -226,7 +226,7 @@ module ActiveMerchant #:nodoc:
         commit('token', post)
       end
 
-      def auth_or_sale(method, authorization, amount, credit_card, options={})
+      def auth_or_sale(method, authorization, amount, credit_card, options = {})
         post = {}
         post[:method] = method
         add_request_id(post)
@@ -246,7 +246,7 @@ module ActiveMerchant #:nodoc:
         commit('v1/', post)
       end
 
-      def verifyOnly(action, authorization, credit_card, options={})
+      def verifyOnly(action, authorization, credit_card, options = {})
         post = {}
         post[:method] = 'verifyOnly'
         add_request_id(post)
@@ -267,7 +267,7 @@ module ActiveMerchant #:nodoc:
         commit('v1/', post)
       end
 
-      def refundWithCard(authorization, amount, credit_card, options={})
+      def refundWithCard(authorization, amount, credit_card, options = {})
         post = {}
         post[:method] = 'refundWithCard'
         add_request_id(post)
@@ -286,7 +286,7 @@ module ActiveMerchant #:nodoc:
         commit('v1/', post)
       end
 
-      def reverse_or_void(method, pgwTID, options={})
+      def reverse_or_void(method, pgwTID, options = {})
         post = {}
         post[:method] = method
         add_request_id(post)

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
       # :threshold              Tells how many times to retry the transaction (if it fails) before contacting the merchant.
       # :comments               Uh... comments
       #
-      def recurring(money, creditcard, options={})
+      def recurring(money, creditcard, options = {})
         ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
 
         requires!(options, %i[periodicity bimonthly monthly biweekly weekly yearly daily], :installments, :order_id)
@@ -184,7 +184,7 @@ module ActiveMerchant #:nodoc:
       end
 
       # Buy the thing
-      def purchase(money, creditcard, options={})
+      def purchase(money, creditcard, options = {})
         requires!(options, :order_id)
         options.update(
           ordertype: 'SALE'

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -15,12 +15,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.vantiv.com/'
       self.display_name = 'Vantiv eCommerce'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :login, :password, :merchant_id)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
           if check?(payment_method)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
           if check?(payment_method)
@@ -52,7 +52,7 @@ module ActiveMerchant #:nodoc:
         check?(payment_method) ? commit(:echeckVerification, request, money) : commit(:authorization, request, money)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         transaction_id, = split_authorization(authorization)
 
         request = build_xml_request do |doc|
@@ -72,7 +72,7 @@ module ActiveMerchant #:nodoc:
         refund(money, authorization, options)
       end
 
-      def refund(money, payment, options={})
+      def refund(money, payment, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
           add_descriptor(doc, options)
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         transaction_id, kind, money = split_authorization(authorization)
 
         request = build_xml_request do |doc|
@@ -227,7 +227,7 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_params(doc, options)
       end
 
-      def add_merchant_data(doc, options={})
+      def add_merchant_data(doc, options = {})
         if options[:affiliate] || options[:campaign] || options[:merchant_grouping_id]
           doc.merchantData do
             doc.affiliate(options[:affiliate]) if options[:affiliate]
@@ -296,7 +296,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_stored_credential_params(doc, options={})
+      def add_stored_credential_params(doc, options = {})
         return unless options[:stored_credential]
 
         if options[:stored_credential][:initial_transaction]
@@ -381,7 +381,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def order_source(options={})
+      def order_source(options = {})
         return options[:order_source] unless options[:stored_credential]
 
         order_source = nil
@@ -448,7 +448,7 @@ module ActiveMerchant #:nodoc:
         parsed
       end
 
-      def commit(kind, request, money=nil)
+      def commit(kind, request, money = nil)
         parsed = parse(kind, ssl_post(url, request, headers))
 
         options = {

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -1,12 +1,12 @@
 module ActiveMerchant
   module Billing
     module MastercardGateway
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :userid, :password)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         if options[:pay_mode]
           post = new_post
           add_invoice(post, amount, options)
@@ -24,7 +24,7 @@ module ActiveMerchant
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = new_post
         add_invoice(post, amount, options)
         add_reference(post, *new_authorization)
@@ -35,7 +35,7 @@ module ActiveMerchant
         commit('authorize', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = new_post
         add_invoice(post, amount, options, :transaction)
         add_reference(post, *next_authorization(authorization))
@@ -45,7 +45,7 @@ module ActiveMerchant
         commit('capture', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = new_post
         add_invoice(post, amount, options, :transaction)
         add_reference(post, *next_authorization(authorization))
@@ -54,14 +54,14 @@ module ActiveMerchant
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = new_post
         add_reference(post, *next_authorization(authorization), :targetTransactionId)
 
         commit('void', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -109,12 +109,12 @@ module ActiveMerchant
         }
       end
 
-      def add_invoice(post, amount, options, node=:order)
+      def add_invoice(post, amount, options, node = :order)
         post[node][:amount] = amount(amount)
         post[node][:currency] = (options[:currency] || currency(amount))
       end
 
-      def add_reference(post, orderid, transactionid, transaction_reference, reference_key=:reference)
+      def add_reference(post, orderid, transactionid, transaction_reference, reference_key = :reference)
         post[:orderid] = orderid
         post[:transactionid] = transactionid
         post[:transaction][reference_key] = transaction_reference if transaction_reference

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -10,12 +10,12 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Mercado Pago'
       self.money_format = :dollars
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :access_token)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         MultiResponse.run do |r|
           r.process { commit('tokenize', 'card_tokens', card_token_request(money, payment, options)) }
           options[:card_token] = r.authorization.split('|').first
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         MultiResponse.run do |r|
           r.process { commit('tokenize', 'card_tokens', card_token_request(money, payment, options)) }
           options[:card_token] = r.authorization.split('|').first
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         authorization, = authorization.split('|')
         post[:capture] = true
@@ -39,20 +39,20 @@ module ActiveMerchant #:nodoc:
         commit('capture', "payments/#{authorization}", post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         authorization, original_amount = authorization.split('|')
         post[:amount] = amount(money).to_f if original_amount && original_amount.to_f > amount(money).to_f
         commit('refund', "payments/#{authorization}/refunds", post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         authorization, = authorization.split('|')
         post = { status: 'cancelled' }
         commit('void', "payments/#{authorization}", post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/merchant_one.rb
+++ b/lib/active_merchant/billing/gateways/merchant_one.rb
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
         post['ccexp'] = "#{sprintf('%02d', creditcard.month)}#{creditcard.year.to_s[-2, 2]}"
       end
 
-      def commit(action, money, parameters={})
+      def commit(action, money, parameters = {})
         parameters['username'] = @options[:username]
         parameters['password'] = @options[:password]
         parse(ssl_post(BASE_URL, post_data(action, parameters)))

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover diners_club jcb]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_id, :merchant_pin)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         commit(payment_method.is_a?(String) ? :stored_purchase : :purchase, post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -45,14 +45,14 @@ module ActiveMerchant #:nodoc:
         commit(:capture, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
 
         commit(:void, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
         commit(:refund, post)
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
         commit(payment_method.is_a?(String) ? :stored_credit : :credit, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
         commit(:refund, request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -69,14 +69,14 @@ module ActiveMerchant #:nodoc:
         commit('Return', request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         requires!(options, :credit_card) unless @use_tokenization
 
         request = build_authorized_request('VoidSale', nil, authorization, options[:credit_card], options)
         commit('VoidSale', request)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         request = build_card_lookup_request(credit_card, options)
         commit('CardLookup', request)
       end

--- a/lib/active_merchant/billing/gateways/micropayment.rb
+++ b/lib/active_merchant/billing/gateways/micropayment.rb
@@ -11,12 +11,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :access_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
         commit('purchase', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
@@ -34,27 +34,27 @@ module ActiveMerchant #:nodoc:
         commit('authorize', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, amount, options)
         commit('capture', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
         commit('void', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, amount, options)
         commit('refund', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(250, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         post['params[title]'] = options[:description] if options[:description]
       end
 
-      def add_payment_method(post, payment_method, options={})
+      def add_payment_method(post, payment_method, options = {})
         post[:number] = payment_method.number
         post[:recurring] = 1 if options[:recurring] == true
         post[:cvc2] = payment_method.verification_value

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
         refund(money, authorization, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
       #           :login      User login
       #           :pwd        User password
       #
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :sender_id, :channel_id, :login, :pwd)
         super
       end
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object
-      def purchase(money, credit_card, options={})
+      def purchase(money, credit_card, options = {})
         execute_new_order(:purchase, money, credit_card, options)
       end
 
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object
-      def authorize(money, credit_card, options={})
+      def authorize(money, credit_card, options = {})
         execute_new_order(:authorize, money, credit_card, options)
       end
 
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
       # Note: you should pass either order_id or description
       #
       # Returns Active Merchant response object
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         execute_dependant(:capture, money, authorization, options)
       end
 
@@ -92,7 +92,7 @@ module ActiveMerchant #:nodoc:
       # Note: you should pass either order_id or description
       #
       # Returns Active Merchant response object
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         execute_dependant(:refund, money, authorization, options)
       end
 
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
       #                 :order_id         Merchant created id for the authorization (optional)
       #
       # Returns Active Merchant response object
-      def void(authorization, options={})
+      def void(authorization, options = {})
         execute_dependant(:void, nil, authorization, options)
       end
 
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
       #               :currency         Sale currency to override money object or default (optional)
       #
       # Returns Active Merchant response object of Authorization operation
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         commit 'refund', crediting_params(authorization, amount: amount(money))
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         requires!(options, :order_id)
         post = {}
         add_payment_source(post, credit_card, options)

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -28,12 +28,12 @@ module ActiveMerchant #:nodoc:
         '500' => 'An internal error occurred;'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_customer_data(post, options) unless payment.is_a?(String)
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_customer_data(post, options) unless payment.is_a?(String)
@@ -53,23 +53,23 @@ module ActiveMerchant #:nodoc:
         commit('authonly', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         post[:code] = authorization
         add_invoice(post, money, options)
         commit('capture', post, authorization)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         add_invoice(post = {}, money, options)
         commit('refund', post, authorization)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit('void', nil, authorization)
       end
 
-      def store(payment, options={})
+      def store(payment, options = {})
         post = {}
         options.update(name: payment.name)
         options = add_customer(options) unless options[:customer_id]
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
         commit('store', post, options[:customer_id])
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/ncr_secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/ncr_secure_pay.rb
@@ -13,12 +13,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.ncrretailonline.com'
       self.display_name = 'NCR Secure Pay'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         commit('preauth', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, money, options)
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
         commit('preauthcomplete', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_invoice(post, money, options)
@@ -52,13 +52,13 @@ module ActiveMerchant #:nodoc:
         commit('credit', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
         commit('void', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -94,12 +94,12 @@ module ActiveMerchant #:nodoc:
         commit('Netaxept/query.aspx', post)
       end
 
-      def add_credentials(post, options, secure=true)
+      def add_credentials(post, options, secure = true)
         post[:merchantId] = @options[:login]
         post[:token] = @options[:password] if secure
       end
 
-      def add_authorization(post, authorization, money=nil)
+      def add_authorization(post, authorization, money = nil)
         post[:transactionId] = authorization
         post[:transactionAmount] = amount(money) if money
       end
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
         post[:securityCode] = options.verification_value
       end
 
-      def commit(path, parameters, xml=true)
+      def commit(path, parameters, xml = true)
         raw = parse(ssl_get(build_url(path, parameters)), xml)
 
         success = false
@@ -141,7 +141,7 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def parse(result, expects_xml=true)
+      def parse(result, expects_xml = true)
         if expects_xml
           doc = REXML::Document.new(result)
           extract_xml(doc.root).merge(container: doc.root.name)
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def build_url(base, parameters=nil)
+      def build_url(base, parameters = nil)
         url = (test? ? self.test_url : self.live_url).dup
         url << base
         if parameters

--- a/lib/active_merchant/billing/gateways/netbanx.rb
+++ b/lib/active_merchant/billing/gateways/netbanx.rb
@@ -22,12 +22,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://processing.paysafe.com/'
       self.display_name = 'Netbanx by PaySafe'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_number, :api_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         # Do a Verification with AVS prior to purchase
         verification_response = verify(payment, options)
         return verification_response if verification_response.message != 'OK'
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'auths', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         # Do a Verification with AVS prior to Auth + Settle
         verification_response = verify(payment, options)
         return verification_response if verification_response.message != 'OK'
@@ -52,14 +52,14 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'auths', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_invoice(post, money, options)
 
         commit(:post, "auths/#{authorization}/settlements", post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         # If the transactions that are pending, API call needs to be Cancellation
         settlement_data = get_settlement(authorization)
         return settlement_data if settlement_data.message != 'OK'
@@ -86,14 +86,14 @@ module ActiveMerchant #:nodoc:
         commit(:get, "settlements/#{authorization}", post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_order_id(post, options)
 
         commit(:post, "auths/#{authorization}/voidauths", post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         post = {}
         add_payment(post, credit_card, options)
         add_order_id(post, options)
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
 
       # note: when passing options[:customer] we only attempt to add the
       #       card to the profile_id passed as the options[:customer]
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         # locale can only be one of en_US, fr_CA, en_GB
         requires!(options, :locale)
         post = {}

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit('sale', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         commit('auth', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
         add_payment_type(post, authorization)
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         commit('credit', post)
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         post = {}
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
         perform_reference_credit(money, reference, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:api_version</tt> -- Omise's API Version (OPTIONAL), default version is '2014-07-27'
       #                            See version at page https://dashboard.omise.co/api-version/edit
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :public_key, :secret_key)
         @public_key  = options[:public_key]
         @secret_key  = options[:secret_key]
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
       #
       #   purchase(money, nil, { :customer_id => customer_id })
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         create_charge(money, payment_method, options)
       end
 
@@ -91,7 +91,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>payment_method</tt> -- The CreditCard object
       # * <tt>options</tt>        -- An optional parameters, such as token or capture
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         options[:capture] = 'false'
         create_charge(money, payment_method, options)
       end
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>charge_id</tt> -- The CreditCard object
       # * <tt>options</tt>   -- An optional parameters, such as token or capture
 
-      def capture(money, charge_id, options={})
+      def capture(money, charge_id, options = {})
         post = {}
         add_amount(post, money, options)
         commit(:post, "charges/#{CGI.escape(charge_id)}/capture", post, options)
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>charge_id</tt> -- The CreditCard object
       # * <tt>options</tt>   -- An optional parameters, such as token or capture
 
-      def refund(money, charge_id, options={})
+      def refund(money, charge_id, options = {})
         options[:amount] = money if money
         commit(:post, "charges/#{CGI.escape(charge_id)}/refunds", options)
       end
@@ -132,7 +132,7 @@ module ActiveMerchant #:nodoc:
       #     'email'       (A customer email)
       #     'description' (A customer description)
 
-      def store(payment_method, options={})
+      def store(payment_method, options = {})
         post, card_params = {}, {}
         add_customer_data(post, options)
         add_token(card_params, payment_method, options)
@@ -145,7 +145,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>customer_id</tt> -- The Customer identifier (REQUIRED).
 
-      def unstore(customer_id, options={})
+      def unstore(customer_id, options = {})
         commit(:delete, "customers/#{CGI.escape(customer_id)}")
       end
 
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'charges', post, options)
       end
 
-      def headers(options={})
+      def headers(options = {})
         key = options[:key] || @secret_key
         {
           'Content-Type'    => 'application/json;utf-8',
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
         parameters.present? ? parameters.to_json : nil
       end
 
-      def https_request(method, endpoint, parameters=nil, options={})
+      def https_request(method, endpoint, parameters = nil, options = {})
         raw_response = response = nil
         begin
           raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), headers(options))
@@ -221,7 +221,7 @@ module ActiveMerchant #:nodoc:
         { message: msg }
       end
 
-      def commit(method, endpoint, params=nil, options={})
+      def commit(method, endpoint, params = nil, options = {})
         response = https_request(method, endpoint, params, options)
         Response.new(
           successful?(response),
@@ -284,7 +284,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'tokens', post, { key: @public_key })
       end
 
-      def add_token(post, credit_card, options={})
+      def add_token(post, credit_card, options = {})
         if options[:token_id].present?
           post[:card] = options[:token_id]
         else
@@ -304,11 +304,11 @@ module ActiveMerchant #:nodoc:
         post[:card] = card
       end
 
-      def add_customer(post, options={})
+      def add_customer(post, options = {})
         post[:customer] = options[:customer_id] if options[:customer_id]
       end
 
-      def add_customer_data(post, options={})
+      def add_customer_data(post, options = {})
         post[:description] = options[:description] if options[:description]
         post[:email]       = options[:email] if options[:email]
       end

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -192,7 +192,7 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def http_request(method, resource, parameters={}, options={})
+      def http_request(method, resource, parameters = {}, options = {})
         url = (test? ? self.test_url : self.live_url) + @merchant_id + '/' + resource
         raw_response = nil
         begin

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -117,39 +117,39 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://docs.oppwa.com'
       self.display_name = 'Open Payment Platform'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :access_token, :entity_id)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         # debit
         options[:registrationId] = payment if payment.is_a?(String)
         execute_dbpa(options[:risk_workflow] ? 'PA.CP' : 'DB',
           money, payment, options)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         # preauthorization PA
         execute_dbpa('PA', money, payment, options)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         # capture CP
         execute_referencing('CP', money, authorization, options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         # refund RF
         execute_referencing('RF', money, authorization, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         # reversal RV
         execute_referencing('RV', nil, authorization, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -237,7 +237,7 @@ module ActiveMerchant #:nodoc:
         commit(order, :refund, options[:trace_number])
       end
 
-      def credit(money, authorization, options= {})
+      def credit(money, authorization, options = {})
         ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, authorization, options)
       end
@@ -355,14 +355,14 @@ module ActiveMerchant #:nodoc:
         xml.tag! :SDMerchantEmail, soft_desc[:merchant_email] || nil
       end
 
-      def add_level_2_tax(xml, options={})
+      def add_level_2_tax(xml, options = {})
         if (level_2 = options[:level_2_data])
           xml.tag! :TaxInd, level_2[:tax_indicator] if [TAX_NOT_PROVIDED, TAX_INCLUDED, NON_TAXABLE_TRANSACTION].include?(level_2[:tax_indicator].to_i)
           xml.tag! :Tax, level_2[:tax].to_i if level_2[:tax]
         end
       end
 
-      def add_level_3_tax(xml, options={})
+      def add_level_3_tax(xml, options = {})
         if (level_3 = options[:level_3_data])
           xml.tag! :PC3VATtaxAmt, byte_limit(level_3[:vat_tax], 12) if level_3[:vat_tax]
           xml.tag! :PC3AltTaxAmt, byte_limit(level_3[:alt_tax], 9) if level_3[:alt_tax]
@@ -371,7 +371,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_level_2_advice_addendum(xml, options={})
+      def add_level_2_advice_addendum(xml, options = {})
         if (level_2 = options[:level_2_data])
           xml.tag! :AMEXTranAdvAddn1, byte_limit(level_2[:advice_addendum_1], 40) if level_2[:advice_addendum_1]
           xml.tag! :AMEXTranAdvAddn2, byte_limit(level_2[:advice_addendum_2], 40) if level_2[:advice_addendum_2]
@@ -380,7 +380,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_level_2_purchase(xml, options={})
+      def add_level_2_purchase(xml, options = {})
         if (level_2 = options[:level_2_data])
           xml.tag! :PCOrderNum,       byte_limit(level_2[:purchase_order], 17) if level_2[:purchase_order]
           xml.tag! :PCDestZip,        byte_limit(format_address_field(level_2[:zip]), 10) if level_2[:zip]
@@ -392,7 +392,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_level_3_purchase(xml, options={})
+      def add_level_3_purchase(xml, options = {})
         if (level_3 = options[:level_3_data])
           xml.tag! :PC3FreightAmt,    byte_limit(level_3[:freight_amount], 12) if level_3[:freight_amount]
           xml.tag! :PC3DutyAmt,       byte_limit(level_3[:duty_amount], 12) if level_3[:duty_amount]
@@ -402,7 +402,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_line_items(xml, options={})
+      def add_line_items(xml, options = {})
         xml.tag! :PC3LineItemCount, byte_limit(options[:line_items].count, 2)
         xml.tag! :PC3LineItemArray do
           options[:line_items].each_with_index do |line_item, index|
@@ -478,7 +478,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_creditcard(xml, creditcard, currency=nil)
+      def add_creditcard(xml, creditcard, currency = nil)
         unless creditcard.nil?
           xml.tag! :AccountNum, creditcard.number
           xml.tag! :Exp, expiry_date(creditcard)
@@ -560,7 +560,7 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:PymtBrandProgramCode, 'ASK')
       end
 
-      def add_refund(xml, currency=nil)
+      def add_refund(xml, currency = nil)
         xml.tag! :AccountNum, nil
 
         xml.tag! :CurrencyCode, currency_code(currency)
@@ -647,7 +647,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def commit(order, message_type, trace_number=nil)
+      def commit(order, message_type, trace_number = nil)
         headers = POST_HEADERS.merge('Content-length' => order.size.to_s)
         if @options[:retry_logic] && trace_number
           headers['Trace-number'] = trace_number.to_s
@@ -673,7 +673,7 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def remote_url(url=:primary)
+      def remote_url(url = :primary)
         if url == :primary
           (self.test? ? self.test_url : self.live_url)
         else

--- a/lib/active_merchant/billing/gateways/pagarme.rb
+++ b/lib/active_merchant/billing/gateways/pagarme.rb
@@ -16,14 +16,14 @@ module ActiveMerchant #:nodoc:
         'processing_error' => STANDARD_ERROR_CODE[:processing_error]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key)
         @api_key = options[:api_key]
 
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_amount(post, money)
         add_payment_method(post, payment_method)
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'transactions', post)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = {}
         add_amount(post, money)
         add_payment_method(post, payment_method)
@@ -43,27 +43,27 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'transactions', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         return Response.new(false, 'Não é possível capturar uma transação sem uma prévia autorização.') if authorization.nil?
 
         post = {}
         commit(:post, "transactions/#{authorization}/capture", post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         return Response.new(false, 'Não é possível estornar uma transação sem uma prévia captura.') if authorization.nil?
 
         void(authorization, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         return Response.new(false, 'Não é possível estornar uma transação autorizada sem uma prévia autorização.') if authorization.nil?
 
         post = {}
         commit(:post, "transactions/#{authorization}/refund", post)
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(127, payment_method, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         post[:card_cvv] = credit_card.verification_value
       end
 
-      def add_metadata(post, options={})
+      def add_metadata(post, options = {})
         post[:metadata] = {}
         post[:metadata][:order_id] = options[:order_id]
         post[:metadata][:ip] = options[:ip]

--- a/lib/active_merchant/billing/gateways/pago_facil.rb
+++ b/lib/active_merchant/billing/gateways/pago_facil.rb
@@ -11,12 +11,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.pagofacil.net/'
       self.display_name = 'PagoFacil'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :branch_id, :merchant_id, :service_id)
         super
       end
 
-      def purchase(money, credit_card, options={})
+      def purchase(money, credit_card, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment(post, credit_card)

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -13,31 +13,31 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.bluefincommerce.com/'
       self.display_name = 'PayConex'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :account_id, :api_accesskey)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment_method, options)
         commit('SALE', post)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment_method, options)
         commit('AUTHORIZATION', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_reference_params(post, authorization, options)
         add_amount(post, money, options)
         commit('CAPTURE', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_reference_params(post, authorization, options)
         add_amount(post, money, options)
@@ -50,7 +50,7 @@ module ActiveMerchant #:nodoc:
         commit('REVERSAL', post)
       end
 
-      def credit(money, payment_method, options={})
+      def credit(money, payment_method, options = {})
         raise ArgumentError, 'Reference credits are not supported. Please supply the original credit card or use the #refund method.' if payment_method.is_a?(String)
 
         post = {}
@@ -58,11 +58,11 @@ module ActiveMerchant #:nodoc:
         commit('CREDIT', post)
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         authorize(0, payment_method, options)
       end
 
-      def store(payment_method, options={})
+      def store(payment_method, options = {})
         post = {}
         add_credentials(post)
         add_payment_method(post, payment_method)

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -183,7 +183,7 @@ module ActiveMerchant #:nodoc:
         commit(action, build_request(action, options), authorization)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         action = 'refundtx'
 
         options[:money] = money
@@ -197,7 +197,7 @@ module ActiveMerchant #:nodoc:
         SUCCESS_CODES.include?(response[:res])
       end
 
-      def build_request(action, options={})
+      def build_request(action, options = {})
         xml = Builder::XmlMarkup.new
         xml.instruct!
 
@@ -220,7 +220,7 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def build_authorization(xml, money, creditcard, options={})
+      def build_authorization(xml, money, creditcard, options = {})
         xml.tag! 'authtx', {
           cref: options[:order_id],
           cname: creditcard.name,
@@ -235,13 +235,13 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def build_capture(xml, money, authorization, options={})
+      def build_capture(xml, money, authorization, options = {})
         xml.tag! 'settletx', {
           tid: authorization
         }
       end
 
-      def build_refund(xml, money, authorization, options={})
+      def build_refund(xml, money, authorization, options = {})
         xml.tag! 'refundtx', {
           tid: authorization,
           amt: amount(money)

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
         '43' => STANDARD_ERROR_CODE[:pickup_card]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :orgid, :username, :password, :tid)
 
         super
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def purchase(amount, creditcard, options={})
+      def purchase(amount, creditcard, options = {})
         post = setup_post('sale')
         add_creditcard(post, creditcard)
         add_amount(post, amount)
@@ -92,7 +92,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def refund(amount, trans_id, options={})
+      def refund(amount, trans_id, options = {})
         # Attempt a void in case the transaction is unsettled
         post = setup_post('void')
         add_reference(post, trans_id)
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
 
       # No void, as PayHub's void does not work on authorizations
 
-      def verify(creditcard, options={})
+      def verify(creditcard, options = {})
         authorize(100, creditcard, options)
       end
 

--- a/lib/active_merchant/billing/gateways/pay_junction_v2.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction_v2.rb
@@ -12,12 +12,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_login, :api_password, :api_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method)
@@ -26,7 +26,7 @@ module ActiveMerchant #:nodoc:
         commit('purchase', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         post[:status] = 'HOLD'
         add_invoice(post, amount, options)
@@ -36,7 +36,7 @@ module ActiveMerchant #:nodoc:
         commit('authorize', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         post[:status] = 'CAPTURE'
         post[:transactionId] = authorization
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:status] = 'VOID'
         post[:transactionId] = authorization
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         post[:action] = 'REFUND'
         post[:transactionId] = authorization
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         post[:action] = 'REFUND'
         add_invoice(post, amount, options)
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
         commit('credit', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
         params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
-      def url(params={})
+      def url(params = {})
         test? ? "#{test_url}/#{params[:transactionId]}" : "#{live_url}/#{params[:transactionId]}"
       end
 

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -94,7 +94,7 @@ module ActiveMerchant
         commit(params, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(0, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
       # options        - A standard ActiveMerchant options hash
       #
       # Returns an ActiveMerchant::Billing::Response object
-      def void(authorization, options={})
+      def void(authorization, options = {})
         send_cancel(authorization)
       end
 

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -45,7 +45,7 @@ module ActiveMerchant #:nodoc:
         commit(build_reference_request(:credit, money, reference, options), options)
       end
 
-      def verify(payment, options={})
+      def verify(payment, options = {})
         if credit_card_type(payment) == 'Amex'
           MultiResponse.run(:use_first_response) do |r|
             r.process { authorize(100, payment, options) }

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         action_with_token(:purchase, money, payment_method, options)
       end
 
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'transactions', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
 
         post[:amount] = amount(money)
@@ -43,11 +43,11 @@ module ActiveMerchant #:nodoc:
         commit(:post, "refunds/#{transaction_id(authorization)}", post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit(:delete, "preauthorizations/#{preauth(authorization)}")
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         # The store request requires a currency and amount of at least $1 USD.
         # This is used for an authorization that is handled internally by Paymill.
         options[:currency] = 'USD'
@@ -94,7 +94,7 @@ module ActiveMerchant #:nodoc:
         { 'Authorization' => ('Basic ' + Base64.strict_encode64("#{@options[:private_key]}:X").chomp) }
       end
 
-      def commit(method, action, parameters=nil)
+      def commit(method, action, parameters = nil)
         begin
           raw_response = ssl_request(method, live_url + action, post_data(parameters), headers)
         rescue ResponseError => e
@@ -328,7 +328,7 @@ module ActiveMerchant #:nodoc:
       class ResponseParser
         attr_reader :raw_response, :parsed, :succeeded, :message, :options
 
-        def initialize(raw_response='', options={})
+        def initialize(raw_response = '', options = {})
           @raw_response = raw_response
           @options = options
         end

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = new_request
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         authorize(0, credit_card, options)
       end
 

--- a/lib/active_merchant/billing/gateways/payu_in.rb
+++ b/lib/active_merchant/billing/gateways/payu_in.rb
@@ -16,12 +16,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.payu.in/'
       self.display_name = 'PayU India'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :key, :salt)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         requires!(options, :order_id)
 
         post = {}
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         raise ArgumentError, 'Amount is required' unless money
 
         post = {}

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -30,24 +30,24 @@ module ActiveMerchant #:nodoc:
         'PEN' => 500
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :account_id, :api_login, :api_key, :payment_country)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         auth_or_sale(post, 'AUTHORIZATION_AND_CAPTURE', amount, payment_method, options)
         commit('purchase', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         auth_or_sale(post, 'AUTHORIZATION', amount, payment_method, options)
         commit('auth', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
 
         add_credentials(post, 'SUBMIT_TRANSACTION', options)
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
 
         add_credentials(post, 'SUBMIT_TRANSACTION', options)
@@ -72,7 +72,7 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
 
         add_credentials(post, 'SUBMIT_TRANSACTION', options)
@@ -82,7 +82,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         minimum = MINIMUMS[options[:currency].upcase] if options[:currency]
         amount = options[:verify_amount] || minimum || 100
 
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         add_extra_parameters(post, options)
       end
 
-      def add_credentials(post, command, options={})
+      def add_credentials(post, command, options = {})
         post[:test] = test? unless command == 'CREATE_TOKEN'
         post[:language] = options[:language] || 'en'
         post[:command] = command

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -83,7 +83,7 @@ module ActiveMerchant
         store: 'registerAccount'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         @options = options
 
         @options[:merchant] ||= 'TEST' if test?
@@ -92,7 +92,7 @@ module ActiveMerchant
         @options[:eci] ||= 'SSL'
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         requires!(options, :order_id)
 
         post = {}
@@ -101,7 +101,7 @@ module ActiveMerchant
         commit(:authorize, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         requires!(options, :order_id)
 
         post = {}
@@ -110,7 +110,7 @@ module ActiveMerchant
         commit(:capture, post)
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         requires!(options, :order_id)
 
         post = {}
@@ -119,7 +119,7 @@ module ActiveMerchant
         commit(:purchase, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         requires!(options, :order_id)
 
         post = {}
@@ -128,7 +128,7 @@ module ActiveMerchant
         commit(:refund, post)
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         requires!(options, :billing_id)
 
         post = {}
@@ -137,7 +137,7 @@ module ActiveMerchant
         commit(:store, post)
       end
 
-      def status(options={})
+      def status(options = {})
         requires!(options, :order_id)
 
         commit(:status, 'customer.orderNumber' => options[:order_id])

--- a/lib/active_merchant/billing/gateways/pro_pay.rb
+++ b/lib/active_merchant/billing/gateways/pro_pay.rb
@@ -133,12 +133,12 @@ module ActiveMerchant #:nodoc:
         '99' => 'Generic decline or unable to parse issuer response code'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :cert_str)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         request = build_xml_request do |xml|
           add_invoice(xml, money, options)
           add_payment(xml, payment, options)
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         request = build_xml_request do |xml|
           add_invoice(xml, money, options)
           add_payment(xml, payment, options)
@@ -164,7 +164,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_invoice(xml, money, options)
           add_account(xml, options)
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_invoice(xml, money, options)
           add_account(xml, options)
@@ -186,11 +186,11 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         refund(nil, authorization, options)
       end
 
-      def credit(money, payment, options={})
+      def credit(money, payment, options = {})
         request = build_xml_request do |xml|
           add_invoice(xml, money, options)
           add_payment(xml, payment, options)
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -68,7 +68,7 @@ module ActiveMerchant
         commit(synchronized_path("/payments/#{identification}/refund"), post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -16,12 +16,12 @@ module ActiveMerchant #:nodoc:
         'S' => 'D'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :username, :password, :merchant, :pem, :pem_password)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_order_number(post, options)
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', post)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_order_number(post, options)
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
         commit('preauth', post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization, options)
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
         commit('captureWithoutAuth', post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization, options)
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
       end
 
       # Credit requires the merchant account to be enabled for "Adhoc Refunds"
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_order_number(post, options)
@@ -80,7 +80,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization, options)
         add_customer_data(post, options)

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -352,7 +352,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def headers(action=nil)
+      def headers(action = nil)
         if action
           {
             'Content-Type' => 'text/xml',

--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -22,12 +22,12 @@ module ActiveMerchant #:nodoc:
         'store'     => 'CC.RG'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :sender, :channel, :login, :password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         request = build_xml_request do |xml|
           add_identification(xml, options)
           add_payment(xml, money, 'sale', options)
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_identification(xml, options, authorization)
           add_payment(xml, money, 'refund', options)
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         request = build_xml_request do |xml|
           add_identification(xml, options)
           add_payment(xml, money, 'authonly', options)
@@ -60,7 +60,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
           add_identification(xml, options, authorization)
           add_payment(xml, money, 'capture', options)
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         request = build_xml_request do |xml|
           add_identification(xml, options, authorization)
           add_payment(xml, nil, 'void', options)
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -15,12 +15,12 @@ module ActiveMerchant #:nodoc:
 
       VERSION = '4.1.0'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :client_login_id, :client_password)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = {}
         post[:sg_APIType] = 1 if options[:three_d_secure]
         trans_type = options[:three_d_secure] ? 'Sale3D' : 'Sale'
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_transaction_data('Auth', post, money, options)
         add_payment(post, payment, options)
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split('|')
         add_transaction_data('Settle', post, money, options.merge!({currency: original_currency}))
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split('|')
         add_transaction_data('Credit', post, money, options.merge!({currency: original_currency}))
@@ -67,7 +67,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def credit(money, payment, options={})
+      def credit(money, payment, options = {})
         post = {}
         add_payment(post, payment, options)
         add_transaction_data('Credit', post, money, options)
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, original_amount, original_currency = authorization.split('|')
         add_transaction_data('Void', post, (original_amount.to_f * 100), options.merge!({currency: original_currency}))
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -130,7 +130,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_MerchantName] = options[:merchant_name] if options[:merchant_name]
       end
 
-      def add_payment(post, payment, options={})
+      def add_payment(post, payment, options = {})
         post[:sg_NameOnCard] = payment.name
         post[:sg_CardNumber] = payment.number
         post[:sg_ExpMonth] = format(payment.month, :two_digits)

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -77,7 +77,7 @@ module ActiveMerchant #:nodoc:
         commit(:credit, post, source)
       end
 
-      def refund(money, reference, options={})
+      def refund(money, reference, options = {})
         post = {}
         add_reference(post, reference)
         add_transaction_data(post, money, options)

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
         commit(:unstore, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description]
       end
 
-      def add_creditcard(post, creditcard, options={})
+      def add_creditcard(post, creditcard, options = {})
         post[:card_num]   = creditcard.number
         post[:card_code]  = creditcard.verification_value if creditcard.verification_value?
         post[:exp_date]   = expdate(creditcard)
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
         post[:last_name]  = creditcard.last_name
       end
 
-      def add_payment_source(params, source, options={})
+      def add_payment_source(params, source, options = {})
         add_creditcard(params, source, options)
       end
 

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -31,17 +31,17 @@ module ActiveMerchant #:nodoc:
         'expired_token' => STANDARD_ERROR_CODE[:card_declined]
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :secret_key)
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         post = create_post_for_auth_or_purchase(money, payment, options)
         commit('charges', post, options)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = create_post_for_auth_or_purchase(money, payment, options)
         post[:captured] = 'false'
         commit('charges', post, options)
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         commit("charges/#{CGI.escape(authorization)}/refund", {}, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -133,7 +133,7 @@ module ActiveMerchant #:nodoc:
         post[:ipaddress] = options[:ip] if options.has_key? :ip
       end
 
-      def add_address(post, address, prefix='')
+      def add_address(post, address, prefix = '')
         prefix += '_' unless prefix.blank?
         unless address.blank? or address.values.blank?
           post[prefix + 'address1']    = address[:address1].to_s
@@ -163,7 +163,7 @@ module ActiveMerchant #:nodoc:
         post[:orderid] = options[:order_id].to_s.gsub(/[^\w.]/, '')
       end
 
-      def add_payment_source(params, source, options={})
+      def add_payment_source(params, source, options = {})
         case determine_funding_source(source)
         when :vault       then add_customer_vault_id(params, source)
         when :credit_card then add_creditcard(params, source, options)

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -39,11 +39,11 @@ module ActiveMerchant #:nodoc:
         commit('CaptureTransaction', do_capture(money, authorization, options), options)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         commit('RefundTransaction', do_refund(money, authorization, options), options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit('CancelTransaction', do_void(authorization, options), options)
       end
 
@@ -139,7 +139,7 @@ module ActiveMerchant #:nodoc:
         soap.tag!('cardExpireYear', card.year.to_s)
       end
 
-      def fill_order_info(soap, money, options, skip_currency=false)
+      def fill_order_info(soap, money, options, skip_currency = false)
         soap.tag!('orderID', options[:order_id].to_s)
         soap.tag!('orderDescription', "Order #{options[:order_id]}")
         soap.tag!('amount', amount(money).to_s)

--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         commit("gateways/#{@options[:gateway_token]}/authorize.xml", request)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         request = build_xml_request('transaction') do |doc|
           add_invoice(doc, money, options)
         end
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
         commit("transactions/#{authorization}/capture.xml", request)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         request = build_xml_request('transaction') do |doc|
           add_invoice(doc, money, options)
           add_extra_options(:gateway_specific_fields, doc, options)
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         commit("transactions/#{authorization}/credit.xml", request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         commit("transactions/#{authorization}/void.xml", '')
       end
 
@@ -98,7 +98,7 @@ module ActiveMerchant #:nodoc:
       #
       # credit_card    - The CreditCard to store
       # options        - A standard ActiveMerchant options hash
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         retain = (options.has_key?(:retain) ? options[:retain] : true)
         save_card(retain, credit_card, options)
       end
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
       #
       # credit_card    - The CreditCard to store
       # options        - A standard ActiveMerchant options hash
-      def unstore(authorization, options={})
+      def unstore(authorization, options = {})
         commit("payment_methods/#{authorization}/redact.xml", '', :put)
       end
 

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -125,7 +125,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def call_api(api, params=nil)
+      def call_api(api, params = nil)
         params ||= {}
         params[:merchant_id] = @options[:login]
         params[:api_key] = @options[:api_key]
@@ -139,7 +139,7 @@ module ActiveMerchant #:nodoc:
         (test? ? self.test_url : self.live_url) + api
       end
 
-      def build_error_response(message, params={})
+      def build_error_response(message, params = {})
         Response.new(
           false,
           message,

--- a/lib/active_merchant/billing/gateways/telr.rb
+++ b/lib/active_merchant/billing/gateways/telr.rb
@@ -28,12 +28,12 @@ module ActiveMerchant #:nodoc:
         'E' => 'R'
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :merchant_id, :api_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         commit(:purchase, amount, options[:currency]) do |doc|
           add_invoice(doc, 'sale', amount, payment_method, options)
           add_payment_method(doc, payment_method, options)
@@ -41,7 +41,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         commit(:authorize, amount, options[:currency]) do |doc|
           add_invoice(doc, 'auth', amount, payment_method, options)
           add_payment_method(doc, payment_method, options)
@@ -49,26 +49,26 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         commit(:capture) do |doc|
           add_invoice(doc, 'capture', amount, authorization, options)
         end
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         _, amount, currency = split_authorization(authorization)
         commit(:void) do |doc|
           add_invoice(doc, 'void', amount.to_i, authorization, options.merge(currency: currency))
         end
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         commit(:refund) do |doc|
           add_invoice(doc, 'refund', amount, authorization, options)
         end
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         commit(:verify) do |doc|
           add_invoice(doc, 'verify', 100, credit_card, options)
           add_payment_method(doc, credit_card, options)
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
         country.code(:alpha2)
       end
 
-      def commit(action, amount=nil, currency=nil)
+      def commit(action, amount = nil, currency = nil)
         currency = default_currency if currency == nil
         request = build_xml_request { |doc| yield(doc) }
         response = ssl_post(live_url, request, headers)

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         commit((payment.is_a?(Check) ? :purchase_echeck : :purchase), post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
 
         transaction_id, payment_type = split_authorization(authorization)
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
         commit((payment_type == 'check' ? :refund_echeck : :refund), post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
 
         transaction_id, = split_authorization(authorization)

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -182,12 +182,12 @@ module ActiveMerchant #:nodoc:
         wallet_sale: 14
       }
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :gateway_id, :reg_key)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         if credit_card?(payment_method)
           action = :purchase
           request = build_xml_transaction_request do |doc|
@@ -216,7 +216,7 @@ module ActiveMerchant #:nodoc:
         commit(action, request)
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         if credit_card?(payment_method)
           request = build_xml_transaction_request do |doc|
             add_credit_card(doc, payment_method)
@@ -234,7 +234,7 @@ module ActiveMerchant #:nodoc:
         commit(:authorize, request)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         transaction_id = split_authorization(authorization)[1]
         request = build_xml_transaction_request do |doc|
           add_amount(doc, amount)
@@ -244,7 +244,7 @@ module ActiveMerchant #:nodoc:
         commit(:capture, request)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         action, transaction_id = split_authorization(authorization)
 
         request = build_xml_transaction_request do |doc|
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
         commit(void_type(action), request)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         action, transaction_id = split_authorization(authorization)
 
         request = build_xml_transaction_request do |doc|
@@ -265,7 +265,7 @@ module ActiveMerchant #:nodoc:
         commit(refund_type(action), request)
       end
 
-      def credit(amount, payment_method, options={})
+      def credit(amount, payment_method, options = {})
         request = build_xml_transaction_request do |doc|
           add_pan(doc, payment_method)
           add_amount(doc, amount)
@@ -274,7 +274,7 @@ module ActiveMerchant #:nodoc:
         commit(:credit, request)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         request = build_xml_transaction_request do |doc|
           add_credit_card(doc, credit_card)
           add_contact(doc, credit_card.name, options)
@@ -283,7 +283,7 @@ module ActiveMerchant #:nodoc:
         commit(:verify, request)
       end
 
-      def store(payment_method, options={})
+      def store(payment_method, options = {})
         store_customer_request = build_xml_payment_storage_request do |doc|
           store_customer_details(doc, payment_method.name, options)
         end
@@ -462,7 +462,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def build_xml_request(wrapper, merchant_product_type=nil)
+      def build_xml_request(wrapper, merchant_product_type = nil)
         Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           xml['soapenv'].Envelope('xmlns:soapenv' => SOAPENV_NAMESPACE) do
             xml['soapenv'].Body do
@@ -485,7 +485,7 @@ module ActiveMerchant #:nodoc:
         doc.root.to_xml
       end
 
-      def add_merchant(doc, product_type=nil)
+      def add_merchant(doc, product_type = nil)
         doc['v1'].merc do
           doc['v1'].id @options[:gateway_id]
           doc['v1'].regKey @options[:reg_key]

--- a/lib/active_merchant/billing/gateways/transact_pro.rb
+++ b/lib/active_merchant/billing/gateways/transact_pro.rb
@@ -17,12 +17,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.transactpro.lv/business/online-payments-acceptance'
       self.display_name = 'Transact Pro'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :guid, :password, :terminal)
         super
       end
 
-      def purchase(amount, payment, options={})
+      def purchase(amount, payment, options = {})
         post = PostData.new
         add_invoice(post, amount, options)
         add_payment(post, payment)
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorize(amount, payment, options={})
+      def authorize(amount, payment, options = {})
         post = PostData.new
         add_invoice(post, amount, options)
         add_payment(post, payment)
@@ -66,7 +66,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         identifier, original_amount = split_authorization(authorization)
         raise ArgumentError.new("Partial capture is not supported, and #{amount.inspect} != #{original_amount.inspect}") if amount && (amount != original_amount)
 
@@ -78,7 +78,7 @@ module ActiveMerchant #:nodoc:
         commit('charge_hold', post, original_amount)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         identifier, original_amount = split_authorization(authorization)
 
         post = PostData.new
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         identifier, amount = split_authorization(authorization)
 
         post = PostData.new
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
         commit('cancel_dms', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -156,7 +156,7 @@ module ActiveMerchant #:nodoc:
         post[:expire] = "#{month}/#{year[2..3]}"
       end
 
-      def add_credentials(post, key=:guid)
+      def add_credentials(post, key = :guid)
         post[key] = @options[:guid]
         post[:pwd] = Digest::SHA1.hexdigest(@options[:password])
       end
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def commit(action, parameters, amount=nil)
+      def commit(action, parameters, amount = nil)
         url = (test? ? test_url : live_url)
         response = parse(ssl_post(url, post_data(action, parameters)))
 

--- a/lib/active_merchant/billing/gateways/usa_epay.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay.rb
@@ -12,7 +12,7 @@ module ActiveMerchant #:nodoc:
       # :software id or :live_url are passed in the options hash it will
       # create an instance of UsaEpayAdvancedGateway.
       #
-      def self.new(options={})
+      def self.new(options = {})
         if options.has_key?(:software_id) || options.has_key?(:live_url)
           UsaEpayAdvancedGateway.new(options)
         else

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -289,7 +289,7 @@ module ActiveMerchant #:nodoc:
       #
       # Note: See run_transaction for additional options.
       #
-      def purchase(money, creditcard, options={})
+      def purchase(money, creditcard, options = {})
         run_sale(options.merge!(amount: money, payment_method: creditcard))
       end
 
@@ -297,7 +297,7 @@ module ActiveMerchant #:nodoc:
       #
       # Note: See run_transaction for additional options.
       #
-      def authorize(money, creditcard, options={})
+      def authorize(money, creditcard, options = {})
         run_auth_only(options.merge!(amount: money, payment_method: creditcard))
       end
 
@@ -305,7 +305,7 @@ module ActiveMerchant #:nodoc:
       #
       # Note: See run_transaction for additional options.
       #
-      def capture(money, identification, options={})
+      def capture(money, identification, options = {})
         capture_transaction(options.merge!(amount: money, reference_number: identification))
       end
 
@@ -313,7 +313,7 @@ module ActiveMerchant #:nodoc:
       #
       # Note: See run_transaction for additional options.
       #
-      def void(identification, options={})
+      def void(identification, options = {})
         void_transaction(options.merge!(reference_number: identification))
       end
 
@@ -321,11 +321,11 @@ module ActiveMerchant #:nodoc:
       #
       # Note: See run_transaction for additional options.
       #
-      def refund(money, identification, options={})
+      def refund(money, identification, options = {})
         refund_transaction(options.merge!(amount: money, reference_number: identification))
       end
 
-      def credit(money, identification, options={})
+      def credit(money, identification, options = {})
         ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
         refund(money, identification, options)
       end
@@ -368,7 +368,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- customer number assigned by gateway
       #
-      def add_customer(options={})
+      def add_customer(options = {})
         request = build_request(__method__, options)
         commit(__method__, request)
       end
@@ -381,7 +381,7 @@ module ActiveMerchant #:nodoc:
       # ==== Options
       #  * Same as add_customer
       #
-      def update_customer(options={})
+      def update_customer(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -429,7 +429,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- boolean; Returns true if successful. Exception thrown all failures.
       #
-      def quick_update_customer(options={})
+      def quick_update_customer(options = {})
         requires! options, :customer_number
         requires! options, :update_data
 
@@ -444,7 +444,7 @@ module ActiveMerchant #:nodoc:
       # ==== Required
       # * <tt>:customer_number</tt>
       #
-      def enable_customer(options={})
+      def enable_customer(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -456,7 +456,7 @@ module ActiveMerchant #:nodoc:
       # ==== Required
       # * <tt>:customer_number</tt>
       #
-      def disable_customer(options={})
+      def disable_customer(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -479,7 +479,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- method_id of new customer payment method
       #
-      def add_customer_payment_method(options={})
+      def add_customer_payment_method(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -494,7 +494,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- either a single hash or an array of hashes of payment methods
       #
-      def get_customer_payment_methods(options={})
+      def get_customer_payment_methods(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -510,7 +510,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- hash of payment method
       #
-      def get_customer_payment_method(options={})
+      def get_customer_payment_method(options = {})
         requires! options, :customer_number, :method_id
 
         request = build_request(__method__, options)
@@ -531,7 +531,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- hash of payment method
       #
-      def update_customer_payment_method(options={})
+      def update_customer_payment_method(options = {})
         requires! options, :method_id
 
         request = build_request(__method__, options)
@@ -544,7 +544,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:customer_number</tt>
       # * <tt>:method_id</tt>
       #
-      def delete_customer_payment_method(options={})
+      def delete_customer_payment_method(options = {})
         requires! options, :customer_number, :method_id
 
         request = build_request(__method__, options)
@@ -556,7 +556,7 @@ module ActiveMerchant #:nodoc:
       # ==== Required
       # * <tt>:customer_number</tt>
       #
-      def delete_customer(options={})
+      def delete_customer(options = {})
         requires! options, :customer_number
 
         request = build_request(__method__, options)
@@ -607,7 +607,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def run_customer_transaction(options={})
+      def run_customer_transaction(options = {})
         requires! options, :customer_number, :command, :amount
 
         request = build_request(__method__, options)
@@ -671,7 +671,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def run_transaction(options={})
+      def run_transaction(options = {})
         request = build_request(__method__, options)
         commit(__method__, request)
       end
@@ -699,7 +699,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def post_auth(options={})
+      def post_auth(options = {})
         requires! options, :authorization_code
 
         request = build_request(__method__, options)
@@ -721,7 +721,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def capture_transaction(options={})
+      def capture_transaction(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -738,7 +738,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def void_transaction(options={})
+      def void_transaction(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -757,7 +757,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def refund_transaction(options={})
+      def refund_transaction(options = {})
         requires! options, :reference_number, :amount
 
         request = build_request(__method__, options)
@@ -777,7 +777,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def override_transaction(options={})
+      def override_transaction(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -820,7 +820,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def run_quick_sale(options={})
+      def run_quick_sale(options = {})
         requires! options, :reference_number, :amount
 
         request = build_request(__method__, options)
@@ -858,7 +858,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction response hash
       #
-      def run_quick_credit(options={})
+      def run_quick_credit(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -875,7 +875,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- transaction hash
       #
-      def get_transaction(options={})
+      def get_transaction(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -892,7 +892,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>response.message</tt> -- message of the referenced transaction
       # * <tt>response.authorization</tt> -- same as :reference_number in options
       #
-      def get_transaction_status(options={})
+      def get_transaction_status(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -990,7 +990,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- hash; keys are the field values
       #
-      def get_transaction_custom(options={})
+      def get_transaction_custom(options = {})
         requires! options, :reference_number, :fields
 
         request = build_request(__method__, options)
@@ -1005,7 +1005,7 @@ module ActiveMerchant #:nodoc:
       # ==== Response
       # * <tt>#message</tt> -- check trace hash
       #
-      def get_check_trace(options={})
+      def get_check_trace(options = {})
         requires! options, :reference_number
 
         request = build_request(__method__, options)
@@ -1078,7 +1078,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def build_customer(soap, options, type, add_customer_data=false)
+      def build_customer(soap, options, type, add_customer_data = false)
         soap.tag! "ns1:#{type}" do
           build_token soap, options
           build_tag soap, :integer, 'CustNum', options[:customer_number]
@@ -1378,7 +1378,7 @@ module ActiveMerchant #:nodoc:
 
       # Transaction Helpers ===========================================
 
-      def build_transaction_request_object(soap, options, name='Params')
+      def build_transaction_request_object(soap, options, name = 'Params')
         soap.tag! name, 'xsi:type' => 'ns1:TransactionRequestObject' do
           TRANSACTION_REQUEST_OBJECT_OPTIONS.each do |k, v|
             build_tag soap, v[0], v[1], options[k]

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -198,7 +198,7 @@ module ActiveMerchant #:nodoc:
         post[:description]  = options[:description]
       end
 
-      def add_payment(post, payment, options={})
+      def add_payment(post, payment, options = {})
         if payment.respond_to?(:routing_number)
           post[:checkformat] = options[:check_format] if options[:check_format]
           if payment.account_type

--- a/lib/active_merchant/billing/gateways/vanco.rb
+++ b/lib/active_merchant/billing/gateways/vanco.rb
@@ -15,19 +15,19 @@ module ActiveMerchant
       self.homepage_url = 'http://vancopayments.com/'
       self.display_name = 'Vanco Payment Solutions'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :user_id, :password, :client_id)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         MultiResponse.run do |r|
           r.process { login }
           r.process { commit(purchase_request(money, payment_method, r.params['response_sessionid'], options), :response_transactionref) }
         end
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         MultiResponse.run do |r|
           r.process { login }
           r.process { commit(refund_request(money, authorization, r.params['response_sessionid']), :response_creditrequestreceived) }

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -13,19 +13,19 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :access_key_id, :secret_access_key, :merchant_id)
         super
       end
 
-      def purchase(amount, payment_method, options={})
+      def purchase(amount, payment_method, options = {})
         MultiResponse.run() do |r|
           r.process { authorize(amount, payment_method, options) }
           r.process { capture(amount, r.authorization, options) }
         end
       end
 
-      def authorize(amount, payment_method, options={})
+      def authorize(amount, payment_method, options = {})
         params = {}
 
         add_invoice(params, amount, options)
@@ -37,20 +37,20 @@ module ActiveMerchant #:nodoc:
         commit('authorize', params, options)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         params = {}
         options[:id_unico] = split_authorization(authorization)[1]
         add_auth_order_id(params, authorization, options)
         commit('deposit', params, options)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         params = {}
         add_auth_order_id(params, authorization, options)
         commit('void', params, options)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         params = {}
         params[:amount] = amount(amount) if amount
         add_auth_order_id(params, authorization, options)
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
         commit('refund', params, options)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -142,7 +142,7 @@ module ActiveMerchant #:nodoc:
         authorization.split('|')
       end
 
-      def commit(action, params, options={})
+      def commit(action, params, options = {})
         raw_response = ssl_request(method(action), url(action, params, options), params.to_json, headers)
         response = parse(raw_response)
       rescue ResponseError => e
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def url(action, params, options={})
+      def url(action, params, options = {})
         if action == 'authorize'
           "#{base_url}/#{@options[:merchant_id]}"
         elsif action == 'refund'

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -168,7 +168,7 @@ module ActiveMerchant #:nodoc:
         JSON.parse(response)
       end
 
-      def commit(action, params, options={})
+      def commit(action, params, options = {})
         begin
           response = parse(
             ssl_post(

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -111,14 +111,14 @@ module ActiveMerchant #:nodoc:
         credit_request(money, payment_method, payment_details.merge(credit: true, **options))
       end
 
-      def verify(payment_method, options={})
+      def verify(payment_method, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, payment_method, options) }
           r.process(:ignore_result) { void(r.authorization, options.merge(authorization_validated: true)) }
         end
       end
 
-      def store(credit_card, options={})
+      def store(credit_card, options = {})
         requires!(options, :customer)
         store_request(credit_card, options)
       end
@@ -432,7 +432,7 @@ module ActiveMerchant #:nodoc:
         add_address(xml, (options[:billing_address] || options[:address]), options)
       end
 
-      def add_stored_credential_options(xml, options={})
+      def add_stored_credential_options(xml, options = {})
         if options[:stored_credential]
           add_stored_credential_using_normalized_fields(xml, options)
         else
@@ -687,7 +687,7 @@ module ActiveMerchant #:nodoc:
         (pair ? pair.last : nil)
       end
 
-      def authorization_from_token_details(options={})
+      def authorization_from_token_details(options = {})
         [options[:order_id], options[:token_id], options[:token_scope], options[:customer]].join('|')
       end
 

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -13,14 +13,14 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://online.worldpay.com'
       self.display_name = 'Worldpay Online Payments'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :client_key, :service_key)
         @client_key = options[:client_key]
         @service_key = options[:service_key]
         super
       end
 
-      def authorize(money, credit_card, options={})
+      def authorize(money, credit_card, options = {})
         response = create_token(true, credit_card.first_name + ' ' + credit_card.last_name, credit_card.month, credit_card.year, credit_card.number, credit_card.verification_value)
         if response.success?
           options[:authorizeOnly] = true
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         if authorization
           commit(:post, "orders/#{CGI.escape(authorization)}/capture", {'captureAmount' => money}, options, 'capture')
         else
@@ -46,7 +46,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def purchase(money, credit_card, options={})
+      def purchase(money, credit_card, options = {})
         response = create_token(true, credit_card.first_name + ' ' + credit_card.last_name, credit_card.month, credit_card.year, credit_card.number, credit_card.verification_value)
         if response.success?
           post = create_post_for_auth_or_purchase(response.authorization, money, options)
@@ -55,18 +55,18 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def refund(money, orderCode, options={})
+      def refund(money, orderCode, options = {})
         obj = money ? {'refundAmount' => money} : {}
         commit(:post, "orders/#{CGI.escape(orderCode)}/refund", obj, options, 'refund')
       end
 
-      def void(orderCode, options={})
+      def void(orderCode, options = {})
         response = commit(:delete, "orders/#{CGI.escape(orderCode)}", nil, options, 'void')
         response = refund(nil, orderCode) if !response.success? && (response.params && response.params['customCode'] != 'ORDER_NOT_FOUND')
         response
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         authorize(0, credit_card, options)
       end
 
@@ -127,7 +127,7 @@ module ActiveMerchant #:nodoc:
         headers
       end
 
-      def commit(method, url, parameters=nil, options = {}, type = false)
+      def commit(method, url, parameters = nil, options = {}, type = false)
         raw_response = response = nil
         success = false
         begin

--- a/lib/active_merchant/billing/gateways/worldpay_us.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_us.rb
@@ -17,12 +17,12 @@ module ActiveMerchant #:nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover jcb]
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :acctid, :subid, :merchantpin)
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_invoice(post, money, options)
         add_payment_method(post, payment_method)
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
         commit('purchase', options, post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         post = {}
         add_invoice(post, money, options)
         add_credit_card(post, payment)
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         commit('authorize', options, post)
       end
 
-      def capture(amount, authorization, options={})
+      def capture(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -49,7 +49,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', options, post)
       end
 
-      def refund(amount, authorization, options={})
+      def refund(amount, authorization, options = {})
         post = {}
         add_invoice(post, amount, options)
         add_reference(post, authorization)
@@ -58,14 +58,14 @@ module ActiveMerchant #:nodoc:
         commit('refund', options, post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         add_reference(post, authorization)
 
         commit('void', options, post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
         @primary_response = nil
       end
 
-      def process(ignore_result=false)
+      def process(ignore_result = false)
         return unless success?
 
         response = yield

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -17,7 +17,7 @@ module ActiveMerchant
       base.send(:attr_accessor, :retry_safe)
     end
 
-    def retry_exceptions(options={})
+    def retry_exceptions(options = {})
       connection_errors = DEFAULT_CONNECTION_ERRORS.merge(options[:connection_exceptions] || {})
 
       retry_network_exceptions(options) do
@@ -34,7 +34,7 @@ module ActiveMerchant
       end
     end
 
-    def self.log(logger, level, message, tag=nil)
+    def self.log(logger, level, message, tag = nil)
       tag ||= self.class.to_s
       message = "[#{tag}] #{message}"
       logger&.send(level, message)

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
       base.class_attribute :proxy_port
     end
 
-    def ssl_get(endpoint, headers={})
+    def ssl_get(endpoint, headers = {})
       ssl_request(:get, endpoint, nil, headers)
     end
 

--- a/test/comm_stub.rb
+++ b/test/comm_stub.rb
@@ -40,7 +40,7 @@ module CommStub
     @last_comm_stub ||= Stub::Complete.new
   end
 
-  def stub_comms(gateway=@gateway, method_to_stub=:ssl_post, &action)
+  def stub_comms(gateway = @gateway, method_to_stub = :ssl_post, &action)
     assert last_comm_stub.complete?, "Tried to stub communications when there's a stub already in progress."
     @last_comm_stub = Stub.new(gateway, method_to_stub, action)
   end

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -1161,7 +1161,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
 
   private
 
-  def auth_assertions(amount, card, options, assertions={})
+  def auth_assertions(amount, card, options, assertions = {})
     # 1: authorize
     assert response = @gateway.authorize(amount, card, options)
     assert_success response
@@ -1183,7 +1183,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def authorize_avs_assertions(credit_card, options, assertions={})
+  def authorize_avs_assertions(credit_card, options, assertions = {})
     assert response = @gateway.authorize(000, credit_card, options)
     assert_equal assertions.key?(:success) ? assertions[:success] : true, response.success?
     assert_equal assertions[:message] || 'Approved', response.message
@@ -1191,7 +1191,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal assertions[:cvv], response.cvv_result['code'], caller.inspect if assertions[:cvv]
   end
 
-  def sale_assertions(amount, card, options, assertions={})
+  def sale_assertions(amount, card, options, assertions = {})
     # 1: sale
     assert response = @gateway.purchase(amount, card, options)
     assert_success response

--- a/test/remote/gateways/remote_mercury_certification_test.rb
+++ b/test/remote/gateways/remote_mercury_certification_test.rb
@@ -105,7 +105,7 @@ class RemoteMercuryCertificationTest < Test::Unit::TestCase
     )
   end
 
-  def options(order_id=nil, other={})
+  def options(order_id = nil, other = {})
     {
       order_id: order_id,
       description: 'ActiveMerchant'

--- a/test/support/mercury_helper.rb
+++ b/test/support/mercury_helper.rb
@@ -46,7 +46,7 @@ module MercuryHelper
 
   private
 
-  def close_batch(gateway=@gateway)
+  def close_batch(gateway = @gateway)
     gateway = ActiveMerchant::Billing::MercuryGateway.new(gateway.options)
     gateway.extend(BatchClosing)
     gateway.close_batch

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,20 +68,20 @@ module ActiveMerchant
     #
     # A message will automatically show the inspection of the response
     # object if things go afoul.
-    def assert_success(response, message=nil)
+    def assert_success(response, message = nil)
       clean_backtrace do
         assert response.success?, build_message(nil, "#{message + "\n" if message}Response expected to succeed: <?>", response)
       end
     end
 
     # The negative of +assert_success+
-    def assert_failure(response, message=nil)
+    def assert_failure(response, message = nil)
       clean_backtrace do
         assert !response.success?, build_message(nil, "#{message + "\n" if message}Response expected to fail: <?>", response)
       end
     end
 
-    def assert_valid(model, message=nil)
+    def assert_valid(model, message = nil)
       errors = model.validate
 
       clean_backtrace do
@@ -101,7 +101,7 @@ module ActiveMerchant
       errors
     end
 
-    def assert_deprecation_warning(message=nil)
+    def assert_deprecation_warning(message = nil)
       ActiveMerchant.expects(:deprecated).with(message || anything)
       yield
     end
@@ -326,15 +326,15 @@ class MockResponse
   attr_reader   :code, :body, :message
   attr_accessor :headers
 
-  def self.succeeded(body, message='')
+  def self.succeeded(body, message = '')
     MockResponse.new(200, body, message)
   end
 
-  def self.failed(body, http_status_code=422, message='')
+  def self.failed(body, http_status_code = 422, message = '')
     MockResponse.new(http_status_code, body, message)
   end
 
-  def initialize(code, body, message='', headers={})
+  def initialize(code, body, message = '', headers = {})
     @code, @body, @message, @headers = code, body, message, headers
   end
 

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -250,7 +250,7 @@ class OppTest < Test::Unit::TestCase
     )
   end
 
-  def failed_response(type, id, code='100.100.101')
+  def failed_response(type, id, code = '100.100.101')
     OppMockResponse.new(400,
       JSON.generate({
         'id' => id,
@@ -274,7 +274,7 @@ class OppTest < Test::Unit::TestCase
     )
   end
 
-  def failed_store_response(id, code='100.100.101')
+  def failed_store_response(id, code = '100.100.101')
     OppMockResponse.new(400,
       JSON.generate({
         'id' => id,

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -113,7 +113,7 @@ class PayboxDirectTest < Test::Unit::TestCase
   private
 
   # Place raw successful response from gateway here
-  def purchase_response(code='00000')
+  def purchase_response(code = '00000')
     "NUMTRANS=0720248861&NUMAPPEL=0713790302&NUMQUESTION=0000790217&SITE=1999888&RANG=99&AUTORISATION=XXXXXX&CODEREPONSE=#{code}&COMMENTAIRE=Demande trait?e avec succ?s ✔漢"
   end
 

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -161,7 +161,7 @@ class PayflowExpressTest < Test::Unit::TestCase
 
   private
 
-  def successful_get_express_details_response(options={street: '111 Main St.'})
+  def successful_get_express_details_response(options = {street: '111 Main St.'})
     <<~RESPONSE
       <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
         <ResponseData>

--- a/test/unit/gateways/payu_in_test.rb
+++ b/test/unit/gateways/payu_in_test.rb
@@ -16,7 +16,7 @@ class PayuInTest < Test::Unit::TestCase
     }
   end
 
-  def assert_parameter(parameter, expected_value, data, options={})
+  def assert_parameter(parameter, expected_value, data, options = {})
     assert (data =~ %r{(?:^|&)#{parameter}=([^&]*)(?:&|$)}), "Unable to find #{parameter} in #{data}"
     value = CGI.unescape($1 || '')
     case expected_value

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -2249,7 +2249,7 @@ class StripeTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def successful_purchase_response(refunded=false)
+  def successful_purchase_response(refunded = false)
     <<-RESPONSE
     {
       "amount": 400,

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -247,7 +247,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   # Place raw successful response from gateway here
-  def successful_purchase_response(refunded=false)
+  def successful_purchase_response(refunded = false)
     <<~RESPONSE
       {
         "id": "ch_test_charge",

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1319,7 +1319,7 @@ class WorldpayTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def successful_refund_inquiry_response(last_event='CAPTURED')
+  def successful_refund_inquiry_response(last_event = 'CAPTURED')
     <<~RESPONSE
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE paymentService PUBLIC "-//Bibit//DTD Bibit PaymentService v1//EN"


### PR DESCRIPTION
Fixes the RuboCop to-do for [Layout/SpaceAroundEqualsInParameterDefault](https://docs.rubocop.org/rubocop/0.85/cops_layout.html#layoutspacearoundequalsinparameterdefault).

All unit tests:
4543 tests, 72248 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed