### PR TITLE
Option {recurring => true} sets recurringFlag on store and trigger for secure_pay_au

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -200,6 +200,11 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'cardNumber', credit_card.number
             xml.tag! 'expiryDate', expdate(credit_card)
             xml.tag! 'cvv', credit_card.verification_value if credit_card.verification_value?
+            xml.tag! 'recurringFlag', 'yes' if options[:recurring]
+          end
+        elsif action == :trigger && options[:recurring]
+          xml.tag! 'CreditCardInfo' do
+            xml.tag! 'recurringFlag', 'yes'
           end
         end
         xml.tag! 'amount', amount(money)

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -145,6 +145,16 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert_equal 'Successful', response.message
   end
 
+  def test_successful_store_with_recurring
+    @gateway.unstore('test1234') rescue nil
+
+    assert response = @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000, recurring: true})
+    assert_success response
+
+    assert_equal 'Successful', response.message
+    assert_equal 'yes', response.params['recurring_flag']
+  end
+
   def test_failed_store
     @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
 
@@ -162,6 +172,17 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert_equal response.params['amount'], '12300'
 
     assert_equal 'Approved', response.message
+  end
+
+  def test_successful_triggered_payment_with_recurring
+    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
+
+    assert response = @gateway.purchase(12300, 'test1234', @options.merge({recurring: true}))
+    assert_success response
+    assert_equal response.params['amount'], '12300'
+
+    assert_equal 'Approved', response.message
+    assert_equal 'yes', response.params['recurring_flag']
   end
 
   def test_failure_triggered_payment

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -63,6 +63,20 @@ class SecurePayAuTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_recurring_flag
+    stub_comms do
+      @gateway.store(@credit_card, {billing_id: 'test3', amount: 123, recurring: true})
+    end.check_request do |endpoint, data, headers|
+      assert_match %r{<recurringFlag>yes<\/recurringFlag>}, data
+    end.respond_with(successful_store_response)
+
+    stub_comms do
+      @gateway.purchase(@amount, '123', {billing_id: 'test3', amount: 123, recurring: true})
+    end.check_request do |endpoint, data, headers|
+      assert_match %r{<recurringFlag>yes<\/recurringFlag>}, data
+    end.respond_with(successful_store_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
> This flags the transaction as recurring. When flagged as recurring the transaction is treated
differently through the authorisation process. In most cases the expiry date and CVV are ignored
by the bank. This allows for easy reoccurring billing, such as subscriptions.
Transactions should only be flagged as recurring if the cardholder establishes a relationship with
the merchant to receive ongoing services or goods and gives permission to the merchant for
ongoing billing.
This is currently only supported by Visa and MasterCard. This does not automate transaction
processing, it simply flags the once off payment as recurring.

-- https://auspost.com.au/payments/docs/securepay/resources/Secure_XML_API_Integration_Guide.pdf