### PR TITLE
Quickbooks: Omit empty strings in address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * RuboCop: Fix Style/Attr [leila-alderman] #3728
 * Payflow: Use application_id to set buttonsource [britth] #3737
 * HPS: Enable refunds using capture transaction [britth] #3738
+* Quickbooks: Omit empty strings in address [leila-alderman] #3743
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -151,8 +151,9 @@ module ActiveMerchant #:nodoc:
         if address = options[:billing_address] || options[:address]
           card_address[:streetAddress] = address[:address1]
           card_address[:city] = address[:city]
-          card_address[:region] = address[:state] || address[:region]
-          card_address[:country] = address[:country]
+          region = address[:state] || address[:region]
+          card_address[:region] = region if region.present?
+          card_address[:country] = address[:country] if address[:country].present?
           card_address[:postalCode] = address[:zip] if address[:zip]
         end
         post[:card][:address] = card_address

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -141,6 +141,25 @@ class RemoteTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_without_state_in_address
+    options = {
+      order_id: '1',
+      billing_address:
+        {
+          zip: 90210,
+          # Submitting a value of an empty string for the `state` field
+          # results in a `region is invalid` error message from Quickbooks.
+          # This test ensures that an empty string is not sent from AM.
+          state: '',
+          country: ''
+        }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'CAPTURED', response.message
+  end
+
   def test_refresh
     response = @gateway.refresh
     assert_success response


### PR DESCRIPTION
This fixes a bug caused by submitting an empty string for the state
field (which is submitted as 'region' to Quickbooks). While `nil` values
for this field are fine because the field is then simply omitted from
the request sent to Quickbooks, sending an empty string results in the
error message `card.address.region is invalid`.

ECS-1355

Unit:
22 tests, 118 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
18 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

All unit tests:
4544 tests, 72251 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed