### PR TITLE
RuboCop: Fix Lint/UnusedMethodArgument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,12 +51,6 @@ Lint/RescueException:
   Exclude:
     - 'lib/active_merchant/billing/gateways/quantum.rb'
 
-# Offense count: 1502
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
-Lint/UnusedBlockArgument:
-  Enabled: false
-
 # Offense count: 284
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Forte: Add service_fee_amount field [meagabeth] #3751
 * WorldPay: Add support for idempotency_key[cdmackeyfree] #3759
 * Orbital: Handle line_tot key as a string [naashton] #3760
+* RuboCop: Fix Lint/UnusedMethodArgument [leila-alderman] #3721
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -75,7 +75,7 @@ module ActiveMerchant
           end
 
           def empty?
-            all? { |k, v| v&.empty? }
+            all? { |_k, v| v&.empty? }
           end
 
           def on(field)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -364,7 +364,7 @@ module ActiveMerchant #:nodoc:
           cvc: credit_card.verification_value
         }
 
-        card.delete_if { |k, v| v.blank? }
+        card.delete_if { |_k, v| v.blank? }
         card[:holderName] ||= 'Not Provided' if credit_card.is_a?(NetworkTokenizationCreditCard)
         requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:card] = card

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -468,7 +468,7 @@ module ActiveMerchant #:nodoc:
         params[:vbvEnabled] = '0'
         params[:scEnabled] = '0'
 
-        params.reject { |k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        params.reject { |_k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
       CURRENCY_CODES['ISK'] = '352'
       CURRENCY_CODES['EUR'] = '978'
       CURRENCY_CODES['USD'] = '840'

--- a/lib/active_merchant/billing/gateways/cardknox.rb
+++ b/lib/active_merchant/billing/gateways/cardknox.rb
@@ -276,7 +276,7 @@ module ActiveMerchant #:nodoc:
           amount:            fields['xAuthAmount'],
           masked_card_num:   fields['xMaskedCardNumber'],
           masked_account_number: fields['MaskedAccountNumber']
-        }.delete_if { |k, v| v.nil? }
+        }.delete_if { |_k, v| v.nil? }
       end
 
       def commit(action, source_type, parameters)
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
         initial_parameters[:Hash] = "s/#{seed}/#{hash}/n" unless @options[:pin].blank?
         parameters = initial_parameters.merge(parameters)
 
-        parameters.reject { |k, v| v.blank? }.collect { |key, value| "x#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |_k, v| v.blank? }.collect { |key, value| "x#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/dibs.rb
+++ b/lib/active_merchant/billing/gateways/dibs.rb
@@ -87,7 +87,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = '840'
       CURRENCY_CODES['DKK'] = '208'
       CURRENCY_CODES['NOK'] = '578'

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
           parse_elements(response, root)
         end
 
-        response.delete_if { |k, v| SENSITIVE_FIELDS.include?(k) }
+        response.delete_if { |k, _v| SENSITIVE_FIELDS.include?(k) }
       end
 
       def parse_elements(response, root)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -439,7 +439,7 @@ module ActiveMerchant #:nodoc:
           parse_elements(response, root)
         end
 
-        response.delete_if { |k, v| SENSITIVE_FIELDS.include?(k) }
+        response.delete_if { |k, _v| SENSITIVE_FIELDS.include?(k) }
       end
 
       def parse_elements(response, root)

--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['NZD'] = '554'
 
       def add_invoice(post, money, options)

--- a/lib/active_merchant/billing/gateways/hdfc.rb
+++ b/lib/active_merchant/billing/gateways/hdfc.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency for HDFC: #{k}") }
       CURRENCY_CODES['AED'] = '784'
       CURRENCY_CODES['AUD'] = '036'
       CURRENCY_CODES['CAD'] = '124'

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -481,7 +481,7 @@ module ActiveMerchant #:nodoc:
         attributes[:id] = truncate(options[:id] || options[:order_id], 24)
         attributes[:reportGroup] = options[:merchant] || 'Default Report Group'
         attributes[:customerId] = options[:customer]
-        attributes.delete_if { |key, value| value == nil }
+        attributes.delete_if { |_key, value| value == nil }
         attributes
       end
 

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -275,7 +275,7 @@ module ActiveMerchant #:nodoc:
         parsed_response_body = parse(error.response.body)
         message = parsed_response_body['message']
 
-        parsed_response_body['errors']&.each do |type, descriptions|
+        parsed_response_body['errors']&.each do |_type, descriptions|
           message += ' | '
           message += descriptions.join(', ')
         end
@@ -291,7 +291,7 @@ module ActiveMerchant #:nodoc:
         error_string = ''
 
         response['last_transaction']['gateway_response']['errors']&.each do |error|
-          error.each do |key, value|
+          error.each do |_key, value|
             error_string += ' | ' unless error_string.blank?
             error_string += value
           end

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -223,7 +223,7 @@ module ActiveMerchant #:nodoc:
         parameters[:pay_type] = 'C'
         parameters[:tran_type] = TRANSACTIONS[action]
 
-        parameters.reject { |k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |_k, v| v.blank? }.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -432,9 +432,9 @@ module ActiveMerchant #:nodoc:
             raise "Unknown signature algorithm #{algorithm}"
           end
 
-        filtered_params = signed_parameters.select { |k, v| !v.blank? }
+        filtered_params = signed_parameters.select { |_k, v| !v.blank? }
         sha_encryptor.hexdigest(
-          filtered_params.sort_by { |k, v| k.upcase }.map { |k, v| "#{k.upcase}=#{v}#{secret}" }.join('')
+          filtered_params.sort_by { |k, _v| k.upcase }.map { |k, v| "#{k.upcase}=#{v}#{secret}" }.join('')
         ).upcase
       end
 

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -367,7 +367,7 @@ module ActiveMerchant #:nodoc:
         params[:version] = API_VERSION
         params[:transaction_type] = action
 
-        params.reject { |k, v| v.blank? }.collect { |k, v| "dc_#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        params.reject { |_k, v| v.blank? }.collect { |k, v| "dc_#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -104,7 +104,7 @@ module ActiveMerchant #:nodoc:
         parameters[:merchant_id]      = @options[:login]
         parameters[:password]         = @options[:password]
 
-        parameters.reject { |k, v| v.blank? }.collect { |key, value| "#{key.to_s.upcase}=#{CGI.escape(value.to_s)}" }.join('&')
+        parameters.reject { |_k, v| v.blank? }.collect { |key, value| "#{key.to_s.upcase}=#{CGI.escape(value.to_s)}" }.join('&')
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/paybox_direct.rb
+++ b/lib/active_merchant/billing/gateways/paybox_direct.rb
@@ -160,7 +160,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response[:numappel].to_s + response[:numtrans].to_s,
           fraud_review: false,
-          sent_params: parameters.delete_if { |key, value| %w[porteur dateval cvv].include?(key.to_s) }
+          sent_params: parameters.delete_if { |key, _value| %w[porteur dateval cvv].include?(key.to_s) }
         )
       end
 

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -306,7 +306,7 @@ module ActiveMerchant
       def post_data(params)
         return nil unless params
 
-        params.reject { |k, v| v.blank? }.collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        params.reject { |_k, v| v.blank? }.collect { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
       end
 
       def generate_hmac(nonce, current_timestamp, payload)

--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -198,7 +198,7 @@ module ActiveMerchant #:nodoc:
       def post_data(params)
         return nil unless params
 
-        no_blanks = params.reject { |key, value| value.blank? }
+        no_blanks = params.reject { |_key, value| value.blank? }
         no_blanks.map { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
       end
 

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['AUD'] = 'AUD'
       CURRENCY_CODES['INR'] = 'INR'
 

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -322,7 +322,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = '840'
 
       def headers

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -310,7 +310,7 @@ module ActiveMerchant #:nodoc:
           error_code: fields['UMerrorcode'],
           acs_url: fields['UMacsurl'],
           payload: fields['UMpayload']
-        }.delete_if { |k, v| v.nil? }
+        }.delete_if { |_k, v| v.nil? }
       end
 
       def commit(action, parameters)

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -85,7 +85,7 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      CURRENCY_CODES = Hash.new { |h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
+      CURRENCY_CODES = Hash.new { |_h, k| raise ArgumentError.new("Unsupported currency: #{k}") }
       CURRENCY_CODES['USD'] = 840
       CURRENCY_CODES['PEN'] = 604
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -687,7 +687,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def order_id_from(raw)
-        pair = raw.detect { |k, v| k.to_s =~ /_order_code$/ }
+        pair = raw.detect { |k, _v| k.to_s =~ /_order_code$/ }
         (pair ? pair.last : nil)
       end
 

--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
 
     def initialize(options = {})
       @name = options.delete(:name)
-      @codes = options.collect { |k, v| CountryCode.new(v) }
+      @codes = options.collect { |_k, v| CountryCode.new(v) }
     end
 
     def code(format)

--- a/test/remote/gateways/remote_paystation_test.rb
+++ b/test/remote/gateways/remote_paystation_test.rb
@@ -38,7 +38,7 @@ class RemotePaystationTest < Test::Unit::TestCase
       ['invalid_transaction', @invalid_transaction_amount, 'Transaction Type Not Supported'],
       ['expired_card', @expired_card_amount, 'Expired Card'],
       ['bank_error', @bank_error_amount, 'Error Communicating with Bank']
-    ].each do |name, amount, message|
+    ].each do |_name, amount, message|
       assert response = @gateway.purchase(amount, @credit_card, @options)
       assert_failure response
       assert_equal message, response.message

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -293,7 +293,7 @@ module ActiveMerchant
       return unless hash.is_a?(Hash)
 
       hash.symbolize_keys!
-      hash.each { |k, v| symbolize_keys(v) }
+      hash.each { |_k, v| symbolize_keys(v) }
     end
   end
 end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -154,7 +154,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_authorize_with_recurring_contract_type
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_authorize_response)
   end
@@ -178,7 +178,7 @@ class AdyenTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds1_standalone)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal eci, JSON.parse(data)['mpiData']['eci']
       assert_equal cavv, JSON.parse(data)['mpiData']['cavv']
       assert_equal cavv_algorithm, JSON.parse(data)['mpiData']['cavvAlgorithm']
@@ -207,7 +207,7 @@ class AdyenTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds2_standalone)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal version, JSON.parse(data)['mpiData']['threeDSVersion']
       assert_equal eci, JSON.parse(data)['mpiData']['eci']
       assert_equal cavv, JSON.parse(data)['mpiData']['cavv']
@@ -298,7 +298,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_maestro_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       if /authorise/.match?(endpoint)
         assert_match(/"overwriteBrand":true/, data)
         assert_match(/"selectedBrand":"maestro"/, data)
@@ -312,7 +312,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_3ds_2_fields_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       data = JSON.parse(data)
       assert_equal 'browser', data['threeDS2RequestData']['deviceChannel']
       assert_equal 'unknown', data['browserInfo']['acceptHeader']
@@ -329,7 +329,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_installments_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 2, JSON.parse(data)['installments']['value']
     end.respond_with(successful_authorize_response)
   end
@@ -337,7 +337,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_capture_delay_hours_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({capture_delay_hours: 4}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 4, JSON.parse(data)['captureDelayHours']
     end.respond_with(successful_authorize_response)
   end
@@ -345,7 +345,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_custom_routing_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({custom_routing_flag: 'abcdefg'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'abcdefg', JSON.parse(data)['additionalData']['customRoutingFlag']
     end.respond_with(successful_authorize_response)
   end
@@ -371,7 +371,7 @@ class AdyenTest < Test::Unit::TestCase
     options = @options.merge({ splits: split_data })
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal split_data, JSON.parse(data)['splits']
     end.respond_with(successful_authorize_response)
   end
@@ -379,7 +379,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_execute_threed_false_with_additional_data
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({execute_threed: false, overwrite_brand: true, selected_brand: 'maestro'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"additionalData":{"overwriteBrand":true,"executeThreeD":false}/, data)
       assert_match(/"selectedBrand":"maestro"/, data)
     end.respond_with(successful_authorize_response)
@@ -388,7 +388,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       assert_false JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -397,7 +397,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_if_execute_threed_missing_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({scaExemption: 'lowValue'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       refute JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -406,7 +406,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_sca_exemption_and_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'lowValue', JSON.parse(data)['additionalData']['scaExemption']
       assert_false JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -415,7 +415,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_sca_exemption_and_execute_threed_true_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'lowValue', JSON.parse(data)['additionalData']['scaExemption']
       assert JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -424,7 +424,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_when_execute_threed_true_3ds1
     stub_comms do
       @gateway.authorize(@amount, '123', @options.merge({sca_exemption: 'lowValue', execute_threed: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       assert JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -433,7 +433,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_when_execute_threed_false_3ds1
     stub_comms do
       @gateway.authorize(@amount, '123', @options.merge({sca_exemption: 'lowValue', execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       refute JSON.parse(data)['additionalData']['executeThreeD']
     end.respond_with(successful_authorize_response)
@@ -442,7 +442,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_update_shopper_statement_and_industry_usage_sent
     stub_comms do
       @gateway.adjust(@amount, '123', @options.merge({update_shopper_statement: 'statement note', industry_usage: 'DelayedCharge'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'statement note', JSON.parse(data)['additionalData']['updateShopperStatement']
       assert_equal 'DelayedCharge', JSON.parse(data)['additionalData']['industryUsage']
     end.respond_with(successful_adjust_response)
@@ -451,7 +451,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_risk_data_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({risk_data: {'operatingSystem' => 'HAL9000'}}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'HAL9000', JSON.parse(data)['additionalData']['riskdata.operatingSystem']
     end.respond_with(successful_authorize_response)
   end
@@ -464,7 +464,7 @@ class AdyenTest < Test::Unit::TestCase
         'promotions.promotion.promotionName' => 'Big Sale promotion'
       }
       @gateway.authorize(@amount, @credit_card, @options.merge({risk_data: risk_data}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal 'express', parsed['additionalData']['riskdata.deliveryMethod']
       assert_equal 'Blue T Shirt', parsed['additionalData']['riskdata.basket.item.productTitle']
@@ -476,7 +476,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"Ecommerce"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
     end.respond_with(successful_authorize_response)
@@ -489,7 +489,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
     end.respond_with(successful_authorize_response)
@@ -501,7 +501,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
     end.respond_with(successful_authorize_response)
@@ -514,7 +514,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
     end.respond_with(successful_authorize_response)
@@ -526,7 +526,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"Ecommerce"/, data)
       assert_match(/"recurringProcessingModel":"CardOnFile"/, data)
     end.respond_with(successful_authorize_response)
@@ -539,7 +539,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"CardOnFile"/, data)
     end.respond_with(successful_authorize_response)
@@ -551,7 +551,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"UnscheduledCardOnFile"/, data)
     end.respond_with(successful_authorize_response)
@@ -564,7 +564,7 @@ class AdyenTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"UnscheduledCardOnFile"/, data)
     end.respond_with(successful_authorize_response)
@@ -575,13 +575,13 @@ class AdyenTest < Test::Unit::TestCase
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"amount\":{\"value\":\"2\",\"currency\":\"JPY\"}/, data)
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(200, @credit_card, @options.merge(currency: 'CLP'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"amount\":{\"value\":\"200\",\"currency\":\"CLP\"}/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -665,7 +665,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_tokenize_only_store
     response = stub_comms do
       @gateway.store(@credit_card, @options.merge({tokenize_only: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
     end.respond_with(successful_store_response)
     assert_equal '#8835205392522157#', response.authorization
@@ -674,7 +674,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
     end.respond_with(successful_store_response)
     assert_success response
@@ -684,7 +684,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_store_with_recurring_contract_type
     stub_comms do
       @gateway.store(@credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_store_response)
   end
@@ -692,7 +692,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_recurring_contract_type_set_for_reference_purchase
     stub_comms do
       @gateway.store('123', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'RECURRING', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_store_response)
   end
@@ -801,7 +801,7 @@ class AdyenTest < Test::Unit::TestCase
     @apple_pay_card.last_name = nil
     response = stub_comms do
       @gateway.authorize(@amount, @apple_pay_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'Not Provided', JSON.parse(data)['card']['holderName']
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -810,7 +810,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_authorize_with_network_tokenization_credit_card
     response = stub_comms do
       @gateway.authorize(@amount, @apple_pay_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal 'YwAAAAAABaYcCMX/OhNRQAAAAAA=', parsed['mpiData']['cavv']
       assert_equal '07', parsed['mpiData']['eci']
@@ -822,7 +822,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_authorize_with_sub_merchant_id
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(sub_merchant_id: '12345abcde67890'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert parsed['additionalData']['subMerchantId']
     end.respond_with(successful_authorize_response)
@@ -840,7 +840,7 @@ class AdyenTest < Test::Unit::TestCase
     options = @options.merge(idempotency_key: 'test123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert headers['Idempotency-Key']
     end.respond_with(successful_authorize_response)
     assert_success response

--- a/test/unit/gateways/allied_wallet_test.rb
+++ b/test/unit/gateways/allied_wallet_test.rb
@@ -78,7 +78,7 @@ class AlliedWalletTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/123456/, data)
     end.respond_with(successful_void_response)
 
@@ -88,7 +88,7 @@ class AlliedWalletTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
 
@@ -105,7 +105,7 @@ class AlliedWalletTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/123456/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -434,7 +434,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           }
         }
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<cardNumber>XXXX4242</cardNumber>}, data
     end.respond_with(successful_update_customer_payment_profile_response)
 
@@ -602,7 +602,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
           recurring_billing: true
         }
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<recurringBilling>true</recurringBilling>}, data
     end.respond_with(successful_create_customer_profile_transaction_response(:auth_capture))
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -76,7 +76,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card.track_data = BAD_TRACK_DATA
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_nil doc.at_xpath('//track1')
         assert_nil doc.at_xpath('//track2')
@@ -89,7 +89,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card.track_data = TRACK1_DATA
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal '%B378282246310005^LONGSON/LONGBOB^1705101130504392?', doc.at_xpath('//track1').content
         assert_nil doc.at_xpath('//track2')
@@ -102,7 +102,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card.track_data = TRACK2_DATA
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_nil doc.at_xpath('//track1')
         assert_equal ';4111111111111111=1803101000020000831?', doc.at_xpath('//track2').content
@@ -116,7 +116,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       @credit_card.track_data = track
       stub_comms do
         @gateway.purchase(@amount, @credit_card)
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         parse(data) do |doc|
           assert_nil doc.at_xpath('//retail')
         end
@@ -127,7 +127,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       @credit_card.track_data = track
       stub_comms do
         @gateway.purchase(@amount, @credit_card)
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         parse(data) do |doc|
           assert_not_nil doc.at_xpath('//retail')
           assert_equal '2', doc.at_xpath('//retail/marketType').content
@@ -142,7 +142,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       @credit_card.track_data = track
       stub_comms do
         @gateway.purchase(@amount, @credit_card, {device_type: 1})
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         parse(data) do |doc|
           assert_not_nil doc.at_xpath('//retail')
           assert_equal '2', doc.at_xpath('//retail/marketType').content
@@ -156,7 +156,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     [@check, @apple_pay_payment_token].each do |payment|
       stub_comms do
         @gateway.purchase(@amount, payment)
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         parse(data) do |doc|
           assert_nil doc.at_xpath('//retail')
         end
@@ -168,7 +168,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card.manual_entry = true
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//retail')
         assert_equal '1', doc.at_xpath('//retail/marketType').content
@@ -179,7 +179,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_market_type_can_be_specified
     stub_comms do
       @gateway.purchase(@amount, @credit_card, market_type: 0)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal '0', doc.at_xpath('//retail/marketType').content
       end
@@ -189,7 +189,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_echeck_authorization
     response = stub_comms do
       @gateway.authorize(@amount, @check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//payment/bankAccount')
         assert_equal '244183602', doc.at_xpath('//routingNumber').content
@@ -210,7 +210,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_echeck_purchase_with_checking_account_type
     response = stub_comms do
       @gateway.purchase(@amount, @check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//payment/bankAccount')
         assert_equal 'checking', doc.at_xpath('//accountType').content
@@ -233,7 +233,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     savings_account = check(account_type: 'savings')
     response = stub_comms do
       @gateway.purchase(@amount, savings_account)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//payment/bankAccount')
         assert_equal 'savings', doc.at_xpath('//accountType').content
@@ -249,7 +249,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_echeck_passing_recurring_flag
     response = stub_comms do
       @gateway.purchase(@amount, @check, recurring: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal settings_from_doc(parse(data))['recurringBilling'], 'true'
     end.respond_with(successful_purchase_response)
 
@@ -266,7 +266,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_apple_pay_authorization
     response = stub_comms do
       @gateway.authorize(@amount, @apple_pay_payment_token)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal @gateway.class::APPLE_PAY_DATA_DESCRIPTOR, doc.at_xpath('//opaqueData/dataDescriptor').content
         assert_equal Base64.strict_encode64(@apple_pay_payment_token.payment_data.to_json), doc.at_xpath('//opaqueData/dataValue').content
@@ -282,7 +282,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_apple_pay_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @apple_pay_payment_token)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal @gateway.class::APPLE_PAY_DATA_DESCRIPTOR, doc.at_xpath('//opaqueData/dataDescriptor').content
         assert_equal Base64.strict_encode64(@apple_pay_payment_token.payment_data.to_json), doc.at_xpath('//opaqueData/dataValue').content
@@ -328,7 +328,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_purchase_with_utf_character
     stub_comms do
       @gateway.purchase(@amount, credit_card('4000100011112224', last_name: 'Wåhlin'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Wåhlin/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -336,7 +336,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_partial_auth
     stub_comms do
       @gateway.purchase(@amount, credit_card, disable_partial_auth: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<settingName>allowPartialAuth<\/settingName>/, data)
       assert_match(/<settingValue>false<\/settingValue>/, data)
     end.respond_with(successful_purchase_response)
@@ -345,14 +345,14 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_email_customer
     stub_comms do
       @gateway.purchase(@amount, credit_card, email_customer: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<settingName>emailCustomer<\/settingName>/, data)
       assert_match(/<settingValue>true<\/settingValue>/, data)
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.purchase(@amount, credit_card, email_customer: false)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<settingName>emailCustomer<\/settingName>/, data)
       assert_match(/<settingValue>false<\/settingValue>/, data)
     end.respond_with(successful_purchase_response)
@@ -361,7 +361,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_header_email_receipt
     stub_comms do
       @gateway.purchase(@amount, credit_card, header_email_receipt: 'yet another field')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<settingName>headerEmailReceipt<\/settingName>/, data)
       assert_match(/<settingValue>yet another field<\/settingValue>/, data)
     end.respond_with(successful_purchase_response)
@@ -370,7 +370,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_level_3_options
     stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(@level_3_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<order>/, data)
       assert_match(/<summaryCommodityCode>#{@level_3_options[:summary_commodity_code]}<\/summaryCommodityCode>/, data)
       assert_match(/<\/order>/, data)
@@ -384,7 +384,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_line_items
     stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(@additional_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<lineItems>/, data)
       assert_match(/<lineItem>/, data)
       assert_match(/<itemId>#{@additional_options[:line_items][0][:item_id]}<\/itemId>/, data)
@@ -405,7 +405,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_passes_level_3_line_items
     stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(@level_3_line_item_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<lineItems>/, data)
       assert_match(/<lineItem>/, data)
       assert_match(/<itemId>#{@level_3_line_item_options[:line_items][0][:item_id]}<\/itemId>/, data)
@@ -710,7 +710,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_unstore
     response = stub_comms do
       @gateway.unstore('35959426#32506918#cim_store')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert_equal '35959426', doc.at_xpath('//deleteCustomerProfileRequest/customerProfileId').content
     end.respond_with(successful_unstore_response)
@@ -751,7 +751,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address
     stub_comms do
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'CO', doc.at_xpath('//billTo/state').content, data
         assert_equal '164 Waverley Street', doc.at_xpath('//billTo/address').content, data
@@ -765,7 +765,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address_with_empty_billing_address
     stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal '', doc.at_xpath('//billTo/address').content, data
         assert_equal '', doc.at_xpath('//billTo/city').content, data
@@ -779,7 +779,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address_with_address2_present
     stub_comms do
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', address2: 'Apt 1234', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'CO', doc.at_xpath('//billTo/state').content, data
         assert_equal '164 Waverley Street Apt 1234', doc.at_xpath('//billTo/address').content, data
@@ -793,7 +793,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address_north_america_with_defaults
     stub_comms do
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'NC', doc.at_xpath('//billTo/state').content, data
         assert_equal '164 Waverley Street', doc.at_xpath('//billTo/address').content, data
@@ -805,7 +805,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address_outsite_north_america
     stub_comms do
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'DE'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'n/a', doc.at_xpath('//billTo/state').content, data
         assert_equal '164 Waverley Street', doc.at_xpath('//billTo/address').content, data
@@ -817,7 +817,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_address_outsite_north_america_with_address2_present
     stub_comms do
       @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', address2: 'Apt 1234', country: 'DE'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'n/a', doc.at_xpath('//billTo/state').content, data
         assert_equal '164 Waverley Street Apt 1234', doc.at_xpath('//billTo/address').content, data
@@ -829,7 +829,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_duplicate_window
     stub_comms do
       @gateway.purchase(@amount, @credit_card, duplicate_window: 0)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal settings_from_doc(parse(data))['duplicateWindow'], '0'
     end.respond_with(successful_purchase_response)
   end
@@ -848,7 +848,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_add_cardholder_authentication_value
     stub_comms do
       @gateway.purchase(@amount, @credit_card, cardholder_authentication_value: 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', authentication_indicator: '2')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', doc.at_xpath('//cardholderAuthentication/cardholderAuthenticationValue').content
         assert_equal '2', doc.at_xpath('//cardholderAuthentication/authenticationIndicator').content
@@ -861,7 +861,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     three_d_secure_opts = { cavv: 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', eci: '2' }
     stub_comms do
       @gateway.purchase(@amount, @credit_card, three_d_secure: three_d_secure_opts)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', doc.at_xpath('//cardholderAuthentication/cardholderAuthenticationValue').content
         assert_equal '2', doc.at_xpath('//cardholderAuthentication/authenticationIndicator').content
@@ -880,7 +880,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
         authentication_indicator: '2',
         three_d_secure: three_d_secure_opts
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'E0Mvq8AAABEiMwARIjNEVWZ3iJk=', doc.at_xpath('//cardholderAuthentication/cardholderAuthenticationValue').content
         assert_equal '2', doc.at_xpath('//cardholderAuthentication/authenticationIndicator').content
@@ -892,7 +892,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_capture_passing_extra_info
     response = stub_comms do
       @gateway.capture(50, '123456789', description: 'Yo', order_id: 'Sweetness')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//order/description'), data
         assert_equal 'Yo', doc.at_xpath('//order/description').content, data
@@ -915,7 +915,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_successful_bank_refund
     response = stub_comms do
       @gateway.refund(50, '12345667', account_type: 'checking', routing_number: '123450987', account_number: '12345667', first_name: 'Louise', last_name: 'Belcher')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'checking', doc.at_xpath('//transactionRequest/payment/bankAccount/accountType').content
         assert_equal '123450987', doc.at_xpath('//transactionRequest/payment/bankAccount/routingNumber').content
@@ -929,7 +929,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_refund_passing_extra_info
     response = stub_comms do
       @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', order_id: '1', description: 'Refund for order 1')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'Bob', doc.at_xpath('//billTo/firstName').content, data
         assert_equal 'Smith', doc.at_xpath('//billTo/lastName').content, data
@@ -1037,7 +1037,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @gateway.class.application_id = 'A1000000'
     stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert_equal 'A1000000', fields_from_doc(doc)['x_solution_id'], data
       assert_equal '1.00', doc.at_xpath('//transactionRequest/amount').content
@@ -1060,7 +1060,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_include_cust_id_for_numeric_values
     stub_comms do
       @gateway.purchase(@amount, @credit_card, customer: '123')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//customer/id'), data
         assert_equal '123', doc.at_xpath('//customer/id').content, data
@@ -1072,7 +1072,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_include_cust_id_for_word_character_values
     stub_comms do
       @gateway.purchase(@amount, @credit_card, customer: '4840_TT')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil doc.at_xpath('//customer/id'), data
         assert_equal '4840_TT', doc.at_xpath('//customer/id').content, data
@@ -1084,7 +1084,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_dont_include_cust_id_for_email_addresses
     stub_comms do
       @gateway.purchase(@amount, @credit_card, customer: 'bob@test.com')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert !doc.at_xpath('//customer/id'), data
       assert_equal '1.00', doc.at_xpath('//transactionRequest/amount').content
@@ -1094,7 +1094,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_dont_include_cust_id_for_phone_numbers
     stub_comms do
       @gateway.purchase(@amount, @credit_card, customer: '111-123-1231')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert !doc.at_xpath('//customer/id'), data
       assert_equal '1.00', doc.at_xpath('//transactionRequest/amount').content
@@ -1114,7 +1114,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'billing', doc.at_xpath('//billTo/firstName').text
         assert_equal 'name', doc.at_xpath('//billTo/lastName').text
@@ -1139,7 +1139,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'billing', doc.at_xpath('//billTo/firstName').text
         assert_equal 'name', doc.at_xpath('//billTo/lastName').text
@@ -1179,7 +1179,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_truncated(data, 20, '//refId')
       assert_truncated(data, 255, '//description')
       assert_address_truncated(data, 50, 'firstName')
@@ -1199,7 +1199,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
       card = credit_card(@credit_card.number, { verification_value: cvv })
       stub_comms do
         @gateway.purchase(@amount, card)
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         parse(data) { |doc| assert_nil doc.at_xpath('//cardCode') }
       end.respond_with(successful_purchase_response)
     end
@@ -1209,7 +1209,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     card = credit_card(@credit_card.number + '0123456789')
     stub_comms do
       @gateway.purchase(@amount, card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal @credit_card.number, doc.at_xpath('//cardNumber').text
       end
@@ -1231,7 +1231,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal credit_card.payment_cryptogram, doc.at_xpath('//creditCard/cryptogram').content
         assert_equal credit_card.number, doc.at_xpath('//creditCard/cardNumber').content
@@ -1251,7 +1251,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal credit_card.payment_cryptogram, doc.at_xpath('//creditCard/cryptogram').content
         assert_equal credit_card.number, doc.at_xpath('//creditCard/cardNumber').content
@@ -1264,7 +1264,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_supports_network_tokenization_true
     response = stub_comms do
       @gateway.supports_network_tokenization?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'authOnlyTransaction', doc.at_xpath('//transactionType').content
         assert_equal '0.01', doc.at_xpath('//amount').content
@@ -1279,7 +1279,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_supports_network_tokenization_false
     response = stub_comms do
       @gateway.supports_network_tokenization?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'authOnlyTransaction', doc.at_xpath('//transactionType').content
         assert_equal '0.01', doc.at_xpath('//amount').content

--- a/test/unit/gateways/axcessms_test.rb
+++ b/test/unit/gateways/axcessms_test.rb
@@ -112,7 +112,7 @@ class AxcessmsTest < Test::Unit::TestCase
   def test_authorize_using_reference_sets_proper_elements
     stub_comms do
       @gateway.authorize(@amount, 'MY_AUTHORIZE_VALUE', @options)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xpath_text(body, '//ReferenceID', 'MY_AUTHORIZE_VALUE')
       assert_no_match(/<Account>/, body)
     end.respond_with(successful_authorize_response)
@@ -121,7 +121,7 @@ class AxcessmsTest < Test::Unit::TestCase
   def test_purchase_using_reference_sets_proper_elements
     stub_comms do
       @gateway.purchase(@amount, 'MY_AUTHORIZE_VALUE', @options)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xpath_text(body, '//ReferenceID', 'MY_AUTHORIZE_VALUE')
       assert_no_match(/<Account>/, body)
     end.respond_with(successful_authorize_response)
@@ -130,7 +130,7 @@ class AxcessmsTest < Test::Unit::TestCase
   def test_setting_mode_sets_proper_element
     stub_comms do
       @gateway.purchase(@amount, 'MY_AUTHORIZE_VALUE', {mode: 'CRAZY_TEST_MODE'})
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xpath_text(body, '//Transaction/@mode', 'CRAZY_TEST_MODE')
     end.respond_with(successful_authorize_response)
   end
@@ -138,7 +138,7 @@ class AxcessmsTest < Test::Unit::TestCase
   def test_defaults_to_integrator_test
     stub_comms do
       @gateway.purchase(@amount, 'MY_AUTHORIZE_VALUE', {})
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xpath_text(body, '//Transaction/@mode', 'INTEGRATOR_TEST')
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/balanced_test.rb
+++ b/test/unit/gateways/balanced_test.rb
@@ -33,7 +33,7 @@ class BalancedTest < Test::Unit::TestCase
   def test_successful_purchase_with_outside_token
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, '/cards/CCVOX2d7Ar6Ze5TOxHsebeH', @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_equal('https://api.balancedpayments.com/cards/CCVOX2d7Ar6Ze5TOxHsebeH/debits', endpoint)
     end.respond_with(debits_response)
 
@@ -221,7 +221,7 @@ class BalancedTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, legacy_outside_token, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_equal('https://api.balancedpayments.com/cards/CC7m1Mtqk6rVJo5tcD1qitAC/debits', endpoint)
     end.respond_with(debits_response)
 
@@ -237,7 +237,7 @@ class BalancedTest < Test::Unit::TestCase
     [v1_authorization, v11_authorization].each do |authorization|
       stub_comms(@gateway, :ssl_request) do
         @gateway.capture(@amount, authorization)
-      end.check_request do |method, endpoint, data, headers|
+      end.check_request do |_method, endpoint, _data, _headers|
         assert_equal('https://api.balancedpayments.com/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5/debits', endpoint)
       end.respond_with(authorized_debits_response)
     end
@@ -250,7 +250,7 @@ class BalancedTest < Test::Unit::TestCase
     [v1_authorization, v11_authorization].each do |authorization|
       stub_comms(@gateway, :ssl_request) do
         @gateway.void(authorization)
-      end.check_request do |method, endpoint, data, headers|
+      end.check_request do |method, endpoint, data, _headers|
         assert_equal :put, method
         assert_equal('https://api.balancedpayments.com/card_holds/HL7dYMhpVBcqAYqxLF5mZtQ5', endpoint)
         assert_match %r{\bis_void=true\b}, data
@@ -265,7 +265,7 @@ class BalancedTest < Test::Unit::TestCase
     [v1_authorization, v11_authorization].each do |authorization|
       stub_comms(@gateway, :ssl_request) do
         @gateway.refund(nil, authorization)
-      end.check_request do |method, endpoint, data, headers|
+      end.check_request do |_method, endpoint, _data, _headers|
         assert_equal('https://api.balancedpayments.com/debits/WD2x6vLS7RzHYEcdymqRyNAO/refunds', endpoint)
       end.respond_with(refunds_response)
     end
@@ -275,7 +275,7 @@ class BalancedTest < Test::Unit::TestCase
     a = address
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: a)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, data, _headers|
       next if endpoint =~ /debits/
 
       clean = proc { |s| Regexp.escape(CGI.escape(s)) }
@@ -293,7 +293,7 @@ class BalancedTest < Test::Unit::TestCase
   def test_passing_address_without_zip
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: address(zip: nil))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, data, _headers|
       next if endpoint =~ /debits/
 
       assert_no_match(%r{address}, data)
@@ -305,7 +305,7 @@ class BalancedTest < Test::Unit::TestCase
   def test_passing_address_with_blank_zip
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, address: address(zip: '   '))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, data, _headers|
       next if endpoint =~ /debits/
 
       assert_no_match(%r{address}, data)

--- a/test/unit/gateways/bambora_apac_test.rb
+++ b/test/unit/gateways/bambora_apac_test.rb
@@ -16,7 +16,7 @@ class BamboraApacTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSinglePayment }, data)
       assert_match(%r{<UserName>username<}, data)
       assert_match(%r{<Password>password<}, data)
@@ -48,7 +48,7 @@ class BamboraApacTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSinglePayment }, data)
       assert_match(%r{<CustRef>1<}, data)
       assert_match(%r{<TrnType>2<}, data)
@@ -61,7 +61,7 @@ class BamboraApacTest < Test::Unit::TestCase
   def test_successful_capture
     response = stub_comms do
       @gateway.capture(@amount, 'receipt')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSingleCapture }, data)
       assert_match(%r{<Receipt>receipt<}, data)
       assert_match(%r{<Amount>100<}, data)
@@ -73,7 +73,7 @@ class BamboraApacTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, 'receipt')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSingleRefund }, data)
       assert_match(%r{<Receipt>receipt<}, data)
       assert_match(%r{<Amount>100<}, data)
@@ -85,7 +85,7 @@ class BamboraApacTest < Test::Unit::TestCase
   def test_successful_void
     response = stub_comms do
       @gateway.void('receipt', amount: 200)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSingleVoid }, data)
       assert_match(%r{<Amount>200<}, data)
     end.respond_with(successful_void_response)

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -65,7 +65,7 @@ class BanwireTest < Test::Unit::TestCase
   def test_successful_amex_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @amex_credit_card, @amex_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/post_code=11560/, data)
     end.respond_with(successful_purchase_amex_response)
 

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -140,7 +140,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_successful_authorize_with_alternate_address
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options_with_alternate_address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/billingAddress.houseNumberOrName=%E6%96%B0%E5%8C%97%E5%B8%82%E5%BA%97%E6%BA%AA%E8%B7%AF3579%E8%99%9F139%E6%A8%93/, data)
       assert_match(/billingAddress.street=Not\+Provided/, data)
     end.respond_with(successful_authorize_response)
@@ -155,7 +155,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       @gateway.authorize(@amount,
         @credit_card,
         @options_with_house_number_and_street)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)
     end.respond_with(successful_authorize_response)
@@ -170,7 +170,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       @gateway.authorize(@amount,
         @credit_card,
         @options_with_shipping_house_number_and_shipping_street)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)
       assert_match(/deliveryAddress.street=Downtown\+Loop/, data)
@@ -197,7 +197,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
           shopper_statement: shopper_statement
         )
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/shopperInteraction=#{shopper_interaction}/, data)
       assert_match(/shopperStatement=#{Regexp.quote(CGI.escape(shopper_statement))}/, data)
       assert_match(/deviceFingerprint=#{device_fingerprint}/, data)
@@ -268,7 +268,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_legacy_capture_psp_reference_passed_for_refund
     response = stub_comms do
       @gateway.refund(@amount, '8814002632606717', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/originalReference=8814002632606717/, data)
     end.respond_with(successful_refund_response)
 
@@ -279,7 +279,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '7914002629995504#8814002632606717', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/originalReference=7914002629995504&/, data)
       assert_no_match(/8814002632606717/, data)
     end.respond_with(successful_refund_response)
@@ -314,7 +314,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_credit_contains_all_fields
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options_with_credit_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match(%r{/refundWithData}, endpoint)
       assert_match(/dateOfBirth=1990-10-11&/, data)
       assert_match(/entityType=NaturalPerson&/, data)
@@ -329,7 +329,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_successful_third_party_payout
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({third_party_payout: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       if /storeDetailAndSubmitThirdParty/.match?(endpoint)
         assert_match(%r{/storeDetailAndSubmitThirdParty}, endpoint)
         assert_match(/dateOfBirth=1990-10-11&/, data)
@@ -372,7 +372,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_authorize_nonfractional_currency
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/amount.value=1/, data)
       assert_match(/amount.currency=JPY/, data)
     end.respond_with(successful_authorize_response)
@@ -383,7 +383,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_authorize_three_decimal_currency
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(currency: 'OMR'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/amount.value=100/, data)
       assert_match(/amount.currency=OMR/, data)
     end.respond_with(successful_authorize_response)
@@ -409,7 +409,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       assert_match(/additionalData.executeThreeD=false/, data)
     end.respond_with(successful_authorize_response)
@@ -418,7 +418,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_if_execute_threed_missing_3ds2
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({scaExemption: 'lowValue'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       refute_match(/additionalData.executeThreeD=false/, data)
     end.respond_with(successful_authorize_response)
@@ -427,7 +427,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_sca_exemption_and_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/additionalData.scaExemption=lowValue/, data)
       assert_match(/additionalData.executeThreeD=false/, data)
     end.respond_with(successful_authorize_response)
@@ -436,7 +436,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_sca_exemption_and_execute_threed_true_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/additionalData.scaExemption=lowValue/, data)
       assert_match(/additionalData.executeThreeD=true/, data)
     end.respond_with(successful_authorize_response)
@@ -445,7 +445,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_when_execute_threed_true_3ds1
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({sca_exemption: 'lowValue', execute_threed: true}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       assert_match(/additionalData.executeThreeD=true/, data)
     end.respond_with(successful_authorize_response)
@@ -454,7 +454,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
   def test_sca_exemption_not_sent_when_execute_threed_false_3ds1
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({sca_exemption: 'lowValue', execute_threed: false}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       refute_match(/additionalData.executeThreeD/, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -60,7 +60,7 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/recurringPayment=true/, data)
     end.respond_with(successful_purchase_response)
 
@@ -71,7 +71,7 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_purchase_with_recurring
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options.merge(recurring: true))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
@@ -81,7 +81,7 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_successful_authorize_with_recurring
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @decrypted_credit_card, @options.merge(recurring: true))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/recurringPayment=1/, data)
     end.respond_with(successful_purchase_response)
 
@@ -235,7 +235,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_ip_is_being_sent
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data =~ /customerIp=123\.123\.123\.123/
     end.returns(successful_purchase_response)
 
@@ -246,7 +246,7 @@ class BeanstreamTest < Test::Unit::TestCase
   def test_includes_network_tokenization_fields
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/3DSecureXID/, data)
       assert_match(/3DSecureECI/, data)
       assert_match(/3DSecureCAVV/, data)
@@ -261,7 +261,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @options[:shipping_address] = address
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ordProvince=--/, data)
       assert_match(/ordPostalCode=000000/, data)
       assert_match(/shipProvince=--/, data)
@@ -277,7 +277,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @options[:shipping_address] = address
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_no_match(/ordProvince=--/, data)
       assert_no_match(/ordPostalCode=000000/, data)
       assert_no_match(/shipProvince=--/, data)
@@ -293,7 +293,7 @@ class BeanstreamTest < Test::Unit::TestCase
     @options[:shipping_email] = 'ship@mail.com'
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @decrypted_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ordEmailAddress=xiaobozzz%40example.com/, data)
       assert_match(/shipEmailAddress=ship%40mail.com/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -27,7 +27,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_authorization
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192.168.0.1/, data)
     end.respond_with(RSP[:approved_auth])
 
@@ -40,7 +40,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192.168.0.1/, data)
     end.respond_with(RSP[:approved_purchase])
 
@@ -53,7 +53,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_failed_authorization
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192.168.0.1/, data)
     end.respond_with(RSP[:declined])
 
@@ -122,7 +122,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '100134230412', @options.merge({card_number: @credit_card.number}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(successful_refund_response)
 
@@ -134,7 +134,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_refund_passing_extra_info
     response = stub_comms do
       @gateway.refund(50, '123456789', @options.merge({card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', doc_type: 'WEB'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/NAME1=Bob/, data)
       assert_match(/NAME2=Smith/, data)
       assert_match(/ZIP=12345/, data)
@@ -148,7 +148,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_failed_refund
     response = stub_comms do
       @gateway.refund(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(failed_refund_response)
 
@@ -162,7 +162,7 @@ class BluePayTest < Test::Unit::TestCase
     assert_deprecation_warning('credit should only be used to credit a payment method') do
       response = stub_comms do
         @gateway.credit(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
       end.respond_with(failed_refund_response)
 
@@ -175,7 +175,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_successful_credit_with_check
     response = stub_comms do
       @gateway.credit(50, @check, @options.merge({doc_type: 'PPD'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/DOC_TYPE=PPD/, data)
     end.respond_with(successful_credit_response)
 

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -69,7 +69,7 @@ class BlueSnapTest < Test::Unit::TestCase
     })
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/shipping-contact-info/, data)
       assert_match(/<address1>123 Main St/, data)
       assert_match(/<city>Springfield/, data)
@@ -95,7 +95,7 @@ class BlueSnapTest < Test::Unit::TestCase
     })
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/card-holder-info/, data)
       assert_match(/<address>123 Street/, data)
       assert_match(/<address2>Apt 1/, data)
@@ -137,7 +137,7 @@ class BlueSnapTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/transaction-meta-data/, data)
       assert_match(/<meta-value>Legacy Product Desc<\/meta-value>/, data)
       assert_match(/<meta-key>description<\/meta-key>/, data)
@@ -182,7 +182,7 @@ class BlueSnapTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_not_match(/transaction-meta-data/, data)
       assert_not_match(/meta-key/, data)
     end.respond_with(successful_purchase_response)
@@ -203,7 +203,7 @@ class BlueSnapTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_not_match(/transaction-meta-data/, data)
       assert_not_match(/meta-key/, data)
     end.respond_with(successful_purchase_response)
@@ -241,7 +241,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_purchase_with_3ds_auth
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options_3ds2)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/<three-d-secure>/, data)
       assert_match(/<eci>#{Regexp.quote(@options_3ds2[:three_d_secure][:eci])}<\/eci>/, data)
       assert_match(/<cavv>#{Regexp.quote(@options_3ds2[:three_d_secure][:cavv])}<\/cavv>/, data)
@@ -259,7 +259,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_does_not_send_3ds_auth_when_empty
     stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_not_match(/<three-d-secure>/, data)
       assert_not_match(/<eci>/, data)
       assert_not_match(/<cavv>/, data)
@@ -288,7 +288,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |type, endpoint, data, headers|
+    end.check_request do |_type, _endpoint, data, _headers|
       assert_match '<store-card>false</store-card>', data
       assert_match '<personal-identification-number>CNPJ</personal-identification-number>', data
     end.respond_with(successful_authorize_response)
@@ -299,7 +299,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_authorize_with_3ds_auth
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options_3ds2)
-    end.check_request do |type, endpoint, data, headers|
+    end.check_request do |_type, _endpoint, data, _headers|
       assert_match(/<three-d-secure>/, data)
       assert_match(/<eci>#{Regexp.quote(@options_3ds2[:three_d_secure][:eci])}<\/eci>/, data)
       assert_match(/<cavv>#{Regexp.quote(@options_3ds2[:three_d_secure][:cavv])}<\/cavv>/, data)
@@ -325,7 +325,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_capture
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.capture(@amount, @credit_card, @options)
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_not_match(/<amount>1.00<\/amount>/, data)
       assert_not_match(/<currency>USD<\/currency>/, data)
     end.respond_with(successful_capture_response)
@@ -337,7 +337,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_partial_capture
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.capture(@amount, @credit_card, @options.merge(include_capture_amount: true))
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/<amount>1.00<\/amount>/, data)
       assert_match(/<currency>USD<\/currency>/, data)
     end.respond_with(successful_capture_response)
@@ -437,7 +437,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_currency_added_correctly
     stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
-    end.check_request do |method, url, data|
+    end.check_request do |_method, _url, data|
       assert_match(/<currency>CAD<\/currency>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -463,7 +463,7 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_does_not_send_level_3_when_empty
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |type, endpoint, data, headers|
+    end.check_request do |_type, _endpoint, data, _headers|
       assert_not_match(/level-3-data/, data)
     end.respond_with(successful_purchase_response)
     assert_success response

--- a/test/unit/gateways/borgun_test.rb
+++ b/test/unit/gateways/borgun_test.rb
@@ -49,7 +49,7 @@ class BorgunTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/140601083732/, data)
     end.respond_with(successful_capture_response)
 
@@ -66,7 +66,7 @@ class BorgunTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, {passenger_itinerary_data: passenger_itinerary_data})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match('PassengerItineraryData', data)
     end.respond_with(successful_authorize_response)
 
@@ -83,7 +83,7 @@ class BorgunTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/140216103700/, data)
     end.respond_with(successful_refund_response)
 
@@ -100,7 +100,7 @@ class BorgunTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/140216103700/, data)
     end.respond_with(successful_void_response)
 
@@ -110,7 +110,7 @@ class BorgunTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -118,7 +118,7 @@ class BorgunTest < Test::Unit::TestCase
   def test_passing_terminal_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, { terminal_id: '3' })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/TerminalID&gt;3/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/bpoint_test.rb
+++ b/test/unit/gateways/bpoint_test.rb
@@ -96,7 +96,7 @@ class BpointTest < Test::Unit::TestCase
     stub_comms do
       # transaction number from successful authorize response
       @gateway.void('219388558', amount: 300)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<OriginalTransactionNumber>219388558</OriginalTransactionNumber>)m, data)
       assert_match(%r(<Amount>300</Amount>)m, data)
     end.respond_with(successful_void_response)
@@ -135,7 +135,7 @@ class BpointTest < Test::Unit::TestCase
   def test_passing_biller_code
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { biller_code: '1234' })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<BillerCode>1234</BillerCode>)m, data)
     end.respond_with(successful_authorize_response)
   end
@@ -143,7 +143,7 @@ class BpointTest < Test::Unit::TestCase
   def test_passing_reference_and_crn
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({ crn1: 'ref' }))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<MerchantReference>1</MerchantReference>)m, data)
       assert_match(%r(<CRN1>ref</CRN1>)m, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -27,7 +27,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_fractional_amounts
     response = stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute_match(/amount=1.00/, data)
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/bridge_pay_test.rb
+++ b/test/unit/gateways/bridge_pay_test.rb
@@ -63,7 +63,7 @@ class BridgePayTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/OK2657/, data)
     end.respond_with(successful_capture_response)
 
@@ -80,7 +80,7 @@ class BridgePayTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/OK9757/, data)
     end.respond_with(successful_refund_response)
 
@@ -97,7 +97,7 @@ class BridgePayTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/OK9757/, data)
     end.respond_with(successful_refund_response)
 
@@ -123,7 +123,7 @@ class BridgePayTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -131,7 +131,7 @@ class BridgePayTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Street=456\+My\+Street/, data)
       assert_match(/Zip=K1C2N6/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/card_connect_test.rb
+++ b/test/unit/gateways/card_connect_test.rb
@@ -195,7 +195,7 @@ class CardConnectTest < Test::Unit::TestCase
   def test_successful_unstore
     stub_comms(@gateway, :ssl_request) do
       @gateway.unstore('1|16700875781344019340')
-    end.check_request do |verb, url, data, headers|
+    end.check_request do |verb, url, _data, _headers|
       assert_equal :delete, verb
       assert_match %r{16700875781344019340/1}, url
     end.respond_with(successful_unstore_response)

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -137,7 +137,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_successful_visacreditcard_purchase_with_descriptors
     stub_comms do
       @gateway.purchase(284, @visacreditcard, @visacredit_descriptor_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/statementNarrative1=merchant/, data)
       assert_match(/statementNarrative2=product/, data)
     end.respond_with(successful_purchase_response_with_descriptors)
@@ -146,7 +146,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_successful_visacreditcard_purchase_with_default_ip
     stub_comms do
       @gateway.purchase(284, @visacreditcard, @visacredit_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/remoteAddress=1\.1\.1\.1/, data)
     end.respond_with(successful_purchase_response_with_descriptors)
   end
@@ -154,7 +154,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_successful_visacreditcard_purchase_with_default_country
     stub_comms do
       @gateway.purchase(284, @visacreditcard, @visacredit_options.delete(:billing_address))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/customerCountryCode=GB/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -189,7 +189,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_successful_amex_purchase_with_localized_invoice_amount
     stub_comms do
       @gateway.purchase(28400, @amex, @visacredit_descriptor_options.merge(currency: 'JPY', order_id: '1234567890'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/item1GrossValue=284&/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -214,7 +214,7 @@ class CardStreamTest < Test::Unit::TestCase
     # Default
     purchase = stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/type=1/, data)
     end.respond_with(successful_purchase_response)
 
@@ -222,7 +222,7 @@ class CardStreamTest < Test::Unit::TestCase
 
     purchase = stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(type: 2))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/type=2/, data)
     end.respond_with(successful_purchase_response)
 
@@ -230,7 +230,7 @@ class CardStreamTest < Test::Unit::TestCase
 
     purchase = stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(currency: 'PEN'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/currencyCode=604/, data)
     end.respond_with(successful_purchase_response)
 
@@ -253,7 +253,7 @@ class CardStreamTest < Test::Unit::TestCase
     post_params = "action=SALE&amount=10000&captureDelay=0&cardCVV=356&cardExpiryMonth=12&cardExpiryYear=14&cardNumber=4929421234600821&countryCode=GB&currencyCode=826&customerAddress=Flat+6%2C+Primrose+Rise+347+Lavender+Road&customerCountryCode=GB&customerName=Longbob+Longsen&customerPostCode=NN17+8YG+&merchantID=login&orderRef=AM+test+purchase&remoteAddress=1.1.1.1&threeDSRequired=N&transactionUnique=#{@visacredit_options[:order_id]}&type=1"
     expected_signature = Digest::SHA512.hexdigest("#{post_params}#{@gateway.options[:shared_secret]}")
 
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data.include?("signature=#{expected_signature}")
     end.returns(successful_authorization_response)
 
@@ -263,7 +263,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(200, @visacreditcard, @visacredit_options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/amount=2&currencyCode=392/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -271,7 +271,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_3ds_response
     purchase = stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(threeds_required: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/threeDSRequired=Y/, data)
     end.respond_with(successful_purchase_response_with_3dsecure)
 
@@ -291,7 +291,7 @@ class CardStreamTest < Test::Unit::TestCase
     end
     stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/threeDSRequired=Y/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -299,7 +299,7 @@ class CardStreamTest < Test::Unit::TestCase
   def test_default_3dsecure_required
     stub_comms do
       @gateway.purchase(142, @visacreditcard, @visacredit_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/threeDSRequired=N/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/cardknox_test.rb
+++ b/test/unit/gateways/cardknox_test.rb
@@ -16,7 +16,7 @@ class CardknoxTest < Test::Unit::TestCase
   def test_successful_purchase_passing_extra_info
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(order_id: '1337', description: 'socool'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/xOrderID=1337/, data)
       assert_match(/xDescription=socool/, data)
     end.respond_with(successful_purchase_response)
@@ -66,7 +66,7 @@ class CardknoxTest < Test::Unit::TestCase
     @credit_card.manual_entry = true
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{xCardNum=4242424242424242}, data
       assert_match %r{xCardPresent=true}, data
     end.respond_with(successful_purchase_response)
@@ -75,7 +75,7 @@ class CardknoxTest < Test::Unit::TestCase
   end
 
   def test_ip_is_being_sent # failed
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data =~ /xIP=123.123.123.123/
     end.returns(successful_purchase_response)
 

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -108,7 +108,7 @@ class Cashnet < Test::Unit::TestCase
   def test_successful_purchase_with_fname_and_lname
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/fname=Longbob/, data)
       assert_match(/lname=Longsen/, data)
     end.respond_with(successful_purchase_response)
@@ -127,7 +127,7 @@ class Cashnet < Test::Unit::TestCase
     gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', custcode: 'TheCustCode')
     stub_comms(gateway, :ssl_request) do
       gateway.purchase(@amount, @credit_card, {})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/custcode=TheCustCode/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -136,7 +136,7 @@ class Cashnet < Test::Unit::TestCase
     gateway = CashnetGateway.new(merchant: 'X', operator: 'X', password: 'test123', merchant_gateway_name: 'X', custcode: 'TheCustCode')
     stub_comms(gateway, :ssl_request) do
       gateway.purchase(@amount, @credit_card, custcode: 'OveriddenCustCode')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/custcode=OveriddenCustCode/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/cecabank_test.rb
+++ b/test/unit/gateways/cecabank_test.rb
@@ -43,7 +43,7 @@ class CecabankTest < Test::Unit::TestCase
   def test_expiration_date_sent_correctly
     stub_comms do
       @gateway.purchase(@amount, credit_card('4242424242424242', month: 1, year: 2014), @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Caducidad=201401&/, data, 'Expected expiration date format is yyyymm')
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/cenpos_test.rb
+++ b/test/unit/gateways/cenpos_test.rb
@@ -115,7 +115,7 @@ class CenposTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1760035844/, data)
     end.respond_with(successful_capture_response)
 
@@ -151,7 +151,7 @@ class CenposTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1760035844/, data)
     end.respond_with(successful_void_response)
 
@@ -161,7 +161,7 @@ class CenposTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('1758584451|4242|1.00')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1758584451/, data)
     end.respond_with(failed_void_response)
 
@@ -178,7 +178,7 @@ class CenposTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1609995363/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -73,7 +73,7 @@ class CheckoutTest < Test::Unit::TestCase
   def test_passes_correct_currency
     stub_comms do
       @gateway.purchase(100, credit_card, @options.merge(currency: 'EUR'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<bill_currencycode>EUR<\/bill_currencycode>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -85,7 +85,7 @@ class CheckoutTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.purchase(100, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<descriptor_name>ZahName<\/descriptor_name>/, data)
       assert_match(/<descriptor_city>Oakland<\/descriptor_city>/, data)
     end.respond_with(successful_purchase_response)
@@ -95,7 +95,7 @@ class CheckoutTest < Test::Unit::TestCase
     @options['orderid'] = '9c38d0506da258e216fa072197faaf37'
     void = stub_comms(@gateway, :ssl_request) do
       @gateway.void('36919371|9c38d0506da258e216fa072197faaf37|1|CAD|100', @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       # Should only be one pair of track id tags.
       assert_equal 2, data.scan(/trackid/).count
     end.respond_with(successful_void_response)

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -74,7 +74,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   def test_purchase_with_additional_fields
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, {descriptor_city: 'london', descriptor_name: 'sherlock'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"billing_descriptor\":{\"name\":\"sherlock\",\"city\":\"london\"}/, data)
     end.respond_with(successful_purchase_response)
 
@@ -112,7 +112,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         previous_charge_id: 'pay_123'
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"stored":"true"}, data)
       assert_match(%r{"payment_type":"Recurring"}, data)
       assert_match(%r{"previous_payment_id":"pay_123"}, data)
@@ -134,7 +134,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         metadata: { manual_entry: true}
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"payment_type":"MOTO"}, data)
     end.respond_with(successful_authorize_response)
 
@@ -148,7 +148,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         callback_url: 'https://www.example.com'
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"success_url"}, data)
       assert_match(%r{"failure_url"}, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -48,7 +48,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
     capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/f3d100a7-18d9-4609-aabc-8a710ad0e210/, data)
     end.respond_with(successful_capture_response)
 
@@ -65,7 +65,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
     refund = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
     end.respond_with(successful_refund_response)
 
@@ -82,7 +82,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
     void = stub_comms(@gateway, :ssl_request) do
       @gateway.void(response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
     end.respond_with(successful_void_response)
 
@@ -92,7 +92,7 @@ class CitrusPayTest < Test::Unit::TestCase
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -100,7 +100,7 @@ class CitrusPayTest < Test::Unit::TestCase
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -108,7 +108,7 @@ class CitrusPayTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -116,7 +116,7 @@ class CitrusPayTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: address)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal('456 My Street', parsed['billing']['address']['street'])
       assert_equal('K1C2N6', parsed['billing']['address']['postcodeZip'])
@@ -126,7 +126,7 @@ class CitrusPayTest < Test::Unit::TestCase
   def test_passing_shipping_name
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, shipping_address: address)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal('Jim', parsed['shipping']['firstName'])
       assert_equal('Smith', parsed['shipping']['lastName'])
@@ -166,7 +166,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_match(/secure.na.tnspayments.com/, endpoint)
     end.respond_with(successful_capture_response)
 
@@ -182,7 +182,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_match(/secure.ap.tnspayments.com/, endpoint)
     end.respond_with(successful_capture_response)
 

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -55,7 +55,7 @@ class ClearhausTest < Test::Unit::TestCase
       response = @gateway.authorize(@amount, @credit_card, @options.merge(pares: '123'))
       assert_success response
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       expr = { card: { pares: '123' } }.to_query
       assert_match expr, data
     end.respond_with(successful_authorize_response)
@@ -66,7 +66,7 @@ class ClearhausTest < Test::Unit::TestCase
       response = @gateway.authorize(@amount, @credit_card, @options.merge(order_id: '123', text_on_statement: 'test'))
       assert_success response
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       order_expr = { reference: '123'}.to_query
       tos_expr   = { text_on_statement: 'test'}.to_query
 
@@ -82,7 +82,7 @@ class ClearhausTest < Test::Unit::TestCase
 
       assert_equal '84412a34-fa29-4369-a098-0165a80e8fda', response.authorization
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match %r{/cards/4110/authorizations}, endpoint
     end.respond_with(successful_authorize_response)
   end
@@ -222,7 +222,7 @@ class ClearhausTest < Test::Unit::TestCase
 
       assert_equal '84412a34-fa29-4369-a098-0165a80e8fda', response.authorization
       assert response.test?
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, _data, headers|
       assert headers['Signature']
       assert_match %r{7e51b92e-ca7e-48e3-8a96-7d66cf1f2da2 RS256-hex}, headers['Signature']
       assert_match %r{25f8283c3cc43911d7$}, headers['Signature']
@@ -241,7 +241,7 @@ class ClearhausTest < Test::Unit::TestCase
 
       assert_equal '84412a34-fa29-4369-a098-0165a80e8fda', response.authorization
       assert response.test?
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, _data, headers|
       assert headers['Signature']
       assert_match %r{7e51b92e-ca7e-48e3-8a96-7d66cf1f2da2 RS256-hex}, headers['Signature']
       assert_match %r{25f8283c3cc43911d7$}, headers['Signature']
@@ -269,7 +269,7 @@ class ClearhausTest < Test::Unit::TestCase
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/amount=2&card/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -70,7 +70,7 @@ class ConektaTest < Test::Unit::TestCase
   def test_successful_purchase_with_installments
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({monthly_installments: '3'}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match %r{monthly_installments=3}, data
     end.respond_with(successful_purchase_response)
 
@@ -155,7 +155,7 @@ class ConektaTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'tok_xxxxxxxxxxxxxxxx', @options.merge(application: application, meta: {its_so_meta: 'even this acronym'}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, _data, headers|
       assert_match(/\"application\"/, headers['X-Conekta-Client-User-Agent'])
       assert_match(/\"name\":\"app\"/, headers['X-Conekta-Client-User-Agent'])
       assert_match(/\"version\":\"1.0\"/, headers['X-Conekta-Client-User-Agent'])

--- a/test/unit/gateways/creditcall_test.rb
+++ b/test/unit/gateways/creditcall_test.rb
@@ -112,7 +112,7 @@ class CreditcallTest < Test::Unit::TestCase
   def test_verification_value_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<CSC>123</CSC>)m, data)
     end.respond_with(successful_authorize_response)
   end
@@ -121,7 +121,7 @@ class CreditcallTest < Test::Unit::TestCase
     @credit_card.verification_value = '  '
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/CSC/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -129,25 +129,25 @@ class CreditcallTest < Test::Unit::TestCase
   def test_options_add_avs_additional_verification_fields
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/AdditionalVerification/, data)
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(verify_zip: 'false', verify_address: 'false'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/AdditionalVerification/, data)
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(verify_zip: 'true', verify_address: 'true'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<AdditionalVerification>\n      <Zip>K1C2N6<\/Zip>\n      <Address>/, data)
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(verify_zip: 'true', verify_address: 'false'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ <AdditionalVerification>\n      <Zip>K1C2N6<\/Zip>\n    <\/AdditionalVerification>\n/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -44,7 +44,7 @@ class CredoraxTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/i8=sample-eci%3Asample-cavv%3Asample-xid/, data)
     end.respond_with(successful_purchase_response)
 
@@ -75,7 +75,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/8a829449535154bc0153595952a2517a/, data)
     end.respond_with(successful_capture_response)
 
@@ -112,7 +112,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/8a829449535154bc0153595952a2517a/, data)
     end.respond_with(successful_void_response)
 
@@ -123,7 +123,7 @@ class CredoraxTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
 
@@ -141,7 +141,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/8a82944a5351570601535955efeb513c/, data)
     end.respond_with(successful_refund_response)
 
@@ -168,7 +168,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     referral_cft = stub_comms do
       @gateway.refund(@amount, response.authorization, { referral_cft: true, first_name: 'John', last_name: 'Smith' })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/8a82944a5351570601535955efeb513c/, data)
       # Confirm that `j5` (first name) and `j13` (surname) parameters are present
       # These fields are required for CFT payouts as of Sept 1, 2020
@@ -185,7 +185,7 @@ class CredoraxTest < Test::Unit::TestCase
   def test_failed_referral_cft
     response = stub_comms do
       @gateway.refund(nil, '', referral_cft: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       # Confirm that the transaction type is `referral_cft`
       assert_match(/O=34/, data)
     end.respond_with(failed_referral_cft_response)
@@ -250,7 +250,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/3ds_channel=02/, data)
       assert_match(/3ds_transtype=01/, data)
       assert_match(/3ds_redirect_url=www.example.com/, data)
@@ -283,7 +283,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @normalized_3ds_2_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/3ds_browsercolordepth=32/, data)
     end.respond_with(successful_purchase_response)
 
@@ -298,7 +298,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/3ds_channel=02/, data)
       assert_match(/3ds_transtype=03/, data)
     end.respond_with(successful_purchase_response)
@@ -314,7 +314,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=sample-eci%3Asample-cavv%3Asample-xid/, data)
       assert_match(/3ds_version=1.0/, data)
     end.respond_with(successful_purchase_response)
@@ -330,7 +330,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/3ds_channel=03/, data)
     end.respond_with(successful_purchase_response)
 
@@ -345,7 +345,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=sample-eci%3Asample-cavv%3Asample-xid/, data)
       assert_match(/3ds_version=1.0/, data)
     end.respond_with(successful_purchase_response)
@@ -361,7 +361,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=sample-eci%3Anone%3Asample-xid/, data)
     end.respond_with(successful_purchase_response)
 
@@ -387,7 +387,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=#{eci}%3A#{cavv}%3Anone/, data)
       assert_match(/3ds_version=2.0/, data)
       assert_match(/3ds_dstrxid=#{ds_transaction_id}/, data)
@@ -408,7 +408,7 @@ class CredoraxTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=#{eci}%3Anone%3Anone/, data)
       assert_match(/3ds_version=#{version}/, data)
       assert_match(/3ds_dstrxid=#{ds_transaction_id}/, data)
@@ -419,7 +419,7 @@ class CredoraxTest < Test::Unit::TestCase
     options_with_3ds = @options.merge({transaction_type: '8'})
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -428,7 +428,7 @@ class CredoraxTest < Test::Unit::TestCase
     options_with_3ds = @options.merge({transaction_type: '8'})
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -437,7 +437,7 @@ class CredoraxTest < Test::Unit::TestCase
     options_with_3ds = @options.merge({transaction_type: '8'})
     stub_comms do
       @gateway.credit(@amount, @credit_card, options_with_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_credit_response)
   end
@@ -446,7 +446,7 @@ class CredoraxTest < Test::Unit::TestCase
     options_with_auth_details = @options.merge({authorization_type: '2', multiple_capture_count: '5' })
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_auth_details)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a10=2/, data)
       assert_match(/a11=5/, data)
     end.respond_with(successful_authorize_response)
@@ -456,7 +456,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -465,7 +465,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:metadata] = { manual_entry: true }
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a2=3/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -474,7 +474,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -487,7 +487,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.capture(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_capture_response)
   end
@@ -500,7 +500,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.void(response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_void_response)
   end
@@ -513,7 +513,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.refund(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_refund_response)
   end
@@ -522,7 +522,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:submerchant_id] = '12345'
     stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_credit_response)
   end
@@ -531,7 +531,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -540,7 +540,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -549,7 +549,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -562,7 +562,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.capture(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_capture_response)
   end
@@ -575,7 +575,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.refund(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_refund_response)
   end
@@ -584,7 +584,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_descriptor] = 'abcdefghijkl'
     stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/i2=abcdefghijkl/, data)
     end.respond_with(successful_credit_response)
   end
@@ -594,7 +594,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_purchase_response)
@@ -605,7 +605,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_authorize_response)
@@ -620,7 +620,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.capture(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_capture_response)
@@ -635,7 +635,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.void(response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_void_response)
@@ -650,7 +650,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.refund(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_refund_response)
@@ -661,7 +661,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:processor_merchant_id] = '123'
     stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/r1=TEST/, data)
       assert_match(/r2=123/, data)
     end.respond_with(successful_credit_response)
@@ -672,7 +672,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_address][:phone] = '555-444-3333'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/c2=555-444-3333/, data)
     end.respond_with(successful_purchase_response)
 
@@ -680,7 +680,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:billing_address][:phone] = nil
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/c2=/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -691,7 +691,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:three_ds_2] = { optional: { '3ds_homephonecountry': 'US' } }
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/c2=555-444-3333/, data)
       assert_match(/3ds_homephonecountry=US/, data)
     end.respond_with(successful_purchase_response)
@@ -701,7 +701,7 @@ class CredoraxTest < Test::Unit::TestCase
     @options[:three_ds_2] = { optional: { '3ds_homephonecountry': 'US' } }
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/c2=/, data)
       assert_not_match(/3ds_homephonecountry=/, data)
     end.respond_with(successful_purchase_response)
@@ -711,7 +711,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -722,7 +722,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -733,7 +733,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=1/, data)
     end.respond_with(successful_authorize_response)
 
@@ -744,7 +744,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=2/, data)
     end.respond_with(successful_authorize_response)
 
@@ -755,7 +755,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -766,7 +766,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -777,7 +777,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_authorize_response)
 
@@ -788,7 +788,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_authorize_response)
 
@@ -799,7 +799,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -810,7 +810,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=9/, data)
     end.respond_with(successful_authorize_response)
 
@@ -821,7 +821,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_authorize_response)
 
@@ -832,7 +832,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
     end.respond_with(successful_authorize_response)
 
@@ -843,7 +843,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=2/, data)
     end.respond_with(successful_authorize_response)
 
@@ -854,7 +854,7 @@ class CredoraxTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(transaction_type: '6')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=6/, data)
     end.respond_with(successful_authorize_response)
 
@@ -864,7 +864,7 @@ class CredoraxTest < Test::Unit::TestCase
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a4=2&a1=/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -90,7 +90,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_purchase_includes_issuer_additional_data
     stub_comms do
       @gateway.purchase(100, @credit_card, order_id: '1', issuer_additional_data: @issuer_additional_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer>\s+<additionalData>#{@issuer_additional_data}<\/additionalData>\s+<\/issuer>/m, data)
     end.respond_with(successful_purchase_response)
   end
@@ -98,7 +98,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_purchase_includes_mdd_fields
     stub_comms do
       @gateway.purchase(100, @credit_card, order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
     end.respond_with(successful_purchase_response)
   end
@@ -106,7 +106,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_purchase_includes_reconciliation_id
     stub_comms do
       @gateway.purchase(100, @credit_card, order_id: '1', reconciliation_id: '181537')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<reconciliationID>181537<\/reconciliationID>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -114,7 +114,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_merchant_description
     stub_comms do
       @gateway.authorize(100, @credit_card, merchant_descriptor_name: 'Test Name', merchant_descriptor_address1: '123 Main Dr', merchant_descriptor_locality: 'Durham')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<merchantDescriptor>.*<name>Test Name</name>.*</merchantDescriptor>)m, data)
       assert_match(%r(<merchantDescriptor>.*<address1>123 Main Dr</address1>.*</merchantDescriptor>)m, data)
       assert_match(%r(<merchantDescriptor>.*<locality>Durham</locality>.*</merchantDescriptor>)m, data)
@@ -124,7 +124,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_purchase_includes_merchant_descriptor
     stub_comms do
       @gateway.purchase(100, @credit_card, merchant_descriptor: 'Spreedly')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<merchantDescriptor>Spreedly<\/merchantDescriptor>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -132,7 +132,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_authorize_includes_issuer_additional_data
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', issuer_additional_data: @issuer_additional_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer>\s+<additionalData>#{@issuer_additional_data}<\/additionalData>\s+<\/issuer>/m, data)
     end.respond_with(successful_authorization_response)
   end
@@ -140,7 +140,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_authorize_includes_mdd_fields
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
     end.respond_with(successful_authorization_response)
   end
@@ -148,7 +148,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_authorize_includes_reconciliation_id
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', reconciliation_id: '181537')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<reconciliationID>181537<\/reconciliationID>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -156,7 +156,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_authorize_includes_commerce_indicator
     stub_comms do
       @gateway.authorize(100, @credit_card, commerce_indicator: 'internet')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<commerceIndicator>internet<\/commerceIndicator>/m, data)
     end.respond_with(successful_authorization_response)
   end
@@ -164,7 +164,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_authorize_includes_installment_total_count
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', installment_total_count: 5)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<installment>\s+<totalCount>5<\/totalCount>\s+<\/installment>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -190,7 +190,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_cart_purchase_single_request_ignore_avs
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_match %r'<ignoreAVSResult>true</ignoreAVSResult>', request_body
       assert_not_match %r'<ignoreCVResult>', request_body
       true
@@ -202,7 +202,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_cart_purchase_single_request_without_ignore_avs
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_not_match %r'<ignoreAVSResult>', request_body
       assert_not_match %r'<ignoreCVResult>', request_body
       true
@@ -217,7 +217,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_cart_purchase_single_request_ignore_ccv
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_not_match %r'<ignoreAVSResult>', request_body
       assert_match %r'<ignoreCVResult>true</ignoreCVResult>', request_body
       true
@@ -230,7 +230,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_cart_purchase_single_request_without_ignore_ccv
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_not_match %r'<ignoreAVSResult>', request_body
       assert_not_match %r'<ignoreCVResult>', request_body
       true
@@ -306,7 +306,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_capture_includes_local_tax_amount
     stub_comms do
       @gateway.capture(100, '1842651133440156177166', local_tax_amount: '0.17')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<otherTax>\s+<localTaxAmount>0.17<\/localTaxAmount>\s+<\/otherTax>/, data)
     end.respond_with(successful_capture_response)
   end
@@ -314,7 +314,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_capture_includes_national_tax_amount
     stub_comms do
       @gateway.capture(100, '1842651133440156177166', national_tax_amount: '0.05')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<otherTax>\s+<nationalTaxAmount>0.05<\/nationalTaxAmount>\s+<\/otherTax>/, data)
     end.respond_with(successful_capture_response)
   end
@@ -332,7 +332,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_capture_includes_mdd_fields
     stub_comms do
       @gateway.capture(100, '1846925324700976124593', order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
     end.respond_with(successful_capture_response)
   end
@@ -359,7 +359,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_requires_error_on_tax_calculation_without_line_items
-    assert_raise(ArgumentError) { @gateway.calculate_tax(@credit_card, @options.delete_if { |key, val| key == :line_items }) }
+    assert_raise(ArgumentError) { @gateway.calculate_tax(@credit_card, @options.delete_if { |key, _val| key == :line_items }) }
   end
 
   def test_default_currency
@@ -457,7 +457,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_credit_includes_merchant_descriptor
     stub_comms do
       @gateway.credit(@amount, @credit_card, merchant_descriptor: 'Spreedly')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<merchantDescriptor>Spreedly<\/merchantDescriptor>/, data)
     end.respond_with(successful_card_credit_response)
   end
@@ -465,7 +465,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_credit_includes_issuer_additional_data
     stub_comms do
       @gateway.credit(@amount, @credit_card, issuer_additional_data: @issuer_additional_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer>\s+<additionalData>#{@issuer_additional_data}<\/additionalData>\s+<\/issuer>/m, data)
     end.respond_with(successful_card_credit_response)
   end
@@ -473,7 +473,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_credit_includes_mdd_fields
     stub_comms do
       @gateway.credit(@amount, @credit_card, mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
     end.respond_with(successful_card_credit_response)
   end
@@ -483,7 +483,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.void(purchase, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<voidService run=\"true\"), data)
     end.respond_with(successful_void_response)
   end
@@ -493,7 +493,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.void(capture, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<voidService run=\"true\"), data)
     end.respond_with(successful_void_response)
   end
@@ -503,7 +503,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.void(authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<ccAuthReversalService run=\"true\"), data)
     end.respond_with(successful_auth_reversal_response)
   end
@@ -513,7 +513,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.void(authorization, issuer_additional_data: @issuer_additional_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer>\s+<additionalData>#{@issuer_additional_data}<\/additionalData>\s+<\/issuer>/m, data)
     end.respond_with(successful_void_response)
   end
@@ -523,7 +523,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.void(authorization, mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
     end.respond_with(successful_void_response)
   end
@@ -547,7 +547,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_validate_add_subscription_amount
     stub_comms do
       @gateway.store(@credit_card, @subscription_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<amount>1.00<\/amount>), data
     end.respond_with(successful_update_subscription_response)
   end
@@ -611,7 +611,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_for_mastercard
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_xml_valid_to_xsd(request_body)
       assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
       true
@@ -629,7 +629,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_for_amex
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_xml_valid_to_xsd(request_body)
       assert_match %r'<ccAuthService run=\"true\">\n  <cavv>MTExMTExMTExMTAwY3J5cHRvZ3I=\n</cavv>\n  <commerceIndicator>aesk</commerceIndicator>\n  <xid>YW0=\n</xid>\n</ccAuthService>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
       true
@@ -656,7 +656,7 @@ class CyberSourceTest < Test::Unit::TestCase
     @options[:commerce_indicator] = 'internet'
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<subsequentAuthFirst\>true/, data)
       assert_not_match(/\<subsequentAuthStoredCredential\>true/, data)
       assert_not_match(/\<subsequentAuth\>/, data)
@@ -675,7 +675,7 @@ class CyberSourceTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/\<subsequentAuthFirst\>/, data)
       assert_match(/\<subsequentAuthStoredCredential\>/, data)
       assert_not_match(/\<subsequentAuth\>/, data)
@@ -693,7 +693,7 @@ class CyberSourceTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/\<subsequentAuthFirst\>/, data)
       assert_match(/\<subsequentAuthStoredCredential\>true/, data)
       assert_match(/\<subsequentAuth\>true/, data)
@@ -711,7 +711,7 @@ class CyberSourceTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/\<subsequentAuthFirst\>/, data)
       assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
       assert_match(/\<subsequentAuth\>true/, data)
@@ -730,7 +730,7 @@ class CyberSourceTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/\<subsequentAuthFirst\>/, data)
       assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
       assert_match(/\<subsequentAuth\>true/, data)
@@ -749,7 +749,7 @@ class CyberSourceTest < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/\<subsequentAuthFirst\>/, data)
       assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
       assert_match(/\<subsequentAuth\>true/, data)
@@ -775,7 +775,7 @@ class CyberSourceTest < Test::Unit::TestCase
     @options[:commerce_indicator] = 'internet'
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<subsequentAuthFirst\>false/, data)
       assert_match(/\<subsequentAuthStoredCredential\>true/, data)
       assert_match(/\<subsequentAuth\>true/, data)
@@ -786,7 +786,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_nonfractional_currency_handling
-    @gateway.expects(:ssl_post).with do |host, request_body|
+    @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_match %r(<grandTotalAmount>1</grandTotalAmount>), request_body
       assert_match %r(<currency>JPY</currency>), request_body
       true
@@ -808,7 +808,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_3ds_enroll_response
     purchase = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(payer_auth_enroll_service: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<payerAuthEnrollService run=\"true\"\/\>/, data)
     end.respond_with(threedeesecure_purchase_response)
 
@@ -821,7 +821,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_3ds_validate_response
     validation = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(payer_auth_validate_service: true, pares: 'ABC123'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<payerAuthValidateService run=\"true\"\>/, data)
       assert_match(/\<signedPARes\>ABC123\<\/signedPARes\>/, data)
     end.respond_with(successful_threedeesecure_validate_response)
@@ -835,7 +835,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
       stub_comms do
         @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: { cavv: 'anything but empty' }))
-      end.check_request do |endpoint, data, headers|
+      end.check_request do |_endpoint, data, _headers|
         assert_match(/commerceIndicator\>#{CyberSourceGateway::ECI_BRAND_MAPPING[brand.to_sym]}</, data)
       end.respond_with(successful_purchase_response)
     end
@@ -865,7 +865,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<eciRaw\>#{eci}/, data)
       assert_match(/<cavv\>#{cavv}/, data)
       assert_match(/<paSpecificationVersion\>#{version}/, data)
@@ -962,7 +962,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<eciRaw\>#{eci}/, data)
       assert_match(/<authenticationData\>#{cavv}/, data)
       assert_match(/<paSpecificationVersion\>#{version}/, data)
@@ -986,7 +986,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<collectionIndicator\>2/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1004,7 +1004,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @elo_credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<xid\>this-is-an-xid/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1023,7 +1023,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @master_credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<xid\>this-is-an-xid/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1043,7 +1043,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<xid\>#{cavv}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1062,7 +1062,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<xid\>this-is-an-xid/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1092,7 +1092,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_address_email_has_a_default_when_email_option_is_empty
     stub_comms do
       @gateway.authorize(100, @credit_card, email: '')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match('<email>null@cybersource.com</email>', data)
     end.respond_with(successful_capture_response)
   end
@@ -1100,7 +1100,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_country_code_sent_as_default_when_submitted_as_empty_string
     stub_comms do
       @gateway.authorize(100, @credit_card, billing_address: { country: '' })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match('<country>US</country>', data)
     end.respond_with(successful_capture_response)
   end
@@ -1113,7 +1113,7 @@ class CyberSourceTest < Test::Unit::TestCase
         'zip' => 'NW16XE',
         'country' => 'GB'
       })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match('<street1>221B Baker Street</street1>', data)
       assert_match('<city>London</city>', data)
       assert_match('<postalCode>NW16XE</postalCode>', data)
@@ -1127,7 +1127,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match("<partnerSolutionID>#{partner_id}</partnerSolutionID>", data)
     end.respond_with(successful_capture_response)
   ensure
@@ -1148,7 +1148,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match("<subsequentAuth/>\n<partnerSolutionID>#{partner_id}</partnerSolutionID>\n<subsequentAuthFirst>true</subsequentAuthFirst>\n<subsequentAuthTransactionID/>\n<subsequentAuthStoredCredential/>", data)
     end.respond_with(successful_capture_response)
   ensure

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -38,7 +38,7 @@ class DLocalTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(installments: installments, installments_id: installments_id))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal installments, JSON.parse(data)['card']['installments']
       assert_equal installments_id, JSON.parse(data)['card']['installments_id']
     end.respond_with(successful_purchase_response)
@@ -65,7 +65,7 @@ class DLocalTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"state\":\"ON\"/, data)
       assert_match(/"city\":\"Ottawa\"/, data)
       assert_match(/"zip_code\":\"K1C2N6\"/, data)
@@ -77,7 +77,7 @@ class DLocalTest < Test::Unit::TestCase
   def test_passing_incomplete_billing_address
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(address1: 'Just a Street')))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"state\":\"ON\"/, data)
       assert_match(/"city\":\"Ottawa\"/, data)
       assert_match(/"zip_code\":\"K1C2N6\"/, data)
@@ -88,7 +88,7 @@ class DLocalTest < Test::Unit::TestCase
   def test_passing_nil_address_1
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(address1: nil)))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/"street\"/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -96,7 +96,7 @@ class DLocalTest < Test::Unit::TestCase
   def test_passing_country_as_string
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"country\":\"CA\"/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -104,7 +104,7 @@ class DLocalTest < Test::Unit::TestCase
   def test_invalid_country
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: address(country: 'INVALID')))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/\"country\":null/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -47,7 +47,7 @@ class DecidirTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(options))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /"card_holder_door_number":1234/
       assert data =~ /"card_holder_birthday":"01011980"/
       assert data =~ /"type":"dni"/
@@ -87,7 +87,7 @@ class DecidirTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(options))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /"aggregate_data":{"indicator":1/
       assert data =~ /"identification_number":"308103480"/
       assert data =~ /"bill_to_pay":"test1"/
@@ -352,7 +352,7 @@ class DecidirTest < Test::Unit::TestCase
 
     stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, visa_debit_card, debit_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"payment_method_id":31/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -364,7 +364,7 @@ class DecidirTest < Test::Unit::TestCase
 
     stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, mastercard, debit_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"payment_method_id":105/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -376,7 +376,7 @@ class DecidirTest < Test::Unit::TestCase
 
     stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, maestro_card, debit_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"payment_method_id":106/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -388,7 +388,7 @@ class DecidirTest < Test::Unit::TestCase
 
     stub_comms(@gateway_for_purchase, :ssl_request) do
       @gateway_for_purchase.purchase(@amount, cabal_card, debit_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"payment_method_id":108/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/dibs_test.rb
+++ b/test/unit/gateways/dibs_test.rb
@@ -62,7 +62,7 @@ class DibsTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1066662996/, data)
     end.respond_with(successful_capture_response)
 
@@ -97,7 +97,7 @@ class DibsTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1066662996/, data)
     end.respond_with(successful_void_response)
 
@@ -107,7 +107,7 @@ class DibsTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
 
@@ -124,7 +124,7 @@ class DibsTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1066662996/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/digitzs_test.rb
+++ b/test/unit/gateways/digitzs_test.rb
@@ -38,7 +38,7 @@ class DigitzsTest < Test::Unit::TestCase
   def test_successful_card_split_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       if /"cardSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)
@@ -52,7 +52,7 @@ class DigitzsTest < Test::Unit::TestCase
   def test_successful_token_split_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_split)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       if /"tokenSplit"/.match?(data)
         assert_match(%r(split), data)
         assert_match(%r("merchantId":"spreedly-susanswidg-32270590-2095203-148657924"), data)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -86,7 +86,7 @@ class ElavonTest < Test::Unit::TestCase
     authorization = '123456;00000000-0000-0000-0000-00000000000'
     response = stub_comms do
       @gateway.capture(@amount, authorization, test_mode: true, partial_shipment_flag: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ssl_transaction_type=CCCOMPLETE/, data)
       assert_match(/ssl_test_mode=TRUE/, data)
       assert_match(/ssl_partial_shipment_flag=Y/, data)
@@ -158,7 +158,7 @@ class ElavonTest < Test::Unit::TestCase
   def test_successful_purchase_with_multi_currency
     response = stub_comms(@multi_currency_gateway) do
       @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ssl_transaction_currency=EUR/, data)
     end.respond_with(successful_purchase_with_multi_currency_response)
 
@@ -168,7 +168,7 @@ class ElavonTest < Test::Unit::TestCase
   def test_successful_purchase_without_multi_currency
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR', multi_currency: false))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/ssl_transaction_currency=EUR/, data)
     end.respond_with(successful_purchase_response)
 
@@ -320,7 +320,7 @@ class ElavonTest < Test::Unit::TestCase
   def test_custom_fields_in_request
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(customer_number: '123', custom_fields: {a_key: 'a value'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/customer_number=123/, data)
       assert_match(/a_key/, data)
       refute_match(/ssl_a_key/, data)
@@ -392,7 +392,7 @@ class ElavonTest < Test::Unit::TestCase
     options = @options.merge(level_3_data: level_3_data)
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ssl_customer_code=bob/, data)
       assert_match(/ssl_salestax=3.45/, data)
       assert_match(/ssl_salestax_indicator=Y/, data)

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -147,7 +147,7 @@ class ElementTest < Test::Unit::TestCase
   def test_successful_purchase_with_card_present_code
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(card_present_code: 'Present'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<CardPresentCode>Present</CardPresentCode>', data
     end.respond_with(successful_purchase_response)
 
@@ -157,7 +157,7 @@ class ElementTest < Test::Unit::TestCase
   def test_successful_purchase_with_payment_type
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(payment_type: 'NotUsed'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<PaymentType>NotUsed</PaymentType>', data
     end.respond_with(successful_purchase_response)
 
@@ -167,7 +167,7 @@ class ElementTest < Test::Unit::TestCase
   def test_successful_purchase_with_submission_type
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(submission_type: 'NotUsed'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<SubmissionType>NotUsed</SubmissionType>', data
     end.respond_with(successful_purchase_response)
 
@@ -177,7 +177,7 @@ class ElementTest < Test::Unit::TestCase
   def test_successful_purchase_with_duplicate_check_disable_flag
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_check_disable_flag: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<DuplicateCheckDisableFlag>True</DuplicateCheckDisableFlag>', data
     end.respond_with(successful_purchase_response)
 
@@ -185,7 +185,7 @@ class ElementTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_check_disable_flag: 'true'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<DuplicateCheckDisableFlag>True</DuplicateCheckDisableFlag>', data
     end.respond_with(successful_purchase_response)
 
@@ -193,7 +193,7 @@ class ElementTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_check_disable_flag: false))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<DuplicateCheckDisableFlag>False</DuplicateCheckDisableFlag>', data
     end.respond_with(successful_purchase_response)
 
@@ -201,7 +201,7 @@ class ElementTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_check_disable_flag: 'xxx'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<DuplicateCheckDisableFlag>False</DuplicateCheckDisableFlag>', data
     end.respond_with(successful_purchase_response)
 
@@ -209,7 +209,7 @@ class ElementTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_check_disable_flag: 'False'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<DuplicateCheckDisableFlag>False</DuplicateCheckDisableFlag>', data
     end.respond_with(successful_purchase_response)
 
@@ -218,7 +218,7 @@ class ElementTest < Test::Unit::TestCase
     # when duplicate_check_disable_flag is NOT passed, should not be in XML at all
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(<DuplicateCheckDisableFlag>False</DuplicateCheckDisableFlag>), data
     end.respond_with(successful_purchase_response)
 
@@ -228,7 +228,7 @@ class ElementTest < Test::Unit::TestCase
   def test_successful_purchase_with_terminal_id
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(terminal_id: '02'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<TerminalID>02</TerminalID>', data
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -85,7 +85,7 @@ class EwayManagedTest < Test::Unit::TestCase
   end
 
   def test_expected_request_on_purchase
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       # Compare the actual and expected XML documents, by converting them to Hashes first
       expected = Hash.from_xml(expected_purchase_request)
       actual = Hash.from_xml(data)
@@ -101,7 +101,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:order_id] = 'order_id'
     options.delete(:invoice)
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['ProcessPayment']['invoiceReference'] == 'order_id'
     }.returns(successful_purchase_response)
@@ -111,7 +111,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:invoice] = 'invoice'
     options.delete(:order_id)
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['ProcessPayment']['invoiceReference'] == 'invoice'
     }.returns(successful_purchase_response)
@@ -121,7 +121,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:order_id] = 'order_id'
     options[:invoice] = 'invoice'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['ProcessPayment']['invoiceReference'] == 'order_id'
     }.returns(successful_purchase_response)
@@ -148,7 +148,7 @@ class EwayManagedTest < Test::Unit::TestCase
   end
 
   def test_expected_request_on_store
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       # Compare the actual and expected XML documents, by converting them to Hashes first
       expected = Hash.from_xml(expected_store_request)
       actual = Hash.from_xml(data)
@@ -164,7 +164,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options.delete(:email)
     options[:billing_address][:email] = 'email+billing@example.com'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['Email'] == 'email+billing@example.com'
     }.returns(successful_store_response)
@@ -174,7 +174,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:billing_address].delete(:email)
     options[:email] = 'email+root@example.com'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['Email'] == 'email+root@example.com'
     }.returns(successful_store_response)
@@ -184,7 +184,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:billing_address][:email] = 'email+billing@example.com'
     options[:email] = 'email+root@example.com'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['Email'] == 'email+billing@example.com'
     }.returns(successful_store_response)
@@ -198,7 +198,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options.delete(:customer)
     options[:billing_address][:customer_ref] = 'customer_ref+billing'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['CustomerRef'] == 'customer_ref+billing'
     }.returns(successful_store_response)
@@ -208,7 +208,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:billing_address].delete(:customer_ref)
     options[:customer] = 'customer_ref+root'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['CustomerRef'] == 'customer_ref+root'
     }.returns(successful_store_response)
@@ -218,7 +218,7 @@ class EwayManagedTest < Test::Unit::TestCase
     options[:billing_address][:customer_ref] = 'customer_ref+billing'
     options[:customer] = 'customer_ref+root'
 
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['Envelope']['Body']['CreateCustomer']['CustomerRef'] == 'customer_ref+billing'
     }.returns(successful_store_response)
@@ -246,7 +246,7 @@ class EwayManagedTest < Test::Unit::TestCase
   end
 
   def test_expected_retrieve_response
-    @gateway.expects(:ssl_post).with { |endpoint, data, headers|
+    @gateway.expects(:ssl_post).with { |_endpoint, data, _headers|
       # Compare the actual and expected XML documents, by converting them to Hashes first
       expected = Hash.from_xml(expected_retrieve_request)
       actual = Hash.from_xml(data)

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -58,7 +58,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_passes_customer_data_from_payment_method_when_no_address_is_provided
     stub_comms do
       @gateway.purchase(@amount, @credit_card, { email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @credit_card.first_name,
@@ -71,7 +71,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_passes_customer_data_from_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, { billing_address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -85,7 +85,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_passes_customer_data_from_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, { address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -99,7 +99,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_purchase_passes_shipping_data
     stub_comms do
       @gateway.purchase(@amount, @credit_card, { shipping_address: @shipping_address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_shipping_data_passed(data, @shipping_address, @email)
     end.respond_with(successful_purchase_response)
   end
@@ -107,13 +107,13 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_localized_currency
     stub_comms do
       @gateway.purchase(100, @credit_card, currency: 'CAD')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '"TotalAmount":"100"', data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.purchase(100, @credit_card, currency: 'JPY')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '"TotalAmount":"1"', data
     end.respond_with(successful_purchase_response)
   end
@@ -191,7 +191,7 @@ class EwayRapidTest < Test::Unit::TestCase
           fax: '1115556666'
         }
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"TransactionType":"CustomTransactionType"}, data)
       assert_match(%r{"RedirectUrl":"http://awesomesauce.com"}, data)
       assert_match(%r{"CustomerIP":"0.0.0.0"}, data)
@@ -241,7 +241,7 @@ class EwayRapidTest < Test::Unit::TestCase
     ActiveMerchant::Billing::EwayRapidGateway.partner_id = 'SomePartner'
     stub_comms do
       @gateway.purchase(200, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"PartnerID":"SomePartner"}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -250,7 +250,7 @@ class EwayRapidTest < Test::Unit::TestCase
     ActiveMerchant::Billing::EwayRapidGateway.partner_id = 'SomePartner'
     stub_comms do
       @gateway.purchase(200, @credit_card, partner_id: 'OtherPartner')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"PartnerID":"OtherPartner"}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -258,7 +258,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_partner_id_is_omitted_when_not_set
     stub_comms do
       @gateway.purchase(200, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{"PartnerID":}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -267,7 +267,7 @@ class EwayRapidTest < Test::Unit::TestCase
     partner_string = 'EWay Rapid PartnerID is capped at 50 characters and will truncate if it is too long.'
     stub_comms do
       @gateway.purchase(200, @credit_card, partner_id: partner_string)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"PartnerID":"#{partner_string.slice(0, 50)}"}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -285,7 +285,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_authorize_passes_customer_data_from_payment_method_when_no_address_is_provided
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @credit_card.first_name,
@@ -298,7 +298,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_authorize_passes_customer_data_from_billing_address
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { billing_address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -312,7 +312,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_authorize_passes_customer_data_from_address
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -326,7 +326,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_authorize_passes_shipping_data
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { shipping_address: @shipping_address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_shipping_data_passed(data, @shipping_address, @email)
     end.respond_with(successful_authorize_response)
   end
@@ -396,7 +396,7 @@ class EwayRapidTest < Test::Unit::TestCase
         phone: '(555)555-5555',
         fax: '(555)555-6666'
       })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '"Method":"CreateTokenCustomer"', data
     end.respond_with(successful_store_response)
 
@@ -409,7 +409,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_store_passes_customer_data_from_billing_address
     stub_comms do
       @gateway.store(@credit_card, { billing_address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -426,7 +426,7 @@ class EwayRapidTest < Test::Unit::TestCase
         @credit_card,
         { shipping_address: @shipping_address, billing_address: @address, email: @email }
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_shipping_data_passed(data, @shipping_address, @email)
     end.respond_with(successful_store_response)
   end
@@ -445,7 +445,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_successful_update
     response = stub_comms do
       @gateway.update('faketoken', nil)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '"Method":"UpdateTokenCustomer"', data
     end.respond_with(successful_update_response)
 
@@ -458,7 +458,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_update_passes_customer_data_from_payment_method_when_no_address_is_provided
     stub_comms do
       @gateway.update('token', @credit_card, { email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @credit_card.first_name,
@@ -471,7 +471,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_update_passes_customer_data_from_billing_address
     stub_comms do
       @gateway.update('token', @credit_card, { billing_address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -485,7 +485,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_update_passes_customer_data_from_address
     stub_comms do
       @gateway.update('token', @credit_card, { address: @address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_customer_data_passed(
         data,
         @address[:name].split[0],
@@ -499,7 +499,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_update_passes_shipping_data
     stub_comms do
       @gateway.update('token', @credit_card, { shipping_address: @shipping_address, email: @email })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_shipping_data_passed(data, @shipping_address, @email)
     end.respond_with(successful_update_response)
   end
@@ -507,7 +507,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '1234567')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match %r{Transaction\/1234567\/Refund$}, endpoint
       json = JSON.parse(data)
       assert_equal '100', json['Refund']['TotalAmount']
@@ -534,7 +534,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def test_successful_stored_card_purchase
     response = stub_comms do
       @gateway.purchase(100, 'the_customer_token', transaction_type: 'MOTO')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '"Method":"TokenPayment"', data
       assert_match '"TransactionType":"MOTO"', data
     end.respond_with(successful_store_purchase_response)

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -31,7 +31,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_metadata
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"metadata":{"foo":"bar"}'
     }.returns(successful_purchase_response_with_metadata)
 
@@ -43,7 +43,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"card_token":"e1q7dbj2"'
     }.returns(successful_purchase_response)
 
@@ -55,7 +55,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token_string
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"card_token":"e1q7dbj2"'
     }.returns(successful_purchase_response)
 
@@ -67,7 +67,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_multi_currency_purchase
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"currency":"USD"'
     }.returns(successful_purchase_response)
 
@@ -81,13 +81,13 @@ class FatZebraTest < Test::Unit::TestCase
   def test_successful_purchase_with_recurring_flag
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(recurring: true))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r("extra":{"ecm":"32"), data)
     end.respond_with(successful_purchase_response)
   end
 
   def test_successful_purchase_with_descriptor
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       json = JSON.parse(body)
       json['extra']['name'] == 'Merchant' && json['extra']['location'] == 'Location'
     }.returns(successful_purchase_response)
@@ -100,7 +100,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_authorization
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"capture":false'
     }.returns(successful_purchase_response)
 
@@ -112,7 +112,7 @@ class FatZebraTest < Test::Unit::TestCase
   end
 
   def test_successful_capture
-    @gateway.expects(:ssl_request).with { |method, url, body, headers|
+    @gateway.expects(:ssl_request).with { |_method, url, _body, _headers|
       url =~ %r[purchases/e1q7dbj2/capture\z]
     }.returns(successful_purchase_response)
 

--- a/test/unit/gateways/first_pay_test.rb
+++ b/test/unit/gateways/first_pay_test.rb
@@ -21,7 +21,7 @@ class FirstPayTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
       assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
       assert_match(/<FIELD KEY="operation_type">sale<\/FIELD>/, data)
@@ -62,7 +62,7 @@ class FirstPayTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
       assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
       assert_match(/<FIELD KEY="operation_type">auth<\/FIELD>/, data)
@@ -101,7 +101,7 @@ class FirstPayTest < Test::Unit::TestCase
   def test_successful_capture
     response = stub_comms do
       @gateway.capture(@amount, '47920')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
       assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
       assert_match(/<FIELD KEY="operation_type">settle<\/FIELD>/, data)
@@ -129,7 +129,7 @@ class FirstPayTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '47925')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
       assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
       assert_match(/<FIELD KEY="operation_type">credit<\/FIELD>/, data)
@@ -157,7 +157,7 @@ class FirstPayTest < Test::Unit::TestCase
   def test_successful_void
     response = stub_comms do
       @gateway.void('47934')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FIELD KEY="transaction_center_id">1234<\/FIELD>/, data)
       assert_match(/<FIELD KEY="gateway_id">a91c38c3-7d7f-4d29-acc7-927b4dca0dbe<\/FIELD>/, data)
       assert_match(/<FIELD KEY="operation_type">void<\/FIELD>/, data)
@@ -188,7 +188,7 @@ class FirstPayTest < Test::Unit::TestCase
     @options[:recurring_type] = 'monthly'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<FIELD KEY="recurring">1</FIELD>}, data)
       assert_match(%r{<FIELD KEY="recurring_start_date">01/01/1900</FIELD>}, data)
       assert_match(%r{<FIELD KEY="recurring_end_date">02/02/1901</FIELD>}, data)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -160,7 +160,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_requests_include_verification_string
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<VerificationStr1>456 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>', data
     end.respond_with(successful_purchase_response)
   end
@@ -169,7 +169,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     stub_comms do
       options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "123 My\nStreet", address2: "K1C2N6\r", city: "Ottawa\r\n" })})
       @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<VerificationStr1>123 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>', data
     end.respond_with(successful_purchase_response)
   end
@@ -177,7 +177,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_tax_fields_are_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(tax1_amount: 830, tax1_number: 'Br59a'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Tax1Amount>830', data
       assert_match '<Tax1Number>Br59a', data
     end.respond_with(successful_purchase_response)
@@ -186,7 +186,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_customer_ref_is_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(customer: '932'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Customer_Ref>932', data
     end.respond_with(successful_purchase_response)
   end
@@ -194,7 +194,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_eci_default_value
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>07</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -205,7 +205,7 @@ class FirstdataE4Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
 
@@ -214,7 +214,7 @@ class FirstdataE4Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -222,7 +222,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_eci_option_value
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(eci: '05'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -296,7 +296,7 @@ class FirstdataE4Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_authentication_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>06</Ecommerce_Flag>', data
       assert_match '<CAVV>SAMPLECAVV</CAVV>', data
       assert_match '<XID>SAMPLEXID</XID>', data
@@ -318,7 +318,7 @@ class FirstdataE4Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Track1>Track Data</Track1>', data
       assert_match '<Ecommerce_Flag>R</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -52,7 +52,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_successful_purchase_with_wallet
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge!({wallet_provider_id: 4}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/WalletProviderID>4</, data)
     end.respond_with(successful_purchase_response)
 
@@ -69,7 +69,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
     }
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Indicator>1</, data)
       assert_match(/Schedule>U</, data)
       assert_match(/TransactionId>new</, data)
@@ -163,7 +163,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_request_includes_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Address><Address1>456 My Street</Address1><Address2>Apt 1</Address2><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
     end.respond_with(successful_purchase_response)
   end
@@ -172,7 +172,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
     stub_comms do
       options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "456 My\nStreet", address2: nil, city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' })})
       @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Address><Address1>456 My Street</Address1><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data
     end.respond_with(successful_purchase_response)
   end
@@ -180,7 +180,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_tax_fields_are_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(tax1_amount: 830, tax1_number: 'Br59a'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Tax1Amount>830', data
       assert_match '<Tax1Number>Br59a', data
     end.respond_with(successful_purchase_response)
@@ -189,7 +189,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_customer_ref_is_sent
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(customer: '932'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Customer_Ref>932', data
     end.respond_with(successful_purchase_response)
   end
@@ -197,7 +197,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_eci_default_value
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>07</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -208,7 +208,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
 
@@ -217,7 +217,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -225,7 +225,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
   def test_eci_option_value
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(eci: '05'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)
   end
@@ -299,7 +299,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_authentication_data)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Ecommerce_Flag>06</Ecommerce_Flag>', data
       assert_match '<CAVV>SAMPLECAVV</CAVV>', data
       assert_match '<XID>SAMPLEXID</XID>', data
@@ -320,7 +320,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<Track1>Track Data</Track1>', data
       assert_match '<Ecommerce_Flag>R</Ecommerce_Flag>', data
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/flo2cash_simple_test.rb
+++ b/test/unit/gateways/flo2cash_simple_test.rb
@@ -19,7 +19,7 @@ class Flo2cashSimpleTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: 'boom')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<Reference>boom</Reference>}, data)
     end.respond_with(successful_purchase_response)
 
@@ -50,7 +50,7 @@ class Flo2cashSimpleTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/P150200005007600/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/flo2cash_test.rb
+++ b/test/unit/gateways/flo2cash_test.rb
@@ -19,7 +19,7 @@ class Flo2cashTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: 'boom')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<Reference>boom</Reference>}, data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
@@ -50,7 +50,7 @@ class Flo2cashTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/P150100005006789/, data)
     end.respond_with(successful_capture_response)
 
@@ -78,7 +78,7 @@ class Flo2cashTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/P150100005006789/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -28,7 +28,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@accepted_amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match(/000000142800000000920000100001/, endpoint)
     end.respond_with(successful_capture_response)
 
@@ -48,7 +48,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_successful_purchase_with_requires_approval_false
     stub_comms do
       @gateway.purchase(@accepted_amount, @credit_card, @options.merge(requires_approval: false))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal false, JSON.parse(data)['cardPaymentMethodSpecificInput']['requiresApproval']
     end.respond_with(successful_authorize_response)
   end
@@ -78,7 +78,7 @@ class GlobalCollectTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.purchase(@accepted_amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 111, JSON.parse(data)['order']['additionalInput']['airlineData']['code']
       assert_equal '20190810', JSON.parse(data)['order']['additionalInput']['airlineData']['flightDate']
       assert_equal 2, JSON.parse(data)['order']['additionalInput']['airlineData']['flightLegs'].length
@@ -88,7 +88,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_purchase_passes_installments
     stub_comms do
       @gateway.purchase(@accepted_amount, @credit_card, @options.merge(number_of_installments: '3'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"numberOfInstallments\":\"3\"/, data)
     end.respond_with(successful_authorize_response, successful_capture_response)
   end
@@ -106,7 +106,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_authorize_with_pre_authorization_flag
     response = stub_comms do
       @gateway.authorize(@accepted_amount, @credit_card, @options.merge(pre_authorization: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PRE_AUTHORIZATION/, data)
     end.respond_with(successful_authorize_response)
 
@@ -116,7 +116,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_authorize_without_pre_authorization_flag
     response = stub_comms do
       @gateway.authorize(@accepted_amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/FINAL_AUTHORIZATION/, data)
     end.respond_with(successful_authorize_response)
 
@@ -140,7 +140,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@accepted_amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r("fraudFields":{"website":"www.example.com","giftMessage":"Happy Day!","customerIpAddress":"127.0.0.1"}), data
       assert_match %r("merchantReference":"123"), data
       assert_match %r("customer":{"personalInformation":{"name":{"firstName":"Longbob","surname":"Longsen"}},"merchantCustomerId":"123987","contactDetails":{"emailAddress":"example@example.com","phoneNumber":"\(555\)555-5555"},"billingAddress":{"street":"456 My Street","additionalInfo":"Apt 1","zip":"K1C2N6","city":"Ottawa","state":"ON","countryCode":"CA"}}}), data
@@ -154,7 +154,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@accepted_amount, credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/thisisaverylong/, data)
     end.respond_with(successful_authorize_response)
 
@@ -199,7 +199,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match(/000000142800000000920000100001/, endpoint)
     end.respond_with(successful_void_response)
 
@@ -209,7 +209,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, endpoint)
     end.respond_with(failed_void_response)
 
@@ -247,7 +247,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@accepted_amount, capture.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match(/000000142800000000920000100001/, endpoint)
     end.respond_with(successful_refund_response)
 
@@ -257,7 +257,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   def test_refund_passes_currency_code
     stub_comms do
       @gateway.refund(@accepted_amount, '000000142800000000920000100001', {currency: 'COP'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"currencyCode\":\"COP\"/, data)
     end.respond_with(failed_refund_response)
   end

--- a/test/unit/gateways/global_transport_test.rb
+++ b/test/unit/gateways/global_transport_test.rb
@@ -52,7 +52,7 @@ class GlobalTransportTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(100, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PNRef=3648890/, data)
     end.respond_with(successful_capture_response)
 
@@ -70,7 +70,7 @@ class GlobalTransportTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(150, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PNRef=8869269/, data)
     end.respond_with(successful_partial_capture_response)
 
@@ -103,7 +103,7 @@ class GlobalTransportTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(100, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PNRef=3648838/, data)
     end.respond_with(successful_refund_response)
 
@@ -127,7 +127,7 @@ class GlobalTransportTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PNRef=3648838/, data)
     end.respond_with(successful_void_response)
 
@@ -162,7 +162,7 @@ class GlobalTransportTest < Test::Unit::TestCase
   def test_truncation
     stub_comms do
       @gateway.purchase(100, credit_card, order_id: 'a' * 17)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/&InvNum=a{16}&/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/hdfc_test.rb
+++ b/test/unit/gateways/hdfc_test.rb
@@ -47,7 +47,7 @@ class HdfcTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/2441955352022771/, data)
     end.respond_with(successful_capture_response)
 
@@ -64,7 +64,7 @@ class HdfcTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/849768440022761/, data)
     end.respond_with(successful_refund_response)
 
@@ -74,7 +74,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -82,7 +82,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_currency
     stub_comms do
       @gateway.purchase(@amount, @credit_card, currency: 'INR')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/currencycode>356</, data)
     end.respond_with(successful_purchase_response)
   end
@@ -96,7 +96,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_order_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: '932823723')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/932823723/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -104,7 +104,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_description
     stub_comms do
       @gateway.purchase(@amount, @credit_card, description: 'Awesome Services By Us')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Awesome Services By Us/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -112,7 +112,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_escaping
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: 'a' * 41, description: "This has 'Hack Characters' ~`!\#$%^=+|\\:'\",;<>{}[]() and non-Hack Characters -_@.")
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/>This has Hack Characters  and non-Hack Characters -_@.</, data)
       assert_match(/>#{"a" * 40}</, data)
     end.respond_with(successful_purchase_response)
@@ -121,7 +121,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/udf4>Jim Smith\nWidgets Inc\n456 My Street\nApt 1\nOttawa ON K1C2N6\nCA/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -129,7 +129,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_phone_number
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/udf3>555555-5555</, data)
     end.respond_with(successful_purchase_response)
   end
@@ -137,7 +137,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_billing_address_without_phone
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address(phone: nil))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/udf3/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -145,7 +145,7 @@ class HdfcTest < Test::Unit::TestCase
   def test_passing_eci
     stub_comms do
       @gateway.purchase(@amount, @credit_card, eci: 22)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/eci>22</, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -41,7 +41,7 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_check_purchase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@check_amount, @check, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:CheckSale><hps:Block1><hps:CheckAction>SALE<\/hps:CheckAction>/, data)
     end.respond_with(successful_check_purchase_response)
 
@@ -53,7 +53,7 @@ class HpsTest < Test::Unit::TestCase
     check.account_type = nil
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@check_amount, check, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:CheckSale><hps:Block1><hps:CheckAction>SALE<\/hps:CheckAction>/, data)
     end.respond_with(successful_check_purchase_response)
 
@@ -65,7 +65,7 @@ class HpsTest < Test::Unit::TestCase
     check.account_holder_type = nil
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@check_amount, check, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:CheckSale><hps:Block1><hps:CheckAction>SALE<\/hps:CheckAction>/, data)
     end.respond_with(successful_check_purchase_response)
 
@@ -153,7 +153,7 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_check_void
     void = stub_comms(@gateway, :ssl_request) do
       @gateway.void('169054', check_void: true)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:Transaction><hps:CheckVoid>/, data)
     end.respond_with(successful_check_void_response)
 
@@ -581,7 +581,7 @@ class HpsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:SecureECommerce>(.*)<\/hps:SecureECommerce>/, data)
       assert_match(/<hps:PaymentDataSource>Visa 3DSecure<\/hps:PaymentDataSource>/, data)
       assert_match(/<hps:TypeOfPaymentData>3DSecure<\/hps:TypeOfPaymentData>/, data)
@@ -608,7 +608,7 @@ class HpsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:SecureECommerce>(.*)<\/hps:SecureECommerce>/, data)
       assert_match(/<hps:PaymentDataSource>MasterCard 3DSecure<\/hps:PaymentDataSource>/, data)
       assert_match(/<hps:TypeOfPaymentData>3DSecure<\/hps:TypeOfPaymentData>/, data)
@@ -635,7 +635,7 @@ class HpsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:SecureECommerce>(.*)<\/hps:SecureECommerce>/, data)
       assert_match(/<hps:PaymentDataSource>Discover 3DSecure<\/hps:PaymentDataSource>/, data)
       assert_match(/<hps:TypeOfPaymentData>3DSecure<\/hps:TypeOfPaymentData>/, data)
@@ -662,7 +662,7 @@ class HpsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<hps:SecureECommerce>(.*)<\/hps:SecureECommerce>/, data)
       assert_match(/<hps:PaymentDataSource>AMEX 3DSecure<\/hps:PaymentDataSource>/, data)
       assert_match(/<hps:TypeOfPaymentData>3DSecure<\/hps:TypeOfPaymentData>/, data)
@@ -689,7 +689,7 @@ class HpsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/<hps:SecureECommerce>(.*)<\/hps:SecureECommerce>/, data)
       refute_match(/<hps:PaymentDataSource>(.*)<\/hps:PaymentDataSource>/, data)
       refute_match(/<hps:TypeOfPaymentData>3DSecure<\/hps:TypeOfPaymentData>/, data)

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -115,7 +115,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     @options[:email] = 'jsmith2@example.com'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<email>#{@options[:email]}<\/email>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -137,7 +137,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '1234', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionId>1234<\/transactionId>/, data)
       assert_match(/<total>-1.00<\/total>/, data)
     end.respond_with(successful_refund_response)
@@ -183,7 +183,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_failed_refund
     response = stub_comms do
       @gateway.refund(@amount, '1234', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionId>1234<\/transactionId>/, data)
       assert_match(/<total>-1.00<\/total>/, data)
     end.respond_with(failed_refund_response)
@@ -196,7 +196,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/beginDate/, data)
       assert_match(/endDate/, data)
       assert_match(%r{<creditCardNum>#{@credit_card.number}</creditCardNum>}, data)
@@ -213,7 +213,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_successful_purchase_with_customer_code
     response = stub_comms do
       @gateway.purchase(@amount, 'CustomerCode', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<customerCode>CustomerCode</customerCode>}, data)
     end.respond_with(successful_purchase_response)
 
@@ -235,7 +235,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
   def test_successful_unstore
     response = stub_comms do
       @gateway.unstore('TheAuthorization', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<customerCode>TheAuthorization</customerCode>}, data)
     end.respond_with(successful_unstore_response)
 
@@ -254,7 +254,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match(/<agentCode>login<\/agentCode>/, data)
       assert_match(/<password>password<\/password>/, data)
       assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
@@ -272,7 +272,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_equal endpoint, 'https://www.iatspayments.com/NetGate/ProcessLinkv3.asmx?op=ProcessCreditCard'
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/ipp_test.rb
+++ b/test/unit/gateways/ipp_test.rb
@@ -16,7 +16,7 @@ class IppTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSinglePayment }, data)
       assert_match(%r{<UserName>username<}, data)
       assert_match(%r{<Password>password<}, data)
@@ -48,7 +48,7 @@ class IppTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSinglePayment }, data)
       assert_match(%r{<CustRef>1<}, data)
       assert_match(%r{<TrnType>2<}, data)
@@ -61,7 +61,7 @@ class IppTest < Test::Unit::TestCase
   def test_successful_capture
     response = stub_comms do
       @gateway.capture(@amount, 'receipt')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSingleCapture }, data)
       assert_match(%r{<Receipt>receipt<}, data)
       assert_match(%r{<Amount>100<}, data)
@@ -73,7 +73,7 @@ class IppTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, 'receipt')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<SubmitSingleRefund }, data)
       assert_match(%r{<Receipt>receipt<}, data)
       assert_match(%r{<Amount>100<}, data)

--- a/test/unit/gateways/iridium_test.rb
+++ b/test/unit/gateways/iridium_test.rb
@@ -114,7 +114,7 @@ class IridiumTest < Test::Unit::TestCase
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(14200, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<TransactionDetails Amount=\"142\"/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -28,7 +28,7 @@ class IxopayTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<description>.+<\/description>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -41,7 +41,7 @@ class IxopayTest < Test::Unit::TestCase
   def test_successful_purchase_with_extra_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(@extra_data))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_purchase_response)
@@ -76,7 +76,7 @@ class IxopayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert match(/<description>.+<\/description>/, data)
     end.respond_with(successful_authorize_response)
 
@@ -91,7 +91,7 @@ class IxopayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(@extra_data))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_authorize_response)
@@ -128,7 +128,7 @@ class IxopayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.capture(@amount, '00eb44f8f0382443cce5|20191028-00eb44f8f0382443cce5', @options.merge(@extra_data))
-    end.check_request do |endpoint, data, header|
+    end.check_request do |_endpoint, data, _header|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_capture_response)
@@ -162,7 +162,7 @@ class IxopayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.refund(@amount, 'eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe', @options.merge(@extra_data))
-    end.check_request do |endpoint, data, header|
+    end.check_request do |_endpoint, data, _header|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_refund_response)
@@ -176,7 +176,7 @@ class IxopayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.refund(@amount, 'eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe', options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<currency>USD<\/currency>/, data)
     end.respond_with(successful_refund_response)
   end
@@ -201,7 +201,7 @@ class IxopayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_void_response)
     response = stub_comms do
       @gateway.void('eb2bef23a30b537b90fb|20191016-b2bef23a30b537b90fbe', @options.merge(@extra_data))
-    end.check_request do |endpoint, data, header|
+    end.check_request do |_endpoint, data, _header|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_void_response)
@@ -230,7 +230,7 @@ class IxopayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, successful_void_response)
     response = stub_comms do
       @gateway.verify(credit_card('4111111111111111'), @options.merge(@extra_data))
-    end.check_request do |endpoint, data, header|
+    end.check_request do |_endpoint, data, _header|
       assert_match(/<extraData key="customData1">some data<\/extraData>/, data)
       assert_match(/<extraData key="customData2">Can be anything really<\/extraData>/, data)
     end.respond_with(successful_authorize_response, successful_void_response)
@@ -272,7 +272,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>INITIAL<\/transactionIndicator>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -286,7 +286,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>INITIAL<\/transactionIndicator>/, data)
     end.respond_with(successful_authorize_response)
 
@@ -300,7 +300,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>RECURRING<\/transactionIndicator>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -314,7 +314,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>RECURRING<\/transactionIndicator>/, data)
     end.respond_with(successful_authorize_response)
 
@@ -328,7 +328,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>CARDONFILE<\/transactionIndicator>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -342,7 +342,7 @@ class IxopayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<transactionIndicator>CARDONFILE<\/transactionIndicator>/, data)
     end.respond_with(successful_authorize_response)
 
@@ -353,7 +353,7 @@ class IxopayTest < Test::Unit::TestCase
   def test_three_decimal_currency_handling
     response = stub_comms do
       @gateway.authorize(14200, @credit_card, @options.merge(currency: 'KWD'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<amount>14.200<\/amount>/, data)
       assert_match(/<currency>KWD<\/currency>/, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -68,7 +68,7 @@ class KushkiTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_no_match %r{extraTaxes}, data if /charges/.match?(endpoint)
     end.respond_with(successful_charge_response, successful_token_response)
 
@@ -99,7 +99,7 @@ class KushkiTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_no_match %r{propina}, data
@@ -136,7 +136,7 @@ class KushkiTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       if /charges/.match?(endpoint)
         assert_match %r{extraTaxes}, data
         assert_match %r{propina}, data

--- a/test/unit/gateways/latitude19_test.rb
+++ b/test/unit/gateways/latitude19_test.rb
@@ -40,7 +40,7 @@ class Latitude19Test < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"amount\":\"1.00\"/, data)
     end.respond_with(successful_capture_response)
     assert_success capture

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -87,7 +87,7 @@ class LitleTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<affiliate>some-affiliate</affiliate>), data)
       assert_match(%r(<campaign>super-awesome-campaign</campaign>), data)
       assert_match(%r(<merchantGroupingId>brilliant-group</merchantGroupingId>), data)
@@ -97,7 +97,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_name_on_card
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<billToAddress>\s*<name>Longbob Longsen<), data)
     end.respond_with(successful_purchase_response)
   end
@@ -105,7 +105,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_order_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: '774488')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/774488/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -113,7 +113,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<billToAddress>.*Widgets.*456.*Apt 1.*Otta.*ON.*K1C.*CA.*555-5/m, data)
     end.respond_with(successful_purchase_response)
   end
@@ -121,7 +121,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_shipping_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, shipping_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<shipToAddress>.*Widgets.*456.*Apt 1.*Otta.*ON.*K1C.*CA.*555-5/m, data)
     end.respond_with(successful_purchase_response)
   end
@@ -131,7 +131,7 @@ class LitleTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, {
         descriptor_name: 'Name', descriptor_phone: 'Phone'
       })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<customBilling>.*<descriptor>Name<)m, data)
       assert_match(%r(<customBilling>.*<phone>Phone<)m, data)
     end.respond_with(successful_authorize_response)
@@ -140,7 +140,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_debt_repayment
     stub_comms do
       @gateway.authorize(@amount, @credit_card, { debt_repayment: true })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<debtRepayment>true</debtRepayment>), data)
     end.respond_with(successful_authorize_response)
   end
@@ -148,7 +148,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_payment_cryptogram
     stub_comms do
       @gateway.purchase(@amount, @decrypted_apple_pay)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/BwABBJQ1AgAAAAAgJDUCAAAAAAA=/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -156,7 +156,7 @@ class LitleTest < Test::Unit::TestCase
   def test_passing_basis_date
     stub_comms do
       @gateway.purchase(@amount, 'token', {basis_expiration_month: '04', basis_expiration_year: '2027'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<expDate>0427<\/expDate>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -171,7 +171,7 @@ class LitleTest < Test::Unit::TestCase
     )
     stub_comms do
       @gateway.purchase(@amount, check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/<checkNum\/>/m, data)
     end.respond_with(successful_purchase_response)
   end
@@ -179,7 +179,7 @@ class LitleTest < Test::Unit::TestCase
   def test_add_applepay_order_source
     stub_comms do
       @gateway.purchase(@amount, @decrypted_apple_pay)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>applepay</orderSource>', data
     end.respond_with(successful_purchase_response)
   end
@@ -187,7 +187,7 @@ class LitleTest < Test::Unit::TestCase
   def test_add_android_pay_order_source
     stub_comms do
       @gateway.purchase(@amount, @decrypted_android_pay)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>androidpay</orderSource>', data
     end.respond_with(successful_purchase_response)
   end
@@ -204,7 +204,7 @@ class LitleTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/100000000000000001/, data)
     end.respond_with(successful_capture_response)
 
@@ -240,7 +240,7 @@ class LitleTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/100000000000000006/, data)
     end.respond_with(successful_refund_response)
 
@@ -267,7 +267,7 @@ class LitleTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<authReversal.*<litleTxnId>100000000000000001</m, data)
     end.respond_with(successful_void_of_auth_response)
 
@@ -283,7 +283,7 @@ class LitleTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(refund.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<void.*<litleTxnId>100000000000000003</m, data)
     end.respond_with(successful_void_of_other_things_response)
 
@@ -322,7 +322,7 @@ class LitleTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<accountNumber>4242424242424242</, data)
     end.respond_with(successful_store_response)
 
@@ -377,7 +377,7 @@ class LitleTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<track>Track Data</track>', data
       assert_match '<orderSource>retail</orderSource>', data
       assert_match %r{<pos>.+<\/pos>}m, data
@@ -387,7 +387,7 @@ class LitleTest < Test::Unit::TestCase
   def test_order_source_with_creditcard_no_track_data
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>ecommerce</orderSource>', data
       assert %r{<pos>.+<\/pos>}m !~ data
     end.respond_with(successful_purchase_response)
@@ -396,7 +396,7 @@ class LitleTest < Test::Unit::TestCase
   def test_order_source_override
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_source: 'recurring')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>recurring</orderSource>', data
     end.respond_with(successful_purchase_response)
   end
@@ -423,7 +423,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>initialCOF</processingType>), data)
     end.respond_with(successful_authorize_stored_credentials)
 
@@ -442,7 +442,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>cardholderInitiatedCOF</processingType>), data)
       assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
       assert_match(%r(<orderSource>ecommerce</orderSource>), data)
@@ -466,7 +466,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>cardholderInitiatedCOF</processingType>), data)
       assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
       assert_match(%r(<orderSource>3dsAuthenticated</orderSource>), data)
@@ -487,7 +487,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>initialCOF</processingType>), data)
     end.respond_with(successful_authorize_stored_credentials)
 
@@ -506,7 +506,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>merchantInitiatedCOF</processingType>), data)
       assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
       assert_match(%r(<orderSource>ecommerce</orderSource>), data)
@@ -527,7 +527,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>initialInstallment</processingType>), data)
     end.respond_with(successful_authorize_stored_credentials)
 
@@ -546,7 +546,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
       assert_match(%r(<orderSource>installment</orderSource>), data)
     end.respond_with(successful_authorize_stored_credentials)
@@ -566,7 +566,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<processingType>initialRecurring</processingType>), data)
     end.respond_with(successful_authorize_stored_credentials)
 
@@ -585,7 +585,7 @@ class LitleTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
       assert_match(%r(<orderSource>recurring</orderSource>), data)
     end.respond_with(successful_authorize_stored_credentials)

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -274,7 +274,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_not_match(%r("payment_method_id":"amex"), data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
 
@@ -287,7 +287,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(payment_method_id: 'diners'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match(%r("payment_method_id":"diners"), data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
 
@@ -298,7 +298,7 @@ class MercadoPagoTest < Test::Unit::TestCase
   def test_successful_purchase_with_notification_url
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(notification_url: 'www.mercado-pago.com'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match(%r("notification_url":"www.mercado-pago.com"), data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
 
@@ -318,7 +318,7 @@ class MercadoPagoTest < Test::Unit::TestCase
     @options[:additional_info] = {'foo' => 'bar', 'baz' => 'quux'}
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       if /payment_method_id/.match?(data)
         assert_match(/"foo":"bar"/, data)
         assert_match(/"baz":"quux"/, data)
@@ -331,7 +331,7 @@ class MercadoPagoTest < Test::Unit::TestCase
   def test_includes_issuer_id
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: '1a2b3c4d'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match(%r("issuer_id":"1a2b3c4d"), data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
 
@@ -347,7 +347,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(taxes: taxes_array))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       single_pattern = "{\"value\":#{taxes_value},\"type\":\"#{taxes_type}\"}"
       pattern = "\"taxes\":[#{single_pattern},#{single_pattern}]"
       assert_match(pattern, data) if endpoint =~ /payments/
@@ -361,7 +361,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(taxes: taxes_object))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       pattern = "\"taxes\":[{\"value\":#{taxes_value},\"type\":\"#{taxes_type}\"}]"
       assert_match(pattern, data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
@@ -372,7 +372,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(net_amount: net_amount))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match("\"net_amount\":#{net_amount}", data) if endpoint =~ /payments/
     end.respond_with(successful_purchase_response)
   end
@@ -385,7 +385,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(taxes: taxes_array))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       single_pattern = "{\"value\":#{taxes_value},\"type\":\"#{taxes_type}\"}"
       pattern = "\"taxes\":[#{single_pattern},#{single_pattern}]"
       assert_match(pattern, data) if endpoint =~ /payments/
@@ -399,7 +399,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(taxes: taxes_object))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       pattern = "\"taxes\":[{\"value\":#{taxes_value},\"type\":\"#{taxes_type}\"}]"
       assert_match(pattern, data) if endpoint =~ /payments/
     end.respond_with(successful_authorize_response)
@@ -410,7 +410,7 @@ class MercadoPagoTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(net_amount: net_amount))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       assert_match("\"net_amount\":#{net_amount}", data) if endpoint =~ /payments/
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -144,7 +144,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
   def test_visa_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({xid: '1', cavv: '2'}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/xid=1/, data)
       assert_match(/cavv=2/, data)
     end.respond_with(successful_purchase_response)
@@ -153,7 +153,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
   def test_mastercard_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({ucaf_collection_ind: '1', ucaf_auth_data: '2'}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ucaf_collection_ind=1/, data)
       assert_match(/ucaf_auth_data=2/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/merchant_partners_test.rb
+++ b/test/unit/gateways/merchant_partners_test.rb
@@ -19,7 +19,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -51,7 +51,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -70,7 +70,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -115,7 +115,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -145,7 +145,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -170,7 +170,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
   def test_successful_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -217,7 +217,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -247,7 +247,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
 
     purchase = stub_comms do
       @gateway.purchase(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content
@@ -275,7 +275,7 @@ class MerchantPartnersTest < Test::Unit::TestCase
 
     credit = stub_comms do
       @gateway.credit(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_not_nil root = doc.at_xpath(@request_root)
         assert_equal @gateway.options[:account_id], root.at_xpath('//acctid').content

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -113,7 +113,7 @@ class MerchantWareTest < Test::Unit::TestCase
     options = {order_id: '1'}
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<trackData>Track Data</trackData>', data
     end.respond_with(successful_authorization_response)
   end

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -97,7 +97,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     store = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/cardExpiryMonth=02\b/, data)
       assert_match(/cardExpiryYear=05\b/, data)
     end.respond_with(successful_store_response)
@@ -114,7 +114,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/customerName=Ren\+\+Stimpy/, data)
       assert_match(/paymentCardName=Chars\+Merchant-Warrior\+Dont\+Like\+\+More\.\+\+Here/, data)
     end.respond_with(successful_purchase_response)
@@ -135,7 +135,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/customerName=Bat\+Man/, data)
       assert_match(/customerCountry=US/, data)
       assert_match(/customerState=NY/, data)
@@ -156,7 +156,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/customerState=N%2FA/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -164,7 +164,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_orderid_truncated
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, order_id: 'ThisIsQuiteALongDescriptionWithLotsOfChars')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/transactionProduct=ThisIsQuiteALongDescriptionWithLot&/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -172,7 +172,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_authorize_recurring_flag_absent
     stub_comms do
       @gateway.authorize(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/recurringFlag&/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -182,7 +182,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(@success_amount, @credit_card, recurring_flag: recurring_flag)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/recurringFlag=#{recurring_flag}&/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -190,7 +190,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_purchase_recurring_flag_absent
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/recurringFlag&/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -200,7 +200,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, recurring_flag: recurring_flag)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/recurringFlag=#{recurring_flag}&/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -208,7 +208,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_authorize_with_soft_descriptor_absent
     stub_comms do
       @gateway.authorize(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/descriptorName&/, data)
       assert_not_match(/descriptorCity&/, data)
       assert_not_match(/descriptorState&/, data)
@@ -218,7 +218,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_authorize_with_soft_descriptor_present
     stub_comms do
       @gateway.authorize(@success_amount, @credit_card, soft_descriptor_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/descriptorName=FOO%2ATest&/, data)
       assert_match(/descriptorCity=Melbourne&/, data)
       assert_match(/descriptorState=VIC&/, data)
@@ -228,7 +228,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_purchase_with_soft_descriptor_absent
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/descriptorName&/, data)
       assert_not_match(/descriptorCity&/, data)
       assert_not_match(/descriptorState&/, data)
@@ -238,7 +238,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_purchase_with_soft_descriptor_present
     stub_comms do
       @gateway.purchase(@success_amount, @credit_card, soft_descriptor_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/descriptorName=FOO%2ATest&/, data)
       assert_match(/descriptorCity=Melbourne&/, data)
       assert_match(/descriptorState=VIC&/, data)
@@ -248,7 +248,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_capture_with_soft_descriptor_absent
     stub_comms do
       @gateway.capture(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/descriptorName&/, data)
       assert_not_match(/descriptorCity&/, data)
       assert_not_match(/descriptorState&/, data)
@@ -258,7 +258,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_capture_with_soft_descriptor_present
     stub_comms do
       @gateway.capture(@success_amount, @credit_card, soft_descriptor_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/descriptorName=FOO%2ATest&/, data)
       assert_match(/descriptorCity=Melbourne&/, data)
       assert_match(/descriptorState=VIC&/, data)
@@ -268,7 +268,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_refund_with_soft_descriptor_absent
     stub_comms do
       @gateway.refund(@success_amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_not_match(/descriptorName&/, data)
       assert_not_match(/descriptorCity&/, data)
       assert_not_match(/descriptorState&/, data)
@@ -278,7 +278,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
   def test_refund_with_soft_descriptor_present
     stub_comms do
       @gateway.refund(@success_amount, @credit_card, soft_descriptor_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/descriptorName=FOO%2ATest&/, data)
       assert_match(/descriptorCity=Melbourne&/, data)
       assert_match(/descriptorState=VIC&/, data)

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -20,7 +20,7 @@ class MercuryTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/InvoiceNo>c111111111.1</, data)
       assert_match(/Frequency>OneTime/, data)
       assert_match(/RecordNo>RecordNumberRequested/, data)
@@ -36,7 +36,7 @@ class MercuryTest < Test::Unit::TestCase
   def test_successful_purchase_with_allow_partial_auth
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(allow_partial_auth: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/PartialAuth>Allow</, data)
     end.respond_with(successful_purchase_response)
 
@@ -68,7 +68,7 @@ class MercuryTest < Test::Unit::TestCase
     @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<Track1>#{Regexp.escape(track_data)}<\/Track1>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -82,7 +82,7 @@ class MercuryTest < Test::Unit::TestCase
     @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<Track2>#{Regexp.escape(stripped_track_data)}<\/Track2>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -96,7 +96,7 @@ class MercuryTest < Test::Unit::TestCase
     @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<Track1>#{Regexp.escape(stripped_data)}<\/Track1>/, data)
     end.respond_with(successful_purchase_response)
 
@@ -109,7 +109,7 @@ class MercuryTest < Test::Unit::TestCase
     @credit_card.track_data = track_data
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<Track1>#{Regexp.escape(track_data)}<\/Track1>/, data)
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -122,7 +122,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_refund_passing_extra_info
     response = stub_comms do
       @gateway.refund(50, '123456789', card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/x_first_name=Bob/, data)
       assert_match(/x_last_name=Smith/, data)
       assert_match(/x_zip=12345/, data)

--- a/test/unit/gateways/micropayment_test.rb
+++ b/test/unit/gateways/micropayment_test.rb
@@ -15,7 +15,7 @@ class MicropaymentTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/accessKey=key/, data)
       assert_match(/number=#{@credit_card.number}/, data)
       assert_match(/cvc2=#{@credit_card.verification_value}/, data)
@@ -40,7 +40,7 @@ class MicropaymentTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/accessKey=key/, data)
       assert_match(/number=#{@credit_card.number}/, data)
       assert_match(/cvc2=#{@credit_card.verification_value}/, data)
@@ -52,7 +52,7 @@ class MicropaymentTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/accessKey=key/, data)
       assert_match(/transactionId=www.spreedly.com-IDhngtaj81a1/, data)
       assert_match(/sessionId=CC747358d9598614c3ba1e9a7b82a28318cd81bc/, data)
@@ -89,7 +89,7 @@ class MicropaymentTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/accessKey=key/, data)
       assert_match(/transactionId=www.spreedly.com-IDhngtaj81a1/, data)
       assert_match(/sessionId=CC747358d9598614c3ba1e9a7b82a28318cd81bc/, data)
@@ -115,7 +115,7 @@ class MicropaymentTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/accessKey=key/, data)
       assert_match(/transactionId=www.spreedly.com-IDhm7nyju168/, data)
       assert_match(/sessionId=CCadc2b593ca98bfd730c383582de00faed995b0/, data)

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -138,7 +138,7 @@ class MoneiTest < Test::Unit::TestCase
     })
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       body = CGI.unescape data
       assert_match %r{<Authentication type="3DSecure">}, body
       assert_match %r{<ResultIndicator>05</ResultIndicator>}, body

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -270,7 +270,7 @@ class MonerisTest < Test::Unit::TestCase
     @credit_card.verification_value = '452'
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{cvd_indicator>1<}, data)
       assert_match(%r{cvd_value>452<}, data)
     end.respond_with(successful_purchase_response)
@@ -282,7 +282,7 @@ class MonerisTest < Test::Unit::TestCase
     @credit_card.verification_value = ''
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{cvd_indicator>0<}, data)
       assert_no_match(%r{cvd_value>}, data)
     end.respond_with(successful_purchase_response)
@@ -292,7 +292,7 @@ class MonerisTest < Test::Unit::TestCase
     @credit_card.verification_value = '452'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{cvd_value>}, data)
       assert_no_match(%r{cvd_indicator>}, data)
     end.respond_with(successful_purchase_response)
@@ -302,7 +302,7 @@ class MonerisTest < Test::Unit::TestCase
     @credit_card.verification_value = ''
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{cvd_value>}, data)
       assert_no_match(%r{cvd_indicator>}, data)
     end.respond_with(successful_purchase_response)
@@ -314,7 +314,7 @@ class MonerisTest < Test::Unit::TestCase
     billing_address = address(address1: '1234 Anystreet', address2: '')
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: '1')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{avs_street_number>1234<}, data)
       assert_match(%r{avs_street_name>Anystreet<}, data)
       assert_match(%r{avs_zipcode>#{billing_address[:zip]}<}, data)
@@ -326,7 +326,7 @@ class MonerisTest < Test::Unit::TestCase
 
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{avs_street_number>}, data)
       assert_no_match(%r{avs_street_name>}, data)
       assert_no_match(%r{avs_zipcode>}, data)
@@ -337,7 +337,7 @@ class MonerisTest < Test::Unit::TestCase
     billing_address = address(address1: '1234 Anystreet', address2: '')
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: '1')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{avs_street_number>}, data)
       assert_no_match(%r{avs_street_name>}, data)
       assert_no_match(%r{avs_zipcode>}, data)
@@ -347,7 +347,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_avs_disabled_and_not_provided
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{avs_street_number>}, data)
       assert_no_match(%r{avs_street_name>}, data)
       assert_no_match(%r{avs_zipcode>}, data)
@@ -368,7 +368,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_customer_can_be_specified
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: '3', customer: 'Joe Jones')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{cust_id>Joe Jones}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -376,7 +376,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_customer_not_specified_card_name_used
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: '3')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{cust_id>Longbob Longsen}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -386,7 +386,7 @@ class MonerisTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match '<pos_code>00</pos_code>', data
       assert_match '<track2>Track Data</track2>', data
     end.respond_with(successful_purchase_response)
@@ -404,7 +404,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -417,7 +417,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -430,7 +430,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -443,7 +443,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -456,7 +456,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -469,7 +469,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -482,7 +482,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -495,7 +495,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -508,7 +508,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -521,7 +521,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -534,7 +534,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id><\/issuer_id>/, data)
       assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)
@@ -547,7 +547,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
       assert_match(/<payment_indicator>U<\/payment_indicator>/, data)
       assert_match(/<payment_information>2<\/payment_information>/, data)
@@ -560,7 +560,7 @@ class MonerisTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(issuer_id: 'xyz987', payment_indicator: 'R', payment_information: '0')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<issuer_id>xyz987<\/issuer_id>/, data)
       assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
       assert_match(/<payment_information>0<\/payment_information>/, data)

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -59,7 +59,7 @@ class MundipaggTest < Test::Unit::TestCase
     @options[:holder_document] = 'a1b2c3d4'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/a1b2c3d4/, data)
     end.respond_with(successful_purchase_response)
 
@@ -71,7 +71,7 @@ class MundipaggTest < Test::Unit::TestCase
     @options.delete(:billing_address)
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       refute data['billing_address']
     end.respond_with(successful_purchase_response)
   end
@@ -271,7 +271,7 @@ class MundipaggTest < Test::Unit::TestCase
     }
     stub_comms do
       gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"gateway_affiliation_id":"abc123"/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -139,7 +139,7 @@ class NabTransactTest < Test::Unit::TestCase
   def test_request_timeout_default
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<timeoutValue>60/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -148,7 +148,7 @@ class NabTransactTest < Test::Unit::TestCase
     gateway = NabTransactGateway.new(login: 'login', password: 'password', request_timeout: 44)
     stub_comms(gateway, :ssl_request) do
       gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<timeoutValue>44/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -156,7 +156,7 @@ class NabTransactTest < Test::Unit::TestCase
   def test_nonfractional_currencies
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/<amount>100<\/amount>/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -215,7 +215,7 @@ class NabTransactTest < Test::Unit::TestCase
   end
 
   def check_transaction_type(type)
-    Proc.new do |endpoint, data, headers|
+    Proc.new do |_endpoint, data, _headers|
       request_hash = Hash.from_xml(data)
       request_hash['NABTransactMessage']['Payment']['TxnList']['Txn']['txnType'] == NabTransactGateway::TRANSACTIONS[type].to_s
     end
@@ -230,7 +230,7 @@ class NabTransactTest < Test::Unit::TestCase
   def assert_metadata(name, location, &block)
     stub_comms(@gateway, :ssl_request) do
       yield
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       metadata_matcher = Regexp.escape(valid_metadata(name, location))
       assert_match %r{#{metadata_matcher}}, data
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/ncr_secure_pay_test.rb
+++ b/test/unit/gateways/ncr_secure_pay_test.rb
@@ -18,7 +18,7 @@ class NcrSecurePayTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<username\>login\<\/username\>/, data)
       assert_match(/\<password\>password\<\/password\>/, data)
       assert_match(/\<action\>sale\<\/action\>/, data)
@@ -43,7 +43,7 @@ class NcrSecurePayTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<username\>login\<\/username\>/, data)
       assert_match(/\<password\>password\<\/password\>/, data)
       assert_match(/\<action\>preauth\<\/action\>/, data)
@@ -67,7 +67,7 @@ class NcrSecurePayTest < Test::Unit::TestCase
   def test_successful_capture
     response = stub_comms do
       @gateway.capture(@amount, '12345', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<username\>login\<\/username\>/, data)
       assert_match(/\<password\>password\<\/password\>/, data)
       assert_match(/\<action\>preauthcomplete\<\/action\>/, data)
@@ -90,7 +90,7 @@ class NcrSecurePayTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '12345', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<username\>login\<\/username\>/, data)
       assert_match(/\<password\>password\<\/password\>/, data)
       assert_match(/\<action\>credit\<\/action\>/, data)
@@ -113,7 +113,7 @@ class NcrSecurePayTest < Test::Unit::TestCase
   def test_successful_void
     response = stub_comms do
       @gateway.void('12345', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\<username\>login\<\/username\>/, data)
       assert_match(/\<password\>password\<\/password\>/, data)
       assert_match(/\<action\>void\<\/action\>/, data)

--- a/test/unit/gateways/netbilling_test.rb
+++ b/test/unit/gateways/netbilling_test.rb
@@ -47,7 +47,7 @@ class NetbillingTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/site_tag=dummy-site-tag/, data)
     end.respond_with(successful_purchase_response)
 
@@ -57,7 +57,7 @@ class NetbillingTest < Test::Unit::TestCase
   def test_site_tag_not_sent_if_not_provided
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/site_tag/, data)
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -21,7 +21,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=sale/, data)
@@ -43,7 +43,7 @@ class NmiTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       test_transaction_options(data)
 
       assert_match(/merchant_defined_field_8=value8/, data)
@@ -65,7 +65,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_purchase_with_echeck
     response = stub_comms do
       @gateway.purchase(@amount, @check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=sale/, data)
@@ -101,7 +101,7 @@ class NmiTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       test_transaction_options(data)
 
       assert_match(/merchant_defined_field_8=value8/, data)
@@ -113,7 +113,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=auth/, data)
@@ -128,7 +128,7 @@ class NmiTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=capture/, data)
@@ -167,7 +167,7 @@ class NmiTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=void/, data)
@@ -195,7 +195,7 @@ class NmiTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=refund/, data)
@@ -217,7 +217,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=credit/, data)
@@ -237,7 +237,7 @@ class NmiTest < Test::Unit::TestCase
   def test_credit_with_options
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @transaction_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       test_transaction_options(data)
     end.respond_with(successful_credit_response)
 
@@ -274,7 +274,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/customer_vault=add_customer/, data)
@@ -304,7 +304,7 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_store_with_echeck
     response = stub_comms do
       @gateway.store(@check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/customer_vault=add_customer/, data)
@@ -346,7 +346,7 @@ class NmiTest < Test::Unit::TestCase
   def test_includes_cvv_tag
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{cvv}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -355,14 +355,14 @@ class NmiTest < Test::Unit::TestCase
     @credit_card.verification_value = nil
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{cvv}, data)
     end.respond_with(successful_purchase_response)
 
     @credit_card.verification_value = '  '
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{cvv}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -386,7 +386,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       assert_match(/billing_method=recurring/, data)
@@ -400,7 +400,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=recurring/, data)
@@ -414,7 +414,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       assert_match(/billing_method=recurring/, data)
@@ -428,7 +428,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=recurring/, data)
@@ -442,7 +442,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       assert_match(/billing_method=installment/, data)
@@ -456,7 +456,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=installment/, data)
@@ -470,7 +470,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       assert_match(/billing_method=installment/, data)
@@ -484,7 +484,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=installment/, data)
@@ -498,7 +498,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       refute_match(/billing_method/, data)
@@ -512,7 +512,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       refute_match(/billing_method/, data)
@@ -526,7 +526,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=stored/, data)
       refute_match(/billing_method/, data)
@@ -540,7 +540,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       refute_match(/billing_method/, data)
@@ -554,7 +554,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=installment/, data)
@@ -568,7 +568,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123').merge(recurring: true)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=installment/, data)
@@ -582,7 +582,7 @@ class NmiTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(recurring: true)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/initiated_by=merchant/, data)
       assert_match(/stored_credential_indicator=used/, data)
       refute_match(/billing_method/, data)
@@ -597,7 +597,7 @@ class NmiTest < Test::Unit::TestCase
   def test_verify(options = {})
     response = stub_comms do
       @gateway.verify(@credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/username=#{@gateway.options[:login]}/, data)
       assert_match(/password=#{@gateway.options[:password]}/, data)
       assert_match(/type=validate/, data)

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -171,7 +171,7 @@ class OpenpayTest < Test::Unit::TestCase
   def test_passing_device_session_id
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, device_session_id: 'TheDeviceSessionID')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"device_session_id":"TheDeviceSessionID"}, data)
     end.respond_with(successful_purchase_response)
 
@@ -181,7 +181,7 @@ class OpenpayTest < Test::Unit::TestCase
   def test_passing_payment_installments
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, payments: '6')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"payments":"6"}, data)
       assert_match(%r{"payment_plan":}, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -177,7 +177,7 @@ class OppTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @valid_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/threeDSecure.eci=eci/, data)
       assert_match(/threeDSecure.verificationId=cavv/, data)
       assert_match(/threeDSecure.xid=xid/, data)

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -34,7 +34,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_ip_address_is_passed
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(ip: '1.2.3.4'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{customerIP%3E1.2.3.4%3C}, data
     end.respond_with(successful_purchase_response)
   end
@@ -73,7 +73,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_purchase_from_canada_includes_state_field
     @options[:billing_address][:country] = 'CA'
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data =~ /state/ && data !~ /region/
     end.returns(successful_purchase_response)
 
@@ -82,7 +82,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_purchase_from_us_includes_state_field
     @options[:billing_address][:country] = 'US'
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data =~ /state/ && data !~ /region/
     end.returns(successful_purchase_response)
 
@@ -91,7 +91,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_purchase_from_any_other_country_includes_region_field
     @options[:billing_address][:country] = 'GB'
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       data =~ /region/ && data !~ /state/
     end.returns(successful_purchase_response)
 
@@ -100,7 +100,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_purchase_with_shipping_address
     @options[:shipping_address] = {country: 'CA'}
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))
       doc.xpath('//xmlns:shippingDetails/xmlns:country').first.text == 'CA' && doc.to_s.include?('<shippingDetails>')
@@ -111,7 +111,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
   def test_purchase_without_shipping_address
     @options[:shipping_address] = nil
-    @gateway.expects(:ssl_post).with do |url, data|
+    @gateway.expects(:ssl_post).with do |_url, data|
       xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))
       doc.to_s.include?('<shippingDetails>') == false
@@ -131,7 +131,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   def test_cvd_fields_pass_correctly
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/cvdIndicator%3E1%3C\/cvdIndicator%3E%0A%20%20%20%20%3Ccvd%3E123%3C\/cvd/, data)
     end.respond_with(successful_purchase_response)
 
@@ -146,7 +146,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/cvdIndicator%3E0%3C\/cvdIndicator%3E%0A%20%20%3C\/card/, data)
     end.respond_with(failed_purchase_response)
   end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -111,7 +111,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_level_2_data
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(level_2_data: @level_2))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<TaxInd>#{@level_2[:tax_indicator].to_i}</TaxInd>}, data
       assert_match %{<Tax>#{@level_2[:tax].to_i}</Tax>}, data
       assert_match %{<AMEXTranAdvAddn1>#{@level_2[:advice_addendum_1]}</AMEXTranAdvAddn1>}, data
@@ -131,7 +131,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_level_3_data
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(level_3_data: @level_3))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<PC3FreightAmt>#{@level_3[:freight_amount].to_i}</PC3FreightAmt>}, data
       assert_match %{<PC3DutyAmt>#{@level_3[:duty_amount].to_i}</PC3DutyAmt>}, data
       assert_match %{<PC3DestCountryCd>#{@level_3[:dest_country]}</PC3DestCountryCd>}, data
@@ -147,7 +147,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_line_items_data
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(line_items: @line_items))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<PC3DtlIndex>1</PC3DtlIndex>}, data
       assert_match %{<PC3DtlDesc>#{@line_items[1][:desc]}</PC3DtlDesc>}, data
       assert_match %{<PC3DtlProdCd>#{@line_items[1][:prod_cd]}</PC3DtlProdCd>}, data
@@ -167,7 +167,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_network_tokenization_credit_card_data
     stub_comms do
       @gateway.purchase(50, network_tokenization_credit_card(nil, eci: '5', transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA='), @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<DPANInd>Y</DPANInd>}, data
       assert_match %{DigitalTokenCryptogram}, data
@@ -177,7 +177,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_visa_purchase
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<CAVV>TESTCAVV</CAVV>}, data
       assert_match %{<XID>TESTXID</XID>}, data
@@ -187,7 +187,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_visa_authorization
     stub_comms do
       @gateway.authorize(50, credit_card, @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<CAVV>TESTCAVV</CAVV>}, data
       assert_match %{<XID>TESTXID</XID>}, data
@@ -197,7 +197,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_master_purchase
     stub_comms do
       @gateway.purchase(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<AAV>TESTCAVV</AAV>}, data
     end.respond_with(successful_purchase_response)
@@ -206,7 +206,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_master_authorization
     stub_comms do
       @gateway.authorize(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<AAV>TESTCAVV</AAV>}, data
     end.respond_with(successful_purchase_response)
@@ -215,7 +215,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_american_express_purchase
     stub_comms do
       @gateway.purchase(50, credit_card(nil, brand: 'american_express'), @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<AEVV>TESTCAVV</AEVV>}, data
       assert_match %{<PymtBrandProgramCode>ASK</PymtBrandProgramCode>}, data
@@ -225,7 +225,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_three_d_secure_data_on_american_express_authorization
     stub_comms do
       @gateway.authorize(50, credit_card(nil, brand: 'american_express'), @options.merge(@three_d_secure_options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<AEVV>TESTCAVV</AEVV>}, data
       assert_match %{<PymtBrandProgramCode>ASK</PymtBrandProgramCode>}, data
@@ -235,19 +235,19 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_currency_exponents
     stub_comms do
       @gateway.purchase(50, credit_card, order_id: '1')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<CurrencyExponent>2<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.purchase(50, credit_card, order_id: '1', currency: 'CAD')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<CurrencyExponent>2<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.purchase(50, credit_card, order_id: '1', currency: 'JPY')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<CurrencyExponent>0<\/CurrencyExponent>}, data
     end.respond_with(successful_purchase_response)
   end
@@ -297,7 +297,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_order_id_format
     response = stub_comms do
       @gateway.purchase(101, credit_card, order_id: ' #101.23,56 $Hi &thére@Friends')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<OrderID>101-23,56 \$Hi &amp;thre@Fr<\/OrderID>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -306,7 +306,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_order_id_format_for_capture
     response = stub_comms do
       @gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1001.1', order_id: '#1001.1')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<OrderID>1001-1<\/OrderID>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -321,7 +321,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms(gateway) do
       gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantID>700000123456<\/MerchantID>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -335,7 +335,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_phone_number
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(phone: '123-456-7890'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1234567890/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -346,7 +346,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(address1: long_address))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1850 Treebeard Drive/, data)
       assert_no_match(/Fields of Rohan/, data)
     end.respond_with(successful_purchase_response)
@@ -360,7 +360,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/John Jacob/, data)
       assert_no_match(/Jones/, data)
     end.respond_with(successful_purchase_response)
@@ -372,7 +372,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(city: long_city))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Friendly Village/, data)
       assert_no_match(/Creek/, data)
     end.respond_with(successful_purchase_response)
@@ -384,7 +384,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(phone: long_phone))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/12345678901234</, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -395,7 +395,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(zip: long_zip))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/1234567890</, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -417,7 +417,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1,
                                          billing_address: address_with_invalid_chars)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Main Street</, data)
       assert_match(/Apt. Number One</, data)
       assert_match(/Rise of the Phoenix</, data)
@@ -434,7 +434,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
         @gateway.add_customer_profile(credit_card,
           billing_address: address_with_invalid_chars)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Main Street</, data)
       assert_match(/Apt. Number One</, data)
       assert_match(/Rise of the Phoenix</, data)
@@ -464,7 +464,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1,
                                   billing_address: long_address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
       assert_match(/Apårtmeñt 123456789012345678</, data)
       assert_match(/¡Vancouver-by-the-s</, data)
@@ -484,7 +484,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
         @gateway.add_customer_profile(credit_card,
           billing_address: long_address)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
       assert_match(/Apårtmeñt 123456789012345678</, data)
       assert_match(/¡Vancouver-by-the-s</, data)
@@ -525,7 +525,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1,
                                          billing_address: billing_address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<AVSDestzip>90001/, data)
       assert_match(/<AVSDestaddress1>456 Main St./, data)
       assert_match(/<AVSDestaddress2/, data)
@@ -541,7 +541,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1,
                                          billing_address: billing_address.merge(dest_country: 'BR'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<AVSDestcountryCode></, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -550,7 +550,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_successful_purchase_with_negative_stored_credentials_indicator
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(mit_stored_credential_ind: 'N'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<MITMsgType>/, data)
       assert_no_match(/<MITStoredCredentialInd>/, data)
     end.respond_with(successful_purchase_response)
@@ -559,7 +559,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_successful_purchase_with_stored_credentials
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(@options_stored_credentials))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<MITMsgType>#{@options_stored_credentials[:mit_msg_type]}</MITMsgType>}, data
       assert_match %{<MITStoredCredentialInd>#{@options_stored_credentials[:mit_stored_credential_ind]}</MITStoredCredentialInd>}, data
       assert_match %{<MITSubmittedTransactionID>#{@options_stored_credentials[:mit_submitted_transaction_id]}</MITSubmittedTransactionID>}, data
@@ -570,7 +570,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -583,7 +583,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CREC</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -595,7 +595,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -608,7 +608,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>MREC</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
       assert_match(/<MITSubmittedTransactionID>abc123</, data)
@@ -621,7 +621,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -634,7 +634,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CUSE</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -646,7 +646,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -659,7 +659,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>MUSE</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
       assert_match(/<MITSubmittedTransactionID>abc123</, data)
@@ -672,7 +672,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -685,7 +685,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:cardholder, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CINS</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -697,7 +697,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, :initial)
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>CSTO</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
     end.respond_with(successful_purchase_response)
@@ -710,7 +710,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     options = stored_credential_options(:merchant, :installment, id: 'abc123')
     response = stub_comms do
       @gateway.purchase(50, credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MITMsgType>MINS</, data)
       assert_match(/<MITStoredCredentialInd>Y</, data)
       assert_match(/<MITSubmittedTransactionID>abc123</, data)
@@ -722,7 +722,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_successful_purchase_with_overridden_normalized_stored_credentials
     stub_comms do
       @gateway.purchase(50, credit_card, @options.merge(@normalized_mit_stored_credential).merge(@options_stored_credentials))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %{<MITMsgType>MRSB</MITMsgType>}, data
       assert_match %{<MITStoredCredentialInd>Y</MITStoredCredentialInd>}, data
       assert_match %{<MITSubmittedTransactionID>123456abcdef</MITSubmittedTransactionID>}, data
@@ -736,7 +736,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
           @gateway.add_customer_profile(credit_card, managed_billing: {start_date: '10-10-2014' })
         end
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MBType>R/, data)
       assert_match(/<MBOrderIdGenerationMethod>IO/, data)
       assert_match(/<MBRecurringStartDate>10102014/, data)
@@ -758,7 +758,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
             })
         end
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MBType>R/, data)
       assert_match(/<MBOrderIdGenerationMethod>IO/, data)
       assert_match(/<MBRecurringStartDate>10102014/, data)
@@ -772,7 +772,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_dont_send_customer_data_by_default
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<CustomerRefNum>K1C2N6/, data)
       assert_no_match(/<CustomerProfileFromOrderInd>456 My Street/, data)
       assert_no_match(/<CustomerProfileOrderOverrideInd>Apt 1/, data)
@@ -784,7 +784,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerProfileFromOrderInd>A/, data)
       assert_match(/<CustomerProfileOrderOverrideInd>NO/, data)
     end.respond_with(successful_purchase_response)
@@ -795,7 +795,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, customer_ref_num: @customer_ref_num)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CustomerProfileFromOrderInd>S/, data)
       assert_match(/<CustomerProfileOrderOverrideInd>NO/, data)
@@ -806,7 +806,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_send_card_indicators_when_provided_purchase
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, card_indicators: @options[:card_indicators])
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CardIndicators>y/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -815,7 +815,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_send_card_indicators_when_provided_authorize
     response = stub_comms do
       @gateway.authorize(50, credit_card, order_id: 1, card_indicators: @options[:card_indicators])
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CardIndicators>y/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -825,7 +825,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.purchase(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<CustomerProfileFromOrderInd>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -835,7 +835,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.authorize(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<CustomerProfileFromOrderInd>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -845,7 +845,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.purchase(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CurrencyCode>124/, data)
       assert_match(/<CurrencyExponent>2/, data)
@@ -857,7 +857,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:customer_profiles] = true
     response = stub_comms do
       @gateway.authorize(50, nil, order_id: 1, customer_ref_num: @customer_ref_num)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerRefNum>ABC/, data)
       assert_match(/<CurrencyCode>124/, data)
       assert_match(/<CurrencyExponent>2/, data)
@@ -868,7 +868,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_send_address_details_for_united_states
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<AVSzip>K1C2N6/, data)
       assert_match(/<AVSaddress1>456 My Street/, data)
       assert_match(/<AVSaddress2>Apt 1/, data)
@@ -886,7 +886,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_dont_send_address_details_for_germany
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: 'DE'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<AVSzip>K1C2N6/, data)
       assert_no_match(/<AVSaddress1>456 My Street/, data)
       assert_no_match(/<AVSaddress2>Apt 1/, data)
@@ -902,7 +902,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_allow_sending_avs_parts_when_no_country_specified
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: nil))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<AVSzip>K1C2N6/, data)
       assert_match(/<AVSaddress1>456 My Street/, data)
       assert_match(/<AVSaddress2>Apt 1/, data)
@@ -918,7 +918,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_american_requests_adhere_to_xml_schema
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       schema_file = File.read("#{File.dirname(__FILE__)}/../../schema/orbital/Request_PTI77.xsd")
       doc = Nokogiri::XML(data)
       xsd = Nokogiri::XML::Schema(schema_file)
@@ -930,7 +930,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def test_german_requests_adhere_to_xml_schema
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address(country: 'DE'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       schema_file = File.read("#{File.dirname(__FILE__)}/../../schema/orbital/Request_PTI77.xsd")
       doc = Nokogiri::XML(data)
       xsd = Nokogiri::XML::Schema(schema_file)
@@ -944,7 +944,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerProfileAction>C/, data)
       assert_match(/<CustomerName>Longbob Longsen/, data)
     end.respond_with(successful_profile_response)
@@ -956,7 +956,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning do
         @gateway.add_customer_profile(credit_card, { billing_address: { email: 'xiaobozzz@example.com' } })
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerProfileAction>C/, data)
       assert_match(/<CustomerEmail>xiaobozzz@example.com/, data)
     end.respond_with(successful_profile_response)
@@ -968,7 +968,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning do
         @gateway.update_customer_profile(credit_card)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CustomerProfileAction>U/, data)
       assert_match(/<CustomerName>Longbob Longsen/, data)
     end.respond_with(successful_profile_response)
@@ -980,7 +980,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning do
         @gateway.retrieve_customer_profile(@customer_ref_num)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<CustomerName>Longbob Longsen/, data)
       assert_match(/<CustomerProfileAction>R/, data)
       assert_match(/<CustomerRefNum>ABC/, data)
@@ -993,7 +993,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_deprecation_warning do
         @gateway.delete_customer_profile(@customer_ref_num)
       end
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/<CustomerName>Longbob Longsen/, data)
       assert_match(/<CustomerProfileAction>D/, data)
       assert_match(/<CustomerRefNum>ABC/, data)
@@ -1014,7 +1014,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:retry_logic] = true
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, trace_number: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert_equal('1', headers['Trace-number'])
       assert_equal('merchant_id', headers['Merchant-Id'])
     end.respond_with(successful_purchase_response)
@@ -1025,7 +1025,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @gateway.options[:retry_logic] = false
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, trace_number: 1)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert_equal(false, headers.has_key?('Trace-number'))
       assert_equal(false, headers.has_key?('Merchant-Id'))
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/pay_conex_test.rb
+++ b/test/unit/gateways/pay_conex_test.rb
@@ -140,7 +140,7 @@ class PayConexTest < Test::Unit::TestCase
   def test_card_present_purchase_passes_track_data
     stub_comms do
       @gateway.purchase(@amount, credit_card_with_track_data('4000100011112224'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/card_tracks/, data)
     end.respond_with(successful_card_present_purchase_response)
   end

--- a/test/unit/gateways/pay_junction_test.rb
+++ b/test/unit/gateways/pay_junction_test.rb
@@ -84,7 +84,7 @@ class PayJunctionTest < Test::Unit::TestCase
     @credit_card.track_data = 'Tracking data'
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match 'dc_track=Tracking+data', data
       assert_no_match(/dc_name=/, data)
       assert_no_match(/dc_number=/, data)

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -113,7 +113,7 @@ class PayeezyGateway < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, check_without_number, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/001/, data)
     end.respond_with(successful_purchase_echeck_response)
 
@@ -126,7 +126,7 @@ class PayeezyGateway < Test::Unit::TestCase
   def test_successful_purchase_with_stored_credentials
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/stored_credentials/, data)
     end.respond_with(successful_purchase_stored_credentials_response)
 
@@ -196,7 +196,7 @@ class PayeezyGateway < Test::Unit::TestCase
   def test_successful_void
     response = stub_comms do
       @gateway.void(@authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       json = '{"transaction_type":"void","method":"credit_card","transaction_tag":"106625152","currency_code":"USD","amount":"4738"}'
       assert_match json, data
     end.respond_with(successful_void_response)
@@ -207,7 +207,7 @@ class PayeezyGateway < Test::Unit::TestCase
   def test_successful_void_with_reversal_id
     stub_comms do
       @gateway.void(@authorization, @options.merge(reversal_id: @reversal_id))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       json = "{\"transaction_type\":\"void\",\"method\":\"credit_card\",\"reversal_id\":\"#{@reversal_id}\",\"currency_code\":\"USD\",\"amount\":\"4738\"}"
       assert_match json, data
     end.respond_with(successful_void_response)
@@ -268,7 +268,7 @@ class PayeezyGateway < Test::Unit::TestCase
   def test_requests_include_verification_string
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       json_address = '{"street":"456 My Street","city":"Ottawa","state_province":"ON","zip_postal_code":"K1C2N6","country":"CA"}'
       assert_match json_address, data
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -58,7 +58,7 @@ class PayflowTest < Test::Unit::TestCase
   def test_authorization_with_three_d_secure_option
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_three_d_secure REXML::Document.new(data), authorize_buyer_auth_result_path
     end.respond_with(successful_authorization_response)
     assert_equal 'Approved', response.message
@@ -84,7 +84,7 @@ class PayflowTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<InvNum>123</InvNum>), data
       assert_match %r(<Description>Description string</Description>), data
       assert_match %r(<OrderDesc>OrderDesc string</OrderDesc>), data
@@ -111,7 +111,7 @@ class PayflowTest < Test::Unit::TestCase
   def test_successful_purchase_with_three_d_secure_option
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_three_d_secure REXML::Document.new(data), purchase_buyer_auth_result_path
     end.respond_with(successful_purchase_with_fraud_review_response)
     assert_success response
@@ -124,7 +124,7 @@ class PayflowTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<AcctNum>6355059797</AcctNum>), data
       assert_match %r(<ACH><AcctType>), data.tr("\n ", '')
     end.respond_with(successful_l2_response)
@@ -139,7 +139,7 @@ class PayflowTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<Date>20190104</Date>), data
       assert_match %r(<Amount>3.23</Amount>), data
       assert_match %r(<Level3Invoice><CountyTax><Amount>), data.tr("\n ", '')
@@ -155,7 +155,7 @@ class PayflowTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<Date>20190104</Date>), data
       assert_match %r(<Amount>3.23</Amount>), data
       assert_match %r(<AcctNum>6355059797</AcctNum>), data
@@ -480,7 +480,7 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_name_field_are_included_instead_of_first_and_last
-    @gateway.expects(:ssl_post).returns(successful_authorization_response).with do |url, data|
+    @gateway.expects(:ssl_post).returns(successful_authorization_response).with do |_url, data|
       data !~ /FirstName/ && data !~ /LastName/ && data =~ /<Name>/
     end
     response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -253,7 +253,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_purchase_truncates_order_id_to_16_chars
     stub_comms do
       @gateway.purchase(@amount, @visa, {order_id: '16chars---------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -261,7 +261,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_authorize_truncates_order_id_to_16_chars
     stub_comms do
       @gateway.authorize(@amount, @visa, {order_id: '16chars---------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -269,7 +269,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_capture_truncates_order_id_to_16_chars
     stub_comms do
       @gateway.capture(@amount, 'identification', {order_id: '16chars---------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -277,7 +277,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_refund_truncates_order_id_to_16_chars
     stub_comms do
       @gateway.refund(@amount, 'identification', {description: 'refund', order_id: '16chars---------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -285,7 +285,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_purchase_truncates_description_to_50_chars
     stub_comms do
       @gateway.purchase(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -293,7 +293,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_authorize_truncates_description_to_50_chars
     stub_comms do
       @gateway.authorize(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -301,7 +301,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_capture_truncates_description_to_50_chars
     stub_comms do
       @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -309,7 +309,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   def test_refund_truncates_description_to_50_chars
     stub_comms do
       @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -324,35 +324,35 @@ class PaymentExpressTest < Test::Unit::TestCase
     # purchase
     stub_comms do
       @gateway.purchase(@amount, @visa, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_authorization_response)
 
     # authorize
     stub_comms do
       @gateway.authorize(@amount, @visa, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_authorization_response)
 
     # capture
     stub_comms do
       @gateway.capture(@amount, 'identification', options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_authorization_response)
 
     # refund
     stub_comms do
       @gateway.refund(@amount, 'identification', {description: 'description'}.merge(options))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_authorization_response)
 
     # store
     stub_comms do
       @gateway.store(@visa, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_store_response)
   end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -157,7 +157,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_descriptors_passed
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(soft_descriptor: 'Eggcellent', soft_descriptor_city: 'New York'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<n2:SoftDescriptor>Eggcellent}, data)
       assert_match(%r{<n2:SoftDescriptorCity>New York}, data)
     end.respond_with(successful_purchase_response)
@@ -476,20 +476,20 @@ class PaypalTest < Test::Unit::TestCase
   def test_mass_pay_transfer_recipient_types
     stub_comms do
       @gateway.transfer 1000, 'fred@example.com'
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r{ReceiverType}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.transfer 1000, 'fred@example.com', receiver_type: 'EmailAddress'
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<ReceiverType>EmailAddress</ReceiverType>}, data
       assert_match %r{<ReceiverEmail>fred@example\.com</ReceiverEmail>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.transfer 1000, 'fred@example.com', receiver_type: 'UserID'
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<ReceiverType>UserID</ReceiverType>}, data
       assert_match %r{<ReceiverID>fred@example\.com</ReceiverID>}, data
     end.respond_with(successful_purchase_response)
@@ -553,7 +553,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_includes_cvv_tag
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{CVV2}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -562,14 +562,14 @@ class PaypalTest < Test::Unit::TestCase
     @credit_card.verification_value = nil
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{CVV2}, data)
     end.respond_with(successful_purchase_response)
 
     @credit_card.verification_value = '  '
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{CVV2}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -614,7 +614,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_3ds_version_1_request
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<n2:Version>124</n2:Version>}, data
       assert_match %r{<AuthStatus3ds>Y</AuthStatus3ds>}, data
       assert_match %r{<Cavv>cavv</Cavv>}, data

--- a/test/unit/gateways/paystation_test.rb
+++ b/test/unit/gateways/paystation_test.rb
@@ -89,7 +89,7 @@ class PaystationTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/0008813023-01/, data)
     end.respond_with(successful_refund_response)
 

--- a/test/unit/gateways/payu_in_test.rb
+++ b/test/unit/gateways/payu_in_test.rb
@@ -203,7 +203,7 @@ class PayuInTest < Test::Unit::TestCase
           phone: ('a-' + ('1' * 51))
         }
       )
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       case endpoint
       when /_payment/
         assert_parameter('txnid', /^a/, data, length: 30)
@@ -291,7 +291,7 @@ class PayuInTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(100, 'abc')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_parameter('command', 'cancel_refund_transaction', data)
       assert_parameter('var1', 'abc', data)
       assert_parameter('var2', /./, data)

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -53,7 +53,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_purchase_with_specified_language
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(language: 'es'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -104,7 +104,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_authorize_with_specified_language
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(language: 'es'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -138,7 +138,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_pending_refund_with_specified_language
     stub_comms do
       @gateway.refund(@amount, '7edbaf68-8f3a-4ae7-b9c7-d1e27e314999', @options.merge(language: 'es'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(pending_refund_response)
   end
@@ -162,7 +162,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_void_with_specified_language
     stub_comms do
       @gateway.void('7edbaf68-8f3a-4ae7-b9c7-d1e27e314999', @options.merge(language: 'es'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(successful_void_response)
   end
@@ -178,7 +178,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_purchase_with_dni_number
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"dniNumber":"5415668464654"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -186,7 +186,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_purchase_with_merchant_buyer_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"merchantBuyerId":"1"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -202,7 +202,7 @@ class PayuLatamTest < Test::Unit::TestCase
   end
 
   def test_request_using_visa_card_with_no_cvv
-    @gateway.expects(:ssl_post).with { |url, body, headers|
+    @gateway.expects(:ssl_post).with { |_url, body, _headers|
       body.match '"securityCode":"000"'
       body.match '"processWithoutCvv2":true'
     }.returns(successful_purchase_response)
@@ -213,7 +213,7 @@ class PayuLatamTest < Test::Unit::TestCase
   end
 
   def test_request_using_amex_card_with_no_cvv
-    @gateway.expects(:ssl_post).with { |url, body, headers|
+    @gateway.expects(:ssl_post).with { |_url, body, _headers|
       body.match '"securityCode":"0000"'
       body.match '"processWithoutCvv2":true'
     }.returns(successful_purchase_response)
@@ -224,7 +224,7 @@ class PayuLatamTest < Test::Unit::TestCase
   end
 
   def test_request_passes_cvv_option
-    @gateway.expects(:ssl_post).with { |url, body, headers|
+    @gateway.expects(:ssl_post).with { |_url, body, _headers|
       body.match '"securityCode":"777"'
       !body.match '"processWithoutCvv2"'
     }.returns(successful_purchase_response)
@@ -246,7 +246,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_capture_with_specified_language
     stub_comms do
       @gateway.capture(@amount, '4000|authorization', @options.merge(language: 'es'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -254,7 +254,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_successful_partial_capture
     stub_comms do
       @gateway.capture(@amount - 1, '4000|authorization', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal '39.99', JSON.parse(data)['transaction']['additionalValues']['TX_VALUE']['value']
     end.respond_with(successful_purchase_response)
   end
@@ -288,7 +288,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.update(options_buyer))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\"buyer\":{\"fullName\":\"Jorge Borges\",\"dniNumber\":\"5415668464456\",\"dniType\":null,\"merchantBuyerId\":\"1\",\"emailAddress\":\"axaxaxas@mlo.org\",\"contactPhone\":\"7563126\",\"shippingAddress\":{\"street1\":\"Calle 200\",\"street2\":\"N107\",\"city\":\"Sao Paulo\",\"state\":\"SP\",\"country\":\"BR\",\"postalCode\":\"01019-030\",\"phone\":\"\(11\)756312345\"}}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -296,7 +296,7 @@ class PayuLatamTest < Test::Unit::TestCase
   def test_buyer_fields_default_to_payer
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\"buyer\":{\"fullName\":\"APPROVED\",\"dniNumber\":\"5415668464654\",\"dniType\":\"TI\",\"merchantBuyerId\":\"1\",\"emailAddress\":\"username@domain.com\",\"contactPhone\":\"7563126\"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -322,7 +322,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/"merchantBuyerId":"1"/, data)
       assert_match(/"street2":null/, data)
       refute_match(/"country"/, data)
@@ -359,7 +359,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_brazil))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\"cnpj\":\"32593371000110\"/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -393,7 +393,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_colombia))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\"additionalValues\":{\"TX_VALUE\":{\"value\":\"40.00\",\"currency\":\"COP\"},\"TX_TAX\":{\"value\":0,\"currency\":\"COP\"},\"TX_TAX_RETURN_BASE\":{\"value\":0,\"currency\":\"COP\"}}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -426,7 +426,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.update(options_mexico))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/\"birthdate\":\"1985-05-25\"/, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/pro_pay_test.rb
+++ b/test/unit/gateways/pro_pay_test.rb
@@ -89,7 +89,7 @@ class ProPayTest < Test::Unit::TestCase
   def test_successful_void
     response = stub_comms do
       @gateway.void('auth', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<transType>07</transType>), data)
     end.respond_with(successful_void_response)
 
@@ -99,7 +99,7 @@ class ProPayTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('invalid-auth', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<transType>07</transType>), data)
     end.respond_with(failed_void_response)
 
@@ -157,7 +157,7 @@ class ProPayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<zip>123453456</, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -28,7 +28,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert_success response
       assert_equal '1145', response.authorization
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       parsed = parse(data)
       if parsed['order_id']
         assert_match %r{/payments}, endpoint
@@ -47,7 +47,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert_success response
       assert_equal '1145', response.authorization
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       parsed_data = parse(data)
       if parsed_data['order_id']
         assert_match %r{/payments}, endpoint
@@ -71,7 +71,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert_success response
       assert_equal '1145', response.authorization
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       parsed_data = parse(data)
       if parsed_data['order_id']
         assert_match %r{/payments}, endpoint
@@ -87,7 +87,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert response = @gateway.void(1145)
       assert_success response
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match %r{/payments/1145/cancel}, endpoint
     end.respond_with({'id' => 1145}.to_json)
   end
@@ -115,7 +115,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert response = @gateway.store(@credit_card, @options)
       assert_success response
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match %r{/card}, endpoint
     end.respond_with(successful_store_response, successful_sauthorize_response)
   end
@@ -125,7 +125,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert response = @gateway.unstore('123')
       assert_success response
       assert response.test?
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_match %r{/cards/\d+/cancel}, endpoint
     end.respond_with({'id' => '123'}.to_json)
   end

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -47,7 +47,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.store(@credit_card, {order_id: 'fa73664073e23597bbdd', description: 'Storing Card'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal(expected_store_parameters_v6, CGI::parse(data))
     end.respond_with(successful_store_response_v6)
 
@@ -62,7 +62,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.store(@credit_card, {order_id: 'ed7546cb4ceb8f017ea4', description: 'Storing Card'})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal(expected_store_parameters_v7, CGI::parse(data))
     end.respond_with(successful_store_response_v7)
 
@@ -147,7 +147,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   def test_finalize_is_disabled_by_default
     stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, '12345')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /finalize=0/
     end.respond_with(successful_capture_response)
   end
@@ -155,7 +155,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   def test_finalize_is_enabled
     stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, '12345', finalize: true)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /finalize=1/
     end.respond_with(successful_capture_response)
   end

--- a/test/unit/gateways/qvalent_test.rb
+++ b/test/unit/gateways/qvalent_test.rb
@@ -91,7 +91,7 @@ class QvalentTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{5d53a33d960c46d00f5dc061947d998c}, data
     end.respond_with(successful_refund_response)
 
@@ -178,7 +178,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_3d_secure_fields
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {xid: '123', cavv: '456', eci: '5'})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/xid=123/, data)
       assert_match(/cavv=456/, data)
       assert_match(/ECI=5/, data)
@@ -190,7 +190,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_stored_credential_fields_initial
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {stored_credential: {initial_transaction: true, reason_type: 'unscheduled', initiator: 'merchant'}})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=MANUAL/, data)
       assert_match(/storedCredentialUsage=INITIAL_STORAGE/, data)
       assert_match(/ECI=SSL/, data)
@@ -202,7 +202,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_stored_credential_fields_recurring
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890'}})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       assert_match(/storedCredentialUsage=RECURRING/, data)
       assert_match(/ECI=REC/, data)
@@ -215,7 +215,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_stored_credential_fields_unscheduled
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'unscheduled', initiator: 'merchant', network_transaction_id: '7890'}})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       assert_match(/storedCredentialUsage=UNSCHEDULED/, data)
       assert_match(/ECI=MTO/, data)
@@ -228,7 +228,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_stored_credential_fields_cardholder_initiated
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'unscheduled', initiator: 'cardholder', network_transaction_id: '7890'}})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       refute_match(/storedCredentialUsage/, data)
       assert_match(/ECI=MTO/, data)
@@ -242,7 +242,7 @@ class QvalentTest < Test::Unit::TestCase
     @credit_card.brand = 'master'
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890'}})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       refute_match(/storedCredentialUsage/, data)
       assert_match(/ECI=REC/, data)

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -126,7 +126,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_3ds_data_passed
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, credit_card, { execute_threed: true, order_id: '156270437866', terminal: 12, sca_exemption: 'LWV' })
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/iniciaPeticion/, data)
       assert_match(/<DS_MERCHANT_TERMINAL>12<\/DS_MERCHANT_TERMINAL>/, data)
       assert_match(/\"threeDSInfo\":\"CardData\"/, data)
@@ -138,7 +138,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
     @credit_card.first_name = 'Julián'
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, @credit_card, { execute_threed: true, order_id: '156270437866', terminal: 12, sca_exemption: 'LWV', description: 'esta es la descripción' })
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/iniciaPeticion/, data)
       assert_match(/<DS_MERCHANT_TERMINAL>12<\/DS_MERCHANT_TERMINAL>/, data)
       assert_match(/\"threeDSInfo\":\"CardData\"/, data)
@@ -151,7 +151,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_moto_flag_passed
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, credit_card, { order_id: '156270437866', moto: true, metadata: { manual_entry: true } })
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/DS_MERCHANT_DIRECTPAYMENT%3Emoto%3C%2FDS_MERCHANT_DIRECTPAYMENT/, data)
     end.respond_with(successful_authorize_with_3ds_response)
   end
@@ -159,7 +159,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_moto_flag_not_passed_if_not_explicitly_requested
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, credit_card, { order_id: '156270437866', metadata: { manual_entry: true } })
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/DS_MERCHANT_DIRECTPAYMENT%3Emoto%3C%2FDS_MERCHANT_DIRECTPAYMENT/, data)
     end.respond_with(successful_authorize_with_3ds_response)
   end
@@ -167,7 +167,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_bad_order_id_format
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, credit_card, order_id: 'Una#cce-ptable44Format')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/MERCHANT_ORDER%3E\d\d\d\dUnaccept%3C/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -175,7 +175,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   def test_order_id_numeric_start_but_too_long
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(100, credit_card, order_id: '1234ThisIs]FineButTooLong')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/MERCHANT_ORDER%3E1234ThisIsFi%3C/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -115,7 +115,7 @@ class RedsysTest < Test::Unit::TestCase
   def test_bad_order_id_format
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(123, credit_card, order_id: 'Una#cce-ptable44Format')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/MERCHANT_ORDER%3E\d\d\d\dUnaccept%3C/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -123,7 +123,7 @@ class RedsysTest < Test::Unit::TestCase
   def test_order_id_numeric_start_but_too_long
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(123, credit_card, order_id: '1234ThisIs]FineButTooLong')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/MERCHANT_ORDER%3E1234ThisIsFi%3C/, data)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/s5_test.rb
+++ b/test/unit/gateways/s5_test.rb
@@ -34,7 +34,7 @@ class S5Test < Test::Unit::TestCase
   def test_successful_purchase_with_recurring_flag
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(recurring: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Recurrence.*REPEATED/, data)
     end.respond_with(successful_purchase_response)
 

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -37,7 +37,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_successful_purchase_with_merchant_options
     purchase = stub_comms do
       @gateway.purchase(@amount, @credit_card, @merchant_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/sg_Descriptor/, data)
       assert_match(/sg_MerchantPhoneNumber/, data)
       assert_match(/sg_MerchantName/, data)
@@ -53,7 +53,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_successful_purchase_with_truthy_stored_credential_mode
     purchase = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/sg_StoredCredentialMode=1/, data)
     end.respond_with(successful_purchase_response)
 
@@ -67,7 +67,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_successful_purchase_with_falsey_stored_credential_mode
     purchase = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential_mode: false))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/sg_StoredCredentialMode=0/, data)
     end.respond_with(successful_purchase_response)
 
@@ -214,7 +214,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_3ds_response
     purchase = stub_comms do
       @gateway.purchase(@amount, @three_ds_enrolled_card, @three_ds_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/Sale3D/, data)
       assert_match(/sg_APIType/, data)
     end.respond_with(successful_3ds_purchase_response)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -111,7 +111,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_paypal_callback_url_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(paypal_callback_url: 'callback.com')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/PayPalCallbackURL=callback\.com/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -119,7 +119,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_basket_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(basket: 'A1.2 Basket section')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/Basket=A1\.2\+Basket\+section/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -127,7 +127,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_gift_aid_payment_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(gift_aid_payment: 1)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/GiftAidPayment=1/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -135,7 +135,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_apply_avscv2_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(apply_avscv2: 1)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ApplyAVSCV2=1/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -143,7 +143,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_disable_3d_security_flag_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(apply_3d_secure: 1)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/Apply3DSecure=1/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -151,7 +151,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_account_type_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(account_type: 'M')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/AccountType=M/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -159,7 +159,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_billing_agreement_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(billing_agreement: 1)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/BillingAgreement=1/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -167,7 +167,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_store_token_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(store: true)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/CreateToken=1/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -175,7 +175,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_basket_xml_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(basket_xml: 'A1.3 BasketXML section')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/BasketXML=A1\.3\+BasketXML\+section/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -183,7 +183,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_customer_xml_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(customer_xml: 'A1.4 CustomerXML section')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/CustomerXML=A1\.4\+CustomerXML\+section/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -191,7 +191,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_surcharge_xml_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(surcharge_xml: 'A1.1 SurchargeXML section')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/SurchargeXML=A1\.1\+SurchargeXML\+section/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -199,7 +199,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_vendor_data_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(vendor_data: 'any data')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/VendorData=any\+data/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -207,7 +207,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_language_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(language: 'FR')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/Language=FR/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -215,7 +215,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_website_is_submitted
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(website: 'transaction-origin.com')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/Website=transaction-origin\.com/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -225,7 +225,7 @@ class SagePayTest < Test::Unit::TestCase
       purchase_with_options(recipient_account_number: '1234567890',
                             recipient_surname: 'Withnail', recipient_postcode: 'AB11AB',
                             recipient_dob: '19701223')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/FIRecipientAcctNumber=1234567890/, data)
       assert_match(/FIRecipientSurname=Withnail/, data)
       assert_match(/FIRecipientPostcode=AB11AB/, data)
@@ -237,7 +237,7 @@ class SagePayTest < Test::Unit::TestCase
     huge_description = 'SagePay transactions fail if the déscription is more than 100 characters. Therefore, we truncate it to 100 characters.' + ' Lots more text ' * 1000
     stub_comms(@gateway, :ssl_request) do
       purchase_with_options(description: huge_description)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/&Description=SagePay\+transactions\+fail\+if\+the\+d%C3%A9scription\+is\+more\+than\+100\+characters.\+Therefore%2C\+we\+trunc&/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -247,7 +247,7 @@ class SagePayTest < Test::Unit::TestCase
 
     stub_comms(gateway, :ssl_request) do
       gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/VPSProtocol=2.23/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -256,7 +256,7 @@ class SagePayTest < Test::Unit::TestCase
     ActiveMerchant::Billing::SagePayGateway.application_id = '00000000-0000-0000-0000-000000000001'
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data.include?('ReferrerID=00000000-0000-0000-0000-000000000001')
     end.respond_with(successful_purchase_response)
   ensure
@@ -266,7 +266,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@credit_card)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/TxType=TOKEN/, data)
     end.respond_with(successful_purchase_response)
 
@@ -327,7 +327,7 @@ class SagePayTest < Test::Unit::TestCase
   def test_repeat_purchase_with_reference_token
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, '1455548a8d178beecd88fe6a285f50ff;{0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474};15353766;BS231FNE14;purchase', @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/RelatedVPSTxId=%7B0D2ACAF0-FA64-6DFF-3869-7ADDDC1E0474%/, data)
       assert_match(/TxType=REPEAT/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/sage_test.rb
+++ b/test/unit/gateways/sage_test.rb
@@ -158,7 +158,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_include_customer_number_for_numeric_values
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({customer: '123'}))
-    end.check_request do |method, data|
+    end.check_request do |_method, data|
       assert data =~ /T_customer_number=123/
     end.respond_with(successful_authorization_response)
   end
@@ -166,7 +166,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_dont_include_customer_number_for_numeric_values
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({customer: 'bob@test.com'}))
-    end.check_request do |method, data|
+    end.check_request do |_method, data|
       assert data !~ /T_customer_number/
     end.respond_with(successful_authorization_response)
   end
@@ -249,7 +249,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, headers|
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:CARDNUMBER>#{credit_card.number}<\/ns1:CARDNUMBER>/, data)
@@ -267,7 +267,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_failed_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, headers|
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:CARDNUMBER>#{credit_card.number}<\/ns1:CARDNUMBER>/, data)
@@ -285,7 +285,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_successful_unstore
     response = stub_comms do
       @gateway.unstore('1234', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, headers|
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:GUID>1234<\/ns1:GUID>/, data)
@@ -301,7 +301,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_failed_unstore
     response = stub_comms do
       @gateway.unstore('1234', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, headers|
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:GUID>1234<\/ns1:GUID>/, data)

--- a/test/unit/gateways/secure_net_test.rb
+++ b/test/unit/gateways/secure_net_test.rb
@@ -118,7 +118,7 @@ class SecureNetTest < Test::Unit::TestCase
     order_id = "SecureNet doesn't like order_ids greater than 25 characters."
     stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: order_id)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ORDERID>SecureNet doesn't like or</, data)
     end.respond_with(successful_purchase_response)
   end
@@ -133,7 +133,7 @@ class SecureNetTest < Test::Unit::TestCase
     options = { description: 'Good Stuff', invoice_description: 'Sweet Invoice', invoice_number: '48' }
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{NOTE>Good Stuff<}, data)
       assert_match(%r{INVOICEDESC>Sweet Invoice<}, data)
       assert_match(%r{INVOICENUM>48<}, data)
@@ -143,7 +143,7 @@ class SecureNetTest < Test::Unit::TestCase
   def test_only_passes_optional_fields_if_specified
     stub_comms do
       @gateway.purchase(@amount, @credit_card, {})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{NOTE}, data)
       assert_no_match(%r{INVOICEDESC}, data)
       assert_no_match(%r{INVOICENUM}, data)
@@ -153,7 +153,7 @@ class SecureNetTest < Test::Unit::TestCase
   def test_passes_with_no_developer_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, {})
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(%r{DEVELOPERID}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -161,7 +161,7 @@ class SecureNetTest < Test::Unit::TestCase
   def test_passes_with_developer_id
     stub_comms do
       @gateway.purchase(@amount, @credit_card, developer_id: '1234')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{DEVELOPERID}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -169,7 +169,7 @@ class SecureNetTest < Test::Unit::TestCase
   def test_passes_with_test_mode
     stub_comms do
       @gateway.purchase(@amount, @credit_card, test_mode: false)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<TEST>FALSE</TEST>}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -177,7 +177,7 @@ class SecureNetTest < Test::Unit::TestCase
   def test_passes_without_test_mode
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{<TEST>TRUE</TEST>}, data)
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -52,13 +52,13 @@ class SecurePayAuTest < Test::Unit::TestCase
   def test_localized_currency
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(currency: 'CAD'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<amount>100<\/amount>}, data
     end.respond_with(successful_purchase_response)
 
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(currency: 'JPY'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<amount>1<\/amount>}, data
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -66,7 +66,7 @@ class SecurionPayTest < Test::Unit::TestCase
   def test_successful_purchase_with_token
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'tok_xxx')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/card=tok_xxx/, data)
       refute_match(/card\[number\]/, data)
     end.respond_with(successful_purchase_response)
@@ -88,7 +88,7 @@ class SecurionPayTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({ description: 'test charge', ip: '127.127.127.127', user_agent: 'browser XXX', referrer: 'http://www.foobar.com', email: 'foo@bar.com' })
       @gateway.purchase(@amount, @credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=test\+charge/, data)
       assert_match(/ip=127\.127\.127\.127/, data)
       assert_match(/user_agent=browser\+XXX/, data)
@@ -101,7 +101,7 @@ class SecurionPayTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({ description: 'test charge', ip: '127.127.127.127', user_agent: 'browser XXX', referrer: 'http://www.foobar.com' })
       @gateway.purchase(@amount, @credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=test\+charge/, data)
       assert_match(/ip=127\.127\.127\.127/, data)
       assert_match(/user_agent=browser\+XXX/, data)
@@ -139,7 +139,7 @@ class SecurionPayTest < Test::Unit::TestCase
   def test_address_is_included_with_card_data
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[addressLine1\]/
     end.respond_with(successful_purchase_response)
   end

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -60,7 +60,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.create_intent(@amount, @visa_token, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/statement_descriptor_suffix=suffix/, data)
     end.respond_with(successful_create_intent_response)
   end
@@ -80,7 +80,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.create_intent(@amount, @visa_token, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, _data, headers|
       assert_equal idempotency_key, headers['Idempotency-Key']
     end.respond_with(successful_create_intent_response)
   end
@@ -123,7 +123,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.create_intent(@amount, @visa_token, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/transfer_data\[destination\]=#{destination}/, data)
       assert_match(/transfer_data\[amount\]=#{amount}/, data)
       assert_match(/on_behalf_of=#{on_behalf_of}/, data)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -287,7 +287,7 @@ class StripeTest < Test::Unit::TestCase
   def test_passing_validate_false_on_store
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@credit_card, validate: false)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/validate=false/, data)
     end.respond_with(successful_new_customer_response)
 
@@ -297,7 +297,7 @@ class StripeTest < Test::Unit::TestCase
   def test_empty_values_not_sent
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, referrer: '')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/referrer/, data)
     end.respond_with(successful_purchase_response)
 
@@ -368,7 +368,7 @@ class StripeTest < Test::Unit::TestCase
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/statement_descriptor_suffix=suffix/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -390,7 +390,7 @@ class StripeTest < Test::Unit::TestCase
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/transfer_data\[destination\]=#{destination}/, data)
       assert_match(/transfer_data\[amount\]=#{amount}/, data)
       assert_match(/on_behalf_of=#{on_behalf_of}/, data)
@@ -546,7 +546,7 @@ class StripeTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'cus_xxx|card_xxx', @options.merge({application: application}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, _data, headers|
       assert_match(/\"application\"/, headers['X-Stripe-Client-User-Agent'])
       assert_match(/\"name\":\"app\"/, headers['X-Stripe-Client-User-Agent'])
       assert_match(/\"version\":\"1.0\"/, headers['X-Stripe-Client-User-Agent'])
@@ -559,7 +559,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_purchase_with_token_including_customer
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'cus_xxx|card_xxx')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/customer=cus_xxx/, data)
       assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
@@ -570,7 +570,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_purchase_with_token
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'card_xxx')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
 
@@ -580,7 +580,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_purchase_with_statement_description
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, statement_description: '5K RACE TICKET')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/statement_descriptor=5K\+RACE\+TICKET/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -670,7 +670,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_refund_application_fee
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('refund_application_fee=true')
     end.returns(successful_partially_refunded_response)
 
@@ -709,7 +709,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_metadata
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('metadata[first_value]=true')
     end.returns(successful_partially_refunded_response)
 
@@ -720,7 +720,7 @@ class StripeTest < Test::Unit::TestCase
   def test_successful_refund_with_reverse_transfer
     stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, 'auth', reverse_transfer: true)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/reverse_transfer=true/, data)
     end.respond_with(successful_partially_refunded_response)
   end
@@ -963,7 +963,7 @@ class StripeTest < Test::Unit::TestCase
   def test_application_fee_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({application_fee: 144}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -971,7 +971,7 @@ class StripeTest < Test::Unit::TestCase
   def test_application_fee_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, 'ch_test_charge', @options.merge({application_fee: 144}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_capture_response)
   end
@@ -979,7 +979,7 @@ class StripeTest < Test::Unit::TestCase
   def test_exchange_rate_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({exchange_rate: 0.96251}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -987,7 +987,7 @@ class StripeTest < Test::Unit::TestCase
   def test_exchange_rate_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, 'ch_test_charge', @options.merge({exchange_rate: 0.96251}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_capture_response)
   end
@@ -995,7 +995,7 @@ class StripeTest < Test::Unit::TestCase
   def test_destination_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid'}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/destination\[account\]=subaccountid/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1003,7 +1003,7 @@ class StripeTest < Test::Unit::TestCase
   def test_destination_amount_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid', destination_amount: @amount - 20}))
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/destination\[amount\]=#{@amount - 20}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1012,7 +1012,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=a\+test\+customer/, data)
       assert_match(/ip=127\.127\.127\.127/, data)
       assert_match(/user_agent=some\+browser/, data)
@@ -1029,7 +1029,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', referrer: 'http://www.shopify.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=a\+test\+customer/, data)
       assert_match(/ip=127\.127\.127\.127/, data)
       assert_match(/user_agent=some\+browser/, data)
@@ -1043,7 +1043,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.purchase(@amount, @credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
       assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
@@ -1055,7 +1055,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.purchase(@amount, @emv_credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
       assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
@@ -1068,7 +1068,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
       @gateway.authorize(@amount, @emv_credit_card, updated_options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
       assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
@@ -1081,7 +1081,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @emv_credit_card.read_method = 'contact_quickchip'
       @gateway.purchase(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/card\[processing_method\]=quick_chip/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1090,7 +1090,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @emv_credit_card.read_method = 'contact_quickchip'
       @gateway.authorize(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       refute_match(/card\[processing_method\]=quick_chip/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -1143,7 +1143,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_metadata_header
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['X-Stripe-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 
@@ -1151,7 +1151,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_version_header
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['Stripe-Version'] == '2013-10-29'
     }.returns(successful_purchase_response)
 
@@ -1159,7 +1159,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_key_header
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response)
 
@@ -1168,7 +1168,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_on_void
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     }.returns(successful_purchase_response(true))
 
@@ -1177,11 +1177,11 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_optional_idempotency_on_verify
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, _post, headers|
       headers && headers['Idempotency-Key'] == nil
     end.returns(successful_void_response)
 
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, _post, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     end.returns(successful_authorization_response)
 
@@ -1191,7 +1191,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_initialize_gateway_with_version
     @gateway = StripeGateway.new(login: 'login', version: '2013-12-03')
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['Stripe-Version'] == '2013-12-03'
     }.returns(successful_purchase_response)
 
@@ -1201,7 +1201,7 @@ class StripeTest < Test::Unit::TestCase
   def test_track_data_and_traditional_should_be_mutually_exclusive
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[name\]/
       assert data !~ /card\[swipe_data\]/
     end.respond_with(successful_purchase_response)
@@ -1209,7 +1209,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @credit_card.track_data = '%B378282246310005^LONGSON/LONGBOB^1705101130504392?'
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data !~ /card\[name\]/
       assert data =~ /card\[swipe_data\]/
     end.respond_with(successful_purchase_response)
@@ -1218,7 +1218,7 @@ class StripeTest < Test::Unit::TestCase
   def test_address_is_included_with_card_data
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[address_line1\]/
     end.respond_with(successful_purchase_response)
   end
@@ -1227,7 +1227,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @emv_credit_card.read_method = 'contactless'
       @gateway.purchase(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[read_method\]=contactless/
     end.respond_with(successful_purchase_response)
   end
@@ -1236,7 +1236,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @emv_credit_card.read_method = 'contactless_magstripe'
       @gateway.purchase(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
@@ -1244,7 +1244,7 @@ class StripeTest < Test::Unit::TestCase
   def test_contactless_flag_is_not_included_with_emv_card_data_by_default
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data !~ /card\[read_method\]=contactless/ && data !~ /card\[read_method\]=contactless_magstripe_mode/
     end.respond_with(successful_purchase_response)
   end
@@ -1254,7 +1254,7 @@ class StripeTest < Test::Unit::TestCase
       @emv_credit_card.encrypted_pin_cryptogram = '8b68af72199529b8'
       @emv_credit_card.encrypted_pin_ksn = 'ffff0102628d12000001'
       @gateway.purchase(@amount, @emv_credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /card\[encrypted_pin\]=8b68af72199529b8/
       assert data =~ /card\[encrypted_pin_key_id\]=ffff0102628d12000001/
     end.respond_with(successful_purchase_response)
@@ -1265,7 +1265,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_expand_parameters
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('expand[0]=balance_transaction')
     end.returns(successful_authorization_response)
 
@@ -1275,7 +1275,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_expand_parameters_as_array
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('expand[0]=balance_transaction&expand[1]=customer')
     end.returns(successful_authorization_response)
 
@@ -1285,7 +1285,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_recurring_flag_not_set_by_default
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       !post.include?('recurring')
     end.returns(successful_authorization_response)
 
@@ -1293,7 +1293,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_recurring_eci_sets_recurring_flag
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('recurring=true')
     end.returns(successful_authorization_response)
 
@@ -1303,7 +1303,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_unknown_eci_does_not_set_recurring_flag
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       !post.include?('recurring')
     end.returns(successful_authorization_response)
 
@@ -1313,7 +1313,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_recurring_true_option_sets_recurring_flag
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       post.include?('recurring=true')
     end.returns(successful_authorization_response)
 
@@ -1323,7 +1323,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_recurring_false_option_does_not_set_recurring_flag
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, post, _headers|
       !post.include?('recurring')
     end.returns(successful_authorization_response)
 
@@ -1335,7 +1335,7 @@ class StripeTest < Test::Unit::TestCase
   def test_new_attributes_are_included_in_update
     stub_comms(@gateway, :ssl_request) do
       @gateway.send(:update, 'cus_3sgheFxeBgTQ3M', 'card_483etw4er9fg4vF3sQdrt3FG', { name: 'John Smith', exp_year: 2021, exp_month: 6 })
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, data, _headers|
       assert data == 'name=John+Smith&exp_year=2021&exp_month=6'
       assert endpoint.include? '/customers/cus_3sgheFxeBgTQ3M/cards/card_483etw4er9fg4vF3sQdrt3FG'
     end.respond_with(successful_update_credit_card_response)
@@ -1358,7 +1358,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_apple_pay
-    @gateway.expects(:ssl_request).with do |method, endpoint, data, headers|
+    @gateway.expects(:ssl_request).with do |method, _endpoint, data, _headers|
       assert_equal :post, method
       assert_match %r'card\[cryptogram\]=111111111100cryptogram&card\[eci\]=05&card\[tokenization_method\]=apple_pay', data
       true
@@ -1379,7 +1379,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_android_pay
-    @gateway.expects(:ssl_request).with do |method, endpoint, data, headers|
+    @gateway.expects(:ssl_request).with do |method, _endpoint, data, _headers|
       assert_equal :post, method
       assert_match %r'card\[cryptogram\]=111111111100cryptogram&card\[eci\]=05&card\[tokenization_method\]=android_pay', data
       true
@@ -1401,7 +1401,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization_apple_pay
-    @gateway.expects(:ssl_request).with do |method, endpoint, data, headers|
+    @gateway.expects(:ssl_request).with do |method, _endpoint, data, _headers|
       assert_equal :post, method
       assert_match %r'card\[cryptogram\]=111111111100cryptogram&card\[eci\]=05&card\[tokenization_method\]=apple_pay', data
       true
@@ -1422,7 +1422,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization_android_pay
-    @gateway.expects(:ssl_request).with do |method, endpoint, data, headers|
+    @gateway.expects(:ssl_request).with do |method, _endpoint, data, _headers|
       assert_equal :post, method
       assert_match %r'card\[cryptogram\]=111111111100cryptogram&card\[eci\]=05&card\[tokenization_method\]=android_pay', data
       true
@@ -1450,7 +1450,7 @@ class StripeTest < Test::Unit::TestCase
   def test_emv_capture_application_fee_ignored
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, 'ch_test_charge', application_fee: 100, icc_data: @emv_credit_card.icc_data)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data !~ /application_fee/, 'request should not include application_fee'
     end.respond_with(successful_capture_response_with_icc_data)
 
@@ -1460,7 +1460,7 @@ class StripeTest < Test::Unit::TestCase
   def test_authorization_with_emv_payment_application_fee_included
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, 'ch_test_charge', application_fee: 100, icc_data: @emv_credit_card.icc_data)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /application_fee/, 'request should include application_fee'
     end.respond_with(successful_capture_response_with_icc_data)
 
@@ -1470,7 +1470,7 @@ class StripeTest < Test::Unit::TestCase
   def test_authorization_with_emv_payment_sets_capture_to_false
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, 'ch_test_charge', application_fee: 100, icc_data: @emv_credit_card.icc_data)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert data =~ /capture\=false/, 'request should set capture to false'
     end.respond_with(successful_capture_response_with_icc_data)
 
@@ -1478,7 +1478,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_passing_stripe_account_header
-    @gateway.expects(:ssl_request).with do |method, url, post, headers|
+    @gateway.expects(:ssl_request).with do |_method, _url, _post, headers|
       headers.include?('Stripe-Account')
     end.returns(successful_authorization_response)
 

--- a/test/unit/gateways/telr_test.rb
+++ b/test/unit/gateways/telr_test.rb
@@ -43,7 +43,7 @@ class TelrTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/029894296182/, data)
     end.respond_with(successful_capture_response)
 
@@ -77,7 +77,7 @@ class TelrTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/029894296182/, data)
     end.respond_with(successful_void_response)
 
@@ -87,7 +87,7 @@ class TelrTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
 
@@ -104,7 +104,7 @@ class TelrTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/029724176180/, data)
     end.respond_with(successful_refund_response)
 
@@ -145,7 +145,7 @@ class TelrTest < Test::Unit::TestCase
 
     ref_purchase = stub_comms do
       @gateway.purchase(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/029724176180/, data)
     end.respond_with(successful_reference_purchase_response)
 

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -48,7 +48,7 @@ class TnsTest < Test::Unit::TestCase
 
     capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/f3d100a7-18d9-4609-aabc-8a710ad0e210/, data)
     end.respond_with(successful_capture_response)
 
@@ -65,7 +65,7 @@ class TnsTest < Test::Unit::TestCase
 
     refund = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
     end.respond_with(successful_refund_response)
 
@@ -82,7 +82,7 @@ class TnsTest < Test::Unit::TestCase
 
     void = stub_comms(@gateway, :ssl_request) do
       @gateway.void(response.authorization)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ce61e06e-8c92-4a0f-a491-6eb473d883dd/, data)
     end.respond_with(successful_void_response)
 
@@ -92,7 +92,7 @@ class TnsTest < Test::Unit::TestCase
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -100,7 +100,7 @@ class TnsTest < Test::Unit::TestCase
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -108,7 +108,7 @@ class TnsTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_authorize_response)
   end
@@ -116,7 +116,7 @@ class TnsTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, billing_address: address)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal('456 My Street', parsed['billing']['address']['street'])
       assert_equal('K1C2N6', parsed['billing']['address']['postcodeZip'])
@@ -126,7 +126,7 @@ class TnsTest < Test::Unit::TestCase
   def test_passing_shipping_name
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, shipping_address: address)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal('Jim', parsed['shipping']['firstName'])
       assert_equal('Smith', parsed['shipping']['lastName'])
@@ -166,7 +166,7 @@ class TnsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_match(/secure.na.tnspayments.com/, endpoint)
     end.respond_with(successful_capture_response)
 
@@ -182,7 +182,7 @@ class TnsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_match(/secure.ap.tnspayments.com/, endpoint)
     end.respond_with(successful_capture_response)
 
@@ -198,7 +198,7 @@ class TnsTest < Test::Unit::TestCase
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_match(/secure.eu.tnspayments.com/, endpoint)
     end.respond_with(successful_capture_response)
 

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -40,7 +40,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/018033747/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -82,7 +82,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/000015377801/, data)
     end.respond_with(successful_capture_response)
 
@@ -118,7 +118,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     void = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/000015212561/, data)
     end.respond_with(successful_void_response)
 
@@ -128,7 +128,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
   def test_failed_void
     response = stub_comms do
       @gateway.void('purchase|5d53a33d960c46d00f5dc061947d998c')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/5d53a33d960c46d00f5dc061947d998c/, data)
     end.respond_with(failed_void_response)
 
@@ -146,7 +146,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/000015212561/, data)
     end.respond_with(successful_refund_response)
 
@@ -172,7 +172,7 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/000028705491/, data)
     end.respond_with(successful_refund_echeck_response)
 

--- a/test/unit/gateways/trust_commerce_test.rb
+++ b/test/unit/gateways/trust_commerce_test.rb
@@ -41,7 +41,7 @@ class TrustCommerceTest < Test::Unit::TestCase
     ActiveMerchant::Billing::TrustCommerceGateway.application_id = 'abc123'
     stub_comms do
       @gateway.purchase(@amount, @check)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{aggregator1}, data)
       assert_match(%r{name=Jim\+Smith}, data)
     end.respond_with(successful_purchase_response)
@@ -50,7 +50,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_purchase_with_custom_fields
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_purchase_response)
   end
@@ -58,7 +58,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_authorize_with_custom_fields
     stub_comms do
       @gateway.authorize(@amount, @check, @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_authorize_response)
   end
@@ -66,7 +66,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_successful_void_from_purchase
     stub_comms do
       @gateway.void('1235|sale')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{action=void}, data)
     end.respond_with(successful_void_response)
   end
@@ -74,7 +74,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_successful_void_from_authorize
     stub_comms do
       @gateway.void('1235|preauth')
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{action=reversal}, data)
     end.respond_with(successful_void_response)
   end
@@ -82,7 +82,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_capture_with_custom_fields
     stub_comms do
       @gateway.capture(@amount, 'auth', @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_capture_response)
   end
@@ -90,7 +90,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_refund_with_custom_fields
     stub_comms do
       @gateway.refund(@amount, 'auth|100', @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_refund_response)
   end
@@ -98,7 +98,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_void_with_custom_fields
     stub_comms do
       @gateway.void('1235|sale', @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_void_response)
   end
@@ -106,7 +106,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_store_with_custom_fields
     stub_comms do
       @gateway.store(@credit_card, @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_store_response)
   end
@@ -114,7 +114,7 @@ class TrustCommerceTest < Test::Unit::TestCase
   def test_succesful_unstore_with_custom_fields
     stub_comms do
       @gateway.unstore('test', @options_with_custom_fields)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r{customfield1=test1}, data)
     end.respond_with(successful_unstore_response)
   end

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -397,7 +397,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
 
     response = stub_comms do
       @gateway.run_check_sale(@options.merge(payment_method: @check))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/123456789012/, data)
     end.respond_with(successful_transaction_response('runCheckSale'))
 

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -56,7 +56,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_purchase_with_echeck_and_extra_options
     response = stub_comms do
       @gateway.purchase(@amount, check(account_type: 'savings'), @options.merge(check_format: 'ARC'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMcheckformat=ARC/, data)
       assert_match(/UMaccounttype=Savings/, data)
     end.respond_with(successful_purchase_response_echeck)
@@ -79,7 +79,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_purchase_passing_extra_info
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(invoice: '1337', description: 'socool'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMinvoice=1337/, data)
       assert_match(/UMdescription=socool/, data)
       assert_match(/UMtestmode=0/, data)
@@ -90,7 +90,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_purchase_passing_extra_test_mode
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(test_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -99,7 +99,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_purchase_email_receipt
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(email: 'bobby@hill.com', cust_receipt: 'Yes', cust_receipt_name: 'socool'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMcustreceipt=Yes/, data)
       assert_match(/UMcustreceiptname=socool/, data)
       assert_match(/UMtestmode=0/, data)
@@ -116,7 +116,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UM02key=abc123},                data
       assert_match %r{UM02amount=1.99},               data
       assert_match %r{UM02description=Second\+payee}, data
@@ -139,7 +139,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UMonError=Continue}, data
     end.respond_with(successful_purchase_response)
     assert_success response
@@ -159,7 +159,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UMaddcustomer=yes},                 data
       assert_match %r{UMschedule=quarterly},              data
       assert_match %r{UMbillsourcekey=bill\+source\+key}, data
@@ -181,7 +181,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UMcustom1=diablo},   data
       assert_match %r{UMcustom2=mephisto}, data
       assert_match %r{UMcustom3=baal},     data
@@ -225,7 +225,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UMline0sku=abc123},    data
       assert_match %r{UMline0cost=1.19},     data
       assert_match %r{UMline0qty=1},         data
@@ -253,7 +253,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_authorize_passing_extra_info
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(invoice: '1337', order_id: 'w00t', description: 'socool'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMinvoice=1337/, data)
       assert_match(/UMorderid=w00t/, data)
       assert_match(/UMdescription=socool/, data)
@@ -265,7 +265,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_authorize_passing_extra_test_mode
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(test_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -283,7 +283,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_capture_passing_extra_info
     response = stub_comms do
       @gateway.capture(@amount, '65074409', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMamount=1.00/, data)
       assert_match(/UMtestmode=0/, data)
     end.respond_with(successful_capture_response)
@@ -293,7 +293,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_capture_passing_extra_test_mode
     response = stub_comms do
       @gateway.capture(@amount, '65074409', @options.merge(test_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_capture_response)
     assert_success response
@@ -320,7 +320,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_refund_passing_extra_info
     response = stub_comms do
       @gateway.refund(@amount, '65074409', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMamount=1.00/, data)
       assert_match(/UMtestmode=0/, data)
     end.respond_with(successful_refund_response)
@@ -330,7 +330,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_refund_passing_extra_test_mode
     response = stub_comms do
       @gateway.refund(@amount, '65074409', @options.merge(test_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_refund_response)
     assert_success response
@@ -357,7 +357,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_void_passing_extra_info
     response = stub_comms do
       @gateway.void('65074409', @options.merge(no_release: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMcommand=cc%3Avoid/, data)
       assert_match(/UMtestmode=0/, data)
     end.respond_with(successful_void_response)
@@ -367,7 +367,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_successful_void_passing_extra_test_mode
     response = stub_comms do
       @gateway.refund(@amount, '65074409', @options.merge(test_mode: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/UMtestmode=1/, data)
     end.respond_with(successful_void_response)
     assert_success response
@@ -508,7 +508,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     @credit_card.manual_entry = true
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{UMcard=4242424242424242},  data
       assert_match %r{UMcardpresent=true},       data
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/vanco_test.rb
+++ b/test/unit/gateways/vanco_test.rb
@@ -29,7 +29,7 @@ class VancoTest < Test::Unit::TestCase
   def test_successful_purchase_with_fund_id
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(fund_id: 'MyEggcellentFund'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<FundID>MyEggcellentFund<\/FundID>), data) if data =~ /<RequestType>EFTAdd/
     end.respond_with(successful_login_response, successful_purchase_with_fund_id_response)
 
@@ -41,7 +41,7 @@ class VancoTest < Test::Unit::TestCase
   def test_successful_purchase_with_ip_address
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(ip: '192.168.0.1'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<CustomerIPAddress>192), data) if data =~ /<RequestType>EFTAdd/
     end.respond_with(successful_login_response, successful_purchase_response)
     assert_success response

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -60,7 +60,7 @@ class WebpayTest < Test::Unit::TestCase
   def test_successful_purchase_with_token
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, 'cus_xxx|card_xxx')
-    end.check_request do |method, endpoint, data, headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/customer=cus_xxx/, data)
       assert_match(/card=card_xxx/, data)
     end.respond_with(successful_purchase_response)
@@ -158,7 +158,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def test_metadata_header
-    @gateway.expects(:ssl_request).once.with { |method, url, post, headers|
+    @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
       headers && headers['X-Webpay-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
     }.returns(successful_purchase_response)
 

--- a/test/unit/gateways/wepay_test.rb
+++ b/test/unit/gateways/wepay_test.rb
@@ -160,7 +160,7 @@ class WepayTest < Test::Unit::TestCase
   def test_no_version_by_default
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert_no_match(/Api-Version/, headers.to_s)
     end.respond_with(successful_authorize_response)
   end
@@ -168,7 +168,7 @@ class WepayTest < Test::Unit::TestCase
   def test_version_override
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(version: '2017-05-31'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert_match(/"Api-Version\"=>\"2017-05-31\"/, headers.to_s)
     end.respond_with(successful_authorize_response)
   end

--- a/test/unit/gateways/wirecard_test.rb
+++ b/test/unit/gateways/wirecard_test.rb
@@ -192,7 +192,7 @@ class WirecardTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FunctionID>32chars-------------------------<\/FunctionID>/, data)
     end.respond_with(successful_authorization_response)
   end
@@ -202,7 +202,7 @@ class WirecardTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FunctionID>32chars-------------------------<\/FunctionID>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -212,7 +212,7 @@ class WirecardTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<FunctionID>\?D\?nde est\? la estaci\?n\?<\/FunctionID>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -236,7 +236,7 @@ class WirecardTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<CommerceType>MOTO<\/CommerceType>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -244,7 +244,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_store_sets_recurring_transaction_type_to_initial
     stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//RECURRING_TRANSACTION/Type', 'Initial')
     end.respond_with(successful_authorization_response)
   end
@@ -252,7 +252,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_store_sets_amount_to_100_by_default
     stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//CC_TRANSACTION/Amount', '100')
     end.respond_with(successful_authorization_response)
   end
@@ -260,7 +260,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_store_sets_amount_to_amount_from_options
     stub_comms do
       @gateway.store(@credit_card, amount: 120)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//CC_TRANSACTION/Amount', '120')
     end.respond_with(successful_authorization_response)
   end
@@ -268,7 +268,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_authorization_using_reference_sets_proper_elements
     stub_comms do
       @gateway.authorize(@amount, '45678', @options)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//GuWID', '45678')
       assert_no_match(/<CREDIT_CARD_DATA>/, body)
     end.respond_with(successful_authorization_response)
@@ -277,7 +277,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_purchase_using_reference_sets_proper_elements
     stub_comms do
       @gateway.purchase(@amount, '87654', @options)
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//GuWID', '87654')
       assert_no_match(/<CREDIT_CARD_DATA>/, body)
     end.respond_with(successful_authorization_response)
@@ -286,7 +286,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_authorization_with_recurring_transaction_type_initial
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(recurring: 'Initial'))
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//RECURRING_TRANSACTION/Type', 'Initial')
     end.respond_with(successful_authorization_response)
   end
@@ -294,7 +294,7 @@ class WirecardTest < Test::Unit::TestCase
   def test_purchase_using_with_recurring_transaction_type_initial
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(recurring: 'Initial'))
-    end.check_request do |endpoint, body, headers|
+    end.check_request do |_endpoint, body, _headers|
       assert_xml_element_text(body, '//RECURRING_TRANSACTION/Type', 'Initial')
     end.respond_with(successful_authorization_response)
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -31,7 +31,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/4242424242424242/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -41,7 +41,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_authorize_by_reference
     response = stub_comms do
       @gateway.authorize(@amount, @options[:order_id].to_s, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/payAsOrder/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -51,7 +51,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_exemption_in_request
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge({exemption_type: 'LV', exemption_placement: 'AUTHENTICATION'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/exemption/, data)
       assert_match(/AUTHENTICATION/, data)
     end.respond_with(successful_authorize_response)
@@ -61,7 +61,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_risk_data_in_request
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(risk_data: risk_data))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       doc = Nokogiri::XML(data)
 
       authentication_risk_data = doc.at_xpath('//riskData//authenticationRiskData')
@@ -118,7 +118,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_reference_transaction_authorize_with_merchant_code
     response = stub_comms do
       @gateway.authorize(@amount, @options[:order_id].to_s, @options.merge({ merchant_code: 'testlogin2'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/testlogin2/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -128,7 +128,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_authorize_passes_ip_and_session_id
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(ip: '127.0.0.1', session_id: '0215ui8ib1'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<session shopperIPAddress="127.0.0.1" id="0215ui8ib1"\/>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -142,7 +142,7 @@ class WorldpayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
     end.respond_with(successful_authorize_response)
@@ -175,7 +175,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_purchase_passes_correct_currency
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/CAD/, data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -236,7 +236,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.void(authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
       assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_void_inquiry_response, successful_void_response)
@@ -296,7 +296,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.refund(@amount, authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
       assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_refund_inquiry_response('CAPTURED'), successful_refund_response)
@@ -316,7 +316,7 @@ class WorldpayTest < Test::Unit::TestCase
       response = @gateway.authorize(@amount, @credit_card, @options)
       authorization = "#{response.authorization}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.capture(@amount, authorization, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('orderModification', {'orderCode' => response.authorization}, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -325,7 +325,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_visa_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<paymentDetails action="REFUND">/, data)
     end.respond_with(successful_visa_credit_response)
     assert_success response
@@ -335,7 +335,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_mastercard_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/<paymentDetails action="REFUND">/, data)
     end.respond_with(successful_mastercard_credit_response)
     assert_success response
@@ -345,13 +345,13 @@ class WorldpayTest < Test::Unit::TestCase
   def test_description
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<description>Purchase</description>), data
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(description: 'Something cool.'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<description>Something cool.</description>), data
     end.respond_with(successful_authorize_response)
   end
@@ -359,13 +359,13 @@ class WorldpayTest < Test::Unit::TestCase
   def test_order_content
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(orderContent), data
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(order_content: "Lots 'o' crazy <data> stuff."))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<orderContent>\s*<!\[CDATA\[Lots 'o' crazy <data> stuff\.\]\]>\s*</orderContent>), data
     end.respond_with(successful_authorize_response)
   end
@@ -373,7 +373,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_capture_time
     stub_comms do
       @gateway.capture(@amount, 'bogus', @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       if /capture/.match?(data)
         t = Time.now
         assert_tag_with_attributes 'date',
@@ -386,7 +386,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_amount_handling
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
         {'value' => '100', 'exponent' => '2', 'currencyCode' => 'GBP'},
         data
@@ -396,7 +396,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_currency_exponent_handling
     stub_comms do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
         {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
         data
@@ -404,7 +404,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :OMR))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
         {'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR'},
         data
@@ -414,7 +414,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_address_handling
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: address))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
       assert_match %r(<address1>456 My Street</address1>), data
@@ -428,7 +428,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: address.with_indifferent_access))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
       assert_match %r(<address1>456 My Street</address1>), data
@@ -442,7 +442,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(address: address))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<firstName>Jim</firstName>), data
       assert_match %r(<lastName>Smith</lastName>), data
       assert_match %r(<address1>456 My Street</address1>), data
@@ -456,7 +456,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: { phone: '555-3323' }))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
@@ -472,7 +472,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_no_address_specified
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(cardAddress), data
       assert_no_match %r(address), data
       assert_no_match %r(firstName), data
@@ -493,7 +493,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: address_with_nils))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
@@ -510,7 +510,7 @@ class WorldpayTest < Test::Unit::TestCase
     us_billing_address = address.merge(country: 'US')
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: us_billing_address, execute_threed: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(firstName), data
       assert_match %r(lastName), data
       assert_match %r(<address1>456 My Street</address1>), data
@@ -526,7 +526,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_state_not_sent_for_3ds_transactions_in_non_us_country
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(billing_address: address, execute_threed: true))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(firstName), data
       assert_match %r(lastName), data
       assert_match %r(<address1>456 My Street</address1>), data
@@ -542,13 +542,13 @@ class WorldpayTest < Test::Unit::TestCase
   def test_email
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(email: 'eggcellent@example.com'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<shopperEmailAddress>eggcellent@example.com</shopperEmailAddress>), data
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(shopperEmailAddress), data
     end.respond_with(successful_authorize_response)
   end
@@ -556,7 +556,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_instalments
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(instalments: 3))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       unless /<capture>/.match?(data)
         assert_match %r(<instalments>3</instalments>), data
         assert_no_match %r(cpf), data
@@ -565,7 +565,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(instalments: 3, cpf: 12341234))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       unless /<capture>/.match?(data)
         assert_match %r(<instalments>3</instalments>), data
         assert_match %r(<cpf>12341234</cpf>), data
@@ -576,13 +576,13 @@ class WorldpayTest < Test::Unit::TestCase
   def test_ip
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge(ip: '192.137.11.44'))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<session shopperIPAddress="192.137.11.44"/>), data
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match %r(<session), data
     end.respond_with(successful_authorize_response)
   end
@@ -619,7 +619,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_auth
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       assert_equal 'Basic dGVzdGxvZ2luOnRlc3RwYXNzd29yZA==', headers['Authorization']
     end.respond_with(successful_authorize_response)
   end
@@ -635,7 +635,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_equal WorldpayGateway.test_url, endpoint
     end.respond_with(successful_authorize_response, successful_capture_response)
   ensure
@@ -645,7 +645,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_refund_amount_contains_debit_credit_indicator
     response = stub_comms do
       @gateway.refund(@amount, @options[:order_id], @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       if /<refund>/.match?(data)
         request_hash = Hash.from_xml(data)
         assert_equal 'credit', request_hash['paymentService']['modify']['orderModification']['refund']['amount']['debitCreditIndicator']
@@ -694,7 +694,7 @@ class WorldpayTest < Test::Unit::TestCase
     @options[:execute_threed] = true
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<cardHolderName>3D</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -705,7 +705,7 @@ class WorldpayTest < Test::Unit::TestCase
     @options[:three_ds_version] = '2.0'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -713,7 +713,7 @@ class WorldpayTest < Test::Unit::TestCase
     @options[:three_ds_version] = '2'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<cardHolderName>Longbob Longsen</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -721,7 +721,7 @@ class WorldpayTest < Test::Unit::TestCase
     @options[:three_ds_version] = '1.0.2'
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<cardHolderName>3D</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
@@ -734,7 +734,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_3ds_version_1_request
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option(version: '1.0.2', xid: 'xid')))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<paymentService version="1.4" merchantCode="testlogin">}, data
       assert_match %r{<eci>eci</eci>}, data
       assert_match %r{<cavv>cavv</cavv>}, data
@@ -746,7 +746,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_3ds_version_2_request
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option(version: '2.1.0', ds_transaction_id: 'ds_transaction_id')))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<paymentService version="1.4" merchantCode="testlogin">}, data
       assert_match %r{<eci>eci</eci>}, data
       assert_match %r{<cavv>cavv</cavv>}, data
@@ -782,7 +782,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @store_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<paymentTokenCreate>), data
       assert_match %r(<createToken/?>), data
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
@@ -800,7 +800,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_authorize_using_token
     response = stub_comms do
       @gateway.authorize(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
       assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
@@ -814,7 +814,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_authorize_with_token_includes_shopper_using_minimal_options
     stub_comms do
       @gateway.authorize(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
     end.respond_with(successful_authorize_response)
   end
@@ -822,7 +822,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_purchase_using_token
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
@@ -833,7 +833,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_verify_using_token
     response = stub_comms do
       @gateway.verify(@token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
@@ -844,7 +844,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_successful_credit_using_token
     response = stub_comms do
       @gateway.credit(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
       assert_match(/<paymentDetails action="REFUND">/, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
@@ -860,7 +860,7 @@ class WorldpayTest < Test::Unit::TestCase
   def test_optional_idempotency_key_header
     response = stub_comms do
       @gateway.authorize(@amount, @token, @options.merge({idempotency_key: 'test123'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, _data, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     end.respond_with(successful_authorize_response)
 
@@ -907,7 +907,7 @@ class WorldpayTest < Test::Unit::TestCase
     @token = 'wrong_order_id|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     response = stub_comms do
       @gateway.authorize(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
       assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
@@ -922,7 +922,7 @@ class WorldpayTest < Test::Unit::TestCase
     @token = 'wrong_order_id|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
@@ -934,7 +934,7 @@ class WorldpayTest < Test::Unit::TestCase
     @token = 'wrong_order_id|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     response = stub_comms do
       @gateway.verify(@token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
@@ -946,7 +946,7 @@ class WorldpayTest < Test::Unit::TestCase
     @token = 'wrong_order_id|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     response = stub_comms do
       @gateway.credit(@amount, @token, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
       assert_match(/<paymentDetails action="REFUND">/, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data

--- a/test/unit/gateways/worldpay_us_test.rb
+++ b/test/unit/gateways/worldpay_us_test.rb
@@ -67,7 +67,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
     capture = stub_comms do
       @gateway.capture(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/postonly=354275517/, data)
     end.respond_with(successful_capture_response)
 
@@ -84,7 +84,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/historykeyid=353583515/, data)
       assert_match(/orderkeyid=252889136/, data)
     end.respond_with(successful_refund_response)
@@ -102,7 +102,7 @@ class WorldpayUsTest < Test::Unit::TestCase
 
     refund = stub_comms do
       @gateway.void(response.authorization)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/historykeyid=353583515/, data)
       assert_match(/orderkeyid=252889136/, data)
     end.respond_with(successful_refund_response)
@@ -136,7 +136,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   def test_passing_cvv
     stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/#{@credit_card.verification_value}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -144,7 +144,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   def test_passing_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ci_billaddr1=456\+My\+Street/, data)
       assert_match(/ci_billzip=K1C2N6/, data)
     end.respond_with(successful_purchase_response)
@@ -153,7 +153,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   def test_passing_phone_number
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match(/ci_phone=%28555%29555-5555/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -161,7 +161,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   def test_passing_billing_address_without_phone
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address(phone: nil))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_no_match(/udf3/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -178,7 +178,7 @@ class WorldpayUsTest < Test::Unit::TestCase
   def test_backup_url
     response = stub_comms(@gateway) do
       @gateway.purchase(@amount, @credit_card, use_backup_url: true)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, _data, _headers|
       assert_equal WorldpayUsGateway.backup_url, endpoint
     end.respond_with(successful_purchase_response)
     assert_success response


### PR DESCRIPTION
Fixes the RuboCop to-do for [Lint/UnusedMethodArgument](https://docs.rubocop.org/rubocop/0.85/cops_lint.html#lintunusedmethodargument).

All unit tests:
4543 tests, 72248 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed