### PR TITLE
Orbital: Fix line_tot conditional check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Orbital: Don't pass xid for transactions using network tokens [britth] #3757
 * Forte: Add service_fee_amount field [meagabeth] #3751
 * WorldPay: Add support for idempotency_key[cdmackeyfree] #3759
+* Orbital: Handle line_tot key as a string [naashton] #3760
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -409,7 +409,7 @@ module ActiveMerchant #:nodoc:
             xml.tag! :PC3LineItem do
               xml.tag! :PC3DtlIndex,  byte_limit(index + 1, 2)
               line_item.each do |key, value|
-                if key == :line_tot
+                if [:line_tot, 'line_tot'].include? key
                   formatted_key = :PC3Dtllinetot
                 else
                   formatted_key = "PC3Dtl#{key.to_s.camelize}".to_sym


### PR DESCRIPTION
`if :line_tot` is not resolving to true in some cases because the value
is actually a string. Expanding the check to evaluate against a string
and symlink should resolve this issue.

CE-762

Unit: 95 tests, 560 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 37 tests, 192 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5946% passed