### PR TITLE
BlueSnap: Add transactionMetaData support

### DIFF
--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -6,8 +6,8 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4263982640269299')
-    @cabal_card = credit_card('6271701225979642', month: 3, year: 2020)
-    @naranja_card = credit_card('5895626746595650', month: 11, year: 2020)
+    @cabal_card = credit_card('6271701225979642', month: 3, year: 2024)
+    @naranja_card = credit_card('5895626746595650', month: 11, year: 2024)
     @declined_card = credit_card('4917484589897107', month: 1, year: 2023)
     @invalid_card = credit_card('4917484589897106', month: 1, year: 2023)
     @three_ds_visa_card = credit_card('4000000000001091', month: 1)
@@ -103,6 +103,86 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, more_options)
     assert_success response
     assert_equal 'Success', response.message
+
+    # description SHOULD BE set as a meta-data field
+    assert_not_empty response.params['transaction-meta-data']
+    meta = response.params['transaction-meta-data']
+
+    assert_equal 1, meta.length
+    assert_equal 'description', meta[0]['meta-key']
+    assert_equal 'Product Description', meta[0]['meta-value']
+    assert_equal 'Description', meta[0]['meta-description']
+  end
+
+  def test_successful_purchase_with_meta_data
+    more_options = @options.merge({
+      order_id: '1',
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      transaction_meta_data: [
+        {
+          meta_key: 'stateTaxAmount',
+          meta_value: '20.00',
+          meta_description: 'State Tax Amount'
+        },
+        {
+          meta_key: 'cityTaxAmount',
+          meta_value: '10.00',
+          meta_description: 'City Tax Amount'
+        },
+        {
+          meta_key: 'description',
+          meta_value: 'Product ABC',
+          meta_description: 'Product Description'
+        }
+      ],
+      soft_descriptor: 'OnCardStatement',
+      personal_identification_number: 'CNPJ'
+    })
+
+    response = @gateway.purchase(@amount, @credit_card, more_options)
+    assert_success response
+    assert_equal 'Success', response.message
+
+    # description SHOULD BE set as a meta-data field
+    assert_not_empty response.params['transaction-meta-data']
+    meta = response.params['transaction-meta-data']
+
+    assert_equal 3, meta.length
+
+    meta.each { |m|
+      assert_true m['meta-key'].length > 0
+      assert_true m['meta-value'].length > 0
+      assert_true m['meta-description'].length > 0
+
+      case m['meta-key']
+      when 'description'
+        assert_equal 'Product ABC', m['meta-value']
+        assert_equal 'Product Description', m['meta-description']
+      when 'cityTaxAmount'
+        assert_equal '10.00', m['meta-value']
+        assert_equal 'City Tax Amount', m['meta-description']
+      when 'stateTaxAmount'
+        assert_equal '20.00', m['meta-value']
+        assert_equal 'State Tax Amount', m['meta-description']
+      end
+    }
+  end
+
+  def test_successful_purchase_with_metadata_empty
+    more_options = @options.merge({
+      order_id: '1',
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      soft_descriptor: 'OnCardStatement',
+      personal_identification_number: 'CNPJ'
+    })
+
+    response = @gateway.purchase(@amount, @credit_card, more_options)
+    assert_success response
+    assert_equal 'Success', response.message
+
+    assert_nil response.params['transaction-meta-data']
   end
 
   def test_successful_purchase_with_3ds2_auth


### PR DESCRIPTION
Fully support `transaction-meta-data` field.

See
[meta-data](https://developers.bluesnap.com/v8976-XML/docs/meta-data).

CE-697

Unit:

34 tests, 193 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

44 tests, 155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed