### PR TITLE
Orbital: Resolve CardIndicators issue

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -756,8 +756,8 @@ module ActiveMerchant #:nodoc:
             add_level2_purchase(xml, parameters)
             add_level3_purchase(xml, parameters)
             add_level3_tax(xml, parameters)
-            add_card_indicators(xml, parameters)
             add_line_items(xml, parameters) if parameters[:line_items]
+            add_card_indicators(xml, parameters)
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, creditcard, three_d_secure)
           end

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -133,6 +133,16 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_card_indicators_and_line_items
+    options = @options.merge(
+      line_items: @line_items,
+      card_indicators: 'y'
+    )
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_level_2_data
     response = @gateway.purchase(@amount, @credit_card, @options.merge(level_2_data: @level_2_options))
 


### PR DESCRIPTION
CardIndicators field is being sent, but not received by the Orbital gateway. In the schema, the line items field needs to come before the card indicators field, but they are switched. This PR updates the order of those elements and adds additional testing.

CE-710

UNIT:
96 tests, 563 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
REMOTE:
38 tests, 195 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.4737% passed
(Same as master)