### PR TITLE
PayU Latam: Support partial refunds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Orbital: Resolve CardIndicators issue [meagabeth] #3771
 * Adyen: Add subMerchant fields [naashton] #3772
 * PayPal Express: reduce param requirements [shasum] #3773
+* PayU Latam: Support partial refunds [leila-alderman] #3774
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -76,9 +76,16 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_credentials(post, 'SUBMIT_TRANSACTION', options)
-        add_transaction_elements(post, 'REFUND', options)
-        add_reference(post, authorization)
 
+        if options[:partial_refund]
+          add_transaction_elements(post, 'PARTIAL_REFUND', options)
+          post[:transaction][:additionalValues] ||= {}
+          post[:transaction][:additionalValues][:TX_VALUE] = invoice_for(amount, options)[:TX_VALUE]
+        else
+          add_transaction_elements(post, 'REFUND', options)
+        end
+
+        add_reference(post, authorization)
         commit('refund', post)
       end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -232,7 +232,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(@amount, @declined_card, @options)
+    response = @gateway.purchase(@amount, @declined_card)
     assert_failure response
     assert_equal 'DECLINED', response.params['transactionResponse']['state']
   end
@@ -298,7 +298,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    response = @gateway.authorize(@amount, @pending_card, @options)
+    response = @gateway.authorize(@amount, @declined_card)
     assert_failure response
     assert_equal 'DECLINED', response.params['transactionResponse']['state']
   end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -140,6 +140,17 @@ class PayuLatamTest < Test::Unit::TestCase
       @gateway.refund(@amount, '7edbaf68-8f3a-4ae7-b9c7-d1e27e314999', @options.merge(language: 'es'))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"language":"es"/, data)
+      assert_match(/"type":"REFUND"/, data)
+    end.respond_with(pending_refund_response)
+  end
+
+  def test_partial_refund
+    stub_comms do
+      @gateway.refund(2000, '7edbaf68-8f3a-4ae7-b9c7-d1e27e314999', @options.merge(partial_refund: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"type":"PARTIAL_REFUND"/, data)
+      assert_match(/"TX_VALUE"/, data)
+      assert_match(/"value":"20.00"/, data)
     end.respond_with(pending_refund_response)
   end
 


### PR DESCRIPTION
Added support for partial refunds indicated by passing
`partial_refund: true`
in the options hash.

Previously, all refunds were treated as full refunds, regardless of the
amount sent to the gateway.

ECS-1401

Unit:
34 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed

Remote:
35 tests, 79 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
91.4286% passed

All unit tests:
4563 tests, 72389 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed