### PR TITLE
Forte: Add service_fee_amount field

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -23,6 +23,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_method, options={})
         post = {}
         add_amount(post, money, options)
+        add_service_fee(post, options)
         add_invoice(post, options)
         add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
@@ -35,6 +36,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment_method, options={})
         post = {}
         add_amount(post, money, options)
+        add_service_fee(post, options)
         add_invoice(post, options)
         add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
@@ -114,6 +116,10 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(post, money, options)
         post[:authorization_amount] = amount(money)
+      end
+
+      def add_service_fee(post, options)
+        post[:service_fee_amount] = options[:service_fee_amount] if options[:service_fee_amount]
       end
 
       def add_billing_address(post, payment, options)

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -64,10 +64,10 @@ class ForteTest < Test::Unit::TestCase
   def test_successful_purchase_with_service_fee
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
-    end.respond_with(MockedResponse.new(successful_purchase_response))
+    end.respond_with(MockedResponse.new(successful_purchase_with_service_fee_response))
     assert_success response
 
-    assert_equal '.05', response.params['service_fee_amount']
+    assert_equal '.5', response.params['service_fee_amount']
     assert response.test?
   end
 
@@ -210,7 +210,6 @@ class ForteTest < Test::Unit::TestCase
         "location_id":"loc_176008",
         "action":"sale",
         "authorization_amount":1.0,
-        "service_fee_amount":".05",
         "authorization_code":"123456",
         "billing_address":{
           "first_name":"Jim",
@@ -353,6 +352,46 @@ class ForteTest < Test::Unit::TestCase
           "response_type":"D",
           "response_code":"U19",
           "response_desc":"INVALID CREDIT CARD NUMBER"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249/settlements"
+        }
+      }
+    '
+  end
+
+  def successful_purchase_with_service_fee_response
+    '
+      {
+        "transaction_id":"trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount": 1.0,
+        "service_fee_amount": ".5",
+        "subtotal_amount": ".5",
+        "authorization_code":"123456",
+        "billing_address":{
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
         },
         "links": {
           "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -61,6 +61,16 @@ class ForteTest < Test::Unit::TestCase
     assert_equal 'INVALID CREDIT CARD NUMBER', response.message
   end
 
+  def test_successful_purchase_with_service_fee
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_purchase_response))
+    assert_success response
+
+    assert_equal '.05', response.params['service_fee_amount']
+    assert response.test?
+  end
+
   def test_successful_authorize
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -200,6 +210,7 @@ class ForteTest < Test::Unit::TestCase
         "location_id":"loc_176008",
         "action":"sale",
         "authorization_amount":1.0,
+        "service_fee_amount":".05",
         "authorization_code":"123456",
         "billing_address":{
           "first_name":"Jim",


### PR DESCRIPTION
Add support for service fee which can be passed in the request body as `service_fee_amount`. To note, merchants must be configured to accept service/convenience fees or they will get a 'U27: CONV FEE NOT ALLOWED' [transaction response code](https://www.forte.net/devdocs/reference/response_codes.htm). The sandbox environment I am working with is not configured for service fees so I was unable to write a remote test for this.

CE-491

Unit:
21 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
22 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed