### PR TITLE
iATS Payments: Pass email address outside of the billing address scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Adyen: Safely add execute_threeds: false [curiousepic] #3756
 * RuboCop: Fix Layout/SpaceAroundEqualsInParameterDefault [leila-alderman] #3720
+* iATS: Allow email to be passed outside of the billing_address context [naashton] #3750
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -42,6 +42,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, options)
         add_ip(post, options)
         add_description(post, options)
+        add_customer_details(post, options)
 
         commit(determine_purchase_type(payment), post)
       end
@@ -158,6 +159,10 @@ module ActiveMerchant #:nodoc:
         post[:begin_date] = Time.now.xmlschema
         post[:end_date] = Time.now.xmlschema
         post[:amount] = 0
+      end
+
+      def add_customer_details(post, options)
+        post[:email] = options[:email] if options[:email]
       end
 
       def expdate(creditcard)

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -28,6 +28,14 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_customer_details
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@customer_details))
+    assert_success response
+    assert response.test?
+    assert_equal 'Success', response.message
+    assert response.authorization
+  end
+
   def test_failed_purchase
     credit_card = credit_card('4111111111111111')
     assert response = @gateway.purchase(200, credit_card, @options)
@@ -66,7 +74,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, credit_card, @options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert refund = @gateway.refund(@amount + 50, purchase.authorization)
     assert_failure refund
   end
 

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -111,6 +111,17 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_customer_details
+    @options[:email] = 'jsmith2@example.com'
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<email>#{@options[:email]}<\/email>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert response
+  end
+
   def test_failed_check_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @check, @options)


### PR DESCRIPTION
Give ability to pass customer details outside of the scope of the
billing address

CE-795

Unit: 18 tests, 178 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 14 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed