### PR TITLE
RuboCop: Fix Layout/MultilineMethodCallBraceLayout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,13 +15,6 @@
 Layout/AlignHash:
   Enabled: false
 
-# Offense count: 232
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineMethodCallBraceLayout:
-  Enabled: false
-
 # Offense count: 1186
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * RuboCop: Fix Style/Alias [leila-alderman] #3727
 * Stripe PI: Allow `on_behalf_of` to be passed alone #3776
 * RuboCop: Fix Performance/RedundantMatch [leila-alderman] #3765
+* RuboCop: Fix Layout/MultilineMethodCallBraceLayout [leila-alderman] #3763
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -568,9 +568,11 @@ module ActiveMerchant
         xml.cardholderAuthentication do
           three_d_secure = options.fetch(:three_d_secure, {})
           xml.authenticationIndicator(
-            options[:authentication_indicator] || three_d_secure[:eci])
+            options[:authentication_indicator] || three_d_secure[:eci]
+          )
           xml.cardholderAuthenticationValue(
-            options[:cardholder_authentication_value] || three_d_secure[:cavv])
+            options[:cardholder_authentication_value] || three_d_secure[:cavv]
+          )
         end
       end
 

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -395,8 +395,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success, message, response,
           test: test_mode,
-          authorization: response[:subscription_id]
-        )
+          authorization: response[:subscription_id])
       end
 
       def recurring_parse(action, xml)

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -73,8 +73,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success, message, response,
           authorization: authorization,
-          test: (response[:mode] != 'LIVE')
-        )
+          test: (response[:mode] != 'LIVE'))
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/balanced.rb
+++ b/lib/active_merchant/billing/gateways/balanced.rb
@@ -165,7 +165,8 @@ module ActiveMerchant #:nodoc:
                 live_url + "/#{path}",
                 post_data(post),
                 headers
-              ))
+              )
+            )
           rescue ResponseError => e
             raise unless e.response.code.to_s =~ /4\d\d/
 

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -78,14 +78,16 @@ module ActiveMerchant #:nodoc:
                 'storeDetailAndSubmitThirdParty',
                 post,
                 @options[:store_payout_account],
-                @options[:store_payout_password])
+                @options[:store_payout_password]
+              )
             }
             r.process {
               commit(
                 'confirmThirdParty',
                 modification_request(r.authorization, @options),
                 @options[:review_payout_account],
-                @options[:review_payout_password])
+                @options[:review_payout_password]
+              )
             }
           end
         else

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -417,8 +417,7 @@ module ActiveMerchant #:nodoc:
           test: test? || response[:authCode] == 'TEST',
           authorization: authorization_from(response),
           cvv_result: CVD_CODES[response[:cvdId]],
-          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
-        )
+          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] })
       end
 
       def recurring_post(data)

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -366,8 +366,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
           avs_result: { code: parsed[:avs_result_code] },
-          cvv_result: parsed[:card_code]
-        )
+          cvv_result: parsed[:card_code])
       end
 
       def message_from(parsed)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -163,12 +163,10 @@ module ActiveMerchant #:nodoc:
             email: scrub_email(options[:email]),
             phone: options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone]),
-            credit_card: credit_card_params
-          )
+            credit_card: credit_card_params)
           Response.new(result.success?, message_from_result(result),
             braintree_customer: (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
-            customer_vault_id: (result.customer.id if result.success?)
-          )
+            customer_vault_id: (result.customer.id if result.success?))
         end
       end
 
@@ -243,8 +241,7 @@ module ActiveMerchant #:nodoc:
               customer_vault_id: (result.customer.id if result.success?),
               credit_card_token: (result.customer.credit_cards[0].token if result.success?)
             },
-            authorization: (result.customer.id if result.success?)
-          )
+            authorization: (result.customer.id if result.success?))
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -932,8 +932,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization,
           fraud_review: in_fraud_review?(response),
           avs_result: { code: response[:avsCode] },
-          cvv_result: response[:cvCode]
-        )
+          cvv_result: response[:cvCode])
       end
 
       # Parse the SOAP response

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -262,8 +262,7 @@ module ActiveMerchant
 
         Response.new(response[:status] == '1', response[:reason], response,
           test: test?,
-          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
-        )
+          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}")
       end
 
       def format_date(month, year)

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -149,8 +149,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response, parameters),
           avs_result: { code: response[:avs_response_code] },
-          cvv_result: response[:cvv_response_code]
-        )
+          cvv_result: response[:cvv_response_code])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -320,8 +320,7 @@ module ActiveMerchant #:nodoc:
           test: @options[:test] || test?,
           authorization: authorization_from(response),
           avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response']
-        )
+          cvv_result: response['cvv2_response'])
       end
 
       def post_data(parameters, options)

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -283,8 +283,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response['transactionid'],
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse']
-        )
+          cvv_result: response['cvvresponse'])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -115,8 +115,7 @@ module ActiveMerchant #:nodoc:
           message_from(response[:ewaytrxnerror]),
           response,
           authorization: response[:ewaytrxnnumber],
-          test: test?
-        )
+          test: test?)
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -224,8 +224,7 @@ module ActiveMerchant #:nodoc:
 
         EwayResponse.new(response[:success], response[:message], response,
           test: test?,
-          authorization: response[:auth_code]
-        )
+          authorization: response[:auth_code])
       end
 
       # Where we build the full SOAP 1.2 request using builder

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -162,8 +162,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2]
-        )
+          cvv_result: response[:cvv2])
       rescue ResponseError => e
         case e.response.code
         when '401'

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -125,8 +125,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response['transactionid'],
           avs_result: {code: response['avsresponse']},
-          cvv_result: response['cvvresponse']
-        )
+          cvv_result: response['cvvresponse'])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -302,7 +302,8 @@ module ActiveMerchant #:nodoc:
           first_name: params[2],
           last_name: params[3],
           month: params[4],
-          year: params[5])
+          year: params[5]
+        )
 
         xml.tag! 'TransarmorToken', params[0]
         xml.tag! 'Expiry_Date', expdate(credit_card)
@@ -358,8 +359,7 @@ module ActiveMerchant #:nodoc:
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
           avs_result: {code: response[:avs]},
           cvv_result: response[:cvv2],
-          error_code: standard_error_code(response)
-        )
+          error_code: standard_error_code(response))
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -269,7 +269,8 @@ module ActiveMerchant #:nodoc:
           first_name: params[2],
           last_name: params[3],
           month: params[4],
-          year: params[5])
+          year: params[5]
+        )
 
         xml.tag! 'TransarmorToken', params[0]
         xml.tag! 'Expiry_Date', expdate(credit_card)
@@ -373,8 +374,7 @@ module ActiveMerchant #:nodoc:
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
           avs_result: {code: response[:avs]},
           cvv_result: response[:cvv2],
-          error_code: standard_error_code(response)
-        )
+          error_code: standard_error_code(response))
       end
 
       def headers(method, url, request)

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -176,8 +176,7 @@ module ActiveMerchant #:nodoc:
           authorization: response['transactionid'],
           test: test?,
           cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] }
-        )
+          avs_result: { code: response['avsresponse'] })
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/instapay.rb
+++ b/lib/active_merchant/billing/gateways/instapay.rb
@@ -143,8 +143,7 @@ module ActiveMerchant #:nodoc:
         Response.new(response[:success], response[:message], response,
           authorization: response[:transaction_id],
           avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result]
-        )
+          cvv_result: response[:cvv_result])
       end
 
       def post_data(action, parameters = {})

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -391,8 +391,7 @@ module ActiveMerchant #:nodoc:
             street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
             postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ]
           },
-          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
-        )
+          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ])
       end
 
       def parse(xml)

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -290,8 +290,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response, money, token),
           avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2]
-        )
+          cvv_result: response[:cvv2])
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -302,8 +302,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(response, money, token),
           avs_result: AVSResult.new(code: response[:avs]),
           cvv_result: CVVResult.new(response[:cvv2]),
-          error_code: success ? nil : error_code_from(response)
-        )
+          error_code: success ? nil : error_code_from(response))
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -267,8 +267,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response[:ordernum],
           avs_result: { code: response[:avs].to_s[2, 1] },
-          cvv_result: response[:avs].to_s[3, 1]
-        )
+          cvv_result: response[:avs].to_s[3, 1])
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -169,8 +169,7 @@ module ActiveMerchant #:nodoc:
           authorization: response['transaction_id'],
           test: test?,
           cvv_result: response['cvv2_result'],
-          avs_result: { code: response['avs_result'] }
-        )
+          avs_result: { code: response['avs_result'] })
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -292,8 +292,7 @@ module ActiveMerchant #:nodoc:
         begin
           data = ssl_post(url(v4), request,
             'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action, v4)
-          )
+            'SOAPAction'   => soap_action(action, v4))
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
           response = parse_error(e.response)
@@ -303,8 +302,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response['AVSResponse'] },
-          cvv_result: response['CVResponse']
-        )
+          cvv_result: response['CVResponse'])
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -263,8 +263,7 @@ module ActiveMerchant #:nodoc:
         begin
           data = ssl_post(url, request,
             'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action)
-          )
+            'SOAPAction'   => soap_action(action))
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
           response = parse_error(e.response, action)
@@ -274,8 +273,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response['AvsResponse'] },
-          cvv_result: response['CvResponse']
-        )
+          cvv_result: response['CvResponse'])
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -180,8 +180,7 @@ module ActiveMerchant #:nodoc:
           authorization: response[:transaction_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code]
-        )
+          cvv_result: response[:card_code])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -286,8 +286,7 @@ module ActiveMerchant #:nodoc:
           authorization: response[:TransactionNo],
           fraud_review: fraud_review?(response),
           avs_result: { code: avs_response_code },
-          cvv_result: cvv_result_code
-        )
+          cvv_result: cvv_result_code)
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/modern_payments_cim.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments_cim.rb
@@ -148,15 +148,13 @@ module ActiveMerchant #:nodoc:
       def commit(action, params)
         data = ssl_post(url(action), build_request(action, params),
           { 'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction' => "#{xmlns(action)}#{action}" }
-        )
+            'SOAPAction' => "#{xmlns(action)}#{action}" })
 
         response = parse(action, data)
         Response.new(successful?(action, response), message_from(action, response), response,
           test: test?,
           authorization: authorization_from(action, response),
-          avs_result: { code: response[:avs_code] }
-        )
+          avs_result: { code: response[:avs_code] })
       end
 
       def authorization_from(action, response)

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -304,7 +304,8 @@ module ActiveMerchant #:nodoc:
           test: test?,
           avs_result: {code: response[:avs_result_code]},
           cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
-          authorization: authorization_from(response))
+          authorization: authorization_from(response)
+        )
       end
 
       # Generates a Moneris authorization string of the form 'trans_id;receipt_id'.

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -117,8 +117,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response['transactionid'],
           avs_result: {code: response['avsresponse']},
-          cvv_result: response['cvvresponse']
-        )
+          cvv_result: response['cvvresponse'])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -235,16 +235,14 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success?(response), message_from(response), response,
           test: test?,
-          authorization: authorization_from(action, response)
-        )
+          authorization: authorization_from(action, response))
       end
 
       def commit_periodic(action, request)
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, build_periodic_request(action, request)))
         Response.new(success?(response), message_from(response), response,
           test: test?,
-          authorization: authorization_from(action, response)
-        )
+          authorization: authorization_from(action, response))
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -145,8 +145,7 @@ module ActiveMerchant
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
         Response.new(response['status'] == 'approved', message_from(response), response,
-          authorization: authorization_from(response, action)
-        )
+          authorization: authorization_from(response, action))
       end
 
       def post_data(action, params)

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -197,8 +197,7 @@ module ActiveMerchant #:nodoc:
           test: test_response?(response),
           authorization: response[:trans_id],
           avs_result: { code: response[:avs_code]},
-          cvv_result: response[:cvv2_code]
-        )
+          cvv_result: response[:cvv2_code])
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code =~ /^[67]\d\d$/
 

--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -204,8 +204,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization,
           avs_result: { code: raw['avsresponse']},
-          cvv_result: raw['cvvresponse']
-        )
+          cvv_result: raw['cvvresponse'])
       end
 
       def build_request(action, parameters)

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -188,8 +188,7 @@ module ActiveMerchant #:nodoc:
           (success ? response['error_code'] : response['description']),
           response,
           test: test?,
-          authorization: response['id']
-        )
+          authorization: response['id'])
       end
 
       def http_request(method, resource, parameters = {}, options = {})

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -125,8 +125,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: avs_result_from(response) },
-          cvv_result: cvv_result_from(response)
-        )
+          cvv_result: cvv_result_from(response))
       end
 
       # The upstream is picky and so we can't use CGI.escape like we want to

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -665,8 +665,7 @@ module ActiveMerchant #:nodoc:
             test: self.test?,
             avs_result: OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
             cvv_result: OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
-          }
-        )
+          })
       end
 
       def remote_url(url = :primary)

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -129,8 +129,7 @@ module ActiveMerchant #:nodoc:
             postal_match: AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
             street_match: AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
           },
-          cvv_result: CVV2_CODES[response['CVV2ResponseCode']]
-        )
+          cvv_result: CVV2_CODES[response['CVV2ResponseCode']])
       end
 
       def url(action)

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -266,8 +266,7 @@ module ActiveMerchant #:nodoc:
         response = parse(action, ssl_post(self.live_url, request))
         Response.new(successful?(response), message_from(response), response,
           test: test?,
-          authorization: authorization || response[:tid]
-        )
+          authorization: authorization || response[:tid])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -189,8 +189,7 @@ module ActiveMerchant #:nodoc:
           avs_result: {code: response['AVS_RESULT_CODE']},
           cvv_result: response['VERIFICATION_RESULT_CODE'],
           error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]),
-          authorization: response['TRANSACTION_ID']
-        )
+          authorization: response['TRANSACTION_ID'])
       end
 
       def response_error(raw_response)

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -339,8 +339,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(successful?(response), message_from(response), response,
           test: test?,
-          authorization: response[:transaction_id] || parameters[:transaction_id]
-        )
+          authorization: response[:transaction_id] || parameters[:transaction_id])
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -70,8 +70,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(successful?(response), message_from(response), response,
           test: test_response?(response),
-          authorization: authorization_from(response)
-        )
+          authorization: authorization_from(response))
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -389,8 +389,7 @@ module ActiveMerchant #:nodoc:
           message_from(response),
           response,
           test: test?,
-          authorization: build_authorization(response)
-        )
+          authorization: build_authorization(response))
       end
 
       def build_authorization(response)

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -303,8 +303,7 @@ module ActiveMerchant #:nodoc:
         # Return a response
         PaymentExpressResponse.new(response[:success] == APPROVED, message_from(response), response,
           test: response[:test_mode] == '1',
-          authorization: authorization_from(action, response)
-        )
+          authorization: authorization_from(action, response))
       end
 
       # Response XML documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#XMLTxnOutput

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -120,8 +120,7 @@ module ActiveMerchant #:nodoc:
           authorization: response['transactionid'],
           fraud_review: fraud_review?(response),
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse']
-        )
+          cvv_result: response['cvvresponse'])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -179,8 +179,7 @@ module ActiveMerchant #:nodoc:
 
         PaystationResponse.new(success?(response), message, response,
           test: (response[:tm]&.casecmp('t')&.zero?),
-          authorization: response[:paystation_transaction_id]
-        )
+          authorization: response[:paystation_transaction_id])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -194,8 +194,7 @@ module ActiveMerchant
 
         Response.new(success, message, params,
           test: (@options[:merchant].to_s == 'TEST'),
-          authorization: post[:order_number]
-        )
+          authorization: post[:order_number])
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'
 

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -182,8 +182,7 @@ module ActiveMerchant
           test: test?,
           authorization: response[:orderid],
           avs_result: { code: response[:avs_code] },
-          cvv_result: response[:cvvresp]
-        )
+          cvv_result: response[:cvvresp])
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -106,8 +106,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: build_authorization(response),
           avs_result: { code: response[:avsresult] },
-          cvv_result: response[:cardidresult]
-        )
+          cvv_result: response[:cardidresult])
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -263,8 +263,7 @@ module ActiveMerchant
           test: test?,
           authorization: response[:CrossReference],
           cvv_result: CVV_CODE[response[:AVSCV2Check]],
-          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] }
-        )
+          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] })
       end
 
       # Put the passed data into a format that can be submitted to PSL

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -147,8 +147,7 @@ module ActiveMerchant #:nodoc:
           authorization: response[:credit_card_trans_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: avs_result(response) },
-          cvv_result: cvv_result(response)
-        )
+          cvv_result: cvv_result(response))
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -219,8 +219,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization,
           avs_result: { code: response[:AVSResponseCode] },
-          cvv_result: response[:CVV2ResponseCode]
-        )
+          cvv_result: response[:CVV2ResponseCode])
       end
 
       # Parse the SOAP response

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -155,8 +155,7 @@ module ActiveMerchant
 
         Response.new(success, message_from(success, response), response,
           test: test?,
-          authorization: authorization_from(response)
-        )
+          authorization: authorization_from(response))
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -166,8 +166,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(successful?(response), message_from(response), response,
           test: test?,
-          authorization: response[:transaction]
-        )
+          authorization: response[:transaction])
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -264,8 +264,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(response, source),
           avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result]
-        )
+          cvv_result: response[:cvv_result])
       end
 
       def url(params, source)
@@ -382,8 +381,7 @@ module ActiveMerchant #:nodoc:
           end
 
           Response.new(success, message, response,
-            authorization: response[:guid]
-          )
+            authorization: response[:guid])
         end
 
         ENVELOPE_NAMESPACES = {

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -353,8 +353,7 @@ module ActiveMerchant #:nodoc:
             street_match: AVS_CODE[response['AddressResult']],
             postal_match: AVS_CODE[response['PostCodeResult']]
           },
-          cvv_result: CVV_CODE[response['CV2Result']]
-        )
+          cvv_result: CVV_CODE[response['CV2Result']])
       end
 
       def authorization_from(response, params, action)

--- a/lib/active_merchant/billing/gateways/sallie_mae.rb
+++ b/lib/active_merchant/billing/gateways/sallie_mae.rb
@@ -122,8 +122,7 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(self.live_url, parameters.to_post_data) || '')
         Response.new(successful?(response), message_from(response), response,
           test: test?,
-          authorization: response['refcode']
-        )
+          authorization: response['refcode'])
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -83,8 +83,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: build_authorization(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code_response_code]
-        )
+          cvv_result: response[:card_code_response_code])
       end
 
       def build_request(request)

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -61,8 +61,7 @@ module ActiveMerchant #:nodoc:
           authorization: response[:transaction_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code]
-        )
+          cvv_result: response[:card_code])
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -185,8 +185,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success?(response), message_from(response), response,
           test: test?,
-          authorization: authorization_from(response)
-        )
+          authorization: authorization_from(response))
       end
 
       def build_periodic_item(action, money, credit_card, options)
@@ -242,8 +241,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(success?(response), message_from(response), response,
           test: test?,
-          authorization: authorization_from(response)
-        )
+          authorization: authorization_from(response))
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -86,8 +86,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(response[:result_code] == 1, message_from(response), response,
           test: test?,
-          authorization: response[:merchant_transaction_reference]
-        )
+          authorization: response[:merchant_transaction_reference])
       end
 
       def message_from(result)

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -190,8 +190,7 @@ module ActiveMerchant #:nodoc:
           response,
           test: test?,
           authorization: (success ? response['id'] : response['error']['charge']),
-          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']])
-        )
+          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']]))
       end
 
       def headers(options = {})

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -267,8 +267,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response[:szTransactionFileName] || parameters[:szTransactionId],
           avs_result: { code: response[:szAVSResponseCode] },
-          cvv_result: response[:szCVV2ResponseCode]
-        )
+          cvv_result: response[:szCVV2ResponseCode])
       end
 
       def url_for(action)

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -230,8 +230,7 @@ module ActiveMerchant #:nodoc:
           authorization: (response['transactionid'] || response['customer_vault_id']),
           test: test?,
           cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] }
-        )
+          avs_result: { code: response['avsresponse'] })
       end
 
       def expdate(creditcard)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -667,8 +667,7 @@ module ActiveMerchant #:nodoc:
           avs_result: { code: avs_code },
           cvv_result: cvc_code,
           emv_authorization: emv_authorization_from_response(response),
-          error_code: success ? nil : error_code_from(response)
-        )
+          error_code: success ? nil : error_code_from(response))
       end
 
       def authorization_from(success, url, method, response)

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -109,8 +109,7 @@ module ActiveMerchant #:nodoc:
                 TRANSACTION_APPROVED_MSG :
                 TRANSACTION_DECLINED_MSG,
                 response,
-                test: test?
-              )
+                test: test?)
             else
               build_error_response(message, response)
             end

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -447,8 +447,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization_from(action, data),
           cvv_result: data['cvv'],
-          avs_result: { code: data['avs'] }
-        )
+          avs_result: { code: data['avs'] })
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -324,8 +324,7 @@ module ActiveMerchant #:nodoc:
           authorization: response[:ref_num],
           cvv_result: response[:cvv2_result_code],
           avs_result: { code: response[:avs_result_code] },
-          error_code: error_code
-        )
+          error_code: error_code)
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/verifi.rb
+++ b/lib/active_merchant/billing/gateways/verifi.rb
@@ -198,8 +198,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: response[:transactionid],
           avs_result: { code: response[:avsresponse] },
-          cvv_result: response[:cvvresponse]
-        )
+          cvv_result: response[:cvvresponse])
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -140,8 +140,7 @@ module ActiveMerchant #:nodoc:
           test: @options[:test] || test?,
           authorization: authorization_from(response),
           avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response']
-        )
+          cvv_result: response['cvv2_response'])
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -175,7 +175,8 @@ module ActiveMerchant #:nodoc:
               ((test? ? test_url : live_url) + action),
               params.to_json,
               headers(options)
-            ))
+            )
+          )
         rescue ResponseError => e
           response = parse(e.response.body)
         end

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -183,8 +183,7 @@ module ActiveMerchant #:nodoc:
           test: test?,
           authorization: authorization,
           avs_result: { code: avs_code(response, options) },
-          cvv_result: response[:CVCResponseCode]
-        )
+          cvv_result: response[:CVCResponseCode])
       rescue ResponseError => e
         if e.response.code == '401'
           return Response.new(false, 'Invalid Login')

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -41,8 +41,7 @@ module ActiveMerchant #:nodoc:
             authorization: false,
             avs_result: {},
             cvv_result: {},
-            error_code: false
-          )
+            error_code: false)
         end
       end
 
@@ -178,8 +177,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization,
           avs_result: {},
           cvv_result: {},
-          error_code: success ? nil : response['customCode']
-        )
+          error_code: success ? nil : response['customCode'])
       end
 
       def test?

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -12,8 +12,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'visa'
-    )
+      brand: 'visa')
 
     @avs_credit_card = credit_card('4400000000000008',
       month: 10,
@@ -21,8 +20,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'visa'
-    )
+      brand: 'visa')
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
       month: 10,
@@ -30,8 +28,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
 
     @three_ds_enrolled_card = credit_card('4917610000000000', month: 10, year: 2020, verification_value: '737', brand: :visa)
 
@@ -41,8 +38,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'cabal'
-    )
+      brand: 'cabal')
 
     @invalid_cabal_credit_card = credit_card('6035 2200 0000 0006',
       month: 10,
@@ -50,8 +46,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'cabal'
-    )
+      brand: 'cabal')
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
       month: 10,
@@ -59,8 +54,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay'
-    )
+      brand: 'unionpay')
 
     @invalid_unionpay_credit_card = credit_card('8171 9999 1234 0000 921',
       month: 10,
@@ -68,8 +62,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay'
-    )
+      brand: 'unionpay')
 
     @declined_card = credit_card('4000300011112220')
 
@@ -83,7 +76,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       brand: 'mastercard'
     )
 
-    @apple_pay_card = network_tokenization_credit_card('4761209980011439',
+    @apple_pay_card = network_tokenization_credit_card(
+      '4761209980011439',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       month: '11',
       year: '2022',
@@ -91,7 +85,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       verification_value: 569
     )
 
-    @google_pay_card = network_tokenization_credit_card('4761209980011439',
+    @google_pay_card = network_tokenization_credit_card(
+      '4761209980011439',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       month: '11',
       year: '2022',
@@ -283,8 +278,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'mastercard'
-    )
+      brand: 'mastercard')
     assert response = @gateway.authorize(@amount, mastercard_threed, @options.merge(threed_dynamic: true))
     assert response.test?
     refute response.authorization.blank?
@@ -399,7 +393,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       installments: 2,
       shopper_statement: 'statement note',
       device_fingerprint: 'm7Cmrf++0cW4P6XfF7m/rA',
-      capture_delay_hours: 4)
+      capture_delay_hours: 4
+    )
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal '[capture-received]', response.message

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -85,7 +85,6 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
     ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
       payment_instrument_name: defaults[:payment_instrument_name],
       payment_network: defaults[:payment_network],
-      transaction_identifier: defaults[:transaction_identifier]
-    )
+      transaction_identifier: defaults[:transaction_identifier])
   end
 end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -680,8 +680,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+      verification_value: nil)
     auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
     assert_equal 'This transaction has been approved', auth.message
@@ -693,8 +692,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   def test_successful_refund_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+      verification_value: nil)
 
     purchase = @gateway.purchase(@amount, credit_card, @options)
     assert_success purchase
@@ -709,8 +707,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   def test_successful_credit_with_network_tokenization
     credit_card = network_tokenization_credit_card('4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil
-    )
+      verification_value: nil)
 
     response = @gateway.credit(@amount, credit_card, @options)
     assert_success response
@@ -722,8 +719,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -60,7 +60,8 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
 
     @recurring_options = @options.merge(
       interval: { unit: :months, length: 1 },
-      occurences: 5)
+      occurences: 5
+    )
   end
 
   def test_successful_visa_purchase

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -390,8 +390,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_email
     assert response = @gateway.purchase(@amount, @credit_card,
-      email: 'customer@example.com'
-    )
+      email: 'customer@example.com')
     assert_success response
     transaction = response.params['braintree_transaction']
     assert_equal 'customer@example.com', transaction['customer_details']['email']
@@ -483,8 +482,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.store(
       credit_card('4111111111111111',
         first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012
-      ),
+        month: 9, year: 2012),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -518,8 +516,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     }
     assert response = @gateway.purchase(@amount, @credit_card,
       billing_address: billing_address,
-      shipping_address: shipping_address
-    )
+      shipping_address: shipping_address)
     assert_success response
     transaction = response.params['braintree_transaction']
     assert_equal '1 E Main St', transaction['billing_details']['street_address']
@@ -541,16 +538,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_successful_purchase_with_three_d_secure_pass_thru
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
     response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params
-    )
+      three_d_secure: three_d_secure_params)
     assert_success response
   end
 
   def test_successful_purchase_with_some_three_d_secure_pass_thru_fields
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id' }
     response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params
-    )
+      three_d_secure: three_d_secure_params)
     assert_success response
   end
 
@@ -581,8 +576,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -599,8 +593,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       year: '2024',
       source: :android_pay,
       transaction_id: '123456789',
-      eci: '05'
-    )
+      eci: '05')
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -617,8 +610,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       year: '2024',
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05'
-    )
+      eci: '05')
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -731,8 +723,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.store(
       credit_card('4111111111111111',
         first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012
-      ),
+        month: 9, year: 2012),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -753,8 +744,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       customer_vault_id,
       credit_card('5105105105105100',
         first_name: 'New First', last_name: 'New Last',
-        month: 10, year: 2014
-      ),
+        month: 10, year: 2014),
       email: 'new@example.com',
       phone: '987-765-5432'
     )
@@ -867,8 +857,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
         lodging_check_in_date: '2050-07-22',
         lodging_check_out_date: '2050-07-25',
         lodging_name: 'Best Hotel Ever'
-      }
-    )
+      })
     assert_success auth
   end
 
@@ -879,8 +868,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
         check_in_date: '2050-12-22',
         check_out_date: '2050-12-25',
         room_rate: '80.00'
-      }
-    )
+      })
     assert_success auth
   end
 

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -10,34 +10,29 @@ class RemoteCardStreamTest < Test::Unit::TestCase
       month: '12',
       year: Time.now.year + 1,
       verification_value: '4887',
-      brand: :american_express
-    )
+      brand: :american_express)
 
     @mastercard = credit_card('5301250070000191',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '419',
-      brand: :master
-    )
+      brand: :master)
 
     @visacreditcard = credit_card('4929421234600821',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '356',
-      brand: :visa
-    )
+      brand: :visa)
 
     @visadebitcard = credit_card('4539791001730106',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '289',
-      brand: :visa
-    )
+      brand: :visa)
 
     @declined_card = credit_card('4000300011112220',
       month: '9',
-      year: Time.now.year + 1
-    )
+      year: Time.now.year + 1)
 
     @amex_options = {
       billing_address: {
@@ -117,8 +112,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
     @three_ds_enrolled_card = credit_card('4012001037141112',
       month: '12',
       year: '2020',
-      brand: :visa
-    )
+      brand: :visa)
   end
 
   def test_successful_visacreditcard_authorization_and_capture

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -15,8 +15,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       month:              '10',
       year:               '2025',
       source:             :network_token,
-      verification_value: nil
-    )
+      verification_value: nil)
 
     @options = {
       order_id: '1',

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -14,32 +14,27 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :elo
-    )
+      brand: :elo)
     @three_ds_unenrolled_card = credit_card('4000000000000051',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+      brand: :visa)
     @three_ds_enrolled_card = credit_card('4000000000000002',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+      brand: :visa)
     @three_ds_invalid_card = credit_card('4000000000000010',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa
-    )
+      brand: :visa)
     @three_ds_enrolled_mastercard = credit_card('5200000000001005',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :master
-    )
+      brand: :master)
 
     @amount = 100
 
@@ -97,8 +92,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)
@@ -533,8 +527,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_successful_response(auth)

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -109,8 +109,7 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
         country:  'US',
         phone:    '1115555555',
         fax:      '1115556666'
-      }
-    )
+      })
     assert_success response
   end
 

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -6,8 +6,7 @@ class EwayTest < Test::Unit::TestCase
     @credit_card_success = credit_card('4444333322221111')
     @credit_card_fail = credit_card('1234567812345678',
       month: Time.now.month,
-      year: Time.now.year - 1
-    )
+      year: Time.now.year - 1)
 
     @params = {
       order_id: '1230123',

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -28,8 +28,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   def test_successful_purchase_with_network_tokenization
     @credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+      verification_value: nil)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -29,8 +29,7 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
   def test_successful_purchase_with_network_tokenization
     @credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+      verification_value: nil)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -313,8 +313,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, credit_card, @options)
     end
@@ -330,8 +329,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -341,8 +339,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -353,8 +350,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -364,8 +360,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -376,8 +371,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -387,8 +381,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -399,8 +392,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -410,8 +402,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -422,8 +413,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -433,8 +423,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -445,8 +434,7 @@ class RemoteHpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -456,8 +444,7 @@ class RemoteHpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -105,8 +105,7 @@ class LinkpointTest < Test::Unit::TestCase
       installments: 12,
       startdate: 'immediate',
       periodicity: :monthly,
-      billing_address: address
-    )
+      billing_address: address)
 
     assert_success response
     assert_equal 'APPROVED', response.params['approved']

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -1057,7 +1057,8 @@ class RemoteLitleCertification < Test::Unit::TestCase
         brand: 'visa',
         number:  '4457000300000007',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
 
     assert response = @gateway.purchase(10010, decrypted_apple_pay, options)
     assert_success response
@@ -1076,7 +1077,8 @@ class RemoteLitleCertification < Test::Unit::TestCase
         brand: 'visa',
         number:  '4457000300000007',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
 
     assert response = @gateway.purchase(10010, decrypted_android_pay, options)
     assert_success response

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -53,7 +53,8 @@ class RemoteLitleTest < Test::Unit::TestCase
         brand: 'visa',
         number:  '44444444400009',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
     @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {
         source: :android_pay,
@@ -62,7 +63,8 @@ class RemoteLitleTest < Test::Unit::TestCase
         brand: 'visa',
         number:  '4457000300000007',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
     @check = check(
       name: 'Tom Black',
       routing_number:  '011075150',
@@ -124,8 +126,7 @@ class RemoteLitleTest < Test::Unit::TestCase
           zip: '03038',
           country: 'US'
         }
-      }
-    )
+      })
     assert_failure response
     assert_equal 'Insufficient Funds', response.message
   end

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -14,22 +14,19 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737'
-    )
+      verification_value: '737')
     @cabal_credit_card = credit_card('6042012045809847',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737'
-    )
+      verification_value: '737')
     @naranja_credit_card = credit_card('5895627823453005',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '123'
-    )
+      verification_value: '123')
     @declined_card = credit_card('5031433215406351',
       first_name: 'OTHE')
     @options = {

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -15,8 +15,7 @@ class RemoteNmiTest < Test::Unit::TestCase
       year: '2024',
       source: :apple_pay,
       eci: '5',
-      transaction_id: '123456789'
-    )
+      transaction_id: '123456789')
     @options = {
       order_id: generate_unique_id,
       billing_address: address,

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -158,7 +158,8 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_visa_network_tokenization_credit_card_with_eci
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
@@ -185,8 +186,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'master'
-    )
+      brand: 'master')
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -198,8 +198,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'american_express'
-    )
+      brand: 'american_express')
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -211,8 +210,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'discover'
-    )
+      brand: 'discover')
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message

--- a/test/remote/gateways/remote_pay_junction_test.rb
+++ b/test/remote/gateways/remote_pay_junction_test.rb
@@ -120,8 +120,7 @@ class PayJunctionTest < Test::Unit::TestCase
     assert response = @gateway.recurring(AMOUNT, @credit_card,
       periodicity: :monthly,
       payments: 12,
-      order_id: generate_unique_id[0..15]
-    )
+      order_id: generate_unique_id[0..15])
 
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message
     assert_equal 'charge', response.params['transaction_action']

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -427,8 +427,7 @@ class RemotePayflowTest < Test::Unit::TestCase
         initial_transaction: {
           type: :purchase,
           amount: 500
-        }
-      )
+        })
     end
 
     assert_success response

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -12,8 +12,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
     @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {
       billing_address: address,

--- a/test/remote/gateways/remote_payway_test.rb
+++ b/test/remote/gateways/remote_payway_test.rb
@@ -11,40 +11,34 @@ class PaywayTest < Test::Unit::TestCase
     @visa = credit_card('4564710000000004',
       month: 2,
       year: 2019,
-      verification_value: '847'
-    )
+      verification_value: '847')
 
     @mastercard = credit_card('5163200000000008',
       month: 8,
       year: 2020,
       verification_value: '070',
-      brand: 'master'
-    )
+      brand: 'master')
 
     @expired = credit_card('4564710000000012',
       month: 2,
       year: 2005,
-      verification_value: '963'
-    )
+      verification_value: '963')
 
     @low = credit_card('4564710000000020',
       month: 5,
       year: 2020,
-      verification_value: '234'
-    )
+      verification_value: '234')
 
     @stolen_mastercard = credit_card('5163200000000016',
       month: 12,
       year: 2019,
       verification_value: '728',
-      brand: 'master'
-    )
+      brand: 'master')
 
     @invalid = credit_card('4564720000000037',
       month: 9,
       year: 2019,
-      verification_value: '030'
-    )
+      verification_value: '030')
   end
 
   def test_successful_visa

--- a/test/remote/gateways/remote_psl_card_test.rb
+++ b/test/remote/gateways/remote_psl_card_test.rb
@@ -25,16 +25,14 @@ class RemotePslCardTest < Test::Unit::TestCase
 
   def test_successful_visa_purchase
     response = @gateway.purchase(@accept_amount, @visa,
-      billing_address: @visa_address
-    )
+      billing_address: @visa_address)
     assert_success response
     assert response.test?
   end
 
   def test_successful_visa_debit_purchase
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address
-    )
+      billing_address: @visa_debit_address)
     assert_success response
   end
 
@@ -42,56 +40,49 @@ class RemotePslCardTest < Test::Unit::TestCase
   def test_visa_debit_purchase_should_not_send_debit_info_if_present
     @visa_debit.start_month = '07'
     response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address
-    )
+      billing_address: @visa_debit_address)
     assert_success response
   end
 
   def test_successful_visa_purchase_specifying_currency
     response = @gateway.purchase(@accept_amount, @visa,
       billing_address: @visa_address,
-      currency: 'GBP'
-    )
+      currency: 'GBP')
     assert_success response
     assert response.test?
   end
 
   def test_successful_solo_purchase
     response = @gateway.purchase(@accept_amount, @solo,
-      billing_address: @solo_address
-    )
+      billing_address: @solo_address)
     assert_success response
     assert response.test?
   end
 
   def test_referred_purchase
     response = @gateway.purchase(@referred_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
-    )
+      billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_declined_purchase
     response = @gateway.purchase(@declined_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
-    )
+      billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_declined_keep_card_purchase
     response = @gateway.purchase(@keep_card_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
-    )
+      billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_successful_authorization
     response = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address
-    )
+      billing_address: @visa_address)
     assert_success response
     assert response.test?
   end
@@ -101,16 +92,14 @@ class RemotePslCardTest < Test::Unit::TestCase
       login: ''
     )
     response = @gateway.authorize(@accept_amount, @uk_maestro,
-      billing_address: @uk_maestro_address
-    )
+      billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_successful_authorization_and_capture
     authorization = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address
-    )
+      billing_address: @visa_address)
     assert_success authorization
     assert authorization.test?
 

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -22,15 +22,13 @@ class RemoteRealexTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
 
     @declined_apple_pay = network_tokenization_credit_card('4000120000001154',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     @amount = 10000
   end
 
@@ -46,8 +44,7 @@ class RemoteRealexTest < Test::Unit::TestCase
         billing_address: {
           zip: '90210',
           country: 'US'
-        }
-      )
+        })
       assert_not_nil response
       assert_success response
       assert response.test?
@@ -63,8 +60,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     )
     response = gateway.purchase(@amount, @visa,
       order_id: generate_unique_id,
-      description: 'Invalid login test'
-    )
+      description: 'Invalid login test')
 
     assert_not_nil response
     assert_failure response
@@ -76,8 +72,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_with_invalid_account
     response = RealexGateway.new(fixtures(:realex_with_account).merge(account: 'invalid')).purchase(@amount, @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex purchase with invalid account'
-    )
+      description: 'Test Realex purchase with invalid account')
 
     assert_not_nil response
     assert_failure response
@@ -97,8 +92,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     [@visa_declined, @mastercard_declined].each do |card|
       response = @gateway.purchase(@amount, card,
         order_id: generate_unique_id,
-        description: 'Test Realex purchase declined'
-      )
+        description: 'Test Realex purchase declined')
       assert_not_nil response
       assert_failure response
 
@@ -155,8 +149,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     [@visa_referral_b, @mastercard_referral_b].each do |card|
       response = @gateway.purchase(@amount, card,
         order_id: generate_unique_id,
-        description: 'Test Realex Referral B'
-      )
+        description: 'Test Realex Referral B')
       assert_not_nil response
       assert_failure response
       assert response.test?
@@ -169,8 +162,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     [@visa_referral_a, @mastercard_referral_a].each do |card|
       response = @gateway.purchase(@amount, card,
         order_id: generate_unique_id,
-        description: 'Test Realex Rqeferral A'
-      )
+        description: 'Test Realex Rqeferral A')
       assert_not_nil response
       assert_failure response
       assert_equal '103', response.params['result']
@@ -182,8 +174,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     [@visa_coms_error, @mastercard_coms_error].each do |card|
       response = @gateway.purchase(@amount, card,
         order_id: generate_unique_id,
-        description: 'Test Realex coms error'
-      )
+        description: 'Test Realex coms error')
       assert_not_nil response
       assert_failure response
 
@@ -197,8 +188,7 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex expiry month error'
-    )
+      description: 'Test Realex expiry month error')
     assert_not_nil response
     assert_failure response
 
@@ -211,8 +201,7 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex expiry year error'
-    )
+      description: 'Test Realex expiry year error')
     assert_not_nil response
     assert_failure response
 
@@ -226,8 +215,7 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @visa,
       order_id: generate_unique_id,
-      description: 'test_chname_error'
-    )
+      description: 'test_chname_error')
     assert_not_nil response
     assert_failure response
 
@@ -240,8 +228,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa_cvn.verification_value = '111'
     response = @gateway.purchase(@amount, @visa_cvn,
       order_id: generate_unique_id,
-      description: 'test_cvn'
-    )
+      description: 'test_cvn')
     assert_not_nil response
     assert_success response
     assert response.authorization.length > 0
@@ -251,8 +238,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @visa,
       order_id: generate_unique_id,
       description: 'test_cust_num',
-      customer: 'my customer id'
-    )
+      customer: 'my customer id')
     assert_not_nil response
     assert_success response
     assert response.authorization.length > 0
@@ -265,8 +251,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
 
     assert_not_nil response
     assert_success response
@@ -284,8 +269,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
     assert auth_response.test?
 
     capture_response = @gateway.capture(nil, auth_response.authorization)
@@ -306,8 +290,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
     assert auth_response.test?
 
     capture_response = @gateway.capture(@amount, auth_response.authorization)
@@ -328,8 +311,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
     assert purchase_response.test?
 
     void_response = @gateway.void(purchase_response.authorization)
@@ -351,8 +333,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
     assert purchase_response.test?
 
     rebate_response = gateway_with_refund_password.refund(@amount, purchase_response.authorization)
@@ -366,8 +347,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_verify
     response = @gateway.verify(@visa,
       order_id: generate_unique_id,
-      description: 'Test Realex verify'
-    )
+      description: 'Test Realex verify')
 
     assert_not_nil response
     assert_success response
@@ -379,8 +359,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_verify_declined
     response = @gateway.verify(@visa_declined,
       order_id: generate_unique_id,
-      description: 'Test Realex verify declined'
-    )
+      description: 'Test Realex verify declined')
 
     assert_not_nil response
     assert_failure response
@@ -398,8 +377,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
 
     assert_not_nil credit_response
     assert_success credit_response
@@ -414,8 +392,7 @@ class RemoteRealexTest < Test::Unit::TestCase
       billing_address: {
         zip: '90210',
         country: 'US'
-      }
-    )
+      })
 
     assert_not_nil credit_response
     assert_failure credit_response
@@ -431,8 +408,7 @@ class RemoteRealexTest < Test::Unit::TestCase
         billing_address: {
           zip: '90210',
           country: 'US'
-        }
-      )
+        })
       assert_not_nil response
       assert_success response
       assert_equal 'M', response.avs_result['code']
@@ -448,8 +424,7 @@ class RemoteRealexTest < Test::Unit::TestCase
         billing_address: {
           zip: '90210',
           country: 'US'
-        }
-      )
+        })
     end
     clean_transcript = @gateway.scrub(transcript)
 

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -133,8 +133,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, capture.authorization,
       description: 'Crediting trx',
-      order_id: generate_unique_id
-    )
+      order_id: generate_unique_id)
     assert_success refund
   end
 
@@ -160,8 +159,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, purchase.authorization,
       description: 'Crediting trx',
-      order_id: generate_unique_id
-    )
+      order_id: generate_unique_id)
 
     assert_success refund
   end

--- a/test/remote/gateways/remote_secure_pay_test.rb
+++ b/test/remote/gateways/remote_secure_pay_test.rb
@@ -6,8 +6,7 @@ class RemoteSecurePayTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4111111111111111',
       month: '7',
-      year: '2014'
-    )
+      year: '2014')
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_skipjack_test.rb
+++ b/test/remote/gateways/remote_skipjack_test.rb
@@ -7,8 +7,7 @@ class RemoteSkipJackTest < Test::Unit::TestCase
     @gateway = SkipJackGateway.new(fixtures(:skip_jack))
 
     @credit_card = credit_card('4445999922225',
-      verification_value: '999'
-    )
+      verification_value: '999')
 
     @amount = 100
 

--- a/test/remote/gateways/remote_stripe_android_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_android_pay_test.rb
@@ -19,8 +19,7 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -35,8 +34,7 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -105,8 +105,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -120,8 +119,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -136,8 +134,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -151,8 +148,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -13,13 +13,11 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     @three_ds_credit_card = credit_card('4000000000003220',
       verification_value: '737',
       month: 10,
-      year: 2020
-    )
+      year: 2020)
     @visa_card = credit_card('4242424242424242',
       verification_value: '737',
       month: 10,
-      year: 2020
-    )
+      year: 2020)
     @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
   end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -13,8 +13,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
@@ -161,7 +160,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         session_id: session_id,
         ip: '127.0.0.1',
         cookie: 'machine=32423423'
-      })
+      }
+    )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -255,7 +255,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         ip: '127.0.0.1',
         cookie: 'machine=32423423',
         stored_credential: stored_credential_params
-      })
+      }
+    )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -277,7 +278,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         ip: '127.0.0.1',
         cookie: 'machine=32423423',
         stored_credential_usage: 'FIRST'
-      })
+      }
+    )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
     assert first_message.test?
@@ -318,7 +320,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         session_id: session_id,
         ip: '127.0.0.1',
         cookie: 'machine=32423423'
-      })
+      }
+    )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert_match %r{missing info for 3D-secure transaction}i, first_message.message
     assert first_message.test?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -216,8 +216,7 @@ module ActiveMerchant
       ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
         payment_instrument_name: defaults[:payment_instrument_name],
         payment_network: defaults[:payment_network],
-        transaction_identifier: defaults[:transaction_identifier]
-      )
+        transaction_identifier: defaults[:transaction_identifier])
     end
 
     def address(options = {})

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -16,8 +16,7 @@ class AdyenTest < Test::Unit::TestCase
       first_name: 'Test',
       last_name: 'Card',
       verification_value: '737',
-      brand: 'visa'
-    )
+      brand: 'visa')
 
     @elo_credit_card = credit_card('5066 9911 1111 1118',
       month: 10,
@@ -25,8 +24,7 @@ class AdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
 
     @cabal_credit_card = credit_card('6035 2277 1642 7021',
       month: 10,
@@ -34,8 +32,7 @@ class AdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'cabal'
-    )
+      brand: 'cabal')
 
     @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
       month: 10,
@@ -43,8 +40,7 @@ class AdyenTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay'
-    )
+      brand: 'unionpay')
 
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
@@ -53,8 +49,7 @@ class AdyenTest < Test::Unit::TestCase
       month: '08',
       year: '2018',
       source: :apple_pay,
-      verification_value: nil
-    )
+      verification_value: nil)
 
     @amount = 100
 

--- a/test/unit/gateways/authorize_net_arb_test.rb
+++ b/test/unit/gateways/authorize_net_arb_test.rb
@@ -27,8 +27,7 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
       duration: {
         start_date: Time.now.strftime('%Y-%m-%d'),
         occurrences: 30
-      }
-    )
+      })
 
     assert_instance_of Response, response
     assert response.success?

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -1152,8 +1152,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   def test_truncation
     card = credit_card('4242424242424242',
       first_name: 'a' * 51,
-      last_name: 'a' * 51
-    )
+      last_name: 'a' * 51)
 
     options = {
       order_id: 'a' * 21,
@@ -1226,8 +1225,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_apple_pay_authorization_with_network_tokenization
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)
@@ -1246,8 +1244,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_failed_apple_pay_authorization_with_network_tokenization_not_supported
     credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -6,7 +6,8 @@ class BanwireTest < Test::Unit::TestCase
   def setup
     @gateway = BanwireGateway.new(
       login: 'desarrollo',
-      currency: 'MXN')
+      currency: 'MXN'
+    )
 
     @credit_card = credit_card('5204164299999999',
       month: 11,

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -54,7 +54,8 @@ class BeanstreamTest < Test::Unit::TestCase
 
     @recurring_options = @options.merge(
       interval: { unit: :months, length: 1 },
-      occurrences: 5)
+      occurrences: 5
+    )
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -234,8 +234,7 @@ class BluePayTest < Test::Unit::TestCase
         rebill_start_date: '1 MONTH',
         rebill_expression: '14 DAYS',
         rebill_cycles: '24',
-        rebill_amount: @amount * 4
-      )
+        rebill_amount: @amount * 4)
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -856,8 +856,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
         lodging_check_in_date: '2050-07-22',
         lodging_check_out_date: '2050-07-25',
         lodging_name: 'Best Hotel Ever'
-      }
-    )
+      })
   end
 
   def test_successful_purchase_with_lodging_data
@@ -875,8 +874,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
         check_in_date: '2050-12-22',
         check_out_date: '2050-12-25',
         room_rate: '80.00'
-      }
-    )
+      })
   end
 
   def test_apple_pay_card
@@ -903,8 +901,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -937,8 +934,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       eci: '05',
       payment_cryptogram: '111111111100cryptogram',
       source: :android_pay,
-      transaction_id: '1234567890'
-    )
+      transaction_id: '1234567890')
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -971,8 +967,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       eci: '05',
       payment_cryptogram: '111111111100cryptogram',
       source: :google_pay,
-      transaction_id: '1234567890'
-    )
+      transaction_id: '1234567890')
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -1045,7 +1040,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, :initial)})
@@ -1060,7 +1056,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC')})
@@ -1074,7 +1071,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: 'recurring'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, :initial)})
@@ -1089,7 +1087,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: 'recurring'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC')})
@@ -1103,7 +1102,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, :initial)})
@@ -1118,7 +1118,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, id: '123ABC')})
@@ -1132,7 +1133,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: 'recurring'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, :initial)})
@@ -1147,7 +1149,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: 'recurring'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, id: '123ABC')})
@@ -1161,7 +1164,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, :initial)})
@@ -1176,7 +1180,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: ''
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, id: '123ABC')})
@@ -1190,7 +1195,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'will_vault'
           },
           transaction_source: 'unscheduled'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, :initial)})
@@ -1205,7 +1211,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
             previous_network_transaction_id: '123ABC'
           },
           transaction_source: 'unscheduled'
-        })
+        }
+      )
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, id: '123ABC')})

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -13,8 +13,7 @@ class CardStreamTest < Test::Unit::TestCase
       month: '12',
       year: '2014',
       verification_value: '356',
-      brand: :visa
-    )
+      brand: :visa)
 
     @visacredit_options = {
       billing_address: {
@@ -44,13 +43,11 @@ class CardStreamTest < Test::Unit::TestCase
       month: '12',
       year: 2014,
       verification_value: '4887',
-      brand: :american_express
-    )
+      brand: :american_express)
 
     @declined_card = credit_card('4000300011112220',
       month: '9',
-      year: '2014'
-    )
+      year: '2014')
   end
 
   def test_successful_visacreditcard_authorization

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -579,8 +579,7 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card, @options)
@@ -597,8 +596,7 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
@@ -621,8 +619,7 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'master',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
-    )
+      payment_cryptogram: '111111111100cryptogram')
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
@@ -639,8 +636,7 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'american_express',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: Base64.encode64('111111111100cryptogram')
-    )
+      payment_cryptogram: Base64.encode64('111111111100cryptogram'))
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -189,8 +189,7 @@ class EwayRapidTest < Test::Unit::TestCase
           country: 'US',
           phone: '1115555555',
           fax: '1115556666'
-        }
-      )
+        })
     end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"TransactionType":"CustomTransactionType"}, data)
       assert_match(%r{"RedirectUrl":"http://awesomesauce.com"}, data)

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -250,8 +250,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -264,8 +263,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -277,8 +275,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -290,8 +287,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -304,8 +300,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -318,8 +313,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -331,8 +325,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -344,8 +337,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay
-    )
+      source: :apple_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -358,8 +350,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -372,8 +363,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -385,8 +375,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -398,8 +387,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -412,8 +400,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -426,8 +413,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -439,8 +425,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -452,8 +437,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay
-    )
+      source: :android_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -466,8 +450,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -480,8 +463,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -493,8 +475,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -506,8 +487,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -520,8 +500,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -534,8 +513,7 @@ class HpsTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -547,8 +525,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -560,8 +537,7 @@ class HpsTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay
-    )
+      source: :google_pay)
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -20,7 +20,8 @@ class LitleTest < Test::Unit::TestCase
         brand: 'visa',
         number:  '44444444400009',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
     @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       {
         source: :android_pay,
@@ -29,7 +30,8 @@ class LitleTest < Test::Unit::TestCase
         brand: 'visa',
         number:  '4457000300000007',
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
-      })
+      }
+    )
     @amount = 100
     @options = {}
     @check = check(

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -11,22 +11,19 @@ class MercadoPagoTest < Test::Unit::TestCase
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737'
-    )
+      verification_value: '737')
     @cabal_credit_card = credit_card('6035227716427021',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737'
-    )
+      verification_value: '737')
     @naranja_credit_card = credit_card('5895627823453005',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '123'
-    )
+      verification_value: '123')
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -91,8 +91,7 @@ class MonerisTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+      verification_value: nil)
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
     assert_equal '101965-0_10;0bbb277b543a17b6781243889a689573', response.authorization
@@ -241,8 +240,7 @@ class MonerisTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorization_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
+      verification_value: nil)
     assert response = @gateway.authorize(100, @credit_card, @options)
     assert_success response
     assert_equal '109232-0_10;d88d9f5f3472898832c54d6b5572757e', response.authorization

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -224,8 +224,7 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 19:31:01+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      })
-    )
+      }))
   end
 
   def successful_store_response(id)
@@ -246,8 +245,7 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 19:31:01+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      })
-    )
+      }))
   end
 
   def failed_response(type, id, code = '100.100.101')
@@ -270,8 +268,7 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 20:40:26+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      })
-    )
+      }))
   end
 
   def failed_store_response(id, code = '100.100.101')
@@ -292,8 +289,7 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 20:40:26+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      })
-    )
+      }))
   end
 
   class OppMockResponse

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -536,7 +536,8 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       dest_state: 'CA',
       dest_name: 'Joan Smith',
       dest_phone: '(123) 456-7890',
-      dest_country: 'US')
+      dest_country: 'US'
+    )
 
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1,

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -10,8 +10,7 @@ class PayboxDirectTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card('1111222233334444',
-      brand: 'visa'
-    )
+      brand: 'visa')
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -314,8 +314,7 @@ class PayflowTest < Test::Unit::TestCase
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
           periodicity: :monthly,
-          initial_transaction: { }
-        )
+          initial_transaction: { })
       end
     end
   end
@@ -325,8 +324,7 @@ class PayflowTest < Test::Unit::TestCase
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
           periodicity: :monthly,
-          initial_transaction: { amount: :purchase }
-        )
+          initial_transaction: { amount: :purchase })
       end
     end
   end

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -12,8 +12,7 @@ class PaymentezTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -609,8 +609,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(response_with_error)
     response = @gateway.setup_authorization(100,
       return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+      cancel_return_url: 'http://example.com')
     assert_equal '10736', response.params['error_codes']
   end
 
@@ -618,8 +617,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(response_with_duplicate_errors)
     response = @gateway.setup_authorization(100,
       return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+      cancel_return_url: 'http://example.com')
 
     assert_equal '10736', response.params['error_codes']
   end
@@ -628,8 +626,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(response_with_errors)
     response = @gateway.setup_authorization(100,
       return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com'
-    )
+      cancel_return_url: 'http://example.com')
 
     assert_equal %w[10736 10002], response.params['error_codes'].split(',')
   end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -263,8 +263,7 @@ class PaypalTest < Test::Unit::TestCase
     xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
       tax: @amount,
       shipping: @amount,
-      handling: @amount
-    )
+      handling: @amount)
 
     doc = REXML::Document.new(xml)
     assert_nil REXML::XPath.first(doc, '//n2:PaymentDetails/n2:TaxTotal')
@@ -275,8 +274,7 @@ class PaypalTest < Test::Unit::TestCase
       tax: @amount,
       shipping: @amount,
       handling: @amount,
-      subtotal: 200
-    )
+      subtotal: 200)
 
     doc = REXML::Document.new(xml)
     assert_equal '1.00', REXML::XPath.first(doc, '//n2:PaymentDetails/n2:TaxTotal').text

--- a/test/unit/gateways/qbms_test.rb
+++ b/test/unit/gateways/qbms_test.rb
@@ -7,7 +7,8 @@ class QbmsTest < Test::Unit::TestCase
     @gateway = QbmsGateway.new(
       login: 'test',
       ticket: 'abc123',
-      pem: 'PEM')
+      pem: 'PEM'
+    )
 
     @amount = 100
     @card = credit_card('4111111111111111')

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -318,8 +318,7 @@ class SagePayTest < Test::Unit::TestCase
     refund = stub_comms do
       @gateway.refund(@amount, capture.authorization,
         order_id: generate_unique_id,
-        description: 'Refund txn'
-      )
+        description: 'Refund txn')
     end.respond_with(successful_refund_response)
     assert_success refund
   end

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -952,8 +952,7 @@ class StripeTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '7'
-    )
+      eci: '7')
 
     @gateway.send(:add_creditcard, post, credit_card, {})
 
@@ -1367,8 +1366,7 @@ class StripeTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '05'
-    )
+      eci: '05')
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1389,8 +1387,7 @@ class StripeTest < Test::Unit::TestCase
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1410,8 +1407,7 @@ class StripeTest < Test::Unit::TestCase
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '05'
-    )
+      eci: '05')
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1432,8 +1428,7 @@ class StripeTest < Test::Unit::TestCase
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
       eci: '05',
-      source: :android_pay
-    )
+      source: :android_pay)
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -18,8 +18,7 @@ class WorldpayTest < Test::Unit::TestCase
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo'
-    )
+      brand: 'elo')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
     @options = {order_id: 1}
     @store_options = {


### PR DESCRIPTION
Fixes the RuboCop to-do for [Layout/MultilineMethodCallBraceLayout](https://docs.rubocop.org/rubocop/0.85/cops_layout.html#layoutmultilinemethodcallbracelayout).

All unit tests:
4561 tests, 72379 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed