### PR TITLE
RuboCop: Fix Naming/ConstantName

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,11 +97,6 @@ Naming/AccessorMethodName:
     - 'test/remote/gateways/remote_authorize_net_cim_test.rb'
     - 'test/unit/gateways/authorize_net_cim_test.rb'
 
-# Offense count: 1
-Naming/ConstantName:
-  Exclude:
-    - 'test/test_helper.rb'
-
 # Offense count: 46
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: lowercase, uppercase

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * RuboCop: Fix Naming/MemoizedInstanceVariableName [leila-alderman] #3722
 * RuboCop: Fix Style/BlockComments [leila-alderman] #3729
 * Checkout V2: Move to single-transaction Purchases [curiousepic] #3761
+* RuboCop: Fix Naming/ConstantName [leila-alderman] #3723
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ end
 
 module ActiveMerchant
   module Assertions
-    AssertionClass = defined?(Minitest) ? MiniTest::Assertion : Test::Unit::AssertionFailedError
+    ASSERTION_CLASS = defined?(Minitest) ? MiniTest::Assertion : Test::Unit::AssertionFailedError
 
     def assert_field(field, value)
       clean_backtrace do
@@ -129,9 +129,9 @@ module ActiveMerchant
 
     def clean_backtrace(&block)
       yield
-    rescue AssertionClass => e
+    rescue ASSERTION_CLASS => e
       path = File.expand_path(__FILE__)
-      raise AssertionClass, e.message, (e.backtrace.reject { |line| File.expand_path(line).match?(/#{path}/) })
+      raise ASSERTION_CLASS, e.message, (e.backtrace.reject { |line| File.expand_path(line).match?(/#{path}/) })
     end
   end
 


### PR DESCRIPTION
Fixes the RuboCop to-do for [Naming/ConstantName](https://docs.rubocop.org/rubocop/0.85/cops_naming.html#namingconstantname).

In this case, RuboCop was incorrectly thinking that `AssertionClass`
should be a constant, likely because of the capitalization used for this
variable. To fix this issue, this variable has been renamed as an
instance variable.

All unit tests:
4543 tests, 72248 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed