### PR TITLE
Blue Snap: Pass shipping info from the shipping_address params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * Decidir: Add support for csmdds fields [naashton] #3786
 * RuboCop: Fix Performance/StringReplacement [leila-alderman] #3782
 * RuboCop: Fix Naming/HeredocDelimiterCase & Naming [leila-alderman] #3781
+* BlueSnap: Add address fields to contact info [naashton] #3777
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -329,16 +329,18 @@ module ActiveMerchant
       end
 
       def add_shipping_contact_info(doc, payment_method, options)
-        # https://developers.bluesnap.com/v8976-XML/docs/shipping-contact-info
-        doc.send('first-name', payment_method.first_name)
-        doc.send('last-name', payment_method.last_name)
+        if address = options[:shipping_address]
+          # https://developers.bluesnap.com/v8976-XML/docs/shipping-contact-info
+          doc.send('first-name', payment_method.first_name)
+          doc.send('last-name', payment_method.last_name)
 
-        doc.country(options[:shipping_country]) if options[:shipping_country]
-        doc.state(options[:shipping_state]) if options[:shipping_state] && STATE_CODE_COUNTRIES.include?(options[:shipping_country])
-        doc.address1(options[:shipping_address1]) if options[:shipping_address1]
-        doc.address2(options[:shipping_address2]) if options[:shipping_address2]
-        doc.city(options[:shipping_city]) if options[:shipping_city]
-        doc.zip(options[:shipping_zip]) if options[:shipping_zip]
+          doc.country(address[:country]) if address[:country]
+          doc.state(address[:state]) if address[:state] && STATE_CODE_COUNTRIES.include?(address[:country])
+          doc.address1(address[:address1]) if address[:address1]
+          doc.address2(address[:address2]) if address[:address2]
+          doc.city(address[:city]) if address[:city]
+          doc.zip(address[:zip]) if address[:zip]
+        end
       end
 
       def add_alt_transaction_purchase(doc, money, payment_method_details, options)

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -209,11 +209,14 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_shipping_contact_info
     more_options = @options.merge({
-      shipping_address1: '123 Main St',
-      shipping_city: 'Springfield',
-      shipping_state: 'NC',
-      shipping_country: 'US',
-      shipping_zip: '27701'
+      shipping_address: {
+        address1: '123 Main St',
+        address2: 'Apt B',
+        city: 'Springfield',
+        state: 'NC',
+        country: 'US',
+        zip: '27701'
+      }
     })
 
     response = @gateway.purchase(@amount, @credit_card, more_options)

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -61,11 +61,14 @@ class BlueSnapTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_shipping_contact_info
     more_options = @options.merge({
-      shipping_address1: '123 Main St',
-      shipping_city: 'Springfield',
-      shipping_state: 'NC',
-      shipping_country: 'US',
-      shipping_zip: '27701'
+      shipping_address: {
+        address1: '123 Main St',
+        adress2: 'Apt B',
+        city: 'Springfield',
+        state: 'NC',
+        country: 'US',
+        zip: '27701'
+      }
     })
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, more_options)


### PR DESCRIPTION
Shipping info will be passed from the shipping_address params instead of
at the transaction level

CE-913

Unit: 38 tests, 223 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 47 tests, 162 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed