### PR TITLE
HPS: Enable refunds using capture txn

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * RuboCop: Fix Naming/PredicateName [leila-alderman] #3724
 * RuboCop: Fix Style/Attr [leila-alderman] #3728
 * Payflow: Use application_id to set buttonsource [britth] #3737
+* HPS: Enable refunds using capture transaction [britth] #3738
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, transaction_id, options={})
-        commit('CreditAddToBatch') do |xml|
+        commit('CreditAddToBatch', transaction_id) do |xml|
           add_amount(xml, money)
           add_reference(xml, transaction_id)
         end
@@ -126,7 +126,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_reference(xml, transaction_id)
-        xml.hps :GatewayTxnId, transaction_id
+        reference = transaction_id.to_s.include?('|') ? transaction_id.split('|').first : transaction_id
+        xml.hps :GatewayTxnId, reference
       end
 
       def add_amount(xml, money)
@@ -323,7 +324,7 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def commit(action, &request)
+      def commit(action, reference = nil, &request)
         data = build_request(action, &request)
 
         response =
@@ -338,7 +339,7 @@ module ActiveMerchant #:nodoc:
           message_from(response),
           response,
           test: test?,
-          authorization: authorization_from(response),
+          authorization: authorization_from(response, reference),
           avs_result: {
             code: response['AVSRsltCode'],
             message: response['AVSRsltText']
@@ -369,7 +370,9 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorization_from(response)
+      def authorization_from(response, reference)
+        return [reference, response['GatewayTxnId']].join('|') if reference
+
         response['GatewayTxnId']
       end
 

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -116,7 +116,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_successful_refund
+  def test_successful_purchase_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
@@ -126,11 +126,37 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_equal '0', refund.params['GatewayRspCode']
   end
 
-  def test_partial_refund
+  def test_successful_capture_refund
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+
+    assert refund = @gateway.refund(@amount, capture.authorization)
+    assert_success refund
+    assert_equal 'Success', refund.params['GatewayRspMsg']
+    assert_equal '0', refund.params['GatewayRspCode']
+  end
+
+  def test_partial_purchase_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount - 1, purchase.authorization)
+    assert_success refund
+    assert_equal 'Success', refund.params['GatewayRspMsg']
+    assert_equal '0', refund.params['GatewayRspCode']
+  end
+
+  def test_partial_capture_refund
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+
+    assert refund = @gateway.refund(@amount - 1, capture.authorization)
     assert_success refund
     assert_equal 'Success', refund.params['GatewayRspMsg']
     assert_equal '0', refund.params['GatewayRspCode']


### PR DESCRIPTION
Currently, if you try to issue a refund using a capture as your
reference transaction, you will get an error. This is because the
authorization value here only refers to the capture, with no
connection to the auth. In other adapters, we solve for this by
building up an authorization value that includes references to the
current transaction as well as reference transactions (and potentially
other data). This allows us to parse this field to return the
correct reference transaction for supplemental actions. This PR
updates HPS to build an authorization value including the authorize
transaction id for captures. It also adds in logic to pluck off
the appropriate value when issuing a refund on a capture txn.

Unit:
54 tests, 267 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
52 tests, 139 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.3846% passed
(preexisting failures also on master)