### PR TITLE
Orbital: Allow level 3 fields to be passed on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,6 @@
 == HEAD
 * Orbital: Add cardIndicators field [meagabeth] #3734
 * Openpay: Add Colombia to supported countries [molbrown] #3740
-* Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
 * RuboCop: Fix Style/TrailingCommaInHashLiteral [leila-alderman] #3718
 * RuboCop: Fix Naming/PredicateName [leila-alderman] #3724
 * RuboCop: Fix Style/Attr [leila-alderman] #3728
@@ -11,6 +10,7 @@
 * HPS: Enable refunds using capture transaction [britth] #3738
 * Quickbooks: Omit empty strings in address [leila-alderman] #3743
 * BlueSnap: Add transactionMetaData support #3745
+* Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -411,7 +411,11 @@ module ActiveMerchant #:nodoc:
             xml.tag! :PC3LineItem do
               xml.tag! :PC3DtlIndex,  byte_limit(index + 1, 2)
               line_item.each do |key, value|
-                formatted_key = "PC3Dtl#{key.to_s.camelize}".to_sym
+                if key == :line_tot
+                  formatted_key = :PC3Dtllinetot
+                else
+                  formatted_key = "PC3Dtl#{key.to_s.camelize}".to_sym
+                end
                 xml.tag! formatted_key, value
               end
             end
@@ -790,6 +794,8 @@ module ActiveMerchant #:nodoc:
             xml.tag! :TxRefNum, tx_ref_num
             add_level_2_purchase(xml, parameters)
             add_level_2_advice_addendum(xml, parameters)
+            add_level_3_purchase(xml, parameters)
+            add_level_3_tax(xml, parameters)
           end
         end
         xml.target!

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -393,6 +393,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_level_3_data
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(level_3_data: @level_3_options))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @gateway.capture(@amount, auth.authorization, @options.merge(level_3_data: @level_3_options))
+    assert_success capture
+  end
+
   def test_authorize_and_void
     assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2'))
     assert_success auth

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -155,7 +155,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_match %{<PC3DtlUOM>#{@line_items[1][:u_o_m]}</PC3DtlUOM>}, data
       assert_match %{<PC3DtlTaxAmt>#{@line_items[1][:tax_amt].to_i}</PC3DtlTaxAmt>}, data
       assert_match %{<PC3DtlTaxRate>#{@line_items[1][:tax_rate]}</PC3DtlTaxRate>}, data
-      assert_match %{<PC3DtlLineTot>#{@line_items[1][:line_tot].to_i}</PC3DtlLineTot>}, data
+      assert_match %{<PC3Dtllinetot>#{@line_items[1][:line_tot].to_i}</PC3Dtllinetot>}, data
       assert_match %{<PC3DtlDisc>#{@line_items[1][:disc].to_i}</PC3DtlDisc>}, data
       assert_match %{<PC3DtlUnitCost>#{@line_items[1][:unit_cost].to_i}</PC3DtlUnitCost>}, data
       assert_match %{<PC3DtlGrossNet>#{@line_items[1][:gross_net]}</PC3DtlGrossNet>}, data


### PR DESCRIPTION
Add level 3 fields to capture transactions. Revert a previous 'fix'
where PC3DtlLineTot was incorrectly assumed to be the correct tag
(should be `PC3Dtllinetot`).

CE-930

Unit: 95 tests, 561 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 37 tests, 192 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5946% passed