### PR TITLE
Cybersource: Ensure issueradditionaldata comes before partnerSolutionId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Adyen: Pass `subMerchantId` as `additionalData` [naashton] #3714
 * Litle: Omit checkNum when nil [leila-alderman] #3719
 * PayU Latam: Improve error response #3717
+* Cybersource: Ensure issueradditionaldata comes before partnerSolutionId [britth] #3733
 
 == Version 1.111.0
 * Fat Zebra: standardized 3DS fields and card on file extra data for Visa scheme rules [montdidier] #3409

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -281,9 +281,9 @@ module ActiveMerchant #:nodoc:
         add_payment_network_token(xml) if network_tokenization?(creditcard_or_reference)
         add_business_rules_data(xml, creditcard_or_reference, options)
         add_stored_credential_subsequent_auth(xml, options)
+        add_issuer_additional_data(xml, options)
         add_partner_solution_id(xml)
         add_stored_credential_options(xml, options)
-        add_issuer_additional_data(xml, options)
         add_merchant_description(xml, options)
 
         xml.target!
@@ -325,6 +325,7 @@ module ActiveMerchant #:nodoc:
         add_mdd_fields(xml, options)
         if !payment_method_or_reference.is_a?(String) && card_brand(payment_method_or_reference) == 'check'
           add_check_service(xml)
+          add_issuer_additional_data(xml, options)
           add_partner_solution_id(xml)
         else
           add_purchase_service(xml, payment_method_or_reference, options)
@@ -332,11 +333,11 @@ module ActiveMerchant #:nodoc:
           add_payment_network_token(xml) if network_tokenization?(payment_method_or_reference)
           add_business_rules_data(xml, payment_method_or_reference, options) unless options[:pinless_debit_card]
           add_stored_credential_subsequent_auth(xml, options)
+          add_issuer_additional_data(xml, options)
           add_partner_solution_id(xml)
           add_stored_credential_options(xml, options)
         end
 
-        add_issuer_additional_data(xml, options)
         add_merchant_description(xml, options)
 
         xml.target!

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -157,6 +157,53 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_authorization_with_issuer_additional_data_and_partner_solution_id
+    @options[:issuer_additional_data] = @issuer_additional_data
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_successful_response(void)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_authorize_with_merchant_descriptor_and_partner_solution_id
+    @options[:merchant_descriptor] = 'Spreedly'
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_successful_response(void)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_authorize_with_issuer_additional_data_stored_creds_merchant_desc_and_partner_solution_id
+    @options[:issuer_additional_data] = @issuer_additional_data
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: '',
+      initial_transaction: true,
+      network_transaction_id: ''
+    }
+    @options[:commerce_indicator] = 'internet'
+    @options[:merchant_descriptor] = 'Spreedly'
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
   def test_successful_authorization_with_elo
     assert response = @gateway.authorize(@amount, @elo_credit_card, @options)
     assert_successful_response(response)
@@ -262,6 +309,47 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(response)
+  end
+
+  def test_successful_purchase_with_issuer_additional_data_and_partner_solution_id
+    @options[:issuer_additional_data] = @issuer_additional_data
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_purchase_with_merchant_descriptor_and_partner_solution_id
+    @options[:merchant_descriptor] = 'Spreedly'
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_purchase_with_issuer_additional_data_stored_creds_merchant_desc_and_partner_solution_id
+    @options[:issuer_additional_data] = @issuer_additional_data
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: '',
+      initial_transaction: true,
+      network_transaction_id: ''
+    }
+    @options[:commerce_indicator] = 'internet'
+    @options[:merchant_descriptor] = 'Spreedly'
+
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
+
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+  ensure
+    ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
   end
 
   def test_successful_purchase_with_reconciliation_id


### PR DESCRIPTION
XML parse error observed if this field comes after partnerSolutionId. Switch order and add tests. Also check merchant_descriptor in case that could cause issues.

Unit:
96 tests, 467 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
93 tests, 481 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.6237% passed