### PR TITLE
BlueSnap: Protect against nil metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Orbital: Update CardIndicators field to fix bug [meagabeth] #3746
 * CyberSource: Always send default address [leila-alderman] #3747
 * Netbanx: Reject partial refund on pending status [rockyhakjoong] #3735
+* BlueSnap: Protect against `nil` metadata [carrigan] #3752
 
 == Version 1.112.0
 * Cybersource: add `maestro` and `diners_club` eci brand mapping [bbraschi] #3708

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -214,7 +214,7 @@ module ActiveMerchant
       end
 
       def add_metadata(doc, options)
-        transaction_meta_data = options.fetch(:transaction_meta_data, {})
+        transaction_meta_data = options[:transaction_meta_data] || []
         return if transaction_meta_data.empty? && !options[:description]
 
         doc.send('transaction-meta-data') do

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -191,6 +191,27 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_nil response.params['transaction-meta-data']
   end
 
+  def test_successful_purchase_with_metadata_nil
+    more_options = @options.merge({
+      order_id: '1',
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      transaction_meta_data: nil,
+      soft_descriptor: 'OnCardStatement',
+      personal_identification_number: 'CNPJ'
+    })
+
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, more_options)
+    end.check_request do |method, url, data|
+      assert_not_match(/transaction-meta-data/, data)
+      assert_not_match(/meta-key/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_nil response.params['transaction-meta-data']
+  end
+
   def test_successful_purchase_with_unused_state_code
     unrecognized_state_code_options = {
       billing_address: {


### PR DESCRIPTION
## Why?

A recent commit added support for receiving meta-data on BlueSnap but did not protect against a `nil` key being submitted for that field. Line 218 with `{ transaction_meta_data: nil }` would raise a NoMethodError.

## What Changed?

This change protects against `{ transaction_meta_data: nil }` for BlueSnap.

## Test Suite

4556 tests, 72358 assertions, 0 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
692 files inspected, no offenses detected