### PR TITLE
RuboCop: Fix Naming/MemoizedInstanceVariableName

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,13 +119,6 @@ Naming/HeredocDelimiterCase:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
-# Offense count: 1
-# Configuration parameters: EnforcedStyleForLeadingUnderscores.
-# SupportedStylesForLeadingUnderscores: disallowed, required, optional
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - 'lib/active_merchant/billing/compatibility.rb'
-
 # Offense count: 15
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: snake_case, camelCase

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * WorldPay: Add support for idempotency_key[cdmackeyfree] #3759
 * Orbital: Handle line_tot key as a string [naashton] #3760
 * RuboCop: Fix Lint/UnusedMethodArgument [leila-alderman] #3721
+* RuboCop: Fix Naming/MemoizedInstanceVariableName [leila-alderman] #3722
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -56,7 +56,7 @@ module ActiveMerchant
         private
 
         def internal_errors
-          @errors ||= Errors.new
+          @internal_errors ||= Errors.new
         end
 
         class Errors < Hash


### PR DESCRIPTION
Fixes the RuboCop to-do for [Naming/MemoizedInstanceVariableName](https://docs.rubocop.org/rubocop/0.85/cops_naming.html#namingmemoizedinstancevariablename).

All unit tests:
4543 tests, 72248 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed