### PR TITLE
RuboCop: Fix Style/Attr

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -277,12 +277,6 @@ Style/AsciiComments:
     - 'test/remote/gateways/remote_data_cash_test.rb'
     - 'test/remote/gateways/remote_nab_transact_test.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/Attr:
-  Exclude:
-    - 'test/unit/gateways/forte_test.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
 * RuboCop: Fix Style/TrailingCommaInHashLiteral [leila-alderman] #3718
 * RuboCop: Fix Naming/PredicateName [leila-alderman] #3724
+* RuboCop: Fix Style/Attr [leila-alderman] #3728
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -171,7 +171,7 @@ class ForteTest < Test::Unit::TestCase
   private
 
   class MockedResponse
-    attr :code, :body
+    attr_reader :code, :body
     def initialize(body, code = 200)
       @code = code
       @body = body


### PR DESCRIPTION
Fixes the RuboCop to-do for [Style/Attr](https://docs.rubocop.org/rubocop/0.85/cops_style.html#styleattr).

All unit tests:
4544 tests, 72251 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed