### PR TITLE
RuboCop: Fix Style/BlockComments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -266,14 +266,6 @@ Style/BarePercentLiterals:
     - 'test/unit/gateways/eway_rapid_test.rb'
     - 'test/unit/gateways/orbital_test.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/BlockComments:
-  Exclude:
-    - 'test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb'
-    - 'test/remote/gateways/remote_netpay_test.rb'
-    - 'test/remote/gateways/remote_payu_in_test.rb'
-
 # Offense count: 77
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Orbital: Handle line_tot key as a string [naashton] #3760
 * RuboCop: Fix Lint/UnusedMethodArgument [leila-alderman] #3721
 * RuboCop: Fix Naming/MemoizedInstanceVariableName [leila-alderman] #3722
+* RuboCop: Fix Style/BlockComments [leila-alderman] #3729
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
+++ b/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
@@ -125,76 +125,75 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     assert_success void
   end
 
-=begin Enable if/when fully enabled account is available to test
-  def test_reference_transactions
-    # Setting an alias
-    assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"1"))
-    assert_success response
-    # Updating an alias
-    assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"2"))
-    assert_success response
-    # Using an alias (i.e. don't provide the credit card)
-    assert response = @gateway.purchase(@amount, "awesomeman", @options.merge(:order_id => Time.now.to_i.to_s + "3"))
-    assert_success response
-  end
-
-  def test_successful_store
-    assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
-    assert_success response
-    assert purchase = @gateway.purchase(@amount, 'test_alias')
-    assert_success purchase
-  end
-
-  def test_successful_store_generated_alias
-    assert response = @gateway.store(@credit_card)
-    assert_success response
-    assert purchase = @gateway.purchase(@amount, response.billing_id)
-    assert_success purchase
-  end
-
-  def test_successful_store
-    assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
-    assert_success response
-    assert purchase = @gateway.purchase(@amount, 'test_alias')
-    assert_success purchase
-  end
-
-  def test_successful_unreferenced_credit
-    assert credit = @gateway.credit(@amount, @credit_card, @options)
-    assert_success credit
-    assert credit.authorization
-    assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, credit.message
-  end
-
-  # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
-  #       section of your account admin before running this test
-  def test_successful_purchase_with_custom_currency_at_the_gateway_level
-    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:currency => 'USD'))
-    assert response = gateway.purchase(@amount, @credit_card)
-    assert_success response
-    assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
-    assert_equal "USD", response.params["currency"]
-  end
-
-  # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
-  #       section of your account admin before running this test
-  def test_successful_purchase_with_custom_currency
-    gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:currency => 'EUR'))
-    assert response = gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
-    assert_success response
-    assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
-    assert_equal "USD", response.params["currency"]
-  end
-
-  # NOTE: You have to contact Barclays to make sure your test account allow 3D Secure transactions before running this test
-  def test_successful_purchase_with_3d_secure
-    assert response = @gateway.purchase(@amount, @credit_card_d3d, @options.merge(:d3d => true))
-    assert_success response
-    assert_equal '46', response.params["STATUS"]
-    assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
-    assert response.params["HTML_ANSWER"]
-  end
-=end
+  # Enable if/when fully enabled account is available to test
+  #   def test_reference_transactions
+  #     # Setting an alias
+  #     assert response = @gateway.purchase(@amount, credit_card('4000100011112224'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"1"))
+  #     assert_success response
+  #     # Updating an alias
+  #     assert response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(:billing_id => "awesomeman", :order_id=>Time.now.to_i.to_s+"2"))
+  #     assert_success response
+  #     # Using an alias (i.e. don't provide the credit card)
+  #     assert response = @gateway.purchase(@amount, "awesomeman", @options.merge(:order_id => Time.now.to_i.to_s + "3"))
+  #     assert_success response
+  #   end
+  #
+  #   def test_successful_store
+  #     assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
+  #     assert_success response
+  #     assert purchase = @gateway.purchase(@amount, 'test_alias')
+  #     assert_success purchase
+  #   end
+  #
+  #   def test_successful_store_generated_alias
+  #     assert response = @gateway.store(@credit_card)
+  #     assert_success response
+  #     assert purchase = @gateway.purchase(@amount, response.billing_id)
+  #     assert_success purchase
+  #   end
+  #
+  #   def test_successful_store
+  #     assert response = @gateway.store(@credit_card, :billing_id => 'test_alias')
+  #     assert_success response
+  #     assert purchase = @gateway.purchase(@amount, 'test_alias')
+  #     assert_success purchase
+  #   end
+  #
+  #   def test_successful_unreferenced_credit
+  #     assert credit = @gateway.credit(@amount, @credit_card, @options)
+  #     assert_success credit
+  #     assert credit.authorization
+  #     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, credit.message
+  #   end
+  #
+  #   # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
+  #   #       section of your account admin before running this test
+  #   def test_successful_purchase_with_custom_currency_at_the_gateway_level
+  #     gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:currency => 'USD'))
+  #     assert response = gateway.purchase(@amount, @credit_card)
+  #     assert_success response
+  #     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
+  #     assert_equal "USD", response.params["currency"]
+  #   end
+  #
+  #   # NOTE: You have to allow USD as a supported currency in the "Account"->"Currencies"
+  #   #       section of your account admin before running this test
+  #   def test_successful_purchase_with_custom_currency
+  #     gateway = BarclaysEpdqExtraPlusGateway.new(fixtures(:barclays_epdq_extra_plus).merge(:currency => 'EUR'))
+  #     assert response = gateway.purchase(@amount, @credit_card, @options.merge(:currency => 'USD'))
+  #     assert_success response
+  #     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
+  #     assert_equal "USD", response.params["currency"]
+  #   end
+  #
+  #   # NOTE: You have to contact Barclays to make sure your test account allow 3D Secure transactions before running this test
+  #   def test_successful_purchase_with_3d_secure
+  #     assert response = @gateway.purchase(@amount, @credit_card_d3d, @options.merge(:d3d => true))
+  #     assert_success response
+  #     assert_equal '46', response.params["STATUS"]
+  #     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
+  #     assert response.params["HTML_ANSWER"]
+  #   end
 
   def test_successful_refund
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_netpay_test.rb
+++ b/test/remote/gateways/remote_netpay_test.rb
@@ -44,47 +44,45 @@ class RemoteNetpayTest < Test::Unit::TestCase
     assert_equal 'Aprobada', refund.message
   end
 
-=begin
-  # Netpay are currently adding support for authorize and capture.
-  # When this is complete, the following remote calls should work.
-
-  def test_successful_authorize
-   assert response = @gateway.authorize(@amount, @credit_card, @options)
-   assert_success response
-   assert_equal 'Aprobada', response.message
-  end
-
-  def test_unsuccessful_authorize
-   # We have to force a decline using the mode option
-   opts = @options.clone
-   opts[:mode] = 'D'
-   assert response = @gateway.authorize(@amount, @declined_card, opts)
-   assert_failure response
-   assert_match %r{Declinada}, response.message
-  end
-
-  def test_successful_authorize_and_capture
-   assert purchase = @gateway.authorize(@amount, @credit_card, @options)
-   assert_success purchase
-   assert capture = @gateway.capture(@amount, purchase.authorization)
-   assert_success capture
-   assert_equal 'Aprobada', capture.message
-  end
-
-  def test_failed_capture
-   assert response = @gateway.capture(@amount, '')
-   assert_failure response
-   assert_equal 'REPLACE WITH GATEWAY FAILURE MESSAGE', response.message
-  end
-
-  def test_invalid_login
-   gateway = NetpayGateway.new(
-               :login => '',
-               :password => ''
-             )
-   assert response = gateway.purchase(@amount, @credit_card, @options)
-   assert_failure response
-   assert_equal 'REPLACE WITH FAILURE MESSAGE', response.message
-  end
-=end
+  #   # Netpay are currently adding support for authorize and capture.
+  #   # When this is complete, the following remote calls should work.
+  #
+  #   def test_successful_authorize
+  #    assert response = @gateway.authorize(@amount, @credit_card, @options)
+  #    assert_success response
+  #    assert_equal 'Aprobada', response.message
+  #   end
+  #
+  #   def test_unsuccessful_authorize
+  #    # We have to force a decline using the mode option
+  #    opts = @options.clone
+  #    opts[:mode] = 'D'
+  #    assert response = @gateway.authorize(@amount, @declined_card, opts)
+  #    assert_failure response
+  #    assert_match %r{Declinada}, response.message
+  #   end
+  #
+  #   def test_successful_authorize_and_capture
+  #    assert purchase = @gateway.authorize(@amount, @credit_card, @options)
+  #    assert_success purchase
+  #    assert capture = @gateway.capture(@amount, purchase.authorization)
+  #    assert_success capture
+  #    assert_equal 'Aprobada', capture.message
+  #   end
+  #
+  #   def test_failed_capture
+  #    assert response = @gateway.capture(@amount, '')
+  #    assert_failure response
+  #    assert_equal 'REPLACE WITH GATEWAY FAILURE MESSAGE', response.message
+  #   end
+  #
+  #   def test_invalid_login
+  #    gateway = NetpayGateway.new(
+  #                :login => '',
+  #                :password => ''
+  #              )
+  #    assert response = gateway.purchase(@amount, @credit_card, @options)
+  #    assert_failure response
+  #    assert_equal 'REPLACE WITH FAILURE MESSAGE', response.message
+  #   end
 end

--- a/test/remote/gateways/remote_payu_in_test.rb
+++ b/test/remote/gateways/remote_payu_in_test.rb
@@ -82,30 +82,28 @@ class RemotePayuInTest < Test::Unit::TestCase
     assert_failure response
     assert_equal '3D-secure enrolled cards are not supported.', response.message
 
-=begin
-    # This is handy for testing that 3DS is working with PayU
-    response = response.responses.first
-
-    # You'll probably need a new bin from http://requestb.in
-    bin = "<requestb.in key>"
-    File.open("3ds.html", "w") do |f|
-      f.puts %(
-        <html>
-        <body>
-          <form action="#{response.params["post_uri"]}" method="POST">
-            <input type="hidden" name="PaReq" value="#{response.params["form_post_vars"]["PaReq"]}" />
-            <input type="hidden" name="MD" value="#{response.params["form_post_vars"]["MD"]}" />
-            <input type="hidden" name="TermUrl" value="http://requestb.in/#{bin}" />
-            <input type="submit" />
-          </form>
-        </body>
-        </html>
-      )
-    end
-    puts "Test 3D-secure via `open 3ds.html`"
-    puts "View results at http://requestb.in/#{bin}?inspect"
-    puts "Finalize with: `curl -v -d PaRes='' -d MD='' '#{response.params["form_post_vars"]["TermUrl"]}'`"
-=end
+    #     # This is handy for testing that 3DS is working with PayU
+    #     response = response.responses.first
+    #
+    #     # You'll probably need a new bin from http://requestb.in
+    #     bin = "<requestb.in key>"
+    #     File.open("3ds.html", "w") do |f|
+    #       f.puts %(
+    #         <html>
+    #         <body>
+    #           <form action="#{response.params["post_uri"]}" method="POST">
+    #             <input type="hidden" name="PaReq" value="#{response.params["form_post_vars"]["PaReq"]}" />
+    #             <input type="hidden" name="MD" value="#{response.params["form_post_vars"]["MD"]}" />
+    #             <input type="hidden" name="TermUrl" value="http://requestb.in/#{bin}" />
+    #             <input type="submit" />
+    #           </form>
+    #         </body>
+    #         </html>
+    #       )
+    #     end
+    #     puts "Test 3D-secure via `open 3ds.html`"
+    #     puts "View results at http://requestb.in/#{bin}?inspect"
+    #     puts "Finalize with: `curl -v -d PaRes='' -d MD='' '#{response.params["form_post_vars"]["TermUrl"]}'`"
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
Fixes the RuboCop to-do for [Style/BlockComments](https://docs.rubocop.org/rubocop/0.85/cops_style.html#styleblockcomments).

All unit tests:
4544 tests, 72251 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed