### PR TITLE
NMI: Add standardized 3DS fields.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * Stripe PI: Allow `on_behalf_of` to be passed alone #3776
 * RuboCop: Fix Performance/RedundantMatch [leila-alderman] #3765
 * RuboCop: Fix Layout/MultilineMethodCallBraceLayout [leila-alderman] #3763
+* NMI: Add standardized 3DS fields [meagabeth] #3775
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -36,6 +36,7 @@ module ActiveMerchant #:nodoc:
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
         add_level3_fields(post, options)
+        add_three_d_secure(post, options)
 
         commit('sale', post)
       end
@@ -49,6 +50,7 @@ module ActiveMerchant #:nodoc:
         add_vendor_data(post, options)
         add_merchant_defined_fields(post, options)
         add_level3_fields(post, options)
+        add_three_d_secure(post, options)
 
         commit('auth', post)
       end
@@ -245,6 +247,18 @@ module ActiveMerchant #:nodoc:
         (1..20).each do |each|
           key = "merchant_defined_field_#{each}".to_sym
           post[key] = options[key] if options[key]
+        end
+      end
+
+      def add_three_d_secure(post, options)
+        return unless options[:three_d_secure]
+
+        if (three_d_secure = options[:three_d_secure])
+          post[:eci] = three_d_secure[:eci]
+          post[:cavv] = three_d_secure[:cavv]
+          post[:xid] = three_d_secure[:xid]
+          post[:three_ds_version] = three_d_secure[:version]
+          post[:directory_server_id] = three_d_secure[:ds_transaction_id]
         end
       end
 

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -103,6 +103,23 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_three_d_secure
+    three_d_secure_options = @options.merge({
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '02',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+      }
+    })
+
+    assert response = @gateway.purchase(@amount, @credit_card, three_d_secure_options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
   def test_successful_authorization
     options = @options.merge(@level3_options)
 


### PR DESCRIPTION
Add standardized 3DS fields to the NMI gateway per the documented convention that active_merchant has adopted. Active Merchant documentation related to 3DS can be found on the [Standardized 3DS Fields wiki](https://github.com/activemerchant/active_merchant/wiki/Standardized-3DS-Fields).

CE-869

Unit:
46 tests, 352 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed