### PR TITLE
CyberSource: Only include non-nil `mdd_` fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * RuboCop: Fix Naming/ConstantName [leila-alderman] #3723
 * Orbital: Fix schema errors [britth] #3766
 * Checkout V2: Start testing via amount code [curiousepic] #3767
+* CyberSource: Don't include empty `mdd_` fields [arbianchi] #3758
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -576,7 +576,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_mdd_fields(xml, options)
-        return unless options.keys.any? { |key| key.to_s.start_with?('mdd_field') }
+        return unless options.keys.any? { |key| key.to_s.start_with?('mdd_field') && options[key] }
 
         xml.tag! 'merchantDefinedData' do
           (1..100).each do |each|


### PR DESCRIPTION
When all `mdd_field` options are `nil`, the merchantDefinedData gets
added as an empty XML tag which causes the gateway to return a parse
error.