### PR TITLE
Worldpay: Add Support for Idempotency Key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * iATS: Allow email to be passed outside of the billing_address context [naashton] #3750
 * Orbital: Don't pass xid for transactions using network tokens [britth] #3757
 * Forte: Add service_fee_amount field [meagabeth] #3751
+* WorldPay: Add support for idempotency_key[cdmackeyfree] #3759
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -568,6 +568,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers(options)
+        idempotency_key = options[:idempotency_key]
+
         headers = {
           'Content-Type' => 'text/xml',
           'Authorization' => encoded_credentials
@@ -575,6 +577,8 @@ module ActiveMerchant #:nodoc:
         if options[:cookie]
           headers['Cookie'] = options[:cookie] if options[:cookie]
         end
+
+        headers['Idempotency-Key'] = idempotency_key if idempotency_key
         headers
       end
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -857,6 +857,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
   end
 
+  def test_optional_idempotency_key_header
+    response = stub_comms do
+      @gateway.authorize(@amount, @token, @options.merge({idempotency_key: 'test123'}))
+    end.check_request do |endpoint, data, headers|
+      headers && headers['Idempotency-Key'] == 'test123'
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_failed_store
     response = stub_comms do
       @gateway.store(@credit_card, @store_options.merge(customer: '_invalidId'))


### PR DESCRIPTION
Add the ability to send through an Idempotency-Key as a header on Worldpay transactions as an option. This is a beta feature for WorldPay, so no remote test was written as we do not have access to use it.

Unit tests:

75 tests, 491 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:

Finished in 78.308251 seconds.

57 tests, 239 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.2281% passed

The tests (which are also failing on master):
test_3ds_version_1_parameters_pass_thru
test_3ds_version_2_parameters_pass_thru
test_successful_credit_using_token
test_successful_mastercard_credit_on_cft_gateway
test_successful_visa_credit_on_cft_gateway