### PR TITLE
WIP: Adds e-check option for Orbital

### DIFF
--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -8,6 +8,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4556761029983886')
     @declined_card = credit_card('4000300011112220')
+    @e_check = check(routing_number: '27000116')
 
     @options = {
       order_id: generate_unique_id,
@@ -109,6 +110,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_echeck
+    response = @gateway.purchase(@amount, @e_check, @options)
+    assert_success response
+    assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_soft_descriptor_hash


### PR DESCRIPTION
This resurrects an old branch from 2017 attempting to add `echeck` capability to the Orbital gateway. It is a work-in-progress and is not polished. There are no unit tests. The effort was abandoned when the requesting customer decided to move on. I was not able to get the one remote test passing although, at the time, the response indicted the test data was not correct.

Remote Tests:

There were 3 failures: the expected `echeck` failure plus 2 3DS failures for American Express that I did not troubleshoot at all. Not sure that they would be impacted by these additions but I did not investigate.

38 tests, 193 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.1053% passed