### PR TITLE
Credorax: Send j5 and j13 params for CFT txns

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Quickbooks: Omit empty strings in address [leila-alderman] #3743
 * BlueSnap: Add transactionMetaData support #3745
 * Orbital: Fix typo in PC3DtlLineTot field [naashton] #3736
+* Credorax: Send first and last name parameters for CFT transactions [britth] #3748
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -193,6 +193,7 @@ module ActiveMerchant #:nodoc:
         add_email(post, options)
 
         if options[:referral_cft]
+          add_customer_name(post, options)
           commit(:referral_cft, post)
         else
           commit(:refund, post)
@@ -315,6 +316,11 @@ module ActiveMerchant #:nodoc:
 
       def add_email(post, options)
         post[:c3] = options[:email] || 'unspecified@example.com'
+      end
+
+      def add_customer_name(post, options)
+        post[:j5] = options[:first_name] if options[:first_name]
+        post[:j13] = options[:last_name] if options[:last_name]
       end
 
       def add_3d_secure(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -330,6 +330,19 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal '34', referral_cft.params['O']
   end
 
+  def test_successful_referral_cft_with_first_and_last_name
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+
+    cft_options = { referral_cft: true, email: 'john.smith@test.com', first_name: 'John', last_name: 'Smith' }
+    referral_cft = @gateway.refund(@amount, response.authorization, cft_options)
+    assert_success referral_cft
+    assert_equal 'Succeeded', referral_cft.message
+    # Confirm that the operation code was `referral_cft`
+    assert_equal '34', referral_cft.params['O']
+  end
+
   def test_failed_referral_cft
     options = @options.merge(@normalized_3ds_2_options)
     response = @gateway.purchase(@amount, @three_ds_card, options)

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -167,9 +167,13 @@ class CredoraxTest < Test::Unit::TestCase
     assert_equal '8a82944a5351570601535955efeb513c;006596;02617cf5f02ccaed239b6521748298c5;purchase', response.authorization
 
     referral_cft = stub_comms do
-      @gateway.refund(@amount, response.authorization, referral_cft: true)
+      @gateway.refund(@amount, response.authorization, { referral_cft: true, first_name: 'John', last_name: 'Smith' })
     end.check_request do |endpoint, data, headers|
       assert_match(/8a82944a5351570601535955efeb513c/, data)
+      # Confirm that `j5` (first name) and `j13` (surname) parameters are present
+      # These fields are required for CFT payouts as of Sept 1, 2020
+      assert_match(/j5=John/, data)
+      assert_match(/j13=Smith/, data)
       # Confirm that the transaction type is `referral_cft`
       assert_match(/O=34/, data)
     end.respond_with(successful_referral_cft_response)


### PR DESCRIPTION
Credorax now requires the following parameters when issuing CFT payouts:
* j5 - Fund recipient's first name
* j13 - Fund recipient's surname

Updates the ~credit and~ referral_cft action to set these two fields,
and checks for their presence in the tests. _(Updated: credorax confirmed that 
they're not required for general credit [6], only actions [34], [35], [37], and [38] - 
of these, currently AM only supports [[34]](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/credorax.rb#L409))_

Remote:
41 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
69 tests, 331 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed