### PR TITLE
Checkout V2: Move to single-transaction Purchases

### DIFF
--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -149,9 +149,9 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(@amount, @declined_card, @options)
+    response = @gateway.purchase(12305, @credit_card, @options)
     assert_failure response
-    assert_equal 'request_invalid: card_number_invalid', response.message
+    assert_equal 'Declined - Do Not Honour', response.message
   end
 
   def test_avs_failed_purchase
@@ -207,8 +207,9 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    response = @gateway.authorize(@amount, @declined_card, @options)
+    response = @gateway.authorize(12314, @credit_card, @options)
     assert_failure response
+    assert_equal 'Invalid Card Number', response.message
   end
 
   def test_partial_capture


### PR DESCRIPTION
When the Checkout V2 adapter was initially implemented, it seems that
the Checkout API couldn't perform a refund on an auto-captured
authorizations (ie, single-transaction purchase), so Purchase used a
multi-response authorization and capture call.

We have recently noticed intermittent Purchases that the adapter
considers successful but in fact the Capture response was a 404.
According to Checkout, this may be due to their id for the authorization
not having yet been instantiated before the Capture reached them. So the
multiresponse is too fast for its own good, and also the adapter's
success criteria isn't sufficient to catch a failed Capture as part of
a Purchase.

However, it seems that the constraint on refunds has since been removed.
So, we can switch to a single-transaction Purchase, by not setting the
capture field as false. There should be no effective difference in terms
of the resulting Response.

Remote:
33 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
29 tests, 129 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed