### PR TITLE
RuboCop: Fix Performance/RedundantMatch

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,13 +160,6 @@ Naming/VariableName:
     - 'test/unit/gateways/card_stream_test.rb'
     - 'test/unit/gateways/worldpay_online_payments_test.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Exclude:
-    - 'lib/active_merchant/billing/gateways/opp.rb'
-    - 'test/unit/gateways/payu_latam_test.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 Performance/StringReplacement:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * PayU Latam: Support partial refunds [leila-alderman] #3774
 * RuboCop: Fix Style/Alias [leila-alderman] #3727
 * Stripe PI: Allow `on_behalf_of` to be passed alone #3776
+* RuboCop: Fix Performance/RedundantMatch [leila-alderman] #3765
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -287,7 +287,7 @@ module ActiveMerchant #:nodoc:
       def add_options(post, options)
         post[:createRegistration] = options[:create_registration] if options[:create_registration] && !options[:registrationId]
         post[:testMode] = options[:test_mode] if test? && options[:test_mode]
-        options.each { |key, value| post[key] = value if key.to_s.match('customParameters\[[a-zA-Z0-9\._]{3,64}\]') }
+        options.each { |key, value| post[key] = value if key.to_s =~ /'customParameters\[[a-zA-Z0-9\._]{3,64}\]'/ }
         post['customParameters[SHOPPER_pluginId]'] = 'activemerchant'
         post['customParameters[custom_disable3DSecure]'] = options[:disable_3d_secure] if options[:disable_3d_secure]
       end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -214,7 +214,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
   def test_request_using_visa_card_with_no_cvv
     @gateway.expects(:ssl_post).with { |_url, body, _headers|
-      body.match '"securityCode":"000"'
+      body =~ /"securityCode":"000"/
       body.match '"processWithoutCvv2":true'
     }.returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @no_cvv_visa_card, @options)
@@ -225,7 +225,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
   def test_request_using_amex_card_with_no_cvv
     @gateway.expects(:ssl_post).with { |_url, body, _headers|
-      body.match '"securityCode":"0000"'
+      body =~ /"securityCode":"0000"/
       body.match '"processWithoutCvv2":true'
     }.returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @no_cvv_amex_card, @options)
@@ -236,7 +236,7 @@ class PayuLatamTest < Test::Unit::TestCase
 
   def test_request_passes_cvv_option
     @gateway.expects(:ssl_post).with { |_url, body, _headers|
-      body.match '"securityCode":"777"'
+      body =~ /"securityCode":"777"/
       !body.match '"processWithoutCvv2"'
     }.returns(successful_purchase_response)
     options = @options.merge(cvv: '777')


### PR DESCRIPTION
Fixes the RuboCop to-do for [Performance/RedundantMatch](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceredundantmatch).

All unit tests:
4561 tests, 72379 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed