### PR TITLE
CyberSource: Always send country code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
 * Credorax: Send first and last name parameters for CFT transactions [britth] #3748
 * Orbital: Update CardIndicators field to fix bug [meagabeth] #3746
+* CyberSource: Always send country code [leila-alderman] #3747
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -266,7 +266,9 @@ module ActiveMerchant #:nodoc:
           zip: '00000',
           country: 'US'
         }
-        options[:billing_address] = options[:billing_address] || options[:address] || default_address
+
+        submitted_address = options[:billing_address] || options[:address] || default_address
+        options[:billing_address] = default_address.merge(submitted_address) { |_k, default, submitted| submitted.blank? ? default : submitted }
         options[:shipping_address] = options[:shipping_address] || {}
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -426,6 +426,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
   end
 
+  def test_successful_purchase_with_country_submitted_as_empty_string
+    @options[:billing_address] = { country: '' }
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(response)
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_equal 'Invalid account number', response.message
@@ -918,22 +924,6 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     }
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(response)
-  end
-
-  def test_missing_field
-    @options = @options.merge({
-      address: {
-        address1: 'Unspecified',
-        city: 'Unspecified',
-        state: 'NC',
-        zip: '00000',
-        country: ''
-      }
-    })
-
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_failure response
-    assert_equal 'Request is missing one or more required fields: c:billTo/c:country', response.message
   end
 
   def test_invalid_field

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1097,6 +1097,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_country_code_sent_as_default_when_submitted_as_empty_string
+    stub_comms do
+      @gateway.authorize(100, @credit_card, billing_address: { country: '' })
+    end.check_request do |endpoint, data, headers|
+      assert_match('<country>US</country>', data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_adds_application_id_as_partner_solution_id
     partner_id = 'partner_id'
     CyberSourceGateway.application_id = partner_id


### PR DESCRIPTION
Previously, when an empty string was submitted for the
`[:billing_address][:country]`, CyberSource would response with an error
message since this field is required.

When a payment method that contained only a phone number with no other
address information was used, this resulted in the payment failing. To
resolve this issue, the `setup_address_hash` method was updated to match
the intent of the already existing comment: to always supply the default
country to CyberSource regardless of whether a `nil` value or an empty
string was initially submitted as the value for `country`.

ECS-1363

Unit:
97 tests, 470 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
95 tests, 490 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
94.7368% passed

All unit tests:
4551 tests, 72299 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed