### PR TITLE
Mundipagg: Add support for SubMerchant fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
 * RuboCop: Fix Performance/RedundantMatch [leila-alderman] #3765
 * RuboCop: Fix Layout/MultilineMethodCallBraceLayout [leila-alderman] #3763
 * NMI: Add standardized 3DS fields [meagabeth] #3775
+* Mundipagg: Add support for SubMerchant fields [meagabeth] #3779
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options) unless payment.is_a?(String)
         add_shipping_address(post, options)
         add_payment(post, payment, options)
+        add_submerchant(post, options)
 
         commit('sale', post)
       end
@@ -50,6 +51,7 @@ module ActiveMerchant #:nodoc:
         add_shipping_address(post, options)
         add_payment(post, payment, options)
         add_capture_flag(post, payment)
+        add_submerchant(post, options)
         commit('authonly', post)
       end
 
@@ -200,6 +202,31 @@ module ActiveMerchant #:nodoc:
         return false if payment.is_a?(String)
 
         %w[sodexo vr].include? card_brand(payment)
+      end
+
+      def add_submerchant(post, options)
+        if submerchant = options[:submerchant]
+          post[:SubMerchant] = {}
+          post[:SubMerchant][:Merchant_Category_Code] = submerchant[:merchant_category_code] if submerchant[:merchant_category_code]
+          post[:SubMerchant][:Payment_Facilitator_Code] = submerchant[:payment_facilitator_code] if submerchant[:payment_facilitator_code]
+          post[:SubMerchant][:Code] = submerchant[:code] if submerchant[:code]
+          post[:SubMerchant][:Name] = submerchant[:name] if submerchant[:name]
+          post[:SubMerchant][:Document] = submerchant[:document] if submerchant[:document]
+          post[:SubMerchant][:Type] = submerchant[:type] if submerchant[:type]
+          post[:SubMerchant][:Phone] = {}
+          post[:SubMerchant][:Phone][:Country_Code] = submerchant[:phone][:country_code] if submerchant.dig(:phone, :country_code)
+          post[:SubMerchant][:Phone][:Number] = submerchant[:phone][:number] if submerchant.dig(:phone, :number)
+          post[:SubMerchant][:Phone][:Area_Code] = submerchant[:phone][:area_code] if submerchant.dig(:phone, :area_code)
+          post[:SubMerchant][:Address] = {}
+          post[:SubMerchant][:Address][:Street] = submerchant[:address][:street] if submerchant.dig(:address, :street)
+          post[:SubMerchant][:Address][:Number] = submerchant[:address][:number] if submerchant.dig(:address, :number)
+          post[:SubMerchant][:Address][:Complement] = submerchant[:address][:complement] if submerchant.dig(:address, :complement)
+          post[:SubMerchant][:Address][:Neighborhood] = submerchant[:address][:neighborhood] if submerchant.dig(:address, :neighborhood)
+          post[:SubMerchant][:Address][:City] = submerchant[:address][:city] if submerchant.dig(:address, :city)
+          post[:SubMerchant][:Address][:State] = submerchant[:address][:state] if submerchant.dig(:address, :state)
+          post[:SubMerchant][:Address][:Country] = submerchant[:address][:country] if submerchant.dig(:address, :country)
+          post[:SubMerchant][:Address][:Zip_Code] = submerchant[:address][:zip_code] if submerchant.dig(:address, :zip_code)
+        end
       end
 
       def headers

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -22,6 +22,32 @@ class RemoteMundipaggTest < Test::Unit::TestCase
       description: 'Store Purchase'
     }
 
+    @submerchant_options = {
+      submerchant: {
+        "merchant_category_code": '44444',
+        "payment_facilitator_code": '5555555',
+        "code": 'code2',
+        "name": 'Sub Tony Stark',
+        "document": '123456789',
+        "type": 'individual',
+        "phone": {
+          "country_code": '55',
+          "number": '000000000',
+          "area_code": '21'
+        },
+        "address": {
+          "street": 'Malibu Point',
+          "number": '10880',
+          "complement": 'A',
+          "neighborhood": 'Central Malibu',
+          "city": 'Malibu',
+          "state": 'CA',
+          "country": 'US',
+          "zip_code": '24210-460'
+        }
+      }
+    }
+
     @excess_length_neighborhood = address({neighborhood: 'Super Long Neighborhood Name' * 5})
     @neighborhood_length_error = 'Invalid parameters; The request is invalid. | The field neighborhood must be a string with a maximum length of 64.'
   end
@@ -67,6 +93,13 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
   end
 
+  def test_successful_purchase_with_submerchant
+    options = @options.update(@submerchant_options)
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+  end
+
   def test_failed_purchase
     test_failed_purchase_with(@declined_card)
   end
@@ -90,6 +123,13 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
   def test_successful_authorize_and_capture_with_alelo_card
     test_successful_authorize_and_capture_with(@alelo_voucher)
+  end
+
+  def test_successful_authorize_with_submerchant
+    options = @options.update(@submerchant_options)
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
   end
 
   def test_failed_authorize


### PR DESCRIPTION
Add ability to send through SubMerchant object which enables the sending of information from sub-accredited.

CE-1027

Unit:
29 tests, 128 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
39 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed