### PR TITLE
Update cardIndicators field to fix bug

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -199,7 +199,6 @@ module ActiveMerchant #:nodoc:
             add_customer_data(xml, creditcard, options)
             add_managed_billing(xml, options)
           end
-          add_card_indicators(xml, options) if @options[:card_indicators]
         end
         commit(order, :authorize, options[:trace_number])
       end
@@ -220,7 +219,6 @@ module ActiveMerchant #:nodoc:
             add_customer_data(xml, creditcard, options)
             add_managed_billing(xml, options)
           end
-          add_card_indicators(xml, options) if @options[:card_indicators]
         end
         commit(order, :purchase, options[:trace_number])
       end
@@ -424,7 +422,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_card_indicators(xml, options)
-        xml.tag! :cardIndicators, options[:card_indicators] if options[:card_indicators]
+        xml.tag! :CardIndicators, options[:card_indicators] if options[:card_indicators]
       end
 
       def add_address(xml, creditcard, options)
@@ -762,6 +760,7 @@ module ActiveMerchant #:nodoc:
             add_level_2_purchase(xml, parameters)
             add_level_3_purchase(xml, parameters)
             add_level_3_tax(xml, parameters)
+            add_card_indicators(xml, parameters)
             add_line_items(xml, parameters) if parameters[:line_items]
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, creditcard, three_d_secure)

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -805,21 +805,19 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_send_card_indicators_when_provided_purchase
-    @gateway.options[:card_indicators] = 'y'
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, card_indicators: @options[:card_indicators])
     end.check_request do |endpoint, data, headers|
-      assert_match(/<cardIndicators>y/, data)
+      assert_match(/<CardIndicators>y/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
   end
 
   def test_send_card_indicators_when_provided_authorize
-    @gateway.options[:card_indicators] = 'y'
     response = stub_comms do
       @gateway.authorize(50, credit_card, order_id: 1, card_indicators: @options[:card_indicators])
     end.check_request do |endpoint, data, headers|
-      assert_match(/<cardIndicators>y/, data)
+      assert_match(/<CardIndicators>y/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
   end


### PR DESCRIPTION
Confirm that card_indicators is being passed to the gateway. We have 1 test failing with this message: @message="Request does not adhere to the DTD. Please correct and send again.", but I was able to confirm that card_indicators is being passed with options. See options hash below. 3DS tests on orbital are still failing, as they have been on master.

{:order_id=>"bc8b1fd1ca40f4d8ba6e072cfa11f38f", :address=>{:name=>"Jim Smith", :address1=>"456 My Street", :address2=>"Apt 1", :company=>"Widgets Inc", :city=>"Ottawa", :state=>"ON", :zip=>"K1C2N6", :country=>"CA", :phone=>"(555)555-5555", :fax=>"(555)555-6666"}, :merchant_id=>"merchant1234", :soft_descriptors=>{:merchant_name=>"Merch", :product_description=>"Description", :merchant_email=>"email@example"}, :card_indicators=>"y"}

Unit:
95 tests, 561 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
36 tests, 184 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.1111% passed