### PR TITLE
Payflow: Use application_id to set buttonsource

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * RuboCop: Fix Style/TrailingCommaInHashLiteral [leila-alderman] #3718
 * RuboCop: Fix Naming/PredicateName [leila-alderman] #3724
 * RuboCop: Fix Style/Attr [leila-alderman] #3728
+* Payflow: Use application_id to set buttonsource [britth] #3737
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -154,6 +154,7 @@ module ActiveMerchant #:nodoc:
               end
             end
           end
+          xml.tag! 'ExtData', 'Name' => 'BUTTONSOURCE', 'Value' => application_id unless application_id.blank?
         end
         xml.target!
       end
@@ -187,6 +188,7 @@ module ActiveMerchant #:nodoc:
               add_credit_card(xml, credit_card, options)
             end
           end
+          xml.tag! 'ExtData', 'Name' => 'BUTTONSOURCE', 'Value' => application_id unless application_id.blank?
         end
         add_level_two_three_fields(xml.target!, options)
       end
@@ -250,6 +252,7 @@ module ActiveMerchant #:nodoc:
               end
             end
           end
+          xml.tag! 'ExtData', 'Name' => 'BUTTONSOURCE', 'Value' => application_id unless application_id.blank?
         end
         add_level_two_three_fields(xml.target!, options)
       end

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -70,6 +70,19 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert !response.fraud_review?
   end
 
+  def test_successful_purchase_with_application_id
+    ActiveMerchant::Billing::PayflowGateway.application_id = 'partner_id'
+
+    assert response = @gateway.purchase(100000, @credit_card, @options)
+    assert_equal 'Approved', response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
+    assert !response.fraud_review?
+  ensure
+    ActiveMerchant::Billing::PayflowGateway.application_id = nil
+  end
+
   # In order for this remote test to pass, you must go into your Payflow test
   # backend and enable the correct filter. Once logged in:
   # "Service Settings" ->
@@ -117,6 +130,20 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
     assert_not_nil response.authorization
+  end
+
+  def test_successful_purchase_with_l3_fields_and_application_id
+    ActiveMerchant::Billing::PayflowGateway.application_id = 'partner_id'
+
+    options = @options.merge(level_three_fields: @l3_json)
+
+    assert response = @gateway.purchase(100000, @credit_card, options)
+    assert_equal 'Approved', response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
+  ensure
+    ActiveMerchant::Billing::PayflowGateway.application_id = nil
   end
 
   def test_declined_purchase
@@ -174,6 +201,19 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert auth.authorization
     assert capture = @gateway.capture(100, auth.authorization)
     assert_success capture
+  end
+
+  def test_successful_authorize_with_application_id
+    ActiveMerchant::Billing::PayflowGateway.application_id = 'partner_id'
+
+    assert response = @gateway.authorize(100000, @credit_card, @options)
+    assert_equal 'Approved', response.message
+    assert_success response
+    assert response.test?
+    assert_not_nil response.authorization
+    assert !response.fraud_review?
+  ensure
+    ActiveMerchant::Billing::PayflowGateway.application_id = nil
   end
 
   def test_authorize_and_partial_capture

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -69,6 +69,9 @@ class PayflowTest < Test::Unit::TestCase
   end
 
   def test_successful_authorization_with_more_options
+    partner_id = 'partner_id'
+    PayflowGateway.application_id = partner_id
+
     options = @options.merge(
       {
         order_id: '123',
@@ -87,6 +90,7 @@ class PayflowTest < Test::Unit::TestCase
       assert_match %r(<OrderDesc>OrderDesc string</OrderDesc>), data
       assert_match %r(<Comment>Comment string</Comment>), data
       assert_match %r(<ExtData Name=\"COMMENT2\" Value=\"Comment2 string\"/>), data
+      assert_match %r(</PayData><ExtData Name=\"BUTTONSOURCE\" Value=\"partner_id\"/></Authorization>), data
     end.respond_with(successful_authorization_response)
     assert_equal 'Approved', response.message
     assert_success response


### PR DESCRIPTION
For rev share flagging purposes, Payflow requires the corresponding
code to be included as ExtData field BUTTONSOURCE, similar to Paypal.
[Example structure as follows](https://stackoverflow.com/a/19414626), confirmed by paypal/payflow support:

```
<Sale>
     <PayData>
          (Invoice)
          (Tender)
     </PayData>
     (ExtData)*
</Sale>
```

This PR updates sale and auth requests to set this field appropriately
when application_id is provided

Unit:
49 tests, 243 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 156 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
68.4211% passed
(unrelated failures preexist on master)