### PR TITLE
[CyberSource] Ensure the default address doesn't override `ActionController::Parameters`

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -268,7 +268,7 @@ module ActiveMerchant #:nodoc:
         }
 
         submitted_address = options[:billing_address] || options[:address] || default_address
-        options[:billing_address] = default_address.merge(submitted_address) { |_k, default, submitted| submitted.blank? ? default : submitted }
+        options[:billing_address] = default_address.merge(submitted_address.symbolize_keys) { |_k, default, submitted| submitted.blank? ? default : submitted }
         options[:shipping_address] = options[:shipping_address] || {}
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1105,6 +1105,22 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_default_address_does_not_override_when_hash_keys_are_strings
+    stub_comms do
+      @gateway.authorize(100, @credit_card, billing_address: {
+        'address1' => '221B Baker Street',
+        'city' => 'London',
+        'zip' => 'NW16XE',
+        'country' => 'GB'
+      })
+    end.check_request do |endpoint, data, headers|
+      assert_match('<street1>221B Baker Street</street1>', data)
+      assert_match('<city>London</city>', data)
+      assert_match('<postalCode>NW16XE</postalCode>', data)
+      assert_match('<country>GB</country>', data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_adds_application_id_as_partner_solution_id
     partner_id = 'partner_id'
     CyberSourceGateway.application_id = partner_id


### PR DESCRIPTION
When `ActionController::Parameters` is passed to Cybersource, the default address fields are used
instead of the passed parameters. See following comment for more information.

References: https://github.com/activemerchant/active_merchant/pull/3747#issuecomment-686720226