### PR TITLE
Orbital: Don't pass xid for txns using network tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Adyen: Safely add execute_threeds: false [curiousepic] #3756
 * RuboCop: Fix Layout/SpaceAroundEqualsInParameterDefault [leila-alderman] #3720
 * iATS: Allow email to be passed outside of the billing_address context [naashton] #3750
+* Orbital: Don't pass xid for transactions using network tokens [britth] #3757
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -515,13 +515,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_xid(xml, creditcard, three_d_secure)
-        xid = if three_d_secure && creditcard.brand == 'visa'
-                three_d_secure[:xid]
-              elsif creditcard.is_a?(NetworkTokenizationCreditCard)
-                creditcard.transaction_id
-              end
+        return unless three_d_secure && creditcard.brand == 'visa'
 
-        xml.tag!(:XID, xid) if xid
+        xml.tag!(:XID, three_d_secure[:xid]) if three_d_secure[:xid]
       end
 
       def add_cavv(xml, creditcard, three_d_secure)

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -171,7 +171,6 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_match %{<AuthenticationECIInd>5</AuthenticationECIInd>}, data
       assert_match %{<DPANInd>Y</DPANInd>}, data
       assert_match %{DigitalTokenCryptogram}, data
-      assert_match %{XID}, data
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
When attempting certain apple pay transactions, the following error
occurs:

```
Error. The Orbital Gateway has received a badly formatted message.
Field [Verified-By-Visa XID] exceeded max length of [40]
```

This is technically because in practice, the creditcard.transaction_id
on these network tokens is (sometimes? always?) longer than 40 characters,
and we aren't trimming it down in any way. However, after looking at the
docs, it does not appear that XID is actually a required field for
transactions made with network tokens - instead, the main field of note
is `DigitalTokenCryptogram`. From docs:
```
An additional cryptogram field (digitalTokenCrytogram) has been added
which is compatible with all card brand specific cryptograms. This field
must also be submitted as Base 64 encoded. The gateway will parse the
data and populate the appropriate fields in the request host message.
```

Orbital suppport mentioned the following about this field when asked
about the transaction error:
```
In Orbital, the DigitalTokenCryptogram replaces the other fields necessary
for the cryptogram. So it's an either-or situation. I believe XID is
specifically the American Express cryptogram field.
```

Additionally, in the initial implementation we believed this field was
not required, but decided to send it just in case it might be needed
(https://github.com/activemerchant/active_merchant/pull/2553#issuecomment-323758987).

Given the results currently observed, this PR removes XID unless
the transaction is a 3DS visa transaction.

Remote:
37 tests, 188 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.1892% passed
(failures also happening on master)

Unit:
95 tests, 560 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed