### PR TITLE
Orbital: Fix schema errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * RuboCop: Fix Style/BlockComments [leila-alderman] #3729
 * Checkout V2: Move to single-transaction Purchases [curiousepic] #3761
 * RuboCop: Fix Naming/ConstantName [leila-alderman] #3723
+* Orbital: Fix schema errors [britth] #3766
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -735,15 +735,15 @@ module ActiveMerchant #:nodoc:
             add_aav(xml, creditcard, three_d_secure)
             # CustomerAni, AVSPhoneType and AVSDestPhoneType could be added here.
 
-            add_dpanind(xml, creditcard)
-            add_aevv(xml, creditcard, three_d_secure)
-            add_digital_token_cryptogram(xml, creditcard)
-
             if parameters[:soft_descriptors].is_a?(OrbitalSoftDescriptors)
               add_soft_descriptors(xml, parameters[:soft_descriptors])
             elsif parameters[:soft_descriptors].is_a?(Hash)
               add_soft_descriptors_from_hash(xml, parameters[:soft_descriptors])
             end
+
+            add_dpanind(xml, creditcard)
+            add_aevv(xml, creditcard, three_d_secure)
+            add_digital_token_cryptogram(xml, creditcard)
 
             set_recurring_ind(xml, parameters)
 

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -155,7 +155,16 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
       brand: 'visa',
       eci: '5'
     )
-    assert response = @gateway.purchase(3000, network_card, @options)
+    # Ensure that soft descriptor fields don't conflict with network token data in schema
+    options = @options.merge(
+      soft_descriptors: {
+        merchant_name: 'Merch',
+        product_description: 'Description',
+        merchant_email: 'email@example'
+      }
+    )
+
+    assert response = @gateway.purchase(3000, network_card, options)
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -271,7 +280,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         order_id: '2',
         currency: 'USD',
         three_d_secure: fixture[:three_d_secure],
-        address: fixture[:address]
+        address: fixture[:address],
+        soft_descriptors: {
+          merchant_name: 'Merch',
+          product_description: 'Description',
+          merchant_email: 'email@example'
+        }
       )
       assert response = @gateway.authorize(100, cc, options)
 


### PR DESCRIPTION
After fixing an issue with problematic values being sent for network
tokenized PMs (#3757), errors relating to the request not adhering to the
DTD would sometimes appear. This happens in the existing code when
soft descriptors are passed along with a network tokenized card.
In the schema, the soft descriptor fields need to come before the
network token fields. This PR updates the order of these elements
and adds additional test conditions.

Unit:
96 tests, 563 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
37 tests, 192 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5946% passed
(same as master)