### PR TITLE
Adyen: Safely add execute_threeds: false

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Adyen: Safely add execute_threeds: false [curiousepic] #3756
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -432,7 +432,8 @@ module ActiveMerchant #:nodoc:
           return unless !options[:execute_threed].nil? || !options[:threed_dynamic].nil?
 
           post[:browserInfo] = { userAgent: options[:user_agent], acceptHeader: options[:accept_header] } if options[:execute_threed] || options[:threed_dynamic]
-          post[:additionalData] = { executeThreeD: options[:execute_threed] } if !options[:execute_threed].nil?
+          post[:additionalData] ||= {}
+          post[:additionalData][:executeThreeD] = options[:execute_threed] if !options[:execute_threed].nil?
         end
       end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -444,6 +444,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_succesful_purchase_with_brand_override_with_execute_threed_false
+    response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({execute_threed: false, overwrite_brand: true, selected_brand: 'maestro'}))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_purchase_with_google_pay
     response = @gateway.purchase(@amount, @google_pay_card, @options)
     assert_success response

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -376,6 +376,15 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_execute_threed_false_with_additional_data
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({execute_threed: false, overwrite_brand: true, selected_brand: 'maestro'}))
+    end.check_request do |endpoint, data, headers|
+      assert_match(/"additionalData":{"overwriteBrand":true,"executeThreeD":false}/, data)
+      assert_match(/"selectedBrand":"maestro"/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_execute_threed_false_sent_3ds2
     stub_comms do
       @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({execute_threed: false}))


### PR DESCRIPTION
In df60a2c5512bf43917a8d5d825d6b7c021dbdd1d when execute_threeds is
false it is assigned to the additionalData as a whole instead of
additively, so previously added additionalData fields were destroyed.
This change adds the field safely.

Remote:
92 tests, 353 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
70 tests, 330 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed