### PR TITLE
Adyen: Add subMerchant fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * RuboCop: Fix Naming/VariableNumber [leila-alderman] #3725
 * Update BIN ranges for Elo cardtype [cdmackeyfree] #3769
 * Orbital: Resolve CardIndicators issue [meagabeth] #3771
+* Adyen: Add subMerchant fields [naashton] #3772
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -228,6 +228,15 @@ module ActiveMerchant #:nodoc:
 
       def add_merchant_data(post, options)
         post[:additionalData][:subMerchantId] = options[:sub_merchant_id] if options[:sub_merchant_id]
+        post[:additionalData][:subMerchantName] = options[:sub_merchant_name] if options[:sub_merchant_name]
+        post[:additionalData][:subMerchantStreet] = options[:sub_merchant_street] if options[:sub_merchant_street]
+        post[:additionalData][:subMerchantCity] = options[:sub_merchant_city] if options[:sub_merchant_city]
+        post[:additionalData][:subMerchantState] = options[:sub_merchant_state] if options[:sub_merchant_state]
+        post[:additionalData][:subMerchantPostalCode] = options[:sub_merchant_postal_code] if options[:sub_merchant_postal_code]
+        post[:additionalData][:subMerchantCountry] = options[:sub_merchant_country] if options[:sub_merchant_country]
+        post[:additionalData][:subMerchantTaxId] = options[:sub_merchant_tax_id] if options[:sub_merchant_tax_id]
+        post[:additionalData][:subMerchantId] = options[:sub_merchant_id] if options[:sub_merchant_id]
+        post[:additionalData][:subMerchantMCC] = options[:sub_merchant_mcc] if options[:sub_merchant_mcc]
       end
 
       def add_risk_data(post, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -83,18 +83,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
       brand: 'mastercard'
     )
 
-    @apple_pay_card = network_tokenization_credit_card('4111111111111111',
+    @apple_pay_card = network_tokenization_credit_card('4761209980011439',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      month: '08',
-      year: '2018',
+      month: '11',
+      year: '2022',
       source: :apple_pay,
-      verification_value: nil
+      verification_value: 569
     )
 
-    @google_pay_card = network_tokenization_credit_card('4111111111111111',
+    @google_pay_card = network_tokenization_credit_card('4761209980011439',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
-      month: '08',
-      year: '2018',
+      month: '11',
+      year: '2022',
       source: :google_pay,
       verification_value: nil
     )
@@ -1042,7 +1042,19 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_sub_merchant_data
+    sub_merchant_data = {
+      sub_merchant_id: '123451234512345',
+      sub_merchant_name: 'Wildsea',
+      sub_merchant_street: '1234 Street St',
+      sub_merchant_city: 'Night City',
+      sub_merchant_state: 'East Block',
+      sub_merchant_postal_code: '112233',
+      sub_merchant_country: 'EUR',
+      sub_merchant_tax_id: '12345abcde67',
+      sub_merchant_mcc: '1234'
+    }
     options = @options.update({
+      installments: 2,
       billing_address: {
         address1: 'Infinite Loop',
         address2: 1,
@@ -1052,7 +1064,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
         zip: '95014'
       }
     })
-    assert response = @gateway.authorize(@amount, @avs_credit_card, options.merge({sub_merchant_id: '123451234512345'}))
+    assert response = @gateway.authorize(@amount, @avs_credit_card, options.merge(sub_merchant_data))
     assert response.test?
     refute response.authorization.blank?
     assert_success response

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -820,11 +820,29 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_authorize_with_sub_merchant_id
+    sub_merchant_data = {
+      sub_merchant_id: '123451234512345',
+      sub_merchant_name: 'Wildsea',
+      sub_merchant_street: '1234 Street St',
+      sub_merchant_city: 'Night City',
+      sub_merchant_state: 'East Block',
+      sub_merchant_postal_code: '112233',
+      sub_merchant_country: 'EUR',
+      sub_merchant_tax_id: '12345abcde67',
+      sub_merchant_mcc: '1234'
+    }
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(sub_merchant_id: '12345abcde67890'))
+      @gateway.authorize(@amount, @credit_card, @options.merge(sub_merchant_data))
     end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert parsed['additionalData']['subMerchantId']
+      assert parsed['additionalData']['subMerchantName']
+      assert parsed['additionalData']['subMerchantStreet']
+      assert parsed['additionalData']['subMerchantCity']
+      assert parsed['additionalData']['subMerchantState']
+      assert parsed['additionalData']['subMerchantPostalCode']
+      assert parsed['additionalData']['subMerchantCountry']
+      assert parsed['additionalData']['subMerchantTaxId']
     end.respond_with(successful_authorize_response)
     assert_success response
   end


### PR DESCRIPTION
Pass in subMerchant fields for reconciliation

Also update `apple_pay` and `google_pay` test cards
CE-985

Unit: 70 tests, 336 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 92 tests, 353 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed