### PR TITLE
PayPal Express: reduce param requirements

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize_reference_transaction(money, options = {})
-        requires!(options, :reference_id, :payment_type, :invoice_id, :description, :ip)
+        requires!(options, :reference_id)
 
         commit 'DoReferenceTransaction', build_reference_transaction_request('Authorization', money, options)
       end

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -576,18 +576,17 @@ class PaypalExpressTest < Test::Unit::TestCase
   def test_authorize_reference_transaction
     @gateway.expects(:ssl_post).returns(successful_authorize_reference_transaction_response)
 
-    response = @gateway.authorize_reference_transaction(2000,
-      {
-        reference_id: 'ref_id',
-        payment_type: 'Any',
-        invoice_id: 'invoice_id',
-        description: 'Description',
-        ip: '127.0.0.1'
-      })
+    response = @gateway.authorize_reference_transaction(2000, reference_id: 'ref_id')
 
     assert_equal 'Success', response.params['ack']
     assert_equal 'Success', response.message
     assert_equal '9R43552341412482K', response.authorization
+  end
+
+  def test_authorize_reference_transaction_requires_fields
+    assert_raise ArgumentError do
+      @gateway.authorize_reference_transaction(2000, {})
+    end
   end
 
   def test_reference_transaction


### PR DESCRIPTION
Similar to commit e99842b5c124e034e0a05c9c9151d50c25e798ff

For reference transactions, PayPal Express does not require payment_type, invoice_id, description or ip. We shouldn't
require them either. They can be optionally passed in, but are not required. This change removes the requirement from reference based authorizations.

PayPal remote tests:
29 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

PayPal Express remote tests:
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

All unit tests:
4563 tests, 72384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

EVS-661