### PR TITLE
RuboCop: Fix Naming/VariableNumber

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,20 +160,6 @@ Naming/VariableName:
     - 'test/unit/gateways/card_stream_test.rb'
     - 'test/unit/gateways/worldpay_online_payments_test.rb'
 
-# Offense count: 11
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: snake_case, normalcase, non_integer
-Naming/VariableNumber:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/merchant_partners.rb'
-    - 'lib/active_merchant/billing/gateways/mercury.rb'
-    - 'lib/active_merchant/billing/gateways/orbital.rb'
-    - 'test/remote/gateways/remote_paypal_test.rb'
-    - 'test/unit/gateways/merchant_ware_test.rb'
-    - 'test/unit/gateways/merchant_ware_version_four_test.rb'
-    - 'test/unit/gateways/orbital_test.rb'
-    - 'test/unit/gateways/paypal/paypal_common_api_test.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 Performance/RedundantMatch:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Orbital: Fix schema errors [britth] #3766
 * Checkout V2: Start testing via amount code [curiousepic] #3767
 * CyberSource: Don't include empty `mdd_` fields [arbianchi] #3758
+* RuboCop: Fix Naming/VariableNumber [leila-alderman] #3725
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/merchant_partners.rb
+++ b/lib/active_merchant/billing/gateways/merchant_partners.rb
@@ -111,9 +111,9 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method)
         if payment_method.is_a?(String)
-          user_profile_id, last_4 = split_authorization(payment_method)
+          user_profile_id, last4 = split_authorization(payment_method)
           post[:userprofileid] = user_profile_id
-          post[:last4digits] = last_4
+          post[:last4digits] = last4
         else
           post[:ccname] = payment_method.name
           post[:ccnum] = payment_method.number

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -211,11 +211,11 @@ module ActiveMerchant #:nodoc:
             # handle with the validation error as it sees fit.
             # Track 2 requires having the STX and ETX stripped. Track 1 does not.
             # Max-length track 1s require having the STX and ETX stripped. Max is 79 bytes including LRC.
-            is_track_2 = credit_card.track_data[0] == ';'
+            is_track2 = credit_card.track_data[0] == ';'
             etx_index = credit_card.track_data.rindex('?') || credit_card.track_data.length
             is_max_track1 = etx_index >= 77
 
-            if is_track_2
+            if is_track2
               xml.tag! 'Track2', credit_card.track_data[1...etx_index]
             elsif is_max_track1
               xml.tag! 'Track1', credit_card.track_data[1...etx_index]

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -355,50 +355,50 @@ module ActiveMerchant #:nodoc:
         xml.tag! :SDMerchantEmail, soft_desc[:merchant_email] || nil
       end
 
-      def add_level_2_tax(xml, options = {})
-        if (level_2 = options[:level_2_data])
-          xml.tag! :TaxInd, level_2[:tax_indicator] if [TAX_NOT_PROVIDED, TAX_INCLUDED, NON_TAXABLE_TRANSACTION].include?(level_2[:tax_indicator].to_i)
-          xml.tag! :Tax, level_2[:tax].to_i if level_2[:tax]
+      def add_level2_tax(xml, options = {})
+        if (level2 = options[:level_2_data])
+          xml.tag! :TaxInd, level2[:tax_indicator] if [TAX_NOT_PROVIDED, TAX_INCLUDED, NON_TAXABLE_TRANSACTION].include?(level2[:tax_indicator].to_i)
+          xml.tag! :Tax, level2[:tax].to_i if level2[:tax]
         end
       end
 
-      def add_level_3_tax(xml, options = {})
-        if (level_3 = options[:level_3_data])
-          xml.tag! :PC3VATtaxAmt, byte_limit(level_3[:vat_tax], 12) if level_3[:vat_tax]
-          xml.tag! :PC3AltTaxAmt, byte_limit(level_3[:alt_tax], 9) if level_3[:alt_tax]
-          xml.tag! :PC3VATtaxRate, byte_limit(level_3[:vat_rate], 4) if level_3[:vat_rate]
-          xml.tag! :PC3AltTaxInd, byte_limit(level_3[:alt_ind], 15) if level_3[:alt_ind]
+      def add_level3_tax(xml, options = {})
+        if (level3 = options[:level_3_data])
+          xml.tag! :PC3VATtaxAmt, byte_limit(level3[:vat_tax], 12) if level3[:vat_tax]
+          xml.tag! :PC3AltTaxAmt, byte_limit(level3[:alt_tax], 9) if level3[:alt_tax]
+          xml.tag! :PC3VATtaxRate, byte_limit(level3[:vat_rate], 4) if level3[:vat_rate]
+          xml.tag! :PC3AltTaxInd, byte_limit(level3[:alt_ind], 15) if level3[:alt_ind]
         end
       end
 
-      def add_level_2_advice_addendum(xml, options = {})
-        if (level_2 = options[:level_2_data])
-          xml.tag! :AMEXTranAdvAddn1, byte_limit(level_2[:advice_addendum_1], 40) if level_2[:advice_addendum_1]
-          xml.tag! :AMEXTranAdvAddn2, byte_limit(level_2[:advice_addendum_2], 40) if level_2[:advice_addendum_2]
-          xml.tag! :AMEXTranAdvAddn3, byte_limit(level_2[:advice_addendum_3], 40) if level_2[:advice_addendum_3]
-          xml.tag! :AMEXTranAdvAddn4, byte_limit(level_2[:advice_addendum_4], 40) if level_2[:advice_addendum_4]
+      def add_level2_advice_addendum(xml, options = {})
+        if (level2 = options[:level_2_data])
+          xml.tag! :AMEXTranAdvAddn1, byte_limit(level2[:advice_addendum_1], 40) if level2[:advice_addendum_1]
+          xml.tag! :AMEXTranAdvAddn2, byte_limit(level2[:advice_addendum_2], 40) if level2[:advice_addendum_2]
+          xml.tag! :AMEXTranAdvAddn3, byte_limit(level2[:advice_addendum_3], 40) if level2[:advice_addendum_3]
+          xml.tag! :AMEXTranAdvAddn4, byte_limit(level2[:advice_addendum_4], 40) if level2[:advice_addendum_4]
         end
       end
 
-      def add_level_2_purchase(xml, options = {})
-        if (level_2 = options[:level_2_data])
-          xml.tag! :PCOrderNum,       byte_limit(level_2[:purchase_order], 17) if level_2[:purchase_order]
-          xml.tag! :PCDestZip,        byte_limit(format_address_field(level_2[:zip]), 10) if level_2[:zip]
-          xml.tag! :PCDestName,       byte_limit(format_address_field(level_2[:name]), 30) if level_2[:name]
-          xml.tag! :PCDestAddress1,   byte_limit(format_address_field(level_2[:address1]), 30) if level_2[:address1]
-          xml.tag! :PCDestAddress2,   byte_limit(format_address_field(level_2[:address2]), 30) if level_2[:address2]
-          xml.tag! :PCDestCity,       byte_limit(format_address_field(level_2[:city]), 20) if level_2[:city]
-          xml.tag! :PCDestState,      byte_limit(format_address_field(level_2[:state]), 2) if level_2[:state]
+      def add_level2_purchase(xml, options = {})
+        if (level2 = options[:level_2_data])
+          xml.tag! :PCOrderNum,       byte_limit(level2[:purchase_order], 17) if level2[:purchase_order]
+          xml.tag! :PCDestZip,        byte_limit(format_address_field(level2[:zip]), 10) if level2[:zip]
+          xml.tag! :PCDestName,       byte_limit(format_address_field(level2[:name]), 30) if level2[:name]
+          xml.tag! :PCDestAddress1,   byte_limit(format_address_field(level2[:address1]), 30) if level2[:address1]
+          xml.tag! :PCDestAddress2,   byte_limit(format_address_field(level2[:address2]), 30) if level2[:address2]
+          xml.tag! :PCDestCity,       byte_limit(format_address_field(level2[:city]), 20) if level2[:city]
+          xml.tag! :PCDestState,      byte_limit(format_address_field(level2[:state]), 2) if level2[:state]
         end
       end
 
-      def add_level_3_purchase(xml, options = {})
-        if (level_3 = options[:level_3_data])
-          xml.tag! :PC3FreightAmt,    byte_limit(level_3[:freight_amount], 12) if level_3[:freight_amount]
-          xml.tag! :PC3DutyAmt,       byte_limit(level_3[:duty_amount], 12) if level_3[:duty_amount]
-          xml.tag! :PC3DestCountryCd, byte_limit(level_3[:dest_country], 3) if level_3[:dest_country]
-          xml.tag! :PC3ShipFromZip,   byte_limit(level_3[:ship_from_zip], 10) if level_3[:ship_from_zip]
-          xml.tag! :PC3DiscAmt,       byte_limit(level_3[:discount_amount], 12) if level_3[:discount_amount]
+      def add_level3_purchase(xml, options = {})
+        if (level3 = options[:level_3_data])
+          xml.tag! :PC3FreightAmt,    byte_limit(level3[:freight_amount], 12) if level3[:freight_amount]
+          xml.tag! :PC3DutyAmt,       byte_limit(level3[:duty_amount], 12) if level3[:duty_amount]
+          xml.tag! :PC3DestCountryCd, byte_limit(level3[:dest_country], 3) if level3[:dest_country]
+          xml.tag! :PC3ShipFromZip,   byte_limit(level3[:ship_from_zip], 10) if level3[:ship_from_zip]
+          xml.tag! :PC3DiscAmt,       byte_limit(level3[:discount_amount], 12) if level3[:discount_amount]
         end
       end
 
@@ -729,8 +729,8 @@ module ActiveMerchant #:nodoc:
             xml.tag! :Amount, amount(money)
             xml.tag! :Comments, parameters[:comments] if parameters[:comments]
 
-            add_level_2_tax(xml, parameters)
-            add_level_2_advice_addendum(xml, parameters)
+            add_level2_tax(xml, parameters)
+            add_level2_advice_addendum(xml, parameters)
 
             add_aav(xml, creditcard, three_d_secure)
             # CustomerAni, AVSPhoneType and AVSDestPhoneType could be added here.
@@ -753,9 +753,9 @@ module ActiveMerchant #:nodoc:
               xml.tag! :TxRefNum, tx_ref_num
             end
 
-            add_level_2_purchase(xml, parameters)
-            add_level_3_purchase(xml, parameters)
-            add_level_3_tax(xml, parameters)
+            add_level2_purchase(xml, parameters)
+            add_level3_purchase(xml, parameters)
+            add_level3_tax(xml, parameters)
             add_card_indicators(xml, parameters)
             add_line_items(xml, parameters) if parameters[:line_items]
             add_stored_credentials(xml, parameters)
@@ -784,13 +784,13 @@ module ActiveMerchant #:nodoc:
             add_xml_credentials(xml)
             xml.tag! :OrderID, format_order_id(order_id)
             xml.tag! :Amount, amount(money)
-            add_level_2_tax(xml, parameters)
+            add_level2_tax(xml, parameters)
             add_bin_merchant_and_terminal(xml, parameters)
             xml.tag! :TxRefNum, tx_ref_num
-            add_level_2_purchase(xml, parameters)
-            add_level_2_advice_addendum(xml, parameters)
-            add_level_3_purchase(xml, parameters)
-            add_level_3_tax(xml, parameters)
+            add_level2_purchase(xml, parameters)
+            add_level2_advice_addendum(xml, parameters)
+            add_level3_purchase(xml, parameters)
+            add_level3_tax(xml, parameters)
           end
         end
         xml.target!

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -149,10 +149,10 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
     assert response.params['transaction_id']
     assert_equal '0.60', response.params['gross_amount']
-    response_2 = @gateway.capture(40, auth.authorization)
-    assert_success response_2
-    assert response_2.params['transaction_id']
-    assert_equal '0.40', response_2.params['gross_amount']
+    response2 = @gateway.capture(40, auth.authorization)
+    assert_success response2
+    assert response2.params['transaction_id']
+    assert_equal '0.40', response2.params['gross_amount']
   end
 
   def test_successful_capture_updating_the_invoice_id

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -32,8 +32,8 @@ class MerchantWareTest < Test::Unit::TestCase
   end
 
   def test_soap_fault_during_authorization
-    response_500 = stub(code: '500', message: 'Internal Server Error', body: fault_authorization_response)
-    @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response_500))
+    response500 = stub(code: '500', message: 'Internal Server Error', body: fault_authorization_response)
+    @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response500))
 
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_instance_of Response, response
@@ -42,8 +42,8 @@ class MerchantWareTest < Test::Unit::TestCase
 
     assert_nil response.authorization
     assert_equal 'Server was unable to process request. ---> strPAN should be at least 13 to at most 19 characters in size. Parameter name: strPAN', response.message
-    assert_equal response_500.code, response.params['http_code']
-    assert_equal response_500.message, response.params['http_message']
+    assert_equal response500.code, response.params['http_code']
+    assert_equal response500.message, response.params['http_message']
   end
 
   def test_failed_authorization

--- a/test/unit/gateways/merchant_ware_version_four_test.rb
+++ b/test/unit/gateways/merchant_ware_version_four_test.rb
@@ -31,8 +31,8 @@ class MerchantWareVersionFourTest < Test::Unit::TestCase
   end
 
   def test_soap_fault_during_authorization
-    response_400 = stub(code: '400', message: 'Bad Request', body: failed_authorize_response)
-    @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response_400))
+    response400 = stub(code: '400', message: 'Bad Request', body: failed_authorize_response)
+    @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response400))
 
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_instance_of Response, response
@@ -41,8 +41,8 @@ class MerchantWareVersionFourTest < Test::Unit::TestCase
 
     assert_nil response.authorization
     assert_equal 'amount cannot be null. Parameter name: amount', response.message
-    assert_equal response_400.code, response.params['http_code']
-    assert_equal response_400.message, response.params['http_message']
+    assert_equal response400.code, response.params['http_code']
+    assert_equal response400.message, response.params['http_message']
   end
 
   def test_failed_authorization

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -14,7 +14,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     )
     @customer_ref_num = 'ABC'
 
-    @level_2 = {
+    @level2 = {
       tax_indicator: '1',
       tax: '10',
       advice_addendum_1: 'taa1 - test',
@@ -30,7 +30,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       zip: address[:zip]
     }
 
-    @level_3 = {
+    @level3 = {
       freight_amount: '15',
       duty_amount: '10',
       dest_country: 'US',
@@ -108,39 +108,39 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
   end
 
-  def test_level_2_data
+  def test_level2_data
     stub_comms do
-      @gateway.purchase(50, credit_card, @options.merge(level_2_data: @level_2))
+      @gateway.purchase(50, credit_card, @options.merge(level_2_data: @level2))
     end.check_request do |_endpoint, data, _headers|
-      assert_match %{<TaxInd>#{@level_2[:tax_indicator].to_i}</TaxInd>}, data
-      assert_match %{<Tax>#{@level_2[:tax].to_i}</Tax>}, data
-      assert_match %{<AMEXTranAdvAddn1>#{@level_2[:advice_addendum_1]}</AMEXTranAdvAddn1>}, data
-      assert_match %{<AMEXTranAdvAddn2>#{@level_2[:advice_addendum_2]}</AMEXTranAdvAddn2>}, data
-      assert_match %{<AMEXTranAdvAddn3>#{@level_2[:advice_addendum_3]}</AMEXTranAdvAddn3>}, data
-      assert_match %{<AMEXTranAdvAddn4>#{@level_2[:advice_addendum_4]}</AMEXTranAdvAddn4>}, data
-      assert_match %{<PCOrderNum>#{@level_2[:purchase_order]}</PCOrderNum>}, data
-      assert_match %{<PCDestZip>#{@level_2[:zip]}</PCDestZip>}, data
-      assert_match %{<PCDestName>#{@level_2[:name]}</PCDestName>}, data
-      assert_match %{<PCDestAddress1>#{@level_2[:address1]}</PCDestAddress1>}, data
-      assert_match %{<PCDestAddress2>#{@level_2[:address2]}</PCDestAddress2>}, data
-      assert_match %{<PCDestCity>#{@level_2[:city]}</PCDestCity>}, data
-      assert_match %{<PCDestState>#{@level_2[:state]}</PCDestState>}, data
+      assert_match %{<TaxInd>#{@level2[:tax_indicator].to_i}</TaxInd>}, data
+      assert_match %{<Tax>#{@level2[:tax].to_i}</Tax>}, data
+      assert_match %{<AMEXTranAdvAddn1>#{@level2[:advice_addendum_1]}</AMEXTranAdvAddn1>}, data
+      assert_match %{<AMEXTranAdvAddn2>#{@level2[:advice_addendum_2]}</AMEXTranAdvAddn2>}, data
+      assert_match %{<AMEXTranAdvAddn3>#{@level2[:advice_addendum_3]}</AMEXTranAdvAddn3>}, data
+      assert_match %{<AMEXTranAdvAddn4>#{@level2[:advice_addendum_4]}</AMEXTranAdvAddn4>}, data
+      assert_match %{<PCOrderNum>#{@level2[:purchase_order]}</PCOrderNum>}, data
+      assert_match %{<PCDestZip>#{@level2[:zip]}</PCDestZip>}, data
+      assert_match %{<PCDestName>#{@level2[:name]}</PCDestName>}, data
+      assert_match %{<PCDestAddress1>#{@level2[:address1]}</PCDestAddress1>}, data
+      assert_match %{<PCDestAddress2>#{@level2[:address2]}</PCDestAddress2>}, data
+      assert_match %{<PCDestCity>#{@level2[:city]}</PCDestCity>}, data
+      assert_match %{<PCDestState>#{@level2[:state]}</PCDestState>}, data
     end.respond_with(successful_purchase_response)
   end
 
-  def test_level_3_data
+  def test_level3_data
     stub_comms do
-      @gateway.purchase(50, credit_card, @options.merge(level_3_data: @level_3))
+      @gateway.purchase(50, credit_card, @options.merge(level_3_data: @level3))
     end.check_request do |_endpoint, data, _headers|
-      assert_match %{<PC3FreightAmt>#{@level_3[:freight_amount].to_i}</PC3FreightAmt>}, data
-      assert_match %{<PC3DutyAmt>#{@level_3[:duty_amount].to_i}</PC3DutyAmt>}, data
-      assert_match %{<PC3DestCountryCd>#{@level_3[:dest_country]}</PC3DestCountryCd>}, data
-      assert_match %{<PC3ShipFromZip>#{@level_3[:ship_from_zip].to_i}</PC3ShipFromZip>}, data
-      assert_match %{<PC3DiscAmt>#{@level_3[:discount_amount].to_i}</PC3DiscAmt>}, data
-      assert_match %{<PC3VATtaxAmt>#{@level_3[:vat_tax].to_i}</PC3VATtaxAmt>}, data
-      assert_match %{<PC3VATtaxRate>#{@level_3[:vat_rate].to_i}</PC3VATtaxRate>}, data
-      assert_match %{<PC3AltTaxAmt>#{@level_3[:alt_tax].to_i}</PC3AltTaxAmt>}, data
-      assert_match %{<PC3AltTaxInd>#{@level_3[:alt_ind]}</PC3AltTaxInd>}, data
+      assert_match %{<PC3FreightAmt>#{@level3[:freight_amount].to_i}</PC3FreightAmt>}, data
+      assert_match %{<PC3DutyAmt>#{@level3[:duty_amount].to_i}</PC3DutyAmt>}, data
+      assert_match %{<PC3DestCountryCd>#{@level3[:dest_country]}</PC3DestCountryCd>}, data
+      assert_match %{<PC3ShipFromZip>#{@level3[:ship_from_zip].to_i}</PC3ShipFromZip>}, data
+      assert_match %{<PC3DiscAmt>#{@level3[:discount_amount].to_i}</PC3DiscAmt>}, data
+      assert_match %{<PC3VATtaxAmt>#{@level3[:vat_tax].to_i}</PC3VATtaxAmt>}, data
+      assert_match %{<PC3VATtaxRate>#{@level3[:vat_rate].to_i}</PC3VATtaxRate>}, data
+      assert_match %{<PC3AltTaxAmt>#{@level3[:alt_tax].to_i}</PC3AltTaxAmt>}, data
+      assert_match %{<PC3AltTaxInd>#{@level3[:alt_ind]}</PC3AltTaxInd>}, data
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -135,19 +135,19 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_equal '1', REXML::XPath.first(request, '//GetBalanceReq/GetBalanceRequest/ReturnAllCurrencies').text
   end
 
-  def test_balance_cleans_up_currencies_values_like_1
+  def test_balance_cleans_up_currencies_values_like_one
     @gateway.stubs(:commit)
-    [1, '1', true].each do |values_like_1|
+    [1, '1', true].each do |values_like_one|
       @gateway.expects(:build_get_balance).with('1')
-      @gateway.balance(values_like_1)
+      @gateway.balance(values_like_one)
     end
   end
 
-  def test_balance_cleans_up_currencies_values_like_0
+  def test_balance_cleans_up_currencies_values_like_zero
     @gateway.stubs(:commit)
-    [0, '0', false, nil, :foo].each do |values_like_0|
+    [0, '0', false, nil, :foo].each do |values_like_zero|
       @gateway.expects(:build_get_balance).with('0')
-      @gateway.balance(values_like_0)
+      @gateway.balance(values_like_zero)
     end
   end
 


### PR DESCRIPTION
Fixes the RuboCop to-do for [Naming/VariableNumber](https://docs.rubocop.org/rubocop/0.85/cops_naming.html#namingvariablenumber).

PayPal remote tests:
29 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4544 tests, 72251 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed